### PR TITLE
Do not fail pending streams when sending GOAWAY.

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/BufferingHttp2ConnectionEncoder.java
+++ b/netty/src/main/java/io/grpc/transport/netty/BufferingHttp2ConnectionEncoder.java
@@ -81,11 +81,6 @@ class BufferingHttp2ConnectionEncoder extends DecoratingHttp2ConnectionEncoder {
     connection().addListener(new Http2ConnectionAdapter() {
 
       @Override
-      public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
-        cancelGoAwayStreams(lastStreamId, errorCode, debugData);
-      }
-
-      @Override
       public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
         cancelGoAwayStreams(lastStreamId, errorCode, debugData);
       }

--- a/netty/src/test/java/io/grpc/transport/netty/BufferingHttp2ConnectionEncoderTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/BufferingHttp2ConnectionEncoderTest.java
@@ -186,7 +186,7 @@ public class BufferingHttp2ConnectionEncoderTest {
   }
 
   @Test
-  public void sendingGoAwayCompletesBufferedStreams() {
+  public void sendingGoAwayShouldNotFailStreams() {
     connection.local().maxActiveStreams(1);
 
     encoderWriteHeaders(3, promise);
@@ -197,8 +197,7 @@ public class BufferingHttp2ConnectionEncoderTest {
     encoder.writeGoAway(ctx, 3, CANCEL.code(), empty, promise);
 
     assertEquals(1, connection.numActiveStreams());
-    // The 2 buffered streams should be completed.
-    verify(promise, times(2)).setFailure(any(GoAwayClosedStreamException.class));
+    verify(promise, never()).setFailure(any(GoAwayClosedStreamException.class));
   }
 
   @Test


### PR DESCRIPTION
If the HEADERS have been written to the buffering encoder we should
allow the stream creation to complete since the HTTP/2 spec does not prohibit
this.