### PR TITLE
Disable Javadoc doclint on Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,15 @@ subprojects {
         sign configurations.archives
     }
 
+    // Disable JavaDoc doclint on Java 8. It's annoying.
+    if (JavaVersion.current().isJava8Compatible()) {
+      allprojects {
+        tasks.withType(Javadoc) {
+          options.addStringOption('Xdoclint:none', '-quiet')
+        }
+      }
+    }
+
     task javadocJar(type: Jar) {
         classifier = 'javadoc'
         from javadoc

--- a/core/src/main/java/io/grpc/transport/Stream.java
+++ b/core/src/main/java/io/grpc/transport/Stream.java
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
 public interface Stream {
   /**
    * Requests up to the given number of messages from the call to be delivered to
-   * {@link StreamListener#messageRead(java.io.InputStream, int)}. No additional messages will be
+   * {@link StreamListener#messageRead(java.io.InputStream)}. No additional messages will be
    * delivered.
    *
    * @param numMessages the requested number of messages to be delivered to the listener.


### PR DESCRIPTION
It breaks the build.