### PR TITLE
Add WritableBuffer interface for zero copy data writes. Fixes #8

### DIFF
--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -33,9 +33,6 @@ package io.grpc;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.Service.Listener;
-import com.google.common.util.concurrent.Service.State;
 
 import io.grpc.transport.ClientStream;
 import io.grpc.transport.ClientStreamListener;
@@ -48,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.concurrent.GuardedBy;

--- a/core/src/main/java/io/grpc/transport/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractClientStream.java
@@ -38,7 +38,6 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -67,7 +66,9 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
    *
    * @param listener the listener to receive notifications
    */
-  protected AbstractClientStream(ClientStreamListener listener) {
+  protected AbstractClientStream(WritableBufferAllocator bufferAllocator,
+                                 ClientStreamListener listener) {
+    super(bufferAllocator);
     this.listener = Preconditions.checkNotNull(listener);
   }
 
@@ -122,7 +123,7 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
    *
    * @param frame the received data frame. Its ownership is transferred to this method.
    */
-  protected void inboundDataReceived(Buffer frame) {
+  protected void inboundDataReceived(ReadableBuffer frame) {
     Preconditions.checkNotNull(frame, "frame");
     boolean needToCloseFrame = true;
     try {
@@ -173,7 +174,7 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
     // remoteEndClosed
     this.status = status;
     this.trailers = trailers;
-    deframe(Buffers.empty(), true);
+    deframe(ReadableBuffers.empty(), true);
   }
 
   @Override
@@ -182,7 +183,7 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
   }
 
   @Override
-  protected final void internalSendFrame(ByteBuffer frame, boolean endOfStream) {
+  protected final void internalSendFrame(WritableBuffer frame, boolean endOfStream) {
     sendFrame(frame, endOfStream);
   }
 
@@ -193,7 +194,7 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
    * @param endOfStream if {@code true} indicates that no more data will be sent on the stream by
    *        this endpoint.
    */
-  protected abstract void sendFrame(ByteBuffer frame, boolean endOfStream);
+  protected abstract void sendFrame(WritableBuffer frame, boolean endOfStream);
 
   /**
    * Report stream closure with status to the application layer if not already reported. This method

--- a/core/src/main/java/io/grpc/transport/AbstractStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractStream.java
@@ -36,7 +36,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 
 import javax.annotation.Nullable;
 
@@ -65,7 +64,7 @@ public abstract class AbstractStream<IdT> implements Stream {
    */
   private Phase outboundPhase = Phase.HEADERS;
 
-  AbstractStream() {
+  AbstractStream(WritableBufferAllocator bufferAllocator) {
     MessageDeframer.Listener inboundMessageHandler = new MessageDeframer.Listener() {
       @Override
       public void bytesRead(int numBytes) {
@@ -87,14 +86,14 @@ public abstract class AbstractStream<IdT> implements Stream {
         remoteEndClosed();
       }
     };
-    MessageFramer.Sink<ByteBuffer> outboundFrameHandler = new MessageFramer.Sink<ByteBuffer>() {
+    MessageFramer.Sink outboundFrameHandler = new MessageFramer.Sink() {
       @Override
-      public void deliverFrame(ByteBuffer frame, boolean endOfStream) {
+      public void deliverFrame(WritableBuffer frame, boolean endOfStream) {
         internalSendFrame(frame, endOfStream);
       }
     };
 
-    framer = new MessageFramer(outboundFrameHandler, 4096);
+    framer = new MessageFramer(outboundFrameHandler, bufferAllocator, 4096);
     this.deframer = new MessageDeframer(inboundMessageHandler);
   }
 
@@ -168,7 +167,7 @@ public abstract class AbstractStream<IdT> implements Stream {
    * @param endOfStream if {@code true} indicates that no more data will be sent on the stream by
    *        this endpoint.
    */
-  protected abstract void internalSendFrame(ByteBuffer frame, boolean endOfStream);
+  protected abstract void internalSendFrame(WritableBuffer frame, boolean endOfStream);
 
   /**
    * Handles a message that was just deframed.
@@ -194,7 +193,7 @@ public abstract class AbstractStream<IdT> implements Stream {
   protected abstract void returnProcessedBytes(int processedBytes);
 
   /**
-   * Called when a {@link #deframe(Buffer, boolean)} operation failed.
+   * Called when a {@link #deframe(ReadableBuffer, boolean)} operation failed.
    *
    * @param cause the actual failure
    */
@@ -212,7 +211,7 @@ public abstract class AbstractStream<IdT> implements Stream {
    * Called to parse a received frame and attempt delivery of any completed
    * messages. Must be called from the transport thread.
    */
-  protected final void deframe(Buffer frame, boolean endOfStream) {
+  protected final void deframe(ReadableBuffer frame, boolean endOfStream) {
     try {
       deframer.deframe(frame, endOfStream);
     } catch (Throwable t) {

--- a/core/src/main/java/io/grpc/transport/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/transport/Http2ClientStream.java
@@ -70,8 +70,9 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
   private Charset errorCharset = Charsets.UTF_8;
   private boolean contentTypeChecked;
 
-  protected Http2ClientStream(ClientStreamListener listener) {
-    super(listener);
+  protected Http2ClientStream(WritableBufferAllocator bufferAllocator,
+                              ClientStreamListener listener) {
+    super(bufferAllocator, listener);
   }
 
   /**
@@ -112,7 +113,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
    * @param frame the received data frame
    * @param endOfStream {@code true} if there will be no more data received for this stream
    */
-  protected void transportDataReceived(Buffer frame, boolean endOfStream) {
+  protected void transportDataReceived(ReadableBuffer frame, boolean endOfStream) {
     if (transportError == null && inboundPhase() == Phase.HEADERS) {
       // Must receive headers prior to receiving any payload as we use headers to check for
       // protocol correctness.
@@ -122,7 +123,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
       // We've already detected a transport error and now we're just accumulating more detail
       // for it.
       transportError = transportError.augmentDescription("DATA-----------------------------\n" +
-          Buffers.readAsString(frame, errorCharset));
+          ReadableBuffers.readAsString(frame, errorCharset));
       frame.close();
       if (transportError.getDescription().length() > 1000 || endOfStream) {
         inboundTransportError(transportError);

--- a/core/src/main/java/io/grpc/transport/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/transport/MessageDeframer.java
@@ -99,8 +99,8 @@ public class MessageDeframer implements Closeable {
   private int requiredLength = HEADER_LENGTH;
   private boolean compressedFlag;
   private boolean endOfStream;
-  private CompositeBuffer nextFrame;
-  private CompositeBuffer unprocessed = new CompositeBuffer();
+  private CompositeReadableBuffer nextFrame;
+  private CompositeReadableBuffer unprocessed = new CompositeReadableBuffer();
   private long pendingDeliveries;
   private boolean deliveryStalled = true;
 
@@ -149,10 +149,10 @@ public class MessageDeframer implements Closeable {
    * @param endOfStream if {@code true}, indicates that {@code data} is the end of the stream from
    *        the remote endpoint.
    * @throws IllegalStateException if {@link #close()} has been called previously or if
-   *         {@link #deframe(Buffer, boolean)} has previously been called with
+   *         {@link #deframe(ReadableBuffer, boolean)} has previously been called with
    *         {@code endOfStream=true}.
    */
-  public void deframe(Buffer data, boolean endOfStream) {
+  public void deframe(ReadableBuffer data, boolean endOfStream) {
     Preconditions.checkNotNull(data, "data");
     boolean needToCloseData = true;
     try {
@@ -275,7 +275,7 @@ public class MessageDeframer implements Closeable {
     int totalBytesRead = 0;
     try {
       if (nextFrame == null) {
-        nextFrame = new CompositeBuffer();
+        nextFrame = new CompositeReadableBuffer();
       }
 
       // Read until the buffer contains all the required bytes.
@@ -331,7 +331,7 @@ public class MessageDeframer implements Closeable {
   }
 
   private InputStream getUncompressedBody() {
-    return Buffers.openStream(nextFrame, true);
+    return ReadableBuffers.openStream(nextFrame, true);
   }
 
   private InputStream getCompressedBody() {
@@ -345,7 +345,7 @@ public class MessageDeframer implements Closeable {
     }
 
     try {
-      return new GZIPInputStream(Buffers.openStream(nextFrame, true));
+      return new GZIPInputStream(ReadableBuffers.openStream(nextFrame, true));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/io/grpc/transport/ReadableBuffer.java
+++ b/core/src/main/java/io/grpc/transport/ReadableBuffer.java
@@ -44,7 +44,7 @@ import java.nio.ByteBuffer;
  * done in {@link ByteBuffer}. It is not expected that callers will attempt to modify the backing
  * array.
  */
-public interface Buffer extends Closeable {
+public interface ReadableBuffer extends Closeable {
 
   /**
    * Gets the current number of readable bytes remaining in this buffer.
@@ -131,7 +131,7 @@ public interface Buffer extends Closeable {
    * @param length the number of bytes to contain in returned Buffer.
    * @throws IndexOutOfBoundsException if required bytes are not readable
    */
-  Buffer readBytes(int length);
+  ReadableBuffer readBytes(int length);
 
   /**
    * Indicates whether or not this buffer exposes a backing array.

--- a/core/src/main/java/io/grpc/transport/ReadableBuffers.java
+++ b/core/src/main/java/io/grpc/transport/ReadableBuffers.java
@@ -42,49 +42,49 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 /**
- * Utility methods for creating {@link Buffer} instances.
+ * Utility methods for creating {@link ReadableBuffer} instances.
  */
-public final class Buffers {
-  private static final Buffer EMPTY_BUFFER = new ByteArrayWrapper(new byte[0]);
+public final class ReadableBuffers {
+  private static final ReadableBuffer EMPTY_BUFFER = new ByteArrayWrapper(new byte[0]);
 
   /**
-   * Returns an empty {@link Buffer} instance.
+   * Returns an empty {@link ReadableBuffer} instance.
    */
-  public static Buffer empty() {
+  public static ReadableBuffer empty() {
     return EMPTY_BUFFER;
   }
 
   /**
    * Shortcut for {@code wrap(bytes, 0, bytes.length}.
    */
-  public static Buffer wrap(byte[] bytes) {
+  public static ReadableBuffer wrap(byte[] bytes) {
     return new ByteArrayWrapper(bytes, 0, bytes.length);
   }
 
   /**
-   * Creates a new {@link Buffer} that is backed by the given byte array.
+   * Creates a new {@link ReadableBuffer} that is backed by the given byte array.
    *
    * @param bytes the byte array being wrapped.
    * @param offset the starting offset for the buffer within the byte array.
    * @param length the length of the buffer from the {@code offset} index.
    */
-  public static Buffer wrap(byte[] bytes, int offset, int length) {
+  public static ReadableBuffer wrap(byte[] bytes, int offset, int length) {
     return new ByteArrayWrapper(bytes, offset, length);
   }
 
   /**
-   * Creates a new {@link Buffer} that is backed by the given {@link ByteBuffer}. Calls to read from
+   * Creates a new {@link ReadableBuffer} that is backed by the given {@link ByteBuffer}. Calls to read from
    * the buffer will increment the position of the {@link ByteBuffer}.
    */
-  public static Buffer wrap(ByteBuffer bytes) {
-    return new ByteBufferWrapper(bytes);
+  public static ReadableBuffer wrap(ByteBuffer bytes) {
+    return new ByteReadableBufferWrapper(bytes);
   }
 
   /**
-   * Reads an entire {@link Buffer} to a new array. After calling this method, the buffer will
+   * Reads an entire {@link ReadableBuffer} to a new array. After calling this method, the buffer will
    * contain no readable bytes.
    */
-  public static byte[] readArray(Buffer buffer) {
+  public static byte[] readArray(ReadableBuffer buffer) {
     Preconditions.checkNotNull(buffer, "buffer");
     int length = buffer.readableBytes();
     byte[] bytes = new byte[length];
@@ -93,18 +93,18 @@ public final class Buffers {
   }
 
   /**
-   * Reads the entire {@link Buffer} to a new {@link String} with the given charset.
+   * Reads the entire {@link ReadableBuffer} to a new {@link String} with the given charset.
    */
-  public static String readAsString(Buffer buffer, Charset charset) {
+  public static String readAsString(ReadableBuffer buffer, Charset charset) {
     Preconditions.checkNotNull(charset, "charset");
     byte[] bytes = readArray(buffer);
     return new String(bytes, charset);
   }
 
   /**
-   * Reads the entire {@link Buffer} to a new {@link String} using UTF-8 decoding.
+   * Reads the entire {@link ReadableBuffer} to a new {@link String} using UTF-8 decoding.
    */
-  public static String readAsStringUtf8(Buffer buffer) {
+  public static String readAsStringUtf8(ReadableBuffer buffer) {
     return readAsString(buffer, UTF_8);
   }
 
@@ -116,18 +116,18 @@ public final class Buffers {
    * @param buffer the buffer backing the new {@link InputStream}.
    * @param owner if {@code true}, the returned stream will close the buffer when closed.
    */
-  public static InputStream openStream(Buffer buffer, boolean owner) {
+  public static InputStream openStream(ReadableBuffer buffer, boolean owner) {
     return new BufferInputStream(owner ? buffer : ignoreClose(buffer));
   }
 
   /**
-   * Decorates the given {@link Buffer} to ignore calls to {@link Buffer#close}.
+   * Decorates the given {@link ReadableBuffer} to ignore calls to {@link ReadableBuffer#close}.
    *
    * @param buffer the buffer to be decorated.
-   * @return a wrapper around {@code buffer} that ignores calls to {@link Buffer#close}.
+   * @return a wrapper around {@code buffer} that ignores calls to {@link ReadableBuffer#close}.
    */
-  public static Buffer ignoreClose(Buffer buffer) {
-    return new ForwardingBuffer(buffer) {
+  public static ReadableBuffer ignoreClose(ReadableBuffer buffer) {
+    return new ForwardingReadableBuffer(buffer) {
       @Override
       public void close() {
         // Ignore.
@@ -136,9 +136,9 @@ public final class Buffers {
   }
 
   /**
-   * A {@link Buffer} that is backed by a byte array.
+   * A {@link ReadableBuffer} that is backed by a byte array.
    */
-  private static class ByteArrayWrapper extends AbstractBuffer {
+  private static class ByteArrayWrapper extends AbstractReadableBuffer {
     int offset;
     final int end;
     final byte[] bytes;
@@ -221,12 +221,12 @@ public final class Buffers {
   }
 
   /**
-   * A {@link Buffer} that is backed by a {@link ByteBuffer}.
+   * A {@link ReadableBuffer} that is backed by a {@link ByteBuffer}.
    */
-  private static class ByteBufferWrapper extends AbstractBuffer {
+  private static class ByteReadableBufferWrapper extends AbstractReadableBuffer {
     final ByteBuffer bytes;
 
-    ByteBufferWrapper(ByteBuffer bytes) {
+    ByteReadableBufferWrapper(ByteBuffer bytes) {
       this.bytes = Preconditions.checkNotNull(bytes, "bytes");
     }
 
@@ -283,12 +283,12 @@ public final class Buffers {
     }
 
     @Override
-    public ByteBufferWrapper readBytes(int length) {
+    public ByteReadableBufferWrapper readBytes(int length) {
       checkReadable(length);
       ByteBuffer buffer = bytes.duplicate();
       bytes.position(bytes.position() + length);
       buffer.limit(bytes.position() + length);
-      return new ByteBufferWrapper(buffer);
+      return new ByteReadableBufferWrapper(buffer);
     }
 
     @Override
@@ -308,12 +308,12 @@ public final class Buffers {
   }
 
   /**
-   * An {@link InputStream} that is backed by a {@link Buffer}.
+   * An {@link InputStream} that is backed by a {@link ReadableBuffer}.
    */
   private static class BufferInputStream extends InputStream {
-    final Buffer buffer;
+    final ReadableBuffer buffer;
 
-    public BufferInputStream(Buffer buffer) {
+    public BufferInputStream(ReadableBuffer buffer) {
       this.buffer = Preconditions.checkNotNull(buffer, "buffer");
     }
 
@@ -344,5 +344,5 @@ public final class Buffers {
     }
   }
 
-  private Buffers() {}
+  private ReadableBuffers() {}
 }

--- a/core/src/main/java/io/grpc/transport/WritableBufferAllocator.java
+++ b/core/src/main/java/io/grpc/transport/WritableBufferAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,45 +29,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.transport.netty;
-
-import static io.netty.util.CharsetUtil.UTF_8;
-
-import com.google.common.io.ByteStreams;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.InputStream;
+package io.grpc.transport;
 
 /**
- * Utility methods for supporting Netty tests.
+ * The preferred way of creating a {@link WritableBuffer}.
  */
-public class NettyTestUtil {
+public interface WritableBufferAllocator {
 
-  static String toString(InputStream in) throws Exception {
-    byte[] bytes = new byte[in.available()];
-    ByteStreams.readFully(in, bytes);
-    return new String(bytes, UTF_8);
-  }
-
-  static ByteBuf messageFrame(String message) throws Exception {
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(os);
-    dos.write(message.getBytes(UTF_8));
-    dos.close();
-
-    // Write the compression header followed by the context frame.
-    return compressionFrame(os.toByteArray());
-  }
-
-  static ByteBuf compressionFrame(byte[] data) {
-    ByteBuf buf = Unpooled.buffer();
-    buf.writeByte(0);
-    buf.writeInt(data.length);
-    buf.writeBytes(data);
-    return buf;
-  }
+  /**
+   * Allocate a new {@link WritableBuffer} that can hold
+   * {@code capacity} bytes.
+   */
+  WritableBuffer allocate(int capacity);
 }

--- a/core/src/test/java/io/grpc/transport/ByteWritableBufferTest.java
+++ b/core/src/test/java/io/grpc/transport/ByteWritableBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,45 +29,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.transport.netty;
+package io.grpc.transport;
 
-import static io.netty.util.CharsetUtil.UTF_8;
+import org.junit.Before;
 
-import com.google.common.io.ByteStreams;
+import java.util.Arrays;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+public class ByteWritableBufferTest extends WritableBufferTestBase {
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.InputStream;
+  private MessageFramerTest.ByteWritableBuffer buffer;
 
-/**
- * Utility methods for supporting Netty tests.
- */
-public class NettyTestUtil {
-
-  static String toString(InputStream in) throws Exception {
-    byte[] bytes = new byte[in.available()];
-    ByteStreams.readFully(in, bytes);
-    return new String(bytes, UTF_8);
+  @Before
+  public void setup() {
+    buffer = new MessageFramerTest.ByteWritableBuffer(100);
   }
 
-  static ByteBuf messageFrame(String message) throws Exception {
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(os);
-    dos.write(message.getBytes(UTF_8));
-    dos.close();
-
-    // Write the compression header followed by the context frame.
-    return compressionFrame(os.toByteArray());
+  @Override
+  protected WritableBuffer buffer() {
+    return buffer;
   }
 
-  static ByteBuf compressionFrame(byte[] data) {
-    ByteBuf buf = Unpooled.buffer();
-    buf.writeByte(0);
-    buf.writeInt(data.length);
-    buf.writeBytes(data);
-    return buf;
+  @Override
+  protected byte[] writtenBytes() {
+    return Arrays.copyOfRange(buffer.data, 0, buffer.readableBytes());
   }
 }

--- a/core/src/test/java/io/grpc/transport/CompositeReadableBufferTest.java
+++ b/core/src/test/java/io/grpc/transport/CompositeReadableBufferTest.java
@@ -47,17 +47,17 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * Tests for {@link CompositeBuffer}.
+ * Tests for {@link CompositeReadableBuffer}.
  */
 @RunWith(JUnit4.class)
-public class CompositeBufferTest {
+public class CompositeReadableBufferTest {
   private static final String EXPECTED_VALUE = "hello world";
 
-  private CompositeBuffer composite;
+  private CompositeReadableBuffer composite;
 
   @Before
   public void setup() {
-    composite = new CompositeBuffer();
+    composite = new CompositeReadableBuffer();
     splitAndAdd(EXPECTED_VALUE);
   }
 
@@ -68,10 +68,10 @@ public class CompositeBufferTest {
 
   @Test
   public void singleBufferShouldSucceed() {
-    composite = new CompositeBuffer();
-    composite.addBuffer(Buffers.wrap(EXPECTED_VALUE.getBytes(UTF_8)));
+    composite = new CompositeReadableBuffer();
+    composite.addBuffer(ReadableBuffers.wrap(EXPECTED_VALUE.getBytes(UTF_8)));
     assertEquals(EXPECTED_VALUE.length(), composite.readableBytes());
-    assertEquals(EXPECTED_VALUE, Buffers.readAsStringUtf8(composite));
+    assertEquals(EXPECTED_VALUE, ReadableBuffers.readAsStringUtf8(composite));
     assertEquals(0, composite.readableBytes());
   }
 
@@ -161,9 +161,9 @@ public class CompositeBufferTest {
 
   @Test
   public void closeShouldCloseBuffers() {
-    composite = new CompositeBuffer();
-    Buffer mock1 = mock(Buffer.class);
-    Buffer mock2 = mock(Buffer.class);
+    composite = new CompositeReadableBuffer();
+    ReadableBuffer mock1 = mock(ReadableBuffer.class);
+    ReadableBuffer mock2 = mock(ReadableBuffer.class);
     composite.addBuffer(mock1);
     composite.addBuffer(mock2);
 
@@ -177,7 +177,7 @@ public class CompositeBufferTest {
     for (int startIndex = 0, endIndex = 0; startIndex < value.length(); startIndex = endIndex) {
       endIndex = Math.min(value.length(), startIndex + partLength);
       String part = value.substring(startIndex, endIndex);
-      composite.addBuffer(Buffers.wrap(part.getBytes(UTF_8)));
+      composite.addBuffer(ReadableBuffers.wrap(part.getBytes(UTF_8)));
     }
 
     assertEquals(value.length(), composite.readableBytes());

--- a/core/src/test/java/io/grpc/transport/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/transport/MessageDeframerTest.java
@@ -68,7 +68,7 @@ public class MessageDeframerTest {
   @Test
   public void simplePayload() {
     deframer.request(1);
-    deframer.deframe(buffer(new byte[]{0, 0, 0, 0, 2, 3, 14}), false);
+    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 2, 3, 14}), false);
     verify(listener).messageRead(messages.capture());
     assertEquals(Bytes.asList(new byte[]{3, 14}), bytes(messages));
     verify(listener, atLeastOnce()).bytesRead(anyInt());
@@ -78,7 +78,7 @@ public class MessageDeframerTest {
   @Test
   public void smallCombinedPayloads() {
     deframer.request(2);
-    deframer.deframe(buffer(new byte[]{0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 2, 14, 15}), false);
+    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 2, 14, 15}), false);
     verify(listener, times(2)).messageRead(messages.capture());
     List<InputStream> streams = messages.getAllValues();
     assertEquals(2, streams.size());
@@ -149,7 +149,7 @@ public class MessageDeframerTest {
   public void largerFrameSize() {
     deframer.request(1);
     deframer.deframe(
-        Buffers.wrap(Bytes.concat(new byte[] {0, 0, 0, 3, (byte) 232}, new byte[1000])), false);
+        ReadableBuffers.wrap(Bytes.concat(new byte[] {0, 0, 0, 3, (byte) 232}, new byte[1000])), false);
     verify(listener).messageRead(messages.capture());
     assertEquals(Bytes.asList(new byte[1000]), bytes(messages));
     verify(listener, atLeastOnce()).bytesRead(anyInt());
@@ -196,8 +196,8 @@ public class MessageDeframerTest {
     }
   }
 
-  private static Buffer buffer(byte[] bytes) {
-    return Buffers.wrap(bytes);
+  private static ReadableBuffer buffer(byte[] bytes) {
+    return ReadableBuffers.wrap(bytes);
   }
 
   private static byte[] compress(byte[] bytes) {

--- a/core/src/test/java/io/grpc/transport/ReadableBufferTestBase.java
+++ b/core/src/test/java/io/grpc/transport/ReadableBufferTestBase.java
@@ -43,15 +43,15 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 /**
- * Abstract base class for tests of {@link Buffer} subclasses.
+ * Abstract base class for tests of {@link ReadableBuffer} subclasses.
  */
 @RunWith(JUnit4.class)
-public abstract class BufferTestBase {
+public abstract class ReadableBufferTestBase {
   protected final String msg = "hello";
 
   @Test
   public void bufferShouldReadAllBytes() {
-    Buffer buffer = buffer();
+    ReadableBuffer buffer = buffer();
     for (int ix = 0; ix < msg.length(); ++ix) {
       assertEquals(msg.length() - ix, buffer.readableBytes());
       assertEquals(msg.charAt(ix), buffer.readUnsignedByte());
@@ -61,7 +61,7 @@ public abstract class BufferTestBase {
 
   @Test
   public void readToArrayShouldSucceed() {
-    Buffer buffer = buffer();
+    ReadableBuffer buffer = buffer();
     byte[] array = new byte[msg.length()];
     buffer.readBytes(array, 0, array.length);
     Arrays.equals(msg.getBytes(UTF_8), array);
@@ -70,7 +70,7 @@ public abstract class BufferTestBase {
 
   @Test
   public void partialReadToArrayShouldSucceed() {
-    Buffer buffer = buffer();
+    ReadableBuffer buffer = buffer();
     byte[] array = new byte[msg.length()];
     buffer.readBytes(array, 1, 2);
     Arrays.equals(new byte[] {'h', 'e'}, Arrays.copyOfRange(array, 1, 3));
@@ -79,7 +79,7 @@ public abstract class BufferTestBase {
 
   @Test
   public void readToStreamShouldSucceed() throws Exception {
-    Buffer buffer = buffer();
+    ReadableBuffer buffer = buffer();
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     buffer.readBytes(stream, msg.length());
     Arrays.equals(msg.getBytes(UTF_8), stream.toByteArray());
@@ -88,7 +88,7 @@ public abstract class BufferTestBase {
 
   @Test
   public void partialReadToStreamShouldSucceed() throws Exception {
-    Buffer buffer = buffer();
+    ReadableBuffer buffer = buffer();
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     buffer.readBytes(stream, 2);
     Arrays.equals(new byte[]{'h', 'e'}, Arrays.copyOfRange(stream.toByteArray(), 0, 2));
@@ -97,7 +97,7 @@ public abstract class BufferTestBase {
 
   @Test
   public void readToByteBufferShouldSucceed() {
-    Buffer buffer = buffer();
+    ReadableBuffer buffer = buffer();
     ByteBuffer byteBuffer = ByteBuffer.allocate(msg.length());
     buffer.readBytes(byteBuffer);
     byteBuffer.flip();
@@ -109,7 +109,7 @@ public abstract class BufferTestBase {
 
   @Test
   public void partialReadToByteBufferShouldSucceed() {
-    Buffer buffer = buffer();
+    ReadableBuffer buffer = buffer();
     ByteBuffer byteBuffer = ByteBuffer.allocate(2);
     buffer.readBytes(byteBuffer);
     byteBuffer.flip();
@@ -119,5 +119,5 @@ public abstract class BufferTestBase {
     assertEquals(3, buffer.readableBytes());
   }
 
-  protected abstract Buffer buffer();
+  protected abstract ReadableBuffer buffer();
 }

--- a/core/src/test/java/io/grpc/transport/ReadableBuffersArrayTest.java
+++ b/core/src/test/java/io/grpc/transport/ReadableBuffersArrayTest.java
@@ -29,47 +29,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.transport.netty;
+package io.grpc.transport;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static io.grpc.transport.ReadableBuffers.wrap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
-import io.grpc.transport.Buffer;
-import io.grpc.transport.BufferTestBase;
-import io.netty.buffer.Unpooled;
-
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
- * Tests for {@link NettyBuffer}.
+ * Tests for the array-backed {@link ReadableBuffer} returned by {@link ReadableBuffers#wrap(byte[], int, int)};
  */
-@RunWith(JUnit4.class)
-public class NettyBufferTest extends BufferTestBase {
-  private NettyBuffer buffer;
-
-  @Before
-  public void setup() {
-    buffer = new NettyBuffer(Unpooled.copiedBuffer(msg, UTF_8));
-  }
+public class ReadableBuffersArrayTest extends ReadableBufferTestBase {
 
   @Test
-  public void closeShouldReleaseBuffer() {
-    buffer.close();
-    assertEquals(0, buffer.buffer().refCnt());
-  }
+  public void bufferShouldExposeArray() {
+    byte[] array = msg.getBytes(UTF_8);
+    ReadableBuffer buffer = wrap(array, 1, msg.length() - 1);
+    assertTrue(buffer.hasArray());
+    assertSame(array, buffer.array());
+    assertEquals(1, buffer.arrayOffset());
 
-  @Test
-  public void closeMultipleTimesShouldReleaseBufferOnce() {
-    buffer.close();
-    buffer.close();
-    assertEquals(0, buffer.buffer().refCnt());
+    // Now read a byte and verify that the offset changes.
+    buffer.readUnsignedByte();
+    assertEquals(2, buffer.arrayOffset());
   }
 
   @Override
-  protected Buffer buffer() {
-    return buffer;
+  protected ReadableBuffer buffer() {
+    return ReadableBuffers.wrap(msg.getBytes(UTF_8), 0, msg.length());
   }
 }

--- a/core/src/test/java/io/grpc/transport/ReadableBuffersByteBufferTest.java
+++ b/core/src/test/java/io/grpc/transport/ReadableBuffersByteBufferTest.java
@@ -29,45 +29,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.transport.netty;
+package io.grpc.transport;
 
-import static io.netty.util.CharsetUtil.UTF_8;
+import static com.google.common.base.Charsets.UTF_8;
 
-import com.google.common.io.ByteStreams;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 /**
- * Utility methods for supporting Netty tests.
+ * Tests for the array-backed {@link ReadableBuffer} returned by {@link ReadableBuffers#wrap(ByteBuffer)}.
  */
-public class NettyTestUtil {
+public class ReadableBuffersByteBufferTest extends ReadableBufferTestBase {
 
-  static String toString(InputStream in) throws Exception {
-    byte[] bytes = new byte[in.available()];
-    ByteStreams.readFully(in, bytes);
-    return new String(bytes, UTF_8);
-  }
-
-  static ByteBuf messageFrame(String message) throws Exception {
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(os);
-    dos.write(message.getBytes(UTF_8));
-    dos.close();
-
-    // Write the compression header followed by the context frame.
-    return compressionFrame(os.toByteArray());
-  }
-
-  static ByteBuf compressionFrame(byte[] data) {
-    ByteBuf buf = Unpooled.buffer();
-    buf.writeByte(0);
-    buf.writeInt(data.length);
-    buf.writeBytes(data);
-    return buf;
+  @Override
+  protected ReadableBuffer buffer() {
+    return ReadableBuffers.wrap(ByteBuffer.wrap(msg.getBytes(UTF_8)));
   }
 }

--- a/core/src/test/java/io/grpc/transport/WritableBufferAllocatorTestBase.java
+++ b/core/src/test/java/io/grpc/transport/WritableBufferAllocatorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -32,59 +32,35 @@
 package io.grpc.transport;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertNotSame;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.stubbing.OngoingStubbing;
 
 /**
- * Tests for {@link AbstractBuffer}.
+ * Abstract base class for tests of {@link WritableBufferAllocator} subclasses.
  */
 @RunWith(JUnit4.class)
-public class AbstractBufferTest {
+public abstract class WritableBufferAllocatorTestBase {
 
-  @Mock
-  private AbstractBuffer buffer;
+  protected abstract WritableBufferAllocator allocator();
 
-  @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
+  @Test
+  public void testBuffersAreDifferent() {
+    WritableBuffer buffer1 = allocator().allocate(100);
+    WritableBuffer buffer2 = allocator().allocate(100);
+
+    assertNotSame(buffer1, buffer2);
+
+    buffer1.release();
+    buffer2.release();
   }
 
   @Test
-  public void readUnsignedShortShouldSucceed() {
-    mockBytes(0xFF, 0xEE);
-    assertEquals(0xFFEE, buffer.readUnsignedShort());
-  }
-
-  @Test
-  public void readUnsignedMediumShouldSucceed() {
-    mockBytes(0xFF, 0xEE, 0xDD);
-    assertEquals(0xFFEEDD, buffer.readUnsignedMedium());
-  }
-
-  @Test
-  public void readPositiveIntShouldSucceed() {
-    mockBytes(0x7F, 0xEE, 0xDD, 0xCC);
-    assertEquals(0x7FEEDDCC, buffer.readInt());
-  }
-
-  @Test
-  public void readNegativeIntShouldSucceed() {
-    mockBytes(0xFF, 0xEE, 0xDD, 0xCC);
-    assertEquals(0xFFEEDDCC, buffer.readInt());
-  }
-
-  private void mockBytes(int... bytes) {
-    when(buffer.readableBytes()).thenReturn(bytes.length);
-    OngoingStubbing<Integer> stub = when(buffer.readUnsignedByte());
-    for (int b : bytes) {
-      stub = stub.thenReturn(b);
-    }
+  public void testCapacity() {
+    WritableBuffer buffer = allocator().allocate(4096);
+    assertEquals(0, buffer.readableBytes());
+    assertEquals(4096, buffer.writableBytes());
   }
 }

--- a/core/src/test/java/io/grpc/transport/WritableBufferTestBase.java
+++ b/core/src/test/java/io/grpc/transport/WritableBufferTestBase.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.transport;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Abstract base class for tests of {@link WritableBuffer} subclasses.
+ */
+@RunWith(JUnit4.class)
+public abstract class WritableBufferTestBase {
+
+  /**
+   * Returns a new buffer for every test case with
+   * at least 100 byte of capacity.
+   */
+  protected abstract WritableBuffer buffer();
+
+  /**
+   * Bytes written to {@link #buffer()}.
+   */
+  protected abstract byte[] writtenBytes();
+
+  @Test(expected = RuntimeException.class)
+  public void testWriteNegativeLength() {
+    buffer().write(new byte[1], 0, -1);
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testWriteNegativeSrcIndex() {
+    buffer().write(new byte[1], -1, 0);
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testWriteSrcIndexAndLengthExceedSrcLength() {
+    buffer().write(new byte[10], 1, 10);
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testWriteSrcIndexAndLengthExceedWritableBytes() {
+    buffer().write(new byte[buffer().writableBytes()], 1, buffer().writableBytes());
+  }
+
+  @Test
+  public void testWritableAndReadableBytes() {
+    int before = buffer().writableBytes();
+    buffer().write(new byte[10], 0, 5);
+
+    assertEquals(5, before - buffer().writableBytes());
+    assertEquals(5, buffer().readableBytes());
+  }
+
+  @Test
+  public void testWriteSrcIndex() {
+    byte b[] = new byte[10];
+    for (byte i = 5; i < 10; i++) {
+      b[i] = i;
+    }
+
+    buffer().write(b, 5, 5);
+
+    assertEquals(5, buffer().readableBytes());
+    byte writtenBytes[] = writtenBytes();
+    assertEquals(5, writtenBytes.length);
+    for (int i = 0; i < writtenBytes.length; i++) {
+      assertEquals(5+i, writtenBytes[i]);
+    }
+  }
+
+  @Test
+  public void testMultipleWrites() {
+    byte[] b = new byte[100];
+    for (byte i = 0; i < b.length; i++) {
+      b[i] = i;
+    }
+
+    // Write in chunks of 10 bytes
+    for (int i = 0; i < 10; i++) {
+      buffer().write(b, 10 * i, 10);
+      assertEquals(10 * (i + 1), buffer().readableBytes());
+    }
+
+    assertArrayEquals(b, writtenBytes());
+  }
+}

--- a/netty/src/test/java/io/grpc/transport/netty/NettyWritableBufferAllocatorTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyWritableBufferAllocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,43 +31,23 @@
 
 package io.grpc.transport.netty;
 
-import static io.netty.util.CharsetUtil.UTF_8;
-
-import com.google.common.io.ByteStreams;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.InputStream;
+import io.grpc.transport.WritableBufferAllocator;
+import io.grpc.transport.WritableBufferAllocatorTestBase;
+import io.netty.buffer.ByteBufAllocator;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
- * Utility methods for supporting Netty tests.
+ * Tests for {@link NettyWritableBufferAllocator}.
  */
-public class NettyTestUtil {
+@RunWith(JUnit4.class)
+public class NettyWritableBufferAllocatorTest extends WritableBufferAllocatorTestBase {
 
-  static String toString(InputStream in) throws Exception {
-    byte[] bytes = new byte[in.available()];
-    ByteStreams.readFully(in, bytes);
-    return new String(bytes, UTF_8);
-  }
+  private final NettyWritableBufferAllocator allocator =
+          new NettyWritableBufferAllocator(ByteBufAllocator.DEFAULT);
 
-  static ByteBuf messageFrame(String message) throws Exception {
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(os);
-    dos.write(message.getBytes(UTF_8));
-    dos.close();
-
-    // Write the compression header followed by the context frame.
-    return compressionFrame(os.toByteArray());
-  }
-
-  static ByteBuf compressionFrame(byte[] data) {
-    ByteBuf buf = Unpooled.buffer();
-    buf.writeByte(0);
-    buf.writeInt(data.length);
-    buf.writeBytes(data);
-    return buf;
+  @Override
+  protected WritableBufferAllocator allocator() {
+    return allocator;
   }
 }

--- a/netty/src/test/java/io/grpc/transport/netty/NettyWritableBufferTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyWritableBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,19 +29,45 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.transport;
+package io.grpc.transport.netty;
 
-import static com.google.common.base.Charsets.UTF_8;
+import io.grpc.transport.WritableBuffer;
+import io.grpc.transport.WritableBufferTestBase;
+import io.netty.buffer.Unpooled;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 /**
- * Tests for the array-backed {@link Buffer} returned by {@link Buffers#wrap(ByteBuffer)}.
+ * Tests for {@link NettyWritableBuffer}.
  */
-public class BuffersByteBufferTest extends BufferTestBase {
+@RunWith(JUnit4.class)
+public class NettyWritableBufferTest extends WritableBufferTestBase {
+
+  private NettyWritableBuffer buffer;
+
+  @Before
+  public void setup() {
+    buffer = new NettyWritableBuffer(Unpooled.buffer(100));
+  }
+
+  @After
+  public void teardown() {
+    buffer.release();
+  }
 
   @Override
-  protected Buffer buffer() {
-    return Buffers.wrap(ByteBuffer.wrap(msg.getBytes(UTF_8)));
+  protected WritableBuffer buffer() {
+    return buffer;
+  }
+
+  @Override
+  protected byte[] writtenBytes() {
+    byte b[] = buffer.bytebuf().array();
+    int fromIdx = buffer.bytebuf().arrayOffset();
+    return Arrays.copyOfRange(b, fromIdx, buffer.readableBytes());
   }
 }

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -6,6 +6,9 @@ description = "gRPC: OkHttp"
 dependencies {
     compile project(':grpc-core'),
             libraries.okhttp
+
+    // Tests depend on base class defined by core module.
+    testCompile project(':grpc-core').sourceSets.test.output
 }
 
 // Configure the animal sniffer plugin

--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
@@ -40,8 +40,9 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.transport.ClientStreamListener;
 import io.grpc.transport.Http2ClientStream;
+import io.grpc.transport.WritableBuffer;
+import okio.Buffer;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -58,9 +59,9 @@ class OkHttpClientStream extends Http2ClientStream {
    * Construct a new client stream.
    */
   static OkHttpClientStream newStream(ClientStreamListener listener,
-                                       AsyncFrameWriter frameWriter,
-                                       OkHttpClientTransport transport,
-                                       OutboundFlowController outboundFlow) {
+                                      AsyncFrameWriter frameWriter,
+                                      OkHttpClientTransport transport,
+                                      OutboundFlowController outboundFlow) {
     return new OkHttpClientStream(listener, frameWriter, transport, outboundFlow);
   }
 
@@ -75,10 +76,10 @@ class OkHttpClientStream extends Http2ClientStream {
   private Object outboundFlowState;
 
   private OkHttpClientStream(ClientStreamListener listener,
-                     AsyncFrameWriter frameWriter,
-                     OkHttpClientTransport transport,
-                     OutboundFlowController outboundFlow) {
-    super(listener);
+                             AsyncFrameWriter frameWriter,
+                             OkHttpClientTransport transport,
+                             OutboundFlowController outboundFlow) {
+    super(new OkHttpWritableBufferAllocator(), listener);
     this.frameWriter = frameWriter;
     this.transport = transport;
     this.outboundFlow = outboundFlow;
@@ -109,17 +110,14 @@ class OkHttpClientStream extends Http2ClientStream {
     synchronized (lock) {
       long length = frame.size();
       window -= length;
-      super.transportDataReceived(new OkHttpBuffer(frame), endOfStream);
+      super.transportDataReceived(new OkHttpReadableBuffer(frame), endOfStream);
     }
   }
 
   @Override
-  protected void sendFrame(ByteBuffer frame, boolean endOfStream) {
+  protected void sendFrame(WritableBuffer frame, boolean endOfStream) {
     Preconditions.checkState(id() != 0, "streamId should be set");
-    okio.Buffer buffer = new okio.Buffer();
-    // Read the data into a buffer.
-    // TODO(madongfly): swap to NIO buffers or zero-copy if/when okhttp/okio supports it
-    buffer.write(frame.array(), frame.arrayOffset(), frame.remaining());
+    Buffer buffer = ((OkHttpWritableBuffer) frame).buffer();
     // Write the data to the remote endpoint.
     // Per http2 SPEC, the max data length should be larger than 64K, while our frame size is
     // only 4K.

--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
@@ -46,7 +46,6 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.Status.Code;
-import io.grpc.transport.ClientStream;
 import io.grpc.transport.ClientStreamListener;
 import io.grpc.transport.ClientTransport;
 

--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpWritableBufferAllocator.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpWritableBufferAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,45 +29,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.transport.netty;
+package io.grpc.transport.okhttp;
 
-import static io.netty.util.CharsetUtil.UTF_8;
-
-import com.google.common.io.ByteStreams;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.InputStream;
+import io.grpc.transport.WritableBufferAllocator;
+import okio.Buffer;
 
 /**
- * Utility methods for supporting Netty tests.
+ * The default allocator for {@link OkHttpWritableBuffer}s used by the OkHttp transport.
  */
-public class NettyTestUtil {
-
-  static String toString(InputStream in) throws Exception {
-    byte[] bytes = new byte[in.available()];
-    ByteStreams.readFully(in, bytes);
-    return new String(bytes, UTF_8);
-  }
-
-  static ByteBuf messageFrame(String message) throws Exception {
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(os);
-    dos.write(message.getBytes(UTF_8));
-    dos.close();
-
-    // Write the compression header followed by the context frame.
-    return compressionFrame(os.toByteArray());
-  }
-
-  static ByteBuf compressionFrame(byte[] data) {
-    ByteBuf buf = Unpooled.buffer();
-    buf.writeByte(0);
-    buf.writeInt(data.length);
-    buf.writeBytes(data);
-    return buf;
+class OkHttpWritableBufferAllocator implements WritableBufferAllocator {
+  @Override
+  public OkHttpWritableBuffer allocate(int capacity) {
+    return new OkHttpWritableBuffer(new Buffer(), capacity);
   }
 }

--- a/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
@@ -47,8 +47,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Service;
-import com.google.common.util.concurrent.Service.State;
 
 import com.squareup.okhttp.internal.spdy.ErrorCode;
 import com.squareup.okhttp.internal.spdy.FrameReader;

--- a/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpWritableBufferAllocatorTest.java
+++ b/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpWritableBufferAllocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,45 +29,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.transport.netty;
+package io.grpc.transport.okhttp;
 
-import static io.netty.util.CharsetUtil.UTF_8;
+import io.grpc.transport.WritableBufferAllocator;
+import io.grpc.transport.WritableBufferAllocatorTestBase;
 
-import com.google.common.io.ByteStreams;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.InputStream;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
- * Utility methods for supporting Netty tests.
+ * Tests for {@link OkHttpWritableBufferAllocator}.
  */
-public class NettyTestUtil {
+@RunWith(JUnit4.class)
+public class OkHttpWritableBufferAllocatorTest extends WritableBufferAllocatorTestBase {
 
-  static String toString(InputStream in) throws Exception {
-    byte[] bytes = new byte[in.available()];
-    ByteStreams.readFully(in, bytes);
-    return new String(bytes, UTF_8);
-  }
+  private final OkHttpWritableBufferAllocator allocator = new OkHttpWritableBufferAllocator();
 
-  static ByteBuf messageFrame(String message) throws Exception {
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(os);
-    dos.write(message.getBytes(UTF_8));
-    dos.close();
-
-    // Write the compression header followed by the context frame.
-    return compressionFrame(os.toByteArray());
-  }
-
-  static ByteBuf compressionFrame(byte[] data) {
-    ByteBuf buf = Unpooled.buffer();
-    buf.writeByte(0);
-    buf.writeInt(data.length);
-    buf.writeBytes(data);
-    return buf;
+  @Override
+  protected WritableBufferAllocator allocator() {
+    return allocator;
   }
 }

--- a/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpWritableBufferTest.java
+++ b/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpWritableBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,45 +29,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.transport.netty;
+package io.grpc.transport.okhttp;
 
-import static io.netty.util.CharsetUtil.UTF_8;
-
-import com.google.common.io.ByteStreams;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.InputStream;
+import io.grpc.transport.WritableBuffer;
+import io.grpc.transport.WritableBufferTestBase;
+import okio.Buffer;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
- * Utility methods for supporting Netty tests.
+ * Tests for {@link OkHttpWritableBuffer}.
  */
-public class NettyTestUtil {
+@RunWith(JUnit4.class)
+public class OkHttpWritableBufferTest extends WritableBufferTestBase {
 
-  static String toString(InputStream in) throws Exception {
-    byte[] bytes = new byte[in.available()];
-    ByteStreams.readFully(in, bytes);
-    return new String(bytes, UTF_8);
+  private OkHttpWritableBuffer buffer;
+
+  @Before
+  public void setup() {
+    buffer = new OkHttpWritableBuffer(new Buffer(), 100);
   }
 
-  static ByteBuf messageFrame(String message) throws Exception {
-    ByteArrayOutputStream os = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(os);
-    dos.write(message.getBytes(UTF_8));
-    dos.close();
-
-    // Write the compression header followed by the context frame.
-    return compressionFrame(os.toByteArray());
+  @Override
+  protected WritableBuffer buffer() {
+    return buffer;
   }
 
-  static ByteBuf compressionFrame(byte[] data) {
-    ByteBuf buf = Unpooled.buffer();
-    buf.writeByte(0);
-    buf.writeInt(data.length);
-    buf.writeBytes(data);
-    return buf;
+  @Override
+  protected byte[] writtenBytes() {
+    return buffer.buffer().readByteArray();
   }
 }


### PR DESCRIPTION
WritableBuffer is a generic interface that allows to transfer data
from gRPC directly to the native transport's buffer implementation.