### PR TITLE
Set encoding for Java source to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ subprojects {
 
     compileJava {
         options.compilerArgs << "-Xlint:unchecked"
+        options.encoding = "UTF-8"
     }
 
     ext {


### PR DESCRIPTION
Our new example uses UTF-8 characters, so the build would otherwise fail if on a system where UTF-8 is not the default locale.
