### PR TITLE
Decrease ArrayDeque memory in SerializingExecutor

### DIFF
--- a/core/src/main/java/io/grpc/SerializingExecutor.java
+++ b/core/src/main/java/io/grpc/SerializingExecutor.java
@@ -55,8 +55,10 @@ public final class SerializingExecutor implements Executor {
   private final Executor executor;
 
   /** A list of Runnables to be run in order. */
+  // Initial size set to 4 because it is a nice number and at least the size necessary for handling
+  // a unary response: onHeaders + onPayload + onClose
   @GuardedBy("internalLock")
-  private final Queue<Runnable> waitQueue = new ArrayDeque<Runnable>();
+  private final Queue<Runnable> waitQueue = new ArrayDeque<Runnable>(4);
 
   /**
    * We explicitly keep track of if the TaskRunner is currently scheduled to


### PR DESCRIPTION
By default, ArrayDeque will be of size 16, which is an overkill for most
calls. "4" is not a magical number itself, but seems a better guess than
16 since we do have some knowledge of how much it will contain.

Resolves #320