### PR TITLE
Allowing Netty TLS bootstrap handler to be sharable.

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
@@ -116,7 +116,7 @@ class ClientConfiguration implements Configuration {
         if (config.testca && config.address instanceof InetSocketAddress) {
           // Override the socket address with the host from the testca.
           InetSocketAddress address = (InetSocketAddress) config.address;
-          config.address = TestUtils.overrideHostFromTestCa(address.getHostName(),
+          config.address = TestUtils.testServerAddress(address.getHostName(),
                   address.getPort());
         }
       }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
@@ -41,12 +41,11 @@ import static java.util.Arrays.asList;
 
 import io.grpc.testing.PayloadType;
 import io.grpc.testing.RpcType;
+import io.grpc.testing.TestUtils;
 import io.grpc.transport.netty.NettyChannelBuilder;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -56,7 +55,6 @@ import java.util.Set;
  * Configuration options for benchmark clients.
  */
 class ClientConfiguration implements Configuration {
-  private static final String TESTCA_HOST = "foo.test.google.fr";
   private static final ClientConfiguration DEFAULT = new ClientConfiguration();
 
   Transport transport = Transport.NETTY_NIO;
@@ -117,14 +115,9 @@ class ClientConfiguration implements Configuration {
 
         if (config.testca && config.address instanceof InetSocketAddress) {
           // Override the socket address with the host from the testca.
-          try {
-            InetSocketAddress prevAddress = (InetSocketAddress) config.address;
-            InetAddress inetAddress = InetAddress.getByName(prevAddress.getHostName());
-            inetAddress = InetAddress.getByAddress(TESTCA_HOST, inetAddress.getAddress());
-            config.address = new InetSocketAddress(inetAddress, prevAddress.getPort());
-          } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
-          }
+          InetSocketAddress address = (InetSocketAddress) config.address;
+          config.address = TestUtils.overrideHostFromTestCa(address.getHostName(),
+                  address.getPort());
         }
       }
 

--- a/build.gradle
+++ b/build.gradle
@@ -252,6 +252,9 @@ subprojects {
     test {
         testLogging {
             exceptionFormat = 'full'
+            showExceptions true
+            showCauses true
+            showStackTraces true
         }
     }
 }

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -28,12 +28,6 @@ dependencies {
 
 test {
     jvmArgs "-Xbootclasspath/p:" + configurations.alpnboot.asPath
-    testLogging {
-        exceptionFormat "full"
-        showExceptions true
-        showCauses true
-        showStackTraces true
-    }
 }
 
 task test_client(type: CreateStartScripts) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -74,7 +74,7 @@ public class Http2NettyTest extends AbstractTransportTest {
   protected ChannelImpl createChannel() {
     try {
       InetAddress address
-          = InetAddress.getByAddress("foo.test.google.fr", new byte[] {127, 0, 0, 1});
+          = InetAddress.getByAddress(TestUtils.TEST_SERVER_HOST, new byte[] {127, 0, 0, 1});
       return NettyChannelBuilder
           .forAddress(new InetSocketAddress(address, serverPort))
           .sslContext(GrpcSslContexts.forClient().trustManager(

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -43,8 +43,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 
 /**
  * Integration tests for GRPC over HTTP2 using the Netty framework.
@@ -73,10 +71,8 @@ public class Http2NettyTest extends AbstractTransportTest {
   @Override
   protected ChannelImpl createChannel() {
     try {
-      InetAddress address
-          = InetAddress.getByAddress(TestUtils.TEST_SERVER_HOST, new byte[] {127, 0, 0, 1});
       return NettyChannelBuilder
-          .forAddress(new InetSocketAddress(address, serverPort))
+          .forAddress(TestUtils.testServerAddress(serverPort))
           .sslContext(GrpcSslContexts.forClient().trustManager(
                   TestUtils.loadCert("ca.pem")).build())
           .build();

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -71,7 +71,7 @@ public class Http2OkHttpTest extends AbstractTransportTest {
   @Override
   protected ChannelImpl createChannel() {
     OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("127.0.0.1", serverPort)
-        .overrideHostForAuthority("foo.test.google.fr");
+        .overrideHostForAuthority(TestUtils.TEST_SERVER_HOST);
     try {
       builder.sslSocketFactory(TestUtils.getSslSocketFactoryForCertainCert(
               TestUtils.loadCert("ca.pem")));

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -5,7 +5,18 @@ dependencies {
             libraries.netty
 
     // Tests depend on base class defined by core module.
-    testCompile project(':grpc-core').sourceSets.test.output
+    testCompile project(':grpc-core').sourceSets.test.output,
+                project(':grpc-testing')
+}
+
+test {
+    jvmArgs "-Xbootclasspath/p:" + configurations.alpnboot.asPath
+    testLogging {
+        exceptionFormat "full"
+        showExceptions true
+        showCauses true
+        showStackTraces true
+    }
 }
 
 javadoc.options.links 'https://netty.io/4.1/api/'

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -11,12 +11,6 @@ dependencies {
 
 test {
     jvmArgs "-Xbootclasspath/p:" + configurations.alpnboot.asPath
-    testLogging {
-        exceptionFormat "full"
-        showExceptions true
-        showCauses true
-        showStackTraces true
-    }
 }
 
 javadoc.options.links 'https://netty.io/4.1/api/'

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
@@ -40,10 +40,13 @@ import io.grpc.MethodDescriptor;
 import io.grpc.transport.ClientStream;
 import io.grpc.transport.ClientStreamListener;
 import io.grpc.transport.ClientTransport;
+import io.grpc.transport.netty.ProtocolNegotiator.FailureListener;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
@@ -91,6 +94,7 @@ class NettyClientTransport implements ClientTransport {
   /** Whether the transport completed shutting down. */
   @GuardedBy("this")
   private boolean terminated;
+  private Throwable failureCause;
 
   NettyClientTransport(SocketAddress address, Class<? extends Channel> channelType,
                        EventLoopGroup group, ProtocolNegotiator negotiator,
@@ -112,7 +116,19 @@ class NettyClientTransport implements ClientTransport {
     }
 
     handler = newHandler();
-    negotiationHandler = negotiator.newHandler(handler);
+    FailureListener closeOnNegotiationFailure = new FailureListener() {
+      @Override
+      public void negotiationFailed(ChannelHandlerContext ctx, Throwable cause) {
+        failureCause = cause;
+        ctx.close().addListener(new ChannelFutureListener() {
+          @Override
+          public void operationComplete(ChannelFuture future) throws Exception {
+            notifyClosed(future);
+          }
+        });
+      }
+    };
+    negotiationHandler = negotiator.newHandler(closeOnNegotiationFailure, handler);
   }
 
   @Override
@@ -132,7 +148,7 @@ class NettyClientTransport implements ClientTransport {
 
     // Write the command requesting the creation of the stream.
     handler.getWriteQueue().enqueue(new CreateStreamCommand(http2Headers, stream),
-        !method.getType().clientSendsOneMessage());
+            !method.getType().clientSendsOneMessage());
     return stream;
   }
 
@@ -159,21 +175,25 @@ class NettyClientTransport implements ClientTransport {
     channel.closeFuture().addListener(new ChannelFutureListener() {
       @Override
       public void operationComplete(ChannelFuture future) throws Exception {
-        if (!future.isSuccess()) {
-          // The close failed. Just notify that transport shutdown failed.
-          notifyTerminated(future.cause());
-          return;
-        }
-
-        if (handler.connectionError() != null) {
-          // The handler encountered a connection error.
-          notifyTerminated(handler.connectionError());
-        } else {
-          // Normal termination of the connection.
-          notifyTerminated(null);
-        }
+        notifyClosed(future);
       }
     });
+  }
+
+  /**
+   * Called after the channel has been closed to notify the application that the transport
+   * has been terminated.
+   */
+  private void notifyClosed(ChannelFuture closeFuture) {
+    if (!closeFuture.isSuccess()) {
+      // The close failed, just use the result of the future.
+      failureCause = closeFuture.cause();
+    } else if (failureCause == null) {
+      // The cause hasn't been previously set, use the error from the handler if it has one.
+      failureCause = handler.connectionError();
+    }
+
+    notifyTerminated(failureCause);
   }
 
   @Override
@@ -183,6 +203,10 @@ class NettyClientTransport implements ClientTransport {
     if (channel != null && channel.isOpen()) {
       channel.close();
     }
+  }
+
+  public Throwable failureCause() {
+    return failureCause;
   }
 
   private void notifyShutdown(Throwable t) {

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerTransport.java
@@ -90,15 +90,7 @@ class NettyServerTransport implements ServerTransport {
     channel.closeFuture().addListener(new ChannelFutureListener() {
       @Override
       public void operationComplete(ChannelFuture future) throws Exception {
-        if (!future.isSuccess()) {
-          notifyTerminated(future.cause());
-        } else if (handler.connectionError() != null) {
-          // The handler encountered a connection error.
-          notifyTerminated(handler.connectionError());
-        } else {
-          // Normal termination of the connection.
-          notifyTerminated(null);
-        }
+        notifyTerminated(handler.connectionError());
       }
     });
 

--- a/netty/src/main/java/io/grpc/transport/netty/ProtocolNegotiator.java
+++ b/netty/src/main/java/io/grpc/transport/netty/ProtocolNegotiator.java
@@ -32,7 +32,6 @@
 package io.grpc.transport.netty;
 
 import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.util.ByteString;
 
@@ -52,19 +51,8 @@ public interface ProtocolNegotiator {
   }
 
   /**
-   * Listener for negotiation failure event.
-   */
-  interface FailureListener {
-
-    /**
-     * Called when the negotiation fails.
-     */
-    void negotiationFailed(ChannelHandlerContext ctx, Throwable cause);
-  }
-
-  /**
    * Creates a new handler to control the protocol negotiation. Once the negotiation
    * has completed successfully, the provided handler is installed.
    */
-  Handler newHandler(FailureListener listener, Http2ConnectionHandler handler);
+  Handler newHandler(Http2ConnectionHandler handler);
 }

--- a/netty/src/main/java/io/grpc/transport/netty/ProtocolNegotiator.java
+++ b/netty/src/main/java/io/grpc/transport/netty/ProtocolNegotiator.java
@@ -32,6 +32,7 @@
 package io.grpc.transport.netty;
 
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.util.ByteString;
 
@@ -51,8 +52,19 @@ public interface ProtocolNegotiator {
   }
 
   /**
+   * Listener for negotiation failure event.
+   */
+  interface FailureListener {
+
+    /**
+     * Called when the negotiation fails.
+     */
+    void negotiationFailed(ChannelHandlerContext ctx, Throwable cause);
+  }
+
+  /**
    * Creates a new handler to control the protocol negotiation. Once the negotiation
    * has completed successfully, the provided handler is installed.
    */
-  Handler newHandler(Http2ConnectionHandler handler);
+  Handler newHandler(FailureListener listener, Http2ConnectionHandler handler);
 }

--- a/netty/src/main/java/io/grpc/transport/netty/WriteQueue.java
+++ b/netty/src/main/java/io/grpc/transport/netty/WriteQueue.java
@@ -34,6 +34,7 @@ package io.grpc.transport.netty;
 import com.google.common.base.Preconditions;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
 
 import java.util.ArrayDeque;
@@ -92,8 +93,8 @@ class WriteQueue {
    * @param flush true if a flush of the write should be schedule, false if a later call to
    *              enqueue will schedule the flush.
    */
-  void enqueue(Object command, boolean flush) {
-    enqueue(command, channel.newPromise(), flush);
+  ChannelFuture enqueue(Object command, boolean flush) {
+    return enqueue(command, channel.newPromise(), flush);
   }
 
   /**
@@ -104,11 +105,12 @@ class WriteQueue {
    * @param flush true if a flush of the write should be schedule, false if a later call to
    *              enqueue will schedule the flush.
    */
-  void enqueue(Object command, ChannelPromise promise, boolean flush) {
+  ChannelFuture enqueue(Object command, ChannelPromise promise, boolean flush) {
     queue.add(new QueuedCommand(command, promise));
     if (flush) {
       scheduleFlush();
     }
+    return promise;
   }
 
   /**

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientStreamTest.java
@@ -44,7 +44,6 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -54,6 +53,7 @@ import static org.mockito.Mockito.when;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.transport.ClientStreamListener;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelPromise;
@@ -328,7 +328,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase {
         return null;
       }
     }).when(writeQueue).enqueue(any(), any(ChannelPromise.class), anyBoolean());
-    doNothing().when(writeQueue).enqueue(any(), anyBoolean());
+    when(writeQueue.enqueue(any(), anyBoolean())).thenReturn(future);
     NettyClientStream stream = new NettyClientStream(listener, channel, handler);
     assertTrue(stream.canSend());
     assertTrue(stream.canReceive());

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
@@ -96,7 +96,7 @@ public class NettyClientTransportTest {
     transports = new NettyClientTransport[2];
 
     // Start the server.
-    address = TestUtils.overrideHostFromTestCa("localhost", TestUtils.pickUnusedPort());
+    address = TestUtils.testServerAddress(TestUtils.pickUnusedPort());
     File serverCert = TestUtils.loadCert("server1.pem");
     File key = TestUtils.loadCert("server1.key");
     SslContext serverContext = GrpcSslContexts.forServer(serverCert, key).build();

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2014, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.transport.netty;
+
+import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import io.grpc.Metadata;
+import io.grpc.testing.TestUtils;
+import io.grpc.transport.ClientTransport;
+import io.grpc.transport.ServerListener;
+import io.grpc.transport.ServerStream;
+import io.grpc.transport.ServerStreamListener;
+import io.grpc.transport.ServerTransport;
+import io.grpc.transport.ServerTransportListener;
+
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.ssl.SslContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tsests for {@link NettyClientTransport}.
+ */
+@RunWith(JUnit4.class)
+public class NettyClientTransportTest {
+
+  @Mock
+  private ServerListener serverListener;
+
+  @Mock
+  private ServerTransportListener serverTransportListener;
+
+  @Mock
+  private ServerStreamListener serverStreamListener;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    when(serverListener.transportCreated(any(ServerTransport.class))).thenReturn(
+            serverTransportListener);
+    when(serverTransportListener.streamCreated(any(ServerStream.class), anyString(),
+            any(Metadata.Headers.class))).thenReturn(serverStreamListener);
+  }
+
+  /**
+   * Verifies that we can create multiple TLS client transports from the same builder.
+   */
+  @Test
+  public void creatingMultipleTlsTransportsShouldSucceed() throws Exception {
+    int port = TestUtils.pickUnusedPort();
+    InetSocketAddress address = TestUtils.overrideHostFromTestCa("localhost", port);
+
+    File serverCert = TestUtils.loadCert("server1.pem");
+    File key = TestUtils.loadCert("server1.key");
+    SslContext serverContext = GrpcSslContexts.forServer(serverCert, key).build();
+    NettyServer server = new NettyServer(address, NioServerSocketChannel.class,
+            new NioEventLoopGroup(),new NioEventLoopGroup(), serverContext, 100,
+            DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
+    server.start(serverListener);
+
+    try {
+      File clientCert = TestUtils.loadCert("ca.pem");
+      SslContext clientContext = GrpcSslContexts.forClient().trustManager(clientCert).build();
+      ProtocolNegotiator negotiator = ProtocolNegotiators.tls(clientContext, address);
+
+      int numTransports = 2;
+      final SettableFuture[] futures = new SettableFuture[numTransports];
+      final NettyClientTransport[] transports = new NettyClientTransport[numTransports];
+      for (int index = 0; index < transports.length; ++index) {
+        transports[index] = new NettyClientTransport(address, NioSocketChannel.class,
+                new NioEventLoopGroup(), negotiator, DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
+        futures[index] = SettableFuture.create();
+        final int ix = index;
+        transports[index].start(new ClientTransport.Listener() {
+          @Override
+          public void transportShutdown() {
+          }
+
+          @Override
+          @SuppressWarnings("unchecked")
+          public void transportTerminated() {
+            futures[ix].set(null);
+          }
+        });
+      }
+
+      // Give the transports a moment to complete negotiation before we tear them down. If we
+      // try closing the transports during negotiation, the failureCause will be non-null.
+      Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+
+      for (int index = 0; index < transports.length; ++index) {
+        transports[index].shutdown();
+        futures[index].get(1, TimeUnit.SECONDS);
+        assertNull(transports[index].failureCause());
+      }
+    } finally {
+      server.shutdown();
+    }
+  }
+}

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
@@ -110,7 +110,6 @@ public class NettyClientTransportTest {
     for (NettyClientTransport transport : transports) {
       transport.shutdown();
     }
-    transports.clear();
 
     if (server != null) {
       server.shutdown();

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
@@ -93,8 +93,6 @@ public class NettyClientTransportTest {
   public void setup() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    transports.clear();
-
     group = new NioEventLoopGroup(1);
 
     // Start the server.
@@ -112,6 +110,7 @@ public class NettyClientTransportTest {
     for (NettyClientTransport transport : transports) {
       transport.shutdown();
     }
+    transports.clear();
 
     if (server != null) {
       server.shutdown();

--- a/netty/src/test/java/io/grpc/transport/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyServerStreamTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -51,6 +50,7 @@ import static org.mockito.Mockito.when;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.transport.ServerStreamListener;
+
 import io.netty.buffer.EmptyByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelPromise;
@@ -246,7 +246,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase {
         return null;
       }
     }).when(writeQueue).enqueue(any(), any(ChannelPromise.class), anyBoolean());
-    doNothing().when(writeQueue).enqueue(any(), anyBoolean());
+    when(writeQueue.enqueue(any(), anyBoolean())).thenReturn(future);
     NettyServerStream stream = new NettyServerStream(channel, http2Stream, handler);
     stream.setListener(serverListener);
     assertTrue(stream.canReceive());

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -126,7 +126,7 @@ public class TestUtils {
   /**
    * Creates a new {@link InetSocketAddress} that overrides the host with {@link #TEST_SERVER_HOST}.
    */
-  public static InetSocketAddress overrideHostFromTestCa(String host, int port) {
+  public static InetSocketAddress testServerAddress(String host, int port) {
     try {
       InetAddress inetAddress = InetAddress.getByName(host);
       inetAddress = InetAddress.getByAddress(TEST_SERVER_HOST, inetAddress.getAddress());
@@ -136,6 +136,19 @@ public class TestUtils {
     }
   }
 
+  /**
+   * Creates a new {@link InetSocketAddress} on localhost that overrides the host with
+   * {@link #TEST_SERVER_HOST}.
+   */
+  public static InetSocketAddress testServerAddress(int port) {
+    try {
+      InetAddress inetAddress = InetAddress.getByName("localhost");
+      inetAddress = InetAddress.getByAddress(TEST_SERVER_HOST, inetAddress.getAddress());
+      return new InetSocketAddress(inetAddress, port);
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+  }
   /**
    * Load a file from the resources folder.
    *

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -45,7 +45,10 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -62,6 +65,7 @@ import javax.security.auth.x500.X500Principal;
  * Common utility functions useful for writing tests.
  */
 public class TestUtils {
+  public static final String TEST_SERVER_HOST = "foo.test.google.fr";
 
   /**
    * Echo the request headers from a client into response headers and trailers. Useful for
@@ -115,6 +119,19 @@ public class TestUtils {
       serverSocket.close();
       return port;
     } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Creates a new {@link InetSocketAddress} that overrides the host with {@link #TEST_SERVER_HOST}.
+   */
+  public static InetSocketAddress overrideHostFromTestCa(String host, int port) {
+    try {
+      InetAddress inetAddress = InetAddress.getByName(host);
+      inetAddress = InetAddress.getByAddress(TEST_SERVER_HOST, inetAddress.getAddress());
+      return new InetSocketAddress(inetAddress, port);
+    } catch (UnknownHostException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
Also adding better handling for failures that occur during the protocol negotiation. Now properly catching the error, closing the channel, and notifying the application that the transport has terminated.

Fixes #504