### PR TITLE
Respect MAX_CONCURRENT_STREAMS in OkHttp client.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/OkHttpSettingsUtil.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/OkHttpSettingsUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.squareup.okhttp.internal.spdy;
+
+/**
+ * A utility class help gRPC get/set the necessary fields of OkHttp's Settings.
+ */
+public class OkHttpSettingsUtil {
+  public static final int MAX_CONCURRENT_STREAMS = Settings.MAX_CONCURRENT_STREAMS;
+
+  public static boolean isSet(Settings settings, int id) {
+    return settings.isSet(id);
+  }
+
+  public static int get(Settings settings, int id) {
+    return settings.get(id);
+  }
+
+  public static void set(Settings settings, int id, int value) {
+    settings.set(id, 0, value);
+  }
+}


### PR DESCRIPTION
If a newStream is called  while MAX_CONCURRENT_STREAMS is reached, then get the call blocked and the request queued, until:
1. a running stream closed, and this newStream() request is accepted.
2. receives go-away from server, fail all pending new stream requests.
3. the available ids are exhausted.