### PR TITLE
Use exit() for integration test client

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -80,6 +80,7 @@ public class TestServiceClient {
     } finally {
       client.tearDown();
     }
+    System.exit(0);
   }
 
   private String serverHost = "localhost";


### PR DESCRIPTION
On my machine, the client currently takes ~3s to run a test. However,
with exit() it takes < 1s. When doing lots of integration tests, those
seconds add up.

We know one of those seconds is the DESTROY_DELAY_SECONDS of
SharedResourceHolder. Part of another second appears to be Netty
creating any threads that weren't previously created when shutting down.