### PR TITLE
Make any lib-generated UNKNOWN have description

### DIFF
--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -308,7 +308,7 @@ public final class ChannelImpl extends Channel {
           activeTransport = null;
         }
         // TODO(notcarl): replace this with something more meaningful
-        transportShutdown(Status.UNKNOWN);
+        transportShutdown(Status.UNKNOWN.withDescription("transport shutdown for unknown reason"));
         transports.remove(transport);
         if (shutdown && transports.isEmpty()) {
           if (terminated) {

--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientHandler.java
@@ -205,11 +205,10 @@ class NettyClientHandler extends Http2ConnectionHandler {
   /**
    * Handler for an inbound HTTP/2 RST_STREAM frame, terminating a stream.
    */
-  private void onRstStreamRead(int streamId)
-      throws Http2Exception {
-    // TODO(nmittler): do something with errorCode?
+  private void onRstStreamRead(int streamId, long errorCode) throws Http2Exception {
     NettyClientStream stream = clientStream(requireHttp2Stream(streamId));
-    stream.transportReportStatus(Status.UNKNOWN, false, new Metadata.Trailers());
+    Status status = HttpUtil.Http2Error.statusForCode((int) errorCode);
+    stream.transportReportStatus(status, false, new Metadata.Trailers());
   }
 
   @Override
@@ -524,7 +523,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
         throws Http2Exception {
-      handler.onRstStreamRead(streamId);
+      handler.onRstStreamRead(streamId, errorCode);
     }
 
     @Override public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data)


### PR DESCRIPTION
Note that even more importantly, this translates a RST_STREAM error code
to a gRPC status code. This is generally useful, but also necessary for
DEADLINE_EXCEEDED to be more reliable in 0eae0d9.

Fixes #687 

@madongfly, I already checked that error code from RST_STREAM is being [propagated by OkHttp](https://github.com/grpc/grpc-java/blob/d2b1b37ed7ba0087fd8a2920549118191ce22f95/okhttp/src/main/java/io/grpc/transport/okhttp/OkHttpClientTransport.java#L660).