### PR TITLE
Allow running test scripts from any directory

### DIFF
--- a/run-test-client.sh
+++ b/run-test-client.sh
@@ -8,5 +8,6 @@ for i in "$@"; do
 done
 TARGET_ARGS="${TARGET_ARGS:2}"
 
+cd "$(dirname "$(readlink -f "$0")")"
 echo "[INFO] Running: $TARGET ($TARGET_CLASS $TARGET_ARGS)"
 ./gradlew -PmainClass="$TARGET_CLASS" -PappArgs="[$TARGET_ARGS]" :grpc-integration-testing:execute

--- a/run-test-server.sh
+++ b/run-test-server.sh
@@ -8,5 +8,6 @@ for i in "$@"; do
 done
 TARGET_ARGS="${TARGET_ARGS:2}"
 
+cd "$(dirname "$(readlink -f "$0")")"
 echo "[INFO] Running: $TARGET ($TARGET_CLASS $TARGET_ARGS)"
 ./gradlew -PmainClass="$TARGET_CLASS" -PappArgs="[$TARGET_ARGS]" :grpc-integration-testing:execute


### PR DESCRIPTION
This was actually a feature lost when swapping to Gradle, and is used by
the grpc/java Dockerfile. But it is useful in general.
