### PR TITLE
Adding support for NPN fallback.

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
@@ -44,6 +44,7 @@ import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.STREAMING_R
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TESTCA;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TLS;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TRANSPORT;
+import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.USE_DEFAULT_CIPHERS;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.WARMUP_DURATION;
 import static io.grpc.benchmarks.qps.Utils.HISTOGRAM_MAX_VALUE;
 import static io.grpc.benchmarks.qps.Utils.HISTOGRAM_PRECISION;
@@ -325,7 +326,7 @@ public class AsyncClient {
   public static void main(String... args) throws Exception {
     ClientConfiguration.Builder configBuilder = ClientConfiguration.newBuilder(
         ADDRESS, CHANNELS, OUTSTANDING_RPCS, CLIENT_PAYLOAD, SERVER_PAYLOAD,
-        TLS, TESTCA, TRANSPORT, DURATION, WARMUP_DURATION, DIRECTEXECUTOR,
+        TLS, TESTCA, USE_DEFAULT_CIPHERS, TRANSPORT, DURATION, WARMUP_DURATION, DIRECTEXECUTOR,
         SAVE_HISTOGRAM, STREAMING_RPCS, FLOW_CONTROL_WINDOW);
     ClientConfiguration config;
     try {

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
@@ -60,6 +60,7 @@ class ClientConfiguration implements Configuration {
   Transport transport = Transport.NETTY_NIO;
   boolean tls;
   boolean testca;
+  boolean useDefaultCiphers;
   boolean directExecutor;
   SocketAddress address;
   int channels = 4;
@@ -231,6 +232,13 @@ class ClientConfiguration implements Configuration {
       @Override
       protected void setClientValue(ClientConfiguration config, String value) {
         config.testca = parseBoolean(value);
+      }
+    },
+    USE_DEFAULT_CIPHERS("", "Use the default JDK ciphers for TLS (Used to support Java 7).",
+            "" + DEFAULT.useDefaultCiphers) {
+      @Override
+      protected void setClientValue(ClientConfiguration config, String value) {
+        config.useDefaultCiphers = parseBoolean(value);
       }
     },
     TRANSPORT("STR", Transport.getDescriptionString(), DEFAULT.transport.name().toLowerCase()) {

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
@@ -42,6 +42,7 @@ import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TARGET_QPS;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TESTCA;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TLS;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TRANSPORT;
+import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.USE_DEFAULT_CIPHERS;
 import static io.grpc.benchmarks.qps.Utils.HISTOGRAM_MAX_VALUE;
 import static io.grpc.benchmarks.qps.Utils.HISTOGRAM_PRECISION;
 import static io.grpc.benchmarks.qps.Utils.newClientChannel;
@@ -85,7 +86,7 @@ public class OpenLoopClient {
   public static void main(String... args) throws Exception {
     ClientConfiguration.Builder configBuilder = ClientConfiguration.newBuilder(
         ADDRESS, TARGET_QPS, CLIENT_PAYLOAD, SERVER_PAYLOAD, TLS,
-        TESTCA, TRANSPORT, DURATION, SAVE_HISTOGRAM, FLOW_CONTROL_WINDOW);
+        TESTCA, USE_DEFAULT_CIPHERS, TRANSPORT, DURATION, SAVE_HISTOGRAM, FLOW_CONTROL_WINDOW);
     ClientConfiguration config;
     try {
       config = configBuilder.build(args);

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ServerConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ServerConfiguration.java
@@ -55,6 +55,7 @@ class ServerConfiguration implements Configuration {
 
   Transport transport = Transport.NETTY_NIO;
   boolean tls;
+  boolean useDefaultCiphers;
   boolean directExecutor;
   SocketAddress address;
   int flowControlWindow = NettyChannelBuilder.DEFAULT_FLOW_CONTROL_WINDOW;
@@ -170,6 +171,13 @@ class ServerConfiguration implements Configuration {
       @Override
       protected void setServerValue(ServerConfiguration config, String value) {
         config.tls = parseBoolean(value);
+      }
+    },
+    USE_DEFAULT_CIPHERS("", "Use the default JDK ciphers for TLS (Used to support Java 7).",
+            "false") {
+      @Override
+      protected void setServerValue(ServerConfiguration config, String value) {
+        config.useDefaultCiphers = parseBoolean(value);
       }
     },
     TRANSPORT("STR", Transport.getDescriptionString(), DEFAULT.transport.name().toLowerCase()) {

--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ subprojects {
         // on the Java version.
         def alpnboot_version = '8.1.2.v20141202'
         if (JavaVersion.current().ordinal() < JavaVersion.VERSION_1_8.ordinal()) {
-            alpnboot_version = '7.1.2.v20141202'
+            alpnboot_version = '7.1.3.v20150130'
         }
 
         alpnboot_package_name = 'org.mortbay.jetty.alpn:alpn-boot:' + alpnboot_version

--- a/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
+++ b/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
@@ -32,31 +32,33 @@
 package io.grpc.netty;
 
 /**
- * Utility class that verifies that Jetty ALPN is properly configured for the system.
+ * Utility class for determining support for Jetty TLS ALPN/NPN.
  */
-final class JettyAlpnVerifier {
-  private JettyAlpnVerifier() {
+final class JettyTlsUtil {
+  private JettyTlsUtil() {
   }
 
   /**
-   * Exception thrown when Jetty ALPN was not found in the boot classloader.
+   * Indicates whether or not the Jetty ALPN jar is installed in the boot classloader.
    */
-  static final class NotFoundException extends Exception {
-    public NotFoundException(Throwable cause) {
-      super("Jetty ALPN not found in boot classloader.", cause);
+  static boolean isJettyAlpnConfigured() {
+    try {
+      Class.forName("org.eclipse.jetty.alpn.ALPN", true, null);
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
     }
   }
 
   /**
-   * Verifies that Jetty ALPN is configured properly on this system.
-   * @throws NotFoundException thrown if Jetty ALPN is missing from the boot classloader.
+   * Indicates whether or not the Jetty NPN jar is installed in the boot classloader.
    */
-  static void verifyJettyAlpn() throws NotFoundException {
+  static boolean isJettyNpnConfigured() {
     try {
-      // Check the boot classloader for the ALPN class.
-      Class.forName("org.eclipse.jetty.alpn.ALPN", true, null);
+      Class.forName("org.eclipse.jetty.npn.NextProtoNego", true, null);
+      return true;
     } catch (ClassNotFoundException e) {
-      throw new NotFoundException(e);
+      return false;
     }
   }
 }


### PR DESCRIPTION
This takes some steps towards #525, but it won't be fixed until we officially support OpenSSL. This is due to the fact that ALPN->NPN fallback isn't supported with Jetty (since only one of the bootstrap plugins can be provided).