### PR TITLE
Remove nano codegen test temporarily. Currently I haven't figuired

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -40,7 +40,7 @@ binaries.all {
 protobufCodeGenPlugins = ["java_plugin:$buildDir/binaries/java_pluginExecutable/java_plugin"]
 
 generateTestProto.dependsOn 'java_pluginExecutable'
-test.dependsOn('testGolden','testNanoGolden')
+test.dependsOn('testGolden')
 
 task testGolden(type: Exec, dependsOn: 'generateTestProto') {
   executable "diff"
@@ -48,9 +48,7 @@ task testGolden(type: Exec, dependsOn: 'generateTestProto') {
        "$projectDir/src/test/golden/TestService.java.txt"
 }
 
-task testNanoGolden(type: Exec, dependsOn: 'java_pluginExecutable') {
-  environment 'TEST_TMP_DIR', temporaryDir
-  commandLine './src/test/run_nano_test.sh'
-}
+// TODO(rocking): use src/test/run_nano_test.sh to verify nano codegen. Currently we have an issue
+// that gradle temporaryDir is not created when doing gradle clean build
 
 


### PR DESCRIPTION
out how to make it work with "gradle clean build"
Somehow temporaryDir is not created when doing gradle clean build,
so the test complains about path not found
