### PR TITLE
Stop running gradle in run-test-{client,server}.sh

### DIFF
--- a/run-test-client.sh
+++ b/run-test-client.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -e
 cd "$(dirname "$0")"
-./gradlew :grpc-integration-testing:installDist
-./integration-testing/build/install/grpc-integration-testing/bin/test-client "$@"
+cat >&2 <<EOF
+Gradle is no longer run automatically. Make sure to run './gradlew installDist' or
+'./gradlew :grpc-integration-testing:installDist' after any changes.
+EOF
+exec ./integration-testing/build/install/grpc-integration-testing/bin/test-client "$@"

--- a/run-test-server.sh
+++ b/run-test-server.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -e
 cd "$(dirname "$0")"
-./gradlew :grpc-integration-testing:installDist
-./integration-testing/build/install/grpc-integration-testing/bin/test-server "$@"
+cat >&2 <<EOF
+Gradle is no longer run automatically. Make sure to run './gradlew installDist' or
+'./gradlew :grpc-integration-testing:installDist' after any changes.
+EOF
+exec ./integration-testing/build/install/grpc-integration-testing/bin/test-server "$@"


### PR DESCRIPTION
This substantially decreases the amount of time to run a client test via
the script.

Resolves #205

This must wait until https://github.com/grpc/grpc/pull/1510 is merged to avoid breaking integration testing.