### PR TITLE
Disable Travis parallel building to reduce memory usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   - buildscripts/make_dependencies.sh # build protoc into /tmp/proto3-a2
   - mkdir -p $HOME/.gradle
   - echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties
-  - echo "org.gradle.parallel=true" >> $HOME/.gradle/gradle.properties
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
We were seeing errors on Travis like:
```
Process 'Gradle Test Executor 2' finished with non-zero exit value 137
```

That doesn't make much sense, other than maybe the OOM killer killing
our processes. Turning off parallel execution seemed to fix the problem,
so we'll just assume memory was the actual problem and doing fewer
things in parallel reduces our maximum memory usage.