### PR TITLE
Use CreateStartScripts for integration-testing

### DIFF
--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.google.protobuf'
-apply plugin:'application'
+apply plugin: 'application'
 
 description = "gRPC: Integration Testing"
 startScripts.enabled = false
@@ -41,17 +41,26 @@ test {
     }
 }
 
-// Allow execution of test client and server.
-task execute(dependsOn: classes, type:JavaExec) {
-    main = project.hasProperty('mainClass') ? project.mainClass : ''
-    classpath = sourceSets.main.runtimeClasspath
-    jvmArgs = ["-Xbootclasspath/p:" + configurations.alpnboot.asPath]
-    workingDir = project.rootDir
+task test_client(type: CreateStartScripts) {
+    mainClassName = "io.grpc.testing.integration.TestServiceClient"
+    applicationName = "test-client"
+    defaultJvmOpts = ["-Xbootclasspath/p:" + configurations.alpnboot.asPath]
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
+}
 
-    // If appArgs were provided, set the program arguments.
-    if (project.hasProperty("appArgs")) {  
-        args = Eval.me(appArgs)  
-    } 
+task test_server(type: CreateStartScripts) {
+    mainClassName = "io.grpc.testing.integration.TestServiceServer"
+    applicationName = "test-server"
+    defaultJvmOpts = ["-Xbootclasspath/p:" + configurations.alpnboot.asPath]
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
+}
+
+applicationDistribution.into("bin") {
+    from(test_client)
+    from(test_server)
+    fileMode = 0755
 }
 
 protobufCodeGenPlugins = ["java_plugin:$javaPluginPath"]

--- a/run-test-client.sh
+++ b/run-test-client.sh
@@ -1,13 +1,4 @@
 #!/bin/bash -e
-TARGET='Test Service Client'
-TARGET_CLASS='io.grpc.testing.integration.TestServiceClient'
-
-TARGET_ARGS=''
-for i in "$@"; do 
-    TARGET_ARGS="$TARGET_ARGS, '$i'"
-done
-TARGET_ARGS="${TARGET_ARGS:2}"
-
 cd "$(dirname "$0")"
-echo "[INFO] Running: $TARGET ($TARGET_CLASS $TARGET_ARGS)"
-./gradlew -PmainClass="$TARGET_CLASS" -PappArgs="[$TARGET_ARGS]" :grpc-integration-testing:execute
+./gradlew :grpc-integration-testing:installDist
+./integration-testing/build/install/grpc-integration-testing/bin/test-client "$@"

--- a/run-test-server.sh
+++ b/run-test-server.sh
@@ -1,13 +1,4 @@
 #!/bin/bash -e
-TARGET='Test Service Server'
-TARGET_CLASS='io.grpc.testing.integration.TestServiceServer'
-
-TARGET_ARGS=''
-for i in "$@"; do 
-    TARGET_ARGS="$TARGET_ARGS, '$i'"
-done
-TARGET_ARGS="${TARGET_ARGS:2}"
-
 cd "$(dirname "$0")"
-echo "[INFO] Running: $TARGET ($TARGET_CLASS $TARGET_ARGS)"
-./gradlew -PmainClass="$TARGET_CLASS" -PappArgs="[$TARGET_ARGS]" :grpc-integration-testing:execute
+./gradlew :grpc-integration-testing:installDist
+./integration-testing/build/install/grpc-integration-testing/bin/test-server "$@"


### PR DESCRIPTION
This makes it easy to run our test client/server without running gradle
every time. For the moment we run 'installDist' in our script since that
is not performed as part of 'build' or 'assemble'. Once we fix our
scripts and improve the documentation, we can remove running installdist
from our script.