### PR TITLE
Have SendGrpcFrameCommand constructor take an AbstractStream object instead of a stream id.

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
@@ -85,8 +85,9 @@ class NettyClientStream extends Http2ClientStream {
 
   @Override
   protected void sendFrame(ByteBuffer frame, boolean endOfStream) {
-    SendGrpcFrameCommand cmd = new SendGrpcFrameCommand(id(), 
-        Utils.toByteBuf(channel.alloc(), frame), endOfStream);
+    SendGrpcFrameCommand cmd =
+            new SendGrpcFrameCommand(this, Utils.toByteBuf(channel.alloc(), frame), endOfStream);
+
     channel.writeAndFlush(cmd);
   }
 

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
@@ -83,7 +83,7 @@ class NettyServerStream extends AbstractServerStream<Integer> {
   @Override
   protected void sendFrame(ByteBuffer frame, boolean endOfStream) {
     SendGrpcFrameCommand cmd =
-        new SendGrpcFrameCommand(id(), Utils.toByteBuf(channel.alloc(), frame), endOfStream);
+        new SendGrpcFrameCommand(this, Utils.toByteBuf(channel.alloc(), frame), endOfStream);
     channel.writeAndFlush(cmd);
   }
 

--- a/netty/src/main/java/io/grpc/transport/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/SendGrpcFrameCommand.java
@@ -31,6 +31,7 @@
 
 package io.grpc.transport.netty;
 
+import io.grpc.transport.AbstractStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;
@@ -39,17 +40,17 @@ import io.netty.buffer.DefaultByteBufHolder;
  * Command sent from the transport to the Netty channel to send a GRPC frame to the remote endpoint.
  */
 class SendGrpcFrameCommand extends DefaultByteBufHolder {
-  private final int streamId;
+  private final AbstractStream<Integer> stream;
   private final boolean endStream;
 
-  SendGrpcFrameCommand(int streamId, ByteBuf content, boolean endStream) {
+  SendGrpcFrameCommand(AbstractStream<Integer> stream, ByteBuf content, boolean endStream) {
     super(content);
-    this.streamId = streamId;
+    this.stream = stream;
     this.endStream = endStream;
   }
 
   int streamId() {
-    return streamId;
+    return stream.id();
   }
 
   boolean endStream() {
@@ -58,12 +59,12 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder {
 
   @Override
   public ByteBufHolder copy() {
-    return new SendGrpcFrameCommand(streamId, content().copy(), endStream);
+    return new SendGrpcFrameCommand(stream, content().copy(), endStream);
   }
 
   @Override
   public ByteBufHolder duplicate() {
-    return new SendGrpcFrameCommand(streamId, content().duplicate(), endStream);
+    return new SendGrpcFrameCommand(stream, content().duplicate(), endStream);
   }
 
   @Override
@@ -96,13 +97,13 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder {
       return false;
     }
     SendGrpcFrameCommand thatCmd = (SendGrpcFrameCommand) that;
-    return thatCmd.streamId == streamId && thatCmd.endStream == endStream
+    return thatCmd.stream.equals(stream) && thatCmd.endStream == endStream
         && thatCmd.content().equals(content());
   }
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(streamId=" + streamId
+    return getClass().getSimpleName() + "(streamId=" + streamId()
         + ", endStream=" + endStream + ", content=" + content()
         + ")";
   }
@@ -110,7 +111,7 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder {
   @Override
   public int hashCode() {
     int hash = content().hashCode();
-    hash = hash * 31 + streamId;
+    hash = hash * 31 + stream.hashCode();
     if (endStream) {
       hash = -hash;
     }


### PR DESCRIPTION
As part of the effort to remove all blocking bits from the `NettyClientStream` with
this commit the `SendGrpcFrameCommand` now takes a stream object instead of the
stream id. This will be necessary as in a non blocking world the stream id might
not have yet been allocated when the `SendGrpcFrameCommand` gets instantiated.
