### PR TITLE
Fix a bug that checked-in generated code are not re-compiled.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ subprojects {
         protobufVersion = '3.0.0-alpha-2'
 
         configureProtoCompilation = {
+          String generatedSourcePath = 'src/generated'
           if (rootProject.childProjects.containsKey('grpc-compiler')) {
             // Only when the codegen is built along with the project, will we be able to recompile
             // the proto files.
@@ -61,17 +62,24 @@ subprojects {
               // it's possible the version of protoc has been changed.
               generateProto.inputs.file "${rootProject.projectDir}/build.gradle"
             }
+            // Delete the generated sources first, so that we can be alerted if they are not re-compiled.
+            project.delete project.fileTree(dir: generatedSourcePath)
+
+            project.sourceSets {
+              main {
+                proto {
+                  plugins {
+                    grpc { }
+                  }
+                }
+              }
+            }
           } else {
             // Otherwise, we just use the checked-in generated code.
             project.sourceSets {
               main {
                 java {
-                  srcDir 'src/generated/main'
-                }
-                proto {
-                  plugins {
-                    grpc { }
-                  }
+                  srcDir "${generatedSourcePath}/main"
                 }
               }
             }


### PR DESCRIPTION
Since commit 287a27a the ``grpc`` codegen plugin must be explicitly
added to the ``plugins`` block of the source set, while it is not.

Remove the generated code before recompiling it to prevent such issue
from being missed by tests.

@ejona86 please review