### PR TITLE
Add test target for codegen

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: "cpp"
 
+description = 'The protoc plugin for gRPC Java'
+
 executables {
   java_plugin {}
 }
@@ -23,3 +25,7 @@ sources {
   }
 }
 
+task test(type: Exec, dependsOn: 'java_pluginExecutable') {
+  environment 'TEST_TMP_DIR', temporaryDir
+  commandLine './run_test.sh'
+}

--- a/compiler/run_test.sh
+++ b/compiler/run_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ -z "$TEST_TMP_DIR" ]; then
+  echo '$TEST_TMP_DIR not set'
+  exit 1;
+fi
+
+cd $(dirname $0)
+
+TEST_SRC_DIR='test'
+INPUT_FILE="$TEST_SRC_DIR/test.proto"
+OUTPUT_FILE="$TEST_TMP_DIR/TestServiceGrpc.src.jar"
+GOLDEN_FILE="$TEST_SRC_DIR/TestService.java.txt"
+
+protoc --plugin=protoc-gen-java_rpc=build/binaries/java_pluginExecutable/java_plugin \
+  --java_rpc_out="$OUTPUT_FILE" --proto_path="$TEST_SRC_DIR" "$INPUT_FILE" && \
+  unzip -o -d "$TEST_TMP_DIR" "$OUTPUT_FILE" && \
+  diff "$TEST_TMP_DIR/com/google/net/stubby/testing/integration/TestServiceGrpc.java" \
+    "$GOLDEN_FILE" && \
+  echo "PASS"

--- a/compiler/test/TestService.java.txt
+++ b/compiler/test/TestService.java.txt
@@ -1,0 +1,327 @@
+package com.google.net.stubby.testing.integration;
+
+import static com.google.net.stubby.stub.Calls.createMethodDescriptor;
+import static com.google.net.stubby.stub.Calls.asyncUnaryCall;
+import static com.google.net.stubby.stub.Calls.asyncServerStreamingCall;
+import static com.google.net.stubby.stub.Calls.asyncClientStreamingCall;
+import static com.google.net.stubby.stub.Calls.duplexStreamingCall;
+import static com.google.net.stubby.stub.Calls.blockingUnaryCall;
+import static com.google.net.stubby.stub.Calls.blockingServerStreamingCall;
+import static com.google.net.stubby.stub.Calls.unaryFutureCall;
+import static com.google.net.stubby.stub.ServerCalls.createMethodDefinition;
+import static com.google.net.stubby.stub.ServerCalls.asyncUnaryRequestCall;
+import static com.google.net.stubby.stub.ServerCalls.asyncStreamingRequestCall;
+
+@javax.annotation.Generated("by gRPC proto compiler")
+public class TestServiceGrpc {
+
+  private static final com.google.net.stubby.stub.Method<com.google.net.stubby.testing.integration.Test.SimpleRequest,
+      com.google.net.stubby.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL =
+      com.google.net.stubby.stub.Method.create(
+          com.google.net.stubby.MethodType.UNARY, "UnaryCall",
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.SimpleRequest.PARSER),
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.SimpleResponse.PARSER));
+  private static final com.google.net.stubby.stub.Method<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+      com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
+      com.google.net.stubby.stub.Method.create(
+          com.google.net.stubby.MethodType.SERVER_STREAMING, "StreamingOutputCall",
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest.PARSER),
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse.PARSER));
+  private static final com.google.net.stubby.stub.Method<com.google.net.stubby.testing.integration.Test.StreamingInputCallRequest,
+      com.google.net.stubby.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
+      com.google.net.stubby.stub.Method.create(
+          com.google.net.stubby.MethodType.CLIENT_STREAMING, "StreamingInputCall",
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.StreamingInputCallRequest.PARSER),
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.StreamingInputCallResponse.PARSER));
+  private static final com.google.net.stubby.stub.Method<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+      com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL =
+      com.google.net.stubby.stub.Method.create(
+          com.google.net.stubby.MethodType.DUPLEX_STREAMING, "FullDuplexCall",
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest.PARSER),
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse.PARSER));
+  private static final com.google.net.stubby.stub.Method<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+      com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL =
+      com.google.net.stubby.stub.Method.create(
+          com.google.net.stubby.MethodType.DUPLEX_STREAMING, "HalfDuplexCall",
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest.PARSER),
+          com.google.net.stubby.proto.ProtoUtils.marshaller(com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse.PARSER));
+
+  public static TestServiceStub newStub(com.google.net.stubby.Channel channel) {
+    return new TestServiceStub(channel, CONFIG);
+  }
+
+  public static TestServiceBlockingStub newBlockingStub(
+      com.google.net.stubby.Channel channel) {
+    return new TestServiceBlockingStub(channel, CONFIG);
+  }
+
+  public static TestServiceFutureStub newFutureStub(
+      com.google.net.stubby.Channel channel) {
+    return new TestServiceFutureStub(channel, CONFIG);
+  }
+
+  public static final TestServiceServiceDescriptor CONFIG =
+      new TestServiceServiceDescriptor();
+
+  @javax.annotation.concurrent.Immutable
+  public static class TestServiceServiceDescriptor extends
+      com.google.net.stubby.stub.AbstractServiceDescriptor<TestServiceServiceDescriptor> {
+    public final com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.SimpleRequest,
+        com.google.net.stubby.testing.integration.Test.SimpleResponse> unaryCall;
+    public final com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+        com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall;
+    public final com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.StreamingInputCallRequest,
+        com.google.net.stubby.testing.integration.Test.StreamingInputCallResponse> streamingInputCall;
+    public final com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+        com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> fullDuplexCall;
+    public final com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+        com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> halfDuplexCall;
+
+    private TestServiceServiceDescriptor() {
+      unaryCall = createMethodDescriptor(
+          "grpc.testing.TestService", METHOD_UNARY_CALL);
+      streamingOutputCall = createMethodDescriptor(
+          "grpc.testing.TestService", METHOD_STREAMING_OUTPUT_CALL);
+      streamingInputCall = createMethodDescriptor(
+          "grpc.testing.TestService", METHOD_STREAMING_INPUT_CALL);
+      fullDuplexCall = createMethodDescriptor(
+          "grpc.testing.TestService", METHOD_FULL_DUPLEX_CALL);
+      halfDuplexCall = createMethodDescriptor(
+          "grpc.testing.TestService", METHOD_HALF_DUPLEX_CALL);
+    }
+
+    private TestServiceServiceDescriptor(
+        java.util.Map<java.lang.String, com.google.net.stubby.MethodDescriptor<?, ?>> methodMap) {
+      unaryCall = (com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.SimpleRequest,
+          com.google.net.stubby.testing.integration.Test.SimpleResponse>) methodMap.get(
+          CONFIG.unaryCall.getName());
+      streamingOutputCall = (com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+          com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse>) methodMap.get(
+          CONFIG.streamingOutputCall.getName());
+      streamingInputCall = (com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.StreamingInputCallRequest,
+          com.google.net.stubby.testing.integration.Test.StreamingInputCallResponse>) methodMap.get(
+          CONFIG.streamingInputCall.getName());
+      fullDuplexCall = (com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+          com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse>) methodMap.get(
+          CONFIG.fullDuplexCall.getName());
+      halfDuplexCall = (com.google.net.stubby.MethodDescriptor<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+          com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse>) methodMap.get(
+          CONFIG.halfDuplexCall.getName());
+    }
+
+    @java.lang.Override
+    protected TestServiceServiceDescriptor build(
+        java.util.Map<java.lang.String, com.google.net.stubby.MethodDescriptor<?, ?>> methodMap) {
+      return new TestServiceServiceDescriptor(methodMap);
+    }
+
+    @java.lang.Override
+    public com.google.common.collect.ImmutableList<com.google.net.stubby.MethodDescriptor<?, ?>> methods() {
+      return com.google.common.collect.ImmutableList.<com.google.net.stubby.MethodDescriptor<?, ?>>of(
+          unaryCall,
+          streamingOutputCall,
+          streamingInputCall,
+          fullDuplexCall,
+          halfDuplexCall);
+    }
+  }
+
+  public static interface TestService {
+
+    public void unaryCall(com.google.net.stubby.testing.integration.Test.SimpleRequest request,
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.SimpleResponse> responseObserver);
+
+    public void streamingOutputCall(com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest request,
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> responseObserver);
+
+    public com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingInputCallResponse> responseObserver);
+
+    public com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest> fullDuplexCall(
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> responseObserver);
+
+    public com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest> halfDuplexCall(
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> responseObserver);
+  }
+
+  public static interface TestServiceBlockingClient {
+
+    public com.google.net.stubby.testing.integration.Test.SimpleResponse unaryCall(com.google.net.stubby.testing.integration.Test.SimpleRequest request);
+
+    public java.util.Iterator<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
+        com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest request);
+  }
+
+  public static interface TestServiceFutureClient {
+
+    public com.google.common.util.concurrent.ListenableFuture<com.google.net.stubby.testing.integration.Test.SimpleResponse> unaryCall(
+        com.google.net.stubby.testing.integration.Test.SimpleRequest request);
+  }
+
+  public static class TestServiceStub extends
+      com.google.net.stubby.stub.AbstractStub<TestServiceStub, TestServiceServiceDescriptor>
+      implements TestService {
+    private TestServiceStub(com.google.net.stubby.Channel channel,
+        TestServiceServiceDescriptor config) {
+      super(channel, config);
+    }
+
+    @java.lang.Override
+    protected TestServiceStub build(com.google.net.stubby.Channel channel,
+        TestServiceServiceDescriptor config) {
+      return new TestServiceStub(channel, config);
+    }
+
+    @java.lang.Override
+    public void unaryCall(com.google.net.stubby.testing.integration.Test.SimpleRequest request,
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.SimpleResponse> responseObserver) {
+      asyncUnaryCall(
+          channel.newCall(config.unaryCall), request, responseObserver);
+    }
+
+    @java.lang.Override
+    public void streamingOutputCall(com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest request,
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+      asyncServerStreamingCall(
+          channel.newCall(config.streamingOutputCall), request, responseObserver);
+    }
+
+    @java.lang.Override
+    public com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncClientStreamingCall(
+          channel.newCall(config.streamingInputCall), responseObserver);
+    }
+
+    @java.lang.Override
+    public com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest> fullDuplexCall(
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+      return duplexStreamingCall(
+          channel.newCall(config.fullDuplexCall), responseObserver);
+    }
+
+    @java.lang.Override
+    public com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest> halfDuplexCall(
+        com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+      return duplexStreamingCall(
+          channel.newCall(config.halfDuplexCall), responseObserver);
+    }
+  }
+
+  public static class TestServiceBlockingStub extends
+      com.google.net.stubby.stub.AbstractStub<TestServiceBlockingStub, TestServiceServiceDescriptor>
+      implements TestServiceBlockingClient {
+    private TestServiceBlockingStub(com.google.net.stubby.Channel channel,
+        TestServiceServiceDescriptor config) {
+      super(channel, config);
+    }
+
+    @java.lang.Override
+    protected TestServiceBlockingStub build(com.google.net.stubby.Channel channel,
+        TestServiceServiceDescriptor config) {
+      return new TestServiceBlockingStub(channel, config);
+    }
+
+    @java.lang.Override
+    public com.google.net.stubby.testing.integration.Test.SimpleResponse unaryCall(com.google.net.stubby.testing.integration.Test.SimpleRequest request) {
+      return blockingUnaryCall(
+          channel.newCall(config.unaryCall), request);
+    }
+
+    @java.lang.Override
+    public java.util.Iterator<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
+        com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest request) {
+      return blockingServerStreamingCall(
+          channel.newCall(config.streamingOutputCall), request);
+    }
+  }
+
+  public static class TestServiceFutureStub extends
+      com.google.net.stubby.stub.AbstractStub<TestServiceFutureStub, TestServiceServiceDescriptor>
+      implements TestServiceFutureClient {
+    private TestServiceFutureStub(com.google.net.stubby.Channel channel,
+        TestServiceServiceDescriptor config) {
+      super(channel, config);
+    }
+
+    @java.lang.Override
+    protected TestServiceFutureStub build(com.google.net.stubby.Channel channel,
+        TestServiceServiceDescriptor config) {
+      return new TestServiceFutureStub(channel, config);
+    }
+
+    @java.lang.Override
+    public com.google.common.util.concurrent.ListenableFuture<com.google.net.stubby.testing.integration.Test.SimpleResponse> unaryCall(
+        com.google.net.stubby.testing.integration.Test.SimpleRequest request) {
+      return unaryFutureCall(
+          channel.newCall(config.unaryCall), request);
+    }
+  }
+
+  public static com.google.net.stubby.ServerServiceDefinition bindService(
+      final TestService serviceImpl) {
+    return com.google.net.stubby.ServerServiceDefinition.builder("grpc.testing.TestService")
+      .addMethod(createMethodDefinition(
+          METHOD_UNARY_CALL,
+          asyncUnaryRequestCall(
+            new com.google.net.stubby.stub.ServerCalls.UnaryRequestMethod<
+                com.google.net.stubby.testing.integration.Test.SimpleRequest,
+                com.google.net.stubby.testing.integration.Test.SimpleResponse>() {
+              @java.lang.Override
+              public void invoke(
+                  com.google.net.stubby.testing.integration.Test.SimpleRequest request,
+                  com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.SimpleResponse> responseObserver) {
+                serviceImpl.unaryCall(request, responseObserver);
+              }
+            })))
+      .addMethod(createMethodDefinition(
+          METHOD_STREAMING_OUTPUT_CALL,
+          asyncUnaryRequestCall(
+            new com.google.net.stubby.stub.ServerCalls.UnaryRequestMethod<
+                com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+                com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse>() {
+              @java.lang.Override
+              public void invoke(
+                  com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest request,
+                  com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+                serviceImpl.streamingOutputCall(request, responseObserver);
+              }
+            })))
+      .addMethod(createMethodDefinition(
+          METHOD_STREAMING_INPUT_CALL,
+          asyncStreamingRequestCall(
+            new com.google.net.stubby.stub.ServerCalls.StreamingRequestMethod<
+                com.google.net.stubby.testing.integration.Test.StreamingInputCallRequest,
+                com.google.net.stubby.testing.integration.Test.StreamingInputCallResponse>() {
+              @java.lang.Override
+              public com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingInputCallRequest> invoke(
+                  com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
+                return serviceImpl.streamingInputCall(responseObserver);
+              }
+            })))
+      .addMethod(createMethodDefinition(
+          METHOD_FULL_DUPLEX_CALL,
+          asyncStreamingRequestCall(
+            new com.google.net.stubby.stub.ServerCalls.StreamingRequestMethod<
+                com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+                com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse>() {
+              @java.lang.Override
+              public com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest> invoke(
+                  com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+                return serviceImpl.fullDuplexCall(responseObserver);
+              }
+            })))
+      .addMethod(createMethodDefinition(
+          METHOD_HALF_DUPLEX_CALL,
+          asyncStreamingRequestCall(
+            new com.google.net.stubby.stub.ServerCalls.StreamingRequestMethod<
+                com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest,
+                com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse>() {
+              @java.lang.Override
+              public com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallRequest> invoke(
+                  com.google.net.stubby.stub.StreamObserver<com.google.net.stubby.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+                return serviceImpl.halfDuplexCall(responseObserver);
+              }
+            }))).build();
+  }
+}

--- a/compiler/test/test.proto
+++ b/compiler/test/test.proto
@@ -1,0 +1,53 @@
+// A simple service definition for testing the protoc plugin.
+syntax = "proto2";
+
+package grpc.testing;
+
+option java_package = "com.google.net.stubby.testing.integration";
+
+message SimpleRequest {
+}
+
+message SimpleResponse {
+}
+
+message StreamingInputCallRequest {
+}
+
+message StreamingInputCallResponse {
+}
+
+message StreamingOutputCallRequest {
+}
+
+message StreamingOutputCallResponse {
+}
+
+service TestService {
+  // One request followed by one response.
+  // The server returns the client payload as-is.
+  rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
+
+  // One request followed by a sequence of responses (streamed download).
+  // The server returns the payload with client desired type and sizes.
+  rpc StreamingOutputCall(StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // A sequence of requests followed by one response (streamed upload).
+  // The server returns the aggregated size of client payload as the result.
+  rpc StreamingInputCall(stream StreamingInputCallRequest)
+      returns (StreamingInputCallResponse);
+
+  // A sequence of requests with each request served by the server immediately.
+  // As one request could lead to multiple responses, this interface
+  // demonstrates the idea of full duplexing.
+  rpc FullDuplexCall(stream StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // A sequence of requests followed by a sequence of responses.
+  // The server buffers all the client requests and then serves them in order. A
+  // stream of responses are returned to the client when the server starts with
+  // first request.
+  rpc HalfDuplexCall(stream StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+}


### PR DESCRIPTION
@ejona86 this is more end-to-end than the original test -- it runs the protoc with the compiled plugin and compare the output with the golden file.
