### PR TITLE
Updating to the latest Netty version.

### DIFF
--- a/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/integration-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -572,7 +572,6 @@ public abstract class AbstractTransportTest {
     return 10485760;
   }
 
-  @org.junit.Ignore
   @Test(timeout = 10000)
   public void gracefulShutdown() throws Exception {
     final List<StreamingOutputCallRequest> requests = Arrays.asList(

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
@@ -294,7 +294,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
    */
   private void goingAway() {
     final Status goAwayStatus = goAwayStatus();
-    final int lastKnownStream = connection().local().lastKnownStream();
+    final int lastKnownStream = connection().local().lastStreamKnownByPeer();
     try {
       connection().forEachActiveStream(new Http2StreamVisitor() {
         @Override


### PR DESCRIPTION
Also re-enabling the gracefulShutdown test now that Netty has been
fixed.