### PR TITLE
Add support for indeterminate length messages. 

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Call;
 import io.grpc.ChannelImpl;
 import io.grpc.DeferredInputStream;
+import io.grpc.KnownLength;
 import io.grpc.Marshaller;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -37,8 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.annotation.Nullable;
 
 /**
  * Abstract base class for Netty end-to-end benchmarks.
@@ -462,7 +461,8 @@ public abstract class AbstractBenchmark {
   /**
    * Implementation of {@link io.grpc.DeferredInputStream} for {@link io.netty.buffer.ByteBuf}.
    */
-  private static class DeferredByteBufInputStream extends DeferredInputStream<ByteBuf> {
+  private static class DeferredByteBufInputStream extends DeferredInputStream<ByteBuf>
+      implements KnownLength {
 
     private ByteBuf buf;
 
@@ -476,12 +476,6 @@ public abstract class AbstractBenchmark {
       buf.readBytes(target, readbableBytes);
       buf = null;
       return readbableBytes;
-    }
-
-    @Nullable
-    @Override
-    public ByteBuf getDeferred() {
-      return buf;
     }
 
     @Override

--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -39,7 +39,6 @@ import io.grpc.transport.ClientStreamListener;
 import io.grpc.transport.ClientTransport;
 import io.grpc.transport.ClientTransportFactory;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,7 +56,7 @@ public final class ChannelImpl extends Channel {
   private static final Logger log = Logger.getLogger(ChannelImpl.class.getName());
 
   private static class NoopClientStream implements ClientStream {
-    @Override public void writeMessage(InputStream message, int length) {}
+    @Override public void writeMessage(InputStream message) {}
 
     @Override public void flush() {}
 
@@ -308,21 +307,13 @@ public final class ChannelImpl extends Channel {
       stream.halfClose();
     }
 
-    private int available(InputStream is) {
-      try {
-        return is.available();
-      } catch (IOException ex) {
-        throw new RuntimeException(ex);
-      }
-    }
-
     @Override
     public void sendPayload(ReqT payload) {
       Preconditions.checkState(stream != null, "Not started");
       boolean failed = true;
       try {
         InputStream payloadIs = method.streamRequest(payload);
-        stream.writeMessage(payloadIs, available(payloadIs));
+        stream.writeMessage(payloadIs);
         failed = false;
       } finally {
         if (failed) {

--- a/core/src/main/java/io/grpc/KnownLength.java
+++ b/core/src/main/java/io/grpc/KnownLength.java
@@ -31,22 +31,12 @@
 
 package io.grpc;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
 /**
- * Extension to {@link InputStream} to allow for deferred production of data. Allows for
- * zero-copy conversions when the goal is to copy the contents of a resource to a
- * stream or buffer.
+ * Tagging interface for objects who's precise serialized length is known before serialization
+ * starts. In the case of {@link java.io.InputStream} calls to
+ * {@link java.io.InputStream#available()} will return an accurate length. Common stream
+ * implementations which conform to this contract while not implementing this interface will
+ * also be recognized by the transport, e.g. {@link java.io.ByteArrayInputStream}.
  */
-public abstract class DeferredInputStream<T> extends InputStream {
-
-  /**
-   * Produce the entire contents of this stream to the specified target.
-   *
-   * @param target to write to.
-   * @return number of bytes written.
-   */
-  public abstract int flushTo(OutputStream target) throws IOException;
+public interface KnownLength {
 }

--- a/core/src/main/java/io/grpc/Marshaller.java
+++ b/core/src/main/java/io/grpc/Marshaller.java
@@ -45,6 +45,8 @@ public interface Marshaller<T> {
 
   /**
    * Given a message, produce an {@link InputStream} for it so that it can be written to the wire.
+   * Where possible implementations should produce streams that are {@link io.grpc.KnownLength}
+   * to improve transport efficiency.
    *
    * @param value to serialize.
    * @return serialized value as stream of bytes.

--- a/core/src/main/java/io/grpc/ServerImpl.java
+++ b/core/src/main/java/io/grpc/ServerImpl.java
@@ -421,7 +421,7 @@ public final class ServerImpl extends Server {
     public void sendPayload(RespT payload) {
       try {
         InputStream message = methodDef.streamResponse(payload);
-        stream.writeMessage(message, message.available());
+        stream.writeMessage(message);
         stream.flush();
       } catch (Throwable t) {
         close(Status.fromThrowable(t), new Metadata.Trailers());

--- a/core/src/main/java/io/grpc/transport/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractServerStream.java
@@ -96,12 +96,12 @@ public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
   }
 
   @Override
-  public final void writeMessage(InputStream message, int length) {
+  public final void writeMessage(InputStream message) {
     if (!headersSent) {
       writeHeaders(new Metadata.Headers());
       headersSent = true;
     }
-    super.writeMessage(message, length);
+    super.writeMessage(message);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/transport/AbstractStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractStream.java
@@ -171,12 +171,11 @@ public abstract class AbstractStream<IdT> implements Stream {
   }
 
   @Override
-  public void writeMessage(InputStream message, int length) {
+  public void writeMessage(InputStream message) {
     Preconditions.checkNotNull(message, "message");
-    Preconditions.checkArgument(length >= 0, "length must be >= 0");
     outboundPhase(Phase.MESSAGE);
     if (!framer.isClosed()) {
-      framer.writePayload(message, length);
+      framer.writePayload(message);
     }
   }
 

--- a/core/src/main/java/io/grpc/transport/ReadableBuffers.java
+++ b/core/src/main/java/io/grpc/transport/ReadableBuffers.java
@@ -35,6 +35,8 @@ import static com.google.common.base.Charsets.UTF_8;
 
 import com.google.common.base.Preconditions;
 
+import io.grpc.KnownLength;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -310,7 +312,7 @@ public final class ReadableBuffers {
   /**
    * An {@link InputStream} that is backed by a {@link ReadableBuffer}.
    */
-  private static class BufferInputStream extends InputStream {
+  private static class BufferInputStream extends InputStream implements KnownLength {
     final ReadableBuffer buffer;
 
     public BufferInputStream(ReadableBuffer buffer) {

--- a/core/src/main/java/io/grpc/transport/Stream.java
+++ b/core/src/main/java/io/grpc/transport/Stream.java
@@ -49,9 +49,10 @@ public interface Stream {
   void request(int numMessages);
 
   /**
-   * Writes a message payload to the remote end-point. The bytes from the stream are immediate read
-   * by the Transport. This method will always return immediately and will not wait for the write to
-   * complete.
+   * Writes a message payload to the remote end-point. The bytes from the stream are immediately
+   * read by the Transport. Where possible callers should use streams that are
+   * {@link io.grpc.KnownLength} to improve efficiency. This method will always return immediately
+   * and will not wait for the write to complete.
    *
    * <p>
    * When the write is "accepted" by the transport, the given callback (if provided) will be called.
@@ -61,9 +62,8 @@ public interface Stream {
    * accepted, the callback will never be invoked.
    *
    * @param message stream containing the serialized message to be sent
-   * @param length the length of the {@link InputStream}.
    */
-  void writeMessage(InputStream message, int length);
+  void writeMessage(InputStream message);
 
   /**
    * Flushes any internally buffered messages to the remote end-point.

--- a/core/src/test/java/io/grpc/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/ServerImplTest.java
@@ -38,7 +38,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.timeout;
@@ -200,7 +199,7 @@ public class ServerImplTest {
 
     call.sendPayload(314);
     ArgumentCaptor<InputStream> inputCaptor = ArgumentCaptor.forClass(InputStream.class);
-    verify(stream).writeMessage(inputCaptor.capture(), eq(3));
+    verify(stream).writeMessage(inputCaptor.capture());
     verify(stream).flush();
     assertEquals(314, INTEGER_MARSHALLER.parse(inputCaptor.getValue()).intValue());
 
@@ -209,7 +208,7 @@ public class ServerImplTest {
     verify(callListener).onHalfClose();
 
     call.sendPayload(50);
-    verify(stream).writeMessage(inputCaptor.capture(), eq(2));
+    verify(stream, times(2)).writeMessage(inputCaptor.capture());
     verify(stream, times(2)).flush();
     assertEquals(50, INTEGER_MARSHALLER.parse(inputCaptor.getValue()).intValue());
 

--- a/netty/src/test/java/io/grpc/transport/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyServerHandlerTest.java
@@ -362,7 +362,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
         }
       }
     }, new NettyWritableBufferAllocator(ByteBufAllocator.DEFAULT));
-    framer.writePayload(new ByteArrayInputStream(CONTENT), CONTENT.length);
+    framer.writePayload(new ByteArrayInputStream(CONTENT));
     framer.flush();
     if (endStream) {
       framer.close();

--- a/netty/src/test/java/io/grpc/transport/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyServerStreamTest.java
@@ -92,7 +92,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase {
   @Test
   public void writeMessageShouldSendResponse() throws Exception {
     byte[] msg = smallMessage();
-    stream.writeMessage(new ByteArrayInputStream(msg), msg.length);
+    stream.writeMessage(new ByteArrayInputStream(msg));
     stream.flush();
     Http2Headers headers = new DefaultHttp2Headers()
         .status(Utils.STATUS_OK)

--- a/netty/src/test/java/io/grpc/transport/netty/NettyStreamTestBase.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyStreamTestBase.java
@@ -163,7 +163,7 @@ public abstract class NettyStreamTestBase {
     assertTrue(stream.isReady());
     byte[] msg = largeMessage();
     // The future is set up to automatically complete, indicating that the write is done.
-    stream.writeMessage(new ByteArrayInputStream(msg), msg.length);
+    stream.writeMessage(new ByteArrayInputStream(msg));
     stream.flush();
     assertTrue(stream.isReady());
     verify(listener()).onReady();
@@ -176,7 +176,7 @@ public abstract class NettyStreamTestBase {
 
     assertTrue(stream.isReady());
     byte[] msg = smallMessage();
-    stream.writeMessage(new ByteArrayInputStream(msg), msg.length);
+    stream.writeMessage(new ByteArrayInputStream(msg));
     stream.flush();
     assertTrue(stream.isReady());
     verify(listener(), never()).onReady();
@@ -189,7 +189,7 @@ public abstract class NettyStreamTestBase {
 
     assertTrue(stream.isReady());
     byte[] msg = largeMessage();
-    stream.writeMessage(new ByteArrayInputStream(msg), msg.length);
+    stream.writeMessage(new ByteArrayInputStream(msg));
     stream.flush();
     assertFalse(stream.isReady());
     verify(listener(), never()).onReady();

--- a/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
@@ -268,7 +268,7 @@ public class OkHttpClientTransportTest {
     OkHttpClientStream stream = streams.get(3);
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     assertEquals(12, input.available());
-    stream.writeMessage(input, input.available());
+    stream.writeMessage(input);
     stream.flush();
     ArgumentCaptor<Buffer> captor = ArgumentCaptor.forClass(Buffer.class);
     verify(frameWriter).data(eq(false), eq(3), captor.capture(), eq(12 + HEADER_LENGTH));
@@ -363,7 +363,7 @@ public class OkHttpClientTransportTest {
     // The first message should be sent out.
     int messageLength = Utils.DEFAULT_WINDOW_SIZE / 2 + 1;
     InputStream input = new ByteArrayInputStream(new byte[messageLength]);
-    stream.writeMessage(input, input.available());
+    stream.writeMessage(input);
     stream.flush();
     verify(frameWriter).data(
         eq(false), eq(3), any(Buffer.class), eq(messageLength + HEADER_LENGTH));
@@ -371,7 +371,7 @@ public class OkHttpClientTransportTest {
 
     // The second message should be partially sent out.
     input = new ByteArrayInputStream(new byte[messageLength]);
-    stream.writeMessage(input, input.available());
+    stream.writeMessage(input);
     stream.flush();
     int partiallySentSize =
         Utils.DEFAULT_WINDOW_SIZE - messageLength - HEADER_LENGTH;
@@ -394,7 +394,7 @@ public class OkHttpClientTransportTest {
     int messageLength = 20;
     setInitialWindowSize(HEADER_LENGTH + 10);
     InputStream input = new ByteArrayInputStream(new byte[messageLength]);
-    stream.writeMessage(input, input.available());
+    stream.writeMessage(input);
     stream.flush();
     // part of the message can be sent.
     verify(frameWriter).data(eq(false), eq(3), any(Buffer.class), eq(HEADER_LENGTH + 10));
@@ -413,7 +413,7 @@ public class OkHttpClientTransportTest {
     // Get 20 tokens back, still can't send any data.
     frameHandler.windowUpdate(3, 20);
     input = new ByteArrayInputStream(new byte[messageLength]);
-    stream.writeMessage(input, input.available());
+    stream.writeMessage(input);
     stream.flush();
     // Only the previous two write operations happened.
     verify(frameWriter, times(2)).data(anyBoolean(), anyInt(), any(Buffer.class), anyInt());
@@ -480,7 +480,7 @@ public class OkHttpClientTransportTest {
     InputStream input =
         new ByteArrayInputStream(sentMessage.getBytes(UTF_8));
     assertEquals(22, input.available());
-    stream.writeMessage(input, input.available());
+    stream.writeMessage(input);
     stream.flush();
     ArgumentCaptor<Buffer> captor =
         ArgumentCaptor.forClass(Buffer.class);
@@ -831,17 +831,17 @@ public class OkHttpClientTransportTest {
 
     // Write a message that will not exceed the notification threshold and queue it.
     InputStream input = new ByteArrayInputStream(new byte[messageLength]);
-    stream.writeMessage(input, input.available());
+    stream.writeMessage(input);
     stream.flush();
     assertTrue(stream.isReady());
 
     // Write another two messages, still be queued.
     input = new ByteArrayInputStream(new byte[messageLength]);
-    stream.writeMessage(input, input.available());
+    stream.writeMessage(input);
     stream.flush();
     assertFalse(stream.isReady());
     input = new ByteArrayInputStream(new byte[messageLength]);
-    stream.writeMessage(input, input.available());
+    stream.writeMessage(input);
     stream.flush();
     assertFalse(stream.isReady());
 

--- a/protobuf-nano/src/main/java/io/grpc/protobuf/nano/DeferredNanoProtoInputStream.java
+++ b/protobuf-nano/src/main/java/io/grpc/protobuf/nano/DeferredNanoProtoInputStream.java
@@ -36,6 +36,7 @@ import com.google.protobuf.nano.CodedOutputByteBufferNano;
 import com.google.protobuf.nano.MessageNano;
 
 import io.grpc.DeferredInputStream;
+import io.grpc.KnownLength;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -46,7 +47,8 @@ import javax.annotation.Nullable;
 /**
  * Implementation of {@link DeferredInputStream} backed by a nano proto.
  */
-public class DeferredNanoProtoInputStream extends DeferredInputStream<MessageNano> {
+public class DeferredNanoProtoInputStream extends DeferredInputStream<MessageNano>
+    implements KnownLength {
 
   // DeferredNanoProtoInputStream is first initialized with a *message*. *partial* is initially
   // null.
@@ -127,11 +129,5 @@ public class DeferredNanoProtoInputStream extends DeferredInputStream<MessageNan
       return partial.available();
     }
     return 0;
-  }
-
-  @Override
-  @Nullable
-  public MessageNano getDeferred() {
-    return message;
   }
 }

--- a/protobuf/src/main/java/io/grpc/protobuf/DeferredProtoInputStream.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/DeferredProtoInputStream.java
@@ -36,6 +36,7 @@ import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.MessageLite;
 
 import io.grpc.DeferredInputStream;
+import io.grpc.KnownLength;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -46,7 +47,8 @@ import javax.annotation.Nullable;
 /**
  * Implementation of {@link io.grpc.DeferredInputStream} backed by a protobuf.
  */
-public class DeferredProtoInputStream extends DeferredInputStream<MessageLite> {
+public class DeferredProtoInputStream extends DeferredInputStream<MessageLite>
+    implements KnownLength {
 
   // DeferredProtoInputStream is first initialized with a *message*. *partial* is initially null.
   // Once there has been a read operation on this stream, *message* is serialized to *partial* and
@@ -56,15 +58,6 @@ public class DeferredProtoInputStream extends DeferredInputStream<MessageLite> {
 
   public DeferredProtoInputStream(MessageLite message) {
     this.message = message;
-  }
-
-  /**
-   * Returns the original protobuf message. Returns null after this stream has been read.
-   */
-  @Override
-  @Nullable
-  public MessageLite getDeferred() {
-    return message;
   }
 
   @Override


### PR DESCRIPTION
This will make using GRPC easier for non-proto payload types. For payload with unknown length we buffer the data produced by the input stream so we can write a header with the serialized length. This can increase memory pressure so implementations are advised to chunk large objects into separate messages where possible.