### PR TITLE
Set likely final size of array in toHttp2Headers

### DIFF
--- a/core/src/main/java/io/grpc/transport/TransportFrameUtil.java
+++ b/core/src/main/java/io/grpc/transport/TransportFrameUtil.java
@@ -78,7 +78,7 @@ public final class TransportFrameUtil {
    */
   public static byte[][] toHttp2Headers(Metadata headers) {
     byte[][] serializedHeaders = headers.serialize();
-    ArrayList<byte[]> result = new ArrayList<byte[]>();
+    ArrayList<byte[]> result = new ArrayList<byte[]>(serializedHeaders.length);
     for (int i = 0; i < serializedHeaders.length; i += 2) {
       byte[] key = serializedHeaders[i];
       byte[] value = serializedHeaders[i + 1];


### PR DESCRIPTION
We know the size won't be more than serializedHeaders.length, is
unlikely to be fewer, and very unlikely to be substantially fewer. This
prevents us from needing to resize the array in all cases.

Resolves #321