### PR TITLE
Reorder the fields of LogHelper to be consistent with initialization order

### DIFF
--- a/compiler/src/java_generator.h
+++ b/compiler/src/java_generator.h
@@ -9,8 +9,8 @@
 #include <google/protobuf/descriptor.h>
 
 class LogHelper {
-  bool abort;
   std::ostream* os;
+  bool abort;
 
  public:
   LogHelper(std::ostream* os, bool abort) : os(os), abort(abort) {}


### PR DESCRIPTION
Otherwise it will be a warning and blaze would refuse to build it.
@ejona86 
