### PR TITLE
Proper buffer closure when receiving DATA with EOS

### DIFF
--- a/core/src/main/java/io/grpc/transport/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/transport/Http2ClientStream.java
@@ -125,7 +125,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
           Buffers.readAsString(frame, errorCharset));
       frame.close();
       if (transportError.getDescription().length() > 1000 || endOfStream) {
-        inboundTransportError(transportError);
+        inboundTransportError(transportError, false);
         if (!endOfStream) {
           // We have enough error detail so lets cancel.
           sendCancel();
@@ -136,8 +136,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
       if (endOfStream) {
         // This is a protocol violation as we expect to receive trailers.
         transportError = Status.INTERNAL.withDescription("Recevied EOS on DATA frame");
-        frame.close();
-        inboundTransportError(transportError);
+        inboundTransportError(transportError, true);
       }
     }
   }
@@ -156,7 +155,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
       transportError = checkContentType(trailers);
     }
     if (transportError != null) {
-      inboundTransportError(transportError);
+      inboundTransportError(transportError, false);
     } else {
       Status status = statusFromTrailers(trailers);
       stripTransportDetails(trailers);

--- a/core/src/main/java/io/grpc/transport/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/transport/MessageDeframer.java
@@ -153,14 +153,23 @@ public class MessageDeframer implements Closeable {
    *         {@code endOfStream=true}.
    */
   public void deframe(Buffer data, boolean endOfStream) {
-    checkNotClosed();
     Preconditions.checkNotNull(data, "data");
-    Preconditions.checkState(!this.endOfStream, "Past end of stream");
-    unprocessed.addBuffer(data);
+    boolean needToCloseData = true;
+    try {
+      checkNotClosed();
+      Preconditions.checkState(!this.endOfStream, "Past end of stream");
 
-    // Indicate that all of the data for this stream has been received.
-    this.endOfStream = endOfStream;
-    deliver();
+      needToCloseData = false;
+      unprocessed.addBuffer(data);
+
+      // Indicate that all of the data for this stream has been received.
+      this.endOfStream = endOfStream;
+      deliver();
+    } finally {
+      if (needToCloseData) {
+        data.close();
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
The Http2ClientStream should not close the buffer in this case since
it's already been given to the deframer and potentially to the user.

Added cleanup code to MessageDeframer and AbstractClientStream to make
sure that we free the Buffer when appropriate.

Fixes #176 