### PR TITLE
On Server side, use Status "UNKNOWN" instead of "INTERNAL" for errors ca...

### DIFF
--- a/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
+++ b/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
@@ -118,9 +118,9 @@ public class ClientAuthInterceptorTests {
     Iterable<String> authorization = headers.getAll(AUTHORIZATION);
     Assert.assertArrayEquals(new String[]{"token1", "token2"},
         Iterables.toArray(authorization, String.class));
-    Iterable<String> extraAuthrization = headers.getAll(EXTRA_AUTHORIZATION);
+    Iterable<String> extraAuthorization = headers.getAll(EXTRA_AUTHORIZATION);
     Assert.assertArrayEquals(new String[]{"token3", "token4"},
-        Iterables.toArray(extraAuthrization, String.class));
+        Iterables.toArray(extraAuthorization, String.class));
   }
 
   @Test
@@ -134,7 +134,7 @@ public class ClientAuthInterceptorTests {
     Mockito.verify(listener).onClose(statusCaptor.capture(), isA(Metadata.Trailers.class));
     Assert.assertNull(headers.getAll(AUTHORIZATION));
     Mockito.verify(call, never()).start(listener, headers);
-    Assert.assertEquals(Status.Code.INTERNAL, statusCaptor.getValue().getCode());
+    Assert.assertEquals(Status.Code.UNKNOWN, statusCaptor.getValue().getCode());
     Assert.assertNotNull(statusCaptor.getValue().getCause());
   }
 

--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -331,7 +331,7 @@ public final class Status {
       }
     }
     // Couldn't find a cause with a Status
-    return INTERNAL.withCause(t);
+    return UNKNOWN.withCause(t);
   }
 
   private static String formatThrowableMessage(Status status) {

--- a/netty/src/test/java/io/grpc/transport/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyServerHandlerTest.java
@@ -229,7 +229,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(streamListener).closed(captor.capture());
     assertEquals(e, captor.getValue().asException().getCause());
-    assertEquals(Code.INTERNAL, captor.getValue().getCode());
+    assertEquals(Code.UNKNOWN, captor.getValue().getCode());
   }
 
   @Test

--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
@@ -350,7 +350,7 @@ public class OkHttpClientTransport implements ClientTransport {
    */
   void abort(Throwable failureCause) {
     log.log(Level.SEVERE, "Transport failed", failureCause);
-    onGoAway(0, Status.fromThrowable(failureCause));
+    onGoAway(0, Status.INTERNAL.withCause(failureCause));
   }
 
   private void onGoAway(int lastKnownStreamId, Status status) {


### PR DESCRIPTION
...used by application code, and provid clearer description, so that the client can know that the error is caused by server-side application instead of gRPC library.

Per the discussion in #299.

@ejona86 @louiscryan 