### PR TITLE
Add java_package proto option for portability

### DIFF
--- a/examples/src/main/proto/math.proto
+++ b/examples/src/main/proto/math.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 
 package io.grpc.examples;
+option java_package = "io.grpc.examples";
 option java_outer_classname = "Math";
 
 message DivArgs {

--- a/examples/src/main/proto/stock.proto
+++ b/examples/src/main/proto/stock.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 
 package io.grpc.examples;
+option java_package = "io.grpc.examples";
 
 // Protocol type definitions
 message StockRequest {


### PR DESCRIPTION
Some protoc Java environments have a package to put all proto namespaces
under, since proto namespaces aren't aligned with Java packages.
