### PR TITLE
Simplify the build instructions now that Netty can be fetched from Maven

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/netty"]
-	path = lib/netty
-	url = https://github.com/netty/netty.git

--- a/README.md
+++ b/README.md
@@ -6,16 +6,6 @@ gRPC-Java - An RPC library and framework
 How to Build
 ------------
 
-### Build Netty
-grpc-java requires Netty 4.1, which is still in flux. The version we need can be
-found in the lib/netty submodule, which requires Maven 3.2 or higher to build:
-```
-$ git submodule update --init
-$ cd lib/netty
-$ mvn install -pl codec-http2 -am -DskipTests=true
-```
-
-### Build gRPC
 grpc-java has a C++ code generation plugin for protoc. Since many Java
 developers don't have C compilers installed and don't need to modify the
 codegen, the build can skip it. To skip, create the file

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -17,21 +17,3 @@ else
   make install
   popd
 fi
-
-# Make and install netty
-pushd lib/netty
-BUILD_NETTY=1
-NETTY_REV_FILE="$HOME/.m2/repository/io/netty/netty-ver"
-REV="$(git rev-parse HEAD)"
-if [ -f "$NETTY_REV_FILE" ]; then
-  REV_LAST="$(cat "$NETTY_REV_FILE")"
-  if [ z"$REV" = z"$REV_LAST" ]; then
-    BUILD_NETTY=0
-    echo "Not building Netty; already at $REV"
-  fi
-fi
-if [ $BUILD_NETTY = 1 ]; then
-  mvn install -pl codec-http2 -am -DskipTests=true
-  echo "$REV" > "$NETTY_REV_FILE"
-fi
-popd


### PR DESCRIPTION
We were previously building Netty from source because we relied on a version that wasn't available in Maven. However, Netty has now been pushed to Maven Central, so there's no longer a need to check it out and build it.