### PR TITLE
Fix race in OkHttp test

### DIFF
--- a/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -151,7 +152,7 @@ public class OkHttpClientTransportTest {
     assertEquals(Status.INTERNAL.getCode(), listener1.status.getCode());
     assertEquals(NETWORK_ISSUE_MESSAGE, listener2.status.getCause().getMessage());
     verify(listener).transportShutdown();
-    verify(listener).transportTerminated();
+    verify(listener, timeout(TIME_OUT_MS)).transportTerminated();
   }
 
   @Test


### PR DESCRIPTION
transportTerminated() is called after closing the streams, so we can't
just wait on the streams and expect it to have been called.
