### PR TITLE
Fix the issue where the intecepting call fails in start(), does not call super.start(), and makes the subsequent use of other methods on the call throw IllegalStateException.

### DIFF
--- a/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
+++ b/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
@@ -78,7 +78,7 @@ public class ClientAuthInterceptor implements ClientInterceptor {
       @Override
       protected Call<ReqT, RespT> delegate() {
         if (startFailed) {
-          return ClientInterceptors.noopCall(realCall);
+          return ClientInterceptors.noopCall();
         } else {
           return realCall;
         }

--- a/core/src/main/java/io/grpc/ClientInterceptors.java
+++ b/core/src/main/java/io/grpc/ClientInterceptors.java
@@ -186,32 +186,31 @@ public class ClientInterceptors {
    * A {@link Call.Listener} which forwards all of its methods to another
    * {@link Call.Listener}.
    */
-  public static class ForwardingListener<T> extends Call.Listener<T> {
+  public static abstract class ForwardingListener<T> extends Call.Listener<T> {
 
-    private final Call.Listener<T> delegate;
-
-    public ForwardingListener(Call.Listener<T> delegate) {
-      this.delegate = delegate;
-    }
+    /**
+     * Returns the delegated {@code Call.Listener}
+     */
+    protected abstract Call.Listener<T> delegate();
 
     @Override
     public void onHeaders(Metadata.Headers headers) {
-      delegate.onHeaders(headers);
+      delegate().onHeaders(headers);
     }
 
     @Override
     public void onPayload(T payload) {
-      delegate.onPayload(payload);
+      delegate().onPayload(payload);
     }
 
     @Override
     public void onClose(Status status, Metadata.Trailers trailers) {
-      delegate.onClose(status, trailers);
+      delegate().onClose(status, trailers);
     }
 
     @Override
     public void onReady(int numMessages) {
-      delegate.onReady(numMessages);
+      delegate().onReady(numMessages);
     }
   }
 }

--- a/core/src/main/java/io/grpc/ClientInterceptors.java
+++ b/core/src/main/java/io/grpc/ClientInterceptors.java
@@ -115,7 +115,7 @@ public class ClientInterceptors {
   /**
    * A {@link Call} which forwards all of it's methods to another {@link Call}.
    */
-  public static abstract class ForwardingCall<ReqT, RespT> extends Call<ReqT, RespT> {
+  public abstract static class ForwardingCall<ReqT, RespT> extends Call<ReqT, RespT> {
 
     /**
      * Returns the delegated {@code Call}
@@ -186,7 +186,7 @@ public class ClientInterceptors {
    * A {@link Call.Listener} which forwards all of its methods to another
    * {@link Call.Listener}.
    */
-  public static abstract class ForwardingListener<T> extends Call.Listener<T> {
+  public abstract static class ForwardingListener<T> extends Call.Listener<T> {
 
     /**
      * Returns the delegated {@code Call.Listener}

--- a/core/src/main/java/io/grpc/ClientInterceptors.java
+++ b/core/src/main/java/io/grpc/ClientInterceptors.java
@@ -174,11 +174,9 @@ public class ClientInterceptors {
    * IllegalStateException}, before it's notified of the error through the listener.  {@link
    * ForwardingCall#delegate()} should return {@code noopCall()} in this case to prevent the {@code
    * IllegalStateException}.
-   *
-   * @param delegate the real delegate of the {@code ForwardingCall}
    */
   @SuppressWarnings("unchecked")
-  public static <ReqT, RespT> Call<ReqT, RespT> noopCall(Call<ReqT, RespT> delegate) {
+  public static <ReqT, RespT> Call<ReqT, RespT> noopCall() {
     return (Call<ReqT, RespT>) NOOP_CALL;
   }
 

--- a/core/src/main/java/io/grpc/ServerInterceptors.java
+++ b/core/src/main/java/io/grpc/ServerInterceptors.java
@@ -146,37 +146,36 @@ public class ServerInterceptors {
   /**
    * Utility base class for decorating {@link ServerCall} instances.
    */
-  public static class ForwardingServerCall<RespT> extends ServerCall<RespT> {
+  public abstract static class ForwardingServerCall<RespT> extends ServerCall<RespT> {
 
-    private final ServerCall<RespT> delegate;
-
-    public ForwardingServerCall(ServerCall<RespT> delegate) {
-      this.delegate = delegate;
-    }
+    /**
+     * Returns the delegated {@code ServerCall}
+     */
+    protected abstract ServerCall<RespT> delegate();
 
     @Override
     public void request(int numMessages) {
-      delegate.request(numMessages);
+      delegate().request(numMessages);
     }
 
     @Override
     public void sendHeaders(Metadata.Headers headers) {
-      delegate.sendHeaders(headers);
+      delegate().sendHeaders(headers);
     }
 
     @Override
     public void sendPayload(RespT payload) {
-      delegate.sendPayload(payload);
+      delegate().sendPayload(payload);
     }
 
     @Override
     public void close(Status status, Metadata.Trailers trailers) {
-      delegate.close(status, trailers);
+      delegate().close(status, trailers);
     }
 
     @Override
     public boolean isCancelled() {
-      return delegate.isCancelled();
+      return delegate().isCancelled();
     }
   }
 

--- a/core/src/main/java/io/grpc/ServerInterceptors.java
+++ b/core/src/main/java/io/grpc/ServerInterceptors.java
@@ -182,37 +182,36 @@ public class ServerInterceptors {
   /**
    * Utility base class for decorating {@link ServerCall.Listener} instances.
    */
-  public static class ForwardingListener<RespT> extends ServerCall.Listener<RespT> {
+  public abstract static class ForwardingListener<RespT> extends ServerCall.Listener<RespT> {
 
-    private final ServerCall.Listener<RespT> delegate;
-
-    public ForwardingListener(ServerCall.Listener<RespT> delegate) {
-      this.delegate = delegate;
-    }
+    /**
+     * Returns the delegated {@code ServerCall.Listener}
+     */
+    protected abstract ServerCall.Listener<RespT> delegate();
 
     @Override
     public void onPayload(RespT payload) {
-      delegate.onPayload(payload);
+      delegate().onPayload(payload);
     }
 
     @Override
     public void onHalfClose() {
-      delegate.onHalfClose();
+      delegate().onHalfClose();
     }
 
     @Override
     public void onCancel() {
-      delegate.onCancel();
+      delegate().onCancel();
     }
 
     @Override
     public void onComplete() {
-      delegate.onComplete();
+      delegate().onComplete();
     }
 
     @Override
     public void onReady(int numMessages) {
-      delegate.onReady(numMessages);
+      delegate().onReady(numMessages);
     }
   }
 }

--- a/core/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -226,8 +226,13 @@ public class ClientInterceptorsTest {
           }
 
           @Override
-          public void start(Call.Listener<RespT> responseListener, Metadata.Headers headers) {
-            super.start(new ForwardingListener<RespT>(responseListener) {
+          public void start(final Call.Listener<RespT> responseListener, Metadata.Headers headers) {
+            super.start(new ForwardingListener<RespT>() {
+              @Override
+              protected Listener<RespT> delegate() {
+                return responseListener;
+              }
+
               @Override
               public void onHeaders(Metadata.Headers headers) {
                 examinedHeaders.add(headers);

--- a/core/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -32,8 +32,13 @@
 package io.grpc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -52,6 +57,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,6 +80,18 @@ public class ClientInterceptorsTest {
   @Before public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(channel.newCall(Mockito.<MethodDescriptor<String, Integer>>any())).thenReturn(call);
+
+    // Emulate the precondition checks in ChannelImpl.CallImpl
+    Answer<Void> checkStartCalled = new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) {
+        verify(call).start(Mockito.<Call.Listener<Integer>>any(), Mockito.<Metadata.Headers>any());
+        return null;
+      }
+    };
+    doAnswer(checkStartCalled).when(call).request(anyInt());
+    doAnswer(checkStartCalled).when(call).halfClose();
+    doAnswer(checkStartCalled).when(call).sendPayload(Mockito.<String>any());
   }
 
   @Test(expected = NullPointerException.class)
@@ -164,8 +183,13 @@ public class ClientInterceptorsTest {
       @Override
       public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
           Channel next) {
-        Call<ReqT, RespT> call = next.newCall(method);
-        return new ForwardingCall<ReqT, RespT>(call) {
+        final Call<ReqT, RespT> call = next.newCall(method);
+        return new ForwardingCall<ReqT, RespT>() {
+          @Override
+          protected Call<ReqT, RespT> delegate() {
+            return call;
+          }
+
           @Override
           public void start(Call.Listener<RespT> responseListener, Metadata.Headers headers) {
             headers.put(credKey, "abcd");
@@ -194,8 +218,13 @@ public class ClientInterceptorsTest {
       @Override
       public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
           Channel next) {
-        Call<ReqT, RespT> call = next.newCall(method);
-        return new ForwardingCall<ReqT, RespT>(call) {
+        final Call<ReqT, RespT> call = next.newCall(method);
+        return new ForwardingCall<ReqT, RespT>() {
+          @Override
+          protected Call<ReqT, RespT> delegate() {
+            return call;
+          }
+
           @Override
           public void start(Call.Listener<RespT> responseListener, Metadata.Headers headers) {
             super.start(new ForwardingListener<RespT>(responseListener) {
@@ -221,6 +250,86 @@ public class ClientInterceptorsTest {
     // Simulate that a headers arrives on the underlying call listener.
     captor.getValue().onHeaders(inboundHeaders);
     assertEquals(Arrays.asList(inboundHeaders), examinedHeaders);
+  }
+
+  @Test
+  public void normalCall() {
+    ClientInterceptor interceptor = new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+          Channel next) {
+        final Call<ReqT, RespT> call = next.newCall(method);
+        return new ForwardingCall<ReqT, RespT>() {
+          @Override
+          protected Call<ReqT, RespT> delegate() {
+            return call;
+          }
+        };
+      }
+    };
+    Channel intercepted = ClientInterceptors.intercept(channel, interceptor);
+    Call<String, Integer> interceptedCall = intercepted.newCall(method);
+    assertNotSame(call, interceptedCall);
+    @SuppressWarnings("unchecked")
+    Call.Listener<Integer> listener = mock(Call.Listener.class);
+    Metadata.Headers headers = new Metadata.Headers();
+    interceptedCall.start(listener, headers);
+    verify(call).start(same(listener), same(headers));
+    interceptedCall.sendPayload("request");
+    verify(call).sendPayload(eq("request"));
+    interceptedCall.halfClose();
+    verify(call).halfClose();
+    interceptedCall.request(1);
+    verify(call).request(1);
+  }
+
+  @Test
+  public void exceptionInStart() {
+    final Exception error = new Exception("emulated error");
+    ClientInterceptor interceptor = new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+          Channel next) {
+        final Call<ReqT, RespT> call = next.newCall(method);
+        return new ForwardingCall<ReqT, RespT>() {
+          private boolean startFailed;
+
+          @Override
+          protected Call<ReqT, RespT> delegate() {
+            if (startFailed) {
+              return ClientInterceptors.noopCall(call);
+            } else {
+              return call;
+            }
+          }
+
+          @Override
+          public void start(Call.Listener<RespT> responseListener, Metadata.Headers headers) {
+            try {
+              throw error;
+              // Normally we call super.start() here, but it will be skipped because of the
+              // exception
+            } catch (Exception e) {
+              startFailed = true;
+              responseListener.onClose(Status.fromThrowable(e), new Metadata.Trailers());
+            }
+          }
+        };
+      }
+    };
+    Channel intercepted = ClientInterceptors.intercept(channel, interceptor);
+    @SuppressWarnings("unchecked")
+    Call.Listener<Integer> listener = mock(Call.Listener.class);
+    Call<String, Integer> interceptedCall = intercepted.newCall(method);
+    assertNotSame(call, interceptedCall);
+    interceptedCall.start(listener, new Metadata.Headers());
+    interceptedCall.sendPayload("request");
+    interceptedCall.halfClose();
+    interceptedCall.request(1);
+    verifyNoMoreInteractions(call);
+    ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
+    verify(listener).onClose(captor.capture(), any(Metadata.Trailers.class));
+    assertSame(error, captor.getValue().getCause());
   }
 
   private static class NoopInterceptor implements ClientInterceptor {

--- a/core/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -302,7 +302,7 @@ public class ClientInterceptorsTest {
           @Override
           protected Call<ReqT, RespT> delegate() {
             if (startFailed) {
-              return ClientInterceptors.noopCall(call);
+              return ClientInterceptors.noopCall();
             } else {
               return call;
             }

--- a/stub/src/main/java/io/grpc/stub/MetadataUtils.java
+++ b/stub/src/main/java/io/grpc/stub/MetadataUtils.java
@@ -73,7 +73,13 @@ public class MetadataUtils {
       @Override
       public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
           Channel next) {
-        return new ForwardingCall<ReqT, RespT>(next.newCall(method)) {
+        final Call<ReqT, RespT> realCall = next.newCall(method);
+        return new ForwardingCall<ReqT, RespT>() {
+          @Override
+          protected Call<ReqT, RespT> delegate() {
+            return realCall;
+          }
+
           @Override
           public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
             headers.merge(extraHeaders);
@@ -116,7 +122,13 @@ public class MetadataUtils {
       @Override
       public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
           Channel next) {
-        return new ForwardingCall<ReqT, RespT>(next.newCall(method)) {
+        final Call<ReqT, RespT> realCall = next.newCall(method);
+        return new ForwardingCall<ReqT, RespT>() {
+          @Override
+          protected Call<ReqT, RespT> delegate() {
+            return realCall;
+          }
+
           @Override
           public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
             headersCapture.set(null);

--- a/stub/src/main/java/io/grpc/stub/MetadataUtils.java
+++ b/stub/src/main/java/io/grpc/stub/MetadataUtils.java
@@ -130,10 +130,15 @@ public class MetadataUtils {
           }
 
           @Override
-          public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
+          public void start(final Listener<RespT> responseListener, Metadata.Headers headers) {
             headersCapture.set(null);
             trailersCapture.set(null);
-            super.start(new ForwardingListener<RespT>(responseListener) {
+            super.start(new ForwardingListener<RespT>() {
+              @Override
+              protected Listener<RespT> delegate() {
+                return responseListener;
+              }
+
               @Override
               public void onHeaders(Metadata.Headers headers) {
                 headersCapture.set(headers);

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -56,12 +56,17 @@ public class TestUtils {
     return new ServerInterceptor() {
       @Override
       public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(String method,
-           ServerCall<RespT> call,
+           final ServerCall<RespT> call,
            final Metadata.Headers requestHeaders,
            ServerCallHandler<ReqT, RespT> next) {
         ServerCall.Listener<ReqT> listener = next.startCall(method,
-            new ServerInterceptors.ForwardingServerCall<RespT>(call) {
+            new ServerInterceptors.ForwardingServerCall<RespT>() {
               boolean sentHeaders;
+
+              @Override
+              protected ServerCall<RespT> delegate() {
+                return call;
+              }
 
               @Override
               public void sendHeaders(Metadata.Headers responseHeaders) {


### PR DESCRIPTION
Fix the issue where the intecepting call fails in start(), does not call super.start(), and makes the subsequent use of other methods on the call throw IllegalStateException.

Change ForwardingCall to an abstract class with a delegate(). ClientAuthInterceptor will delegate to a no-op Call if start has failed.

Also change ForwardingListener and the server-side counterparts to the same pattern. 

This is an alternative to #251 as suggested by @ejona86