### PR TITLE
Upgrade to com.google.protobuf:protobuf-gradle-plugin:0.1.0

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -55,7 +55,10 @@ applicationDistribution.into("bin") {
 }
 
 protobufCodeGenPlugins = ["java_plugin:$javaPluginPath"]
-generateProto.dependsOn ':grpc-compiler:local_archJava_pluginExecutable'
+
+project.afterEvaluate {
+  generateProto.dependsOn ':grpc-compiler:local_archJava_pluginExecutable'
+}
 
 // Allow intellij projects to refer to generated-sources
 idea {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ subprojects {
                 okhttp: 'com.squareup.okhttp:okhttp:2.2.0',
                 protobuf: 'com.google.protobuf:protobuf-java:3.0.0-alpha-2',
                 protobuf_nano: 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-2',
-                protobuf_plugin: 'ws.antonov.gradle.plugins:gradle-plugin-protobuf:0.9.1',
+                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.1.0',
 
                 // TODO: Unreleased dependencies.
                 // These must already be installed in the local maven repository.

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -194,7 +194,10 @@ artifacts {
 
 protobufCodeGenPlugins = ["java_plugin:$javaPluginPath"]
 
-generateTestProto.dependsOn 'local_archJava_pluginExecutable'
+project.afterEvaluate {
+  generateTestProto.dependsOn 'local_archJava_pluginExecutable'
+}
+
 // Ignore test for the moment on Windows. It will be easier to run once the
 // gradle protobuf plugin can support nano.
 if (osdetector.os != 'windows') {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,7 +23,10 @@ dependencies {
 }
 
 protobufCodeGenPlugins = ["java_plugin:$javaPluginPath"]
-generateProto.dependsOn ':grpc-compiler:local_archJava_pluginExecutable'
+
+project.afterEvaluate {
+  generateProto.dependsOn ':grpc-compiler:local_archJava_pluginExecutable'
+}
 
 task routeGuideServer(type: JavaExec) {
     main = "io.grpc.examples.routeguide.RouteGuideServer"

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -55,7 +55,10 @@ task execute(dependsOn: classes, type:JavaExec) {
 }
 
 protobufCodeGenPlugins = ["java_plugin:$javaPluginPath"]
-generateProto.dependsOn ':grpc-compiler:local_archJava_pluginExecutable'
+
+project.afterEvaluate {
+  generateProto.dependsOn ':grpc-compiler:local_archJava_pluginExecutable'
+}
 
 // Allow intellij projects to refer to generated-sources
 idea {


### PR DESCRIPTION
[Commit 76f0a09](https://github.com/aantono/gradle-plugin-protobuf/commit/76f0a09390763ee2d402ff0df79ae8cee396df2a) after the previous release
(ws.antonov.gradle.plugins:gradle-plugin-protobuf:0.9.1) defers the
generation of generateProto tasks to post-evaluation of the project,
which make them no longer available in the evaluation phase. We need to
move the manipulation of these tasks to post-evaluation too.

@ejona86 please review