### PR TITLE
More flush reduction for Netty

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -160,6 +160,7 @@ public abstract class AbstractBenchmark {
     serverBuilder.addService(
         ServerServiceDefinition.builder("benchmark")
             .addMethod("unary",
+                MethodType.UNARY,
                 new ByteBufOutputMarshaller(),
                 new ByteBufOutputMarshaller(),
                 new ServerCallHandler<ByteBuf, ByteBuf>() {

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ subprojects {
 
                 // TODO: Unreleased dependencies.
                 // These must already be installed in the local maven repository.
-                netty: 'io.netty:netty-codec-http2:4.1.0.Beta5-SNAPSHOT',
+                netty: 'io.netty:netty-codec-http2:4.1.0.Beta6-SNAPSHOT',
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -195,7 +195,7 @@
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowedAnnotations" value="Override, Test, Before, After, BeforeClass, AfterClass"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MethodName">

--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -247,14 +247,11 @@ public final class ChannelImpl extends Channel {
   private class CallImpl<ReqT, RespT> extends Call<ReqT, RespT> {
     private final MethodDescriptor<ReqT, RespT> method;
     private final SerializingExecutor callExecutor;
-    private final boolean unaryRequest;
     private ClientStream stream;
 
     public CallImpl(MethodDescriptor<ReqT, RespT> method, SerializingExecutor executor) {
       this.method = method;
       this.callExecutor = executor;
-      this.unaryRequest = method.getType() == MethodType.UNARY
-          || method.getType() == MethodType.SERVER_STREAMING;
     }
 
     @Override
@@ -332,7 +329,7 @@ public final class ChannelImpl extends Channel {
       // For unary requests, we don't flush since we know that halfClose should be coming soon. This
       // allows us to piggy-back the END_STREAM=true on the last payload frame without opening the
       // possibility of broken applications forgetting to call halfClose without noticing.
-      if (!unaryRequest) {
+      if (!method.getType().clientSendsOneMessage()) {
         stream.flush();
       }
     }

--- a/core/src/main/java/io/grpc/ServerMethodDefinition.java
+++ b/core/src/main/java/io/grpc/ServerMethodDefinition.java
@@ -39,15 +39,17 @@ import java.io.InputStream;
  */
 public final class ServerMethodDefinition<RequestT, ResponseT> {
   private final String name;
+  private final MethodType type;
   private final Marshaller<RequestT> requestMarshaller;
   private final Marshaller<ResponseT> responseMarshaller;
   private final ServerCallHandler<RequestT, ResponseT> handler;
 
   // ServerMethodDefinition has no form of public construction. It is only created within the
   // context of a ServerServiceDefinition.Builder.
-  ServerMethodDefinition(String name, Marshaller<RequestT> requestMarshaller,
+  ServerMethodDefinition(String name, MethodType type, Marshaller<RequestT> requestMarshaller,
       Marshaller<ResponseT> responseMarshaller, ServerCallHandler<RequestT, ResponseT> handler) {
     this.name = name;
+    this.type = type;
     this.requestMarshaller = requestMarshaller;
     this.responseMarshaller = responseMarshaller;
     this.handler = handler;
@@ -57,21 +59,27 @@ public final class ServerMethodDefinition<RequestT, ResponseT> {
    * Create a new instance.
    *
    * @param name the simple name of a method.
+   * @param type the type of the method.
    * @param requestMarshaller marshaller for request messages.
    * @param responseMarshaller marshaller for response messages.
    * @param handler to dispatch calls to.
    * @return a new instance.
    */
   public static <RequestT, ResponseT> ServerMethodDefinition<RequestT, ResponseT> create(
-      String name, Marshaller<RequestT> requestMarshaller,
+      String name, MethodType type, Marshaller<RequestT> requestMarshaller,
       Marshaller<ResponseT> responseMarshaller, ServerCallHandler<RequestT, ResponseT> handler) {
-    return new ServerMethodDefinition<RequestT, ResponseT>(name, requestMarshaller,
+    return new ServerMethodDefinition<RequestT, ResponseT>(name, type, requestMarshaller,
         responseMarshaller, handler);
   }
 
   /** The simple name of the method. It is not an absolute path. */
   public String getName() {
     return name;
+  }
+
+  /** The type of the method. */
+  public MethodType getMethodType() {
+    return type;
   }
 
   /**
@@ -108,6 +116,6 @@ public final class ServerMethodDefinition<RequestT, ResponseT> {
   public ServerMethodDefinition<RequestT, ResponseT> withServerCallHandler(
       ServerCallHandler<RequestT, ResponseT> handler) {
     return new ServerMethodDefinition<RequestT, ResponseT>(
-        name, requestMarshaller, responseMarshaller, handler);
+        name, type, requestMarshaller, responseMarshaller, handler);
   }
 }

--- a/core/src/main/java/io/grpc/ServerServiceDefinition.java
+++ b/core/src/main/java/io/grpc/ServerServiceDefinition.java
@@ -88,10 +88,12 @@ public final class ServerServiceDefinition {
      * @param responseMarshaller marshaller for serializing outgoing responses
      * @param handler handler for incoming calls
      */
-    public <ReqT, RespT> Builder addMethod(String name, Marshaller<ReqT> requestMarshaller,
-        Marshaller<RespT> responseMarshaller, ServerCallHandler<ReqT, RespT> handler) {
+    public <ReqT, RespT> Builder addMethod(String name, MethodType type,
+        Marshaller<ReqT> requestMarshaller, Marshaller<RespT> responseMarshaller,
+        ServerCallHandler<ReqT, RespT> handler) {
       return addMethod(new ServerMethodDefinition<ReqT, RespT>(
           Preconditions.checkNotNull(name, "name must not be null"),
+          Preconditions.checkNotNull(type, "type must not be null"),
           Preconditions.checkNotNull(requestMarshaller, "requestMarshaller must not be null"),
           Preconditions.checkNotNull(responseMarshaller, "responseMarshaller must not be null"),
           Preconditions.checkNotNull(handler, "handler must not be null")));

--- a/core/src/main/java/io/grpc/transport/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractServerStream.java
@@ -34,6 +34,7 @@ package io.grpc.transport;
 import com.google.common.base.Preconditions;
 
 import io.grpc.Metadata;
+import io.grpc.MethodType;
 import io.grpc.Status;
 
 import java.io.InputStream;
@@ -78,6 +79,13 @@ public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
   @Override
   protected ServerStreamListener listener() {
     return this.listener;
+  }
+
+  /**
+   * The method type of the call.
+   */
+  protected MethodType getMethodType() {
+    return listener.getMethodType();
   }
 
   @Override

--- a/core/src/test/java/io/grpc/MutableHandlerRegistryImplTest.java
+++ b/core/src/test/java/io/grpc/MutableHandlerRegistryImplTest.java
@@ -57,12 +57,12 @@ public class MutableHandlerRegistryImplTest {
   @SuppressWarnings("unchecked")
   private ServerCallHandler<String, Integer> handler = mock(ServerCallHandler.class);
   private ServerServiceDefinition basicServiceDefinition = ServerServiceDefinition.builder("basic")
-      .addMethod("flow", requestMarshaller, responseMarshaller, handler).build();
+      .addMethod("flow", MethodType.UNARY, requestMarshaller, responseMarshaller, handler).build();
   @SuppressWarnings("rawtypes")
   private ServerMethodDefinition flowMethodDefinition = basicServiceDefinition.getMethods().get(0);
   private ServerServiceDefinition multiServiceDefinition = ServerServiceDefinition.builder("multi")
-      .addMethod("couple", requestMarshaller, responseMarshaller, handler)
-      .addMethod("few", requestMarshaller, responseMarshaller, handler).build();
+      .addMethod("couple", MethodType.UNARY, requestMarshaller, responseMarshaller, handler)
+      .addMethod("few", MethodType.UNARY, requestMarshaller, responseMarshaller, handler).build();
   @SuppressWarnings("rawtypes")
   private ServerMethodDefinition coupleMethodDefinition =
       multiServiceDefinition.getMethod("couple");
@@ -127,7 +127,8 @@ public class MutableHandlerRegistryImplTest {
     assertNull(registry.addService(basicServiceDefinition));
     assertNotNull(registry.lookupMethod("/basic/flow"));
     ServerServiceDefinition replaceServiceDefinition = ServerServiceDefinition.builder("basic")
-        .addMethod("another", requestMarshaller, responseMarshaller, handler).build();
+        .addMethod("another", MethodType.UNARY, requestMarshaller, responseMarshaller, handler)
+        .build();
     ServerMethodDefinition<?, ?> anotherMethodDefinition =
         replaceServiceDefinition.getMethods().get(0);
     assertSame(basicServiceDefinition, registry.addService(replaceServiceDefinition));

--- a/core/src/test/java/io/grpc/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/ServerImplTest.java
@@ -42,7 +42,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -168,7 +167,7 @@ public class ServerImplTest {
     final AtomicReference<ServerCall<Integer>> callReference
         = new AtomicReference<ServerCall<Integer>>();
     registry.addService(ServerServiceDefinition.builder("Waiter")
-        .addMethod("serve", STRING_MARSHALLER, INTEGER_MARSHALLER,
+        .addMethod("serve", MethodType.UNARY, STRING_MARSHALLER, INTEGER_MARSHALLER,
           new ServerCallHandler<String, Integer>() {
             @Override
             public ServerCall.Listener<String> startCall(String fullMethodName,
@@ -201,7 +200,6 @@ public class ServerImplTest {
     call.sendPayload(314);
     ArgumentCaptor<InputStream> inputCaptor = ArgumentCaptor.forClass(InputStream.class);
     verify(stream).writeMessage(inputCaptor.capture(), eq(3));
-    verify(stream).flush();
     assertEquals(314, INTEGER_MARSHALLER.parse(inputCaptor.getValue()).intValue());
 
     streamListener.halfClosed(); // All full; no dessert.
@@ -210,7 +208,6 @@ public class ServerImplTest {
 
     call.sendPayload(50);
     verify(stream).writeMessage(inputCaptor.capture(), eq(2));
-    verify(stream, times(2)).flush();
     assertEquals(50, INTEGER_MARSHALLER.parse(inputCaptor.getValue()).intValue());
 
     Metadata.Trailers trailers = new Metadata.Trailers();
@@ -232,7 +229,7 @@ public class ServerImplTest {
     CyclicBarrier barrier = executeBarrier(executor);
     final Status status = Status.ABORTED.withDescription("Oh, no!");
     registry.addService(ServerServiceDefinition.builder("Waiter")
-        .addMethod("serve", STRING_MARSHALLER, INTEGER_MARSHALLER,
+        .addMethod("serve", MethodType.UNARY, STRING_MARSHALLER, INTEGER_MARSHALLER,
           new ServerCallHandler<String, Integer>() {
             @Override
             public ServerCall.Listener<String> startCall(String fullMethodName,

--- a/core/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -68,7 +68,7 @@ public class ServerInterceptorsTest {
   private String methodName = "/someRandom.Name";
   @Mock private ServerCall<Integer> call;
   private ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("basic")
-      .addMethod("flow", requestMarshaller, responseMarshaller, handler).build();
+      .addMethod("flow", MethodType.UNARY, requestMarshaller, responseMarshaller, handler).build();
   private Headers headers = new Headers();
 
   /** Set up for test. */
@@ -134,8 +134,9 @@ public class ServerInterceptorsTest {
     @SuppressWarnings("unchecked")
     ServerCallHandler<String, Integer> handler2 = mock(ServerCallHandler.class);
     serviceDefinition = ServerServiceDefinition.builder("basic")
-        .addMethod("flow", requestMarshaller, responseMarshaller, handler)
-        .addMethod("flow2", requestMarshaller, responseMarshaller, handler2).build();
+        .addMethod("flow", MethodType.UNARY, requestMarshaller, responseMarshaller, handler)
+        .addMethod("flow2", MethodType.UNARY, requestMarshaller, responseMarshaller, handler2)
+        .build();
     ServerServiceDefinition intercepted = ServerInterceptors.intercept(
         serviceDefinition, Arrays.<ServerInterceptor>asList(new NoopInterceptor()));
     getMethod(intercepted, "flow").getServerCallHandler().startCall(methodName, call, headers);
@@ -192,7 +193,8 @@ public class ServerInterceptorsTest {
           }
         };
     ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("basic")
-        .addMethod("flow", requestMarshaller, responseMarshaller, handler).build();
+        .addMethod("flow", MethodType.UNARY, requestMarshaller, responseMarshaller, handler)
+        .build();
     ServerServiceDefinition intercepted = ServerInterceptors.intercept(
         serviceDefinition, Arrays.asList(interceptor1, interceptor2));
     assertSame(listener,

--- a/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -409,7 +409,7 @@ public abstract class AbstractTransportTest {
     }
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void serverStreamingShouldBeFlowControlled() throws Exception {
     final StreamingOutputCallRequest request = StreamingOutputCallRequest.newBuilder()
         .setResponseType(COMPRESSABLE)

--- a/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -89,7 +89,7 @@ public abstract class AbstractTransportTest {
       ProtoUtils.keyForProto(Messages.SimpleContext.getDefaultInstance());
   private static ScheduledExecutorService testServiceExecutor;
   private static ServerImpl server;
-  private static int OPERATION_TIMEOUT = 5000;
+  private static int OPERATION_TIMEOUT = 5000000;
 
   protected static void startStaticServer(AbstractServerBuilder<?> builder) {
     testServiceExecutor = Executors.newScheduledThreadPool(2);
@@ -409,7 +409,7 @@ public abstract class AbstractTransportTest {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
   public void serverStreamingShouldBeFlowControlled() throws Exception {
     final StreamingOutputCallRequest request = StreamingOutputCallRequest.newBuilder()
         .setResponseType(COMPRESSABLE)

--- a/integration-testing/src/test/java/io/grpc/testing/integration/NettyTransportIoEfficiencyTest.java
+++ b/integration-testing/src/test/java/io/grpc/testing/integration/NettyTransportIoEfficiencyTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.testing.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+
+import io.grpc.ChannelImpl;
+import io.grpc.ServerImpl;
+import io.grpc.ServerInterceptors;
+import io.grpc.stub.StreamObserver;
+import io.grpc.stub.StreamRecorder;
+import io.grpc.testing.TestUtils;
+import io.grpc.transport.netty.NegotiationType;
+import io.grpc.transport.netty.NettyChannelBuilder;
+import io.grpc.transport.netty.NettyServerBuilder;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Tests to verify IO efficiency of the Netty transport implementation.
+ */
+@RunWith(JUnit4.class)
+public class NettyTransportIoEfficiencyTest {
+
+  private static final Messages.SimpleRequest SMALL_REQUEST = Messages.SimpleRequest.newBuilder()
+      .setResponseSize(1)
+      .setResponseType(Messages.PayloadType.COMPRESSABLE)
+      .setPayload(Messages.Payload.newBuilder()
+          .setBody(ByteString.copyFrom(new byte[1])))
+      .build();
+  private static int serverPort = Util.pickUnusedPort();
+  private ServerImpl server;
+  protected ChannelImpl channel;
+  protected TestServiceGrpc.TestServiceBlockingStub blockingStub;
+  protected TestServiceGrpc.TestService asyncStub;
+
+  @After
+  public void tearDown() throws Exception {
+    ClientCountingChannel.flushCount = 0;
+    ServerCountingChannel.flushCount = 0;
+    server.shutdownNow();
+    channel.shutdownNow();
+  }
+
+  @Test(timeout = 10000)
+  public void smallUnaryBlocking() throws Exception {
+    startServer(false);
+    startClient(false);
+    blockingStub.unaryCall(SMALL_REQUEST);
+    // Expect 1 flush each from client and server as they know the call is unary and so group
+    // header, payload & trailers (server) into a single flush.
+    assertEquals(1, ClientCountingChannel.flushCount);
+    assertEquals(1, ServerCountingChannel.flushCount);
+  }
+
+  @Test(timeout = 10000)
+  public void largeUnaryWithWindowUpdate() throws Exception {
+    startServer(false);
+    startClient(false);
+    // Use payload slightly greater than a multiple of the window size.
+    int payloadSize = 65535 * 5 + 10;
+    int payloadWrites = 6;
+    final Messages.SimpleRequest request = Messages.SimpleRequest.newBuilder()
+        .setResponseSize(payloadSize)
+        .setResponseType(Messages.PayloadType.COMPRESSABLE)
+        .setPayload(Messages.Payload.newBuilder()
+            .setBody(ByteString.copyFrom(new byte[payloadSize])))
+        .build();
+    blockingStub.unaryCall(request);
+    int maxWindowUpdates = (payloadSize / (65535 / 2));
+    int minWindowUpdates = (payloadSize / 65535);
+    // We use bounds checking as we don't have precisely predictable behavior here. The number
+    // of DATA frames read in a unit depends on how big a chunk we get from the IO layer.
+    assertTrue(maxWindowUpdates + payloadWrites >= ClientCountingChannel.flushCount);
+    assertTrue(minWindowUpdates + payloadWrites <= ClientCountingChannel.flushCount);
+    assertTrue(maxWindowUpdates + payloadWrites >= ServerCountingChannel.flushCount);
+    assertTrue(minWindowUpdates + payloadWrites <= ServerCountingChannel.flushCount);
+  }
+
+  @Test(timeout = 10000)
+  public void largeUnaryWithWindowUpdateAndDirectExecutor() throws Exception {
+    System.err.println("START");
+    try {
+      startServer(true);
+      startClient(true);
+      // Use payload slightly greater than a multiple of the window size.
+      int payloadSize = 65535 * 5 + 10;
+      int payloadWrites = 6;
+      final Messages.SimpleRequest request = Messages.SimpleRequest.newBuilder()
+          .setResponseSize(payloadSize)
+          .setResponseType(Messages.PayloadType.COMPRESSABLE)
+          .setPayload(Messages.Payload.newBuilder()
+              .setBody(ByteString.copyFrom(new byte[payloadSize])))
+          .build();
+      blockingStub.unaryCall(request);
+      int maxWindowUpdates = (payloadSize / (65535 / 2));
+      int minWindowUpdates = (payloadSize / 65535);
+      // No benefit for unary calls over non-direct executor here as deframer is already running in
+      // transport thread so returning bytes to the flow controller causes window-updates to be
+      // coalesced by the flush in read-complete.
+      assertTrue(maxWindowUpdates + payloadWrites >= ClientCountingChannel.flushCount);
+      assertTrue(minWindowUpdates + payloadWrites <= ClientCountingChannel.flushCount);
+      assertTrue(maxWindowUpdates + payloadWrites >= ServerCountingChannel.flushCount);
+      assertTrue(minWindowUpdates + payloadWrites <= ServerCountingChannel.flushCount);
+    } finally {
+      System.err.println("END");
+    }
+  }
+
+  @Test(timeout = 10000)
+  public void smallServerStreaming() throws Exception {
+    startServer(false);
+    startClient(false);
+    Messages.ResponseParameters.Builder smallParam = Messages.ResponseParameters.newBuilder()
+        .setSize(1)
+        .setIntervalUs(0);
+    final Messages.StreamingOutputCallRequest request =
+        Messages.StreamingOutputCallRequest.newBuilder()
+        .setResponseType(Messages.PayloadType.COMPRESSABLE)
+        .addResponseParameters(smallParam)
+        .addResponseParameters(smallParam)
+        .addResponseParameters(smallParam)
+        .addResponseParameters(smallParam)
+        .build();
+    StreamRecorder<Messages.StreamingOutputCallResponse> recorder = StreamRecorder.create();
+    asyncStub.streamingOutputCall(request, recorder);
+    recorder.awaitCompletion();
+    assertEquals(1, ClientCountingChannel.flushCount);
+    // 1 flush for headers, 1 for each message & 1 for trailers
+    assertEquals(6, ServerCountingChannel.flushCount);
+  }
+
+  @Test(timeout = 10000)
+  public void smallServerStreamingDirectExecutor() throws Exception {
+    startServer(true);
+    startClient(true);
+    Messages.ResponseParameters.Builder smallParam = Messages.ResponseParameters.newBuilder()
+        .setSize(1)
+        .setIntervalUs(0);
+    final Messages.StreamingOutputCallRequest request =
+        Messages.StreamingOutputCallRequest.newBuilder()
+            .setResponseType(Messages.PayloadType.COMPRESSABLE)
+            .addResponseParameters(smallParam)
+            .addResponseParameters(smallParam)
+            .addResponseParameters(smallParam)
+            .addResponseParameters(smallParam)
+            .build();
+    StreamRecorder<Messages.StreamingOutputCallResponse> recorder = StreamRecorder.create();
+    asyncStub.streamingOutputCall(request, recorder);
+    recorder.awaitCompletion();
+    assertEquals(1, ClientCountingChannel.flushCount);
+    // Using direct executor causes all the writes that the server streams back to be coalesced
+    // into a single flush.
+    assertEquals(1, ServerCountingChannel.flushCount);
+  }
+
+  @Test(timeout = 10000)
+  public void largeServerStreaming() throws Exception {
+    startServer(false);
+    startClient(false);
+    Messages.ResponseParameters.Builder largeParam = Messages.ResponseParameters.newBuilder()
+        .setSize(65535)
+        .setIntervalUs(0);
+    final Messages.StreamingOutputCallRequest request =
+        Messages.StreamingOutputCallRequest.newBuilder()
+            .setResponseType(Messages.PayloadType.COMPRESSABLE)
+            .addResponseParameters(largeParam)
+            .addResponseParameters(largeParam)
+            .addResponseParameters(largeParam)
+            .addResponseParameters(largeParam)
+            .build();
+    int payloadSize = 65535 * 5 + 10;
+    StreamRecorder<Messages.StreamingOutputCallResponse> recorder = StreamRecorder.create();
+    asyncStub.streamingOutputCall(request, recorder);
+    recorder.awaitCompletion();
+    int maxWindowUpdates = (payloadSize / (65535 / 2));
+    int minWindowUpdates = (payloadSize / 65535);
+    // 1 for request & 5 window updates back to server.
+    assertEquals(6, ClientCountingChannel.flushCount);
+
+    // 1 flush for headers and a min/max range for window updates
+    assertTrue(maxWindowUpdates + 1 >= ServerCountingChannel.flushCount);
+    assertTrue(minWindowUpdates + 1 <= ServerCountingChannel.flushCount);
+  }
+
+  @Test(timeout = 10000)
+  public void smallClientStreaming() throws Exception {
+    startServer(false);
+    startClient(false);
+    Messages.StreamingInputCallRequest smallPayload =
+        Messages.StreamingInputCallRequest.newBuilder()
+        .setPayload(Messages.Payload.newBuilder()
+            .setBody(ByteString.copyFrom(new byte[1])))
+        .build();
+    final List<Messages.StreamingInputCallRequest> requests = Arrays.asList(
+        smallPayload, smallPayload, smallPayload, smallPayload);
+    StreamRecorder<Messages.StreamingInputCallResponse> recorder = StreamRecorder.create();
+    StreamObserver<Messages.StreamingInputCallRequest> requestObserver =
+        asyncStub.streamingInputCall(recorder);
+    for (Messages.StreamingInputCallRequest request : requests) {
+      requestObserver.onValue(request);
+    }
+    requestObserver.onCompleted();
+    recorder.awaitCompletion();
+
+    // 1 flush for headers, 1 for each each message & 1 for trailing empty DATA.
+    assertEquals(6, ClientCountingChannel.flushCount);
+    // BROKEN: Should be 1 but because we don't differentiate between unary and streaming responses
+    // in generated stubs, they both use ServerCalls.asyncStreamingCall which causes us to
+    // make an unneeded call to call.request for the unary response case which triggers a flush.
+    assertEquals(2, ServerCountingChannel.flushCount);
+  }
+
+  private void startClient(boolean directExecutor) {
+    try {
+      NettyChannelBuilder builder = NettyChannelBuilder
+          .forAddress(new InetSocketAddress(InetAddress.getLocalHost(), serverPort))
+          .channelType(ClientCountingChannel.class)
+          .negotiationType(NegotiationType.PLAINTEXT);
+      if (directExecutor) {
+        builder.executor(MoreExecutors.newDirectExecutorService());
+      }
+      channel = builder.build();
+      blockingStub = TestServiceGrpc.newBlockingStub(channel);
+      asyncStub  = TestServiceGrpc.newStub(channel);
+      blockingStub.unaryCall(SMALL_REQUEST);
+      // Need to sleep so that SETTINGS_ACK is received and processed as it can cause a flush.
+      Thread.sleep(1000);
+      ClientCountingChannel.flushCount = 0;
+      ServerCountingChannel.flushCount = 0;
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private void startServer(boolean directExecutor)
+      throws Exception {
+    NettyServerBuilder builder = NettyServerBuilder.forPort(serverPort)
+        .channelType(ServerSocketChannel.class);
+    ExecutorService testServiceExecutor;
+    if (directExecutor) {
+      builder.executor(MoreExecutors.newDirectExecutorService());
+      testServiceExecutor = MoreExecutors.newDirectExecutorService();
+    } else {
+      testServiceExecutor = Executors.newScheduledThreadPool(2);
+    }
+    builder.addService(ServerInterceptors.intercept(
+        TestServiceGrpc.bindService(new TestServiceImpl(testServiceExecutor)),
+        TestUtils.echoRequestHeadersInterceptor(Util.METADATA_KEY)));
+    server = builder.build();
+    server.start();
+  }
+
+
+  public static class ClientCountingChannel extends NioSocketChannel {
+
+    public static volatile int flushCount = 0;
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+      flushCount++;
+      super.doWrite(in);
+      Thread.dumpStack();
+    }
+  }
+
+  public static class ServerCountingChannel extends NioSocketChannel {
+    public static volatile int flushCount = 0;
+
+    public ServerCountingChannel(Channel parent, SocketChannel socket) {
+      super(parent, socket);
+    }
+
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+      flushCount++;
+      super.doWrite(in);
+    }
+  }
+
+
+
+  public static class ServerSocketChannel extends NioServerSocketChannel {
+    @Override
+    protected int doReadMessages(List<Object> buf) throws Exception {
+      java.nio.channels.SocketChannel ch = javaChannel().accept();
+      try {
+        if (ch != null) {
+          buf.add(new ServerCountingChannel(this, ch));
+          return 1;
+        }
+      } catch (Throwable t) {
+        try {
+          ch.close();
+        } catch (Throwable t2) {
+          // Ignore
+        }
+      }
+      return 0;
+    }
+  }
+}

--- a/integration-testing/src/test/java/io/grpc/testing/integration/NettyTransportIoEfficiencyTest.java
+++ b/integration-testing/src/test/java/io/grpc/testing/integration/NettyTransportIoEfficiencyTest.java
@@ -308,7 +308,6 @@ public class NettyTransportIoEfficiencyTest {
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
       flushCount++;
       super.doWrite(in);
-      Thread.dumpStack();
     }
   }
 

--- a/netty/src/main/java/io/grpc/transport/netty/AbstractNettyCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/AbstractNettyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -28,32 +28,35 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package io.grpc.transport.netty;
 
-import com.google.common.base.Preconditions;
-
-import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
- * A command to create a new stream. This is created by {@link NettyClientStream} and passed to the
- * {@link NettyClientHandler} for processing in the Channel thread.
+ * Common base class for commands executed on the Netty event loop.
  */
-class CreateStreamCommand {
-  private final Http2Headers headers;
-  private final NettyClientStream stream;
+public class AbstractNettyCommand {
 
-  CreateStreamCommand(Http2Headers headers,
-                      NettyClientStream stream) {
-    this.stream = Preconditions.checkNotNull(stream, "stream");
-    this.headers = Preconditions.checkNotNull(headers, "headers");
+  protected final boolean flush;
+
+  public AbstractNettyCommand(boolean flush) {
+    this.flush = flush;
   }
 
-  NettyClientStream stream() {
-    return stream;
+  public void flushIfNecessary(ChannelHandlerContext ctx) {
+    if (flush) {
+      ctx.flush();
+    }
   }
 
-  Http2Headers headers() {
-    return headers;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    AbstractNettyCommand that = (AbstractNettyCommand) o;
+
+    return flush == that.flush;
+
   }
 }

--- a/netty/src/main/java/io/grpc/transport/netty/AbstractNettyCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/AbstractNettyCommand.java
@@ -28,6 +28,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package io.grpc.transport.netty;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -39,10 +40,17 @@ public class AbstractNettyCommand {
 
   protected final boolean flush;
 
+  /**
+   * Construct a new command.
+   * @param flush true if command should trigger a flush after write.
+   */
   public AbstractNettyCommand(boolean flush) {
     this.flush = flush;
   }
 
+  /**
+   * Called after writing the command to trigger a flush if necessary.
+   */
   public void flushIfNecessary(ChannelHandlerContext ctx) {
     if (flush) {
       ctx.flush();
@@ -51,12 +59,15 @@ public class AbstractNettyCommand {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
     AbstractNettyCommand that = (AbstractNettyCommand) o;
 
     return flush == that.flush;
-
   }
 }

--- a/netty/src/main/java/io/grpc/transport/netty/CancelStreamNettyCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/CancelStreamNettyCommand.java
@@ -59,7 +59,7 @@ class CancelStreamNettyCommand extends AbstractNettyCommand {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(streamId=" + stream.id() + ", flush=" + flush +")";
+    return getClass().getSimpleName() + "(streamId=" + stream.id() + ", flush=" + flush + ")";
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/transport/netty/CreateStreamNettyCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/CreateStreamNettyCommand.java
@@ -33,17 +33,48 @@ package io.grpc.transport.netty;
 
 import com.google.common.base.Preconditions;
 
+import io.netty.handler.codec.http2.Http2Headers;
+
 /**
- * Command sent from a Netty client stream to the handler to cancel the stream.
+ * A command to create a new stream. This is created by {@link NettyClientStream} and passed to the
+ * {@link NettyClientHandler} for processing in the Channel thread.
  */
-class CancelStreamCommand {
+class CreateStreamNettyCommand extends AbstractNettyCommand {
+  private final Http2Headers headers;
   private final NettyClientStream stream;
 
-  CancelStreamCommand(NettyClientStream stream) {
+  CreateStreamNettyCommand(boolean flush,
+                           Http2Headers headers,
+                           NettyClientStream stream) {
+    super(flush);
     this.stream = Preconditions.checkNotNull(stream, "stream");
+    this.headers = Preconditions.checkNotNull(headers, "headers");
   }
 
   NettyClientStream stream() {
     return stream;
+  }
+
+  Http2Headers headers() {
+    return headers;
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (that == null || !super.equals(that)) {
+      return false;
+    }
+    CreateStreamNettyCommand thatCmd = (CreateStreamNettyCommand) that;
+    return thatCmd.headers.equals(headers);
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + "(headers=" + headers + ", flush=" + flush +")";
+  }
+
+  @Override
+  public int hashCode() {
+    return headers.hashCode();
   }
 }

--- a/netty/src/main/java/io/grpc/transport/netty/CreateStreamNettyCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/CreateStreamNettyCommand.java
@@ -70,7 +70,7 @@ class CreateStreamNettyCommand extends AbstractNettyCommand {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(headers=" + headers + ", flush=" + flush +")";
+    return getClass().getSimpleName() + "(headers=" + headers + ", flush=" + flush + ")";
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
@@ -65,7 +65,9 @@ class NettyClientStream extends Http2ClientStream {
   @Override
   public void request(final int numMessages) {
     if (channel.eventLoop().inEventLoop()) {
-      // Processing data read in the event loop so can call into the deframer immediately.
+      // Processing data read in the event loop so can call into the deframer immediately and since
+      // we are in an event triggered by a read all writes caused by this will be flushed on
+      // completion.
       requestMessagesFromDeframer(numMessages);
     } else {
       channel.eventLoop().execute(new Runnable() {

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
@@ -167,14 +167,10 @@ class NettyClientTransport implements ClientTransport {
     Http2Headers http2Headers = Utils.convertClientHeaders(headers, ssl, defaultPath, authority);
 
     // Write the command requesting the creation of the stream.
-    CreateStreamCommand msg = new CreateStreamCommand(http2Headers, stream);
-    if (method.getType().clientSendsOneMessage()) {
-      // No need to flush yet if the client is required to send at least one message
-      channel.write(msg);
-    } else {
-      channel.writeAndFlush(msg);
-    }
-
+    CreateStreamNettyCommand msg = new CreateStreamNettyCommand(
+        Utils.shouldFlush(channel, !method.getType().clientSendsOneMessage()),
+        http2Headers, stream);
+    channel.write(msg);
     return stream;
   }
 

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
@@ -166,7 +166,8 @@ class NettyClientTransport implements ClientTransport {
     AsciiString defaultPath = new AsciiString("/" + method.getName());
     Http2Headers http2Headers = Utils.convertClientHeaders(headers, ssl, defaultPath, authority);
 
-    // Write the command requesting the creation of the stream.
+    // Write the command requesting the creation of the stream. No need to flush if the
+    // client is required to send at least one message.
     CreateStreamNettyCommand msg = new CreateStreamNettyCommand(
         Utils.shouldFlush(channel, !method.getType().clientSendsOneMessage()),
         http2Headers, stream);

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServer.java
@@ -101,6 +101,7 @@ public class NettyServer implements Server {
     if (NioServerSocketChannel.class.isAssignableFrom(channelType)) {
       b.option(SO_BACKLOG, 128);
       b.childOption(SO_KEEPALIVE, true);
+      // b.childOption(ChannelOption.TCP_NODELAY, false);
     }
     b.childHandler(new ChannelInitializer<Channel>() {
       @Override

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServer.java
@@ -101,7 +101,6 @@ public class NettyServer implements Server {
     if (NioServerSocketChannel.class.isAssignableFrom(channelType)) {
       b.option(SO_BACKLOG, 128);
       b.childOption(SO_KEEPALIVE, true);
-      // b.childOption(ChannelOption.TCP_NODELAY, false);
     }
     b.childHandler(new ChannelInitializer<Channel>() {
       @Override

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
@@ -107,8 +107,9 @@ class NettyServerStream extends AbstractServerStream<Integer> {
     final int numBytes = bytebuf.readableBytes();
     // Add the bytes to outbound flow control.
     onSendingBytes(numBytes);
-    channel.write(new SendGrpcFrameCommand(Utils.shouldFlush(channel, flush),
-          this, bytebuf, endOfStream)).addListener(
+    SendGrpcFrameCommand command = new SendGrpcFrameCommand(Utils.shouldFlush(channel, flush),
+        this, bytebuf, endOfStream);
+    channel.write(command).addListener(
         new ChannelFutureListener() {
           @Override
           public void operationComplete(ChannelFuture future) throws Exception {
@@ -117,7 +118,6 @@ class NettyServerStream extends AbstractServerStream<Integer> {
             onSentBytes(numBytes);
           }
         });
-
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/transport/netty/SendResponseHeadersCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/SendResponseHeadersCommand.java
@@ -77,7 +77,7 @@ class SendResponseHeadersCommand extends AbstractNettyCommand {
   @Override
   public String toString() {
     return getClass().getSimpleName() + "(streamId=" + streamId + ", headers=" + headers
-        + ", endOfStream=" + endOfStream + ", flush=" + flush +")";
+        + ", endOfStream=" + endOfStream + ", flush=" + flush + ")";
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/transport/netty/SendResponseHeadersCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/SendResponseHeadersCommand.java
@@ -38,12 +38,14 @@ import io.netty.handler.codec.http2.Http2Headers;
 /**
  * Command sent from the transport to the Netty channel to send response headers to the client.
  */
-class SendResponseHeadersCommand {
+class SendResponseHeadersCommand extends AbstractNettyCommand {
   private final int streamId;
   private final Http2Headers headers;
   private final boolean endOfStream;
 
-  SendResponseHeadersCommand(int streamId, Http2Headers headers, boolean endOfStream) {
+  SendResponseHeadersCommand(boolean flush, int streamId, Http2Headers headers,
+                             boolean endOfStream) {
+    super(flush);
     this.streamId = streamId;
     this.headers = Preconditions.checkNotNull(headers);
     this.endOfStream = endOfStream;
@@ -63,7 +65,7 @@ class SendResponseHeadersCommand {
 
   @Override
   public boolean equals(Object that) {
-    if (that == null || !that.getClass().equals(SendResponseHeadersCommand.class)) {
+    if (that == null || !super.equals(that)) {
       return false;
     }
     SendResponseHeadersCommand thatCmd = (SendResponseHeadersCommand) that;
@@ -75,7 +77,7 @@ class SendResponseHeadersCommand {
   @Override
   public String toString() {
     return getClass().getSimpleName() + "(streamId=" + streamId + ", headers=" + headers
-        + ", endOfStream=" + endOfStream + ")";
+        + ", endOfStream=" + endOfStream + ", flush=" + flush +")";
   }
 
   @Override

--- a/netty/src/test/java/io/grpc/transport/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyServerHandlerTest.java
@@ -152,7 +152,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
     ByteBuf content = Unpooled.copiedBuffer(CONTENT);
 
     // Send a frame and verify that it was written.
-    handler.write(ctx, new SendGrpcFrameCommand(stream, content, false), promise);
+    handler.write(ctx, new SendGrpcFrameCommand(true, stream, content, false), promise);
     verify(promise, never()).setFailure(any(Throwable.class));
     ByteBuf bufWritten = captureWrite(ctx);
     verify(ctx, atLeastOnce()).flush();

--- a/stub/src/main/java/io/grpc/stub/Calls.java
+++ b/stub/src/main/java/io/grpc/stub/Calls.java
@@ -172,10 +172,11 @@ public class Calls {
       ReqT param,
       Call.Listener<RespT> responseListener) {
     call.start(responseListener, new Metadata.Headers());
-    call.request(1);
     try {
       call.sendPayload(param);
       call.halfClose();
+      // Request after sending the payload otherwise we prematurely trigger a flush.
+      call.request(1);
     } catch (Throwable t) {
       call.cancel();
       throw Throwables.propagate(t);


### PR DESCRIPTION
@ejona86 @nmittler 

Update to handle flush reduction change in Netty
Check if we're in the Netty event loop, i.e. a read has occurred and we're using direct executor, when writing so flushes can coalesce

This PR is a work in progress but probably worth discussing now

Partially fixes 
https://github.com/grpc/grpc-java/issues/332
and
https://github.com/grpc/grpc-java/issues/331
