### PR TITLE
Implement GrpcCallContext & GrpcSession

### DIFF
--- a/core/src/main/java/io/grpc/GrpcCallContext.java
+++ b/core/src/main/java/io/grpc/GrpcCallContext.java
@@ -1,0 +1,87 @@
+package io.grpc;
+
+/**
+ * Holds state pertaining to a single GRPC call.
+ */
+public class GrpcCallContext {
+
+  private final GrpcSession session;
+  private final String methodName;
+  private final Metadata.Headers headers;
+
+  /**
+   * Constructor.
+   *
+   * @param methodName name of method being called
+   * @param headers    headers for current call
+   * @param session    session associated with the current call
+   */
+  public GrpcCallContext(String methodName, Metadata.Headers headers, GrpcSession session) {
+    this.methodName = methodName;
+    this.headers = headers;
+    this.session = session;
+  }
+
+  /**
+   * Get the methodName for the current call.
+   *
+   * @return method name for the current call
+   */
+  public String getMethodName() {
+    return methodName;
+  }
+
+  /**
+   * Get the headers for the current call.
+   *
+   * @return headers for the current call
+   */
+  public Metadata.Headers getHeaders() {
+    return headers;
+  }
+
+  /**
+   * Gets the current GrpcSession, which lasts across multiple method calls on a single
+   * transport-defined session (likely a TCP connection).
+   *
+   * @return current session
+   */
+  public GrpcSession getSession() {
+    return session;
+  }
+
+  static final ThreadLocal<GrpcCallContext> THREAD_LOCAL = new ThreadLocal<GrpcCallContext>();
+
+  /**
+   * Gets the active GrpcCallContext (from the ThreadLocal).
+   *
+   * @return active GrpcCallContext
+   */
+  public static GrpcCallContext get() {
+    GrpcCallContext session = THREAD_LOCAL.get();
+    assert session != null;
+
+    return session;
+  }
+
+  /**
+   * Sets the active GrpcCallContext (sets the ThreadLocal). Should only be called when no
+   * GrpcCallContext is active.
+   *
+   * @param session GrpcCallContext to set as active
+   */
+  static void enter(GrpcCallContext session) {
+    assert THREAD_LOCAL.get() == null;
+    THREAD_LOCAL.set(session);
+  }
+
+  /**
+   * Gets the active GrpcCallContext (clears the ThreadLocal). Should only be called when a
+   * GrpcCallContext is active.
+   */
+  static void exit() {
+    assert THREAD_LOCAL.get() != null;
+    THREAD_LOCAL.set(null);
+  }
+
+}

--- a/core/src/main/java/io/grpc/GrpcSession.java
+++ b/core/src/main/java/io/grpc/GrpcSession.java
@@ -1,0 +1,35 @@
+package io.grpc;
+
+import java.net.SocketAddress;
+import java.security.cert.Certificate;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
+/**
+ * Holds state pertaining to a single transport connection.
+ */
+public class GrpcSession {
+
+  private final SocketAddress remoteAddress;
+
+  /**
+   * Constructor.
+   *
+   * @param remoteAddress address of the remote peer
+   */
+  public GrpcSession(SocketAddress remoteAddress) {
+    this.remoteAddress = remoteAddress;
+  }
+
+  /**
+   * Gets the address of the remote peer of this connection.
+   *
+   * @return address of remote peer
+   */
+  public SocketAddress getRemoteAddress() {
+    return remoteAddress;
+  }
+
+}

--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -254,6 +254,7 @@ public abstract class Metadata {
   public static class Headers extends Metadata {
     private String path;
     private String authority;
+    private GrpcSession session;
 
     /**
      * Called by the transport layer to create headers from their binary serialized values.
@@ -278,6 +279,17 @@ public abstract class Metadata {
 
     public void setPath(String path) {
       this.path = path;
+    }
+
+    /**
+     * The session which this request is part of.
+     */
+    public GrpcSession getSession() {
+      return session;
+    }
+
+    public void setSession(GrpcSession session) {
+      this.session = session;
     }
 
     /**

--- a/core/src/main/java/io/grpc/ServerImpl.java
+++ b/core/src/main/java/io/grpc/ServerImpl.java
@@ -321,6 +321,8 @@ public class ServerImpl implements Server {
     /** Never returns {@code null}. */
     private <ReqT, RespT> ServerStreamListener startCall(ServerStream stream, String fullMethodName,
         ServerMethodDefinition<ReqT, RespT> methodDef, Metadata.Headers headers) {
+      GrpcSession session = headers.getSession();
+
       // TODO(ejona86): should we update fullMethodName to have the canonical path of the method?
       final ServerCallImpl<ReqT, RespT> call = new ServerCallImpl<ReqT, RespT>(stream, methodDef);
       ServerCall.Listener<ReqT> listener
@@ -329,7 +331,8 @@ public class ServerImpl implements Server {
         throw new NullPointerException(
             "startCall() returned a null listener for method " + fullMethodName);
       }
-      return call.newServerStreamListener(listener);
+      GrpcCallContext context = new GrpcCallContext(fullMethodName, headers, session);
+      return call.newServerStreamListener(listener, context);
     }
   }
 
@@ -483,8 +486,9 @@ public class ServerImpl implements Server {
       return cancelled;
     }
 
-    private ServerStreamListenerImpl newServerStreamListener(ServerCall.Listener<ReqT> listener) {
-      return new ServerStreamListenerImpl(listener);
+    private ServerStreamListenerImpl newServerStreamListener(ServerCall.Listener<ReqT> listener,
+                                                             GrpcCallContext context) {
+      return new ServerStreamListenerImpl(listener, context);
     }
 
     /**
@@ -493,9 +497,12 @@ public class ServerImpl implements Server {
      */
     private class ServerStreamListenerImpl implements ServerStreamListener {
       private final ServerCall.Listener<ReqT> listener;
+      private final GrpcCallContext callContext;
 
-      public ServerStreamListenerImpl(ServerCall.Listener<ReqT> listener) {
+      public ServerStreamListenerImpl(ServerCall.Listener<ReqT> listener,
+                                      GrpcCallContext callContext) {
         this.listener = Preconditions.checkNotNull(listener, "listener must not be null");
+        this.callContext = Preconditions.checkNotNull(callContext, "callContext must not be null");
       }
 
       @Override
@@ -521,7 +528,12 @@ public class ServerImpl implements Server {
           return;
         }
 
-        listener.onHalfClose();
+        GrpcCallContext.enter(callContext);
+        try {
+          listener.onHalfClose();
+        } finally {
+          GrpcCallContext.exit();
+        }
       }
 
       @Override

--- a/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -34,12 +34,14 @@ package io.grpc.testing.integration;
 import static io.grpc.testing.integration.Messages.PayloadType.COMPRESSABLE;
 import static io.grpc.testing.integration.Util.assertEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.google.common.net.HostAndPort;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.EmptyProtos.Empty;
 
@@ -563,6 +565,19 @@ public abstract class AbstractTransportTest {
     Assert.assertEquals(contextValue, trailersCapture.get().get(METADATA_KEY));
   }
 
+  /**
+   * Helper method called by derived tests, to test that the server sees the remote address.
+   */
+  public void testRemoteAddress(String expectRemoteAddress) throws Exception {
+    final SimpleRequest request = SimpleRequest.newBuilder()
+        .setFillRemoteAddress(true)
+        .build();
+
+    SimpleResponse response = blockingStub.unaryCall(request);
+    HostAndPort remoteAddress = HostAndPort.fromString(response.getRemoteAddress());
+    assertEquals("/127.0.0.1", remoteAddress.getHostText());
+    assertNotEquals(0, remoteAddress.getPort());
+  }
 
   protected int unaryPayloadLength() {
     // 10MiB.

--- a/integration-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/integration-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -35,6 +35,8 @@ import com.google.common.collect.Queues;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.EmptyProtos;
 
+import io.grpc.GrpcCallContext;
+import io.grpc.GrpcSession;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.integration.Messages.Payload;
 import io.grpc.testing.integration.Messages.PayloadType;
@@ -101,6 +103,10 @@ public class TestServiceImpl implements TestServiceGrpc.TestService {
       responseBuilder.getPayloadBuilder()
           .setType(compressable ? PayloadType.COMPRESSABLE : PayloadType.UNCOMPRESSABLE)
           .setBody(payload);
+    }
+    if (req.getFillRemoteAddress()) {
+      GrpcSession session = GrpcCallContext.get().getSession();
+      responseBuilder.setRemoteAddress(session.getRemoteAddress().toString());
     }
     responseObserver.onValue(responseBuilder.build());
     responseObserver.onCompleted();

--- a/integration-testing/src/main/proto/io/grpc/testing/integration/messages.proto
+++ b/integration-testing/src/main/proto/io/grpc/testing/integration/messages.proto
@@ -74,6 +74,9 @@ message SimpleRequest {
 
   // Whether SimpleResponse should include OAuth scope.
   optional bool fill_oauth_scope = 5;
+
+  // Whether SimpleResponse should include remote_address (the client address)
+  optional bool fill_remote_address = 6;
 }
 
 // Unary response, as configured by the request.
@@ -85,6 +88,8 @@ message SimpleResponse {
   optional string username = 2;
   // OAuth scope.
   optional string oauth_scope = 3;
+  // Remote Address (i.e. the client address)
+  optional string remote_address = 4;
 }
 
 message SimpleContext {

--- a/integration-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/integration-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -39,6 +39,7 @@ import io.netty.handler.ssl.SslContext;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -68,6 +69,11 @@ public class Http2NettyTest extends AbstractTransportTest {
   @AfterClass
   public static void stopServer() {
     stopStaticServer();
+  }
+
+  @Test(timeout = 10000)
+  public void remoteAddress() throws Exception {
+    testRemoteAddress("/127.0.0.1");
   }
 
   @Override

--- a/integration-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/integration-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -37,6 +37,7 @@ import io.grpc.transport.okhttp.OkHttpChannelBuilder;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -55,6 +56,11 @@ public class Http2OkHttpTest extends AbstractTransportTest {
   @AfterClass
   public static void stopServer() throws Exception {
     stopStaticServer();
+  }
+
+  @Test(timeout = 10000)
+  public void remoteAddress() throws Exception {
+    testRemoteAddress("/127.0.0.1");
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerTransport.java
@@ -34,6 +34,7 @@ package io.grpc.transport.netty;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.AbstractService;
 
+import io.grpc.GrpcSession;
 import io.grpc.transport.ServerListener;
 import io.grpc.transport.ServerTransportListener;
 import io.netty.channel.Channel;
@@ -52,6 +53,7 @@ import io.netty.handler.codec.http2.Http2InboundFrameLogger;
 import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
 import io.netty.handler.codec.http2.Http2StreamRemovalPolicy;
 import io.netty.handler.ssl.SslContext;
+import io.netty.util.Attribute;
 import io.netty.util.internal.logging.InternalLogLevel;
 
 import javax.annotation.Nullable;
@@ -106,6 +108,11 @@ class NettyServerTransport extends AbstractService {
     }
     channel.pipeline().addLast(streamRemovalPolicy);
     channel.pipeline().addLast(handler);
+
+    GrpcSession session = new GrpcSession(channel.remoteAddress());
+    Attribute<GrpcSession> attr = channel.attr(Utils.ATTRIBUTE_KEY_SESSION);
+    assert attr.get() == null;
+    attr.set(session);
 
     notifyStarted();
   }

--- a/netty/src/main/java/io/grpc/transport/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/transport/netty/Utils.java
@@ -34,6 +34,7 @@ package io.grpc.transport.netty;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import io.grpc.GrpcSession;
 import io.grpc.Metadata;
 import io.grpc.SharedResourceHolder.Resource;
 import io.grpc.transport.HttpUtil;
@@ -45,6 +46,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.AsciiString;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
@@ -75,6 +77,9 @@ class Utils {
 
   public static final Resource<EventLoopGroup> DEFAULT_WORKER_EVENT_LOOP_GROUP =
       new DefaultEventLoopGroupResource(0, "grpc-default-worker-ELG");
+
+  public static final AttributeKey<GrpcSession> ATTRIBUTE_KEY_SESSION =
+      AttributeKey.valueOf(GrpcSession.class, "GrpcSession");
 
   /**
    * Copies the content of the given {@link ByteBuffer} to a new {@link ByteBuf} instance.


### PR DESCRIPTION
Starting with a very minimal implementation:
the GrpcCallContext is set on a thread-local for onHalfClose,
it has a reference to a GrpcSession;
GrpcSession has a remoteAddress which is tested.