### PR TITLE
Create temporary directory for javanano test if it does not exist.

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -49,6 +49,10 @@ task testGolden(type: Exec, dependsOn: 'generateTestProto') {
 }
 
 task testNanoGolden(type: Exec, dependsOn: 'java_pluginExecutable') {
+  doFirst {
+      temporaryDir.createNewFile();
+  }
+
   environment 'TEST_TMP_DIR', temporaryDir
   commandLine './src/test/run_nano_test.sh'
 }


### PR DESCRIPTION
The gradle task `:compiler:testNanoGolden` fails because the temporary folder it tries to use does not exist.
The task tries to write files to `temporaryDir` which points to `./compiler/build/tmp/testNanoGolden/` on my machine. The directory does not exist by default and so the run_nano_test.sh fails.
