### PR TITLE
Improve Metadata

### DIFF
--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -199,6 +199,10 @@ public abstract class Metadata {
    *
    * <p>Names are ASCII string bytes. If the name ends with "-bin", the value can be raw binary.
    * Otherwise, the value must be printable ASCII characters or space.
+   *
+   * <p>The returned byte arrays <em>must not</em> be modified.
+   *
+   * <p>This method is intended for transport use only.
    */
   public byte[][] serialize() {
     Preconditions.checkState(serializable, "Can't serialize raw metadata");
@@ -261,6 +265,8 @@ public abstract class Metadata {
 
     /**
      * Called by the transport layer to create headers from their binary serialized values.
+     *
+     * <p>This method does not copy the provided byte arrays. The byte arrays must not be mutated.
      */
     public Headers(byte[]... headers) {
       super(headers);
@@ -339,6 +345,8 @@ public abstract class Metadata {
   public static class Trailers extends Metadata {
     /**
      * Called by the transport layer to create trailers from their binary serialized values.
+     *
+     * <p>This method does not copy the provided byte arrays. The byte arrays must not be mutated.
      */
     public Trailers(byte[]... headers) {
       super(headers);
@@ -434,6 +442,13 @@ public abstract class Metadata {
       return name;
     }
 
+    /**
+     * Get the name as bytes using ASCII-encoding.
+     *
+     * <p>The returned byte arrays <em>must not</em> be modified.
+     *
+     * <p>This method is intended for transport use only.
+     */
     // TODO (louiscryan): Migrate to ByteString
     public byte[] asciiName() {
       return asciiName;

--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -225,7 +225,11 @@ public abstract class Metadata {
             "Cannot merge non-serializable metadata into serializable metadata without keys");
       }
     }
-    store.putAll(other.store);
+    for (MetadataEntry entry : other.store.values()) {
+      // Must copy the MetadataEntries since they are mutated. If the two Metadata objects are used
+      // from different threads it would cause thread-safety issues.
+      store.put(entry.key.name(), new MetadataEntry(entry));
+    }
   }
 
   /**
@@ -544,6 +548,16 @@ public abstract class Metadata {
       Preconditions.checkNotNull(serialized);
       this.serializedBinary = serialized;
       this.isBinary = isBinary;
+    }
+
+    /**
+     * Copy constructor.
+     */
+    private MetadataEntry(MetadataEntry entry) {
+      this.parsed = entry.parsed;
+      this.key = entry.key;
+      this.isBinary = entry.isBinary;
+      this.serializedBinary = entry.serializedBinary;
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/io/grpc/MetadataTest.java
+++ b/core/src/test/java/io/grpc/MetadataTest.java
@@ -39,10 +39,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.Lists;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Locale;
 
@@ -68,6 +71,38 @@ public class MetadataTest {
   private static final String LANCE = "lance";
   private static final byte[] LANCE_BYTES = LANCE.getBytes(US_ASCII);
   private static final Metadata.Key<Fish> KEY = Metadata.Key.of("test-bin", FISH_MARSHALLER);
+
+  @Test
+  public void testMutations() {
+    Fish lance = new Fish(LANCE);
+    Fish cat = new Fish("cat");
+    Metadata.Headers metadata = new Metadata.Headers();
+
+    assertEquals(null, metadata.get(KEY));
+    metadata.put(KEY, lance);
+    assertEquals(Arrays.asList(lance), Lists.newArrayList(metadata.getAll(KEY)));
+    assertEquals(lance, metadata.get(KEY));
+    metadata.put(KEY, lance);
+    assertEquals(Arrays.asList(lance, lance), Lists.newArrayList(metadata.getAll(KEY)));
+    assertTrue(metadata.remove(KEY, lance));
+    assertEquals(Arrays.asList(lance), Lists.newArrayList(metadata.getAll(KEY)));
+
+    assertFalse(metadata.remove(KEY, cat));
+    metadata.put(KEY, cat);
+    assertEquals(cat, metadata.get(KEY));
+    metadata.put(KEY, lance);
+    assertEquals(Arrays.asList(lance, cat, lance), Lists.newArrayList(metadata.getAll(KEY)));
+    assertEquals(lance, metadata.get(KEY));
+    assertTrue(metadata.remove(KEY, lance));
+    assertEquals(Arrays.asList(cat, lance), Lists.newArrayList(metadata.getAll(KEY)));
+    metadata.put(KEY, lance);
+    assertTrue(metadata.remove(KEY, cat));
+    assertEquals(Arrays.asList(lance, lance), Lists.newArrayList(metadata.getAll(KEY)));
+
+    assertEquals(Arrays.asList(lance, lance), Lists.newArrayList(metadata.removeAll(KEY)));
+    assertEquals(null, metadata.getAll(KEY));
+    assertEquals(null, metadata.get(KEY));
+  }
 
   @Test
   public void testWriteParsed() {

--- a/core/src/test/java/io/grpc/MetadataTest.java
+++ b/core/src/test/java/io/grpc/MetadataTest.java
@@ -134,17 +134,24 @@ public class MetadataTest {
     assertSame(lance, raw.get(KEY));
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void testFailSerializeRaw() {
+  @Test
+  public void testSerializeRaw() {
     Metadata.Headers raw = new Metadata.Headers(KEY.asciiName(), LANCE_BYTES);
-    raw.serialize();
+    byte[][] serialized = raw.serialize();
+    assertArrayEquals(serialized[0], KEY.asciiName());
+    assertArrayEquals(serialized[1], LANCE_BYTES);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testFailMergeRawIntoSerializable() {
+  @Test
+  public void testMergeByteConstructed() {
     Metadata.Headers raw = new Metadata.Headers(KEY.asciiName(), LANCE_BYTES);
     Metadata.Headers serializable = new Metadata.Headers();
     serializable.merge(raw);
+
+    byte[][] serialized = serializable.serialize();
+    assertArrayEquals(serialized[0], KEY.asciiName());
+    assertArrayEquals(serialized[1], LANCE_BYTES);
+    assertEquals(new Fish(LANCE), serializable.get(KEY));
   }
 
   @Test


### PR DESCRIPTION
The actual objective was to remove the "is serializable" aspect of Metadata; the idea that only some Metadata could be serialized. The rest of the changes were things noticed or needed while trying to get to that goal.

Commits have useful descriptions providing more information about the change.

@louiscryan