### PR TITLE
okhttp:Clean up stream after AbstractClientStream.inboundTransportError

### DIFF
--- a/core/src/main/java/io/grpc/transport/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractClientStream.java
@@ -253,8 +253,14 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
       listenerClosed = true;
       closeDeframer();
       listener.closed(newStatus, trailers);
+      onListenerClosed();
     }
   }
+
+  /**
+   * Be called right after the listener is closed.
+   */
+  protected abstract void onListenerClosed();
 
   /**
    * Executes the pending listener close task, if one exists.

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
@@ -92,4 +92,9 @@ class NettyClientStream extends Http2ClientStream {
   protected void returnProcessedBytes(int processedBytes) {
     handler.returnProcessedBytes(id(), processedBytes);
   }
+
+  @Override
+  protected void onListenerClosed() {
+    // Do nothing.
+  }
 }

--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
@@ -148,18 +148,8 @@ class OkHttpClientStream extends Http2ClientStream {
 
   @Override
   protected void sendCancel() {
-    if (transport.finishStream(id(), Status.CANCELLED)) {
-      frameWriter.rstStream(id(), ErrorCode.CANCEL);
-      transport.stopIfNecessary();
-    }
-  }
-
-  @Override
-  public void remoteEndClosed() {
-    super.remoteEndClosed();
-    if (transport.finishStream(id(), null)) {
-      transport.stopIfNecessary();
-    }
+    frameWriter.rstStream(id(), ErrorCode.CANCEL);
+    transportReportStatus(Status.CANCELLED, true, new Metadata.Trailers());
   }
 
   void setOutboundFlowState(Object outboundFlowState) {
@@ -168,5 +158,12 @@ class OkHttpClientStream extends Http2ClientStream {
 
   Object getOutboundFlowState() {
     return outboundFlowState;
+  }
+
+  @Override
+  protected void onListenerClosed() {
+    if (id() != null) {
+      transport.removeStream(id());
+    }
   }
 }


### PR DESCRIPTION
With this change, the stream removal will be done by AbstractClientStream.onListenerClosed(), which is called right after the stream closed the stream listener.

Resolves #279