### PR TITLE
Don't close streams when sending GOAWAY

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
@@ -94,12 +94,6 @@ class NettyClientHandler extends Http2ConnectionHandler {
     nextStreamId = connection.local().nextStreamId();
     connection.addListener(new Http2ConnectionAdapter() {
       @Override
-      public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
-        goAwayStatus(statusFromGoAway(errorCode, debugData));
-        goingAway();
-      }
-
-      @Override
       public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
         goAwayStatus(statusFromGoAway(errorCode, debugData));
         goingAway();


### PR DESCRIPTION
This reverts a change introduced in f920bad which caused all streams to
be closed when sending GOAWAY as part of graceful shutdown. This is
because lastKnownId() returns -1 when a GOAWAY has not been received.

The test doesn't pass, but at least appears to revert to the old
behavior. It is unknown if the test fails to pass due to client or
server, but given reports that the old code was working, we are thinking
that server-side GOAWAY handling is what is preventing the test from
passing.