### PR TITLE
Improve Status exception message

### DIFF
--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -303,6 +303,14 @@ public final class Status {
     return INTERNAL.withCause(t);
   }
 
+  private static String formatThrowableMessage(Status status) {
+    if (status.description == null) {
+      return status.code.toString();
+    } else {
+      return status.code + ": " + status.description;
+    }
+  }
+
   private final Code code;
   private final String description;
   private final Throwable cause;
@@ -416,7 +424,7 @@ public final class Status {
     private final Status status;
 
     public OperationException(Status status) {
-      super(status.getCode() + ": " + status.getDescription(), status.getCause());
+      super(formatThrowableMessage(status), status.getCause());
       this.status = status;
     }
 
@@ -433,7 +441,7 @@ public final class Status {
     private final Status status;
 
     public OperationRuntimeException(Status status) {
-      super(status.getCode() + ": " + status.getDescription(), status.getCause());
+      super(formatThrowableMessage(status), status.getCause());
       this.status = status;
     }
 

--- a/core/src/test/java/io/grpc/StatusTest.java
+++ b/core/src/test/java/io/grpc/StatusTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Status}. */
+@RunWith(JUnit4.class)
+public class StatusTest {
+  @Test
+  public void verifyExceptionMessage() {
+    assertEquals("UNKNOWN", Status.UNKNOWN.asRuntimeException().getMessage());
+    assertEquals("CANCELLED: This is a test",
+        Status.CANCELLED.withDescription("This is a test").asRuntimeException().getMessage());
+    assertEquals("UNKNOWN", Status.UNKNOWN.asException().getMessage());
+    assertEquals("CANCELLED: This is a test",
+        Status.CANCELLED.withDescription("This is a test").asException().getMessage());
+  }
+}


### PR DESCRIPTION
When the description is null, the exception message would be in the form
of "INTERNAL: null", which isn't very attractive, and makes it seem like
an error in itself. If the description is null, just use "INTERNAL".