### PR TITLE
Minor readability changes

### DIFF
--- a/core/src/main/java/io/grpc/transport/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/transport/AbstractServerStream.java
@@ -44,6 +44,8 @@ import java.util.logging.Logger;
 
 /**
  * Abstract base class for {@link ServerStream} implementations.
+ *
+ * @param <IdT> the type of the stream identifier
  */
 public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
     implements ServerStream {
@@ -89,7 +91,7 @@ public abstract class AbstractServerStream<IdT> extends AbstractStream<IdT>
   }
 
   @Override
-  public void writeHeaders(Metadata.Headers headers) {
+  public final void writeHeaders(Metadata.Headers headers) {
     Preconditions.checkNotNull(headers, "headers");
     outboundPhase(Phase.HEADERS);
     headersSent = true;

--- a/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyServerStream.java
@@ -52,11 +52,11 @@ class NettyServerStream extends AbstractServerStream<Integer> {
   private final Channel channel;
   private final NettyServerHandler handler;
   private final Http2Stream http2Stream;
-  private WriteQueue writeQueue;
+  private final WriteQueue writeQueue;
 
   NettyServerStream(Channel channel, Http2Stream http2Stream, NettyServerHandler handler) {
     super(new NettyWritableBufferAllocator(channel.alloc()));
-    writeQueue = handler.getWriteQueue();
+    this.writeQueue = handler.getWriteQueue();
     this.channel = checkNotNull(channel, "channel");
     this.http2Stream = checkNotNull(http2Stream, "http2Stream");
     this.handler = checkNotNull(handler, "handler");


### PR DESCRIPTION
Improved some consistency. writeHeaders was the only non-final
implementation method of ServerStream, even though it is really no
different than the others.

This was heavily inspired by #633, but only the obviously-good pieces.