### PR TITLE
Breaking out ClientCallFactory abstract class

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
@@ -31,18 +31,18 @@ public class TestServiceGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.parser()));
 
-  public static TestServiceStub newStub(io.grpc.Channel channel) {
-    return new TestServiceStub(channel);
+  public static TestServiceStub newStub(io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceStub(callFactory);
   }
 
   public static TestServiceBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
-    return new TestServiceBlockingStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceBlockingStub(callFactory);
   }
 
   public static TestServiceFutureStub newFutureStub(
-      io.grpc.Channel channel) {
-    return new TestServiceFutureStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceFutureStub(callFactory);
   }
 
   public static interface TestService {
@@ -67,82 +67,82 @@ public class TestServiceGrpc {
 
   public static class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub>
       implements TestService {
-    private TestServiceStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceStub(io.grpc.Channel channel,
+    private TestServiceStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceStub build(io.grpc.Channel channel,
+    protected TestServiceStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceStub(channel, callOptions);
+      return new TestServiceStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.SimpleRequest> streamingCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.SimpleResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_STREAMING_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_STREAMING_CALL, callOptions), responseObserver);
     }
   }
 
   public static class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub>
       implements TestServiceBlockingClient {
-    private TestServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceBlockingStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceBlockingStub(io.grpc.Channel channel,
+    private TestServiceBlockingStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceBlockingStub build(io.grpc.Channel channel,
+    protected TestServiceBlockingStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceBlockingStub(channel, callOptions);
+      return new TestServiceBlockingStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.testing.SimpleResponse unaryCall(io.grpc.testing.SimpleRequest request) {
       return blockingUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request);
     }
   }
 
   public static class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub>
       implements TestServiceFutureClient {
-    private TestServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceFutureStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceFutureStub(io.grpc.Channel channel,
+    private TestServiceFutureStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceFutureStub build(io.grpc.Channel channel,
+    protected TestServiceFutureStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceFutureStub(channel, callOptions);
+      return new TestServiceFutureStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.SimpleResponse> unaryCall(
         io.grpc.testing.SimpleRequest request) {
       return futureUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request);
     }
   }
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
@@ -31,18 +31,18 @@ public class WorkerGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerArgs.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerStatus.parser()));
 
-  public static WorkerStub newStub(io.grpc.Channel channel) {
-    return new WorkerStub(channel);
+  public static WorkerStub newStub(io.grpc.ClientCallFactory callFactory) {
+    return new WorkerStub(callFactory);
   }
 
   public static WorkerBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
-    return new WorkerBlockingStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new WorkerBlockingStub(callFactory);
   }
 
   public static WorkerFutureStub newFutureStub(
-      io.grpc.Channel channel) {
-    return new WorkerFutureStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new WorkerFutureStub(callFactory);
   }
 
   public static interface Worker {
@@ -62,69 +62,69 @@ public class WorkerGrpc {
 
   public static class WorkerStub extends io.grpc.stub.AbstractStub<WorkerStub>
       implements Worker {
-    private WorkerStub(io.grpc.Channel channel) {
-      super(channel);
+    private WorkerStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private WorkerStub(io.grpc.Channel channel,
+    private WorkerStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected WorkerStub build(io.grpc.Channel channel,
+    protected WorkerStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new WorkerStub(channel, callOptions);
+      return new WorkerStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.ClientArgs> runTest(
         io.grpc.stub.StreamObserver<io.grpc.testing.ClientStatus> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_RUN_TEST, callOptions), responseObserver);
+          callFactory.newCall(METHOD_RUN_TEST, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.ServerArgs> runServer(
         io.grpc.stub.StreamObserver<io.grpc.testing.ServerStatus> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_RUN_SERVER, callOptions), responseObserver);
+          callFactory.newCall(METHOD_RUN_SERVER, callOptions), responseObserver);
     }
   }
 
   public static class WorkerBlockingStub extends io.grpc.stub.AbstractStub<WorkerBlockingStub>
       implements WorkerBlockingClient {
-    private WorkerBlockingStub(io.grpc.Channel channel) {
-      super(channel);
+    private WorkerBlockingStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private WorkerBlockingStub(io.grpc.Channel channel,
+    private WorkerBlockingStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected WorkerBlockingStub build(io.grpc.Channel channel,
+    protected WorkerBlockingStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new WorkerBlockingStub(channel, callOptions);
+      return new WorkerBlockingStub(callFactory, callOptions);
     }
   }
 
   public static class WorkerFutureStub extends io.grpc.stub.AbstractStub<WorkerFutureStub>
       implements WorkerFutureClient {
-    private WorkerFutureStub(io.grpc.Channel channel) {
-      super(channel);
+    private WorkerFutureStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private WorkerFutureStub(io.grpc.Channel channel,
+    private WorkerFutureStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected WorkerFutureStub build(io.grpc.Channel channel,
+    protected WorkerFutureStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new WorkerFutureStub(channel, callOptions);
+      return new WorkerFutureStub(callFactory, callOptions);
     }
   }
 

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -138,7 +138,7 @@ public class TransportBenchmark {
         .build();
     server.start();
     channel = channelBuilder.build();
-    stub = TestServiceGrpc.newBlockingStub(channel);
+    stub = TestServiceGrpc.newBlockingStub(channel.callFactory());
     // Wait for channel to start
     stub.unaryCall(SimpleRequest.getDefaultInstance());
   }

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -38,7 +38,7 @@ import com.google.protobuf.ByteString;
 
 import io.grpc.AbstractChannelBuilder;
 import io.grpc.AbstractServerBuilder;
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.ServerImpl;
 import io.grpc.benchmarks.qps.AsyncServer;
 import io.grpc.inprocess.InProcessChannelBuilder;
@@ -51,6 +51,7 @@ import io.grpc.testing.Payload;
 import io.grpc.testing.SimpleRequest;
 import io.grpc.testing.SimpleResponse;
 import io.grpc.testing.TestServiceGrpc;
+
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
@@ -80,7 +81,7 @@ public class TransportBenchmark {
   @Param({"true", "false"})
   public boolean direct;
 
-  private ChannelImpl channel;
+  private Channel channel;
   private ServerImpl server;
   private TestServiceGrpc.TestServiceBlockingStub stub;
 

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -3,7 +3,7 @@ package io.grpc.benchmarks.netty;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.CallOptions;
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.Drainable;
 import io.grpc.KnownLength;
@@ -20,6 +20,7 @@ import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.ClientCalls;
 import io.grpc.stub.StreamObserver;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.EmptyByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -161,7 +162,7 @@ public abstract class AbstractBenchmark {
   protected MethodDescriptor<ByteBuf, ByteBuf> unaryMethod;
   private MethodDescriptor<ByteBuf, ByteBuf> pingPongMethod;
   private MethodDescriptor<ByteBuf, ByteBuf> flowControlledStreaming;
-  protected ChannelImpl[] channels;
+  protected Channel[] channels;
 
   public AbstractBenchmark() {
   }
@@ -350,7 +351,7 @@ public abstract class AbstractBenchmark {
     // Build and start the clients and servers
     server = serverBuilder.build();
     server.start();
-    channels = new ChannelImpl[channelCount];
+    channels = new Channel[channelCount];
     for (int i = 0; i < channelCount; i++) {
       // Use a dedicated event-loop for each channel
       channels[i] = channelBuilder
@@ -368,7 +369,7 @@ public abstract class AbstractBenchmark {
                                  final AtomicLong counter,
                                  final AtomicBoolean done,
                                  final long counterDelta) {
-    for (final ChannelImpl channel : channels) {
+    for (final Channel channel : channels) {
       for (int i = 0; i < callsPerChannel; i++) {
         StreamObserver<ByteBuf> observer = new StreamObserver<ByteBuf>() {
           @Override
@@ -404,7 +405,7 @@ public abstract class AbstractBenchmark {
                                      final AtomicLong counter,
                                      final AtomicBoolean done,
                                      final long counterDelta) {
-    for (final ChannelImpl channel : channels) {
+    for (final Channel channel : channels) {
       for (int i = 0; i < callsPerChannel; i++) {
         final ClientCall<ByteBuf, ByteBuf> streamingCall =
             channel.callFactory().newCall(pingPongMethod, CALL_OPTIONS);
@@ -449,7 +450,7 @@ public abstract class AbstractBenchmark {
                                                    final AtomicLong counter,
                                                    final AtomicBoolean done,
                                                    final long counterDelta) {
-    for (final ChannelImpl channel : channels) {
+    for (final Channel channel : channels) {
       for (int i = 0; i < callsPerChannel; i++) {
         final ClientCall<ByteBuf, ByteBuf> streamingCall =
             channel.callFactory().newCall(flowControlledStreaming, CALL_OPTIONS);
@@ -487,7 +488,7 @@ public abstract class AbstractBenchmark {
    * Shutdown all the client channels and then shutdown the server.
    */
   protected void teardown() throws Exception {
-    for (ChannelImpl channel : channels) {
+    for (Channel channel : channels) {
       channel.shutdown();
     }
     server.shutdown().awaitTermination(5, TimeUnit.SECONDS);

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -386,7 +386,7 @@ public abstract class AbstractBenchmark {
             if (!done.get()) {
               ByteBuf slice = request.slice();
               ClientCalls.asyncUnaryCall(
-                  channel.newCall(unaryMethod, CALL_OPTIONS), slice, this);
+                  channel.callFactory().newCall(unaryMethod, CALL_OPTIONS), slice, this);
             }
           }
         };
@@ -407,7 +407,7 @@ public abstract class AbstractBenchmark {
     for (final ChannelImpl channel : channels) {
       for (int i = 0; i < callsPerChannel; i++) {
         final ClientCall<ByteBuf, ByteBuf> streamingCall =
-            channel.newCall(pingPongMethod, CALL_OPTIONS);
+            channel.callFactory().newCall(pingPongMethod, CALL_OPTIONS);
         final AtomicReference<StreamObserver<ByteBuf>> requestObserverRef =
             new AtomicReference<StreamObserver<ByteBuf>>();
         StreamObserver<ByteBuf> requestObserver = ClientCalls.asyncBidiStreamingCall(
@@ -452,7 +452,7 @@ public abstract class AbstractBenchmark {
     for (final ChannelImpl channel : channels) {
       for (int i = 0; i < callsPerChannel; i++) {
         final ClientCall<ByteBuf, ByteBuf> streamingCall =
-            channel.newCall(flowControlledStreaming, CALL_OPTIONS);
+            channel.callFactory().newCall(flowControlledStreaming, CALL_OPTIONS);
         final AtomicReference<StreamObserver<ByteBuf>> requestObserverRef =
             new AtomicReference<StreamObserver<ByteBuf>>();
         StreamObserver<ByteBuf> requestObserver = ClientCalls.asyncBidiStreamingCall(

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/SingleThreadBlockingQpsBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/SingleThreadBlockingQpsBenchmark.java
@@ -52,7 +52,7 @@ public class SingleThreadBlockingQpsBenchmark extends AbstractBenchmark {
   @Benchmark
   public void blockingUnary() throws Exception {
     ClientCalls.blockingUnaryCall(
-        channels[0].newCall(unaryMethod, CallOptions.DEFAULT), Unpooled.EMPTY_BUFFER);
+        channels[0].callFactory().newCall(unaryMethod, CallOptions.DEFAULT), Unpooled.EMPTY_BUFFER);
   }
 
   /**

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -223,28 +223,28 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
   if (impl) {
     p->Print(
         *vars,
-        "private $impl_name$($Channel$ channel) {\n");
+        "private $impl_name$($CallFactory$ callFactory) {\n");
     p->Indent();
-    p->Print("super(channel);\n");
+    p->Print("super(callFactory);\n");
     p->Outdent();
     p->Print("}\n\n");
     p->Print(
         *vars,
-        "private $impl_name$($Channel$ channel,\n"
+        "private $impl_name$($CallFactory$ callFactory,\n"
         "    $CallOptions$ callOptions) {\n");
     p->Indent();
-    p->Print("super(channel, callOptions);\n");
+    p->Print("super(callFactory, callOptions);\n");
     p->Outdent();
     p->Print("}\n\n");
     p->Print(
         *vars,
         "@$Override$\n"
-        "protected $impl_name$ build($Channel$ channel,\n"
+        "protected $impl_name$ build($CallFactory$ callFactory,\n"
         "    $CallOptions$ callOptions) {\n");
     p->Indent();
     p->Print(
         *vars,
-        "return new $impl_name$(channel, callOptions);\n");
+        "return new $impl_name$(callFactory, callOptions);\n");
     p->Outdent();
     p->Print("}\n");
   }
@@ -341,7 +341,7 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
           p->Print(
               *vars,
               "return $calls_method$(\n"
-              "    channel.newCall($method_field_name$, callOptions), $params$);\n");
+              "    callFactory.newCall($method_field_name$, callOptions), $params$);\n");
           break;
         case ASYNC_CALL:
           if (server_streaming) {
@@ -365,7 +365,7 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
           p->Print(
               *vars,
               "$last_line_prefix$$calls_method$(\n"
-              "    channel.newCall($method_field_name$, callOptions), $params$);\n");
+              "    callFactory.newCall($method_field_name$, callOptions), $params$);\n");
           break;
         case FUTURE_CALL:
           CHECK(!client_streaming && !server_streaming)
@@ -376,7 +376,7 @@ static void PrintStub(const google::protobuf::ServiceDescriptor* service,
           p->Print(
               *vars,
               "return $calls_method$(\n"
-              "    channel.newCall($method_field_name$, callOptions), request);\n");
+              "    callFactory.newCall($method_field_name$, callOptions), request);\n");
           break;
       }
       p->Outdent();
@@ -495,31 +495,31 @@ static void PrintService(const ServiceDescriptor* service,
 
   p->Print(
       *vars,
-      "public static $service_name$Stub newStub($Channel$ channel) {\n");
+      "public static $service_name$Stub newStub($CallFactory$ callFactory) {\n");
   p->Indent();
   p->Print(
       *vars,
-      "return new $service_name$Stub(channel);\n");
+      "return new $service_name$Stub(callFactory);\n");
   p->Outdent();
   p->Print("}\n\n");
   p->Print(
       *vars,
       "public static $service_name$BlockingStub newBlockingStub(\n"
-      "    $Channel$ channel) {\n");
+      "    $CallFactory$ callFactory) {\n");
   p->Indent();
   p->Print(
       *vars,
-      "return new $service_name$BlockingStub(channel);\n");
+      "return new $service_name$BlockingStub(callFactory);\n");
   p->Outdent();
   p->Print("}\n\n");
   p->Print(
       *vars,
       "public static $service_name$FutureStub newFutureStub(\n"
-      "    $Channel$ channel) {\n");
+      "    $CallFactory$ callFactory) {\n");
   p->Indent();
   p->Print(
       *vars,
-      "return new $service_name$FutureStub(channel);\n");
+      "return new $service_name$FutureStub(callFactory);\n");
   p->Outdent();
   p->Print("}\n\n");
 
@@ -571,7 +571,7 @@ void GenerateService(const ServiceDescriptor* service,
   map<string, string> vars;
   vars["String"] = "java.lang.String";
   vars["Override"] = "java.lang.Override";
-  vars["Channel"] = "io.grpc.Channel";
+  vars["CallFactory"] = "io.grpc.ClientCallFactory";
   vars["CallOptions"] = "io.grpc.CallOptions";
   vars["MethodType"] = "io.grpc.MethodDescriptor.MethodType";
   vars["ServerMethodDefinition"] =

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -52,18 +52,18 @@ public class TestServiceGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
 
-  public static TestServiceStub newStub(io.grpc.Channel channel) {
-    return new TestServiceStub(channel);
+  public static TestServiceStub newStub(io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceStub(callFactory);
   }
 
   public static TestServiceBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
-    return new TestServiceBlockingStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceBlockingStub(callFactory);
   }
 
   public static TestServiceFutureStub newFutureStub(
-      io.grpc.Channel channel) {
-    return new TestServiceFutureStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceFutureStub(callFactory);
   }
 
   public static interface TestService {
@@ -100,110 +100,110 @@ public class TestServiceGrpc {
 
   public static class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub>
       implements TestService {
-    private TestServiceStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceStub(io.grpc.Channel channel,
+    private TestServiceStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceStub build(io.grpc.Channel channel,
+    protected TestServiceStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceStub(channel, callOptions);
+      return new TestServiceStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          channel.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          channel.newCall(METHOD_STREAMING_INPUT_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_STREAMING_INPUT_CALL, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_FULL_BIDI_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_FULL_BIDI_CALL, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_HALF_BIDI_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_HALF_BIDI_CALL, callOptions), responseObserver);
     }
   }
 
   public static class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub>
       implements TestServiceBlockingClient {
-    private TestServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceBlockingStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceBlockingStub(io.grpc.Channel channel,
+    private TestServiceBlockingStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceBlockingStub build(io.grpc.Channel channel,
+    protected TestServiceBlockingStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceBlockingStub(channel, callOptions);
+      return new TestServiceBlockingStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          channel.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request);
+          callFactory.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request);
     }
   }
 
   public static class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub>
       implements TestServiceFutureClient {
-    private TestServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceFutureStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceFutureStub(io.grpc.Channel channel,
+    private TestServiceFutureStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceFutureStub build(io.grpc.Channel channel,
+    protected TestServiceFutureStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceFutureStub(channel, callOptions);
+      return new TestServiceFutureStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return futureUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request);
     }
   }
 

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -114,18 +114,18 @@ public class TestServiceGrpc {
                   }
           }));
 
-  public static TestServiceStub newStub(io.grpc.Channel channel) {
-    return new TestServiceStub(channel);
+  public static TestServiceStub newStub(io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceStub(callFactory);
   }
 
   public static TestServiceBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
-    return new TestServiceBlockingStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceBlockingStub(callFactory);
   }
 
   public static TestServiceFutureStub newFutureStub(
-      io.grpc.Channel channel) {
-    return new TestServiceFutureStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceFutureStub(callFactory);
   }
 
   public static interface TestService {
@@ -162,110 +162,110 @@ public class TestServiceGrpc {
 
   public static class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub>
       implements TestService {
-    private TestServiceStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceStub(io.grpc.Channel channel,
+    private TestServiceStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceStub build(io.grpc.Channel channel,
+    protected TestServiceStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceStub(channel, callOptions);
+      return new TestServiceStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          channel.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          channel.newCall(METHOD_STREAMING_INPUT_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_STREAMING_INPUT_CALL, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_FULL_BIDI_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_FULL_BIDI_CALL, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_HALF_BIDI_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_HALF_BIDI_CALL, callOptions), responseObserver);
     }
   }
 
   public static class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub>
       implements TestServiceBlockingClient {
-    private TestServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceBlockingStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceBlockingStub(io.grpc.Channel channel,
+    private TestServiceBlockingStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceBlockingStub build(io.grpc.Channel channel,
+    protected TestServiceBlockingStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceBlockingStub(channel, callOptions);
+      return new TestServiceBlockingStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          channel.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request);
+          callFactory.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request);
     }
   }
 
   public static class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub>
       implements TestServiceFutureClient {
-    private TestServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceFutureStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceFutureStub(io.grpc.Channel channel,
+    private TestServiceFutureStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceFutureStub build(io.grpc.Channel channel,
+    protected TestServiceFutureStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceFutureStub(channel, callOptions);
+      return new TestServiceFutureStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return futureUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request);
     }
   }
 

--- a/core/src/main/java/io/grpc/AbstractChannelBuilder.java
+++ b/core/src/main/java/io/grpc/AbstractChannelBuilder.java
@@ -75,7 +75,8 @@ public abstract class AbstractChannelBuilder<BuilderT extends AbstractChannelBui
 
   @Nullable
   private ExecutorService userExecutor;
-  private final List<ClientInterceptor> interceptors = new ArrayList<ClientInterceptor>();
+  private final List<ClientInterceptor> interceptors =
+          new ArrayList<ClientInterceptor>();
 
   @Nullable
   private String userAgent;
@@ -96,8 +97,8 @@ public abstract class AbstractChannelBuilder<BuilderT extends AbstractChannelBui
 
   /**
    * Adds interceptors that will be called before the channel performs its real work. This is
-   * functionally equivalent to using {@link ClientInterceptors#intercept(Channel, List)}, but while
-   * still having access to the original {@code ChannelImpl}.
+   * functionally equivalent to using {@link ClientInterceptors#intercept(ClientCallFactory, List)},
+   * but while still having access to the original {@code ChannelImpl}.
    */
   public final BuilderT intercept(List<ClientInterceptor> interceptors) {
     this.interceptors.addAll(interceptors);
@@ -106,8 +107,9 @@ public abstract class AbstractChannelBuilder<BuilderT extends AbstractChannelBui
 
   /**
    * Adds interceptors that will be called before the channel performs its real work. This is
-   * functionally equivalent to using {@link ClientInterceptors#intercept(Channel,
-   * ClientInterceptor...)}, but while still having access to the original {@code ChannelImpl}.
+   * functionally equivalent to using {@link ClientInterceptors#intercept(ClientCallFactory,
+   * ClientInterceptor...)}, but while still having access to the original
+   * {@code ChannelImpl}.
    */
   public final BuilderT intercept(ClientInterceptor... interceptors) {
     return intercept(Arrays.asList(interceptors));

--- a/core/src/main/java/io/grpc/AbstractChannelBuilder.java
+++ b/core/src/main/java/io/grpc/AbstractChannelBuilder.java
@@ -150,6 +150,7 @@ public abstract class AbstractChannelBuilder<BuilderT extends AbstractChannelBui
     final ChannelEssentials essentials = buildEssentials();
     ChannelImpl channel = new ChannelImpl(essentials.transportFactory, executor, userAgent,
         interceptors);
+    // TODO(nmittler): find a better way to do this that doesn't require ChannelImpl.
     channel.setTerminationRunnable(new Runnable() {
       @Override
       public void run() {

--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -31,8 +31,7 @@
 
 package io.grpc;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
+import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
 
 import io.grpc.ClientCallImpl.ClientTransportProvider;
 import io.grpc.Metadata.Headers;
@@ -42,7 +41,6 @@ import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransport.PingCallback;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ExperimentalApi;
-import io.grpc.internal.HttpUtil;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.internal.SharedResourceHolder;
 
@@ -51,9 +49,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -339,103 +335,6 @@ public final class ChannelImpl implements Channel {
       }
     }
   }
-
-  /**
-   * Intended for internal use only.
-   */
-  // TODO(johnbcoughlin) make this package private when we can do so with the tests.
-  @VisibleForTesting
-  public static final Metadata.Key<Long> TIMEOUT_KEY =
-      Metadata.Key.of(HttpUtil.TIMEOUT, new TimeoutMarshaller());
-
-  /**
-   * Marshals a microseconds representation of the timeout to and from a string representation,
-   * consisting of an ASCII decimal representation of a number with at most 8 digits, followed by a
-   * unit:
-   * u = microseconds
-   * m = milliseconds
-   * S = seconds
-   * M = minutes
-   * H = hours
-   *
-   * <p>The representation is greedy with respect to precision. That is, 2 seconds will be
-   * represented as `2000000u`.</p>
-   *
-   * <p>See <a href="https://github.com/grpc/grpc-common/blob/master/PROTOCOL-HTTP2.md#requests">the
-   * request header definition</a></p>
-   */
-  @VisibleForTesting
-  static class TimeoutMarshaller implements Metadata.AsciiMarshaller<Long> {
-    @Override
-    public String toAsciiString(Long timeoutMicros) {
-      Preconditions.checkArgument(timeoutMicros >= 0, "Negative timeout");
-      long timeout;
-      String timeoutUnit;
-      // the smallest integer with 9 digits
-      int cutoff = 100000000;
-      if (timeoutMicros < cutoff) {
-        timeout = timeoutMicros;
-        timeoutUnit = "u";
-      } else if (timeoutMicros / 1000 < cutoff) {
-        timeout = timeoutMicros / 1000;
-        timeoutUnit = "m";
-      } else if (timeoutMicros / (1000 * 1000) < cutoff) {
-        timeout = timeoutMicros / (1000 * 1000);
-        timeoutUnit = "S";
-      } else if (timeoutMicros / (60 * 1000 * 1000) < cutoff) {
-        timeout = timeoutMicros / (60 * 1000 * 1000);
-        timeoutUnit = "M";
-      } else if (timeoutMicros / (60L * 60L * 1000L * 1000L) < cutoff) {
-        timeout = timeoutMicros / (60L * 60L * 1000L * 1000L);
-        timeoutUnit = "H";
-      } else {
-        throw new IllegalArgumentException("Timeout too large");
-      }
-      return Long.toString(timeout) + timeoutUnit;
-    }
-
-    @Override
-    public Long parseAsciiString(String serialized) {
-      String valuePart = serialized.substring(0, serialized.length() - 1);
-      char unit = serialized.charAt(serialized.length() - 1);
-      long factor;
-      switch (unit) {
-        case 'u':
-          factor = 1; break;
-        case 'm':
-          factor = 1000L; break;
-        case 'S':
-          factor = 1000L * 1000L; break;
-        case 'M':
-          factor = 60L * 1000L * 1000L; break;
-        case 'H':
-          factor = 60L * 60L * 1000L * 1000L; break;
-        default:
-          throw new IllegalArgumentException(String.format("Invalid timeout unit: %s", unit));
-      }
-      return Long.parseLong(valuePart) * factor;
-    }
-  }
-
-  static final SharedResourceHolder.Resource<ScheduledExecutorService> TIMER_SERVICE =
-      new SharedResourceHolder.Resource<ScheduledExecutorService>() {
-        @Override
-        public ScheduledExecutorService create() {
-          return Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-              Thread thread = new Thread(r);
-              thread.setDaemon(true);
-              return thread;
-            }
-          });
-        }
-
-        @Override
-        public void close(ScheduledExecutorService instance) {
-          instance.shutdown();
-        }
-      };
 
   private static final class InactiveTransport implements ClientTransport {
     private final Status shutdownStatus;

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -36,7 +36,7 @@ package io.grpc;
  * request messages to the server and receive zero or more response messages back.
  *
  * <p>Instances are created
- * by a {@link Channel} and used by stubs to invoke their remote behavior.
+ * by a {@link ClientCallFactory} and used by stubs to invoke their remote behavior.
  *
  * <p>More advanced usages may consume this interface directly as opposed to using a stub. Common
  * reasons for doing so would be the need to interact with flow-control or when acting as a generic

--- a/core/src/main/java/io/grpc/ClientCallFactory.java
+++ b/core/src/main/java/io/grpc/ClientCallFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * Copyright 2014, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -34,13 +34,37 @@ package io.grpc;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Intercepts the creation of {@link ClientCall} instances, allowing modification of call behavior.
+ * A factory for manufacturing {@link ClientCall} instances.
  */
 @ThreadSafe
-public interface ClientInterceptor {
+public abstract class ClientCallFactory {
 
   /**
-   * Decorates the given {@link ClientCallFactory} with logic provided by this interceptor.
+   * Create a {@link ClientCall} to the remote operation specified by the given
+   * {@link MethodDescriptor}, and with the default call options.
+   *
+   * @param method describes the name and parameter types of the operation to call.
+   * @return a {@link ClientCall} bound to the specified method.
+   * @deprecated use {@link #newCall(MethodDescriptor, CallOptions)}
+   *
    */
-  ClientCallFactory intercept(ClientCallFactory next);
+  @Deprecated
+  public final <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+      MethodDescriptor<RequestT, ResponseT> method) {
+    return newCall(method, CallOptions.DEFAULT);
+  }
+
+  /**
+   * Create a {@link ClientCall} to the remote operation specified by the given
+   * {@link MethodDescriptor}. The returned {@link ClientCall} does not trigger any remote
+   * behavior until {@link ClientCall#start(ClientCall.Listener, Metadata.Headers)} is
+   * invoked.
+   *
+   * @param method describes the name and parameter types of the operation to call.
+   * @param callOptions runtime options to be applied to this call.
+   * @return a {@link ClientCall} bound to the specified method.
+   *
+   */
+  public abstract <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+      MethodDescriptor<RequestT, ResponseT> method, CallOptions callOptions);
 }

--- a/core/src/main/java/io/grpc/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/ClientCallImpl.java
@@ -31,7 +31,7 @@
 
 package io.grpc;
 
-import static io.grpc.ChannelImpl.TIMEOUT_KEY;
+import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -40,7 +40,7 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SerializingExecutor;
 
 import java.io.InputStream;
@@ -123,9 +123,9 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     }
 
     // Fill out the User-Agent header.
-    headers.removeAll(HttpUtil.USER_AGENT_KEY);
+    headers.removeAll(GrpcUtil.USER_AGENT_KEY);
     if (userAgent != null) {
-      headers.put(HttpUtil.USER_AGENT_KEY, userAgent);
+      headers.put(GrpcUtil.USER_AGENT_KEY, userAgent);
     }
 
     try {

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * Description of a remote method used by {@link Channel} to initiate a call.
+ * Description of a remote method used by {@link ClientCallFactory} to initiate a call.
  *
  * <p>Provides the name of the operation to execute as well as {@link Marshaller} instances
  * used to parse and serialize request and response messages.

--- a/core/src/main/java/io/grpc/ServerImpl.java
+++ b/core/src/main/java/io/grpc/ServerImpl.java
@@ -31,12 +31,13 @@
 
 package io.grpc;
 
-import static io.grpc.ChannelImpl.TIMER_SERVICE;
+import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
 
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerStream;
@@ -327,7 +328,7 @@ public final class ServerImpl extends Server {
     }
 
     private Future<?> scheduleTimeout(final ServerStream stream, Metadata.Headers headers) {
-      Long timeoutMicros = headers.get(ChannelImpl.TIMEOUT_KEY);
+      Long timeoutMicros = headers.get(GrpcUtil.TIMEOUT_KEY);
       if (timeoutMicros == null) {
         return DEFAULT_TIMEOUT_FUTURE;
       }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -31,17 +31,29 @@
 
 package io.grpc.internal;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
 import io.grpc.Metadata;
 import io.grpc.Status;
 
 import java.net.HttpURLConnection;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 
 import javax.annotation.Nullable;
 
 /**
- * Constants for GRPC-over-HTTP (or HTTP/2).
+ * Common utilities for GRPC.
  */
-public final class HttpUtil {
+public final class GrpcUtil {
+
+  /**
+   * {@link io.grpc.Metadata.Key} for the timeout header.
+   */
+  public static final Metadata.Key<Long> TIMEOUT_KEY =
+          Metadata.Key.of(GrpcUtil.TIMEOUT, new TimeoutMarshaller());
 
   /**
    * {@link io.grpc.Metadata.Key} for the Content-Type request/response header.
@@ -74,6 +86,98 @@ public final class HttpUtil {
    * The Timeout header name.
    */
   public static final String TIMEOUT = "grpc-timeout";
+
+  /**
+   * Shared executor for managing deadline.
+   */
+  public static final SharedResourceHolder.Resource<ScheduledExecutorService> TIMER_SERVICE =
+      new SharedResourceHolder.Resource<ScheduledExecutorService>() {
+        @Override
+        public ScheduledExecutorService create() {
+          return Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setDaemon(true);
+                return thread;
+              }
+            });
+        }
+
+        @Override
+        public void close(ScheduledExecutorService instance) {
+          instance.shutdown();
+        }
+      };
+
+  /**
+   * Marshals a microseconds representation of the timeout to and from a string representation,
+   * consisting of an ASCII decimal representation of a number with at most 8 digits, followed by a
+   * unit:
+   * u = microseconds
+   * m = milliseconds
+   * S = seconds
+   * M = minutes
+   * H = hours
+   *
+   * <p>The representation is greedy with respect to precision. That is, 2 seconds will be
+   * represented as `2000000u`.</p>
+   *
+   * <p>See <a href="https://github.com/grpc/grpc-common/blob/master/PROTOCOL-HTTP2.md#requests">the
+   * request header definition</a></p>
+   */
+  @VisibleForTesting
+  static class TimeoutMarshaller implements Metadata.AsciiMarshaller<Long> {
+    @Override
+    public String toAsciiString(Long timeoutMicros) {
+      Preconditions.checkArgument(timeoutMicros >= 0, "Negative timeout");
+      long timeout;
+      String timeoutUnit;
+      // the smallest integer with 9 digits
+      int cutoff = 100000000;
+      if (timeoutMicros < cutoff) {
+        timeout = timeoutMicros;
+        timeoutUnit = "u";
+      } else if (timeoutMicros / 1000 < cutoff) {
+        timeout = timeoutMicros / 1000;
+        timeoutUnit = "m";
+      } else if (timeoutMicros / (1000 * 1000) < cutoff) {
+        timeout = timeoutMicros / (1000 * 1000);
+        timeoutUnit = "S";
+      } else if (timeoutMicros / (60 * 1000 * 1000) < cutoff) {
+        timeout = timeoutMicros / (60 * 1000 * 1000);
+        timeoutUnit = "M";
+      } else if (timeoutMicros / (60L * 60L * 1000L * 1000L) < cutoff) {
+        timeout = timeoutMicros / (60L * 60L * 1000L * 1000L);
+        timeoutUnit = "H";
+      } else {
+        throw new IllegalArgumentException("Timeout too large");
+      }
+      return Long.toString(timeout) + timeoutUnit;
+    }
+
+    @Override
+    public Long parseAsciiString(String serialized) {
+      String valuePart = serialized.substring(0, serialized.length() - 1);
+      char unit = serialized.charAt(serialized.length() - 1);
+      long factor;
+      switch (unit) {
+        case 'u':
+          factor = 1; break;
+        case 'm':
+          factor = 1000L; break;
+        case 'S':
+          factor = 1000L * 1000L; break;
+        case 'M':
+          factor = 60L * 1000L * 1000L; break;
+        case 'H':
+          factor = 60L * 60L * 1000L * 1000L; break;
+        default:
+          throw new IllegalArgumentException(String.format("Invalid timeout unit: %s", unit));
+      }
+      return Long.parseLong(valuePart) * factor;
+    }
+  }
 
   /**
    * Maps HTTP error response status codes to transport codes.
@@ -199,7 +303,7 @@ public final class HttpUtil {
   public static String getGrpcUserAgent(String transportName,
                                         @Nullable String applicationUserAgent) {
     StringBuilder builder = new StringBuilder("grpc-java-").append(transportName);
-    String version = HttpUtil.class.getPackage().getImplementationVersion();
+    String version = GrpcUtil.class.getPackage().getImplementationVersion();
     if (version != null) {
       builder.append("/");
       builder.append(version);
@@ -211,5 +315,5 @@ public final class HttpUtil {
     return builder.toString();
   }
 
-  private HttpUtil() {}
+  private GrpcUtil() {}
 }

--- a/core/src/main/java/io/grpc/internal/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStream.java
@@ -166,7 +166,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
   private static Status statusFromHttpStatus(Metadata metadata) {
     Integer httpStatus = metadata.get(HTTP2_STATUS);
     if (httpStatus != null) {
-      Status status = HttpUtil.httpStatusToGrpcStatus(httpStatus);
+      Status status = GrpcUtil.httpStatusToGrpcStatus(httpStatus);
       return status.isOk() ? status
           : status.augmentDescription("extracted status from HTTP :status " + httpStatus);
     }
@@ -204,8 +204,8 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
       return null;
     }
     contentTypeChecked = true;
-    String contentType = headers.get(HttpUtil.CONTENT_TYPE_KEY);
-    if (TEMP_CHECK_CONTENT_TYPE && !HttpUtil.CONTENT_TYPE_GRPC.equalsIgnoreCase(contentType)) {
+    String contentType = headers.get(GrpcUtil.CONTENT_TYPE_KEY);
+    if (TEMP_CHECK_CONTENT_TYPE && !GrpcUtil.CONTENT_TYPE_GRPC.equalsIgnoreCase(contentType)) {
       // Malformed content-type so report an error
       return Status.INTERNAL.withDescription("invalid content-type " + contentType);
     }
@@ -216,7 +216,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
    * Inspect the raw metadata and figure out what charset is being used.
    */
   private static Charset extractCharset(Metadata headers) {
-    String contentType = headers.get(HttpUtil.CONTENT_TYPE_KEY);
+    String contentType = headers.get(GrpcUtil.CONTENT_TYPE_KEY);
     if (contentType != null) {
       String[] split = contentType.split("charset=");
       try {

--- a/core/src/test/java/io/grpc/ChannelImplTest.java
+++ b/core/src/test/java/io/grpc/ChannelImplTest.java
@@ -110,28 +110,6 @@ public class ChannelImplTest {
   }
 
   @Test
-  public void timeoutTest() {
-    ChannelImpl.TimeoutMarshaller marshaller =
-        new ChannelImpl.TimeoutMarshaller();
-    assertEquals("1000u", marshaller.toAsciiString(1000L));
-    assertEquals(1000L, (long) marshaller.parseAsciiString("1000u"));
-
-    assertEquals("100000m", marshaller.toAsciiString(100000000L));
-    assertEquals(100000000L, (long) marshaller.parseAsciiString("100000m"));
-
-    assertEquals("100000S", marshaller.toAsciiString(100000000000L));
-    assertEquals(100000000000L, (long) marshaller.parseAsciiString("100000S"));
-
-    // 1,666,667 * 60 has 9 digits
-    assertEquals("1666666M", marshaller.toAsciiString(100000000000000L));
-    assertEquals(60000000000000L, (long) marshaller.parseAsciiString("1000000M"));
-
-    // 1,666,667 * 60 has 9 digits
-    assertEquals("1666666H", marshaller.toAsciiString(6000000000000000L));
-    assertEquals(3600000000000000L, (long) marshaller.parseAsciiString("1000000H"));
-  }
-
-  @Test
   public void immediateDeadlineExceeded() {
     ClientCall<String, Integer> call =
         channel.callFactory().newCall(method,

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -31,19 +31,20 @@
 
 package io.grpc.internal;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import io.grpc.Status;
-import io.grpc.internal.HttpUtil.Http2Error;
+import io.grpc.internal.GrpcUtil.Http2Error;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link HttpUtil}. */
+/** Unit tests for {@link GrpcUtil}. */
 @RunWith(JUnit4.class)
-public class HttpUtilTest {
+public class GrpcUtilTest {
   @Test
   public void http2ErrorForCode() {
     // Try edge cases manually, to make the test obviously correct for important cases.
@@ -72,5 +73,26 @@ public class HttpUtilTest {
     assertSame(Http2Error.NO_ERROR.status(), Http2Error.statusForCode(0));
     assertSame(Http2Error.HTTP_1_1_REQUIRED.status(), Http2Error.statusForCode(0xD));
     assertSame(Status.Code.INTERNAL, Http2Error.statusForCode(0xD + 1).getCode());
+  }
+
+  @Test
+  public void timeoutMarshallerTest() {
+    GrpcUtil.TimeoutMarshaller marshaller = new GrpcUtil.TimeoutMarshaller();
+    assertEquals("1000u", marshaller.toAsciiString(1000L));
+    assertEquals(1000L, (long) marshaller.parseAsciiString("1000u"));
+
+    assertEquals("100000m", marshaller.toAsciiString(100000000L));
+    assertEquals(100000000L, (long) marshaller.parseAsciiString("100000m"));
+
+    assertEquals("100000S", marshaller.toAsciiString(100000000000L));
+    assertEquals(100000000000L, (long) marshaller.parseAsciiString("100000S"));
+
+    // 1,666,667 * 60 has 9 digits
+    assertEquals("1666666M", marshaller.toAsciiString(100000000000000L));
+    assertEquals(60000000000000L, (long) marshaller.parseAsciiString("1000000M"));
+
+    // 1,666,667 * 60 has 9 digits
+    assertEquals("1666666H", marshaller.toAsciiString(6000000000000000L));
+    assertEquals(3600000000000000L, (long) marshaller.parseAsciiString("1000000H"));
   }
 }

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -24,18 +24,18 @@ public class GreeterGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloResponse.parser()));
 
-  public static GreeterStub newStub(io.grpc.Channel channel) {
-    return new GreeterStub(channel);
+  public static GreeterStub newStub(io.grpc.ClientCallFactory callFactory) {
+    return new GreeterStub(callFactory);
   }
 
   public static GreeterBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
-    return new GreeterBlockingStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new GreeterBlockingStub(callFactory);
   }
 
   public static GreeterFutureStub newFutureStub(
-      io.grpc.Channel channel) {
-    return new GreeterFutureStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new GreeterFutureStub(callFactory);
   }
 
   public static interface Greeter {
@@ -57,75 +57,75 @@ public class GreeterGrpc {
 
   public static class GreeterStub extends io.grpc.stub.AbstractStub<GreeterStub>
       implements Greeter {
-    private GreeterStub(io.grpc.Channel channel) {
-      super(channel);
+    private GreeterStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private GreeterStub(io.grpc.Channel channel,
+    private GreeterStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected GreeterStub build(io.grpc.Channel channel,
+    protected GreeterStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new GreeterStub(channel, callOptions);
+      return new GreeterStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public void sayHello(io.grpc.examples.helloworld.HelloRequest request,
         io.grpc.stub.StreamObserver<io.grpc.examples.helloworld.HelloResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(METHOD_SAY_HELLO, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_SAY_HELLO, callOptions), request, responseObserver);
     }
   }
 
   public static class GreeterBlockingStub extends io.grpc.stub.AbstractStub<GreeterBlockingStub>
       implements GreeterBlockingClient {
-    private GreeterBlockingStub(io.grpc.Channel channel) {
-      super(channel);
+    private GreeterBlockingStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private GreeterBlockingStub(io.grpc.Channel channel,
+    private GreeterBlockingStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected GreeterBlockingStub build(io.grpc.Channel channel,
+    protected GreeterBlockingStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new GreeterBlockingStub(channel, callOptions);
+      return new GreeterBlockingStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.examples.helloworld.HelloResponse sayHello(io.grpc.examples.helloworld.HelloRequest request) {
       return blockingUnaryCall(
-          channel.newCall(METHOD_SAY_HELLO, callOptions), request);
+          callFactory.newCall(METHOD_SAY_HELLO, callOptions), request);
     }
   }
 
   public static class GreeterFutureStub extends io.grpc.stub.AbstractStub<GreeterFutureStub>
       implements GreeterFutureClient {
-    private GreeterFutureStub(io.grpc.Channel channel) {
-      super(channel);
+    private GreeterFutureStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private GreeterFutureStub(io.grpc.Channel channel,
+    private GreeterFutureStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected GreeterFutureStub build(io.grpc.Channel channel,
+    protected GreeterFutureStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new GreeterFutureStub(channel, callOptions);
+      return new GreeterFutureStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.helloworld.HelloResponse> sayHello(
         io.grpc.examples.helloworld.HelloRequest request) {
       return futureUnaryCall(
-          channel.newCall(METHOD_SAY_HELLO, callOptions), request);
+          callFactory.newCall(METHOD_SAY_HELLO, callOptions), request);
     }
   }
 

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -45,18 +45,18 @@ public class RouteGuideGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.parser()));
 
-  public static RouteGuideStub newStub(io.grpc.Channel channel) {
-    return new RouteGuideStub(channel);
+  public static RouteGuideStub newStub(io.grpc.ClientCallFactory callFactory) {
+    return new RouteGuideStub(callFactory);
   }
 
   public static RouteGuideBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
-    return new RouteGuideBlockingStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new RouteGuideBlockingStub(callFactory);
   }
 
   public static RouteGuideFutureStub newFutureStub(
-      io.grpc.Channel channel) {
-    return new RouteGuideFutureStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new RouteGuideFutureStub(callFactory);
   }
 
   public static interface RouteGuide {
@@ -90,103 +90,103 @@ public class RouteGuideGrpc {
 
   public static class RouteGuideStub extends io.grpc.stub.AbstractStub<RouteGuideStub>
       implements RouteGuide {
-    private RouteGuideStub(io.grpc.Channel channel) {
-      super(channel);
+    private RouteGuideStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private RouteGuideStub(io.grpc.Channel channel,
+    private RouteGuideStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected RouteGuideStub build(io.grpc.Channel channel,
+    protected RouteGuideStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new RouteGuideStub(channel, callOptions);
+      return new RouteGuideStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public void getFeature(io.grpc.examples.routeguide.Point request,
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(METHOD_GET_FEATURE, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_GET_FEATURE, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void listFeatures(io.grpc.examples.routeguide.Rectangle request,
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
       asyncServerStreamingCall(
-          channel.newCall(METHOD_LIST_FEATURES, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_LIST_FEATURES, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Point> recordRoute(
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteSummary> responseObserver) {
       return asyncClientStreamingCall(
-          channel.newCall(METHOD_RECORD_ROUTE, callOptions), responseObserver);
+          callFactory.newCall(METHOD_RECORD_ROUTE, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> routeChat(
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_ROUTE_CHAT, callOptions), responseObserver);
+          callFactory.newCall(METHOD_ROUTE_CHAT, callOptions), responseObserver);
     }
   }
 
   public static class RouteGuideBlockingStub extends io.grpc.stub.AbstractStub<RouteGuideBlockingStub>
       implements RouteGuideBlockingClient {
-    private RouteGuideBlockingStub(io.grpc.Channel channel) {
-      super(channel);
+    private RouteGuideBlockingStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private RouteGuideBlockingStub(io.grpc.Channel channel,
+    private RouteGuideBlockingStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected RouteGuideBlockingStub build(io.grpc.Channel channel,
+    protected RouteGuideBlockingStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new RouteGuideBlockingStub(channel, callOptions);
+      return new RouteGuideBlockingStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public io.grpc.examples.routeguide.Feature getFeature(io.grpc.examples.routeguide.Point request) {
       return blockingUnaryCall(
-          channel.newCall(METHOD_GET_FEATURE, callOptions), request);
+          callFactory.newCall(METHOD_GET_FEATURE, callOptions), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.examples.routeguide.Feature> listFeatures(
         io.grpc.examples.routeguide.Rectangle request) {
       return blockingServerStreamingCall(
-          channel.newCall(METHOD_LIST_FEATURES, callOptions), request);
+          callFactory.newCall(METHOD_LIST_FEATURES, callOptions), request);
     }
   }
 
   public static class RouteGuideFutureStub extends io.grpc.stub.AbstractStub<RouteGuideFutureStub>
       implements RouteGuideFutureClient {
-    private RouteGuideFutureStub(io.grpc.Channel channel) {
-      super(channel);
+    private RouteGuideFutureStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private RouteGuideFutureStub(io.grpc.Channel channel,
+    private RouteGuideFutureStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected RouteGuideFutureStub build(io.grpc.Channel channel,
+    protected RouteGuideFutureStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new RouteGuideFutureStub(channel, callOptions);
+      return new RouteGuideFutureStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.routeguide.Feature> getFeature(
         io.grpc.examples.routeguide.Point request) {
       return futureUnaryCall(
-          channel.newCall(METHOD_GET_FEATURE, callOptions), request);
+          callFactory.newCall(METHOD_GET_FEATURE, callOptions), request);
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderClient.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderClient.java
@@ -31,7 +31,7 @@
 
 package io.grpc.examples.header;
 
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.ClientCallFactory;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
 public class CustomHeaderClient {
   private static final Logger logger = Logger.getLogger(CustomHeaderClient.class.getName());
 
-  private final ChannelImpl originChannel;
+  private final Channel originChannel;
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
   /**

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderClient.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderClient.java
@@ -31,8 +31,8 @@
 
 package io.grpc.examples.header;
 
-import io.grpc.Channel;
 import io.grpc.ChannelImpl;
+import io.grpc.ClientCallFactory;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.examples.helloworld.GreeterGrpc;
@@ -63,8 +63,9 @@ public class CustomHeaderClient {
             NettyChannelBuilder.forAddress(host, port).negotiationType(NegotiationType.PLAINTEXT)
                     .build();
     ClientInterceptor interceptor = new HeaderClientInterceptor();
-    Channel channel = ClientInterceptors.intercept(originChannel, interceptor);
-    blockingStub = GreeterGrpc.newBlockingStub(channel);
+    ClientCallFactory callFactory = ClientInterceptors.intercept(originChannel.callFactory(),
+            interceptor);
+    blockingStub = GreeterGrpc.newBlockingStub(callFactory);
   }
 
   private void shutdown() throws InterruptedException {

--- a/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
+++ b/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
@@ -32,8 +32,8 @@
 package io.grpc.examples.header;
 
 import io.grpc.CallOptions;
-import io.grpc.Channel;
 import io.grpc.ClientCall;
+import io.grpc.ClientCallFactory;
 import io.grpc.ClientInterceptor;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
@@ -43,36 +43,43 @@ import io.grpc.MethodDescriptor;
 import java.util.logging.Logger;
 
 /**
- * A interceptor to handle client header.
+ * A factory for client-side call interceptors to handle client header.
  */
 public class HeaderClientInterceptor implements ClientInterceptor {
 
-  private static final Logger logger = Logger.getLogger(HeaderClientInterceptor.class.getName());
+  private static final Logger logger = Logger.getLogger(
+          HeaderClientInterceptor.class.getName());
 
   private static Metadata.Key<String> customHeadKey =
       Metadata.Key.of("custom_client_header_key", Metadata.ASCII_STRING_MARSHALLER);
 
   @Override
-  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
-      CallOptions callOptions, Channel next) {
-    return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
-
+  public ClientCallFactory intercept(final ClientCallFactory next) {
+    return new ClientCallFactory() {
       @Override
-      public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
-        /* put custom header */
-        headers.put(customHeadKey, "customRequestValue");
-        super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
+      public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+              MethodDescriptor<ReqT, RespT> method,
+              CallOptions callOptions) {
+        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+
           @Override
-          public void onHeaders(Metadata.Headers headers) {
-            /**
-             * if you don't need receive header from server,
-             * you can use {@link io.grpc.stub.MetadataUtils attachHeaders}
-             * directly to send header
-             */
-            logger.info("header received from server:" + headers.toString());
-            super.onHeaders(headers);
+          public void start(Listener<RespT> responseListener, Metadata.Headers headers) {
+            /* put custom header */
+            headers.put(customHeadKey, "customRequestValue");
+            super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
+              @Override
+              public void onHeaders(Metadata.Headers headers) {
+                /**
+                 * if you don't need receive header from server,
+                 * you can use {@link io.grpc.stub.MetadataUtils attachHeaders}
+                 * directly to send header
+                 */
+                logger.info("header received from server:" + headers.toString());
+                super.onHeaders(headers);
+              }
+            }, headers);
           }
-        }, headers);
+        };
       }
     };
   }

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
@@ -31,7 +31,7 @@
 
 package io.grpc.examples.helloworld;
 
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
 public class HelloWorldClient {
   private static final Logger logger = Logger.getLogger(HelloWorldClient.class.getName());
 
-  private final ChannelImpl channel;
+  private final Channel channel;
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
   /** Construct client connecting to HelloWorld server at {@code host:port}. */
@@ -69,7 +69,6 @@ public class HelloWorldClient {
       logger.info("Greeting: " + response.getMessage());
     } catch (RuntimeException e) {
       logger.log(Level.WARNING, "RPC failed", e);
-      return;
     }
   }
 

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
@@ -53,7 +53,7 @@ public class HelloWorldClient {
     channel =
         NettyChannelBuilder.forAddress(host, port).negotiationType(NegotiationType.PLAINTEXT)
             .build();
-    blockingStub = GreeterGrpc.newBlockingStub(channel);
+    blockingStub = GreeterGrpc.newBlockingStub(channel.callFactory());
   }
 
   public void shutdown() throws InterruptedException {

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
@@ -33,7 +33,7 @@ package io.grpc.examples.routeguide;
 
 import com.google.common.util.concurrent.SettableFuture;
 
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.examples.routeguide.RouteGuideGrpc.RouteGuideBlockingStub;
 import io.grpc.examples.routeguide.RouteGuideGrpc.RouteGuideStub;
 import io.grpc.netty.NegotiationType;
@@ -53,7 +53,7 @@ import java.util.logging.Logger;
 public class RouteGuideClient {
   private static final Logger logger = Logger.getLogger(RouteGuideClient.class.getName());
 
-  private final ChannelImpl channel;
+  private final Channel channel;
   private final RouteGuideBlockingStub blockingStub;
   private final RouteGuideStub asyncStub;
 

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
@@ -62,8 +62,8 @@ public class RouteGuideClient {
     channel = NettyChannelBuilder.forAddress(host, port)
         .negotiationType(NegotiationType.PLAINTEXT)
         .build();
-    blockingStub = RouteGuideGrpc.newBlockingStub(channel);
-    asyncStub = RouteGuideGrpc.newStub(channel);
+    blockingStub = RouteGuideGrpc.newBlockingStub(channel.callFactory());
+    asyncStub = RouteGuideGrpc.newStub(channel.callFactory());
   }
 
   public void shutdown() throws InterruptedException {

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -59,18 +59,18 @@ public class TestServiceGrpc {
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
 
-  public static TestServiceStub newStub(io.grpc.Channel channel) {
-    return new TestServiceStub(channel);
+  public static TestServiceStub newStub(io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceStub(callFactory);
   }
 
   public static TestServiceBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
-    return new TestServiceBlockingStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceBlockingStub(callFactory);
   }
 
   public static TestServiceFutureStub newFutureStub(
-      io.grpc.Channel channel) {
-    return new TestServiceFutureStub(channel);
+      io.grpc.ClientCallFactory callFactory) {
+    return new TestServiceFutureStub(callFactory);
   }
 
   public static interface TestService {
@@ -115,130 +115,130 @@ public class TestServiceGrpc {
 
   public static class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub>
       implements TestService {
-    private TestServiceStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceStub(io.grpc.Channel channel,
+    private TestServiceStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceStub build(io.grpc.Channel channel,
+    protected TestServiceStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceStub(channel, callOptions);
+      return new TestServiceStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(METHOD_EMPTY_CALL, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_EMPTY_CALL, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public void streamingOutputCall(io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          channel.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request, responseObserver);
+          callFactory.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request, responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          channel.newCall(METHOD_STREAMING_INPUT_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_STREAMING_INPUT_CALL, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_FULL_DUPLEX_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_FULL_DUPLEX_CALL, callOptions), responseObserver);
     }
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          channel.newCall(METHOD_HALF_DUPLEX_CALL, callOptions), responseObserver);
+          callFactory.newCall(METHOD_HALF_DUPLEX_CALL, callOptions), responseObserver);
     }
   }
 
   public static class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub>
       implements TestServiceBlockingClient {
-    private TestServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceBlockingStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceBlockingStub(io.grpc.Channel channel,
+    private TestServiceBlockingStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceBlockingStub build(io.grpc.Channel channel,
+    protected TestServiceBlockingStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceBlockingStub(channel, callOptions);
+      return new TestServiceBlockingStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public com.google.protobuf.EmptyProtos.Empty emptyCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          channel.newCall(METHOD_EMPTY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_EMPTY_CALL, callOptions), request);
     }
 
     @java.lang.Override
     public io.grpc.testing.integration.Messages.SimpleResponse unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request) {
       return blockingUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Messages.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          channel.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request);
+          callFactory.newCall(METHOD_STREAMING_OUTPUT_CALL, callOptions), request);
     }
   }
 
   public static class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub>
       implements TestServiceFutureClient {
-    private TestServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
+    private TestServiceFutureStub(io.grpc.ClientCallFactory callFactory) {
+      super(callFactory);
     }
 
-    private TestServiceFutureStub(io.grpc.Channel channel,
+    private TestServiceFutureStub(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      super(channel, callOptions);
+      super(callFactory, callOptions);
     }
 
     @java.lang.Override
-    protected TestServiceFutureStub build(io.grpc.Channel channel,
+    protected TestServiceFutureStub build(io.grpc.ClientCallFactory callFactory,
         io.grpc.CallOptions callOptions) {
-      return new TestServiceFutureStub(channel, callOptions);
+      return new TestServiceFutureStub(callFactory, callOptions);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> emptyCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          channel.newCall(METHOD_EMPTY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_EMPTY_CALL, callOptions), request);
     }
 
     @java.lang.Override
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Messages.SimpleRequest request) {
       return futureUnaryCall(
-          channel.newCall(METHOD_UNARY_CALL, callOptions), request);
+          callFactory.newCall(METHOD_UNARY_CALL, callOptions), request);
     }
   }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -51,13 +51,14 @@ import com.google.protobuf.EmptyProtos.Empty;
 
 import io.grpc.AbstractServerBuilder;
 import io.grpc.CallOptions;
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.ServerImpl;
 import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.auth.ClientAuthInterceptor;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.protobuf.ProtoUtils;
 import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
@@ -121,7 +122,7 @@ public abstract class AbstractTransportTest {
     testServiceExecutor.shutdown();
   }
 
-  protected ChannelImpl channel;
+  protected Channel channel;
   protected TestServiceGrpc.TestServiceBlockingStub blockingStub;
   protected TestServiceGrpc.TestService asyncStub;
 
@@ -144,7 +145,7 @@ public abstract class AbstractTransportTest {
     }
   }
 
-  protected abstract ChannelImpl createChannel();
+  protected abstract Channel createChannel();
 
   @Test(timeout = 10000)
   public void emptyUnary() throws Exception {
@@ -588,7 +589,7 @@ public abstract class AbstractTransportTest {
                     .withDeadlineAfter(configuredTimeoutMinutes, TimeUnit.MINUTES);
     stub.emptyCall(Empty.getDefaultInstance());
     long transferredTimeoutMinutes = TimeUnit.MICROSECONDS.toMinutes(
-        requestHeadersCapture.get().get(ChannelImpl.TIMEOUT_KEY));
+        requestHeadersCapture.get().get(GrpcUtil.TIMEOUT_KEY));
     Assert.assertTrue(
             "configuredTimeoutMinutes=" + configuredTimeoutMinutes
                     + ", transferredTimeoutMinutes=" + transferredTimeoutMinutes,

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -33,12 +33,13 @@ package io.grpc.testing.integration;
 
 import com.google.common.io.Files;
 
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import io.grpc.testing.TestUtils;
+
 import io.netty.handler.ssl.SslContext;
 
 import java.io.File;
@@ -228,7 +229,7 @@ public class TestServiceClient {
 
   private class Tester extends AbstractTransportTest {
     @Override
-    protected ChannelImpl createChannel() {
+    protected Channel createChannel() {
       if (!useOkHttp) {
         InetAddress address;
         try {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -31,10 +31,11 @@
 
 package io.grpc.testing.integration;
 
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
+
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
@@ -67,7 +68,7 @@ public class Http2NettyLocalChannelTest extends AbstractTransportTest {
   }
 
   @Override
-  protected ChannelImpl createChannel() {
+  protected Channel createChannel() {
     return NettyChannelBuilder
         .forAddress(new LocalAddress("in-process-1"))
         .negotiationType(NegotiationType.PLAINTEXT)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -31,11 +31,12 @@
 
 package io.grpc.testing.integration;
 
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.testing.TestUtils;
+
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 import org.junit.AfterClass;
@@ -73,7 +74,7 @@ public class Http2NettyTest extends AbstractTransportTest {
   }
 
   @Override
-  protected ChannelImpl createChannel() {
+  protected Channel createChannel() {
     try {
       return NettyChannelBuilder
           .forAddress(TestUtils.testServerAddress(serverPort))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -34,11 +34,12 @@ package io.grpc.testing.integration;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.TlsVersion;
 
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import io.grpc.testing.TestUtils;
+
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 import org.junit.AfterClass;
@@ -75,7 +76,7 @@ public class Http2OkHttpTest extends AbstractTransportTest {
   }
 
   @Override
-  protected ChannelImpl createChannel() {
+  protected Channel createChannel() {
     OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("127.0.0.1", serverPort)
         .connectionSpec(new ConnectionSpec.Builder(OkHttpChannelBuilder.DEFAULT_CONNECTION_SPEC)
             .cipherSuites(TestUtils.preferredTestCiphers().toArray(new String[0]))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
@@ -31,7 +31,7 @@
 
 package io.grpc.testing.integration;
 
-import io.grpc.ChannelImpl;
+import io.grpc.Channel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 
@@ -40,7 +40,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link InProcess}. */
+/** Unit tests for {@link io.grpc.inprocess.InProcessTransport}. */
 @RunWith(JUnit4.class)
 public class InProcessTest extends AbstractTransportTest {
   private static String serverName = "test";
@@ -57,7 +57,7 @@ public class InProcessTest extends AbstractTransportTest {
   }
 
   @Override
-  protected ChannelImpl createChannel() {
+  protected Channel createChannel() {
     return InProcessChannelBuilder.forName(serverName).build();
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -42,8 +42,9 @@ import com.google.common.base.Ticker;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientTransport.PingCallback;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
-import io.grpc.internal.HttpUtil;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -215,7 +216,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
    */
   private void onRstStreamRead(int streamId, long errorCode) throws Http2Exception {
     NettyClientStream stream = clientStream(requireHttp2Stream(streamId));
-    Status status = HttpUtil.Http2Error.statusForCode((int) errorCode);
+    Status status = GrpcUtil.Http2Error.statusForCode((int) errorCode);
     stream.transportReportStatus(status, false, new Metadata.Trailers());
   }
 
@@ -435,7 +436,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
   }
 
   private Status statusFromGoAway(long errorCode, ByteBuf debugData) {
-    Status status = HttpUtil.Http2Error.statusForCode((int) errorCode);
+    Status status = GrpcUtil.Http2Error.statusForCode((int) errorCode);
     if (debugData.isReadable()) {
       // If a debug message was provided, use it.
       String msg = debugData.toString(UTF_8);

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -31,15 +31,15 @@
 
 package io.grpc.netty;
 
-import static io.grpc.internal.HttpUtil.CONTENT_TYPE_KEY;
-import static io.grpc.internal.HttpUtil.USER_AGENT_KEY;
+import static io.grpc.internal.GrpcUtil.CONTENT_TYPE_KEY;
+import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 import static io.netty.util.CharsetUtil.UTF_8;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.grpc.Metadata;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.internal.TransportFrameUtil;
 import io.netty.channel.EventLoopGroup;
@@ -62,15 +62,15 @@ import java.util.concurrent.TimeUnit;
 class Utils {
 
   public static final ByteString STATUS_OK = new ByteString("200".getBytes(UTF_8));
-  public static final ByteString HTTP_METHOD = new ByteString(HttpUtil.HTTP_METHOD.getBytes(UTF_8));
+  public static final ByteString HTTP_METHOD = new ByteString(GrpcUtil.HTTP_METHOD.getBytes(UTF_8));
   public static final ByteString HTTPS = new ByteString("https".getBytes(UTF_8));
   public static final ByteString HTTP = new ByteString("http".getBytes(UTF_8));
   public static final ByteString CONTENT_TYPE_HEADER = new ByteString(CONTENT_TYPE_KEY.name()
       .getBytes(UTF_8));
   public static final ByteString CONTENT_TYPE_GRPC = new ByteString(
-      HttpUtil.CONTENT_TYPE_GRPC.getBytes(UTF_8));
+      GrpcUtil.CONTENT_TYPE_GRPC.getBytes(UTF_8));
   public static final ByteString TE_HEADER = new ByteString("te".getBytes(UTF_8));
-  public static final ByteString TE_TRAILERS = new ByteString(HttpUtil.TE_TRAILERS.getBytes(UTF_8));
+  public static final ByteString TE_TRAILERS = new ByteString(GrpcUtil.TE_TRAILERS.getBytes(UTF_8));
   public static final ByteString USER_AGENT = new ByteString(USER_AGENT_KEY.name().getBytes(UTF_8));
 
   public static final Resource<EventLoopGroup> DEFAULT_BOSS_EVENT_LOOP_GROUP =
@@ -129,7 +129,7 @@ class Utils {
     }
 
     // Set the User-Agent header.
-    String userAgent = HttpUtil.getGrpcUserAgent("netty", headers.get(USER_AGENT_KEY));
+    String userAgent = GrpcUtil.getGrpcUserAgent("netty", headers.get(USER_AGENT_KEY));
     http2Headers.set(USER_AGENT, new ByteString(userAgent.getBytes(UTF_8)));
 
     return http2Headers;

--- a/netty/src/test/java/io/grpc/netty/BufferingHttp2ConnectionEncoderTest.java
+++ b/netty/src/test/java/io/grpc/netty/BufferingHttp2ConnectionEncoderTest.java
@@ -31,7 +31,7 @@
 
 package io.grpc.netty;
 
-import static io.grpc.internal.HttpUtil.Http2Error.CANCEL;
+import static io.grpc.internal.GrpcUtil.Http2Error.CANCEL;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_FRAME_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
 import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL;

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -32,7 +32,7 @@
 package io.grpc.netty;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static io.grpc.internal.HttpUtil.USER_AGENT_KEY;
+import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -48,7 +48,7 @@ import io.grpc.StatusException;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
@@ -130,7 +130,7 @@ public class NettyClientTransportTest {
     assertEquals(1, serverListener.streamListeners.size());
 
     Metadata.Headers headers = serverListener.streamListeners.get(0).headers;
-    assertEquals(HttpUtil.getGrpcUserAgent("netty", null), headers.get(USER_AGENT_KEY));
+    assertEquals(GrpcUtil.getGrpcUserAgent("netty", null), headers.get(USER_AGENT_KEY));
   }
 
   @Test
@@ -148,7 +148,7 @@ public class NettyClientTransportTest {
     // Verify that the received headers contained the User-Agent.
     assertEquals(1, serverListener.streamListeners.size());
     Metadata.Headers receivedHeaders = serverListener.streamListeners.get(0).headers;
-    assertEquals(HttpUtil.getGrpcUserAgent("netty", userAgent),
+    assertEquals(GrpcUtil.getGrpcUserAgent("netty", userAgent),
             receivedHeaders.get(USER_AGENT_KEY));
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/Headers.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Headers.java
@@ -31,15 +31,15 @@
 
 package io.grpc.okhttp;
 
-import static io.grpc.internal.HttpUtil.CONTENT_TYPE_KEY;
-import static io.grpc.internal.HttpUtil.USER_AGENT_KEY;
+import static io.grpc.internal.GrpcUtil.CONTENT_TYPE_KEY;
+import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 
 import com.google.common.base.Preconditions;
 
 import com.squareup.okhttp.internal.spdy.Header;
 
 import io.grpc.Metadata;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.TransportFrameUtil;
 
 import okio.ByteString;
@@ -53,10 +53,10 @@ import java.util.List;
 public class Headers {
 
   public static final Header SCHEME_HEADER = new Header(Header.TARGET_SCHEME, "https");
-  public static final Header METHOD_HEADER = new Header(Header.TARGET_METHOD, HttpUtil.HTTP_METHOD);
+  public static final Header METHOD_HEADER = new Header(Header.TARGET_METHOD, GrpcUtil.HTTP_METHOD);
   public static final Header CONTENT_TYPE_HEADER =
-      new Header(CONTENT_TYPE_KEY.name(), HttpUtil.CONTENT_TYPE_GRPC);
-  public static final Header TE_HEADER = new Header("te", HttpUtil.TE_TRAILERS);
+      new Header(CONTENT_TYPE_KEY.name(), GrpcUtil.CONTENT_TYPE_GRPC);
+  public static final Header TE_HEADER = new Header("te", GrpcUtil.TE_TRAILERS);
 
   /**
    * Serializes the given headers and creates a list of OkHttp {@link Header}s to be used when
@@ -79,8 +79,8 @@ public class Headers {
     String path = headers.getPath() != null ? headers.getPath() : defaultPath;
     okhttpHeaders.add(new Header(Header.TARGET_PATH, path));
 
-    String userAgent = HttpUtil.getGrpcUserAgent("okhttp", headers.get(USER_AGENT_KEY));
-    okhttpHeaders.add(new Header(HttpUtil.USER_AGENT_KEY.name(), userAgent));
+    String userAgent = GrpcUtil.getGrpcUserAgent("okhttp", headers.get(USER_AGENT_KEY));
+    okhttpHeaders.add(new Header(GrpcUtil.USER_AGENT_KEY.name(), userAgent));
 
     // All non-pseudo headers must come after pseudo headers.
     okhttpHeaders.add(CONTENT_TYPE_HEADER);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -58,8 +58,8 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
-import io.grpc.internal.HttpUtil;
 import io.grpc.internal.SerializingExecutor;
 
 import okio.Buffer;
@@ -720,7 +720,7 @@ class OkHttpClientTransport implements ClientTransport {
 
     @Override
     public void goAway(int lastGoodStreamId, ErrorCode errorCode, ByteString debugData) {
-      Status status = HttpUtil.Http2Error.statusForCode(errorCode.httpCode);
+      Status status = GrpcUtil.Http2Error.statusForCode(errorCode.httpCode);
       if (debugData != null && debugData.size() > 0) {
         // If a debug message was provided, use it.
         status.augmentDescription(debugData.utf8());

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -76,7 +76,7 @@ import io.grpc.StatusException;
 import io.grpc.internal.AbstractStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.okhttp.OkHttpClientTransport.ClientFrameHandler;
 
 import okio.Buffer;
@@ -315,8 +315,8 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     clientTransport.newStream(method, new Metadata.Headers(), listener);
-    Header userAgentHeader = new Header(HttpUtil.USER_AGENT_KEY.name(),
-            HttpUtil.getGrpcUserAgent("okhttp", null));
+    Header userAgentHeader = new Header(GrpcUtil.USER_AGENT_KEY.name(),
+            GrpcUtil.getGrpcUserAgent("okhttp", null));
     List<Header> expectedHeaders = Arrays.asList(SCHEME_HEADER, METHOD_HEADER,
             new Header(Header.TARGET_AUTHORITY, "notarealauthority:80"),
             new Header(Header.TARGET_PATH, "/fakemethod"),
@@ -332,13 +332,13 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener = new MockStreamListener();
     String userAgent = "fakeUserAgent";
     Metadata.Headers metadata = new Metadata.Headers();
-    metadata.put(HttpUtil.USER_AGENT_KEY, userAgent);
+    metadata.put(GrpcUtil.USER_AGENT_KEY, userAgent);
     clientTransport.newStream(method, metadata, listener);
     List<Header> expectedHeaders = Arrays.asList(SCHEME_HEADER, METHOD_HEADER,
         new Header(Header.TARGET_AUTHORITY, "notarealauthority:80"),
         new Header(Header.TARGET_PATH, "/fakemethod"),
-        new Header(HttpUtil.USER_AGENT_KEY.name(),
-            HttpUtil.getGrpcUserAgent("okhttp", userAgent)),
+        new Header(GrpcUtil.USER_AGENT_KEY.name(),
+            GrpcUtil.getGrpcUserAgent("okhttp", userAgent)),
         CONTENT_TYPE_HEADER, TE_HEADER);
     verify(frameWriter, timeout(TIME_OUT_MS))
         .synStream(eq(false), eq(false), eq(3), eq(0), eq(expectedHeaders));

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -55,7 +55,7 @@ public abstract class AbstractStub<S extends AbstractStub<?>> {
   /**
    * Constructor for use by subclasses, with the default {@code CallOptions}.
    *
-   * @param callFactory the channel that this stub will use to do communications
+   * @param callFactory the {@link ClientCallFactory} that this stub will use to do communications
    */
   protected AbstractStub(ClientCallFactory callFactory) {
     this(callFactory, CallOptions.DEFAULT);
@@ -64,7 +64,7 @@ public abstract class AbstractStub<S extends AbstractStub<?>> {
   /**
    * Constructor for use by subclasses, with the default {@code CallOptions}.
    *
-   * @param callFactory the channel that this stub will use to do communications
+   * @param callFactory the {@link ClientCallFactory} that this stub will use to do communications
    * @param callOptions the runtime call options to be applied to every call on this stub
    */
   protected AbstractStub(ClientCallFactory callFactory, CallOptions callOptions) {
@@ -87,9 +87,10 @@ public abstract class AbstractStub<S extends AbstractStub<?>> {
   }
 
   /**
-   * Returns a new stub with the given channel for the provided method configurations.
+   * Returns a new stub with the given {@link ClientCallFactory} for the provided method
+   * configurations.
    *
-   * @param callFactory the channel that this stub will use to do communications
+   * @param callFactory the {@link ClientCallFactory} that this stub will use to do communications
    * @param callOptions the runtime call options to be applied to every call on this stub
    */
   protected abstract S build(ClientCallFactory callFactory, CallOptions callOptions);
@@ -124,7 +125,8 @@ public abstract class AbstractStub<S extends AbstractStub<?>> {
   }
 
   /**
-   * Returns a new stub that has the given interceptors attached to the underlying channel.
+   * Returns a new stub that has the given interceptors attached to the underlying
+   * {@link ClientCallFactory}.
    */
   public final S withInterceptors(ClientInterceptor... interceptors) {
     return build(ClientInterceptors.intercept(callFactory, interceptors), callOptions);

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -73,9 +73,9 @@ public abstract class AbstractStub<S extends AbstractStub<?>> {
   }
 
   /**
-   * The underlying channel of the stub.
+   * The underlying {@link ClientCallFactory} of the stub.
    */
-  public ClientCallFactory getChannel() {
+  public ClientCallFactory getCallFactory() {
     return callFactory;
   }
 
@@ -117,9 +117,9 @@ public abstract class AbstractStub<S extends AbstractStub<?>> {
   }
 
   /**
-   * Returns a new stub that uses the given channel.
+   * Returns a new stub that uses the given {@link ClientCallFactory}.
    */
-  public final S withChannel(ClientCallFactory newCallFactory) {
+  public final S withCallFactory(ClientCallFactory newCallFactory) {
     return build(newCallFactory, callOptions);
   }
 

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -32,7 +32,7 @@
 package io.grpc.stub;
 
 import io.grpc.CallOptions;
-import io.grpc.Channel;
+import io.grpc.ClientCallFactory;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 
@@ -49,34 +49,34 @@ import javax.annotation.Nullable;
  * @param <S> the concrete type of this stub.
  */
 public abstract class AbstractStub<S extends AbstractStub<?>> {
-  protected final Channel channel;
+  protected final ClientCallFactory callFactory;
   protected final CallOptions callOptions;
 
   /**
    * Constructor for use by subclasses, with the default {@code CallOptions}.
    *
-   * @param channel the channel that this stub will use to do communications
+   * @param callFactory the channel that this stub will use to do communications
    */
-  protected AbstractStub(Channel channel) {
-    this(channel, CallOptions.DEFAULT);
+  protected AbstractStub(ClientCallFactory callFactory) {
+    this(callFactory, CallOptions.DEFAULT);
   }
 
   /**
    * Constructor for use by subclasses, with the default {@code CallOptions}.
    *
-   * @param channel the channel that this stub will use to do communications
+   * @param callFactory the channel that this stub will use to do communications
    * @param callOptions the runtime call options to be applied to every call on this stub
    */
-  protected AbstractStub(Channel channel, CallOptions callOptions) {
-    this.channel = channel;
+  protected AbstractStub(ClientCallFactory callFactory, CallOptions callOptions) {
+    this.callFactory = callFactory;
     this.callOptions = callOptions;
   }
 
   /**
    * The underlying channel of the stub.
    */
-  public Channel getChannel() {
-    return channel;
+  public ClientCallFactory getChannel() {
+    return callFactory;
   }
 
   /**
@@ -89,10 +89,10 @@ public abstract class AbstractStub<S extends AbstractStub<?>> {
   /**
    * Returns a new stub with the given channel for the provided method configurations.
    *
-   * @param channel the channel that this stub will use to do communications
+   * @param callFactory the channel that this stub will use to do communications
    * @param callOptions the runtime call options to be applied to every call on this stub
    */
-  protected abstract S build(Channel channel, CallOptions callOptions);
+  protected abstract S build(ClientCallFactory callFactory, CallOptions callOptions);
 
   /**
    * Returns a new stub with an absolute deadline in nanoseconds in the clock as per {@link
@@ -104,7 +104,7 @@ public abstract class AbstractStub<S extends AbstractStub<?>> {
    * @param deadlineNanoTime nanoseconds in the clock as per {@link System#nanoTime()}
    */
   public final S withDeadlineNanoTime(@Nullable Long deadlineNanoTime) {
-    return build(channel, callOptions.withDeadlineNanoTime(deadlineNanoTime));
+    return build(callFactory, callOptions.withDeadlineNanoTime(deadlineNanoTime));
   }
 
   /**
@@ -113,20 +113,20 @@ public abstract class AbstractStub<S extends AbstractStub<?>> {
    * @see CallOptions#withDeadlineAfter
    */
   public final S withDeadlineAfter(long duration, TimeUnit unit) {
-    return build(channel, callOptions.withDeadlineAfter(duration, unit));
+    return build(callFactory, callOptions.withDeadlineAfter(duration, unit));
   }
 
   /**
    * Returns a new stub that uses the given channel.
    */
-  public final S withChannel(Channel newChannel) {
-    return build(newChannel, callOptions);
+  public final S withChannel(ClientCallFactory newCallFactory) {
+    return build(newCallFactory, callOptions);
   }
 
   /**
    * Returns a new stub that has the given interceptors attached to the underlying channel.
    */
   public final S withInterceptors(ClientInterceptor... interceptors) {
-    return build(ClientInterceptors.intercept(channel, interceptors), callOptions);
+    return build(ClientInterceptors.intercept(callFactory, interceptors), callOptions);
   }
 }


### PR DESCRIPTION
Overview of the changes:

- Renamed Channel to ClientCallFactory
- Created a new Channel interface containing the public methods from ChannelImpl
- Modified ClientInterceptor to be a factory for ClientCallFactory instances.
- Modified the compiler to use ClientCallFactory rather than Channel.

This takes several steps towards addressing #545.

Some of the discussion leading up to this is here: https://github.com/grpc/grpc-java/issues/64#issuecomment-112221220