### PR TITLE
okhttp: Sends reset if client receives halfClose before sending halfClose.

### DIFF
--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
@@ -208,6 +208,11 @@ class OkHttpClientStream extends Http2ClientStream {
   @Override
   public void remoteEndClosed() {
     super.remoteEndClosed();
+    if (canSend()) {
+      // If server's end-of-stream is received before client sends end-of-stream, we just send a
+      // reset to server to fully close the server side stream.
+      frameWriter.rstStream(id(), ErrorCode.CANCEL);
+    }
     transport.finishStream(id(), null, null);
   }
 


### PR DESCRIPTION
So that the server side stream can be fully closed.

This fixed #300

@ejona86 