### PR TITLE
Updating integ test protos to be consistent with C

### DIFF
--- a/integration-testing/src/main/proto/io/grpc/testing/integration/empty.proto
+++ b/integration-testing/src/main/proto/io/grpc/testing/integration/empty.proto
@@ -1,12 +1,36 @@
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
 //
-// Copyright 2014 Google Inc. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
 //
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file or at
-// https://developers.google.com/open-source/licenses/bsd
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 syntax = "proto2";
 
-package proto2;
+package grpc.testing;
 
 option java_package = "com.google.protobuf";
 option java_outer_classname = "EmptyProtos";
@@ -16,7 +40,7 @@ option java_outer_classname = "EmptyProtos";
 // return value of a service API. For instance:
 //
 //   service Foo {
-//     rpc Bar (proto2.Empty) returns (proto2.Empty) { };
+//     rpc Bar (grpc.testing.Empty) returns (grpc.testing.Empty) { };
 //   };
+//
 message Empty {}
-

--- a/integration-testing/src/main/proto/io/grpc/testing/integration/messages.proto
+++ b/integration-testing/src/main/proto/io/grpc/testing/integration/messages.proto
@@ -1,12 +1,38 @@
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
 //
-// Copyright 2014 Google Inc. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
 //
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file or at
-// https://developers.google.com/open-source/licenses/bsd
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Message definitions to be used by integration test service definitions.
+
 syntax = "proto3";
 
-package stubby.testing;
+package grpc.testing;
 
 option java_package = "io.grpc.testing.integration";
 
@@ -22,7 +48,7 @@ enum PayloadType {
   RANDOM = 2;
 }
 
-// A block of data, to simply increase message size.
+// A block of data, to simply increase gRPC message size.
 message Payload {
   // The type of data in body.
   optional PayloadType type = 1;
@@ -42,6 +68,12 @@ message SimpleRequest {
 
   // Optional input payload sent along with the request.
   optional Payload payload = 3;
+
+  // Whether SimpleResponse should include username.
+  optional bool fill_username = 4;
+
+  // Whether SimpleResponse should include OAuth scope.
+  optional bool fill_oauth_scope = 5;
 }
 
 // Unary response, as configured by the request.
@@ -50,11 +82,9 @@ message SimpleResponse {
   optional Payload payload = 1;
   // The user the request came from, for verifying authentication was
   // successful when the client expected it.
-  optional int64 effective_gaia_user_id = 2;
-}
-
-message SimpleContext {
-  optional string value = 1;
+  optional string username = 2;
+  // OAuth scope.
+  optional string oauth_scope = 3;
 }
 
 // Client-streaming request.
@@ -102,4 +132,3 @@ message StreamingOutputCallResponse {
   // Payload to increase response size.
   optional Payload payload = 1;
 }
-


### PR DESCRIPTION
See https://github.com/grpc/grpc/tree/master/test/cpp/interop

Their protos are missing the java package options. I'll file a separate
PR to resolve this.

Fixes #135 
