### PR TITLE
Add ping to ClientTransport and ChannelImpl

### DIFF
--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -37,11 +37,13 @@ import com.google.common.base.Throwables;
 import io.grpc.transport.ClientStream;
 import io.grpc.transport.ClientStreamListener;
 import io.grpc.transport.ClientTransport;
+import io.grpc.transport.ClientTransport.PingCallback;
 import io.grpc.transport.ClientTransportFactory;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -176,6 +178,21 @@ public final class ChannelImpl extends Channel {
   }
 
   /**
+   * Pings the remote endpoint to verify that the transport is still active. When an acknowledgement
+   * is received, the given callback will be invoked using the given executor.
+   *
+   * <p>If the underlying transport has no mechanism by when to send a ping, this method may throw
+   * an {@link UnsupportedOperationException}. The operation may
+   * {@linkplain PingCallback#pingFailed(Throwable) fail} due to transient transport errors. In
+   * that case, trying again may succeed.
+   *
+   * @see ClientTransport#ping(PingCallback, Executor)
+   */
+  public void ping(PingCallback callback, Executor executor) {
+    obtainActiveTransport().ping(callback, executor);
+  }
+
+  /*
    * Creates a new outgoing call on the channel.
    */
   @Override

--- a/core/src/main/java/io/grpc/transport/Http2Ping.java
+++ b/core/src/main/java/io/grpc/transport/Http2Ping.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.transport;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Maps;
+
+import io.grpc.transport.ClientTransport.PingCallback;
+
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * Represents an outstanding PING operation on an HTTP/2 channel. This can be used by HTTP/2-based
+ * transports to implement {@link ClientTransport#ping}.
+ *
+ * <p>A typical transport need only support one outstanding ping at a time. So, if a ping is
+ * requested while an operation is already in progress, the given callback is notified when the
+ * existing operation completes.
+ */
+public class Http2Ping {
+  private static final Logger log = Logger.getLogger(Http2Ping.class.getName());
+
+  /**
+   * The PING frame includes 8 octets of payload data, e.g. 64 bits.
+   */
+  private final long data;
+
+  /**
+   * Used to measure elapsed time.
+   */
+  private final Stopwatch stopwatch;
+
+  /**
+   * The registered callbacks and the executor used to invoke them.
+   */
+  @GuardedBy("this") private Map<PingCallback, Executor> callbacks = Maps.newLinkedHashMap();
+
+  /**
+   * False until the operation completes, either successfully (other side sent acknowledgement) or
+   * unsuccessfully.
+   */
+  @GuardedBy("this") private boolean completed;
+
+  /**
+   * If non-null, indicates the ping failed.
+   */
+  @GuardedBy("this") private Throwable failureCause;
+
+  /**
+   * The round-trip time for the ping, in microseconds. This value is only meaningful when
+   * {@link #completed} is true and {@link #failureCause} is null.
+   */
+  @GuardedBy("this") private long roundTripTimeMicros;
+
+  /**
+   * Creates a new ping operation. The caller is responsible for sending a ping on an HTTP/2 channel
+   * using the given payload. The caller is also responsible for starting the stopwatch when the
+   * PING frame is sent.
+   *
+   * @param data the ping payload
+   * @param stopwatch a stopwatch for measuring round-trip time
+   */
+  public Http2Ping(long data, Stopwatch stopwatch) {
+    this.data = data;
+    this.stopwatch = stopwatch;
+  }
+
+  /**
+   * Registers a callback that is invoked when the ping operation completes. If this ping operation
+   * is already completed, the callback is invoked immediately.
+   *
+   * @param callback the callback to invoke
+   * @param executor the executor to use
+   */
+  public void addCallback(final ClientTransport.PingCallback callback, Executor executor) {
+    Runnable runnable;
+    synchronized (this) {
+      if (!completed) {
+        callbacks.put(callback, executor);
+        return;
+      }
+      // otherwise, invoke callback immediately (but not while holding lock)
+      runnable = this.failureCause != null ? asRunnable(callback, failureCause)
+                                           : asRunnable(callback, roundTripTimeMicros);
+    }
+    doExecute(executor, runnable);
+  }
+
+  /**
+   * Returns the expected ping payload for this outstanding operation.
+   *
+   * @return the expected payload for this outstanding ping
+   */
+  public long payload() {
+    return data;
+  }
+
+  /**
+   * Completes this operation successfully. The stopwatch given during construction is used to
+   * measure the elapsed time. Registered callbacks are invoked and provided the measured elapsed
+   * time.
+   *
+   * @return true if the operation is marked as complete; false if it was already complete
+   */
+  public boolean complete() {
+    Map<ClientTransport.PingCallback, Executor> callbacks;
+    long roundTripTimeMicros;
+    synchronized (this) {
+      if (completed) {
+        return false;
+      }
+      completed = true;
+      roundTripTimeMicros = this.roundTripTimeMicros = stopwatch.elapsed(TimeUnit.MICROSECONDS);
+      callbacks = this.callbacks;
+      this.callbacks = null;
+    }
+    for (Map.Entry<ClientTransport.PingCallback, Executor> entry : callbacks.entrySet()) {
+      doExecute(entry.getValue(), asRunnable(entry.getKey(), roundTripTimeMicros));
+    }
+    return true;
+  }
+
+  /**
+   * Completes this operation exceptionally. Registered callbacks are invoked and provided the
+   * given throwable as the cause of failure.
+   *
+   * @param failureCause the cause of failure
+   */
+  public void failed(Throwable failureCause) {
+    Map<ClientTransport.PingCallback, Executor> callbacks;
+    synchronized (this) {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      this.failureCause = failureCause;
+      callbacks = this.callbacks;
+      this.callbacks = null;
+    }
+    for (Map.Entry<ClientTransport.PingCallback, Executor> entry : callbacks.entrySet()) {
+      doExecute(entry.getValue(), asRunnable(entry.getKey(), failureCause));
+    }
+  }
+
+  /**
+   * Notifies the given callback that the ping operation failed.
+   *
+   * @param callback the callback
+   * @param executor the executor used to invoke the callback
+   * @param cause the cause of failure
+   */
+  public static void notifyFailed(PingCallback callback, Executor executor, Throwable cause) {
+    doExecute(executor, asRunnable(callback, cause));
+  }
+
+  /**
+   * Executes the given runnable. This prevents exceptions from propagating so that an exception
+   * thrown by one callback won't prevent subsequent callbacks from being executed.
+   */
+  private static void doExecute(Executor executor, Runnable runnable) {
+    try {
+      executor.execute(runnable);
+    } catch (Throwable th) {
+      log.log(Level.SEVERE, "Failed to execute PingCallback", th);
+    }
+  }
+
+  /**
+   * Returns a runnable that, when run, invokes the given callback, providing the given round-trip
+   * duration.
+   */
+  private static Runnable asRunnable(final ClientTransport.PingCallback callback,
+                                     final long roundTripTimeMicros) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        callback.pingAcknowledged(roundTripTimeMicros);
+      }
+    };
+
+  }
+
+  /**
+   * Returns a runnable that, when run, invokes the given callback, providing the given cause of
+   * failure.
+   */
+  private static Runnable asRunnable(final ClientTransport.PingCallback callback,
+                                     final Throwable failureCause) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        callback.pingFailed(failureCause);
+      }
+    };
+  }
+}

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
@@ -33,12 +33,16 @@ package io.grpc.transport.netty;
 
 import static io.netty.util.CharsetUtil.UTF_8;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Ticker;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.transport.ClientTransport.PingCallback;
+import io.grpc.transport.Http2Ping;
 import io.grpc.transport.HttpUtil;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -57,6 +61,8 @@ import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.handler.codec.http2.Http2StreamVisitor;
 
+import java.util.Random;
+import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -70,9 +76,12 @@ class NettyClientHandler extends Http2ConnectionHandler {
   private static final Logger logger = Logger.getLogger(NettyClientHandler.class.getName());
 
   private final Http2Connection.PropertyKey streamKey;
+  private final Ticker ticker;
+  private final Random random = new Random();
   private WriteQueue clientWriteQueue;
   private int connectionWindowSize;
   private Throwable connectionError;
+  private Http2Ping ping;
   private Status goAwayStatus;
   private ChannelHandlerContext ctx;
   private int nextStreamId;
@@ -80,8 +89,16 @@ class NettyClientHandler extends Http2ConnectionHandler {
   public NettyClientHandler(BufferingHttp2ConnectionEncoder encoder, Http2Connection connection,
                             Http2FrameReader frameReader,
                             int connectionWindowSize, int streamWindowSize) {
+    this(encoder, connection, frameReader, connectionWindowSize, streamWindowSize,
+         Ticker.systemTicker());
+  }
+
+  @VisibleForTesting
+  NettyClientHandler(BufferingHttp2ConnectionEncoder encoder, Http2Connection connection,
+      Http2FrameReader frameReader, int connectionWindowSize, int streamWindowSize, Ticker ticker) {
     super(new DefaultHttp2ConnectionDecoder(connection, encoder, frameReader,
         new LazyFrameListener()), encoder);
+    this.ticker = ticker;
     Preconditions.checkArgument(connectionWindowSize > 0, "connectionWindowSize must be positive");
     this.connectionWindowSize = connectionWindowSize;
     try {
@@ -145,6 +162,8 @@ class NettyClientHandler extends Http2ConnectionHandler {
       cancelStream(ctx, (CancelStreamCommand) msg, promise);
     } else if (msg instanceof RequestMessagesCommand) {
       ((RequestMessagesCommand) msg).requestMessages();
+    } else if (msg instanceof SendPingCommand) {
+      sendPingFrame(ctx, (SendPingCommand) msg, promise);
     } else {
       throw new AssertionError("Write called for unexpected type: " + msg.getClass().getName());
     }
@@ -211,6 +230,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
     try {
       logger.fine("Network channel is closed");
       goAwayStatus(goAwayStatus().augmentDescription("Network channel closed"));
+      cancelPing();
       // Report status to the application layer for any open streams
       connection().forEachActiveStream(new Http2StreamVisitor() {
         @Override
@@ -233,6 +253,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
     // Save the error.
     connectionError = cause;
     goAwayStatus(Status.fromThrowable(connectionError));
+    cancelPing();
 
     super.onConnectionError(ctx, cause, http2Ex);
   }
@@ -316,6 +337,50 @@ class NettyClientHandler extends Http2ConnectionHandler {
   }
 
   /**
+   * Sends a PING frame. If a ping operation is already outstanding, the callback in the message is
+   * registered to be called when the existing operation completes, and no new frame is sent.
+   */
+  private void sendPingFrame(ChannelHandlerContext ctx, SendPingCommand msg,
+      ChannelPromise promise) {
+    PingCallback callback = msg.callback();
+    Executor executor = msg.executor();
+    if (!ctx.channel().isOpen()) {
+      Http2Ping.notifyFailed(callback, executor, getPingFailure());
+      return;
+    }
+
+    // we only allow one outstanding ping at a time, so just add the callback to
+    // any outstanding operation
+    if (ping != null) {
+      ping.addCallback(callback, executor);
+      return;
+    }
+
+    // set outstanding operation
+    long data = random.nextLong();
+    ByteBuf buffer = ctx.alloc().buffer(8);
+    buffer.writeLong(data);
+    Stopwatch stopwatch = Stopwatch.createStarted(ticker);
+    ping = new Http2Ping(data, stopwatch);
+    ping.addCallback(callback, executor);
+    // and then write the ping
+    encoder().writePing(ctx, false, buffer, promise);
+    ctx.flush();
+    final Http2Ping finalPing = ping;
+    promise.addListener(new ChannelFutureListener() {
+      @Override
+      public void operationComplete(ChannelFuture future) throws Exception {
+        if (!future.isSuccess()) {
+          finalPing.failed(future.cause());
+          if (ping == finalPing) {
+            ping = null;
+          }
+        }
+      }
+    });
+  }
+
+  /**
    * Handler for a GOAWAY being either sent or received. Fails any streams created after the
    * last known stream.
    */
@@ -351,6 +416,23 @@ class NettyClientHandler extends Http2ConnectionHandler {
 
   private void goAwayStatus(Status status) {
     goAwayStatus = goAwayStatus == null ? status : goAwayStatus;
+  }
+
+  private void cancelPing() {
+    if (ping != null) {
+      ping.failed(getPingFailure());
+      ping = null;
+    }
+  }
+
+  private Throwable getPingFailure() {
+    if (connectionError != null) {
+      return connectionError;
+    } else if (goAwayStatus != null) {
+      return goAwayStatus.asException();
+    } else {
+      return Status.UNAVAILABLE.withDescription("Connection closed").asException();
+    }
   }
 
   private Status statusFromGoAway(long errorCode, ByteBuf debugData) {
@@ -428,6 +510,23 @@ class NettyClientHandler extends Http2ConnectionHandler {
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
         throws Http2Exception {
       handler.onRstStreamRead(streamId);
+    }
+
+    @Override public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data)
+        throws Http2Exception {
+      Http2Ping p = handler.ping;
+      if (p != null) {
+        long ackPayload = data.readLong();
+        if (p.payload() == ackPayload) {
+          p.complete();
+          handler.ping = null;
+        } else {
+          logger.log(Level.WARNING, String.format("Received unexpected ping ack. "
+              + "Expecting %d, got %d", p.payload(), ackPayload));
+        }
+      } else {
+        logger.warning("Received unexpected ping ack. No ping outstanding");
+      }
     }
   }
 }

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
@@ -64,6 +64,7 @@ import io.netty.util.AsciiString;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -115,6 +116,12 @@ class NettyClientTransport implements ClientTransport {
 
     handler = newHandler();
     negotiationHandler = negotiator.newHandler(handler);
+  }
+
+  @Override
+  public void ping(PingCallback callback, Executor executor) {
+    // Write the command requesting the ping
+    handler.getWriteQueue().enqueue(new SendPingCommand(callback, executor), true);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/transport/netty/SendPingCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/SendPingCommand.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.transport.netty;
+
+import io.grpc.transport.ClientTransport.PingCallback;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Command sent from the transport to the Netty channel to send a PING frame.
+ */
+class SendPingCommand {
+  private final PingCallback callback;
+  private final Executor executor;
+
+  SendPingCommand(PingCallback callback, Executor executor) {
+    this.callback = callback;
+    this.executor = executor;
+  }
+
+  PingCallback callback() {
+    return callback;
+  }
+
+  Executor executor() {
+    return executor;
+  }
+}


### PR DESCRIPTION
Adds a mechanism for sending HTTP/2 ping frame from client to server. This can be a basis for health-checking.

Also adds a couple of simple utility methods to `ChannelImpl`. The `tryStartTransport` isn't too valuable yet since the connect may occur asynchronously (and the real intent is to get the transport both started and be able to wait for it to become connected/ready). It will be more useful when combined with a listener that can receive updates when the channel becomes connected and disconnected (and can then use this method to automatically re-start a transport, in the event it gets shutdown/disconnected).