### PR TITLE
okhttp: Call onError for IOException thrown by FrameReader.nextFrame().

### DIFF
--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
@@ -493,7 +493,9 @@ public class OkHttpClientTransport implements ClientTransport {
         while (frameReader.nextFrame(this)) {
         }
       } catch (IOException ioe) {
-        onIoException(ioe);
+        // We call onError instead of onIoException here, because OkHttp wraps many protocol errors
+        // as IOException, we should send GoAway for such errors.
+        onError(ErrorCode.PROTOCOL_ERROR, ioe.getMessage());
       } finally {
         try {
           frameReader.close();

--- a/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
@@ -162,9 +162,9 @@ public class OkHttpClientTransportTest {
     listener2.waitUntilStreamClosed();
     assertEquals(0, streams.size());
     assertEquals(Status.INTERNAL.getCode(), listener1.status.getCode());
-    assertEquals(NETWORK_ISSUE_MESSAGE, listener2.status.getCause().getMessage());
-    assertEquals(Status.INTERNAL.getCode(), listener1.status.getCode());
-    assertEquals(NETWORK_ISSUE_MESSAGE, listener2.status.getCause().getMessage());
+    assertEquals("Protocol error\n" + NETWORK_ISSUE_MESSAGE, listener1.status.getDescription());
+    assertEquals(Status.INTERNAL.getCode(), listener2.status.getCode());
+    assertEquals("Protocol error\n" + NETWORK_ISSUE_MESSAGE, listener2.status.getDescription());
     verify(transportListener).transportShutdown();
     verify(transportListener, timeout(TIME_OUT_MS)).transportTerminated();
   }


### PR DESCRIPTION
Since OkHttp wraps many protocol error as IOException, we need to send GoAway for such errors.

Fixes #487 

@ejona86, Please take a look, thanks!