### PR TITLE
Cache Gradle and not really Maven

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,10 @@ notifications:
 cache:
   directories:
     - /tmp/proto3-a2
-    - $HOME/.m2
+    - $HOME/.m2/repository/io/netty
+    - $HOME/.gradle/caches/modules-2
+    - $HOME/.gradle/wrapper
+
+before_cache:
+  - rm $HOME/.gradle/caches/modules-2/modules-2.lock
+  - find $HOME/.gradle/wrapper -not -name "*-all.zip" -delete

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -21,7 +21,7 @@ fi
 # Make and install netty
 pushd lib/netty
 BUILD_NETTY=1
-NETTY_REV_FILE="$HOME/.m2/netty-ver"
+NETTY_REV_FILE="$HOME/.m2/repository/io/netty/netty-ver"
 REV="$(git rev-parse HEAD)"
 if [ -f "$NETTY_REV_FILE" ]; then
   REV_LAST="$(cat "$NETTY_REV_FILE")"


### PR DESCRIPTION
Artifacts that Gradle caches from Maven Central go in
~/.gradle/caches/modules-2, not ~/.m2. We only need .m2 for the
locally-install Netty.