### PR TITLE
Don't overwrite error message if bad headers

### DIFF
--- a/core/src/main/java/io/grpc/transport/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/transport/Http2ClientStream.java
@@ -99,7 +99,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
     if (transportError != null) {
       // Note we don't immediately report the transport error, instead we wait for more data on the
       // stream so we can accumulate more detail into the error before reporting it.
-      transportError = transportError.withDescription("\n" + headers.toString());
+      transportError = transportError.augmentDescription("\n" + headers.toString());
       errorCharset = extractCharset(headers);
     } else {
       stripTransportDetails(headers);


### PR DESCRIPTION
If we notice something wrong with the headers, then we choose a nice
error message. But we are accidentally overwriting that message with
additional error details.

Resolves #359.