### PR TITLE
Add Jacoco code coverage

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -41,3 +41,18 @@ javadoc {
         options.links subproject.javadoc.options.links.toArray(new String[0])
     }
 }
+
+task jacocoMerge(type: JacocoMerge) {
+    destinationFile = file("${buildDir}/jacoco/test.exec")
+    executionData = files(rootProject.subprojects.jacocoTestReport.executionData)
+        .minus(files("${buildDir}/jacoco/test.exec"))
+        .filter { f -> f.exists() }
+}
+
+jacocoTestReport {
+    dependsOn(jacocoMerge)
+
+    additionalSourceDirs = files(rootProject.subprojects.sourceSets.main.allSource.srcDirs)
+    sourceDirectories = files(rootProject.subprojects.sourceSets.main.allSource.srcDirs)
+    classDirectories = files(rootProject.subprojects.sourceSets.main.output)
+}

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ subprojects {
     apply plugin: "idea"
     apply plugin: "osdetector"
     apply plugin: "signing"
+    apply plugin: "jacoco"
 
     group = "io.grpc"
     version = "0.1.0-SNAPSHOT"


### PR DESCRIPTION
After running tests, you can run jacocoTestReport. The jacocoTestReport
task does not depend on the tests, so they should be run separately.

There is still a lot of noise in the jacoco output since we aren't yet
filtering generated code.