### PR TITLE
For demonstration purpose, will be closed after discussion.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,17 +123,18 @@ subprojects {
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',
-                mockito: 'org.mockito:mockito-core:1.10.19'
+                mockito: 'org.mockito:mockito-core:1.10.19',
+                tcnative: 'io.netty:netty-tcnative:1.1.33.Fork3'
         ]
 
         // Determine the correct version of Jetty ALPN boot to use based
         // on the Java version.
-        def alpnboot_version = '8.1.2.v20141202'
+        def alpnboot_version = '1.1.10.v20150130'
         if (JavaVersion.current().ordinal() < JavaVersion.VERSION_1_8.ordinal()) {
-            alpnboot_version = '7.1.2.v20141202'
+            alpnboot_version = '1.1.10.v20150130'
         }
 
-        alpnboot_package_name = 'org.mortbay.jetty.alpn:alpn-boot:' + alpnboot_version
+        alpnboot_package_name = 'org.mortbay.jetty.npn:npn-boot:' + alpnboot_version
     }
 
     // Define a separate configuration for managing the dependency on Jetty alpnboot jar.

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -23,7 +23,8 @@ dependencies {
             project(':grpc-testing'),
             libraries.junit,
             libraries.mockito,
-            libraries.oauth_client
+            libraries.oauth_client,
+            libraries.tcnative
 }
 
 test {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -39,6 +39,7 @@ import io.grpc.testing.TestUtils;
 import io.grpc.transport.netty.GrpcSslContexts;
 import io.grpc.transport.netty.NettyServerBuilder;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslProvider;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -135,7 +136,7 @@ public class TestServiceServer {
     SslContext sslContext = null;
     if (useTls) {
       sslContext = GrpcSslContexts.forServer(
-              TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key")).build();
+              TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key")).sslProvider(SslProvider.OPENSSL).build();
     }
     server = NettyServerBuilder.forPort(port)
         .sslContext(sslContext)

--- a/netty/src/main/java/io/grpc/transport/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/transport/netty/GrpcSslContexts.java
@@ -48,9 +48,9 @@ public class GrpcSslContexts {
   private GrpcSslContexts() {}
 
   private static ApplicationProtocolConfig DEFAULT_APN = new ApplicationProtocolConfig(
-          Protocol.ALPN,
-          SelectorFailureBehavior.FATAL_ALERT,
-          SelectedListenerFailureBehavior.FATAL_ALERT,
+          Protocol.NPN,
+          SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+          SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
           "h2",
           "h2-17",
           "h2-16",


### PR DESCRIPTION
@ejona86 

I'm trying to run the netty test server that only support NPN. with this change, and running with jdk7u75 as http://www.eclipse.org/jetty/documentation/9.2.8.v20150217/npn-chapter.html suggested, but got the following error:
```
simonma@simonma-linux:~/github/grpc-java$ java -version
java version "1.7.0_75"
Java(TM) SE Runtime Environment (build 1.7.0_75-b13)
Java HotSpot(TM) 64-Bit Server VM (build 24.75-b04, mixed mode)
simonma@simonma-linux:~/github/grpc-java$ ./run-test-server.sh 
Gradle is no longer run automatically. Make sure to run './gradlew installDist' or
'./gradlew :grpc-interop-testing:installDist' after any changes.

Using fake CA for TLS certificate. Test clients should expect host
*.test.google.fr and our test CA. For the Java test client binary, use:
--server_host_override=foo.test.google.fr --use_test_ca=true

Exception in thread "main" java.lang.UnsatisfiedLinkError: failed to load the required native library
	at io.netty.handler.ssl.OpenSsl.ensureAvailability(OpenSsl.java:154)
	at io.netty.handler.ssl.OpenSslContext.<init>(OpenSslContext.java:137)
	at io.netty.handler.ssl.OpenSslServerContext.<init>(OpenSslServerContext.java:316)
	at io.netty.handler.ssl.OpenSslServerContext.<init>(OpenSslServerContext.java:227)
	at io.netty.handler.ssl.SslContext.newServerContextInternal(SslContext.java:403)
	at io.netty.handler.ssl.SslContextBuilder.build(SslContextBuilder.java:207)
	at io.grpc.testing.integration.TestServiceServer.start(TestServiceServer.java:138)
	at io.grpc.testing.integration.TestServiceServer.main(TestServiceServer.java:76)
Caused by: java.lang.UnsatisfiedLinkError: no netty-tcnative in java.library.path
	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1886)
	at java.lang.Runtime.loadLibrary0(Runtime.java:849)
	at java.lang.System.loadLibrary(System.java:1088)
	at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:168)
	at io.netty.handler.ssl.OpenSsl.<clinit>(OpenSsl.java:58)
	... 7 more
Shutting down
java.lang.NullPointerException
	at io.grpc.testing.integration.TestServiceServer.stop(TestServiceServer.java:150)
	at io.grpc.testing.integration.TestServiceServer.access$000(TestServiceServer.java:51)
	at io.grpc.testing.integration.TestServiceServer$1.run(TestServiceServer.java:70)
```

Do you know what I'm missing? thanks!