### PR TITLE
Some more minor flush optimizations

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -176,6 +176,7 @@ public abstract class AbstractBenchmark {
     serverBuilder.addService(
         ServerServiceDefinition.builder("benchmark")
             .addMethod("unary",
+                MethodType.UNARY,
                 new ByteBufOutputMarshaller(),
                 new ByteBufOutputMarshaller(),
                 new ServerCallHandler<ByteBuf, ByteBuf>() {
@@ -209,6 +210,7 @@ public abstract class AbstractBenchmark {
                   }
                 })
             .addMethod("pingPong",
+                MethodType.DUPLEX_STREAMING,
                 new ByteBufOutputMarshaller(),
                 new ByteBufOutputMarshaller(),
                 new ServerCallHandler<ByteBuf, ByteBuf>() {
@@ -244,6 +246,7 @@ public abstract class AbstractBenchmark {
                   }
                 })
             .addMethod("flowControlledStreaming",
+                MethodType.DUPLEX_STREAMING,
                 new ByteBufOutputMarshaller(),
                 new ByteBufOutputMarshaller(),
                 new ServerCallHandler<ByteBuf, ByteBuf>() {

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
@@ -31,6 +31,7 @@
 
 package io.grpc.benchmarks.netty;
 
+import io.grpc.MethodType;
 import io.grpc.MutableHandlerRegistryImpl;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
@@ -82,7 +83,8 @@ public class HandlerRegistryBenchmark {
       ServerServiceDefinition.Builder serviceBuilder = ServerServiceDefinition.builder(serviceName);
       for (int methodIndex = 0; methodIndex < methodCountPerService; ++methodIndex) {
         String methodName = randomString();
-        serviceBuilder.addMethod(ServerMethodDefinition.create(methodName, null, null, null));
+        serviceBuilder.addMethod(
+            ServerMethodDefinition.create(methodName, MethodType.UNARY, null, null, null));
         fullMethodNames.add("/" + serviceName + "/" + methodName);
       }
       registry.addService(serviceBuilder.build());

--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -247,14 +247,11 @@ public final class ChannelImpl extends Channel {
   private class CallImpl<ReqT, RespT> extends Call<ReqT, RespT> {
     private final MethodDescriptor<ReqT, RespT> method;
     private final SerializingExecutor callExecutor;
-    private final boolean unaryRequest;
     private ClientStream stream;
 
     public CallImpl(MethodDescriptor<ReqT, RespT> method, SerializingExecutor executor) {
       this.method = method;
       this.callExecutor = executor;
-      this.unaryRequest = method.getType() == MethodType.UNARY
-          || method.getType() == MethodType.SERVER_STREAMING;
     }
 
     @Override
@@ -332,7 +329,7 @@ public final class ChannelImpl extends Channel {
       // For unary requests, we don't flush since we know that halfClose should be coming soon. This
       // allows us to piggy-back the END_STREAM=true on the last payload frame without opening the
       // possibility of broken applications forgetting to call halfClose without noticing.
-      if (!unaryRequest) {
+      if (!method.getType().clientSendsOneMessage()) {
         stream.flush();
       }
     }

--- a/core/src/main/java/io/grpc/ServerImpl.java
+++ b/core/src/main/java/io/grpc/ServerImpl.java
@@ -290,6 +290,7 @@ public final class ServerImpl extends Server {
   }
 
   private static class NoopListener implements ServerStreamListener {
+
     @Override
     public void messageRead(InputStream value) {
       try {
@@ -414,7 +415,7 @@ public final class ServerImpl extends Server {
 
     @Override
     public void sendHeaders(Metadata.Headers headers) {
-      stream.writeHeaders(headers);
+      stream.writeHeaders(headers, !methodDef.getMethodType().serverSendsOneMessage());
     }
 
     @Override
@@ -422,7 +423,9 @@ public final class ServerImpl extends Server {
       try {
         InputStream message = methodDef.streamResponse(payload);
         stream.writeMessage(message, message.available());
-        stream.flush();
+        if (!methodDef.getMethodType().serverSendsOneMessage()) {
+          stream.flush();
+        }
       } catch (Throwable t) {
         close(Status.fromThrowable(t), new Metadata.Trailers());
         throw Throwables.propagate(t);

--- a/core/src/main/java/io/grpc/ServerMethodDefinition.java
+++ b/core/src/main/java/io/grpc/ServerMethodDefinition.java
@@ -39,15 +39,17 @@ import java.io.InputStream;
  */
 public final class ServerMethodDefinition<RequestT, ResponseT> {
   private final String name;
+  private final MethodType type;
   private final Marshaller<RequestT> requestMarshaller;
   private final Marshaller<ResponseT> responseMarshaller;
   private final ServerCallHandler<RequestT, ResponseT> handler;
 
   // ServerMethodDefinition has no form of public construction. It is only created within the
   // context of a ServerServiceDefinition.Builder.
-  ServerMethodDefinition(String name, Marshaller<RequestT> requestMarshaller,
+  ServerMethodDefinition(String name, MethodType type, Marshaller<RequestT> requestMarshaller,
       Marshaller<ResponseT> responseMarshaller, ServerCallHandler<RequestT, ResponseT> handler) {
     this.name = name;
+    this.type = type;
     this.requestMarshaller = requestMarshaller;
     this.responseMarshaller = responseMarshaller;
     this.handler = handler;
@@ -57,21 +59,27 @@ public final class ServerMethodDefinition<RequestT, ResponseT> {
    * Create a new instance.
    *
    * @param name the simple name of a method.
+   * @param type the type of the method.
    * @param requestMarshaller marshaller for request messages.
    * @param responseMarshaller marshaller for response messages.
    * @param handler to dispatch calls to.
    * @return a new instance.
    */
   public static <RequestT, ResponseT> ServerMethodDefinition<RequestT, ResponseT> create(
-      String name, Marshaller<RequestT> requestMarshaller,
+      String name, MethodType type, Marshaller<RequestT> requestMarshaller,
       Marshaller<ResponseT> responseMarshaller, ServerCallHandler<RequestT, ResponseT> handler) {
-    return new ServerMethodDefinition<RequestT, ResponseT>(name, requestMarshaller,
+    return new ServerMethodDefinition<RequestT, ResponseT>(name, type, requestMarshaller,
         responseMarshaller, handler);
   }
 
   /** The simple name of the method. It is not an absolute path. */
   public String getName() {
     return name;
+  }
+
+  /** The type of the method. */
+  public MethodType getMethodType() {
+    return type;
   }
 
   /**
@@ -108,6 +116,6 @@ public final class ServerMethodDefinition<RequestT, ResponseT> {
   public ServerMethodDefinition<RequestT, ResponseT> withServerCallHandler(
       ServerCallHandler<RequestT, ResponseT> handler) {
     return new ServerMethodDefinition<RequestT, ResponseT>(
-        name, requestMarshaller, responseMarshaller, handler);
+        name, type, requestMarshaller, responseMarshaller, handler);
   }
 }

--- a/core/src/main/java/io/grpc/ServerServiceDefinition.java
+++ b/core/src/main/java/io/grpc/ServerServiceDefinition.java
@@ -88,10 +88,12 @@ public final class ServerServiceDefinition {
      * @param responseMarshaller marshaller for serializing outgoing responses
      * @param handler handler for incoming calls
      */
-    public <ReqT, RespT> Builder addMethod(String name, Marshaller<ReqT> requestMarshaller,
-        Marshaller<RespT> responseMarshaller, ServerCallHandler<ReqT, RespT> handler) {
+    public <ReqT, RespT> Builder addMethod(String name, MethodType type,
+        Marshaller<ReqT> requestMarshaller, Marshaller<RespT> responseMarshaller,
+        ServerCallHandler<ReqT, RespT> handler) {
       return addMethod(new ServerMethodDefinition<ReqT, RespT>(
           Preconditions.checkNotNull(name, "name must not be null"),
+          Preconditions.checkNotNull(type, "type must not be null"),
           Preconditions.checkNotNull(requestMarshaller, "requestMarshaller must not be null"),
           Preconditions.checkNotNull(responseMarshaller, "responseMarshaller must not be null"),
           Preconditions.checkNotNull(handler, "handler must not be null")));

--- a/core/src/main/java/io/grpc/transport/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractServerStream.java
@@ -87,18 +87,18 @@ public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
   }
 
   @Override
-  public void writeHeaders(Metadata.Headers headers) {
+  public void writeHeaders(Metadata.Headers headers, boolean flush) {
     Preconditions.checkNotNull(headers, "headers");
     outboundPhase(Phase.HEADERS);
     headersSent = true;
-    internalSendHeaders(headers);
+    internalSendHeaders(headers, flush);
     outboundPhase(Phase.MESSAGE);
   }
 
   @Override
   public final void writeMessage(InputStream message, int length) {
     if (!headersSent) {
-      writeHeaders(new Metadata.Headers());
+      writeHeaders(new Metadata.Headers(), false);
       headersSent = true;
     }
     super.writeMessage(message, length);
@@ -164,8 +164,9 @@ public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
    * Sends response headers to the remote end points.
    *
    * @param headers the headers to be sent to client.
+   * @param flush true if the headers should be sent immediately, false otherwise.
    */
-  protected abstract void internalSendHeaders(Metadata.Headers headers);
+  protected abstract void internalSendHeaders(Metadata.Headers headers, boolean flush);
 
   /**
    * Sends an outbound frame to the remote end point.

--- a/core/src/main/java/io/grpc/transport/ServerStream.java
+++ b/core/src/main/java/io/grpc/transport/ServerStream.java
@@ -45,8 +45,9 @@ public interface ServerStream extends Stream {
    * or {@code #close}.
    *
    * @param headers to send to client.
+   * @param flush true if the headers should be sent immediately, false otherwise.
    */
-  void writeHeaders(Metadata.Headers headers);
+  void writeHeaders(Metadata.Headers headers, boolean flush);
 
   /**
    * Closes the stream for both reading and writing. A status code of

--- a/core/src/main/java/io/grpc/transport/ServerStreamListener.java
+++ b/core/src/main/java/io/grpc/transport/ServerStreamListener.java
@@ -35,6 +35,7 @@ import io.grpc.Status;
 
 /** An observer of server-side stream events. */
 public interface ServerStreamListener extends StreamListener {
+
   /**
    * Called when the remote side of the transport gracefully closed, indicating the client had no
    * more data to send. No further messages will be received on the stream.

--- a/core/src/test/java/io/grpc/MutableHandlerRegistryImplTest.java
+++ b/core/src/test/java/io/grpc/MutableHandlerRegistryImplTest.java
@@ -57,12 +57,12 @@ public class MutableHandlerRegistryImplTest {
   @SuppressWarnings("unchecked")
   private ServerCallHandler<String, Integer> handler = mock(ServerCallHandler.class);
   private ServerServiceDefinition basicServiceDefinition = ServerServiceDefinition.builder("basic")
-      .addMethod("flow", requestMarshaller, responseMarshaller, handler).build();
+      .addMethod("flow", MethodType.UNARY, requestMarshaller, responseMarshaller, handler).build();
   @SuppressWarnings("rawtypes")
   private ServerMethodDefinition flowMethodDefinition = basicServiceDefinition.getMethods().get(0);
   private ServerServiceDefinition multiServiceDefinition = ServerServiceDefinition.builder("multi")
-      .addMethod("couple", requestMarshaller, responseMarshaller, handler)
-      .addMethod("few", requestMarshaller, responseMarshaller, handler).build();
+      .addMethod("couple", MethodType.UNARY, requestMarshaller, responseMarshaller, handler)
+      .addMethod("few", MethodType.UNARY, requestMarshaller, responseMarshaller, handler).build();
   @SuppressWarnings("rawtypes")
   private ServerMethodDefinition coupleMethodDefinition =
       multiServiceDefinition.getMethod("couple");
@@ -127,7 +127,8 @@ public class MutableHandlerRegistryImplTest {
     assertNull(registry.addService(basicServiceDefinition));
     assertNotNull(registry.lookupMethod("/basic/flow"));
     ServerServiceDefinition replaceServiceDefinition = ServerServiceDefinition.builder("basic")
-        .addMethod("another", requestMarshaller, responseMarshaller, handler).build();
+        .addMethod("another", MethodType.UNARY, requestMarshaller, responseMarshaller, handler)
+        .build();
     ServerMethodDefinition<?, ?> anotherMethodDefinition =
         replaceServiceDefinition.getMethods().get(0);
     assertSame(basicServiceDefinition, registry.addService(replaceServiceDefinition));

--- a/core/src/test/java/io/grpc/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/ServerImplTest.java
@@ -168,7 +168,7 @@ public class ServerImplTest {
     final AtomicReference<ServerCall<Integer>> callReference
         = new AtomicReference<ServerCall<Integer>>();
     registry.addService(ServerServiceDefinition.builder("Waiter")
-        .addMethod("serve", STRING_MARSHALLER, INTEGER_MARSHALLER,
+        .addMethod("serve", MethodType.DUPLEX_STREAMING, STRING_MARSHALLER, INTEGER_MARSHALLER,
           new ServerCallHandler<String, Integer>() {
             @Override
             public ServerCall.Listener<String> startCall(String fullMethodName,
@@ -232,7 +232,7 @@ public class ServerImplTest {
     CyclicBarrier barrier = executeBarrier(executor);
     final Status status = Status.ABORTED.withDescription("Oh, no!");
     registry.addService(ServerServiceDefinition.builder("Waiter")
-        .addMethod("serve", STRING_MARSHALLER, INTEGER_MARSHALLER,
+        .addMethod("serve", MethodType.UNARY, STRING_MARSHALLER, INTEGER_MARSHALLER,
           new ServerCallHandler<String, Integer>() {
             @Override
             public ServerCall.Listener<String> startCall(String fullMethodName,

--- a/core/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -68,7 +68,7 @@ public class ServerInterceptorsTest {
   private String methodName = "/someRandom.Name";
   @Mock private ServerCall<Integer> call;
   private ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("basic")
-      .addMethod("flow", requestMarshaller, responseMarshaller, handler).build();
+      .addMethod("flow", MethodType.UNARY, requestMarshaller, responseMarshaller, handler).build();
   private Headers headers = new Headers();
 
   /** Set up for test. */
@@ -134,8 +134,9 @@ public class ServerInterceptorsTest {
     @SuppressWarnings("unchecked")
     ServerCallHandler<String, Integer> handler2 = mock(ServerCallHandler.class);
     serviceDefinition = ServerServiceDefinition.builder("basic")
-        .addMethod("flow", requestMarshaller, responseMarshaller, handler)
-        .addMethod("flow2", requestMarshaller, responseMarshaller, handler2).build();
+        .addMethod("flow", MethodType.UNARY, requestMarshaller, responseMarshaller, handler)
+        .addMethod("flow2", MethodType.UNARY, requestMarshaller, responseMarshaller, handler2)
+        .build();
     ServerServiceDefinition intercepted = ServerInterceptors.intercept(
         serviceDefinition, Arrays.<ServerInterceptor>asList(new NoopInterceptor()));
     getMethod(intercepted, "flow").getServerCallHandler().startCall(methodName, call, headers);
@@ -192,7 +193,8 @@ public class ServerInterceptorsTest {
           }
         };
     ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("basic")
-        .addMethod("flow", requestMarshaller, responseMarshaller, handler).build();
+        .addMethod("flow", MethodType.UNARY, requestMarshaller, responseMarshaller, handler)
+        .build();
     ServerServiceDefinition intercepted = ServerInterceptors.intercept(
         serviceDefinition, Arrays.asList(interceptor1, interceptor2));
     assertSame(listener,

--- a/integration-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/integration-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -293,7 +293,14 @@ public class TestServiceImpl implements TestServiceGrpc.TestService {
         Chunk nextChunk = chunks.peek();
         if (nextChunk != null) {
           scheduled = true;
-          executor.schedule(dispatchTask, nextChunk.delayMicroseconds, TimeUnit.MICROSECONDS);
+          if (nextChunk.delayMicroseconds == 0) {
+            // Allow for immediate execution, useful when testing flush
+            // coalescing in the transport thread.
+            dispatchTask.run();
+          } else {
+            ((ScheduledExecutorService) executor).schedule(
+                dispatchTask, nextChunk.delayMicroseconds, TimeUnit.MICROSECONDS);
+          }
           return;
         }
       }

--- a/integration-testing/src/test/java/io/grpc/testing/integration/NettyTransportIoEfficiencyTest.java
+++ b/integration-testing/src/test/java/io/grpc/testing/integration/NettyTransportIoEfficiencyTest.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.testing.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+
+import io.grpc.ChannelImpl;
+import io.grpc.ServerImpl;
+import io.grpc.ServerInterceptors;
+import io.grpc.stub.StreamObserver;
+import io.grpc.stub.StreamRecorder;
+import io.grpc.testing.TestUtils;
+import io.grpc.transport.netty.NegotiationType;
+import io.grpc.transport.netty.NettyChannelBuilder;
+import io.grpc.transport.netty.NettyServerBuilder;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Executors;
+
+/**
+ * Tests to verify IO efficiency of the Netty transport implementation.
+ */
+@RunWith(JUnit4.class)
+public class NettyTransportIoEfficiencyTest {
+
+  private static final Messages.SimpleRequest SMALL_REQUEST = Messages.SimpleRequest.newBuilder()
+      .setResponseSize(1)
+      .setResponseType(Messages.PayloadType.COMPRESSABLE)
+      .setPayload(Messages.Payload.newBuilder()
+          .setBody(ByteString.copyFrom(new byte[1])))
+      .build();
+  private static int serverPort = Util.pickUnusedPort();
+  private ServerImpl server;
+  protected ChannelImpl channel;
+  protected TestServiceGrpc.TestServiceBlockingStub blockingStub;
+  protected TestServiceGrpc.TestService asyncStub;
+
+  @After
+  public void tearDown() throws Exception {
+    ClientCountingChannel.flushCount = 0;
+    ServerCountingChannel.flushCount = 0;
+    server.shutdownNow();
+    channel.shutdownNow();
+  }
+
+  @Test(timeout = 10000)
+  public void smallUnaryBlocking() throws Exception {
+    startServer(false);
+    startClient(false);
+    blockingStub.unaryCall(SMALL_REQUEST);
+    // Expect 1 flush each from client and server as they know the call is unary and so group
+    // header, payload & trailers (server) into a single flush.
+    assertEquals(1, ClientCountingChannel.flushCount);
+    // FIXME: Should always be 1 but requires fixing ServerCalls to eliminate useless request call.
+    assertTrue(2 >= ServerCountingChannel.flushCount);
+  }
+
+  @Test(timeout = 10000)
+  public void largeUnaryWithWindowUpdate() throws Exception {
+    startServer(false);
+    startClient(false);
+    // Use payload slightly greater than a multiple of the window size.
+    int payloadSize = 65535 * 5 + 10;
+    int payloadWrites = 6;
+    final Messages.SimpleRequest request = Messages.SimpleRequest.newBuilder()
+        .setResponseSize(payloadSize)
+        .setResponseType(Messages.PayloadType.COMPRESSABLE)
+        .setPayload(Messages.Payload.newBuilder()
+            .setBody(ByteString.copyFrom(new byte[payloadSize])))
+        .build();
+    blockingStub.unaryCall(request);
+    int maxWindowUpdates = (payloadSize / (65535 / 2));
+    // We use bounds checking as we don't have precisely predictable behavior here. The number
+    // of DATA frames read in a unit depends on how big a chunk we get from the IO layer.
+    System.err.println("ClientCountingChannel.flushCount " + ClientCountingChannel.flushCount);
+    System.err.println("ServerCountingChannel.flushCount " + ServerCountingChannel.flushCount);
+    assertTrue(maxWindowUpdates + payloadWrites >= ClientCountingChannel.flushCount);
+    // +1 here for headers
+    assertTrue(maxWindowUpdates + payloadWrites + 1 >= ServerCountingChannel.flushCount);
+  }
+
+  @Test(timeout = 10000)
+  public void largeUnaryWithWindowUpdateAndDirectExecutor() throws Exception {
+    System.err.println("START");
+    try {
+      startServer(true);
+      startClient(true);
+      // Use payload slightly greater than a multiple of the window size.
+      int payloadSize = 65535 * 5 + 10;
+      int payloadWrites = 6;
+      final Messages.SimpleRequest request = Messages.SimpleRequest.newBuilder()
+          .setResponseSize(payloadSize)
+          .setResponseType(Messages.PayloadType.COMPRESSABLE)
+          .setPayload(Messages.Payload.newBuilder()
+              .setBody(ByteString.copyFrom(new byte[payloadSize])))
+          .build();
+      blockingStub.unaryCall(request);
+      int maxWindowUpdates = (payloadSize / (65535 / 2));
+      // No benefit for unary calls over non-direct executor here as deframer is already running in
+      // transport thread so returning bytes to the flow controller causes window-updates to be
+      // coalesced by the flush in read-complete.
+      assertTrue(maxWindowUpdates + payloadWrites >= ClientCountingChannel.flushCount);
+      assertTrue(maxWindowUpdates + payloadWrites >= ServerCountingChannel.flushCount);
+    } finally {
+      System.err.println("END");
+    }
+  }
+
+  @Test(timeout = 10000)
+  public void smallServerStreaming() throws Exception {
+    startServer(false);
+    startClient(false);
+    Messages.ResponseParameters.Builder smallParam = Messages.ResponseParameters.newBuilder()
+        .setSize(1)
+        .setIntervalUs(0);
+    final Messages.StreamingOutputCallRequest request =
+        Messages.StreamingOutputCallRequest.newBuilder()
+            .setResponseType(Messages.PayloadType.COMPRESSABLE)
+            .addResponseParameters(smallParam)
+            .addResponseParameters(smallParam)
+            .addResponseParameters(smallParam)
+            .addResponseParameters(smallParam)
+            .build();
+    StreamRecorder<Messages.StreamingOutputCallResponse> recorder = StreamRecorder.create();
+    asyncStub.streamingOutputCall(request, recorder);
+    recorder.awaitCompletion();
+    assertEquals(1, ClientCountingChannel.flushCount);
+    // Maximum is 1 flush for headers, 1 for each message & 1 for trailers but write queue will
+    // typically coalesce to ~3.
+    assertTrue(ServerCountingChannel.flushCount <= 6);
+  }
+
+  @Test(timeout = 10000)
+  public void smallServerStreamingDirectExecutor() throws Exception {
+    startServer(true);
+    startClient(true);
+    Messages.ResponseParameters.Builder smallParam = Messages.ResponseParameters.newBuilder()
+        .setSize(1)
+        .setIntervalUs(0);
+    final Messages.StreamingOutputCallRequest request =
+        Messages.StreamingOutputCallRequest.newBuilder()
+            .setResponseType(Messages.PayloadType.COMPRESSABLE)
+            .addResponseParameters(smallParam)
+            .addResponseParameters(smallParam)
+            .addResponseParameters(smallParam)
+            .addResponseParameters(smallParam)
+            .build();
+    StreamRecorder<Messages.StreamingOutputCallResponse> recorder = StreamRecorder.create();
+    asyncStub.streamingOutputCall(request, recorder);
+    recorder.awaitCompletion();
+    assertEquals(1, ClientCountingChannel.flushCount);
+    // Using direct executor causes all the writes that the server streams back to be coalesced
+    // into a single flush.
+    assertEquals(1, ServerCountingChannel.flushCount);
+  }
+
+  @Test(timeout = 10000)
+  public void largeServerStreaming() throws Exception {
+    startServer(false);
+    startClient(false);
+    Messages.ResponseParameters.Builder largeParam = Messages.ResponseParameters.newBuilder()
+        .setSize(65535)
+        .setIntervalUs(0);
+    final Messages.StreamingOutputCallRequest request =
+        Messages.StreamingOutputCallRequest.newBuilder()
+            .setResponseType(Messages.PayloadType.COMPRESSABLE)
+            .addResponseParameters(largeParam)
+            .addResponseParameters(largeParam)
+            .addResponseParameters(largeParam)
+            .addResponseParameters(largeParam)
+            .build();
+    int payloadSize = 65535 * 4 + 10;
+    StreamRecorder<Messages.StreamingOutputCallResponse> recorder = StreamRecorder.create();
+    asyncStub.streamingOutputCall(request, recorder);
+    recorder.awaitCompletion();
+    int maxWindowUpdates = (payloadSize / (65535 / 2));
+    // 1 for request & 5 window updates back to server.
+    assertTrue(6 >= ClientCountingChannel.flushCount);
+
+    // 1 flush for headers &
+    assertTrue(maxWindowUpdates + 1 >= ServerCountingChannel.flushCount);
+  }
+
+  @Test(timeout = 10000)
+  public void smallClientStreaming() throws Exception {
+    startServer(false);
+    startClient(false);
+    Messages.StreamingInputCallRequest smallPayload =
+        Messages.StreamingInputCallRequest.newBuilder()
+            .setPayload(Messages.Payload.newBuilder()
+                .setBody(ByteString.copyFrom(new byte[1])))
+            .build();
+    final List<Messages.StreamingInputCallRequest> requests = Arrays.asList(
+        smallPayload, smallPayload, smallPayload, smallPayload);
+    StreamRecorder<Messages.StreamingInputCallResponse> recorder = StreamRecorder.create();
+    StreamObserver<Messages.StreamingInputCallRequest> requestObserver =
+        asyncStub.streamingInputCall(recorder);
+    for (Messages.StreamingInputCallRequest request : requests) {
+      requestObserver.onValue(request);
+    }
+    requestObserver.onCompleted();
+    recorder.awaitCompletion();
+
+    // Maximum is 1 flush for headers, 1 for each each message & 1 for trailing empty DATA but
+    // the write queue typically coalesces to ~2.
+    assertTrue(ClientCountingChannel.flushCount <= 6);
+    // BROKEN: Should be 1 but because we don't differentiate between unary and streaming responses
+    // in generated stubs, they both use ServerCalls.asyncStreamingCall which causes us to
+    // make an unneeded call to call.request for the unary response case which triggers a flush.
+    assertTrue(ServerCountingChannel.flushCount <= 2);
+  }
+
+  private void startClient(boolean directExecutor) {
+    try {
+      NettyChannelBuilder builder = NettyChannelBuilder
+          .forAddress(new InetSocketAddress(InetAddress.getLocalHost(), serverPort))
+          .channelType(ClientCountingChannel.class)
+          .negotiationType(NegotiationType.PLAINTEXT);
+      if (directExecutor) {
+        builder.executor(MoreExecutors.newDirectExecutorService());
+      }
+      channel = builder.build();
+      blockingStub = TestServiceGrpc.newBlockingStub(channel);
+      asyncStub  = TestServiceGrpc.newStub(channel);
+      blockingStub.unaryCall(SMALL_REQUEST);
+      // Need to sleep so that SETTINGS_ACK is received and processed as it can cause a flush.
+      Thread.sleep(1000);
+      ClientCountingChannel.flushCount = 0;
+      ServerCountingChannel.flushCount = 0;
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private void startServer(boolean directExecutor)
+      throws Exception {
+    NettyServerBuilder builder = NettyServerBuilder.forPort(serverPort)
+        .channelType(ServerSocketChannel.class);
+    if (directExecutor) {
+      builder.executor(MoreExecutors.newDirectExecutorService());
+    }
+    builder.addService(ServerInterceptors.intercept(
+        TestServiceGrpc.bindService(new TestServiceImpl(Executors.newScheduledThreadPool(2))),
+        TestUtils.echoRequestHeadersInterceptor(Util.METADATA_KEY)));
+    server = builder.build();
+    server.start();
+  }
+
+
+  public static class ClientCountingChannel extends NioSocketChannel {
+
+    public static volatile int flushCount = 0;
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+      flushCount++;
+      //Thread.dumpStack();
+      super.doWrite(in);
+    }
+  }
+
+  public static class ServerCountingChannel extends NioSocketChannel {
+    public static volatile int flushCount = 0;
+
+    public ServerCountingChannel(Channel parent, SocketChannel socket) {
+      super(parent, socket);
+    }
+
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+      flushCount++;
+      super.doWrite(in);
+    }
+  }
+
+
+
+  public static class ServerSocketChannel extends NioServerSocketChannel {
+    @Override
+    protected int doReadMessages(List<Object> buf) throws Exception {
+      java.nio.channels.SocketChannel ch = javaChannel().accept();
+      try {
+        if (ch != null) {
+          buf.add(new ServerCountingChannel(this, ch));
+          return 1;
+        }
+      } catch (Throwable t) {
+        try {
+          ch.close();
+        } catch (Throwable t2) {
+          // Ignore
+        }
+      }
+      return 0;
+    }
+  }
+}

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
@@ -161,9 +161,9 @@ class NettyClientHandler extends Http2ConnectionHandler {
   /**
    * Returns the given processed bytes back to inbound flow control.
    */
-  void returnProcessedBytes(Http2Stream stream, int bytes) {
+  boolean returnProcessedBytes(Http2Stream stream, int bytes) {
     try {
-      decoder().flowController().consumeBytes(ctx, stream, bytes);
+      return decoder().flowController().consumeBytes(ctx, stream, bytes);
     } catch (Http2Exception e) {
       throw new RuntimeException(e);
     }

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
@@ -148,7 +148,8 @@ class NettyClientStream extends Http2ClientStream {
 
   @Override
   protected void returnProcessedBytes(int processedBytes) {
-    handler.returnProcessedBytes(http2Stream, processedBytes);
-    writeQueue.scheduleFlush();
+    if (handler.returnProcessedBytes(http2Stream, processedBytes)) {
+      writeQueue.scheduleFlush();
+    }
   }
 }

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerHandler.java
@@ -249,9 +249,9 @@ class NettyServerHandler extends Http2ConnectionHandler {
   /**
    * Returns the given processed bytes back to inbound flow control.
    */
-  void returnProcessedBytes(Http2Stream http2Stream, int bytes) {
+  boolean returnProcessedBytes(Http2Stream http2Stream, int bytes) {
     try {
-      decoder().flowController().consumeBytes(ctx, http2Stream, bytes);
+      return decoder().flowController().consumeBytes(ctx, http2Stream, bytes);
     } catch (Http2Exception e) {
       throw new RuntimeException(e);
     }

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
@@ -86,10 +86,9 @@ class NettyServerStream extends AbstractServerStream<Integer> {
   }
 
   @Override
-  protected void internalSendHeaders(Metadata.Headers headers) {
+  protected void internalSendHeaders(Metadata.Headers headers, boolean flush) {
     writeQueue.enqueue(new SendResponseHeadersCommand(id(),
-        Utils.convertServerHeaders(headers), false),
-        true);
+        Utils.convertServerHeaders(headers), false), flush);
   }
 
   @Override
@@ -118,7 +117,8 @@ class NettyServerStream extends AbstractServerStream<Integer> {
 
   @Override
   protected void returnProcessedBytes(int processedBytes) {
-    handler.returnProcessedBytes(http2Stream, processedBytes);
-    writeQueue.scheduleFlush();
+    if (handler.returnProcessedBytes(http2Stream, processedBytes)) {
+      writeQueue.scheduleFlush();
+    }
   }
 }

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
@@ -234,7 +234,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     createStream();
 
     writeQueue.enqueue(new CancelStreamCommand(stream), promise, true);
-
     ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
     verify(ctx).write(eq(expected), any(ChannelPromise.class));
 

--- a/netty/src/test/java/io/grpc/transport/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyHandlerTestBase.java
@@ -166,6 +166,13 @@ public abstract class NettyHandlerTestBase {
       }
     });
 
+    when(eventLoop.inEventLoop()).thenAnswer(new Answer<Boolean>() {
+      @Override
+      public Boolean answer(InvocationOnMock invocation) throws Throwable {
+        return inEventLoop;
+      }
+    });
+
     mockFuture(succeededFuture, true);
 
     doAnswer(new Answer<Void>() {

--- a/netty/src/test/java/io/grpc/transport/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyServerStreamTest.java
@@ -97,7 +97,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase {
     Http2Headers headers = new DefaultHttp2Headers()
         .status(Utils.STATUS_OK)
         .set(Utils.CONTENT_TYPE_HEADER, Utils.CONTENT_TYPE_GRPC);
-    verify(writeQueue).enqueue(new SendResponseHeadersCommand(STREAM_ID, headers, false), true);
+    verify(writeQueue).enqueue(new SendResponseHeadersCommand(STREAM_ID, headers, false), false);
     verify(writeQueue).enqueue(eq(new SendGrpcFrameCommand(stream, messageFrame(MESSAGE), false)),
         any(ChannelPromise.class),
         eq(true));
@@ -106,7 +106,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase {
   @Test
   public void writeHeadersShouldSendHeaders() throws Exception {
     Metadata.Headers headers = new Metadata.Headers();
-    stream().writeHeaders(headers);
+    stream().writeHeaders(headers, true);
     verify(writeQueue).enqueue(new SendResponseHeadersCommand(STREAM_ID,
         Utils.convertServerHeaders(headers), false), true);
   }
@@ -114,11 +114,11 @@ public class NettyServerStreamTest extends NettyStreamTestBase {
   @Test
   public void duplicateWriteHeadersShouldFail() throws Exception {
     Metadata.Headers headers = new Metadata.Headers();
-    stream().writeHeaders(headers);
+    stream().writeHeaders(headers, false);
     verify(writeQueue).enqueue(new SendResponseHeadersCommand(STREAM_ID,
-        Utils.convertServerHeaders(headers), false), true);
+        Utils.convertServerHeaders(headers), false), false);
     try {
-      stream().writeHeaders(headers);
+      stream().writeHeaders(headers, true);
       fail("Can only write response headers once");
     } catch (IllegalStateException ise) {
       // Success

--- a/stub/src/main/java/io/grpc/stub/Calls.java
+++ b/stub/src/main/java/io/grpc/stub/Calls.java
@@ -172,10 +172,11 @@ public class Calls {
       ReqT param,
       Call.Listener<RespT> responseListener) {
     call.start(responseListener, new Metadata.Headers());
-    call.request(1);
     try {
       call.sendPayload(param);
       call.halfClose();
+      // Request after sending the payload otherwise we prematurely trigger a flush.
+      call.request(1);
     } catch (Throwable t) {
       call.cancel();
       throw Throwables.propagate(t);

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -51,8 +51,8 @@ public class ServerCalls {
    */
   public static <ReqT, RespT> ServerMethodDefinition<ReqT, RespT> createMethodDefinition(
       Method<ReqT, RespT> method, ServerCallHandler<ReqT, RespT> handler) {
-    return ServerMethodDefinition.create(method.getName(), method.getRequestMarshaller(),
-        method.getResponseMarshaller(), handler);
+    return ServerMethodDefinition.create(method.getName(), method.getType(),
+        method.getRequestMarshaller(), method.getResponseMarshaller(), handler);
   }
 
   /**
@@ -77,7 +77,8 @@ public class ServerCalls {
               // close(OK) inside invoke(), while close(OK) is not allowed before onHalfClose().
               this.request = request;
 
-              // Request delivery of the next inbound message.
+              // Request delivery of the next inbound message so we can detect mismatch between
+              // the servers expectation of a unary call and the client behavior.
               call.request(1);
             } else {
               call.close(


### PR DESCRIPTION
Reduce number of explicit flushes after releasing bytes to flow control
Reduce use of explicit flush for cases where a subsequent flush is known to follow immediately
Add test to validate the number of physical writes per call type
