### PR TITLE
Set hard-coded deadline to just under 1 year

### DIFF
--- a/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
+++ b/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
@@ -55,7 +55,7 @@ public class StubConfigTest {
     // Create a default stub
     TestServiceGrpc.TestServiceBlockingStub stub =
         TestServiceGrpc.newBlockingStub(new FakeChannel());
-    assertEquals(TimeUnit.DAYS.toMicros(10 * 365),
+    assertEquals(TimeUnit.DAYS.toMicros(364),
         stub.getServiceDescriptor().fullDuplexCall.getTimeout());
     // Reconfigure it
     stub = stub.configureNewStub()
@@ -65,7 +65,7 @@ public class StubConfigTest {
     assertEquals(TimeUnit.SECONDS.toMicros(2),
         stub.getServiceDescriptor().fullDuplexCall.getTimeout());
     // Default config unchanged
-    assertEquals(TimeUnit.DAYS.toMicros(10 * 365),
+    assertEquals(TimeUnit.DAYS.toMicros(364),
         TestServiceGrpc.CONFIG.fullDuplexCall.getTimeout());
   }
 

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -69,7 +69,7 @@ public class ClientCalls {
     // TODO(zhangkun83): if timeout is not defined in proto file, use a default timeout here.
     // If timeout is defined in proto file, Method should carry the timeout.
     return MethodDescriptor.create(method.getType(), fullServiceName + "/" + method.getName(),
-        10 * 365, TimeUnit.DAYS, method.getRequestMarshaller(), method.getResponseMarshaller());
+        364, TimeUnit.DAYS, method.getRequestMarshaller(), method.getResponseMarshaller());
   }
 
   /**


### PR DESCRIPTION
10 years exceeds the maximum for some systems at the moment. Change to 1
year to workaround such systems while they get changed. And since "have
the default be a large number instead of not present" is a temporary fix
anyway.