### PR TITLE
Allow IntelliJ to refer to generated sources for benchmark protos

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -35,3 +35,17 @@ dependencies {
 
 protobufCodeGenPlugins = ["java_plugin:$rootDir/compiler/build/binaries/java_pluginExecutable/java_plugin"]
 generateProto.dependsOn ':grpc-compiler:java_pluginExecutable'
+
+// Allow intellij projects to refer to generated-sources
+idea {
+    module {
+        // The whole build dir is excluded by default, but we need build/generated-sources,
+        // which contains the generated proto classes.
+        excludeDirs = [file('.gradle')]
+        if (buildDir.exists()) {
+            excludeDirs += files(buildDir.listFiles())
+            excludeDirs -= file("$buildDir/generated-sources")
+        }
+    }
+}
+


### PR DESCRIPTION
@nmittler @ejona86 

Same fix as was done for integration tests
