### PR TITLE
OkHttp: Temporally support multiple h2-xx protocol on client side.

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
+++ b/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
@@ -68,10 +68,11 @@ import javax.net.ssl.SSLEngine;
  * endpoint.
  */
 public class Http2Negotiator {
-  // TODO(madongfly): Remove "h2-15" and "h2-16" at a right time.
+  // TODO(madongfly): Remove "h2-xx" at a right time.
   private static final List<String> SUPPORTED_PROTOCOLS = Collections.unmodifiableList(
       Arrays.asList(
           Http2OrHttpChooser.SelectedProtocol.HTTP_2.protocolName(),
+          "h2-14",
           "h2-15",
           "h2-16"));
 


### PR DESCRIPTION
Since the user provided SSLSocketFactory (especially in Android) may already do the handshake when creates the SSLSocket, and it may choose a different protocol name other than the one OkHttp is using.

Resolves #293