### PR TITLE
Fix style violations added in 986d221

### DIFF
--- a/core/src/test/java/io/grpc/transport/MessageFramerTest.java
+++ b/core/src/test/java/io/grpc/transport/MessageFramerTest.java
@@ -50,7 +50,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.ByteArrayInputStream;
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Tests for {@link MessageFramer}.
@@ -78,7 +77,7 @@ public class MessageFramerTest {
     writePayload(framer, new byte[] {3, 14});
     verifyNoMoreInteractions(sink);
     framer.flush();
-    verify(sink).deliverFrame(toWriteBuffer(new byte[]{0, 0, 0, 0, 2, 3, 14}), false, true);
+    verify(sink).deliverFrame(toWriteBuffer(new byte[] {0, 0, 0, 0, 2, 3, 14}), false, true);
     assertEquals(1, allocator.allocCount);
     verifyNoMoreInteractions(sink);
   }
@@ -89,11 +88,11 @@ public class MessageFramerTest {
     framer = new MessageFramer(sink, allocator);
     writePayload(framer, new byte[] {3});
     verifyNoMoreInteractions(sink);
-    writePayload(framer, new byte[]{14});
+    writePayload(framer, new byte[] {14});
     verifyNoMoreInteractions(sink);
     framer.flush();
     verify(sink).deliverFrame(
-        toWriteBuffer(new byte[]{0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 1, 14}), false, true);
+        toWriteBuffer(new byte[] {0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 1, 14}), false, true);
     verifyNoMoreInteractions(sink);
     assertEquals(1, allocator.allocCount);
   }
@@ -104,7 +103,7 @@ public class MessageFramerTest {
     verifyNoMoreInteractions(sink);
     framer.close();
     verify(sink).deliverFrame(
-        toWriteBuffer(new byte[]{0, 0, 0, 0, 7, 3, 14, 1, 5, 9, 2, 6}), true, true);
+        toWriteBuffer(new byte[] {0, 0, 0, 0, 7, 3, 14, 1, 5, 9, 2, 6}), true, true);
     verifyNoMoreInteractions(sink);
     assertEquals(1, allocator.allocCount);
   }
@@ -125,7 +124,7 @@ public class MessageFramerTest {
     verifyNoMoreInteractions(sink);
 
     framer.flush();
-    verify(sink).deliverFrame(toWriteBuffer(new byte[]{5}), false, true);
+    verify(sink).deliverFrame(toWriteBuffer(new byte[] {5}), false, true);
     verifyNoMoreInteractions(sink);
     assertEquals(2, allocator.allocCount);
   }
@@ -141,7 +140,7 @@ public class MessageFramerTest {
     verifyNoMoreInteractions(sink);
 
     framer.flush();
-    verify(sink).deliverFrame(toWriteBufferWithMinSize(new byte[]{1, 3}, 12), false, true);
+    verify(sink).deliverFrame(toWriteBufferWithMinSize(new byte[] {1, 3}, 12), false, true);
     verifyNoMoreInteractions(sink);
     assertEquals(2, allocator.allocCount);
   }
@@ -159,7 +158,7 @@ public class MessageFramerTest {
     writePayload(framer, new byte[] {3, 14});
     framer.flush();
     framer.flush();
-    verify(sink).deliverFrame(toWriteBuffer(new byte[]{0, 0, 0, 0, 2, 3, 14}), false, true);
+    verify(sink).deliverFrame(toWriteBuffer(new byte[] {0, 0, 0, 0, 2, 3, 14}), false, true);
     verifyNoMoreInteractions(sink);
     assertEquals(1, allocator.allocCount);
   }

--- a/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
@@ -403,8 +403,8 @@ public class OkHttpClientTransportTest {
     verify(frameWriter).data(eq(false), eq(3), any(Buffer.class), eq(10));
     frameHandler.windowUpdate(0, 10);
 
-    // Decrease initial window size to HEADER_LENGTH, since we've already sent out HEADER_LENGTH + 20 bytes
-    // data, the window size should be -20 now.
+    // Decrease initial window size to HEADER_LENGTH, since we've already sent
+    // out HEADER_LENGTH + 20 bytes data, the window size should be -20 now.
     setInitialWindowSize(HEADER_LENGTH);
     // Get 20 tokens back, still can't send any data.
     frameHandler.windowUpdate(3, 20);


### PR DESCRIPTION
The unused AtomicInteger is caught by checkstyle so causes Travis-CI
to fail.