### PR TITLE
Fixing benchmarks build in eclipse.

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -14,13 +14,13 @@ buildscript {
     }
     dependencies {
         classpath libraries.protobuf_plugin
-        classpath "me.champeau.gradle:jmh-gradle-plugin:0.2.0"
+        classpath libraries.jmh_gradle_plugin
     }
 }
-apply plugin: 'me.champeau.gradle.jmh'
+apply plugin: jmh_plugin_name
 
 jmh {
-    jmhVersion = '1.7.1'
+    jmhVersion = jmh_version
     warmupIterations = 10
     iterations = 10
     fork = 1
@@ -39,7 +39,8 @@ dependencies {
             project(':grpc-integration-testing'),
             libraries.junit,
             libraries.mockito,
-            libraries.hdrhistogram
+            libraries.hdrhistogram,
+            libraries.jmh_core
 
     alpnboot alpnboot_package_name
 }

--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,17 @@ subprojects {
           }
         }
 
+        jmh_plugin_name = 'me.champeau.gradle.jmh'
+        jmh_version = '1.9.1'
+
         libraries = [
                 guava: 'com.google.guava:guava:18.0',
                 // used to collect benchmark results
                 hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.4',
                 hpack: 'com.twitter:hpack:0.10.1',
                 javaee_api: 'javax:javaee-api:7.0',
+                jmh_core: 'org.openjdk.jmh:jmh-core:' + jmh_version,
+                jmh_gradle_plugin: 'me.champeau.gradle:jmh-gradle-plugin:0.2.0',
                 jsonp: 'org.glassfish:javax.json:1.0.4',
                 jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
                 oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.1.0',


### PR DESCRIPTION
Eclipse doesn't seem to be JMH aware and therefore doesn't pick up the
jmh dependency automatically. Adding it explicitly as a dependency of
the benchmarks module.