### PR TITLE
updates to test native epoll

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -39,7 +39,9 @@ dependencies {
             project(':grpc-integration-testing'),
             libraries.junit,
             libraries.mockito,
-            libraries.hdrhistogram
+            libraries.hdrhistogram,
+            libraries.netty_tcnative,
+            libraries.netty_transport_native_epoll
 
     alpnboot alpnboot_package_name
 }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
@@ -62,6 +62,7 @@ class ClientConfiguration {
   boolean tls;
   boolean testca;
   boolean directExecutor;
+  boolean nettyNativeTransport;
   int port;
   int channels = 4;
   int outstandingRpcsPerChannel = 10;
@@ -205,19 +206,31 @@ class ClientConfiguration {
       TLS("", "Enable TLS.", new Action() {
         @Override
         public void applyNew(ClientConfiguration config, String value) {
-          config.tls = true;
+          Boolean tls = Boolean.TRUE;
+          if (!value.isEmpty()) {
+            tls = Boolean.parseBoolean(value);
+          }
+          config.tls = tls;
         }
       }),
       TESTCA("", "Use the provided Test Certificate for TLS.", new Action() {
         @Override
         public void applyNew(ClientConfiguration config, String value) {
-          config.testca = true;
+          Boolean testca = Boolean.TRUE;
+          if (!value.isEmpty()) {
+            testca = Boolean.parseBoolean(value);
+          }
+          config.testca = testca;
         }
       }),
       OKHTTP("", "Use OkHttp as the Transport.", new Action() {
         @Override
         public void applyNew(ClientConfiguration config, String value) {
-          config.okhttp = true;
+          Boolean okhttp = Boolean.TRUE;
+          if (!value.isEmpty()) {
+            okhttp = Boolean.parseBoolean(value);
+          }
+          config.okhttp = okhttp;
         }
       }),
       DURATION("SECONDS", "Duration of the benchmark.", new Action() {
@@ -238,7 +251,23 @@ class ClientConfiguration {
           new Action() {
             @Override
             public void applyNew(ClientConfiguration config, String value) {
-              config.directExecutor = true;
+              Boolean directExecutor = Boolean.TRUE;
+              if (!value.isEmpty()) {
+                directExecutor = Boolean.parseBoolean(value);
+              }
+              config.directExecutor = directExecutor;
+            }
+          }),
+      NETTY_NATIVE_TRANSPORT("", "Whether to use Netty's native transport. Only supported when "
+          + "using the Netty transport on linux.",
+          new Action() {
+            @Override
+            public void applyNew(ClientConfiguration config, String value) {
+              Boolean nettyNativeTransport = Boolean.TRUE;
+              if (!value.isEmpty()) {
+                nettyNativeTransport = Boolean.parseBoolean(value);
+              }
+              config.nettyNativeTransport = nettyNativeTransport;
             }
           }),
       SAVE_HISTOGRAM("FILE", "Write the histogram with the latency recordings to file.",

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
@@ -206,31 +206,28 @@ class ClientConfiguration {
       TLS("", "Enable TLS.", new Action() {
         @Override
         public void applyNew(ClientConfiguration config, String value) {
-          Boolean tls = Boolean.TRUE;
+          config.tls = true;
           if (!value.isEmpty()) {
-            tls = Boolean.parseBoolean(value);
+            config.tls = Boolean.parseBoolean(value);
           }
-          config.tls = tls;
         }
       }),
       TESTCA("", "Use the provided Test Certificate for TLS.", new Action() {
         @Override
         public void applyNew(ClientConfiguration config, String value) {
-          Boolean testca = Boolean.TRUE;
+          config.testca = true;
           if (!value.isEmpty()) {
-            testca = Boolean.parseBoolean(value);
+            config.testca = Boolean.parseBoolean(value);
           }
-          config.testca = testca;
         }
       }),
       OKHTTP("", "Use OkHttp as the Transport.", new Action() {
         @Override
         public void applyNew(ClientConfiguration config, String value) {
-          Boolean okhttp = Boolean.TRUE;
+          config.okhttp = true;
           if (!value.isEmpty()) {
-            okhttp = Boolean.parseBoolean(value);
+            config.okhttp = Boolean.parseBoolean(value);
           }
-          config.okhttp = okhttp;
         }
       }),
       DURATION("SECONDS", "Duration of the benchmark.", new Action() {
@@ -251,23 +248,21 @@ class ClientConfiguration {
           new Action() {
             @Override
             public void applyNew(ClientConfiguration config, String value) {
-              Boolean directExecutor = Boolean.TRUE;
+              config.directExecutor = true;
               if (!value.isEmpty()) {
-                directExecutor = Boolean.parseBoolean(value);
+                config.directExecutor = Boolean.parseBoolean(value);
               }
-              config.directExecutor = directExecutor;
             }
           }),
       NETTY_NATIVE_TRANSPORT("", "Whether to use Netty's native transport. Only supported when "
-          + "using the Netty transport on linux.",
+          + "using the Netty transport on Linux.",
           new Action() {
             @Override
             public void applyNew(ClientConfiguration config, String value) {
-              Boolean nettyNativeTransport = Boolean.TRUE;
+              config.nettyNativeTransport = true;
               if (!value.isEmpty()) {
-                nettyNativeTransport = Boolean.parseBoolean(value);
+                config.nettyNativeTransport = Boolean.parseBoolean(value);
               }
-              config.nettyNativeTransport = nettyNativeTransport;
             }
           }),
       SAVE_HISTOGRAM("FILE", "Write the histogram with the latency recordings to file.",

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,8 @@ subprojects {
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.4.1',
 
                 netty: 'io.netty:netty-codec-http2:4.1.0.Beta5',
+                netty_tcnative: "io.netty:netty-tcnative:1.1.33.Fork2:${osdetector.classifier}",
+                netty_transport_native_epoll: "io.netty:netty-transport-native-epoll:4.1.0.Beta5:${osdetector.classifier}",
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',

--- a/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
+++ b/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
@@ -123,21 +123,19 @@ public final class Http2Negotiator {
         final SettableFuture<Void> completeFuture = SettableFuture.create();
         if (isOpenSsl(sslContext.getClass())) {
           sslEngine = sslContext.newEngine(ctx.alloc());
-          SSLParameters sslParams = new SSLParameters();
-          sslParams.setEndpointIdentificationAlgorithm("HTTPS");
-          sslEngine.setSSLParameters(sslParams);
           completeFuture.set(null);
         } else {
           // Using JDK SSL
           sslEngine
               = sslContext.newEngine(ctx.alloc(), inetAddress.getHostName(), inetAddress.getPort());
-          SSLParameters sslParams = new SSLParameters();
-          sslParams.setEndpointIdentificationAlgorithm("HTTPS");
-          sslEngine.setSSLParameters(sslParams);
           if (!installJettyTlsProtocolSelection(sslEngine, completeFuture, false)) {
             throw new IllegalStateException("NPN/ALPN extensions not installed");
           }
         }
+        SSLParameters sslParams = new SSLParameters();
+        sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+        sslEngine.setSSLParameters(sslParams);
+
         SslHandler sslHandler = new SslHandler(sslEngine, false);
         sslHandler.handshakeFuture().addListener(
             new GenericFutureListener<Future<? super Channel>>() {

--- a/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
+++ b/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
@@ -37,6 +37,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpRequest;
@@ -48,6 +49,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.Http2ClientUpgradeCodec;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2OrHttpChooser;
+import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.util.concurrent.Future;
@@ -56,6 +58,7 @@ import io.netty.util.concurrent.GenericFutureListener;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.net.InetSocketAddress;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,6 +68,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 
 /**
  * A utility class that provides support methods for negotiating the use of HTTP/2 with the remote
@@ -93,8 +97,11 @@ public final class Http2Negotiator {
    */
   public static ChannelHandler serverTls(SSLEngine sslEngine) {
     Preconditions.checkNotNull(sslEngine, "sslEngine");
-    if (!installJettyTlsProtocolSelection(sslEngine, SettableFuture.<Void>create(), true)) {
-      throw new IllegalStateException("NPN/ALPN extensions not installed");
+    if (!isOpenSsl(sslEngine.getClass())) {
+      // Using JDK SSL
+      if (!installJettyTlsProtocolSelection(sslEngine, SettableFuture.<Void>create(), true)) {
+        throw new IllegalStateException("NPN/ALPN extensions not installed");
+      }
     }
     return new SslHandler(sslEngine, false);
   }
@@ -104,26 +111,50 @@ public final class Http2Negotiator {
    * be negotiated, the {@code handler} is added and writes to the {@link Channel} may happen
    * immediately, even before the TLS Handshake is complete.
    */
-  public static ChannelHandler tls(final SSLEngine sslEngine, final ChannelHandler handler) {
-    Preconditions.checkNotNull(sslEngine, "sslEngine");
-    final SettableFuture<Void> completeFuture = SettableFuture.create();
-    if (!installJettyTlsProtocolSelection(sslEngine, completeFuture, false)) {
-      throw new IllegalStateException("NPN/ALPN extensions not installed");
-    }
-    SslHandler sslHandler = new SslHandler(sslEngine, false);
-    sslHandler.handshakeFuture().addListener(
-        new GenericFutureListener<Future<? super Channel>>() {
-          @Override
-          public void operationComplete(Future<? super Channel> future) throws Exception {
-            // If an error occurred during the handshake, throw it to the pipeline.
-            if (future.isSuccess()) {
-              completeFuture.get();
-            } else {
-              future.get();
-            }
+  public static ChannelHandler tls(final SslContext sslContext, final InetSocketAddress inetAddress,
+      final ChannelHandler handler) {
+    Preconditions.checkNotNull(sslContext, "sslContext");
+    Preconditions.checkNotNull(inetAddress, "inetAddress");
+
+    return new ChannelHandlerAdapter() {
+      @Override
+      public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        SSLEngine sslEngine;
+        final SettableFuture<Void> completeFuture = SettableFuture.create();
+        if (isOpenSsl(sslContext.getClass())) {
+          sslEngine = sslContext.newEngine(ctx.alloc());
+          SSLParameters sslParams = new SSLParameters();
+          sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+          sslEngine.setSSLParameters(sslParams);
+          completeFuture.set(null);
+        } else {
+          // Using JDK SSL
+          sslEngine
+              = sslContext.newEngine(ctx.alloc(), inetAddress.getHostName(), inetAddress.getPort());
+          SSLParameters sslParams = new SSLParameters();
+          sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+          sslEngine.setSSLParameters(sslParams);
+          if (!installJettyTlsProtocolSelection(sslEngine, completeFuture, false)) {
+            throw new IllegalStateException("NPN/ALPN extensions not installed");
           }
-        });
-    return new BufferUntilTlsNegotiatedHandler(sslHandler, handler);
+        }
+        SslHandler sslHandler = new SslHandler(sslEngine, false);
+        sslHandler.handshakeFuture().addListener(
+            new GenericFutureListener<Future<? super Channel>>() {
+              @Override
+              public void operationComplete(Future<? super Channel> future) throws Exception {
+                // If an error occurred during the handshake, throw it to the pipeline.
+                if (future.isSuccess()) {
+                  completeFuture.get();
+                } else {
+                  future.get();
+                }
+              }
+            });
+        ChannelHandler tlsHandler = new BufferUntilTlsNegotiatedHandler(sslHandler, handler);
+        ctx.pipeline().replace(this, "tlsHandler", tlsHandler);
+      }
+    };
   }
 
   /**
@@ -146,6 +177,13 @@ public final class Http2Negotiator {
    */
   public static ChannelHandler plaintext(final ChannelHandler handler) {
     return new BufferUntilChannelActiveHandler(handler);
+  }
+
+  /**
+   * Returns {@code true} if the given class is for use with Netty OpenSsl.
+   */
+  private static boolean isOpenSsl(Class<?> clazz) {
+    return clazz.getSimpleName().toLowerCase().contains("openssl");
   }
 
   /**

--- a/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
+++ b/netty/src/main/java/io/grpc/transport/netty/Http2Negotiator.java
@@ -116,7 +116,7 @@ public final class Http2Negotiator {
     Preconditions.checkNotNull(sslContext, "sslContext");
     Preconditions.checkNotNull(inetAddress, "inetAddress");
 
-    return new ChannelHandlerAdapter() {
+    ChannelHandler sslBootstrapHandler = new ChannelHandlerAdapter() {
       @Override
       public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         SSLEngine sslEngine;
@@ -151,10 +151,10 @@ public final class Http2Negotiator {
                 }
               }
             });
-        ChannelHandler tlsHandler = new BufferUntilTlsNegotiatedHandler(sslHandler, handler);
-        ctx.pipeline().replace(this, "tlsHandler", tlsHandler);
+        ctx.pipeline().replace(this, "sslHandler", sslHandler);
       }
     };
+    return new BufferUntilTlsNegotiatedHandler(sslBootstrapHandler, handler);
   }
 
   /**

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
@@ -68,9 +68,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.concurrent.GuardedBy;
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLParameters;
 
 /**
  * A Netty-based {@link ClientTransport} implementation.
@@ -138,13 +136,7 @@ class NettyClientTransport implements ClientTransport {
             throw new RuntimeException(ex);
           }
         }
-        // TODO(ejona86): specify allocator. The method currently ignores it though.
-        SSLEngine sslEngine
-            = sslContext.newEngine(null, inetAddress.getHostString(), inetAddress.getPort());
-        SSLParameters sslParams = new SSLParameters();
-        sslParams.setEndpointIdentificationAlgorithm("HTTPS");
-        sslEngine.setSSLParameters(sslParams);
-        negotiationHandler = Http2Negotiator.tls(sslEngine, handler);
+        negotiationHandler = Http2Negotiator.tls(sslContext, inetAddress, handler);
         ssl = true;
         break;
       default:


### PR DESCRIPTION
QPS results:

*** NIO_PLAINTEXT ***
Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     715
90%ile Latency (in micros):     1056
95%ile Latency (in micros):     1213
99%ile Latency (in micros):     1750
99.9%ile Latency (in micros):   5211
Maximum Latency (in micros):    25951
QPS:                            51810

*** EPOLL_PLAINTEXT ***
Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     649
90%ile Latency (in micros):     949
95%ile Latency (in micros):     1086
99%ile Latency (in micros):     1492
99.9%ile Latency (in micros):   4531
Maximum Latency (in micros):    43391
QPS:                            57355

*** NIO_TLS ***
Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     3235
90%ile Latency (in micros):     3773
95%ile Latency (in micros):     3983
99%ile Latency (in micros):     5079
99.9%ile Latency (in micros):   7695
Maximum Latency (in micros):    17759
QPS:                            12443

*** EPOLL_TLS (OpenSsl) ***
Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     1144
90%ile Latency (in micros):     1497
95%ile Latency (in micros):     1660
99%ile Latency (in micros):     2297
99.9%ile Latency (in micros):   6007
Maximum Latency (in micros):    40767
QPS:                            33881