### PR TITLE
Log stack traces of test failures to the console.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,4 +189,11 @@ subprojects {
             }
         }
     }
+    // At a test failure, log the stack trace to the console so that we don't
+    // have to open the HTML in a browser.
+    test {
+        testLogging {
+            exceptionFormat = 'full'
+        }
+    }
 }


### PR DESCRIPTION
By default we have to open a HTML page in a browser to see the details,
which is not possible if the test was run in Travis. Resolves #235

@ejona86 please review