### PR TITLE
Unify build properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Gradle
 build
+gradle.properties
 .gradle
 
 # IntelliJ IDEA

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -175,7 +175,7 @@ it and the architecture of your JVM. For a fully fledged deployment, you will
 need to deploy the codegen for all other supported OSes and architectures.
 
 To deploy the codegen for an OS and architecture, you must run the following
-commands on that OS and specify the architecture by the flag ``-Darch=<arch>``.
+commands on that OS and specify the architecture by the flag ``-PtargetArch=<arch>``.
 
 We currently distribute the following OSes and architectures:
 - Linux: ``x86_32``, ``x86_64``
@@ -184,13 +184,13 @@ We currently distribute the following OSes and architectures:
 
 If you are doing a snapshot deployment:
 ```
-grpc-java$ ./gradlew clean grpc-compiler:uploadArchives -Darch=<arch>
+grpc-java$ ./gradlew clean grpc-compiler:uploadArchives -PtargetArch=<arch>
 ```
 
 If you are doing a release deployment:
 ```
-grpc-java$ ./gradlew clean grpc-compiler:uploadArchives -Darch=<arch> \
-    -DrepositoryId=<repository-id>
+grpc-java$ ./gradlew clean grpc-compiler:uploadArchives -PtargetArch=<arch> \
+    -PrepositoryId=<repository-id>
 ```
 where ``<repository-id>`` is the ID of the staging repository that you have
 found from the OSSRH UI after the first deployment, usually in the form of

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ $ mvn install -pl codec-http2 -am -DskipTests=true
 The codegen plugin is C++ code and requires protobuf 3.0.0-alpha-2.
 
 If you are not changing the codegen plugin, nor any of the ``.proto`` files in
-the source tree, you can skip this chapter and add ``grpc.skip.codegen=true``
-to ``$HOME/.gradle/gradle.properties``.  It will make the build script skip the
+the source tree, you can skip this chapter and add ``skipCodegen=true``
+to ``<project-root>/gradle.properties``.  It will make the build script skip the
 build and invocation of the codegen, and use generated code that has been
 checked in.
 
@@ -73,15 +73,15 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew install ^
-    -Pvc.protobuf.include=C:\path\to\protobuf-3.0.0-alpha-2\src ^
-    -Pvc.protobuf.libs=C:\path\to\protobuf-3.0.0-alpha-2\vsprojects\Release
+    -PvcProtobufInclude=C:\path\to\protobuf-3.0.0-alpha-2\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf-3.0.0-alpha-2\vsprojects\Release
 ```
 
 Since specifying those properties every build is bothersome, you can instead
-create ``%HOMEDRIVE%%HOMEPATH%\.gradle\gradle.properties`` with contents like:
+create ``<project-root>\gradle.properties`` with contents like:
 ```
-vc.protobuf.include=C:\\path\\to\\protobuf-3.0.0-alpha-2\\src
-vc.protobuf.libs=C:\\path\\to\\protobuf-3.0.0-alpha-2\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf-3.0.0-alpha-2\\src
+vcProtobufLibs=C:\\path\\to\\protobuf-3.0.0-alpha-2\\vsprojects\\Release
 ```
 
 The build script will build the codegen for the same architecture as the Java
@@ -90,8 +90,9 @@ be compiled for 64-bit, that means you must have compiled Protobuf in 64-bit.
 
 ### Notes for MinGW on Windows
 If you have both MinGW and VC++ installed on Windows, VC++ will be used by
-default. To override this default and use MinGW, add ``-Dvc.disable`` to your
-Gradle command line.
+default. To override this default and use MinGW, add ``-PvcDisable=true``
+to your Gradle command line or add ``vcDisable=true`` to your
+``<project-root>\gradle.properties``.
 
 Navigating Around the Source
 ----------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -153,24 +153,19 @@ subprojects {
     uploadArchives.repositories.mavenDeployer {
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
         String stagingUrl
-        if (System.getProperty('repositoryId')) {
-          stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' + System.getProperty('repositoryId')
+        if (rootProject.hasProperty('repositoryId')) {
+          stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
+              rootProject.repositoryId
         } else {
           stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
         }
-        repository(url: stagingUrl) {
-            if (rootProject.hasProperty("ossrhUsername")
-                    && rootProject.hasProperty("ossrhPassword")) {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
+        def configureAuth = {
+          if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
+            authentication(userName: rootProject.ossrhUsername, password: rootProject.ossrhPassword)
+          }
         }
-
-        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-            if (rootProject.hasProperty("ossrhUsername")
-                    && rootProject.hasProperty("ossrhPassword")) {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-        }
+        repository(url: stagingUrl, configureAuth)
+        snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/', configureAuth)
     }
 
     [

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -35,16 +35,14 @@ def addLibraryIfNotLinked = { libName, argList ->
   }
 }
 
-def String arch = osdetector.arch
-if (System.getProperty('arch')) {
-  arch = System.getProperty('arch')
-}
+def String arch = rootProject.hasProperty('targetArch') ? rootProject.targetArch : osdetector.arch
+def boolean vcDisable = rootProject.hasProperty('vcDisable') ? rootProject.vcDisable : false
 
 model {
   toolChains {
     // If you have both VC and Gcc installed, VC will be selected, unless you
-    // use '-Dvc.disable'
-    if (System.getProperty('vc.disable') == null) {
+    // set 'vcDisable=true'
+    if (!vcDisable) {
       visualCpp(VisualCpp) {
       }
     }
@@ -101,12 +99,12 @@ binaries.all {
     addEnvArgs("LDFLAGS", linker.args)
   } else if (toolChain in VisualCpp) {
     cppCompiler.args "/EHsc", "/MD"
-    if (rootProject.hasProperty('vc.protobuf.include')) {
-      cppCompiler.args "/I" + rootProject.properties['vc.protobuf.include']
+    if (rootProject.hasProperty('vcProtobufInclude')) {
+      cppCompiler.args "/I${rootProject.vcProtobufInclude}"
     }
     linker.args "libprotobuf.lib", "libprotoc.lib"
-    if (rootProject.hasProperty('vc.protobuf.libs')) {
-      linker.args "/LIBPATH:" + rootProject.properties['vc.protobuf.libs']
+    if (rootProject.hasProperty('vcProtobufLibs')) {
+      linker.args "/LIBPATH:${rootProject.vcProtobufLibs}"
     }
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,9 +25,8 @@ project(':grpc-all').projectDir = "$rootDir/all" as File
 project(':grpc-benchmarks').projectDir = "$rootDir/benchmarks" as File
 project(':grpc-examples').projectDir = "$rootDir/examples" as File
 
-if (settings.hasProperty('grpc.skip.codegen')
-    && settings.getProperty('grpc.skip.codegen').toBoolean()) {
-  println '*** Skipping the build of codegen and compilation of proto files because grpc.skip.codegen=true'
+if (settings.hasProperty('skipCodegen') && skipCodegen.toBoolean()) {
+  println '*** Skipping the build of codegen and compilation of proto files because skipCodegen=true'
 } else {
   include ":grpc-compiler"
   project(':grpc-compiler').projectDir = "$rootDir/compiler" as File


### PR DESCRIPTION
- Switch all system properties to project properties.
- Use the ``javaLocalNamingStyle`` instead of the ``dot.delimited.style`` for property names, so that it can be directly referenced by ``rootProject.propertyName``.
- Recommend users to put GRPC-specific properties in project-level ``build.properties`` instead of the user-level.

@ejona86 please review