### PR TITLE
okhttp: don't crash if receive window_update for an non-exit stream which may have existed.

### DIFF
--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
@@ -618,7 +618,19 @@ public class OkHttpClientTransport implements ClientTransport {
         }
         return;
       }
-      outboundFlow.windowUpdate(streamId, (int) delta);
+
+      if (streamId == Utils.CONNECTION_STREAM_ID) {
+        outboundFlow.windowUpdate(null, (int) delta);
+        return;
+      }
+
+      OkHttpClientStream stream = streams.get(streamId);
+      if (stream != null) {
+        outboundFlow.windowUpdate(stream, (int) delta);
+      } else if (!mayHaveCreatedStream(streamId)) {
+        onError(ErrorCode.PROTOCOL_ERROR,
+            "Received window_update for unknown stream: " + streamId);
+      }
     }
 
     @Override


### PR DESCRIPTION
Just ignore it.

This fixes #441

@ejona86 