### PR TITLE
Simplify locking model of OkHttp Transport, avoid potential deadlock.

### DIFF
--- a/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/transport/okhttp/OkHttpClientTransportTest.java
@@ -195,7 +195,7 @@ public class OkHttpClientTransportTest {
     assertEquals("Protocol error\n" + NETWORK_ISSUE_MESSAGE, listener1.status.getDescription());
     assertEquals(Status.INTERNAL.getCode(), listener2.status.getCode());
     assertEquals("Protocol error\n" + NETWORK_ISSUE_MESSAGE, listener2.status.getDescription());
-    verify(transportListener).transportShutdown();
+    verify(transportListener, timeout(TIME_OUT_MS)).transportShutdown();
     verify(transportListener, timeout(TIME_OUT_MS)).transportTerminated();
   }
 


### PR DESCRIPTION
1. Remove the stream lock, use transport lock instead.
2. Protected streams map with the transport lock instead of using synchronized map.

Fixes #583

@ejona86 Please take a look, thanks!