### PR TITLE
Remove target from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Maven
-target
-
 # Gradle
 build
 .gradle


### PR DESCRIPTION
We are no longer using Maven, so target/ directories should not longer
be ignored.
