### PR TITLE
Changing the protobuf branch name in the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The codegen plugin requires protobuf 3.0.0-alpha-2:
 ```
 $ git clone https://github.com/google/protobuf.git
 $ cd protobuf
-$ git checkout v3.0.0-alpha-2
+$ git checkout alpha-2-fix
 $ ./autogen.sh
 $ ./configure
 $ make


### PR DESCRIPTION
It looks like the protobuf repo changed.  v3.0.0-alpha-2 doesn't exist anymore.  I'm trying to install grpc, and I think I have the right branch in protobuf.