### PR TITLE
Fake infinite timeout; 1s is not a good hard-coded timeout

### DIFF
--- a/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
+++ b/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
@@ -55,7 +55,7 @@ public class StubConfigTest {
     // Create a default stub
     TestServiceGrpc.TestServiceBlockingStub stub =
         TestServiceGrpc.newBlockingStub(new FakeChannel());
-    assertEquals(TimeUnit.SECONDS.toMicros(1),
+    assertEquals(TimeUnit.DAYS.toMicros(10 * 365),
         stub.getServiceDescriptor().fullDuplexCall.getTimeout());
     // Reconfigure it
     stub = stub.configureNewStub()
@@ -65,7 +65,7 @@ public class StubConfigTest {
     assertEquals(TimeUnit.SECONDS.toMicros(2),
         stub.getServiceDescriptor().fullDuplexCall.getTimeout());
     // Default config unchanged
-    assertEquals(TimeUnit.SECONDS.toMicros(1),
+    assertEquals(TimeUnit.DAYS.toMicros(10 * 365),
         TestServiceGrpc.CONFIG.fullDuplexCall.getTimeout());
   }
 

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -69,7 +69,7 @@ public class ClientCalls {
     // TODO(zhangkun83): if timeout is not defined in proto file, use a default timeout here.
     // If timeout is defined in proto file, Method should carry the timeout.
     return MethodDescriptor.create(method.getType(), fullServiceName + "/" + method.getName(),
-        1, TimeUnit.SECONDS, method.getRequestMarshaller(), method.getResponseMarshaller());
+        10 * 365, TimeUnit.DAYS, method.getRequestMarshaller(), method.getResponseMarshaller());
   }
 
   /**


### PR DESCRIPTION
Stubs don't have any timeout. However, MethodDescriptor does and
requires a timeout. We really want "no timeout," which is infinite, but
we use 10 years as the next best thing. CallOptions will end up fixing
this hack as MethodDescriptor will no longer have timeout.

Before, the hard-coded 1s didn't matter, because nobody was observing
it. Since 77878a0 it is now being sent to servers, and some servers
enforce it. Oops.

@johnbcoughlin, FYI :-)