### PR TITLE
Add an option to Android interop test.

### DIFF
--- a/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/TesterActivity.java
+++ b/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/TesterActivity.java
@@ -112,7 +112,7 @@ public class TesterActivity extends AppCompatActivity
 
     // TODO (madongfly) support server_host_override, useTls and useTestCa in the App UI.
     new InteropTester(testCase, host, port, "foo.test.google.fr", true,
-        getResources().openRawResource(R.raw.ca),
+        getResources().openRawResource(R.raw.ca), null,
         new InteropTester.TestListener() {
       @Override public void onPreTest() {
         resultText.setText("Testing...");

--- a/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/TesterInstrumentation.java
+++ b/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/TesterInstrumentation.java
@@ -52,6 +52,7 @@ public class TesterInstrumentation extends Instrumentation {
   private String serverHostOverride;
   private boolean useTls;
   private boolean useTestCa;
+  private String androidSocketFactoryTls;
 
   @Override
   public void onCreate(Bundle args) {
@@ -63,6 +64,7 @@ public class TesterInstrumentation extends Instrumentation {
     serverHostOverride = args.getString("server_host_override", null);
     useTls = Boolean.parseBoolean(args.getString("use_tls", "true"));
     useTestCa = Boolean.parseBoolean(args.getString("use_test_ca", "false"));
+    androidSocketFactoryTls = args.getString("android_socket_factory_tls", null);
 
     InputStream testCa = null;
     if (useTestCa) {
@@ -84,6 +86,7 @@ public class TesterInstrumentation extends Instrumentation {
     }
 
     new InteropTester(testCase, host, port, serverHostOverride, useTls, testCa,
+        androidSocketFactoryTls,
         new InteropTester.TestListener() {
           @Override
           public void onPreTest() {
@@ -99,6 +102,7 @@ public class TesterInstrumentation extends Instrumentation {
               finish(1, bundle);
             }
           }
-        }).execute();
+        }
+    ).execute();
   }
 }


### PR DESCRIPTION
to configure TLS protocol on SSLCertificateSocketFactory directly.

This is how our current internal users configure the TLS protocol, with this option, we can test and verify future changes will not break internal users.

@ejona86 Please take a look, thanks!