### PR TITLE
Use mutation methods for stub reconfiguration.

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -588,9 +588,7 @@ public abstract class AbstractTransportTest {
   public void sendsTimeoutHeader() {
     long configuredTimeoutMinutes = 100;
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel)
-        .configureNewStub()
-        .setDeadlineAfter(configuredTimeoutMinutes, TimeUnit.MINUTES)
-        .build();
+        .withDeadlineAfter(configuredTimeoutMinutes, TimeUnit.MINUTES);
     stub.emptyCall(Empty.getDefaultInstance());
     long transferredTimeoutMinutes = TimeUnit.MICROSECONDS.toMinutes(
         requestHeadersCapture.get().get(ChannelImpl.TIMEOUT_KEY));
@@ -607,9 +605,8 @@ public abstract class AbstractTransportTest {
     // warm up the channel and JVM
     blockingStub.emptyCall(Empty.getDefaultInstance());
     TestServiceGrpc.newBlockingStub(channel)
-        .configureNewStub()
-        .setDeadlineAfter(50, TimeUnit.MILLISECONDS)
-        .build().emptyCall(Empty.getDefaultInstance());
+        .withDeadlineAfter(50, TimeUnit.MILLISECONDS)
+        .emptyCall(Empty.getDefaultInstance());
   }
 
   @Test(timeout = 10000)
@@ -618,9 +615,7 @@ public abstract class AbstractTransportTest {
     // warm up the channel and JVM
     blockingStub.emptyCall(Empty.getDefaultInstance());
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel)
-        .configureNewStub()
-        .setDeadlineAfter(10, TimeUnit.MILLISECONDS)
-        .build();
+        .withDeadlineAfter(10, TimeUnit.MILLISECONDS);
     try {
       stub.emptyCall(Empty.getDefaultInstance());
       fail("Expected deadline to be exceeded");
@@ -647,9 +642,8 @@ public abstract class AbstractTransportTest {
         .build();
     StreamRecorder<StreamingOutputCallResponse> recorder = StreamRecorder.create();
     TestServiceGrpc.newStub(channel)
-        .configureNewStub()
-        .setDeadlineAfter(30, TimeUnit.MILLISECONDS)
-        .build().streamingOutputCall(request, recorder);
+        .withDeadlineAfter(30, TimeUnit.MILLISECONDS)
+        .streamingOutputCall(request, recorder);
     recorder.awaitCompletion();
     assertEquals(Status.DEADLINE_EXCEEDED, Status.fromThrowable(recorder.getError()));
     assertNotEquals(0, recorder.getValues().size());
@@ -723,9 +717,8 @@ public abstract class AbstractTransportTest {
     GoogleCredentials credentials =
         (ServiceAccountCredentials) GoogleCredentials.fromStream(credentialsStream);
     credentials = credentials.createScoped(Arrays.<String>asList(authScope));
-    TestServiceGrpc.TestServiceBlockingStub stub = blockingStub.configureNewStub()
-        .addInterceptor(new ClientAuthInterceptor(credentials, testServiceExecutor))
-        .build();
+    TestServiceGrpc.TestServiceBlockingStub stub = blockingStub
+        .withInterceptors(new ClientAuthInterceptor(credentials, testServiceExecutor));
     final SimpleRequest request = SimpleRequest.newBuilder()
         .setFillUsername(true)
         .setFillOauthScope(true)
@@ -756,9 +749,8 @@ public abstract class AbstractTransportTest {
   /** Sends a large unary rpc with compute engine credentials. */
   public void computeEngineCreds(String serviceAccount, String oauthScope) throws Exception {
     ComputeEngineCredentials credentials = new ComputeEngineCredentials();
-    TestServiceGrpc.TestServiceBlockingStub stub = blockingStub.configureNewStub()
-        .addInterceptor(new ClientAuthInterceptor(credentials, testServiceExecutor))
-        .build();
+    TestServiceGrpc.TestServiceBlockingStub stub = blockingStub
+        .withInterceptors(new ClientAuthInterceptor(credentials, testServiceExecutor));
     final SimpleRequest request = SimpleRequest.newBuilder()
         .setFillUsername(true)
         .setFillOauthScope(true)

--- a/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
+++ b/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
@@ -87,8 +87,7 @@ public class StubConfigTest {
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
     assertNull(stub.getCallOptions().getDeadlineNanoTime());
     // Reconfigure it
-    TestServiceGrpc.TestServiceBlockingStub reconfiguredStub =
-        stub.configureNewStub().setDeadlineNanoTime(2L).build();
+    TestServiceGrpc.TestServiceBlockingStub reconfiguredStub = stub.withDeadlineNanoTime(2L);
     // New altered config
     assertEquals(2L, (long) reconfiguredStub.getCallOptions().getDeadlineNanoTime());
     // Default config unchanged
@@ -102,7 +101,7 @@ public class StubConfigTest {
     SimpleRequest request = SimpleRequest.getDefaultInstance();
     stub.unaryCall(request, responseObserver);
     verify(channel).newCall(same(TestServiceGrpc.METHOD_UNARY_CALL), same(options1));
-    stub = stub.configureNewStub().setDeadlineNanoTime(2L).build();
+    stub = stub.withDeadlineNanoTime(2L);
     CallOptions options2 = stub.getCallOptions();
     assertNotSame(options1, options2);
     stub.unaryCall(request, responseObserver);

--- a/stub/src/main/java/io/grpc/stub/MetadataUtils.java
+++ b/stub/src/main/java/io/grpc/stub/MetadataUtils.java
@@ -59,8 +59,7 @@ public class MetadataUtils {
   public static <T extends AbstractStub> T attachHeaders(
       T stub,
       final Metadata.Headers extraHeaders) {
-    return (T) stub.configureNewStub().addInterceptor(
-        newAttachHeadersInterceptor(extraHeaders)).build();
+    return (T) stub.withInterceptors(newAttachHeadersInterceptor(extraHeaders));
   }
 
   /**
@@ -100,8 +99,8 @@ public class MetadataUtils {
       T stub,
       AtomicReference<Metadata.Headers> headersCapture,
       AtomicReference<Metadata.Trailers> trailersCapture) {
-    return (T) stub.configureNewStub().addInterceptor(
-        newCaptureMetadataInterceptor(headersCapture, trailersCapture)).build();
+    return (T) stub.withInterceptors(
+        newCaptureMetadataInterceptor(headersCapture, trailersCapture));
   }
 
   /**


### PR DESCRIPTION
This makes the reconfiguration code more concise.
Resolves #168 

- Remove configureNewStub().
- Add mutation methods withDeadlineNanoTime(), withChannel() etc that
  returns the reconfigured stub.

@ejona86 