### PR TITLE
Remove "Operation" from Status exceptions

### DIFF
--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -49,10 +49,10 @@ import javax.annotation.concurrent.Immutable;
  * information: {@code Status.NOT_FOUND.withDescription("Could not find 'important_file.txt'");}
  *
  * <p>For clients, every remote call will return a status on completion. In the case of errors this
- * status may be propagated to blocking stubs as a {@link java.lang.RuntimeException} or to
- * a listener as an explicit parameter.
+ * status may be propagated to blocking stubs as a {@link RuntimeException} or to a listener as an
+ * explicit parameter.
  *
- * <p>Similarly servers can report a status by throwing {@link OperationRuntimeException}
+ * <p>Similarly servers can report a status by throwing {@link StatusRuntimeException}
  * or by passing the status to a callback.
  *
  * <p>Utility functions are provided to convert a status to an exception and to extract them
@@ -424,16 +424,16 @@ public final class Status {
    * Convert this {@link Status} to a {@link RuntimeException}. Use {@code #fromThrowable}
    * to recover this {@link Status} instance when the returned exception is in the causal chain.
    */
-  public RuntimeException asRuntimeException() {
-    return new OperationRuntimeException(this);
+  public StatusRuntimeException asRuntimeException() {
+    return new StatusRuntimeException(this);
   }
 
   /**
    * Convert this {@link Status} to an {@link Exception}. Use {@code #fromThrowable}
    * to recover this {@link Status} instance when the returned exception is in the causal chain.
    */
-  public Exception asException() {
-    return new OperationException(this);
+  public StatusException asException() {
+    return new StatusException(this);
   }
 
   /** A string representation of the status useful for debugging. */
@@ -450,7 +450,10 @@ public final class Status {
 
   /**
    * Exception thrown by implementations while managing an operation.
+   *
+   * @deprecated Use {@link StatusException} instead
    */
+  @Deprecated
   public static class OperationException extends Exception {
     private static final long serialVersionUID = -660954903976144640L;
     private final Status status;
@@ -467,7 +470,10 @@ public final class Status {
 
   /**
    * Runtime exception thrown by implementations while managing an operation.
+   *
+   * @deprecated Use {@link StatusRuntimeException} instead
    */
+  @Deprecated
   public static class OperationRuntimeException extends RuntimeException {
     private static final long serialVersionUID = 1950934672280720624L;
     private final Status status;

--- a/core/src/main/java/io/grpc/StatusException.java
+++ b/core/src/main/java/io/grpc/StatusException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+/**
+ * {@link Status} in Exception form, for propagating Status information via exceptions.
+ *
+ * @see StatusRuntimeException
+ */
+@SuppressWarnings("deprecation")
+public class StatusException extends Status.OperationException {
+  public StatusException(Status status) {
+    super(status);
+  }
+}

--- a/core/src/main/java/io/grpc/StatusRuntimeException.java
+++ b/core/src/main/java/io/grpc/StatusRuntimeException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+/**
+ * {@link Status} in RuntimeException form, for propagating Status information via exceptions.
+ *
+ * @see StatusException
+ */
+@SuppressWarnings("deprecation")
+public class StatusRuntimeException extends Status.OperationRuntimeException {
+  public StatusRuntimeException(Status status) {
+    super(status);
+  }
+}


### PR DESCRIPTION
Operation is a term no longer used in gRPC. Status.Exception seems clear
and is concise.

The return types of as\*Exception() is now explicitly the
Status.\*Exception type.

@louiscryan, thoughts?