### PR TITLE
Update to protobuf-gradle-plugin:0.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ subprojects {
                 okhttp: 'com.squareup.okhttp:okhttp:2.2.0',
                 protobuf: 'com.google.protobuf:protobuf-java:3.0.0-alpha-2',
                 protobuf_nano: 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-2',
-                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.1.0',
+                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.2.1',
 
                 // TODO: Unreleased dependencies.
                 // These must already be installed in the local maven repository.
@@ -68,15 +68,8 @@ subprojects {
         alpnboot_package_name = 'org.mortbay.jetty.alpn:alpn-boot:' + alpnboot_version
 
         def exeSuffix = osdetector.os == 'windows' ? ".exe" : ""
-        // The split is to workaround everything after the colon in C:\ being
-        // removed due to a bug in the protobuf plugin.
-        // https://github.com/aantono/gradle-plugin-protobuf/issues/23
-        def splitRootDir = rootDir
-        if (osdetector.os == 'windows') {
-          splitRootDir = splitRootDir.getPath().split(":", 2)[1]
-        }
         protocPluginBaseName = 'protoc-gen-grpc-java'
-        javaPluginPath = "$splitRootDir/compiler/build/binaries/java_pluginExecutable/local_arch/$protocPluginBaseName$exeSuffix"
+        javaPluginPath = "$rootDir/compiler/build/binaries/java_pluginExecutable/local_arch/$protocPluginBaseName$exeSuffix"
     }
 
     dependencies {


### PR DESCRIPTION
Remove the workaround for windows paths as [the fix](https://github.com/google/protobuf-gradle-plugin/commit/2183166d9ad26bd033b5f16f8c64c57913b28662) is included in protobuf-gradle-plugin:0.2.1

@ejona86 please review