### PR TITLE
Fix an issue caused by the intercepting call failing in start() and skip super.start()

### DIFF
--- a/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
+++ b/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
@@ -89,7 +89,7 @@ public class ClientAuthInterceptor implements ClientInterceptor {
           headers.merge(cachedSaved);
           super.start(responseListener, headers);
         } catch (IOException ioe) {
-          responseListener.onClose(Status.fromThrowable(ioe), new Metadata.Trailers());
+          super.startFailed(responseListener, ioe);
         }
       }
     };

--- a/core/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -32,8 +32,13 @@
 package io.grpc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -52,6 +57,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,6 +80,18 @@ public class ClientInterceptorsTest {
   @Before public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(channel.newCall(Mockito.<MethodDescriptor<String, Integer>>any())).thenReturn(call);
+
+    // Emulate the precondition checks in ChannelImpl.CallImpl
+    Answer<Void> checkStartCalled = new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) {
+        verify(call).start(Mockito.<Call.Listener<Integer>>any(), Mockito.<Metadata.Headers>any());
+        return null;
+      }
+    };
+    doAnswer(checkStartCalled).when(call).request(anyInt());
+    doAnswer(checkStartCalled).when(call).halfClose();
+    doAnswer(checkStartCalled).when(call).sendPayload(Mockito.<String>any());
   }
 
   @Test(expected = NullPointerException.class)
@@ -221,6 +240,69 @@ public class ClientInterceptorsTest {
     // Simulate that a headers arrives on the underlying call listener.
     captor.getValue().onHeaders(inboundHeaders);
     assertEquals(Arrays.asList(inboundHeaders), examinedHeaders);
+  }
+
+  @Test
+  public void normalCall() {
+    ClientInterceptor interceptor = new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+          Channel next) {
+        Call<ReqT, RespT> call = next.newCall(method);
+        return new ForwardingCall<ReqT, RespT>(call);
+      }
+    };
+    Channel intercepted = ClientInterceptors.intercept(channel, interceptor);
+    Call<String, Integer> interceptedCall = intercepted.newCall(method);
+    assertNotSame(call, interceptedCall);
+    @SuppressWarnings("unchecked")
+    Call.Listener<Integer> listener = mock(Call.Listener.class);
+    Metadata.Headers headers = new Metadata.Headers();
+    interceptedCall.start(listener, headers);
+    verify(call).start(same(listener), same(headers));
+    interceptedCall.sendPayload("request");
+    verify(call).sendPayload(eq("request"));
+    interceptedCall.halfClose();
+    verify(call).halfClose();
+    interceptedCall.request(1);
+    verify(call).request(1);
+  }
+
+  @Test
+  public void exceptionInStart() {
+    final Exception error = new Exception("emulated error");
+    ClientInterceptor interceptor = new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+          Channel next) {
+        Call<ReqT, RespT> call = next.newCall(method);
+        return new ForwardingCall<ReqT, RespT>(call) {
+          @Override
+          public void start(Call.Listener<RespT> responseListener, Metadata.Headers headers) {
+            try {
+              throw error;
+              // Normally we call super.start() here, but it will be skipped because of the
+              // exception
+            } catch (Exception e) {
+              super.startFailed(responseListener, e);
+            }
+          }
+        };
+      }
+    };
+    Channel intercepted = ClientInterceptors.intercept(channel, interceptor);
+    @SuppressWarnings("unchecked")
+    Call.Listener<Integer> listener = mock(Call.Listener.class);
+    Call<String, Integer> interceptedCall = intercepted.newCall(method);
+    assertNotSame(call, interceptedCall);
+    interceptedCall.start(listener, new Metadata.Headers());
+    interceptedCall.sendPayload("request");
+    interceptedCall.halfClose();
+    interceptedCall.request(1);
+    verifyNoMoreInteractions(call);
+    ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
+    verify(listener).onClose(captor.capture(), any(Metadata.Trailers.class));
+    assertSame(error, captor.getValue().getCause());
   }
 
   private static class NoopInterceptor implements ClientInterceptor {


### PR DESCRIPTION
#240 
The proposal is to add a ``startFailed()`` in ``ForwardingCall`` for over-riders to call when they have errors in their own ``start()``.
@ejona86 please take a look.