### PR TITLE
Make checkstyle fail build by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ subprojects {
     checkstyle {
         configFile = file("$rootDir/checkstyle.xml")
         toolVersion = "6.5"
-        ignoreFailures = true
+        ignoreFailures = false
         if (rootProject.hasProperty("checkstyle.ignoreFailures")) {
             ignoreFailures = rootProject.properties["checkstyle.ignoreFailures"].toBoolean()
         }


### PR DESCRIPTION
It seems almost every developer has caused Travis CI to break due to
checkstyle failures. To prevent further breakages, checkstyle will now
fail the build by default.

Specifying checkstyle.ignoreFailures=true in ~/.gradle/gradle.properties
will turn the failures into warnings, which was the old behavior.