### PR TITLE
Don't use reflection for epoll/unix domain sockets

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -39,12 +39,9 @@ dependencies {
             project(':grpc-interop-testing'),
             libraries.junit,
             libraries.mockito,
-            libraries.hdrhistogram
-    if (osdetector.os == "linux") {
-        // These are only available on linux.
-        compile libraries.netty_tcnative,
-                libraries.netty_transport_native_epoll
-    }
+            libraries.hdrhistogram,
+            libraries.netty_tcnative,
+            libraries.netty_transport_native_epoll
 
     alpnboot alpnboot_package_name
 }

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,16 @@ subprojects {
           }
         }
 
+        def tcnative_suffix = "";
+        if (osdetector.classifier in ["linux-x86_64", "osx-x86_64", "windows-x86_64"]) {
+            // The native code is only pre-compiled on certain platforms.
+            tcnative_suffix = ":" + osdetector.classifier
+        }
+        def epoll_suffix = "";
+        if (osdetector.classifier in ["linux-x86_64"]) {
+            // The native code is only pre-compiled on certain platforms.
+            epoll_suffix = ":" + osdetector.classifier
+        }
         libraries = [
                 guava: 'com.google.guava:guava:18.0',
                 // used to collect benchmark results
@@ -108,8 +118,8 @@ subprojects {
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.4.1',
 
                 netty: 'io.netty:netty-codec-http2:4.1.0.Beta5',
-                netty_tcnative: "io.netty:netty-tcnative:1.1.33.Fork2:${osdetector.classifier}",
-                netty_transport_native_epoll: "io.netty:netty-transport-native-epoll:4.1.0.Beta5:${osdetector.classifier}",
+                netty_tcnative: 'io.netty:netty-tcnative:1.1.33.Fork2' + tcnative_suffix,
+                netty_transport_native_epoll: 'io.netty:netty-transport-native-epoll:4.1.0.Beta5' + epoll_suffix,
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',


### PR DESCRIPTION
The classes are available, even on Windows. Trying to use them though
won't work. You'll get an error like:
java.lang.UnsatisfiedLinkError: no netty-transport-native-epoll in java.library.path