### PR TITLE
Add CallOptions.

### DIFF
--- a/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
+++ b/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
@@ -34,6 +34,7 @@ package io.grpc.auth;
 import com.google.auth.Credentials;
 import com.google.common.base.Preconditions;
 
+import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
@@ -68,10 +69,10 @@ public class ClientAuthInterceptor implements ClientInterceptor {
 
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
-                                                       Channel next) {
+      CallOptions callOptions, Channel next) {
     // TODO(ejona86): If the call fails for Auth reasons, this does not properly propagate info that
     // would be in WWW-Authenticate, because it does not yet have access to the header.
-    return new CheckedForwardingClientCall<ReqT, RespT>(next.newCall(method)) {
+    return new CheckedForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
       @Override
       protected void checkedStart(Listener<RespT> responseListener, Metadata.Headers headers)
           throws Exception {

--- a/benchmarks/src/generated/main/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/TestServiceGrpc.java
@@ -113,24 +113,31 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(config.unaryCall), request, responseObserver);
+          channel.newCall(config.unaryCall, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.SimpleRequest> streamingCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.SimpleResponse> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.streamingCall), responseObserver);
+          channel.newCall(config.streamingCall, callOptions), responseObserver);
     }
   }
 
@@ -142,16 +149,23 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceBlockingStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceBlockingStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceBlockingStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceBlockingStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.testing.SimpleResponse unaryCall(io.grpc.testing.SimpleRequest request) {
       return blockingUnaryCall(
-          channel.newCall(config.unaryCall), request);
+          channel.newCall(config.unaryCall, callOptions), request);
     }
   }
 
@@ -163,17 +177,24 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceFutureStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceFutureStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceFutureStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceFutureStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.SimpleResponse> unaryCall(
         io.grpc.testing.SimpleRequest request) {
       return unaryFutureCall(
-          channel.newCall(config.unaryCall), request);
+          channel.newCall(config.unaryCall, callOptions), request);
     }
   }
 

--- a/benchmarks/src/generated/main/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/WorkerGrpc.java
@@ -108,24 +108,31 @@ public class WorkerGrpc {
       super(channel, config);
     }
 
+    private WorkerStub(io.grpc.Channel channel,
+        WorkerServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected WorkerStub build(io.grpc.Channel channel,
-        WorkerServiceDescriptor config) {
-      return new WorkerStub(channel, config);
+        WorkerServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new WorkerStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.ClientArgs> runTest(
         io.grpc.stub.StreamObserver<io.grpc.testing.ClientStatus> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.runTest), responseObserver);
+          channel.newCall(config.runTest, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.ServerArgs> runServer(
         io.grpc.stub.StreamObserver<io.grpc.testing.ServerStatus> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.runServer), responseObserver);
+          channel.newCall(config.runServer, callOptions), responseObserver);
     }
   }
 
@@ -137,10 +144,17 @@ public class WorkerGrpc {
       super(channel, config);
     }
 
+    private WorkerBlockingStub(io.grpc.Channel channel,
+        WorkerServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected WorkerBlockingStub build(io.grpc.Channel channel,
-        WorkerServiceDescriptor config) {
-      return new WorkerBlockingStub(channel, config);
+        WorkerServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new WorkerBlockingStub(channel, config, callOptions);
     }
   }
 
@@ -152,10 +166,17 @@ public class WorkerGrpc {
       super(channel, config);
     }
 
+    private WorkerFutureStub(io.grpc.Channel channel,
+        WorkerServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected WorkerFutureStub build(io.grpc.Channel channel,
-        WorkerServiceDescriptor config) {
-      return new WorkerFutureStub(channel, config);
+        WorkerServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new WorkerFutureStub(channel, config, callOptions);
     }
   }
 

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/SingleThreadBlockingQpsBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/SingleThreadBlockingQpsBenchmark.java
@@ -1,5 +1,6 @@
 package io.grpc.benchmarks.netty;
 
+import io.grpc.CallOptions;
 import io.grpc.stub.ClientCalls;
 import io.netty.buffer.Unpooled;
 
@@ -50,7 +51,8 @@ public class SingleThreadBlockingQpsBenchmark extends AbstractBenchmark {
    */
   @Benchmark
   public void blockingUnary() throws Exception {
-    ClientCalls.blockingUnaryCall(channels[0].newCall(unaryMethod), Unpooled.EMPTY_BUFFER);
+    ClientCalls.blockingUnaryCall(
+        channels[0].newCall(unaryMethod, CallOptions.DEFAULT), Unpooled.EMPTY_BUFFER);
   }
 
   /**

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -328,13 +328,23 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
     p->Print("}\n\n");
     p->Print(
         *vars,
+        "private $impl_name$($Channel$ channel,\n"
+        "    $service_name$ServiceDescriptor config,\n"
+        "    $CallOptions$ callOptions) {\n");
+    p->Indent();
+    p->Print("super(channel, config, callOptions);\n");
+    p->Outdent();
+    p->Print("}\n\n");
+    p->Print(
+        *vars,
         "@$Override$\n"
         "protected $impl_name$ build($Channel$ channel,\n"
-        "    $service_name$ServiceDescriptor config) {\n");
+        "    $service_name$ServiceDescriptor config,\n"
+        "    $CallOptions$ callOptions) {\n");
     p->Indent();
     p->Print(
         *vars,
-        "return new $impl_name$(channel, config);\n");
+        "return new $impl_name$(channel, config, callOptions);\n");
     p->Outdent();
     p->Print("}\n");
   }
@@ -430,7 +440,7 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
           p->Print(
               *vars,
               "return $calls_method$(\n"
-              "    channel.newCall(config.$lower_method_name$), $params$);\n");
+              "    channel.newCall(config.$lower_method_name$, callOptions), $params$);\n");
           break;
         case ASYNC_CALL:
           if (server_streaming) {
@@ -454,7 +464,7 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
           p->Print(
               *vars,
               "$last_line_prefix$$calls_method$(\n"
-              "    channel.newCall(config.$lower_method_name$), $params$);\n");
+              "    channel.newCall(config.$lower_method_name$, callOptions), $params$);\n");
           break;
         case FUTURE_CALL:
           CHECK(!client_streaming && !server_streaming)
@@ -465,7 +475,7 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
           p->Print(
               *vars,
               "return $calls_method$(\n"
-              "    channel.newCall(config.$lower_method_name$), request);\n");
+              "    channel.newCall(config.$lower_method_name$, callOptions), request);\n");
           break;
       }
       p->Outdent();
@@ -653,6 +663,7 @@ void GenerateService(const ServiceDescriptor* service,
   vars["String"] = "java.lang.String";
   vars["Override"] = "java.lang.Override";
   vars["Channel"] = "io.grpc.Channel";
+  vars["CallOptions"] = "io.grpc.CallOptions";
   vars["MethodType"] = "io.grpc.MethodType";
   vars["ServerServiceDefinition"] =
       "io.grpc.ServerServiceDefinition";

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -167,45 +167,52 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(config.unaryCall), request, responseObserver);
+          channel.newCall(config.unaryCall, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          channel.newCall(config.streamingOutputCall), request, responseObserver);
+          channel.newCall(config.streamingOutputCall, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          channel.newCall(config.streamingInputCall), responseObserver);
+          channel.newCall(config.streamingInputCall, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.fullDuplexCall), responseObserver);
+          channel.newCall(config.fullDuplexCall, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.halfDuplexCall), responseObserver);
+          channel.newCall(config.halfDuplexCall, callOptions), responseObserver);
     }
   }
 
@@ -217,23 +224,30 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceBlockingStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceBlockingStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceBlockingStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceBlockingStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          channel.newCall(config.unaryCall), request);
+          channel.newCall(config.unaryCall, callOptions), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          channel.newCall(config.streamingOutputCall), request);
+          channel.newCall(config.streamingOutputCall, callOptions), request);
     }
   }
 
@@ -245,17 +259,24 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceFutureStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceFutureStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceFutureStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceFutureStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return unaryFutureCall(
-          channel.newCall(config.unaryCall), request);
+          channel.newCall(config.unaryCall, callOptions), request);
     }
   }
 

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -229,45 +229,52 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(config.unaryCall), request, responseObserver);
+          channel.newCall(config.unaryCall, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          channel.newCall(config.streamingOutputCall), request, responseObserver);
+          channel.newCall(config.streamingOutputCall, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          channel.newCall(config.streamingInputCall), responseObserver);
+          channel.newCall(config.streamingInputCall, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.fullDuplexCall), responseObserver);
+          channel.newCall(config.fullDuplexCall, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.halfDuplexCall), responseObserver);
+          channel.newCall(config.halfDuplexCall, callOptions), responseObserver);
     }
   }
 
@@ -279,23 +286,30 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceBlockingStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceBlockingStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceBlockingStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceBlockingStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          channel.newCall(config.unaryCall), request);
+          channel.newCall(config.unaryCall, callOptions), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          channel.newCall(config.streamingOutputCall), request);
+          channel.newCall(config.streamingOutputCall, callOptions), request);
     }
   }
 
@@ -307,17 +321,24 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceFutureStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceFutureStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceFutureStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceFutureStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return unaryFutureCall(
-          channel.newCall(config.unaryCall), request);
+          channel.newCall(config.unaryCall, callOptions), request);
     }
   }
 

--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * The collection of runtime options for a new RPC call.
+ *
+ * <p>A field that is not set is {@code null}.
+ */
+@Immutable
+public final class CallOptions {
+  /**
+   * A blank {@code CallOptions} that all fields are not set.
+   */
+  public static final CallOptions DEFAULT = new CallOptions();
+
+  // Although {@code CallOptions} is immutable, its fields are not final, so that we can initialize
+  // them outside of constructor. Otherwise the constructor will have a potentially long list of
+  // unnamed arguments, which is undesirable.
+  private Long deadlineNanoTime;
+
+  /**
+   * Returns a new {@code CallOptions} with the given absolute deadline in nanoseconds in the clock
+   * as per {@link System#nanoTime()}.
+   *
+   * <p>This is mostly used for propagating an existing deadline. {@link #withDeadlineAfter} is the
+   * recommended way of setting a new deadline,
+   *
+   * @param deadlineNanoTime the deadline in the clock as per {@link System#nanoTime()}.
+   *                         {@code null} for unsetting the deadline.
+   */
+  public CallOptions withDeadlineNanoTime(@Nullable Long deadlineNanoTime) {
+    CallOptions newOptions = new CallOptions(this);
+    newOptions.deadlineNanoTime = deadlineNanoTime;
+    return newOptions;
+  }
+
+  /**
+   * Returns a new {@code CallOptions} with a deadline that is after the given {@code duration} from
+   * now.
+   */
+  public CallOptions withDeadlineAfter(long duration, TimeUnit unit) {
+    return withDeadlineNanoTime(System.nanoTime() + unit.toNanos(duration));
+  }
+
+  /**
+   * Returns the deadline in nanoseconds in the clock as per {@link System#nanoTime()}. {@code null}
+   * if the deadline is not set.
+   */
+  @Nullable
+  public Long getDeadlineNanoTime() {
+    return deadlineNanoTime;
+  }
+
+  private CallOptions() {
+  }
+
+  /**
+   * Copy constructor.
+   */
+  private CallOptions(CallOptions other) {
+    deadlineNanoTime = other.deadlineNanoTime;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buffer = new StringBuilder();
+    buffer.append("[deadlineNanoTime=").append(deadlineNanoTime);
+    if (deadlineNanoTime != null) {
+      buffer.append(" (").append(deadlineNanoTime - System.nanoTime()).append(" ns from now)");
+    }
+    buffer.append("]");
+    return buffer.toString();
+  }
+}

--- a/core/src/main/java/io/grpc/Channel.java
+++ b/core/src/main/java/io/grpc/Channel.java
@@ -49,14 +49,30 @@ public abstract class Channel {
 
   /**
    * Create a {@link ClientCall} to the remote operation specified by the given
+   * {@link MethodDescriptor}, and with the default call options.
+   *
+   * @param methodDescriptor describes the name and parameter types of the operation to call.
+   * @return a {@link ClientCall} bound to the specified method.
+   * @deprecated use {@link newCall(MethodDescriptor, CallOptions)}
+   *
+   */
+  @Deprecated
+  public final <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+      MethodDescriptor<RequestT, ResponseT> methodDescriptor) {
+    return newCall(methodDescriptor, CallOptions.DEFAULT);
+  }
+
+  /**
+   * Create a {@link ClientCall} to the remote operation specified by the given
    * {@link MethodDescriptor}. The returned {@link ClientCall} does not trigger any remote
    * behavior until {@link ClientCall#start(ClientCall.Listener, Metadata.Headers)} is
    * invoked.
    *
    * @param methodDescriptor describes the name and parameter types of the operation to call.
+   * @param callOptions runtime options to be applied to this call.
    * @return a {@link ClientCall} bound to the specified method.
    *
    */
   public abstract <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
-      MethodDescriptor<RequestT, ResponseT> methodDescriptor);
+      MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions);
 }

--- a/core/src/main/java/io/grpc/ClientInterceptors.java
+++ b/core/src/main/java/io/grpc/ClientInterceptors.java
@@ -87,8 +87,9 @@ public class ClientInterceptors {
     }
 
     @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(MethodDescriptor<ReqT, RespT> method) {
-      return new ProcessInterceptorChannel(channel, interceptors).newCall(method);
+    public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions) {
+      return new ProcessInterceptorChannel(channel, interceptors).newCall(method, callOptions);
     }
   }
 
@@ -102,15 +103,18 @@ public class ClientInterceptors {
     }
 
     @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(MethodDescriptor<ReqT, RespT> method) {
+    public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions) {
       if (interceptors != null && interceptors.hasNext()) {
-        return interceptors.next().interceptCall(method, this);
+        return interceptors.next().interceptCall(method, callOptions, this);
       } else {
         Preconditions.checkState(interceptors != null,
             "The channel has already been called. "
             + "Some interceptor must have called on \"next\" twice.");
         interceptors = null;
-        return channel.newCall(method);
+        return channel.newCall(
+            Preconditions.checkNotNull(method, "method"),
+            Preconditions.checkNotNull(callOptions, "callOptions"));
       }
     }
   }

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -34,7 +34,6 @@ package io.grpc;
 import com.google.common.base.Preconditions;
 
 import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -53,23 +52,20 @@ public class MethodDescriptor<RequestT, ResponseT> {
   private final String name;
   private final Marshaller<RequestT> requestMarshaller;
   private final Marshaller<ResponseT> responseMarshaller;
-  private final long timeoutMicros;
 
   public static <RequestT, ResponseT> MethodDescriptor<RequestT, ResponseT> create(
-      MethodType type, String name, long timeout, TimeUnit timeoutUnit,
+      MethodType type, String name,
       Marshaller<RequestT> requestMarshaller,
       Marshaller<ResponseT> responseMarshaller) {
     return new MethodDescriptor<RequestT, ResponseT>(
-        type, name, timeoutUnit.toMicros(timeout), requestMarshaller, responseMarshaller);
+        type, name, requestMarshaller, responseMarshaller);
   }
 
-  private MethodDescriptor(MethodType type, String name, long timeoutMicros,
+  private MethodDescriptor(MethodType type, String name,
                            Marshaller<RequestT> requestMarshaller,
                            Marshaller<ResponseT> responseMarshaller) {
     this.type = Preconditions.checkNotNull(type);
     this.name = name;
-    Preconditions.checkArgument(timeoutMicros > 0);
-    this.timeoutMicros = timeoutMicros;
     this.requestMarshaller = requestMarshaller;
     this.responseMarshaller = responseMarshaller;
   }
@@ -86,13 +82,6 @@ public class MethodDescriptor<RequestT, ResponseT> {
    */
   public String getName() {
     return name;
-  }
-
-  /**
-   * Timeout for the operation in microseconds.
-   */
-  public long getTimeout() {
-    return timeoutMicros;
   }
 
   /**
@@ -113,17 +102,5 @@ public class MethodDescriptor<RequestT, ResponseT> {
    */
   public InputStream streamRequest(RequestT requestMessage) {
     return requestMarshaller.stream(requestMessage);
-  }
-
-  /**
-   * Create a new descriptor with a different timeout.
-   *
-   * @param timeout to set on cloned descriptor.
-   * @param unit of time for {@code timeout}.
-   * @return a cloned instance with the specified timeout set.
-   */
-  public MethodDescriptor<RequestT, ResponseT> withTimeout(long timeout, TimeUnit unit) {
-    return new MethodDescriptor<RequestT, ResponseT>(type, name, unit.toMicros(timeout),
-        requestMarshaller, responseMarshaller);
   }
 }

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,35 +31,28 @@
 
 package io.grpc;
 
-import javax.annotation.concurrent.ThreadSafe;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-/**
- * Interface for intercepting outgoing calls before they are dispatched by a {@link Channel}.
- *
- * <p>Implementers use this mechanism to add cross-cutting behavior to {@link Channel} and
- * stub implementations. Common examples of such behavior include:
- * <ul>
- * <li>Adding credentials to header metadata</li>
- * <li>Logging and monitoring call behavior</li>
- * <li>Request and response rewriting</li>
- * </ul>
- */
-@ThreadSafe
-public interface ClientInterceptor {
-  /**
-   * Intercept {@link ClientCall} creation by the {@code next} {@link Channel}.
-   *
-   * <p>Many variations of interception are possible. Complex implementations may return a wrapper
-   * around the result of {@code next.newCall()}, whereas a simpler implementation may just modify
-   * the header metadata prior to returning the result of {@code next.newCall()}.
-   *
-   * @param method the remote method to be called.
-   * @param callOptions the runtime options to be applied to this call.
-   * @param next the channel which is being intercepted.
-   * @return the call object for the remote operation, never {@code null}.
-   */
-  <RequestT, ResponseT> ClientCall<RequestT, ResponseT> interceptCall(
-      MethodDescriptor<RequestT, ResponseT> method,
-      CallOptions callOptions,
-      Channel next);
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link CallOptions}. */
+@RunWith(JUnit4.class)
+public class CallOptionsTest {
+  @Test
+  public void defaultsAreAllNull() {
+    assertNull(CallOptions.DEFAULT.getDeadlineNanoTime());
+  }
+
+  @Test
+  public void mutation() {
+    CallOptions options1 = CallOptions.DEFAULT.withDeadlineNanoTime(10L);
+    assertNull(CallOptions.DEFAULT.getDeadlineNanoTime());
+    assertEquals(10L, (long) options1.getDeadlineNanoTime());
+    CallOptions options2 = options1.withDeadlineNanoTime(null);
+    assertEquals(10L, (long) options1.getDeadlineNanoTime());
+    assertNull(options2.getDeadlineNanoTime());
+  }
 }

--- a/examples/src/generated/main/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -96,17 +96,24 @@ public class GreeterGrpc {
       super(channel, config);
     }
 
+    private GreeterStub(io.grpc.Channel channel,
+        GreeterServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected GreeterStub build(io.grpc.Channel channel,
-        GreeterServiceDescriptor config) {
-      return new GreeterStub(channel, config);
+        GreeterServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new GreeterStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public void sayHello(io.grpc.examples.helloworld.HelloRequest request,
         io.grpc.stub.StreamObserver<io.grpc.examples.helloworld.HelloResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(config.sayHello), request, responseObserver);
+          channel.newCall(config.sayHello, callOptions), request, responseObserver);
     }
   }
 
@@ -118,16 +125,23 @@ public class GreeterGrpc {
       super(channel, config);
     }
 
+    private GreeterBlockingStub(io.grpc.Channel channel,
+        GreeterServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected GreeterBlockingStub build(io.grpc.Channel channel,
-        GreeterServiceDescriptor config) {
-      return new GreeterBlockingStub(channel, config);
+        GreeterServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new GreeterBlockingStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.examples.helloworld.HelloResponse sayHello(io.grpc.examples.helloworld.HelloRequest request) {
       return blockingUnaryCall(
-          channel.newCall(config.sayHello), request);
+          channel.newCall(config.sayHello, callOptions), request);
     }
   }
 
@@ -139,17 +153,24 @@ public class GreeterGrpc {
       super(channel, config);
     }
 
+    private GreeterFutureStub(io.grpc.Channel channel,
+        GreeterServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected GreeterFutureStub build(io.grpc.Channel channel,
-        GreeterServiceDescriptor config) {
-      return new GreeterFutureStub(channel, config);
+        GreeterServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new GreeterFutureStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.helloworld.HelloResponse> sayHello(
         io.grpc.examples.helloworld.HelloRequest request) {
       return unaryFutureCall(
-          channel.newCall(config.sayHello), request);
+          channel.newCall(config.sayHello, callOptions), request);
     }
   }
 

--- a/examples/src/generated/main/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -150,38 +150,45 @@ public class RouteGuideGrpc {
       super(channel, config);
     }
 
+    private RouteGuideStub(io.grpc.Channel channel,
+        RouteGuideServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected RouteGuideStub build(io.grpc.Channel channel,
-        RouteGuideServiceDescriptor config) {
-      return new RouteGuideStub(channel, config);
+        RouteGuideServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new RouteGuideStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public void getFeature(io.grpc.examples.routeguide.Point request,
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(config.getFeature), request, responseObserver);
+          channel.newCall(config.getFeature, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void listFeatures(io.grpc.examples.routeguide.Rectangle request,
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
       asyncServerStreamingCall(
-          channel.newCall(config.listFeatures), request, responseObserver);
+          channel.newCall(config.listFeatures, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Point> recordRoute(
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteSummary> responseObserver) {
       return asyncClientStreamingCall(
-          channel.newCall(config.recordRoute), responseObserver);
+          channel.newCall(config.recordRoute, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> routeChat(
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.routeChat), responseObserver);
+          channel.newCall(config.routeChat, callOptions), responseObserver);
     }
   }
 
@@ -193,23 +200,30 @@ public class RouteGuideGrpc {
       super(channel, config);
     }
 
+    private RouteGuideBlockingStub(io.grpc.Channel channel,
+        RouteGuideServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected RouteGuideBlockingStub build(io.grpc.Channel channel,
-        RouteGuideServiceDescriptor config) {
-      return new RouteGuideBlockingStub(channel, config);
+        RouteGuideServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new RouteGuideBlockingStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.examples.routeguide.Feature getFeature(io.grpc.examples.routeguide.Point request) {
       return blockingUnaryCall(
-          channel.newCall(config.getFeature), request);
+          channel.newCall(config.getFeature, callOptions), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.examples.routeguide.Feature> listFeatures(
         io.grpc.examples.routeguide.Rectangle request) {
       return blockingServerStreamingCall(
-          channel.newCall(config.listFeatures), request);
+          channel.newCall(config.listFeatures, callOptions), request);
     }
   }
 
@@ -221,17 +235,24 @@ public class RouteGuideGrpc {
       super(channel, config);
     }
 
+    private RouteGuideFutureStub(io.grpc.Channel channel,
+        RouteGuideServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected RouteGuideFutureStub build(io.grpc.Channel channel,
-        RouteGuideServiceDescriptor config) {
-      return new RouteGuideFutureStub(channel, config);
+        RouteGuideServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new RouteGuideFutureStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.routeguide.Feature> getFeature(
         io.grpc.examples.routeguide.Point request) {
       return unaryFutureCall(
-          channel.newCall(config.getFeature), request);
+          channel.newCall(config.getFeature, callOptions), request);
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
+++ b/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
@@ -31,6 +31,7 @@
 
 package io.grpc.examples.header;
 
+import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
@@ -53,8 +54,8 @@ public class HeaderClientInterceptor implements ClientInterceptor {
 
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
-                                                             Channel next) {
-    return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method)) {
+      CallOptions callOptions, Channel next) {
+    return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
 
       @Override
       public void start(Listener<RespT> responseListener, Metadata.Headers headers) {

--- a/interop-testing/src/generated/main/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/io/grpc/testing/integration/TestServiceGrpc.java
@@ -189,52 +189,59 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(config.emptyCall), request, responseObserver);
+          channel.newCall(config.emptyCall, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(config.unaryCall), request, responseObserver);
+          channel.newCall(config.unaryCall, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void streamingOutputCall(io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          channel.newCall(config.streamingOutputCall), request, responseObserver);
+          channel.newCall(config.streamingOutputCall, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          channel.newCall(config.streamingInputCall), responseObserver);
+          channel.newCall(config.streamingInputCall, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.fullDuplexCall), responseObserver);
+          channel.newCall(config.fullDuplexCall, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return duplexStreamingCall(
-          channel.newCall(config.halfDuplexCall), responseObserver);
+          channel.newCall(config.halfDuplexCall, callOptions), responseObserver);
     }
   }
 
@@ -246,29 +253,36 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceBlockingStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceBlockingStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceBlockingStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceBlockingStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public com.google.protobuf.EmptyProtos.Empty emptyCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          channel.newCall(config.emptyCall), request);
+          channel.newCall(config.emptyCall, callOptions), request);
     }
 
     @java.lang.Override
     public io.grpc.testing.integration.Messages.SimpleResponse unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request) {
       return blockingUnaryCall(
-          channel.newCall(config.unaryCall), request);
+          channel.newCall(config.unaryCall, callOptions), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Messages.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          channel.newCall(config.streamingOutputCall), request);
+          channel.newCall(config.streamingOutputCall, callOptions), request);
     }
   }
 
@@ -280,24 +294,31 @@ public class TestServiceGrpc {
       super(channel, config);
     }
 
+    private TestServiceFutureStub(io.grpc.Channel channel,
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      super(channel, config, callOptions);
+    }
+
     @java.lang.Override
     protected TestServiceFutureStub build(io.grpc.Channel channel,
-        TestServiceServiceDescriptor config) {
-      return new TestServiceFutureStub(channel, config);
+        TestServiceServiceDescriptor config,
+        io.grpc.CallOptions callOptions) {
+      return new TestServiceFutureStub(channel, config, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> emptyCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return unaryFutureCall(
-          channel.newCall(config.emptyCall), request);
+          channel.newCall(config.emptyCall, callOptions), request);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Messages.SimpleRequest request) {
       return unaryFutureCall(
-          channel.newCall(config.unaryCall), request);
+          channel.newCall(config.unaryCall, callOptions), request);
     }
   }
 

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientTransportTest.java
@@ -205,7 +205,7 @@ public class NettyClientTransportTest {
   private static class Rpc {
     static final String MESSAGE = "hello";
     static final MethodDescriptor<String, String> METHOD = MethodDescriptor.create(
-            MethodType.UNARY, "/testService/test", 10, TimeUnit.SECONDS, StringMarshaller.INSTANCE,
+            MethodType.UNARY, "/testService/test", StringMarshaller.INSTANCE,
             StringMarshaller.INSTANCE);
 
     final ClientStream stream;

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -47,7 +47,6 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
@@ -69,7 +68,7 @@ public class ClientCalls {
     // TODO(zhangkun83): if timeout is not defined in proto file, use a default timeout here.
     // If timeout is defined in proto file, Method should carry the timeout.
     return MethodDescriptor.create(method.getType(), fullServiceName + "/" + method.getName(),
-        364, TimeUnit.DAYS, method.getRequestMarshaller(), method.getResponseMarshaller());
+        method.getRequestMarshaller(), method.getResponseMarshaller());
   }
 
   /**

--- a/stub/src/main/java/io/grpc/stub/MetadataUtils.java
+++ b/stub/src/main/java/io/grpc/stub/MetadataUtils.java
@@ -31,6 +31,7 @@
 
 package io.grpc.stub;
 
+import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
@@ -73,8 +74,9 @@ public class MetadataUtils {
       @Override
       public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
           MethodDescriptor<ReqT, RespT> method,
+          CallOptions callOptions,
           Channel next) {
-        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method)) {
+        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
           @Override
           public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
             headers.merge(extraHeaders);
@@ -116,8 +118,9 @@ public class MetadataUtils {
       @Override
       public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
           MethodDescriptor<ReqT, RespT> method,
+          CallOptions callOptions,
           Channel next) {
-        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method)) {
+        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
           @Override
           public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
             headersCapture.set(null);


### PR DESCRIPTION
- Pass ``CallOptions`` to ``Channel.newCall()`` and ``ClientInterceptor.interceptCall()``.
- Remove timeout from ``AbstractStub.StubConfigBuilder`` and add deadline, which is stored in a ``CallOptions`` inside the stub.
- Deadline is converted to timeout before transmitting on the wire. Fail the call with DEADLINE_EXCEEDED if it's already expired.

Resolves #150

@ejona86 @louiscryan @nmittler 
