### PR TITLE
Sanitize ClientCalls.

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
@@ -6,7 +6,7 @@ import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.unaryFutureCall;
+import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -196,7 +196,7 @@ public class TestServiceGrpc {
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.SimpleResponse> unaryCall(
         io.grpc.testing.SimpleRequest request) {
-      return unaryFutureCall(
+      return futureUnaryCall(
           channel.newCall(config.unaryCall, callOptions), request);
     }
   }

--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
@@ -3,7 +3,7 @@ package io.grpc.testing;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.duplexStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.unaryFutureCall;
@@ -139,7 +139,7 @@ public class TestServiceGrpc {
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.SimpleRequest> streamingCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.SimpleResponse> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.streamingCall, callOptions), responseObserver);
     }
   }

--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
@@ -6,7 +6,7 @@ import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.unaryFutureCall;
+import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;

--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
@@ -3,7 +3,7 @@ package io.grpc.testing;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.duplexStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.unaryFutureCall;
@@ -127,14 +127,14 @@ public class WorkerGrpc {
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.ClientArgs> runTest(
         io.grpc.stub.StreamObserver<io.grpc.testing.ClientStatus> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.runTest, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.ServerArgs> runServer(
         io.grpc.stub.StreamObserver<io.grpc.testing.ServerStatus> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.runServer, callOptions), responseObserver);
     }
   }

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -408,7 +408,8 @@ public abstract class AbstractBenchmark {
             channel.newCall(pingPongMethod, CALL_OPTIONS);
         final AtomicReference<StreamObserver<ByteBuf>> requestObserverRef =
             new AtomicReference<StreamObserver<ByteBuf>>();
-        StreamObserver<ByteBuf> requestObserver = ClientCalls.duplexStreamingCall(streamingCall,
+        StreamObserver<ByteBuf> requestObserver = ClientCalls.asyncDuplexStreamingCall(
+            streamingCall,
             new StreamObserver<ByteBuf>() {
               @Override
               public void onValue(ByteBuf value) {
@@ -452,7 +453,8 @@ public abstract class AbstractBenchmark {
             channel.newCall(flowControlledStreaming, CALL_OPTIONS);
         final AtomicReference<StreamObserver<ByteBuf>> requestObserverRef =
             new AtomicReference<StreamObserver<ByteBuf>>();
-        StreamObserver<ByteBuf> requestObserver = ClientCalls.duplexStreamingCall(streamingCall,
+        StreamObserver<ByteBuf> requestObserver = ClientCalls.asyncDuplexStreamingCall(
+            streamingCall,
             new StreamObserver<ByteBuf>() {
               @Override
               public void onValue(ByteBuf value) {

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -475,7 +475,7 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
               << "Future interface doesn't support streaming. "
               << "client_streaming=" << client_streaming << ", "
               << "server_streaming=" << server_streaming;
-          (*vars)["calls_method"] = "unaryFutureCall";
+          (*vars)["calls_method"] = "futureUnaryCall";
           p->Print(
               *vars,
               "return $calls_method$(\n"
@@ -658,7 +658,7 @@ void PrintImports(Printer* p, bool generate_nano) {
       "import static "
       "io.grpc.stub.ClientCalls.blockingServerStreamingCall;\n"
       "import static "
-      "io.grpc.stub.ClientCalls.unaryFutureCall;\n"
+      "io.grpc.stub.ClientCalls.futureUnaryCall;\n"
       "import static "
       "io.grpc.stub.ServerCalls.asyncUnaryCall;\n"
       "import static "

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -449,7 +449,7 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
         case ASYNC_CALL:
           if (server_streaming) {
             if (client_streaming) {
-              (*vars)["calls_method"] = "duplexStreamingCall";
+              (*vars)["calls_method"] = "asyncDuplexStreamingCall";
               (*vars)["params"] = "responseObserver";
             } else {
               (*vars)["calls_method"] = "asyncServerStreamingCall";
@@ -652,7 +652,7 @@ void PrintImports(Printer* p, bool generate_nano) {
       "import static "
       "io.grpc.stub.ClientCalls.asyncClientStreamingCall;\n"
       "import static "
-      "io.grpc.stub.ClientCalls.duplexStreamingCall;\n"
+      "io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;\n"
       "import static "
       "io.grpc.stub.ClientCalls.blockingUnaryCall;\n"
       "import static "

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -3,7 +3,7 @@ package io.grpc.testing.integration;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.duplexStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.unaryFutureCall;
@@ -210,14 +210,14 @@ public class TestServiceGrpc {
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.fullDuplexCall, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.halfDuplexCall, callOptions), responseObserver);
     }
   }

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -6,7 +6,7 @@ import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.unaryFutureCall;
+import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -281,7 +281,7 @@ public class TestServiceGrpc {
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
-      return unaryFutureCall(
+      return futureUnaryCall(
           channel.newCall(config.unaryCall, callOptions), request);
     }
   }

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -3,7 +3,7 @@ package io.grpc.testing.integration;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.duplexStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.unaryFutureCall;
@@ -272,14 +272,14 @@ public class TestServiceGrpc {
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.fullDuplexCall, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.halfDuplexCall, callOptions), responseObserver);
     }
   }

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -6,7 +6,7 @@ import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.unaryFutureCall;
+import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -343,7 +343,7 @@ public class TestServiceGrpc {
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
-      return unaryFutureCall(
+      return futureUnaryCall(
           channel.newCall(config.unaryCall, callOptions), request);
     }
   }

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -3,7 +3,7 @@ package io.grpc.examples.helloworld;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.duplexStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.unaryFutureCall;

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -6,7 +6,7 @@ import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.unaryFutureCall;
+import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -171,7 +171,7 @@ public class GreeterGrpc {
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.helloworld.HelloResponse> sayHello(
         io.grpc.examples.helloworld.HelloRequest request) {
-      return unaryFutureCall(
+      return futureUnaryCall(
           channel.newCall(config.sayHello, callOptions), request);
     }
   }

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -6,7 +6,7 @@ import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.unaryFutureCall;
+import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -256,7 +256,7 @@ public class RouteGuideGrpc {
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.routeguide.Feature> getFeature(
         io.grpc.examples.routeguide.Point request) {
-      return unaryFutureCall(
+      return futureUnaryCall(
           channel.newCall(config.getFeature, callOptions), request);
     }
   }

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -3,7 +3,7 @@ package io.grpc.examples.routeguide;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.duplexStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.unaryFutureCall;
@@ -192,7 +192,7 @@ public class RouteGuideGrpc {
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> routeChat(
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.routeChat, callOptions), responseObserver);
     }
   }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -3,7 +3,7 @@ package io.grpc.testing.integration;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.duplexStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.unaryFutureCall;
@@ -240,14 +240,14 @@ public class TestServiceGrpc {
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.fullDuplexCall, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      return duplexStreamingCall(
+      return asyncDuplexStreamingCall(
           channel.newCall(config.halfDuplexCall, callOptions), responseObserver);
     }
   }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -6,7 +6,7 @@ import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncDuplexStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.unaryFutureCall;
+import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -317,14 +317,14 @@ public class TestServiceGrpc {
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> emptyCall(
         com.google.protobuf.EmptyProtos.Empty request) {
-      return unaryFutureCall(
+      return futureUnaryCall(
           channel.newCall(config.emptyCall, callOptions), request);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Messages.SimpleRequest request) {
-      return unaryFutureCall(
+      return futureUnaryCall(
           channel.newCall(config.unaryCall, callOptions), request);
     }
   }

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -101,7 +101,7 @@ public class ClientCalls {
    */
   public static <ReqT, RespT> RespT blockingUnaryCall(ClientCall<ReqT, RespT> call, ReqT param) {
     try {
-      return getUnchecked(unaryFutureCall(call, param));
+      return getUnchecked(futureUnaryCall(call, param));
     } catch (Throwable t) {
       call.cancel();
       throw Throwables.propagate(t);
@@ -126,7 +126,7 @@ public class ClientCalls {
    *
    * @return a future for the single response message.
    */
-  public static <ReqT, RespT> ListenableFuture<RespT> unaryFutureCall(
+  public static <ReqT, RespT> ListenableFuture<RespT> futureUnaryCall(
       ClientCall<ReqT, RespT> call,
       ReqT param) {
     GrpcFuture<RespT> responseFuture = new GrpcFuture<RespT>(call);

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -67,7 +67,7 @@ public class ClientCallsTest {
 
   @Test public void unaryFutureCallSuccess() throws Exception {
     Integer req = 2;
-    ListenableFuture<String> future = ClientCalls.unaryFutureCall(call, req);
+    ListenableFuture<String> future = ClientCalls.futureUnaryCall(call, req);
     ArgumentCaptor<ClientCall.Listener<String>> listenerCaptor = ArgumentCaptor.forClass(null);
     verify(call).start(listenerCaptor.capture(), any(Metadata.Headers.class));
     ClientCall.Listener<String> listener = listenerCaptor.getValue();
@@ -80,7 +80,7 @@ public class ClientCallsTest {
 
   @Test public void unaryFutureCallFailed() throws Exception {
     Integer req = 2;
-    ListenableFuture<String> future = ClientCalls.unaryFutureCall(call, req);
+    ListenableFuture<String> future = ClientCalls.futureUnaryCall(call, req);
     ArgumentCaptor<ClientCall.Listener<String>> listenerCaptor = ArgumentCaptor.forClass(null);
     verify(call).start(listenerCaptor.capture(), any(Metadata.Headers.class));
     ClientCall.Listener<String> listener = listenerCaptor.getValue();
@@ -96,7 +96,7 @@ public class ClientCallsTest {
 
   @Test public void unaryFutureCallCancelled() throws Exception {
     Integer req = 2;
-    ListenableFuture<String> future = ClientCalls.unaryFutureCall(call, req);
+    ListenableFuture<String> future = ClientCalls.futureUnaryCall(call, req);
     ArgumentCaptor<ClientCall.Listener<String>> listenerCaptor = ArgumentCaptor.forClass(null);
     verify(call).start(listenerCaptor.capture(), any(Metadata.Headers.class));
     ClientCall.Listener<String> listener = listenerCaptor.getValue();


### PR DESCRIPTION
- Remove blockingClientStreamingCall() which is not used, and we don't
  actually want that API.
- Rename duplexStreamingCall() to asyncDuplexStreamingCall() to align
  with other async methods.
- In unary call and client streaming call, do not request for additional
  response after the first response.

@ejona86 