### PR TITLE
Have Gradle observe LDFLAGS/CXXFLAGS/CPPFLAGS

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -9,7 +9,16 @@ executables {
 binaries.all {
   if (toolChain in Gcc) {
     cppCompiler.args "-std=c++11"
+    if (System.env.CXXFLAGS) {
+      cppCompiler.args System.env.CXXFLAGS
+    }
+    if (System.env.CPPFLAGS) {
+      cppCompiler.args System.env.CPPFLAGS
+    }
     linker.args "-lprotoc", "-lprotobuf"
+    if (System.env.LDFLAGS) {
+      linker.args System.env.LDFLAGS
+    }
   }
 }
 


### PR DESCRIPTION
This allows building with a private proto installation (one in home
directory or elsewhere) by specifying -I and -L.

@zhangkun83, you are probably interested.
