### PR TITLE
Enable parallel Gradle builds for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - buildscripts/make_dependencies.sh # build protoc into /tmp/proto3-a2
   - mkdir -p $HOME/.gradle
   - echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties
+  - echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Parallel doesn't mix well with deployment, so if that becomes part of
Travis, we would need to pass -Dorg.gradle.parallel=false to the gradle
command line. But otherwise parallel builds have been solid.