### PR TITLE
Fix the filesets to be checked by checkstyle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,13 +127,11 @@ subprojects {
     }
 
     checkstyleMain {
-        source = fileTree(dir: "src", include: "**/*.java",
-            excludes: ["${buildDir}/generated-sources", "**/TestServiceGrpc.java"])
+        source = fileTree(dir: "src/main", include: "**/*.java")
     }
 
     checkstyleTest {
-        source = fileTree(dir: "test", include: "**/*.java",
-            exclude: "${buildDir}/generated-sources")
+        source = fileTree(dir: "src/test", include: "**/*.java")
     }
 
     task javadocJar(type: Jar) {


### PR DESCRIPTION
@ejona86 please review.

Excludes for generated is unnecessary because it's under ``src/generated`` which is not included in the first place.