### PR TITLE
Upgrade to protobuf plugin 0.3.1

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'application'
-apply plugin: 'protobuf'
+apply plugin: 'com.google.protobuf'
 
 
 description = "grpc Benchmarks"

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ subprojects {
                 okhttp: 'com.squareup.okhttp:okhttp:2.2.0',
                 protobuf: 'com.google.protobuf:protobuf-java:3.0.0-alpha-2',
                 protobuf_nano: 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-2',
-                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.2.1',
+                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.3.1',
 
                 // TODO: Unreleased dependencies.
                 // These must already be installed in the local maven repository.

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: "cpp"
-apply plugin: "protobuf"
+apply plugin: "com.google.protobuf"
 
 description = 'The protoc plugin for gRPC Java'
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'application'
-apply plugin: 'protobuf'
+apply plugin: 'com.google.protobuf'
 
 description = "grpc Examples"
 

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'protobuf'
+apply plugin: 'com.google.protobuf'
 apply plugin:'application'
 
 description = "gRPC: Integration Testing"


### PR DESCRIPTION
The plugin has been published on [Gradle Plugins Portal](https://plugins.gradle.org/plugin/com.google.protobuf).

Conforming to the Gradle standard that plugin IDs must be name-spaced, the plugin ID has been changed to ``com.google.protobuf``.

@ejona86 please review.