### PR TITLE
Cleanup and Nitpicking

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
@@ -36,7 +36,6 @@ import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -85,11 +84,13 @@ class NettyClientTransport implements ClientTransport {
   private static final Logger log = Logger.getLogger(NettyClientTransport.class.getName());
 
   private final SocketAddress address;
-  private final EventLoopGroup eventGroup;
+  private final EventLoopGroup group;
   private final Http2Negotiator.Negotiation negotiation;
   private final NettyClientHandler handler;
   private final boolean ssl;
   private final AsciiString authority;
+  // We should not send on the channel until negotiation completes. This is a hard requirement
+  // by SslHandler but is appropriate for HTTP/1.1 Upgrade as well.
   private Channel channel;
   private Listener listener;
   /**
@@ -108,10 +109,10 @@ class NettyClientTransport implements ClientTransport {
   private boolean terminated;
 
   NettyClientTransport(SocketAddress address, NegotiationType negotiationType,
-      EventLoopGroup eventGroup, SslContext sslContext) {
+      EventLoopGroup group, SslContext sslContext) {
     Preconditions.checkNotNull(negotiationType, "negotiationType");
     this.address = Preconditions.checkNotNull(address, "address");
-    this.eventGroup = Preconditions.checkNotNull(eventGroup, "eventGroup");
+    this.group = Preconditions.checkNotNull(group, "group");
 
     InetSocketAddress inetAddress = null;
     if (address instanceof InetSocketAddress) {
@@ -197,7 +198,7 @@ class NettyClientTransport implements ClientTransport {
   public void start(Listener transportListener) {
     listener = Preconditions.checkNotNull(transportListener, "listener");
     Bootstrap b = new Bootstrap();
-    b.group(eventGroup);
+    b.group(group);
     if (address instanceof LocalAddress) {
       b.channel(LocalChannel.class);
     } else {
@@ -208,6 +209,8 @@ class NettyClientTransport implements ClientTransport {
 
     // Start the connection operation to the server.
     final ChannelFuture connectFuture = b.connect(address);
+    channel = connectFuture.channel();
+
     connectFuture.addListener(new ChannelFutureListener() {
       @Override
       public void operationComplete(ChannelFuture future) throws Exception {
@@ -236,9 +239,6 @@ class NettyClientTransport implements ClientTransport {
       }
     });
 
-    // We should not send on the channel until negotiation completes. This is a hard requirement
-    // by SslHandler but is appropriate for HTTP/1.1 Upgrade as well.
-    channel = connectFuture.channel();
     // Handle transport shutdown when the channel is closed.
     channel.closeFuture().addListener(new ChannelFutureListener() {
       @Override


### PR DESCRIPTION
- Renamed 'eventGroup' property to 'group' as this what's used elsewhere.
- Moved assignment of the channel before the listener is added as currently
  there is a (theoretical) chance that the listener is executed before the assignment
  to channel happens, namely in case the Future is already done when the listener
  is added.
- Removed comment that seemed out of place / relict.
