### PR TITLE
Remove readlink -f in run-test*.sh scripts

### DIFF
--- a/run-test-client.sh
+++ b/run-test-client.sh
@@ -8,6 +8,6 @@ for i in "$@"; do
 done
 TARGET_ARGS="${TARGET_ARGS:2}"
 
-cd "$(dirname "$(readlink -f "$0")")"
+cd "$(dirname "$0")"
 echo "[INFO] Running: $TARGET ($TARGET_CLASS $TARGET_ARGS)"
 ./gradlew -PmainClass="$TARGET_CLASS" -PappArgs="[$TARGET_ARGS]" :grpc-integration-testing:execute

--- a/run-test-server.sh
+++ b/run-test-server.sh
@@ -8,6 +8,6 @@ for i in "$@"; do
 done
 TARGET_ARGS="${TARGET_ARGS:2}"
 
-cd "$(dirname "$(readlink -f "$0")")"
+cd "$(dirname "$0")"
 echo "[INFO] Running: $TARGET ($TARGET_CLASS $TARGET_ARGS)"
 ./gradlew -PmainClass="$TARGET_CLASS" -PappArgs="[$TARGET_ARGS]" :grpc-integration-testing:execute


### PR DESCRIPTION
readlink -f allows the script to be run via a symlink yet still
function.  However, OS X doesn't have the -f flag. We don't really care
too much about symlinking to the scripts, so just drop readlink -f.

Resolves #203.