### PR TITLE
Minor readability changes

### DIFF
--- a/core/src/main/java/io/grpc/transport/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractServerStream.java
@@ -40,9 +40,14 @@ import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 /**
  * Abstract base class for {@link ServerStream} implementations.
+ *
+ * @param <IdT> the type of the stream identifier
  */
+@NotThreadSafe
 public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
     implements ServerStream {
   private static final Logger log = Logger.getLogger(AbstractServerStream.class.getName());
@@ -76,7 +81,7 @@ public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
   }
 
   @Override
-  protected ServerStreamListener listener() {
+  protected final ServerStreamListener listener() {
     return this.listener;
   }
 
@@ -87,7 +92,7 @@ public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
   }
 
   @Override
-  public void writeHeaders(Metadata.Headers headers) {
+  public final void writeHeaders(Metadata.Headers headers) {
     Preconditions.checkNotNull(headers, "headers");
     outboundPhase(Phase.HEADERS);
     headersSent = true;
@@ -238,7 +243,7 @@ public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
   }
 
   @Override
-  public boolean isClosed() {
+  public final boolean isClosed() {
     return super.isClosed() || listenerClosed;
   }
 

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
@@ -47,12 +47,12 @@ import io.netty.handler.codec.http2.Http2Stream;
 /**
  * Server stream for a Netty HTTP2 transport.
  */
-class NettyServerStream extends AbstractServerStream<Integer> {
+final class NettyServerStream extends AbstractServerStream<Integer> {
 
   private final Channel channel;
   private final NettyServerHandler handler;
   private final Http2Stream http2Stream;
-  private WriteQueue writeQueue;
+  private final WriteQueue writeQueue;
 
   NettyServerStream(Channel channel, Http2Stream http2Stream, NettyServerHandler handler) {
     super(new NettyWritableBufferAllocator(channel.alloc()));
@@ -108,7 +108,8 @@ class NettyServerStream extends AbstractServerStream<Integer> {
             // the client that they can send more bytes.
             onSentBytes(numBytes);
           }
-        }), flush);
+        }),
+        flush);
   }
 
   @Override


### PR DESCRIPTION
Since it is easy to make methods and classes non final, and near impossible to go the other way, make them final.  

On a side note: there seems to be a lot of methods in AbstractClientStream, AbstractServerStream, and AbstractStream.  Some method culling would probably be a good thing to do eventually.
 