### PR TITLE
Fixing integration tests

### DIFF
--- a/core/src/main/java/io/grpc/transport/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/transport/MessageDeframer.java
@@ -134,10 +134,10 @@ public class MessageDeframer implements Closeable {
    * @param numMessages the requested number of messages to be delivered to the listener.
    */
   public void request(int numMessages) {
+    Preconditions.checkArgument(numMessages > 0, "numMessages must be > 0");
     if (isClosed()) {
       return;
     }
-    Preconditions.checkArgument(numMessages > 0, "numMessages must be > 0");
     pendingDeliveries += numMessages;
     deliver();
   }


### PR DESCRIPTION
Allowing MessageDeframer.request to be called after the deframer has
been closed.  The stub helpers blindly call request after receiving each
message.
