### PR TITLE
Temporally support Http protocol name "h2-16" for OkHttp client.

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
+++ b/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
@@ -68,10 +68,12 @@ import javax.net.ssl.SSLEngine;
  * endpoint.
  */
 public class Http2Negotiator {
+  // TODO(madongfly): Remove "h2-15" and "h2-16" at a right time.
   private static final List<String> SUPPORTED_PROTOCOLS = Collections.unmodifiableList(
       Arrays.asList(
           Http2OrHttpChooser.SelectedProtocol.HTTP_2.protocolName(),
-          "h2-15"));
+          "h2-15",
+          "h2-16"));
 
   // Prefer ALPN to NPN so try it first.
   private static final String[] JETTY_TLS_NEGOTIATION_IMPL =


### PR DESCRIPTION
Fixes #22 for real.

Manually tested with jdk8 by:
./run-test-server.sh
./run-test-client.sh --server_host_override=foo.test.google.fr --use_test_ca=true --use_okhttp=true