### PR TITLE
Include gradle 2.3 in Travis-CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ cache:
 
 before_cache:
   - rm $HOME/.gradle/caches/modules-2/modules-2.lock
-  - find $HOME/.gradle/wrapper -not -name "*-all.zip" -delete
+  - find $HOME/.gradle/wrapper -not -name "*-all.zip" -and -not -name "*.-bin.zip" -delete


### PR DESCRIPTION
Gradle 2.3 is using a -bin.zip name instead of a -all.zip name like 2.2.