### PR TITLE
isReady() should return false until stream allocated

### DIFF
--- a/core/src/main/java/io/grpc/transport/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractServerStream.java
@@ -72,7 +72,7 @@ public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
 
     // Now that the stream has actually been initialized, call the listener's onReady callback if
     // appropriate.
-    notifyIfReady();
+    onStreamAllocated();
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
@@ -92,7 +92,7 @@ class NettyClientStream extends Http2ClientStream {
 
     // Now that the stream has actually been initialized, call the listener's onReady callback if
     // appropriate.
-    notifyIfReady();
+    onStreamAllocated();
   }
 
   /**

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientStreamTest.java
@@ -42,7 +42,9 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 import io.grpc.Metadata;
@@ -276,10 +278,14 @@ public class NettyClientStreamTest extends NettyStreamTestBase {
 
   @Test
   public void setHttp2StreamShouldNotifyReady() {
+    listener = mock(ClientStreamListener.class);
+    stream = new NettyClientStream(listener, channel, handler);
     stream().id(STREAM_ID);
     verify(listener, never()).onReady();
+    assertFalse(stream.isReady());
     stream().setHttp2Stream(http2Stream);
     verify(listener).onReady();
+    assertTrue(stream.isReady());
   }
 
   @Override
@@ -288,6 +294,8 @@ public class NettyClientStreamTest extends NettyStreamTestBase {
     assertTrue(stream.canSend());
     assertTrue(stream.canReceive());
     stream.id(STREAM_ID);
+    stream.setHttp2Stream(http2Stream);
+    reset(listener);
     return stream;
   }
 

--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
@@ -126,6 +126,16 @@ class OkHttpClientStream extends Http2ClientStream {
     this.id = id;
   }
 
+  /**
+   * Notification that this stream was allocated for the connection. This means the stream has
+   * passed through any delay caused by MAX_CONCURRENT_STREAMS.
+   */
+  public void allocated() {
+    // Now that the stream has actually been initialized, call the listener's onReady callback if
+    // appropriate.
+    onStreamAllocated();
+  }
+
   public void transportHeadersReceived(List<Header> headers, boolean endOfStream) {
     synchronized (lock) {
       if (endOfStream) {

--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
@@ -251,6 +251,7 @@ public class OkHttpClientTransport implements ClientTransport {
     stream.id(nextStreamId);
     streams.put(stream.id(), stream);
     frameWriter.synStream(false, false, stream.id(), 0, requestHeaders);
+    stream.allocated();
     // For unary and server streaming, there will be a data frame soon, no need to flush the header.
     if (stream.getType() != MethodType.UNARY
         && stream.getType() != MethodType.SERVER_STREAMING) {


### PR DESCRIPTION
isReady() can provide pushback while the call is in progress, but it
can also provide the pushback necessary when the client creates more
streams than permitted by MAX_CONCURRENT_STREAMS.

As part of this commit, OkHttp is now calling onReady() after call
creation (it previously never called onReady()).

This addresses the basic concerns of #371, but does not implement full
flow control for OkHttp.