### PR TITLE
Use default type of KeyStore in Android interop test App, so that it can work on lower versions.

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.android.integrationtest"
-        minSdkVersion 18
+        minSdkVersion 9
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTester.java
+++ b/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTester.java
@@ -327,7 +327,7 @@ public final class InteropTester extends AsyncTask<Void, Void, String> {
     if (testCa == null) {
       return (SSLSocketFactory) SSLSocketFactory.getDefault();
     }
-    KeyStore ks = KeyStore.getInstance("AndroidKeyStore");
+    KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null);
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
     X509Certificate cert = (X509Certificate) cf.generateCertificate(testCa);


### PR DESCRIPTION

The previously used "AndroidKeyStore" was introduced in Android 4.3