### PR TITLE
Cleanup warnings

### DIFF
--- a/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
+++ b/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
@@ -48,16 +48,16 @@ public class ClientAuthInterceptorTests {
   Credentials credentials;
 
   @Mock
-  MethodDescriptor descriptor;
+  MethodDescriptor<String, Integer> descriptor;
 
   @Mock
-  Call.Listener listener;
+  Call.Listener<Integer> listener;
 
   @Mock
   Channel channel;
 
   @Mock
-  Call call;
+  Call<String, Integer> call;
 
   ClientAuthInterceptor interceptor;
 
@@ -117,7 +117,7 @@ public class ClientAuthInterceptorTests {
       }
     };
     interceptor = new ClientAuthInterceptor(oAuth2Credentials, Executors.newSingleThreadExecutor());
-    Call interceptedCall = interceptor.interceptCall(descriptor, channel);
+    Call<String, Integer> interceptedCall = interceptor.interceptCall(descriptor, channel);
     Metadata.Headers headers = new Metadata.Headers();
     interceptedCall.start(listener, headers);
     verify(call).start(listener, headers);

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@ subprojects {
         mavenLocal()
     }
 
-    compileJava {
-        options.compilerArgs << "-Xlint:unchecked"
-        options.encoding = "UTF-8"
+    [compileJava, compileTestJava].each() {
+        it.options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation", "-Xlint:-options"]
+        it.options.encoding = "UTF-8"
     }
 
     javadoc.options.encoding = "UTF-8"

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -167,7 +167,8 @@ static void PrintServiceDescriptor(
   // The reconfiguring constructor
   p->Print(
       *vars,
-      "\nprivate $service_name$ServiceDescriptor(\n"
+      "\n@SuppressWarnings(\"unchecked\")\n"
+      "private $service_name$ServiceDescriptor(\n"
       "    $Map$<$String$, $MethodDescriptor$<?, ?>> methodMap) {\n");
   p->Indent();
   for (int i = 0; i < service->method_count(); ++i) {

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -90,6 +90,7 @@ public class TestServiceGrpc {
           "grpc.testing.TestService", METHOD_HALF_DUPLEX_CALL);
     }
 
+    @SuppressWarnings("unchecked")
     private TestServiceServiceDescriptor(
         java.util.Map<java.lang.String, io.grpc.MethodDescriptor<?, ?>> methodMap) {
       unaryCall = (io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -152,6 +152,7 @@ public class TestServiceGrpc {
           "grpc.testing.TestService", METHOD_HALF_DUPLEX_CALL);
     }
 
+    @SuppressWarnings("unchecked")
     private TestServiceServiceDescriptor(
         java.util.Map<java.lang.String, io.grpc.MethodDescriptor<?, ?>> methodMap) {
       unaryCall = (io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,

--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -430,6 +430,8 @@ public final class Status {
     }
   }
 
+  // We support Guava 14
+  @SuppressWarnings("deprecation")
   @Override
   public String toString() {
     return Objects.toStringHelper(this)

--- a/core/src/main/java/io/grpc/transport/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractClientStream.java
@@ -289,6 +289,8 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
    */
   protected abstract void sendCancel();
 
+  // We support Guava 14
+  @SuppressWarnings("deprecation")
   @Override
   protected Objects.ToStringHelper toStringHelper() {
     Objects.ToStringHelper toStringHelper = super.toStringHelper();

--- a/core/src/main/java/io/grpc/transport/AbstractStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractStream.java
@@ -306,6 +306,8 @@ public abstract class AbstractStream<IdT> implements Stream {
     return toStringHelper().toString();
   }
 
+  // We support Guava 14
+  @SuppressWarnings("deprecation")
   protected Objects.ToStringHelper toStringHelper() {
     return Objects.toStringHelper(this)
         .add("id", id())

--- a/core/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -175,6 +175,7 @@ public class ClientInterceptorsTest {
       }
     };
     Channel intercepted = ClientInterceptors.intercept(channel, interceptor);
+    @SuppressWarnings("unchecked")
     Call.Listener<Integer> listener = mock(Call.Listener.class);
     Call<String, Integer> interceptedCall = intercepted.newCall(method);
     // start() on the intercepted call will eventually reach the call created by the real channel
@@ -209,11 +210,12 @@ public class ClientInterceptorsTest {
       }
     };
     Channel intercepted = ClientInterceptors.intercept(channel, interceptor);
+    @SuppressWarnings("unchecked")
     Call.Listener<Integer> listener = mock(Call.Listener.class);
     Call<String, Integer> interceptedCall = intercepted.newCall(method);
     interceptedCall.start(listener, new Metadata.Headers());
     // Capture the underlying call listener that will receive headers from the transport.
-    ArgumentCaptor<Call.Listener> captor = ArgumentCaptor.forClass(Call.Listener.class);
+    ArgumentCaptor<Call.Listener<Integer>> captor = ArgumentCaptor.forClass(null);
     verify(call).start(captor.capture(), Mockito.<Metadata.Headers>any());
     Metadata.Headers inboundHeaders = new Metadata.Headers();
     // Simulate that a headers arrives on the underlying call listener.

--- a/integration-testing/src/main/java/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/integration-testing/src/main/java/io/grpc/testing/integration/TestServiceGrpc.java
@@ -100,6 +100,7 @@ public class TestServiceGrpc {
           "grpc.testing.TestService", METHOD_HALF_DUPLEX_CALL);
     }
 
+    @SuppressWarnings("unchecked")
     private TestServiceServiceDescriptor(
         java.util.Map<java.lang.String, io.grpc.MethodDescriptor<?, ?>> methodMap) {
       emptyCall = (io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,


### PR DESCRIPTION
-Xlint:-options is not available on some earlier JDK 7s, but won't fail
if unsupported. It prevents the warning wanting bootclasspath specified
since target/source is 1.6.