### PR TITLE
Stall MessageDeframer pro-actively

### DIFF
--- a/core/src/main/java/io/grpc/transport/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractClientStream.java
@@ -88,12 +88,8 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
    * responsible for properly closing streams when protocol errors occur.
    *
    * @param errorStatus the error to report
-   * @param stopDelivery if {@code true}, interrupts any further delivery of inbound messages that
-   *        may already be queued up in the deframer. If {@code false}, the listener will be
-   *        notified immediately after all currently completed messages in the deframer have been
-   *        delivered to the application.
    */
-  protected void inboundTransportError(Status errorStatus, boolean stopDelivery) {
+  protected void inboundTransportError(Status errorStatus) {
     if (inboundPhase() == Phase.STATUS) {
       log.log(Level.INFO, "Received transport error on closed stream {0} {1}",
           new Object[]{id(), errorStatus});
@@ -101,7 +97,7 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
     }
     // For transport errors we immediately report status to the application layer
     // and do not wait for additional payloads.
-    transportReportStatus(errorStatus, stopDelivery, new Metadata.Trailers());
+    transportReportStatus(errorStatus, false, new Metadata.Trailers());
   }
 
   /**
@@ -136,7 +132,7 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
       if (inboundPhase() == Phase.HEADERS) {
         // Have not received headers yet so error
         inboundTransportError(Status.INTERNAL
-            .withDescription("headers not received before payload"), false);
+            .withDescription("headers not received before payload"));
         return;
       }
       inboundPhase(Phase.MESSAGE);

--- a/core/src/main/java/io/grpc/transport/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/transport/Http2ClientStream.java
@@ -125,7 +125,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
           Buffers.readAsString(frame, errorCharset));
       frame.close();
       if (transportError.getDescription().length() > 1000 || endOfStream) {
-        inboundTransportError(transportError, false);
+        inboundTransportError(transportError);
         if (!endOfStream) {
           // We have enough error detail so lets cancel.
           sendCancel();
@@ -136,7 +136,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
       if (endOfStream) {
         // This is a protocol violation as we expect to receive trailers.
         transportError = Status.INTERNAL.withDescription("Recevied EOS on DATA frame");
-        inboundTransportError(transportError, true);
+        inboundTransportError(transportError);
       }
     }
   }
@@ -155,7 +155,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
       transportError = checkContentType(trailers);
     }
     if (transportError != null) {
-      inboundTransportError(transportError, false);
+      inboundTransportError(transportError);
     } else {
       Status status = statusFromTrailers(trailers);
       stripTransportDetails(trailers);

--- a/core/src/test/java/io/grpc/transport/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/transport/MessageDeframerTest.java
@@ -116,6 +116,7 @@ public class MessageDeframerTest {
     verify(listener).messageRead(messages.capture());
     assertEquals(Bytes.asList(new byte[] {3, 14, 1, 5, 9, 2, 6}), bytes(messages));
     verify(listener, atLeastOnce()).bytesRead(anyInt());
+    verify(listener).deliveryStalled();
     verifyNoMoreInteractions(listener);
   }
 
@@ -130,6 +131,7 @@ public class MessageDeframerTest {
     verify(listener).messageRead(messages.capture());
     assertEquals(Bytes.asList(new byte[] {3}), bytes(messages));
     verify(listener, atLeastOnce()).bytesRead(anyInt());
+    verify(listener).deliveryStalled();
     verifyNoMoreInteractions(listener);
   }
 


### PR DESCRIPTION
This allows sooner delivery of errors. We never needed to stop delivery
for unexpected EOS, but instead the application would have been required
to request() another message before delivering. Stalling MessageDeframer
sooner removes the need for the application to request another message
before noticing that the buffers are empty.