### PR TITLE
Refactor OkHttpProtocolNegotiator, move Android related operations into an inner class.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpTlsUpgrader.java
@@ -69,7 +69,7 @@ public final class OkHttpTlsUpgrader {
     spec.apply(sslSocket, false);
     if (spec.supportsTlsExtensions()) {
       String negotiatedProtocol =
-          OkHttpProtocolNegotiator.negotiate(sslSocket, host, TLS_PROTOCOLS);
+          OkHttpProtocolNegotiator.get().negotiate(sslSocket, host, TLS_PROTOCOLS);
       Preconditions.checkState(SUPPORTED_HTTP2_PROTOCOLS.contains(negotiatedProtocol),
           "negotiated protocol %s is unsupported", negotiatedProtocol);
     }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/OkHttpProtocolNegotiator.java
@@ -43,116 +43,20 @@ import javax.net.ssl.SSLSocket;
  * A helper class located in package com.squareup.okhttp.internal for TLS negotiation.
  */
 public class OkHttpProtocolNegotiator {
-  private static Platform platform = Platform.get();
+  private static final Platform PLATFORM = Platform.get();
+  private static OkHttpProtocolNegotiator NEGOTIATOR = createNegotiator();
 
-  // setUseSessionTickets(boolean)
-  private static final OptionalMethod<Socket> SET_USE_SESSION_TICKETS =
-      new OptionalMethod<Socket>(null, "setUseSessionTickets", Boolean.TYPE);
-  // setHostname(String)
-  private static final OptionalMethod<Socket> SET_HOSTNAME =
-      new OptionalMethod<Socket>(null, "setHostname", String.class);
-  // byte[] getAlpnSelectedProtocol()
-  private static final OptionalMethod<Socket> GET_ALPN_SELECTED_PROTOCOL =
-      new OptionalMethod<Socket>(byte[].class, "getAlpnSelectedProtocol");
-  // setAlpnSelectedProtocol(byte[])
-  private static final OptionalMethod<Socket> SET_ALPN_PROTOCOLS =
-      new OptionalMethod<Socket>(null, "setAlpnProtocols", byte[].class);
-  // byte[] getNpnSelectedProtocol()
-  private static final OptionalMethod<Socket> GET_NPN_SELECTED_PROTOCOL =
-      new OptionalMethod<Socket>(byte[].class, "getNpnSelectedProtocol");
-  private static boolean android;
+  private OkHttpProtocolNegotiator() {}
 
-  /**
-   * Start and wait until the negotiation is done, returns the negotiated protocol.
-   */
-  public static String negotiate(
-      SSLSocket sslSocket, String hostname, List<Protocol> protocols) throws IOException {
-    configureTlsExtensions(sslSocket, hostname, protocols);
-
-    // It's possible that the user provided SSLSocketFactory has already done the handshake
-    // when creates the SSLSocket.
-    String negotiatedProtocol = getSelectedProtocol(sslSocket);
-    if (negotiatedProtocol == null) {
-      try {
-        // Force handshake.
-        sslSocket.startHandshake();
-
-        negotiatedProtocol = OkHttpProtocolNegotiator.getSelectedProtocol(sslSocket);
-        if (negotiatedProtocol == null) {
-          throw new RuntimeException("protocol negotiation failed");
-        }
-      } finally {
-        afterHandshake(sslSocket);
-      }
-    }
-    return negotiatedProtocol;
+  public static OkHttpProtocolNegotiator get() {
+    return NEGOTIATOR;
   }
 
   /**
-   * Override {@link Platform}'s configureTlsExtensions for Android older than 5.0, since OkHttp
-   * (2.3+) only support such function for Android 5.0+.
+   * Creates corresponding negotiator according to whether on Android.
    */
-  private static void configureTlsExtensions(
-      SSLSocket sslSocket, String hostname, List<Protocol> protocols) {
-    if (!android) {
-      platform.configureTlsExtensions(sslSocket, hostname, protocols);
-      return;
-    }
-
-    // Enable SNI and session tickets.
-    if (hostname != null) {
-      SET_USE_SESSION_TICKETS.invokeOptionalWithoutCheckedException(sslSocket, true);
-      SET_HOSTNAME.invokeOptionalWithoutCheckedException(sslSocket, hostname);
-    }
-
-    // Enable ALPN.
-    if (SET_ALPN_PROTOCOLS.isSupported(sslSocket)) {
-      Object[] parameters = {platform.concatLengthPrefixed(protocols)};
-      SET_ALPN_PROTOCOLS.invokeWithoutCheckedException(sslSocket, parameters);
-    }
-  }
-
-  private static void afterHandshake(SSLSocket sslSocket) {
-    if (!android) {
-      platform.afterHandshake(sslSocket);
-    }
-  }
-
-  /** Returns the negotiated protocol, or null if no protocol was negotiated. */
-  public static String getSelectedProtocol(SSLSocket socket) {
-    if (!android) {
-      return platform.getSelectedProtocol(socket);
-    }
-
-    if (GET_ALPN_SELECTED_PROTOCOL.isSupported(socket)) {
-      try {
-        byte[] alpnResult =
-            (byte[]) GET_ALPN_SELECTED_PROTOCOL.invokeWithoutCheckedException(socket);
-        if (alpnResult != null) {
-          return new String(alpnResult, Util.UTF_8);
-        }
-      } catch (Exception e) {
-        // In some implementations, querying selected protocol before the handshake will fail with
-        // exception.
-      }
-    }
-
-    if (GET_NPN_SELECTED_PROTOCOL.isSupported(socket)) {
-      try {
-        byte[] npnResult = (byte[]) GET_NPN_SELECTED_PROTOCOL.invokeWithoutCheckedException(socket);
-        if (npnResult != null) {
-          return new String(npnResult, Util.UTF_8);
-        }
-      } catch (Exception e) {
-        // In some implementations, querying selected protocol before the handshake will fail with
-        // exception.
-      }
-    }
-    return null;
-  }
-
-  static {
-    android = true;
+  private static OkHttpProtocolNegotiator createNegotiator() {
+    boolean android = true;
     try {
       // Attempt to find Android 2.3+ APIs.
       Class.forName("com.android.org.conscrypt.OpenSSLSocketImpl");
@@ -163,6 +67,119 @@ public class OkHttpProtocolNegotiator {
       } catch (ClassNotFoundException ignored2) {
         android = false;
       }
+    }
+    return android ? new AndroidNegotiator() : new OkHttpProtocolNegotiator();
+  }
+
+  /**
+   * Start and wait until the negotiation is done, returns the negotiated protocol.
+   */
+  public String negotiate(
+      SSLSocket sslSocket, String hostname, List<Protocol> protocols) throws IOException {
+    configureTlsExtensions(sslSocket, hostname, protocols);
+    try {
+      // Force handshake.
+      sslSocket.startHandshake();
+
+      String negotiatedProtocol = getSelectedProtocol(sslSocket);
+      if (negotiatedProtocol == null) {
+        throw new RuntimeException("protocol negotiation failed");
+      }
+      return negotiatedProtocol;
+    } finally {
+      PLATFORM.afterHandshake(sslSocket);
+    }
+  }
+
+  /** Configure TLS extensions. */
+  protected void configureTlsExtensions(
+      SSLSocket sslSocket, String hostname, List<Protocol> protocols) {
+    PLATFORM.configureTlsExtensions(sslSocket, hostname, protocols);
+  }
+
+  /** Returns the negotiated protocol, or null if no protocol was negotiated. */
+  public String getSelectedProtocol(SSLSocket socket) {
+    return PLATFORM.getSelectedProtocol(socket);
+  }
+
+  private static class AndroidNegotiator extends OkHttpProtocolNegotiator {
+    // setUseSessionTickets(boolean)
+    private static final OptionalMethod<Socket> SET_USE_SESSION_TICKETS =
+        new OptionalMethod<Socket>(null, "setUseSessionTickets", Boolean.TYPE);
+    // setHostname(String)
+    private static final OptionalMethod<Socket> SET_HOSTNAME =
+        new OptionalMethod<Socket>(null, "setHostname", String.class);
+    // byte[] getAlpnSelectedProtocol()
+    private static final OptionalMethod<Socket> GET_ALPN_SELECTED_PROTOCOL =
+        new OptionalMethod<Socket>(byte[].class, "getAlpnSelectedProtocol");
+    // setAlpnSelectedProtocol(byte[])
+    private static final OptionalMethod<Socket> SET_ALPN_PROTOCOLS =
+        new OptionalMethod<Socket>(null, "setAlpnProtocols", byte[].class);
+    // byte[] getNpnSelectedProtocol()
+    private static final OptionalMethod<Socket> GET_NPN_SELECTED_PROTOCOL =
+        new OptionalMethod<Socket>(byte[].class, "getNpnSelectedProtocol");
+    private static boolean android;
+
+    @Override
+    public String negotiate(SSLSocket sslSocket, String hostname, List<Protocol> protocols)
+        throws IOException {
+      // First check if a protocol has already been selected, since it's possible that the user
+      // provided SSLSocketFactory has already done the handshake when creates the SSLSocket.
+      String negotiatedProtocol = getSelectedProtocol(sslSocket);
+      if (negotiatedProtocol == null) {
+        negotiatedProtocol = super.negotiate(sslSocket, hostname, protocols);
+      }
+      return negotiatedProtocol;
+    }
+
+    /**
+     * Override {@link Platform}'s configureTlsExtensions for Android older than 5.0, since OkHttp
+     * (2.3+) only support such function for Android 5.0+.
+     */
+    @Override
+    protected void configureTlsExtensions(
+        SSLSocket sslSocket, String hostname, List<Protocol> protocols) {
+      // Enable SNI and session tickets.
+      if (hostname != null) {
+        SET_USE_SESSION_TICKETS.invokeOptionalWithoutCheckedException(sslSocket, true);
+        SET_HOSTNAME.invokeOptionalWithoutCheckedException(sslSocket, hostname);
+      }
+
+      // Enable ALPN.
+      if (SET_ALPN_PROTOCOLS.isSupported(sslSocket)) {
+        Object[] parameters = {PLATFORM.concatLengthPrefixed(protocols)};
+        SET_ALPN_PROTOCOLS.invokeWithoutCheckedException(sslSocket, parameters);
+      }
+    }
+
+    @Override
+    public String getSelectedProtocol(SSLSocket socket) {
+      if (GET_ALPN_SELECTED_PROTOCOL.isSupported(socket)) {
+        try {
+          byte[] alpnResult =
+              (byte[]) GET_ALPN_SELECTED_PROTOCOL.invokeWithoutCheckedException(socket);
+          if (alpnResult != null) {
+            return new String(alpnResult, Util.UTF_8);
+          }
+        } catch (Exception e) {
+          // In some implementations, querying selected protocol before the handshake will fail with
+          // exception.
+        }
+      }
+
+      if (GET_NPN_SELECTED_PROTOCOL.isSupported(socket)) {
+        try {
+          byte[] npnResult =
+              (byte[]) GET_NPN_SELECTED_PROTOCOL.invokeWithoutCheckedException(socket);
+          if (npnResult != null) {
+            return new String(npnResult, Util.UTF_8);
+          }
+        } catch (Exception e) {
+          // In some implementations, querying selected protocol before the handshake will fail with
+          // exception.
+        }
+      }
+      return null;
     }
   }
 }


### PR DESCRIPTION
After this refactor, the upcoming NPN fallback support will be clearer and easier to review.

@ejona86 Please take a look, thanks!