### PR TITLE
Depend on proto 3.0.0-alpha-2 instead of snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ $ cd lib/netty
 $ mvn install -pl codec-http2 -am -DskipTests=true
 ```
 
-The codegen plugin requires a recent protobuf build from master (what will
-become proto3):
+The codegen plugin requires protobuf 3.0.0-alpha-2:
 ```
 $ git clone https://github.com/google/protobuf.git
 $ cd protobuf
+$ git checkout v3.0.0-alpha-2
 $ ./autogen.sh
 $ ./configure
 $ make

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ subprojects {
                 jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
                 oauth_client: 'com.google.oauth-client:google-oauth-client:1.18.0-rc',
                 okhttp: 'com.squareup.okhttp:okhttp:2.2.0',
-                protobuf: 'com.google.protobuf:protobuf-java:3.0.0-pre',
-                protobuf_nano: 'com.google.protobuf.nano:protobuf-javanano:2.6.2-pre',
+                protobuf: 'com.google.protobuf:protobuf-java:3.0.0-alpha-2',
+                protobuf_nano: 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-2',
                 protobuf_plugin: 'ws.antonov.gradle.plugins:gradle-plugin-protobuf:0.9.1',
 
                 // TODO: Unreleased dependencies.


### PR DESCRIPTION
There has now been a release of the proto code we need, so use it
instead of master.
