### PR TITLE
Use TLS for Netty integration tests

### DIFF
--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     alpnboot alpnboot_package_name
 }
 
+test {
+    jvmArgs "-Xbootclasspath/p:" + configurations.alpnboot.asPath
+}
+
 // Allow execution of test client and server.
 task execute(dependsOn: classes, type:JavaExec) {
     main = project.hasProperty('mainClass') ? project.mainClass : ''


### PR DESCRIPTION
Reduces the need to run integration tests manually for verification, as discussed in #202 and #204.

The main concern is that now ALPN needs to be working for the tests, which was not previously the case. However, that is _more_ reason to enable TLS.

Resolves #204