### PR TITLE
Adding alpn_boot configuration to the parent build file.

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -27,10 +27,6 @@ jmh {
     jvmArgs = "-server -Xms768m -Xmx768m -dsa -da -XX:+AggressiveOpts -XX:+UseBiasedLocking -XX:+UseFastAccessorMethods -XX:+OptimizeStringConcat"
 }
 
-configurations {
-    alpnboot
-}
-
 dependencies {
     compile project(':grpc-core'),
             project(':grpc-netty'),
@@ -42,8 +38,6 @@ dependencies {
             libraries.hdrhistogram,
             libraries.netty_tcnative,
             libraries.netty_transport_native_epoll
-
-    alpnboot alpnboot_package_name
 }
 
 configureProtoCompilation()

--- a/build.gradle
+++ b/build.gradle
@@ -136,9 +136,17 @@ subprojects {
         alpnboot_package_name = 'org.mortbay.jetty.alpn:alpn-boot:' + alpnboot_version
     }
 
+    // Define a separate configuration for managing the dependency on Jetty alpnboot jar.
+    configurations {
+        alpnboot
+    }
+
     dependencies {
         testCompile libraries.junit,
                     libraries.mockito
+
+        // Make the Jetty alpnboot jar available to submodules via the alpnboot configuration.
+        alpnboot alpnboot_package_name
     }
 
     signing {

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -13,10 +13,6 @@ buildscript {
     }
 }
 
-configurations {
-    alpnboot
-}
-
 dependencies {
     compile project(':grpc-core'),
             project(':grpc-netty'),
@@ -26,8 +22,6 @@ dependencies {
             project(':grpc-testing'),
             libraries.junit,
             libraries.mockito
-
-    alpnboot alpnboot_package_name
 }
 
 test {


### PR DESCRIPTION
This allows all modules access to the alpnboot jar without having to copy&paste the configuration.