### PR TITLE
Support building on Windows

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -54,7 +54,7 @@ applicationDistribution.into("bin") {
     fileMode = 0755
 }
 
-protobufCodeGenPlugins = ["java_plugin:$rootDir/compiler/build/binaries/java_pluginExecutable/java_plugin"]
+protobufCodeGenPlugins = ["java_plugin:$javaPluginPath"]
 generateProto.dependsOn ':grpc-compiler:java_pluginExecutable'
 
 // Allow intellij projects to refer to generated-sources

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 subprojects {
     apply plugin: "java"
     apply plugin: "maven"
@@ -51,6 +53,16 @@ subprojects {
         }
 
         alpnboot_package_name = 'org.mortbay.jetty.alpn:alpn-boot:' + alpnboot_version
+
+        def exeSuffix = Os.isFamily(Os.FAMILY_WINDOWS) ? ".exe" : ""
+        // The split is to workaround everything after the colon in C:\ being
+        // removed due to a bug in the protobuf plugin.
+        // https://github.com/aantono/gradle-plugin-protobuf/issues/23
+        def splitRootDir = rootDir
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+          splitRootDir = splitRootDir.getPath().split(":", 2)[1]
+        }
+        javaPluginPath = "$splitRootDir/compiler/build/binaries/java_pluginExecutable/java_plugin$exeSuffix"
     }
 
     dependencies {

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: "cpp"
 apply plugin: "protobuf"
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 description = 'The protoc plugin for gRPC Java'
 
 buildscript {
@@ -34,17 +36,36 @@ binaries.all {
     if (System.env.LDFLAGS) {
       linker.args System.env.LDFLAGS
     }
+  } else if (toolChain in VisualCpp) {
+    cppCompiler.args "/EHsc", "/MD"
+    if (rootProject.hasProperty('protobuf.include')) {
+      cppCompiler.args "/I" + rootProject.properties['protobuf.include']
+    }
+    linker.args "libprotobuf.lib", "libprotoc.lib"
+    if (rootProject.hasProperty('protobuf.libs')) {
+      linker.args "/LIBPATH:" + rootProject.properties['protobuf.libs']
+    }
   }
 }
 
-protobufCodeGenPlugins = ["java_plugin:$buildDir/binaries/java_pluginExecutable/java_plugin"]
+protobufCodeGenPlugins = ["java_plugin:$javaPluginPath"]
 
 generateTestProto.dependsOn 'java_pluginExecutable'
-test.dependsOn('testGolden','testNanoGolden')
+// Ignore test for the moment on Windows. It will be easier to run once the
+// gradle protobuf plugin can support nano.
+if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+  test.dependsOn('testGolden','testNanoGolden')
+}
 
 task testGolden(type: Exec, dependsOn: 'generateTestProto') {
-  executable "diff"
-  args "$buildDir/generated-sources/test/io/grpc/testing/integration/TestServiceGrpc.java",
+  if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+    executable "diff"
+  } else {
+    executable "fc"
+  }
+  // File isn't found on Windows if last slash is forward-slash
+  def slash = System.getProperty("file.separator")
+  args "$buildDir/generated-sources/test/io/grpc/testing/integration" + slash + "TestServiceGrpc.java",
        "$projectDir/src/test/golden/TestService.java.txt"
 }
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -20,7 +20,7 @@ dependencies {
             libraries.jsonp
 }
 
-protobufCodeGenPlugins = ["java_plugin:$rootDir/compiler/build/binaries/java_pluginExecutable/java_plugin"]
+protobufCodeGenPlugins = ["java_plugin:$javaPluginPath"]
 generateProto.dependsOn ':grpc-compiler:java_pluginExecutable'
 
 task routeGuideServer(type: JavaExec) {


### PR DESCRIPTION
This change has not yet been tested on Linux.

Protoc should be in PATH and the project properties protobuf.include and
protobuf.libs should be set. For example:

gradlew build -Pprotobuf.include=C:\path\to\protobuf-3.0.0-alpha-2\src ^
  -Pprotobuf.libs=C:\path\to\protobuf-3.0.0-alpha-2\vsprojects\Release

When running more than once, it is probably more convenient to create
%HOMEDRIVE%%HOMEPATH%\.gradle\gradle.properties with contents like:

protobuf.include=C:\\path\\to\\protobuf-3.0.0-alpha-2\\src
protobuf.libs=C:\\path\\to\\protobuf-3.0.0-alpha-2\\vsprojects\\Release

This mostly resolves #87. Just the README would need to be updated.