### PR TITLE
Make Channel/Server abstract classes

### DIFF
--- a/core/src/main/java/io/grpc/Channel.java
+++ b/core/src/main/java/io/grpc/Channel.java
@@ -41,11 +41,11 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>Applications can add common cross-cutting behaviors to stubs by decorating Channel
  * implementations using {@link ClientInterceptor}. It is expected that most application
- * code will not use this interface directly but rather work with stubs that have been bound to a
+ * code will not use this class directly but rather work with stubs that have been bound to a
  * Channel that was decorated during application initialization,
  */
 @ThreadSafe
-public interface Channel {
+public abstract class Channel {
 
   /**
    * Create a {@link Call} to the remote operation specified by the given
@@ -57,6 +57,6 @@ public interface Channel {
    * @return a {@link Call} bound to the specified method.
    *
    */
-  public <RequestT, ResponseT> Call<RequestT, ResponseT> newCall(
+  public abstract <RequestT, ResponseT> Call<RequestT, ResponseT> newCall(
       MethodDescriptor<RequestT, ResponseT> methodDescriptor);
 }

--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -52,7 +52,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** A communication channel for making outgoing RPCs. */
 @ThreadSafe
-public final class ChannelImpl implements Channel {
+public final class ChannelImpl extends Channel {
 
   private static final Logger log = Logger.getLogger(ChannelImpl.class.getName());
 

--- a/core/src/main/java/io/grpc/ClientInterceptors.java
+++ b/core/src/main/java/io/grpc/ClientInterceptors.java
@@ -77,7 +77,7 @@ public class ClientInterceptors {
     return new InterceptorChannel(channel, interceptors);
   }
 
-  private static class InterceptorChannel implements Channel {
+  private static class InterceptorChannel extends Channel {
     private final Channel channel;
     private final Iterable<ClientInterceptor> interceptors;
 
@@ -92,7 +92,7 @@ public class ClientInterceptors {
     }
   }
 
-  private static class ProcessInterceptorChannel implements Channel {
+  private static class ProcessInterceptorChannel extends Channel {
     private final Channel channel;
     private Iterator<ClientInterceptor> interceptors;
 

--- a/core/src/main/java/io/grpc/Server.java
+++ b/core/src/main/java/io/grpc/Server.java
@@ -34,8 +34,8 @@ package io.grpc;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Server for listening for and dispatching incoming calls. Although Server is an interface, it is
- * not expected to be implemented by application code or interceptors.
+ * Server for listening for and dispatching incoming calls. It is not expected to be implemented by
+ * application code or interceptors.
  */
 @ThreadSafe
-public interface Server {}
+public abstract class Server {}

--- a/core/src/main/java/io/grpc/ServerImpl.java
+++ b/core/src/main/java/io/grpc/ServerImpl.java
@@ -61,7 +61,7 @@ import java.util.concurrent.TimeUnit;
  * <p>Starting the server starts the underlying transport for servicing requests. Stopping the
  * server stops servicing new requests and waits for all connections to terminate.
  */
-public class ServerImpl implements Server {
+public final class ServerImpl extends Server {
   private static final ServerStreamListener NOOP_LISTENER = new NoopListener();
 
   /** Executor for application processing. */

--- a/integration-testing/src/test/java/io/grpc/stub/StubConfigTest.java
+++ b/integration-testing/src/test/java/io/grpc/stub/StubConfigTest.java
@@ -70,7 +70,7 @@ public class StubConfigTest {
   }
 
 
-  private static class FakeChannel implements Channel {
+  private static class FakeChannel extends Channel {
     @Override
     public <ReqT, RespT> Call<ReqT, RespT> newCall(MethodDescriptor<ReqT, RespT> method) {
       return null;


### PR DESCRIPTION
Abstract classes allow us greater ability to change them over time. They
previously were interfaces to allow us to use Guava's AbstractService.

Resolves #65