### PR TITLE
Use CreateStartScripts for examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,25 +1,31 @@
 grpc Examples
 ==============================================
 
-In order to run the examples simply execute one of the gradle tasks `routeGuideServer`,
-`routeGuideClient`, `helloWorldServer`, or `helloWorldClient`.
-
-For example, say you want to play around with the route guide examples. First you want to start
-the server and then have the client connect to it and let the good times roll.
-
-Assuming you are in the grpc-java root folder you would first start the route guide server
-by running
+To build the examples, run in this directory:
 
 ```
-$ ./gradlew :grpc-examples:routeGuideServer
+$ ../gradlew installDist
 ```
 
-and in a different terminal window then run the route guide client by typing
+This creates the scripts `hello-world-server`, `hello-world-client`,
+`route-guide-server`, and `route-guide-client` in the
+`build/install/grpc-examples/bin/` directory that run the examples. Each
+example requires the server to be running before starting the client.
+
+For example, to try the hello world example first run:
 
 ```
-$ ./gradlew :grpc-examples:routeGuideClient
+$ ./build/install/grpc-examples/bin/hello-world-server
+```
+
+And in a different terminal window run:
+
+```
+$ ./build/install/grpc-examples/bin/hello-world-client
 ```
 
 That's it!
 
-Please refer to [Getting Started Guide for Java] (https://github.com/grpc/grpc-common/blob/master/java/javatutorial.md) for more information.
+Please refer to [Getting Started Guide for Java]
+(https://github.com/grpc/grpc-common/blob/master/java/javatutorial.md) for more
+information.

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,28 +23,40 @@ dependencies {
 
 configureProtoCompilation()
 
-task routeGuideServer(type: JavaExec) {
-    main = "io.grpc.examples.routeguide.RouteGuideServer"
-    description = "Executes the route guide server."
-    classpath = sourceSets.main.runtimeClasspath
+task routeGuideServer(type: CreateStartScripts) {
+    mainClassName = "io.grpc.examples.routeguide.RouteGuideServer"
+    applicationName = "route-guide-server"
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
-task routeGuideClient(type: JavaExec) {
-    main = "io.grpc.examples.routeguide.RouteGuideClient"
-    description = "Executes the route guide client."
-    classpath = sourceSets.main.runtimeClasspath
+task routeGuideClient(type: CreateStartScripts) {
+    mainClassName = "io.grpc.examples.routeguide.RouteGuideClient"
+    applicationName = "route-guide-client"
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
-task helloWorldServer(type: JavaExec) {
-    main = "io.grpc.examples.helloworld.HelloWorldServer"
-    description = "Executes the hello world server."
-    classpath = sourceSets.main.runtimeClasspath
+task helloWorldServer(type: CreateStartScripts) {
+    mainClassName = "io.grpc.examples.helloworld.HelloWorldServer"
+    applicationName = "hello-world-server"
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
-task helloWorldClient(type: JavaExec) {
-    main = "io.grpc.examples.helloworld.HelloWorldClient"
-    description = "Executes the hello world client."
-    classpath = sourceSets.main.runtimeClasspath
+task helloWorldClient(type: CreateStartScripts) {
+    mainClassName = "io.grpc.examples.helloworld.HelloWorldClient"
+    applicationName = "hello-world-client"
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
+}
+
+applicationDistribution.into("bin") {
+    from(routeGuideServer)
+    from(routeGuideClient)
+    from(helloWorldServer)
+    from(helloWorldClient)
+    fileMode = 0755
 }
 
 // Allow intellij projects to refer to generated-sources


### PR DESCRIPTION
This makes it easy to run our test client/server without the "magic" of
executing directly from Gradle. This makes it more obvious what code is
being run and prevents confusion due to Gradle "hanging" when starting
the server.

This also fixes build errors when running 'installDist' at the root
project.

Resolves #394