### PR TITLE
Fix the issue where the intercepting call fails in start(), does not call super.start(), and makes the subsequent use of other methods on the call throw IllegalStateException.

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingCall.java
+++ b/core/src/main/java/io/grpc/ForwardingCall.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+/**
+ * A {@link Call} which forwards all of it's methods to another {@link Call}.
+ */
+public abstract class ForwardingCall<ReqT, RespT> extends Call<ReqT, RespT> {
+  /**
+   * Returns the delegated {@code Call}.
+   */
+  protected abstract Call<ReqT, RespT> delegate();
+
+  @Override
+  public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
+    this.delegate().start(responseListener, headers);
+  }
+
+  @Override
+  public void request(int numMessages) {
+    this.delegate().request(numMessages);
+  }
+
+  @Override
+  public void cancel() {
+    this.delegate().cancel();
+  }
+
+  @Override
+  public void halfClose() {
+    this.delegate().halfClose();
+  }
+
+  @Override
+  public void sendPayload(ReqT payload) {
+    this.delegate().sendPayload(payload);
+  }
+
+  /**
+   * A simplified version of {@link ForwardingCall} where subclasses can pass in a {@link Call} as
+   * the delegate.
+   */
+  public abstract static class SimpleForwardingCall<ReqT, RespT>
+      extends ForwardingCall<ReqT, RespT> {
+    private final Call<ReqT, RespT> delegate;
+
+    protected SimpleForwardingCall(Call<ReqT, RespT> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    protected Call<ReqT, RespT> delegate() {
+      return delegate;
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/ForwardingCallListener.java
+++ b/core/src/main/java/io/grpc/ForwardingCallListener.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+/**
+ * A {@link Call.Listener} which forwards all of its methods to another {@link Call.Listener}.
+ */
+public abstract class ForwardingCallListener<RespT> extends Call.Listener<RespT> {
+  /**
+   * Returns the delegated {@code Call.Listener}.
+   */
+  protected abstract Call.Listener<RespT> delegate();
+
+  @Override
+  public void onHeaders(Metadata.Headers headers) {
+    delegate().onHeaders(headers);
+  }
+
+  @Override
+  public void onPayload(RespT payload) {
+    delegate().onPayload(payload);
+  }
+
+  @Override
+  public void onClose(Status status, Metadata.Trailers trailers) {
+    delegate().onClose(status, trailers);
+  }
+
+  @Override
+  public void onReady(int numMessages) {
+    delegate().onReady(numMessages);
+  }
+
+  /**
+   * A simplified version of {@link ForwardingCallListener} where subclasses can pass in a {@link
+   * Call.Listener} as the delegate.
+   */
+  public abstract static class SimpleForwardingCallListener<RespT>
+      extends ForwardingCallListener<RespT> {
+
+    private final Call.Listener<RespT> delegate;
+
+    protected SimpleForwardingCallListener(Call.Listener<RespT> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    protected Call.Listener<RespT> delegate() {
+      return delegate;
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/ForwardingServerCall.java
+++ b/core/src/main/java/io/grpc/ForwardingServerCall.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+/**
+ * A {@link ServerCall} which forwards all of it's methods to another {@link ServerCall}.
+ */
+public abstract class ForwardingServerCall<RespT> extends ServerCall<RespT> {
+  /**
+   * Returns the delegated {@code ServerCall}.
+   */
+  protected abstract ServerCall<RespT> delegate();
+
+  @Override
+  public void request(int numMessages) {
+    delegate().request(numMessages);
+  }
+
+  @Override
+  public void sendHeaders(Metadata.Headers headers) {
+    delegate().sendHeaders(headers);
+  }
+
+  @Override
+  public void sendPayload(RespT payload) {
+    delegate().sendPayload(payload);
+  }
+
+  @Override
+  public void close(Status status, Metadata.Trailers trailers) {
+    delegate().close(status, trailers);
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return delegate().isCancelled();
+  }
+
+  /**
+   * A simplified version of {@link ForwardingServerCall} where subclasses can pass in a {@link
+   * ServerCall} as the delegate.
+   */
+  public abstract static class SimpleForwardingServerCall<RespT>
+      extends ForwardingServerCall<RespT> {
+
+    private final ServerCall<RespT> delegate;
+
+    protected SimpleForwardingServerCall(ServerCall<RespT> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    protected ServerCall<RespT> delegate() {
+      return delegate;
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/ForwardingServerCallListener.java
+++ b/core/src/main/java/io/grpc/ForwardingServerCallListener.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+/**
+ * A {@link ServerCall.Listener} which forwards all of its methods to another {@link
+ * ServerCall.Listener}.
+ */
+public abstract class ForwardingServerCallListener<ReqT> extends ServerCall.Listener<ReqT> {
+  /**
+   * Returns the delegated {@code ServerCall.Listener}.
+   */
+  protected abstract ServerCall.Listener<ReqT> delegate();
+
+  @Override
+  public void onPayload(ReqT payload) {
+    delegate().onPayload(payload);
+  }
+
+  @Override
+  public void onHalfClose() {
+    delegate().onHalfClose();
+  }
+
+  @Override
+  public void onCancel() {
+    delegate().onCancel();
+  }
+
+  @Override
+  public void onComplete() {
+    delegate().onComplete();
+  }
+
+  @Override
+  public void onReady(int numMessages) {
+    delegate().onReady(numMessages);
+  }
+
+  /**
+   * A simplified version of {@link ForwardingServerCallListener} where subclasses can pass in a
+   * {@link ServerCall.Listener} as the delegate.
+   */
+  public abstract static class SimpleForwardingServerCallListener<ReqT>
+      extends ForwardingServerCallListener<ReqT> {
+
+    private final ServerCall.Listener<ReqT> delegate;
+
+    protected SimpleForwardingServerCallListener(ServerCall.Listener<ReqT> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    protected ServerCall.Listener<ReqT> delegate() {
+      return delegate;
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/ServerInterceptors.java
+++ b/core/src/main/java/io/grpc/ServerInterceptors.java
@@ -34,6 +34,9 @@ package io.grpc;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -145,75 +148,25 @@ public class ServerInterceptors {
 
   /**
    * Utility base class for decorating {@link ServerCall} instances.
+   *
+   * @deprecated Use {@link SimpleForwardingServerCall}
    */
-  public static class ForwardingServerCall<RespT> extends ServerCall<RespT> {
-
-    private final ServerCall<RespT> delegate;
-
+  @Deprecated
+  public static class ForwardingServerCall<RespT> extends SimpleForwardingServerCall<RespT> {
     public ForwardingServerCall(ServerCall<RespT> delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public void request(int numMessages) {
-      delegate.request(numMessages);
-    }
-
-    @Override
-    public void sendHeaders(Metadata.Headers headers) {
-      delegate.sendHeaders(headers);
-    }
-
-    @Override
-    public void sendPayload(RespT payload) {
-      delegate.sendPayload(payload);
-    }
-
-    @Override
-    public void close(Status status, Metadata.Trailers trailers) {
-      delegate.close(status, trailers);
-    }
-
-    @Override
-    public boolean isCancelled() {
-      return delegate.isCancelled();
+      super(delegate);
     }
   }
 
   /**
    * Utility base class for decorating {@link ServerCall.Listener} instances.
+   *
+   * @deprecated Use {@link SimpleForwardingServerCallListener}
    */
-  public static class ForwardingListener<RespT> extends ServerCall.Listener<RespT> {
-
-    private final ServerCall.Listener<RespT> delegate;
-
-    public ForwardingListener(ServerCall.Listener<RespT> delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public void onPayload(RespT payload) {
-      delegate.onPayload(payload);
-    }
-
-    @Override
-    public void onHalfClose() {
-      delegate.onHalfClose();
-    }
-
-    @Override
-    public void onCancel() {
-      delegate.onCancel();
-    }
-
-    @Override
-    public void onComplete() {
-      delegate.onComplete();
-    }
-
-    @Override
-    public void onReady(int numMessages) {
-      delegate.onReady(numMessages);
+  @Deprecated
+  public static class ForwardingListener<ReqT> extends SimpleForwardingServerCallListener<ReqT> {
+    public ForwardingListener(ServerCall.Listener<ReqT> delegate) {
+      super(delegate);
     }
   }
 }

--- a/stub/src/main/java/io/grpc/stub/MetadataUtils.java
+++ b/stub/src/main/java/io/grpc/stub/MetadataUtils.java
@@ -34,8 +34,8 @@ package io.grpc.stub;
 import io.grpc.Call;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
-import io.grpc.ClientInterceptors.ForwardingCall;
-import io.grpc.ClientInterceptors.ForwardingListener;
+import io.grpc.ForwardingCall.SimpleForwardingCall;
+import io.grpc.ForwardingCallListener.SimpleForwardingCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -73,7 +73,7 @@ public class MetadataUtils {
       @Override
       public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
           Channel next) {
-        return new ForwardingCall<ReqT, RespT>(next.newCall(method)) {
+        return new SimpleForwardingCall<ReqT, RespT>(next.newCall(method)) {
           @Override
           public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
             headers.merge(extraHeaders);
@@ -116,12 +116,12 @@ public class MetadataUtils {
       @Override
       public <ReqT, RespT> Call<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
           Channel next) {
-        return new ForwardingCall<ReqT, RespT>(next.newCall(method)) {
+        return new SimpleForwardingCall<ReqT, RespT>(next.newCall(method)) {
           @Override
           public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
             headersCapture.set(null);
             trailersCapture.set(null);
-            super.start(new ForwardingListener<RespT>(responseListener) {
+            super.start(new SimpleForwardingCallListener<RespT>(responseListener) {
               @Override
               public void onHeaders(Metadata.Headers headers) {
                 headersCapture.set(headers);

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -31,11 +31,11 @@
 
 package io.grpc.testing;
 
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 
 import java.util.Arrays;
@@ -60,7 +60,7 @@ public class TestUtils {
            final Metadata.Headers requestHeaders,
            ServerCallHandler<ReqT, RespT> next) {
         ServerCall.Listener<ReqT> listener = next.startCall(method,
-            new ServerInterceptors.ForwardingServerCall<RespT>(call) {
+            new SimpleForwardingServerCall<RespT>(call) {
               boolean sentHeaders;
 
               @Override


### PR DESCRIPTION
- Create ``ClientInterceptors.CheckedForwardingCall`` that handles exceptions in start logic.
- Create ``Forwarding[Server]Call[Listener]`` for generic decoration use cases, with ``abstract delegate()`` for flexibility.
- Create ``SimpleForwarding[Server]Call[Listener]`` to replace now deprecated forwarding classes.

This is an alternative to #264
@ejona86 please take a look.
Resolves #240