### PR TITLE
Force JavaDoc to intepret code as UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ subprojects {
         options.encoding = "UTF-8"
     }
 
+    javadoc.options.encoding = "UTF-8"
+
     ext {
         libraries = [
                 guava: 'com.google.guava:guava:18.0',


### PR DESCRIPTION
We are already specifying to javac that our code is UTF-8, but we also
need to specify to JavaDoc, even though we don't have any non-ASCII
characters in JavaDoc comments.

Tested with LC_ALL=C