### PR TITLE
Add property ``protoc=/path/to/protoc``

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ default. To override this default and use MinGW, add ``-PvcDisable=true``
 to your Gradle command line or add ``vcDisable=true`` to your
 ``<project-root>\gradle.properties``.
 
+### Notes for unsupported operating systems
+The build script pulls pre-compiled ``protoc`` from Maven Central by default.
+We have built ``protoc`` binaries for popular systems, but they may not work
+for your system. If ``protoc`` cannot be downloaded or would not run, you can
+use the one that has been built by your own, by adding this property to
+``<project-root>/gradle.properties``:
+```
+protoc=/path/to/protoc
+```
+
 Navigating Around the Source
 ----------------------------
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,11 @@ subprojects {
             // the proto files.
             project.apply plugin: 'com.google.protobuf'
             project.protobufCodeGenPlugins = ["grpc:$javaPluginPath"]
-            project.protocDep = "com.google.protobuf:protoc:${protobufVersion}"
+            if (project.hasProperty('protoc')) {
+              project.protocPath = project.protoc
+            } else {
+              project.protocDep = "com.google.protobuf:protoc:${protobufVersion}"
+            }
             project.generatedFileDir = "${projectDir}/src/generated"
             project.afterEvaluate {
               generateProto.dependsOn ':grpc-compiler:java_pluginExecutable'
@@ -98,7 +102,7 @@ subprojects {
                 okhttp: 'com.squareup.okhttp:okhttp:2.2.0',
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufVersion}",
-                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.4.0',
+                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.4.1',
 
                 netty: 'io.netty:netty-codec-http2:4.1.0.Beta5',
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -187,7 +187,11 @@ artifacts {
   }
 }
 
-project.protocDep = "com.google.protobuf:protoc:${protobufVersion}"
+if (project.hasProperty('protoc')) {
+  project.protocPath = project.protoc
+} else {
+  project.protocDep = "com.google.protobuf:protoc:${protobufVersion}"
+}
 protobufCodeGenPlugins = ["grpc:$javaPluginPath"]
 
 project.afterEvaluate {


### PR DESCRIPTION
This allows people who cannot run the pre-compiled ``protoc`` pulled
from Maven Central to use their own ``protoc``.

Upgrade to protobuf-gradle-plugin:0.4.1 to display error messages of
protoc failures.

@ejona86 please review