### PR TITLE
Remove Guava's Service from server transport

### DIFF
--- a/core/src/main/java/io/grpc/AbstractChannelBuilder.java
+++ b/core/src/main/java/io/grpc/AbstractChannelBuilder.java
@@ -127,7 +127,7 @@ public abstract class AbstractChannelBuilder<BuilderT extends AbstractChannelBui
      * Constructor.
      *
      * @param transportFactory the created channel uses this factory to create transports
-     * @param terminationRunnable will be called at the channel's life-cycle events
+     * @param terminationRunnable will be called at the channel termination
      */
     public ChannelEssentials(ClientTransportFactory transportFactory,
         @Nullable Runnable terminationRunnable) {

--- a/core/src/main/java/io/grpc/transport/Server.java
+++ b/core/src/main/java/io/grpc/transport/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,24 +31,26 @@
 
 package io.grpc.transport;
 
+import java.io.IOException;
+
 /**
- * A listener to a server for transport creation events. Notifications must occur from the transport
- * thread.
+ * A server accepts new incomming connections. This is would commonly encapsulate a bound socket
+ * that {@code accept(}}s new connections.
  */
-public interface ServerListener {
-
+public interface Server {
   /**
-   * Called upon the establishment of a new client connection.
+   * Starts transport. Implementations must not call {@code listener} until after {@code start()}
+   * returns. The method only returns after it has done the equivalent of bind()ing, so it will be
+   * able to service any connections created after returning.
    *
-   * @param transport the new transport to be observed.
-   * @return a listener for stream creation events on the transport.
+   * @param listener non-{@code null} listener of server events
+   * @throws IOException if unable to bind
    */
-  ServerTransportListener transportCreated(ServerTransport transport);
+  void start(ServerListener listener) throws IOException;
 
   /**
-   * The server is shutting down. No new transports will be processed, but existing streams may
-   * continue. Shutdown is only caused by a call to {@link Server#shutdown()}. All resources have
-   * been released.
+   * Initiates an orderly shutdown of the server. Existing transports continue, but new transports
+   * will not be created (once {@link ServerListener#serverShutdown()} callback called).
    */
-  void serverShutdown();
+  void shutdown();
 }

--- a/core/src/main/java/io/grpc/transport/ServerTransport.java
+++ b/core/src/main/java/io/grpc/transport/ServerTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,24 +31,12 @@
 
 package io.grpc.transport;
 
-/**
- * A listener to a server for transport creation events. Notifications must occur from the transport
- * thread.
- */
-public interface ServerListener {
-
+/** An inbound connection. */
+public interface ServerTransport {
   /**
-   * Called upon the establishment of a new client connection.
-   *
-   * @param transport the new transport to be observed.
-   * @return a listener for stream creation events on the transport.
+   * Initiates an orderly shutdown of the transport. Existing streams continue, but new streams will
+   * eventually begin failing. New streams "eventually" begin failing because shutdown may need to
+   * be processed on a separate thread.
    */
-  ServerTransportListener transportCreated(ServerTransport transport);
-
-  /**
-   * The server is shutting down. No new transports will be processed, but existing streams may
-   * continue. Shutdown is only caused by a call to {@link Server#shutdown()}. All resources have
-   * been released.
-   */
-  void serverShutdown();
+  void shutdown();
 }

--- a/core/src/main/java/io/grpc/transport/ServerTransportListener.java
+++ b/core/src/main/java/io/grpc/transport/ServerTransportListener.java
@@ -34,7 +34,8 @@ package io.grpc.transport;
 import io.grpc.Metadata;
 
 /**
- * A observer of a server-side transport for stream creation events.
+ * A observer of a server-side transport for stream creation events. Notifications must occur from
+ * the transport thread.
  */
 public interface ServerTransportListener {
 
@@ -48,4 +49,9 @@ public interface ServerTransportListener {
    */
   ServerStreamListener streamCreated(ServerStream stream, String method,
       Metadata.Headers headers);
+
+  /**
+   * The transport completed shutting down. All resources have been released.
+   */
+  void transportTerminated();
 }

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -80,7 +80,7 @@ public class RouteGuideServer {
   }
 
   /** Start serving requests. */
-  public void start() {
+  public void start() throws IOException {
     grpcServer = NettyServerBuilder.forPort(port)
         .addService(RouteGuideGrpc.bindService(new RouteGuideService(features)))
         .build().start();

--- a/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -71,6 +71,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -93,11 +94,14 @@ public abstract class AbstractTransportTest {
   protected static void startStaticServer(AbstractServerBuilder<?> builder) {
     testServiceExecutor = Executors.newScheduledThreadPool(2);
 
-    server = builder
-        .addService(ServerInterceptors.intercept(
-            TestServiceGrpc.bindService(new TestServiceImpl(testServiceExecutor)),
-            TestUtils.echoRequestHeadersInterceptor(Util.METADATA_KEY)))
-        .build().start();
+    builder.addService(ServerInterceptors.intercept(
+        TestServiceGrpc.bindService(new TestServiceImpl(testServiceExecutor)),
+        TestUtils.echoRequestHeadersInterceptor(Util.METADATA_KEY)));
+    try {
+      server = builder.build().start();
+    } catch (IOException ex) {
+      throw new RuntimeException(ex);
+    }
   }
 
   protected static void stopStaticServer() {


### PR DESCRIPTION
ServerImpl.start() now throws IOException to make the error explicit.
This was previously being papered over by wrapping the exception in
RuntimeException.

Resolves #35.