### PR TITLE
Update usage of deprecated API, and add back two accidentally removed blank lines.

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -262,7 +262,7 @@ public class TestServiceClient {
         if (useTls) {
           try {
             SSLSocketFactory factory = useTestCa
-                ? TestUtils.getSslSocketFactoryForCertainCert(TestUtils.loadCert("ca.pem"))
+                ? TestUtils.newSslSocketFactoryForCa(TestUtils.loadCert("ca.pem"))
                 : (SSLSocketFactory) SSLSocketFactory.getDefault();
             builder.sslSocketFactory(factory);
           } catch (Exception e) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -33,12 +33,14 @@ package io.grpc.testing.integration;
 
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.TlsVersion;
+
 import io.grpc.ChannelImpl;
 import io.grpc.testing.TestUtils;
 import io.grpc.transport.netty.GrpcSslContexts;
 import io.grpc.transport.netty.NettyServerBuilder;
 import io.grpc.transport.okhttp.OkHttpChannelBuilder;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
@ejona86 

Sorry, I checked in the last commit too hurry, missed updating one more usage that exposed after a ./gradlew clean.

And seems IntelliJ removed two blank lines when I do reformat (when I selected some code, I thought it would only affect the selected code).