### PR TITLE
Revert swapping to the "canonical HTTP mapping"

### DIFF
--- a/core/src/main/java/io/grpc/transport/HttpUtil.java
+++ b/core/src/main/java/io/grpc/transport/HttpUtil.java
@@ -79,50 +79,24 @@ public final class HttpUtil {
   public static Status httpStatusToGrpcStatus(int httpStatusCode) {
     // Specific HTTP code handling.
     switch (httpStatusCode) {
-      case HttpURLConnection.HTTP_BAD_REQUEST:  // 400
-        return Status.INVALID_ARGUMENT;
       case HttpURLConnection.HTTP_UNAUTHORIZED:  // 401
         return Status.UNAUTHENTICATED;
       case HttpURLConnection.HTTP_FORBIDDEN:  // 403
         return Status.PERMISSION_DENIED;
-      case HttpURLConnection.HTTP_NOT_FOUND:  // 404
-        return Status.NOT_FOUND;
-      case HttpURLConnection.HTTP_CONFLICT:  // 409
-        return Status.ABORTED;
-      case 416:  // Requested range not satisfiable
-        return Status.OUT_OF_RANGE;
-      case 429:  // Too many requests
-        return Status.RESOURCE_EXHAUSTED;
-      case 499:  // Client closed request
-        return Status.CANCELLED;
-      case HttpURLConnection.HTTP_NOT_IMPLEMENTED:  // 501
-        return Status.UNIMPLEMENTED;
-      case HttpURLConnection.HTTP_UNAVAILABLE:  // 503
-        return Status.UNAVAILABLE;
-      case HttpURLConnection.HTTP_GATEWAY_TIMEOUT:  // 504
-        return Status.DEADLINE_EXCEEDED;
       default:
     }
     // Generic HTTP code handling.
-    if (httpStatusCode < 200) {
-      // 1xx and below
+    if (httpStatusCode < 100) {
+      // 0xx. These don't exist.
       return Status.UNKNOWN;
+    }
+    if (httpStatusCode < 200) {
+      // 1xx. These headers should have been ignored.
+      return Status.INTERNAL;
     }
     if (httpStatusCode < 300) {
       // 2xx
       return Status.OK;
-    }
-    if (httpStatusCode < 400) {
-      // 3xx
-      return Status.UNKNOWN;
-    }
-    if (httpStatusCode < 500) {
-      // 4xx
-      return Status.FAILED_PRECONDITION;
-    }
-    if (httpStatusCode < 600) {
-      // 5xx
-      return Status.INTERNAL;
     }
     return Status.UNKNOWN;
   }

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientStreamTest.java
@@ -238,7 +238,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase {
     verify(writeQueue).enqueue(any(CancelStreamCommand.class), eq(true));
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(listener).closed(captor.capture(), any(Metadata.Trailers.class));
-    assertEquals(Status.INTERNAL.getCode(), captor.getValue().getCode());
+    assertEquals(Status.UNKNOWN.getCode(), captor.getValue().getCode());
     assertTrue(stream.isClosed());
 
   }


### PR DESCRIPTION
The mapping is poorly suited for gRPC. C and Go don't even do any
mapping. We can improve the mapping in the future, but it is very
important that users don't start depending on the current mapping.

This change is "inspired by" the original code, but is even more
conservative.

Fixes #477