### PR TITLE
Reduce flow control window for interop tests

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -250,6 +250,7 @@ public class TestServiceClient {
           }
         }
         return NettyChannelBuilder.forAddress(new InetSocketAddress(address, serverPort))
+            .flowControlWindow(65 * 1024)
             .negotiationType(useTls ? NegotiationType.TLS : NegotiationType.PLAINTEXT)
             .sslContext(sslContext)
             .build();

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -56,6 +56,7 @@ public class Http2NettyLocalChannelTest extends AbstractTransportTest {
     startStaticServer(
         NettyServerBuilder
             .forAddress(new LocalAddress("in-process-1"))
+            .flowControlWindow(65 * 1024)
             .channelType(LocalServerChannel.class));
   }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -57,6 +57,7 @@ public class Http2NettyTest extends AbstractTransportTest {
   public static void startServer() {
     try {
       startStaticServer(NettyServerBuilder.forPort(serverPort)
+          .flowControlWindow(65 * 1024)
           .sslContext(GrpcSslContexts
               .forServer(TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"))
               .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)


### PR DESCRIPTION
Many of the interop tests were designed with the default 64 KB flow
control window in mind. If we test with 1 MB then it defeats the flow
control testing.

65 KB is an arbitrary number, but I chose it to be rather small, but
still not the HTTP/2-default 64 KB because implementations have had
trouble with applying flow control changes correctly.