### PR TITLE
Properly set inbound and outbound connection and stream window sizes

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -64,7 +64,7 @@ public abstract class AbstractBenchmark {
    * Standard flow-control window sizes.
    */
   public enum FlowWindowSize {
-    SMALL(16383), MEDIUM(65535), LARGE(1048575), JUMBO(16777215);
+    SMALL(16383), MEDIUM(65535), LARGE(1048575), JUMBO(8388607);
 
     private final int bytes;
     FlowWindowSize(int bytes) {
@@ -140,7 +140,13 @@ public abstract class AbstractBenchmark {
 
     // Always use a different worker group from the client.
     serverBuilder.workerEventLoopGroup(new NioEventLoopGroup());
+
+    // Always set connection and stream window size to same value
     serverBuilder.connectionWindowSize(windowSize.bytes());
+    serverBuilder.streamWindowSize(windowSize.bytes());
+    channelBuilder.connectionWindowSize(windowSize.bytes());
+    channelBuilder.streamWindowSize(windowSize.bytes());
+
     channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
     serverBuilder.maxConcurrentCallsPerConnection(maxConcurrentStreams);
 


### PR DESCRIPTION
Improves throughput in benchmarks. Interesting to note the bandwidth anomaly for JUMBO payload sizes

Before
```
Benchmark                                                     (clientInboundFlowWindow)  (maxConcurrentStreams)  (responseSize)   Mode  Cnt     Score     Error  Units
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                     MEDIUM                       1           LARGE  thrpt   20  3351.350 ± 109.036  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                     MEDIUM                       1           JUMBO  thrpt   20  2790.097 ± 104.119  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                     MEDIUM                      10           LARGE  thrpt   20  6939.464 ± 391.386  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                     MEDIUM                      10           JUMBO  thrpt   20  4468.688 ± 456.290  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      LARGE                       1           LARGE  thrpt   20  3314.568 ± 125.267  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      LARGE                       1           JUMBO  thrpt   20  2726.119 ± 102.488  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      LARGE                      10           LARGE  thrpt   20  6955.859 ± 306.830  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      LARGE                      10           JUMBO  thrpt   20  4595.532 ± 424.273  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      JUMBO                       1           LARGE  thrpt   20  3312.975 ± 134.877  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      JUMBO                       1           JUMBO  thrpt   20  2761.654 ± 116.206  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      JUMBO                      10           LARGE  thrpt   20  7125.712 ± 263.194  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      JUMBO                      10           JUMBO  thrpt   20  4481.482 ± 531.216  ops/s
```
With proper flow-windows
```
Benchmark                                                     (clientInboundFlowWindow)  (maxConcurrentStreams)  (responseSize)   Mode  Cnt     Score     Error  Units
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                     MEDIUM                       1           LARGE  thrpt   20  3304.626 ± 110.943  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                     MEDIUM                       1           JUMBO  thrpt   20  2777.045 ± 124.364  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                     MEDIUM                      10           LARGE  thrpt   20  2774.740 ±  99.287  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                     MEDIUM                      10           JUMBO  thrpt   20  2096.918 ± 495.754  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      LARGE                       1           LARGE  thrpt   20  6993.063 ± 433.202  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      LARGE                       1           JUMBO  thrpt   20  5193.056 ± 122.303  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      LARGE                      10           LARGE  thrpt   20  8265.015 ± 417.371  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      LARGE                      10           JUMBO  thrpt   20  4996.989 ± 177.047  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      JUMBO                       1           LARGE  thrpt   20  7384.874 ± 490.910  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      JUMBO                       1           JUMBO  thrpt   20  5897.575 ± 286.991  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      JUMBO                      10           LARGE  thrpt   20  8841.500 ± 710.635  ops/s
StreamingResponseBandwidthBenchmark.stream:megabitsPerSecond                      JUMBO                      10           JUMBO  thrpt   20  4915.330 ± 357.087  ops/s
```