### PR TITLE
Migrate from PARSER to parser() as a way of getting the parser of a protobuf message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <artifactId>maven-protoc-plugin</artifactId>
       <version>0.4.2</version>
       <configuration>
-        <protocArtifact>com.google.protobuf:protoc:3.0.0-alpha-3:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.0.0-alpha-3.1:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
         <pluginArtifact>io.grpc:protoc-gen-grpc-java:0.7.1:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
@@ -106,7 +106,7 @@ sourceSets {
   }
 }
 
-protocDep = "com.google.protobuf:protoc:3.0.0-alpha-3"
+protocDep = "com.google.protobuf:protoc:3.0.0-alpha-3.1"
 protobufNativeCodeGenPluginDeps = ["grpc:io.grpc:protoc-gen-grpc-java:0.7.1"]
 ```
 
@@ -150,13 +150,13 @@ This section is only necessary if you are making changes to the code
 generation. Most users only need to use `skipCodegen=true` as discussed above.
 
 ### Build Protobuf
-The codegen plugin is C++ code and requires protobuf 3.0.0-alpha-3.
+The codegen plugin is C++ code and requires protobuf 3.0.0-alpha-3.1.
 
 For Linux, Mac and MinGW:
 ```
 $ git clone https://github.com/google/protobuf.git
 $ cd protobuf
-$ git checkout v3.0.0-alpha-3
+$ git checkout v3.0.0-alpha-3.1
 $ ./autogen.sh
 $ ./configure
 $ make
@@ -195,15 +195,15 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew install ^
-    -PvcProtobufInclude=C:\path\to\protobuf-3.0.0-alpha-3\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.0.0-alpha-3\vsprojects\Release
+    -PvcProtobufInclude=C:\path\to\protobuf-3.0.0-alpha-3.1\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf-3.0.0-alpha-3.1\vsprojects\Release
 ```
 
 Since specifying those properties every build is bothersome, you can instead
 create ``<project-root>\gradle.properties`` with contents like:
 ```
-vcProtobufInclude=C:\\path\\to\\protobuf-3.0.0-alpha-3\\src
-vcProtobufLibs=C:\\path\\to\\protobuf-3.0.0-alpha-3\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf-3.0.0-alpha-3.1\\src
+vcProtobufLibs=C:\\path\\to\\protobuf-3.0.0-alpha-3.1\\vsprojects\\Release
 ```
 
 The build script will build the codegen for the same architecture as the Java

--- a/benchmarks/src/generated/main/io/grpc/testing/ClientArgs.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/ClientArgs.java
@@ -717,6 +717,10 @@ public  final class ClientArgs extends
     }
   };
 
+  public static com.google.protobuf.Parser<ClientArgs> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<ClientArgs> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/ClientConfig.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/ClientConfig.java
@@ -916,6 +916,10 @@ public  final class ClientConfig extends
     }
   };
 
+  public static com.google.protobuf.Parser<ClientConfig> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<ClientConfig> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/ClientStats.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/ClientStats.java
@@ -635,6 +635,10 @@ public  final class ClientStats extends
     }
   };
 
+  public static com.google.protobuf.Parser<ClientStats> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<ClientStats> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/ClientStatus.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/ClientStatus.java
@@ -473,6 +473,10 @@ public  final class ClientStatus extends
     }
   };
 
+  public static com.google.protobuf.Parser<ClientStatus> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<ClientStatus> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/HistogramData.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/HistogramData.java
@@ -729,6 +729,10 @@ public  final class HistogramData extends
     }
   };
 
+  public static com.google.protobuf.Parser<HistogramData> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<HistogramData> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/Mark.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/Mark.java
@@ -308,6 +308,10 @@ public  final class Mark extends
     }
   };
 
+  public static com.google.protobuf.Parser<Mark> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<Mark> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/Payload.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/Payload.java
@@ -482,6 +482,10 @@ public  final class Payload extends
     }
   };
 
+  public static com.google.protobuf.Parser<Payload> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<Payload> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/ServerArgs.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/ServerArgs.java
@@ -717,6 +717,10 @@ public  final class ServerArgs extends
     }
   };
 
+  public static com.google.protobuf.Parser<ServerArgs> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<ServerArgs> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/ServerConfig.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/ServerConfig.java
@@ -489,6 +489,10 @@ public  final class ServerConfig extends
     }
   };
 
+  public static com.google.protobuf.Parser<ServerConfig> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<ServerConfig> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/ServerStats.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/ServerStats.java
@@ -511,6 +511,10 @@ public  final class ServerStats extends
     }
   };
 
+  public static com.google.protobuf.Parser<ServerStats> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<ServerStats> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/ServerStatus.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/ServerStatus.java
@@ -527,6 +527,10 @@ public  final class ServerStatus extends
     }
   };
 
+  public static com.google.protobuf.Parser<ServerStatus> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<ServerStatus> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/SimpleRequest.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/SimpleRequest.java
@@ -710,6 +710,10 @@ public  final class SimpleRequest extends
     }
   };
 
+  public static com.google.protobuf.Parser<SimpleRequest> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<SimpleRequest> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/SimpleResponse.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/SimpleResponse.java
@@ -473,6 +473,10 @@ public  final class SimpleResponse extends
     }
   };
 
+  public static com.google.protobuf.Parser<SimpleResponse> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<SimpleResponse> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/StatsRequest.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/StatsRequest.java
@@ -371,6 +371,10 @@ public  final class StatsRequest extends
     }
   };
 
+  public static com.google.protobuf.Parser<StatsRequest> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<StatsRequest> getParserForType() {
     return PARSER;

--- a/benchmarks/src/generated/main/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/TestServiceGrpc.java
@@ -19,14 +19,14 @@ public class TestServiceGrpc {
       io.grpc.testing.SimpleResponse> METHOD_UNARY_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.UNARY, "UnaryCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.SimpleRequest,
       io.grpc.testing.SimpleResponse> METHOD_STREAMING_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.DUPLEX_STREAMING, "StreamingCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.parser()));
 
   public static TestServiceStub newStub(io.grpc.Channel channel) {
     return new TestServiceStub(channel, CONFIG);

--- a/benchmarks/src/generated/main/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/io/grpc/testing/WorkerGrpc.java
@@ -19,14 +19,14 @@ public class WorkerGrpc {
       io.grpc.testing.ClientStatus> METHOD_RUN_TEST =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.DUPLEX_STREAMING, "RunTest",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientArgs.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientStatus.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientArgs.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientStatus.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.ServerArgs,
       io.grpc.testing.ServerStatus> METHOD_RUN_SERVER =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.DUPLEX_STREAMING, "RunServer",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerArgs.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerStatus.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerArgs.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerStatus.parser()));
 
   public static WorkerStub newStub(io.grpc.Channel channel) {
     return new WorkerStub(channel, CONFIG);

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ subprojects {
         protocPluginBaseName = 'protoc-gen-grpc-java'
         javaPluginPath = "$rootDir/compiler/build/binaries/java_pluginExecutable/$protocPluginBaseName$exeSuffix"
 
-        protobufVersion = '3.0.0-alpha-3'
+        protobufVersion = '3.0.0-alpha-3.1'
 
         configureProtoCompilation = {
           String generatedSourcePath = 'src/generated'

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -8,8 +8,8 @@ set -ev
 if [ -f /tmp/proto3-a3/bin/protoc ]; then
   echo "Not building protobuf. Already built"
 else
-  wget -O - https://github.com/google/protobuf/archive/v3.0.0-alpha-3.tar.gz | tar xz -C /tmp
-  pushd /tmp/protobuf-3.0.0-alpha-3
+  wget -O - https://github.com/google/protobuf/archive/v3.0.0-alpha-3.1.tar.gz | tar xz -C /tmp
+  pushd /tmp/protobuf-3.0.0-alpha-3.1
   ./autogen.sh
   # install here so we don't need sudo
   ./configure --prefix=/tmp/proto3-a3

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,7 +1,7 @@
 FROM protoc-artifacts:latest
 
 RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
-    git checkout v3.0.0-alpha-3 && \
+    git checkout v3.0.0-alpha-3.1 && \
     ./autogen.sh && \
     CXXFLAGS=-m32 ./configure --disable-shared --prefix=/protobuf-32 && \
     make clean && make && make install"'

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -13,7 +13,7 @@ build your own codegen.
 
 * Linux, Mac OS X with Clang, or Windows with MSYS2
 * Java 7 or up
-* [Protobuf](https://github.com/google/protobuf) 3.0.0-alpha-3 or up
+* [Protobuf](https://github.com/google/protobuf) 3.0.0-alpha-3.1 or up
 
 ## Compiling and testing the codegen
 Change to the `compiler` directory:

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -117,8 +117,8 @@ static void PrintMethodFields(
           "    $output_type$> $method_field_name$ =\n"
           "    $Method$.create(\n"
           "        $MethodType$.$method_type$, \"$method_name$\",\n"
-          "        $ProtoUtils$.marshaller($input_type$.PARSER),\n"
-          "        $ProtoUtils$.marshaller($output_type$.PARSER));\n");
+          "        $ProtoUtils$.marshaller($input_type$.parser()),\n"
+          "        $ProtoUtils$.marshaller($output_type$.parser()));\n");
     }
   }
   p->Print("\n");

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -19,32 +19,32 @@ public class TestServiceGrpc {
       io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.UNARY, "UnaryCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleResponse.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.SERVER_STREAMING, "StreamingOutputCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.integration.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.CLIENT_STREAMING, "StreamingInputCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallResponse.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.DUPLEX_STREAMING, "FullDuplexCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.DUPLEX_STREAMING, "HalfDuplexCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
 
   public static TestServiceStub newStub(io.grpc.Channel channel) {
     return new TestServiceStub(channel, CONFIG);

--- a/examples/src/generated/main/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -19,8 +19,8 @@ public class GreeterGrpc {
       io.grpc.examples.helloworld.HelloResponse> METHOD_SAY_HELLO =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.UNARY, "SayHello",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloResponse.parser()));
 
   public static GreeterStub newStub(io.grpc.Channel channel) {
     return new GreeterStub(channel, CONFIG);

--- a/examples/src/generated/main/io/grpc/examples/helloworld/HelloRequest.java
+++ b/examples/src/generated/main/io/grpc/examples/helloworld/HelloRequest.java
@@ -436,6 +436,10 @@ public  final class HelloRequest extends
     }
   };
 
+  public static com.google.protobuf.Parser<HelloRequest> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<HelloRequest> getParserForType() {
     return PARSER;

--- a/examples/src/generated/main/io/grpc/examples/helloworld/HelloResponse.java
+++ b/examples/src/generated/main/io/grpc/examples/helloworld/HelloResponse.java
@@ -436,6 +436,10 @@ public  final class HelloResponse extends
     }
   };
 
+  public static com.google.protobuf.Parser<HelloResponse> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<HelloResponse> getParserForType() {
     return PARSER;

--- a/examples/src/generated/main/io/grpc/examples/routeguide/Feature.java
+++ b/examples/src/generated/main/io/grpc/examples/routeguide/Feature.java
@@ -686,6 +686,10 @@ public  final class Feature extends
     }
   };
 
+  public static com.google.protobuf.Parser<Feature> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<Feature> getParserForType() {
     return PARSER;

--- a/examples/src/generated/main/io/grpc/examples/routeguide/Point.java
+++ b/examples/src/generated/main/io/grpc/examples/routeguide/Point.java
@@ -423,6 +423,10 @@ public  final class Point extends
     }
   };
 
+  public static com.google.protobuf.Parser<Point> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<Point> getParserForType() {
     return PARSER;

--- a/examples/src/generated/main/io/grpc/examples/routeguide/Rectangle.java
+++ b/examples/src/generated/main/io/grpc/examples/routeguide/Rectangle.java
@@ -751,6 +751,10 @@ public  final class Rectangle extends
     }
   };
 
+  public static com.google.protobuf.Parser<Rectangle> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<Rectangle> getParserForType() {
     return PARSER;

--- a/examples/src/generated/main/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -19,26 +19,26 @@ public class RouteGuideGrpc {
       io.grpc.examples.routeguide.Feature> METHOD_GET_FEATURE =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.UNARY, "GetFeature",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.parser()));
   private static final io.grpc.stub.Method<io.grpc.examples.routeguide.Rectangle,
       io.grpc.examples.routeguide.Feature> METHOD_LIST_FEATURES =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.SERVER_STREAMING, "ListFeatures",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Rectangle.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Rectangle.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.parser()));
   private static final io.grpc.stub.Method<io.grpc.examples.routeguide.Point,
       io.grpc.examples.routeguide.RouteSummary> METHOD_RECORD_ROUTE =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.CLIENT_STREAMING, "RecordRoute",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteSummary.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteSummary.parser()));
   private static final io.grpc.stub.Method<io.grpc.examples.routeguide.RouteNote,
       io.grpc.examples.routeguide.RouteNote> METHOD_ROUTE_CHAT =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.DUPLEX_STREAMING, "RouteChat",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.parser()));
 
   public static RouteGuideStub newStub(io.grpc.Channel channel) {
     return new RouteGuideStub(channel, CONFIG);

--- a/examples/src/generated/main/io/grpc/examples/routeguide/RouteNote.java
+++ b/examples/src/generated/main/io/grpc/examples/routeguide/RouteNote.java
@@ -684,6 +684,10 @@ public  final class RouteNote extends
     }
   };
 
+  public static com.google.protobuf.Parser<RouteNote> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<RouteNote> getParserForType() {
     return PARSER;

--- a/examples/src/generated/main/io/grpc/examples/routeguide/RouteSummary.java
+++ b/examples/src/generated/main/io/grpc/examples/routeguide/RouteSummary.java
@@ -595,6 +595,10 @@ public  final class RouteSummary extends
     }
   };
 
+  public static com.google.protobuf.Parser<RouteSummary> parser() {
+    return PARSER;
+  }
+
   @java.lang.Override
   public com.google.protobuf.Parser<RouteSummary> getParserForType() {
     return PARSER;

--- a/interop-testing/src/generated/main/com/google/protobuf/EmptyProtos.java
+++ b/interop-testing/src/generated/main/com/google/protobuf/EmptyProtos.java
@@ -324,6 +324,10 @@ public final class EmptyProtos {
       }
     };
 
+    public static com.google.protobuf.Parser<Empty> parser() {
+      return PARSER;
+    }
+
     @java.lang.Override
     public com.google.protobuf.Parser<Empty> getParserForType() {
       return PARSER;

--- a/interop-testing/src/generated/main/io/grpc/testing/integration/Messages.java
+++ b/interop-testing/src/generated/main/io/grpc/testing/integration/Messages.java
@@ -654,6 +654,10 @@ public final class Messages {
       }
     };
 
+    public static com.google.protobuf.Parser<Payload> parser() {
+      return PARSER;
+    }
+
     @java.lang.Override
     public com.google.protobuf.Parser<Payload> getParserForType() {
       return PARSER;
@@ -1596,6 +1600,10 @@ public final class Messages {
       }
     };
 
+    public static com.google.protobuf.Parser<SimpleRequest> parser() {
+      return PARSER;
+    }
+
     @java.lang.Override
     public com.google.protobuf.Parser<SimpleRequest> getParserForType() {
       return PARSER;
@@ -2517,6 +2525,10 @@ public final class Messages {
       }
     };
 
+    public static com.google.protobuf.Parser<SimpleResponse> parser() {
+      return PARSER;
+    }
+
     @java.lang.Override
     public com.google.protobuf.Parser<SimpleResponse> getParserForType() {
       return PARSER;
@@ -2966,6 +2978,10 @@ public final class Messages {
         }
       }
     };
+
+    public static com.google.protobuf.Parser<SimpleContext> parser() {
+      return PARSER;
+    }
 
     @java.lang.Override
     public com.google.protobuf.Parser<SimpleContext> getParserForType() {
@@ -3533,6 +3549,10 @@ public final class Messages {
       }
     };
 
+    public static com.google.protobuf.Parser<StreamingInputCallRequest> parser() {
+      return PARSER;
+    }
+
     @java.lang.Override
     public com.google.protobuf.Parser<StreamingInputCallRequest> getParserForType() {
       return PARSER;
@@ -3932,6 +3952,10 @@ public final class Messages {
         }
       }
     };
+
+    public static com.google.protobuf.Parser<StreamingInputCallResponse> parser() {
+      return PARSER;
+    }
 
     @java.lang.Override
     public com.google.protobuf.Parser<StreamingInputCallResponse> getParserForType() {
@@ -4421,6 +4445,10 @@ public final class Messages {
         }
       }
     };
+
+    public static com.google.protobuf.Parser<ResponseParameters> parser() {
+      return PARSER;
+    }
 
     @java.lang.Override
     public com.google.protobuf.Parser<ResponseParameters> getParserForType() {
@@ -5617,6 +5645,10 @@ public final class Messages {
       }
     };
 
+    public static com.google.protobuf.Parser<StreamingOutputCallRequest> parser() {
+      return PARSER;
+    }
+
     @java.lang.Override
     public com.google.protobuf.Parser<StreamingOutputCallRequest> getParserForType() {
       return PARSER;
@@ -6182,6 +6214,10 @@ public final class Messages {
         }
       }
     };
+
+    public static com.google.protobuf.Parser<StreamingOutputCallResponse> parser() {
+      return PARSER;
+    }
 
     @java.lang.Override
     public com.google.protobuf.Parser<StreamingOutputCallResponse> getParserForType() {

--- a/interop-testing/src/generated/main/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/io/grpc/testing/integration/TestServiceGrpc.java
@@ -19,38 +19,38 @@ public class TestServiceGrpc {
       com.google.protobuf.EmptyProtos.Empty> METHOD_EMPTY_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.UNARY, "EmptyCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.integration.Messages.SimpleRequest,
       io.grpc.testing.integration.Messages.SimpleResponse> METHOD_UNARY_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.UNARY, "UnaryCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleResponse.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.SERVER_STREAMING, "StreamingOutputCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
       io.grpc.testing.integration.Messages.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.CLIENT_STREAMING, "StreamingInputCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallResponse.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.DUPLEX_STREAMING, "FullDuplexCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
   private static final io.grpc.stub.Method<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL =
       io.grpc.stub.Method.create(
           io.grpc.MethodType.DUPLEX_STREAMING, "HalfDuplexCall",
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.PARSER),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.PARSER));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
 
   public static TestServiceStub newStub(io.grpc.Channel channel) {
     return new TestServiceStub(channel, CONFIG);


### PR DESCRIPTION
Upgrade to protobuf-3.0.0-alpha-3.1 that adds `parser()`. `PARSER` will go away eventually.
protobuf-3.0.0-alpha-3.1 has been pushed to Maven Central.

@ejona86 