### PR TITLE
Update Netty to 9d70cf3 to pick up flush elimination

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
@@ -130,6 +130,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
 
     // Initialize the connection window if we haven't already.
     initConnectionWindow();
+    ctx.flush();
   }
 
   /**

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
@@ -132,5 +132,7 @@ class NettyClientStream extends Http2ClientStream {
   @Override
   protected void returnProcessedBytes(int processedBytes) {
     handler.returnProcessedBytes(http2Stream, processedBytes);
+    // Need to flush as window update may have been written
+    channel.flush();
   }
 }

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
@@ -105,5 +105,7 @@ class NettyServerStream extends AbstractServerStream<Integer> {
   @Override
   protected void returnProcessedBytes(int processedBytes) {
     handler.returnProcessedBytes(http2Stream, processedBytes);
+    // Need to flush as window update may have been written
+    channel.flush();
   }
 }

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
@@ -190,7 +190,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
 
     ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
     verify(ctx).write(eq(expected), eq(promise));
-    verify(ctx).flush();
   }
 
   @Test
@@ -221,7 +220,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
 
     ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
     verify(ctx).write(eq(expected), eq(promise));
-    verify(ctx).flush();
 
     promise = mock(ChannelPromise.class);
     handler.write(ctx, new CancelStreamCommand(stream), promise);
@@ -235,7 +233,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     handler.write(ctx, new SendGrpcFrameCommand(stream, content, true), promise);
     verify(promise, never()).setFailure(any(Throwable.class));
     ByteBuf bufWritten = captureWrite(ctx);
-    verify(ctx).flush();
     int startIndex = bufWritten.readerIndex() + Http2CodecUtil.FRAME_HEADER_LENGTH;
     int length = bufWritten.writerIndex() - startIndex;
     ByteBuf writtenContent = bufWritten.slice(startIndex, length);


### PR DESCRIPTION
Picks up https://github.com/netty/netty/commit/8271c8a which eliminates explicit flushing from Nettys HTTP2 codec.