### PR TITLE
Disable Netty eventloop graceful termination

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/transport/netty/Utils.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Common utility methods.
@@ -198,7 +199,7 @@ class Utils {
 
     @Override
     public void close(EventLoopGroup instance) {
-      instance.shutdownGracefully();
+      instance.shutdownGracefully(0, 0, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
When shutting down the Netty event loop, we have already guaranteed that
all users of it are no longer running. Doing a shutdownGracefully is
just delaying graceful JVM termination by two seconds. This is very
noticeable for short-lived processes, like our integration tests.

We would actually also prefer to shutdown quickly and get a
RejectedExecutionException for any newly queued tasks, because that
would be a legitimate bug.

shutdown() is deprecated, thus we do shutdownGracefully with a timeout
of 0.