### PR TITLE
Delete the generated files only before generateProto.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,16 +58,19 @@ subprojects {
               project.protocDep = "com.google.protobuf:protoc:${protobufVersion}"
             }
             project.generatedFileDir = "${projectDir}/src/generated"
+            task deleteGeneratedSource << {
+              project.delete project.fileTree(dir: generatedSourcePath)
+            }
             project.afterEvaluate {
               generateProto.dependsOn ':grpc-compiler:java_pluginExecutable'
+              // Delete the generated sources first, so that we can be alerted if they are not re-compiled.
+              generateProto.dependsOn deleteGeneratedSource
               // Recompile protos when the codegen has been changed
               generateProto.inputs.file javaPluginPath
               // Recompile protos when build.gradle has been changed, because
               // it's possible the version of protoc has been changed.
               generateProto.inputs.file "${rootProject.projectDir}/build.gradle"
             }
-            // Delete the generated sources first, so that we can be alerted if they are not re-compiled.
-            project.delete project.fileTree(dir: generatedSourcePath)
 
             project.sourceSets {
               main {


### PR DESCRIPTION
Previously generated files were deleted at configuration time. Running
non-build tasks such as ``clean`` or ``tasks`` would delete the
generated files and tracked by git, which is annoying. Now we delete
them only before the ``generateProto`` task, which solves the problem.

After this change, the case that ``generateProto`` is not executed at
all, is no longer covered. However, it is much less likely than the
still-covered case that ``generateProto`` is not re-generating all files
due to misconfiguration.

Addresses [#387#issuecomment-102220365](https://github.com/grpc/grpc-java/pull/387#issuecomment-102220365)

@ejona86 please review