### PR TITLE
Add some details for building on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ Now to build grpc-java itself:
 $ ./gradlew install
 ```
 
+When building on Windows and VC++, you need to specify project properties for
+Gradle to find protobuf:
+```
+.\gradlew install -Pprotobuf.include=C:\path\to\protobuf-3.0.0-alpha-2\src ^
+    -Pprotobuf.libs=C:\path\to\protobuf-3.0.0-alpha-2\vsprojects\Release
+```
+
+Since specifying those properties every build is bothersome, you can instead
+create %HOMEDRIVE%%HOMEPATH%\.gradle\gradle.properties with contents like:
+```
+protobuf.include=C:\\path\\to\\protobuf-3.0.0-alpha-2\\src
+protobuf.libs=C:\\path\\to\\protobuf-3.0.0-alpha-2\\vsprojects\\Release
+```
+
 Navigating Around the Source
 ----------------------------
 


### PR DESCRIPTION
More will be necessary, as we don't describe how to build protobuf
itself, but this should be a clear improvement.