### PR TITLE
Add precondition to throw more informative exception when calling request() before start() has been called.

### DIFF
--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -265,6 +265,7 @@ public final class ChannelImpl implements Channel {
 
     @Override
     public void request(int numMessages) {
+      Preconditions.checkState(stream != null, "Not started");
       stream.request(numMessages);
     }
 


### PR DESCRIPTION
Resolves #239
@ejona86 please take a look.