### PR TITLE
Enable Travis for all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ jdk:
 os:
   - linux
 
-branches:
-  only:
-    - master
-
 notifications:
   email: false
 


### PR DESCRIPTION
We are using branches for other flows of development, so we really want
it running everywhere.

I'll back-port this change to v0.7.x branch.