### PR TITLE
Fail travis build if codegen isn't committed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ before_install:
   - mkdir -p $HOME/.gradle
   - echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties
 
+before_script:
+  - test -z "$(git status --porcelain)" || (git status && echo Error Working directory is not clean. Forget to commit generated files? && false)
+
 jdk:
   - oraclejdk8
 


### PR DESCRIPTION
This doesn't catch 100% of such problems, as it runs before tests have
been run. However, almost all of our protos are used in 'main' so this
limitation shouldn't be a big deal.

If it does become a problem, we change it from 'before_script' to
'script', but then we'll also need to include gradle build instructions.