### PR TITLE
Apply client side timeouts

### DIFF
--- a/core/src/main/java/io/grpc/transport/ClientStream.java
+++ b/core/src/main/java/io/grpc/transport/ClientStream.java
@@ -31,6 +31,8 @@
 
 package io.grpc.transport;
 
+import io.grpc.Status;
+
 /**
  * Extension of {@link Stream} to support client-side termination semantics.
  */
@@ -41,8 +43,10 @@ public interface ClientStream extends Stream {
    * sent or received, however it may still be possible to receive buffered messages for a brief
    * period until {@link ClientStreamListener#closed} is called. This method is safe to be called
    * at any time and multiple times.
+   *
+   * @param reason must be one of Status.CANCELLED or Status.DEADLINE_EXCEEDED
    */
-  void cancel();
+  void cancel(Status reason);
 
   /**
    * Closes the local side of this stream and flushes any remaining messages. After this is called,

--- a/core/src/main/java/io/grpc/transport/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/transport/Http2ClientStream.java
@@ -128,7 +128,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
       if (transportError.getDescription().length() > 1000 || endOfStream) {
         inboundTransportError(transportError);
         // We have enough error detail so lets cancel.
-        sendCancel();
+        sendCancel(Status.CANCELLED);
       }
     } else {
       inboundDataReceived(frame);
@@ -155,7 +155,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
     }
     if (transportError != null) {
       inboundTransportError(transportError);
-      sendCancel();
+      sendCancel(Status.CANCELLED);
     } else {
       Status status = statusFromTrailers(trailers);
       stripTransportDetails(trailers);

--- a/netty/src/main/java/io/grpc/transport/netty/CancelStreamCommand.java
+++ b/netty/src/main/java/io/grpc/transport/netty/CancelStreamCommand.java
@@ -31,19 +31,35 @@
 
 package io.grpc.transport.netty;
 
+import static io.grpc.Status.Code.CANCELLED;
+import static io.grpc.Status.Code.DEADLINE_EXCEEDED;
+
 import com.google.common.base.Preconditions;
+
+import io.grpc.Status;
+
+import java.util.EnumSet;
 
 /**
  * Command sent from a Netty client stream to the handler to cancel the stream.
  */
 class CancelStreamCommand {
   private final NettyClientStream stream;
+  private final Status reason;
 
-  CancelStreamCommand(NettyClientStream stream) {
+  CancelStreamCommand(NettyClientStream stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream, "stream");
+    Preconditions.checkNotNull(reason);
+    Preconditions.checkArgument(EnumSet.of(CANCELLED, DEADLINE_EXCEEDED).contains(reason.getCode()),
+        "Invalid cancellation reason");
+    this.reason = reason;
   }
 
   NettyClientStream stream() {
     return stream;
+  }
+
+  Status reason() {
+    return reason;
   }
 }

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
@@ -318,7 +318,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
   private void cancelStream(ChannelHandlerContext ctx, CancelStreamCommand cmd,
       ChannelPromise promise) {
     NettyClientStream stream = cmd.stream();
-    stream.transportReportStatus(Status.CANCELLED, true, new Metadata.Trailers());
+    stream.transportReportStatus(cmd.reason(), true, new Metadata.Trailers());
     encoder().writeRstStream(ctx, stream.id(), Http2Error.CANCEL.code(), promise);
   }
 

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientStream.java
@@ -35,6 +35,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 
+import io.grpc.Status;
 import io.grpc.transport.ClientStreamListener;
 import io.grpc.transport.Http2ClientStream;
 import io.grpc.transport.WritableBuffer;
@@ -118,9 +119,9 @@ class NettyClientStream extends Http2ClientStream {
   }
 
   @Override
-  protected void sendCancel() {
+  protected void sendCancel(Status reason) {
     // Send the cancel command to the handler.
-    writeQueue.enqueue(new CancelStreamCommand(this), true);
+    writeQueue.enqueue(new CancelStreamCommand(this, reason), true);
   }
 
   @Override

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
@@ -181,7 +181,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     verify(stream).id(eq(3));
     when(stream.id()).thenReturn(3);
     // Cancel the stream.
-    writeQueue.enqueue(new CancelStreamCommand(stream), true);
+    writeQueue.enqueue(new CancelStreamCommand(stream, Status.CANCELLED), true);
 
     assertTrue(createPromise.isSuccess());
     verify(stream).transportReportStatus(eq(Status.CANCELLED), eq(true),
@@ -216,7 +216,18 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
   public void cancelShouldSucceed() throws Exception {
     createStream();
     verify(channel, times(1)).flush();
-    writeQueue.enqueue(new CancelStreamCommand(stream), true);
+    writeQueue.enqueue(new CancelStreamCommand(stream, Status.CANCELLED), true);
+
+    ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
+    verify(ctx).write(eq(expected), eq(promise));
+    verify(channel, times(2)).flush();
+  }
+
+  @Test
+  public void cancelDeadlineExceededShouldSucceed() throws Exception {
+    createStream();
+    verify(channel, times(1)).flush();
+    writeQueue.enqueue(new CancelStreamCommand(stream, Status.DEADLINE_EXCEEDED), true);
 
     ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
     verify(ctx).write(eq(expected), eq(promise));
@@ -233,7 +244,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     verify(stream).id(idCaptor.capture());
     when(stream.id()).thenReturn(idCaptor.getValue());
     ChannelPromise cancelPromise = mock(ChannelPromise.class);
-    writeQueue.enqueue(new CancelStreamCommand(stream), cancelPromise, true);
+    writeQueue.enqueue(new CancelStreamCommand(stream, Status.CANCELLED), cancelPromise, true);
     verify(cancelPromise).setSuccess();
     verify(channel, times(2)).flush();
     verifyNoMoreInteractions(ctx);
@@ -248,14 +259,29 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
   public void cancelTwiceShouldSucceed() throws Exception {
     createStream();
 
-    writeQueue.enqueue(new CancelStreamCommand(stream), promise, true);
+    writeQueue.enqueue(new CancelStreamCommand(stream, Status.CANCELLED), promise, true);
 
     ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
     verify(ctx).write(eq(expected), any(ChannelPromise.class));
 
     promise = mock(ChannelPromise.class);
 
-    writeQueue.enqueue(new CancelStreamCommand(stream), promise, true);
+    writeQueue.enqueue(new CancelStreamCommand(stream, Status.CANCELLED), promise, true);
+    verify(promise).setSuccess();
+  }
+
+  @Test
+  public void cancelTwiceDifferentReasons() throws Exception {
+    createStream();
+
+    writeQueue.enqueue(new CancelStreamCommand(stream, Status.DEADLINE_EXCEEDED), promise, true);
+
+    ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
+    verify(ctx).write(eq(expected), any(ChannelPromise.class));
+
+    promise = mock(ChannelPromise.class);
+
+    writeQueue.enqueue(new CancelStreamCommand(stream, Status.CANCELLED), promise, true);
     verify(promise).setSuccess();
   }
 
@@ -357,7 +383,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), true);
     verify(stream).id(3);
     when(stream.id()).thenReturn(3);
-    writeQueue.enqueue(new CancelStreamCommand(stream), true);
+    writeQueue.enqueue(new CancelStreamCommand(stream, Status.CANCELLED), true);
     verify(stream).transportReportStatus(eq(Status.CANCELLED), eq(true),
             any(Metadata.Trailers.class));
   }

--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientStream.java
@@ -209,8 +209,8 @@ class OkHttpClientStream extends Http2ClientStream {
   }
 
   @Override
-  protected void sendCancel() {
-    transport.finishStream(id(), Status.CANCELLED, ErrorCode.CANCEL);
+  protected void sendCancel(Status reason) {
+    transport.finishStream(id(), reason, ErrorCode.CANCEL);
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java
@@ -270,10 +270,10 @@ class OkHttpClientTransport implements ClientTransport {
       } catch (InterruptedException e) {
         // Restore the interrupt.
         Thread.currentThread().interrupt();
-        clientStream.cancel();
+        clientStream.cancel(Status.CANCELLED);
         throw new RuntimeException(e);
       } catch (ExecutionException e) {
-        clientStream.cancel();
+        clientStream.cancel(Status.CANCELLED);
         throw new RuntimeException(e.getCause() != null ? e.getCause() : e);
       }
     }
@@ -457,7 +457,8 @@ class OkHttpClientTransport implements ClientTransport {
         frameWriter.rstStream(streamId, ErrorCode.CANCEL);
       }
       if (status != null) {
-        boolean isCancelled = status.getCode() == Code.CANCELLED;
+        boolean isCancelled = (status.getCode() == Code.CANCELLED
+            || status.getCode() == Code.DEADLINE_EXCEEDED);
         stream.transportReportStatus(status, isCancelled, new Metadata.Trailers());
       }
       if (!startPendingStreams()) {


### PR DESCRIPTION
@ejona86 opening this as a work in progress to get some advice.

A couple of questions:

- It seems hard to satisfy the contract for `ClientStreamListener.close`, that it always be the last method called on the listener, if we have a stream racing with a deadline to call it. One solution is to have the listener impl provide its own idempotence via a CAS or some other mechanism, but that obviously doesn't satisfy the public contract on the interface. It's not clear to me how important that is.
- The first call on a Netty channel takes at least 120 millis, due (I think) to `obtainActiveTransport()`. Reading briefly into that code though, I don't see any obvious expensive asynchronous operations. Thoughts on this? It would be bad to always time out the first call on a channel.