### PR TITLE
Fix netty closure check

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServer.java
@@ -121,7 +121,7 @@ public class NettyServer implements Server {
 
   @Override
   public void shutdown() {
-    if (channel == null || channel.isOpen()) {
+    if (channel == null || !channel.isOpen()) {
       return;
     }
     channel.close().addListener(new ChannelFutureListener() {


### PR DESCRIPTION
During Service removal a condition was inverted but incompletely, which
caused the Netty server to never shutdown.

@nmittler 