### PR TITLE
Have SendGrpcFrameCommand constructor take an AbstractStream object instead of a stream id.

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
@@ -85,8 +85,9 @@ class NettyClientStream extends Http2ClientStream {
 
   @Override
   protected void sendFrame(ByteBuffer frame, boolean endOfStream) {
-    SendGrpcFrameCommand cmd = new SendGrpcFrameCommand(id(), 
-        Utils.toByteBuf(channel.alloc(), frame), endOfStream);
+    SendGrpcFrameCommand cmd =
+            new SendGrpcFrameCommand(this, Utils.toByteBuf(channel.alloc(), frame), endOfStream);
+
     channel.writeAndFlush(cmd);
   }
 

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
@@ -83,7 +83,7 @@ class NettyServerStream extends AbstractServerStream<Integer> {
   @Override
   protected void sendFrame(ByteBuffer frame, boolean endOfStream) {
     SendGrpcFrameCommand cmd =
-        new SendGrpcFrameCommand(id(), Utils.toByteBuf(channel.alloc(), frame), endOfStream);
+        new SendGrpcFrameCommand(this, Utils.toByteBuf(channel.alloc(), frame), endOfStream);
     channel.writeAndFlush(cmd);
   }
 

--- a/netty/src/main/java/io/grpc/transport/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/SendGrpcFrameCommand.java
@@ -31,6 +31,7 @@
 
 package io.grpc.transport.netty;
 
+import io.grpc.transport.AbstractStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;
@@ -39,17 +40,17 @@ import io.netty.buffer.DefaultByteBufHolder;
  * Command sent from the transport to the Netty channel to send a GRPC frame to the remote endpoint.
  */
 class SendGrpcFrameCommand extends DefaultByteBufHolder {
-  private final int streamId;
+  private final AbstractStream<Integer> stream;
   private final boolean endStream;
 
-  SendGrpcFrameCommand(int streamId, ByteBuf content, boolean endStream) {
+  SendGrpcFrameCommand(AbstractStream<Integer> stream, ByteBuf content, boolean endStream) {
     super(content);
-    this.streamId = streamId;
+    this.stream = stream;
     this.endStream = endStream;
   }
 
   int streamId() {
-    return streamId;
+    return stream.id();
   }
 
   boolean endStream() {
@@ -58,12 +59,12 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder {
 
   @Override
   public ByteBufHolder copy() {
-    return new SendGrpcFrameCommand(streamId, content().copy(), endStream);
+    return new SendGrpcFrameCommand(stream, content().copy(), endStream);
   }
 
   @Override
   public ByteBufHolder duplicate() {
-    return new SendGrpcFrameCommand(streamId, content().duplicate(), endStream);
+    return new SendGrpcFrameCommand(stream, content().duplicate(), endStream);
   }
 
   @Override
@@ -96,13 +97,13 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder {
       return false;
     }
     SendGrpcFrameCommand thatCmd = (SendGrpcFrameCommand) that;
-    return thatCmd.streamId == streamId && thatCmd.endStream == endStream
+    return thatCmd.stream.equals(stream) && thatCmd.endStream == endStream
         && thatCmd.content().equals(content());
   }
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(streamId=" + streamId
+    return getClass().getSimpleName() + "(streamId=" + streamId()
         + ", endStream=" + endStream + ", content=" + content()
         + ")";
   }
@@ -110,7 +111,7 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder {
   @Override
   public int hashCode() {
     int hash = content().hashCode();
-    hash = hash * 31 + streamId;
+    hash = hash * 31 + stream.hashCode();
     if (endStream) {
       hash = -hash;
     }

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
@@ -209,7 +209,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     createStream();
 
     // Send a frame and verify that it was written.
-    handler.write(ctx, new SendGrpcFrameCommand(stream.id(), content, true), promise);
+    handler.write(ctx, new SendGrpcFrameCommand(stream, content, true), promise);
     verify(promise, never()).setFailure(any(Throwable.class));
     verify(ctx).write(any(ByteBuf.class), eq(promise));
     verify(ctx).flush();
@@ -218,7 +218,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
   @Test
   public void sendForUnknownStreamShouldFail() throws Exception {
     when(stream.id()).thenReturn(3);
-    handler.write(ctx, new SendGrpcFrameCommand(stream.id(), content, true), promise);
+    handler.write(ctx, new SendGrpcFrameCommand(stream, content, true), promise);
     verify(promise).setFailure(any(Throwable.class));
   }
 

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientStreamTest.java
@@ -108,7 +108,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase {
     stream().id(STREAM_ID);
     stream.writeMessage(input, input.available(), accepted);
     stream.flush();
-    verify(channel).writeAndFlush(new SendGrpcFrameCommand(1, messageFrame(MESSAGE), false));
+    verify(channel).writeAndFlush(new SendGrpcFrameCommand(stream, messageFrame(MESSAGE), false));
     verify(accepted).run();
   }
 

--- a/netty/src/test/java/io/grpc/transport/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyServerHandlerTest.java
@@ -143,7 +143,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
     ByteBuf content = Unpooled.copiedBuffer(CONTENT);
 
     // Send a frame and verify that it was written.
-    handler.write(ctx, new SendGrpcFrameCommand(stream.id(), content, false), promise);
+    handler.write(ctx, new SendGrpcFrameCommand(stream, content, false), promise);
     verify(promise, never()).setFailure(any(Throwable.class));
     verify(ctx).write(any(ByteBuf.class), eq(promise));
     assertEquals(0, content.refCnt());

--- a/netty/src/test/java/io/grpc/transport/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyServerStreamTest.java
@@ -73,7 +73,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase {
         .status(Utils.STATUS_OK)
         .set(Utils.CONTENT_TYPE_HEADER, Utils.CONTENT_TYPE_GRPC);
     verify(channel).writeAndFlush(new SendResponseHeadersCommand(STREAM_ID, headers, false));
-    verify(channel).writeAndFlush(new SendGrpcFrameCommand(STREAM_ID, messageFrame(MESSAGE), false));
+    verify(channel).writeAndFlush(new SendGrpcFrameCommand(stream, messageFrame(MESSAGE), false));
     verify(accepted).run();
   }
 

--- a/netty/src/test/java/io/grpc/transport/netty/NettyStreamTestBase.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyStreamTestBase.java
@@ -119,6 +119,7 @@ public abstract class NettyStreamTestBase {
 
     input = new ByteArrayInputStream(MESSAGE.getBytes(UTF_8));
     stream = createStream();
+    stream.id(STREAM_ID);
   }
 
   @Test


### PR DESCRIPTION
Let's give this another try @ejona86 :-). That's passing now.

As part of the effort to remove all blocking bits from the NettyClientStream with
this commit the SendGrpcFrameCommand now takes a stream object instead of the
stream id. This will be necessary as in a non blocking world the stream id might
not have yet been allocated when the SendGrpcFrameCommand gets instantiated.