### PR TITLE
netty: Remove goAwayStatus when client closing

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
@@ -186,12 +186,6 @@ class NettyClientHandler extends Http2ConnectionHandler {
     stream.transportReportStatus(Status.UNKNOWN, false, new Metadata.Trailers());
   }
 
-  @Override
-  public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-    goAwayStatus(Status.UNAVAILABLE.withDescription("Network channel closed by the client"));
-    super.close(ctx, promise);
-  }
-
   /**
    * Handler for the Channel shutting down.
    */


### PR DESCRIPTION
Client closing doesn't really many anything special, since it is still
fully-operational. We don't want a later goAwayStatus() from getting
squelched because we were shutting down.