### PR TITLE
Avoid GCM in unit tests

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -36,6 +36,7 @@ import io.grpc.testing.TestUtils;
 import io.grpc.transport.netty.GrpcSslContexts;
 import io.grpc.transport.netty.NettyChannelBuilder;
 import io.grpc.transport.netty.NettyServerBuilder;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -56,8 +57,10 @@ public class Http2NettyTest extends AbstractTransportTest {
   public static void startServer() {
     try {
       startStaticServer(NettyServerBuilder.forPort(serverPort)
-          .sslContext(GrpcSslContexts.forServer(
-                  TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key")).build()));
+          .sslContext(GrpcSslContexts
+              .forServer(TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"))
+              .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
+              .build()));
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }
@@ -73,8 +76,10 @@ public class Http2NettyTest extends AbstractTransportTest {
     try {
       return NettyChannelBuilder
           .forAddress(TestUtils.testServerAddress(serverPort))
-          .sslContext(GrpcSslContexts.forClient().trustManager(
-                  TestUtils.loadCert("ca.pem")).build())
+          .sslContext(GrpcSslContexts.forClient()
+              .trustManager(TestUtils.loadCert("ca.pem"))
+              .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
+              .build())
           .build();
     } catch (Exception ex) {
       throw new RuntimeException(ex);

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
@@ -58,6 +58,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 import org.junit.After;
 import org.junit.Before;
@@ -174,7 +175,8 @@ public class NettyClientTransportTest {
   private NettyClientTransport newTransport() throws IOException {
     // Create the protocol negotiator.
     File clientCert = TestUtils.loadCert("ca.pem");
-    SslContext clientContext = GrpcSslContexts.forClient().trustManager(clientCert).build();
+    SslContext clientContext = GrpcSslContexts.forClient().trustManager(clientCert)
+        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
     ProtocolNegotiator negotiator = ProtocolNegotiators.tls(clientContext, address);
 
     NettyClientTransport transport = new NettyClientTransport(address, NioSocketChannel.class,
@@ -186,7 +188,8 @@ public class NettyClientTransportTest {
   private void startServer(int maxStreamsPerConnection) throws IOException {
     File serverCert = TestUtils.loadCert("server1.pem");
     File key = TestUtils.loadCert("server1.key");
-    SslContext serverContext = GrpcSslContexts.forServer(serverCert, key).build();
+    SslContext serverContext = GrpcSslContexts.forServer(serverCert, key)
+        .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
     server = new NettyServer(address, NioServerSocketChannel.class,
             group, group, serverContext, maxStreamsPerConnection,
             DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);


### PR DESCRIPTION
GCM is very slow, and doesn't provide any benefit in unit tests. Even if
we were using tcnative and GCM is fast, using more available ciphers in
tests still makes sense. With this change building with Java 7 works
again, although that isn't the reason for the change.

On my machine with parallel building, it cuts full build time from
92 seconds to 39 seconds. For an incremental build after only changing
an interop test, the build time is cut from 73 seconds to 15 seconds.

@nmittler 