### PR TITLE
netty: Vastly improve connection error handling

### DIFF
--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
@@ -522,11 +522,11 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     sendPing(callback, MoreExecutors.directExecutor());
     assertEquals(0, callback.invocationCount);
 
-    Throwable connectionError = new Throwable();
-    handler.onConnectionError(ctx, connectionError, null);
+    Status failureStatus = Status.INTERNAL.withDescription("forced failure");
+    handler.onConnectionError(ctx, failureStatus.asRuntimeException(), null);
     // ping failed on connection error
     assertEquals(1, callback.invocationCount);
-    assertSame(connectionError, callback.failureCause);
+    assertSame(failureStatus, Status.fromThrowable(callback.failureCause));
   }
 
   private void sendPing(PingCallback callback, Executor executor) {

--- a/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/transport/netty/NettyClientHandlerTest.java
@@ -43,7 +43,6 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -512,21 +511,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     assertTrue(callback.failureCause instanceof StatusException);
     assertEquals(Status.Code.UNAVAILABLE,
         ((StatusException) callback.failureCause).getStatus().getCode());
-  }
-
-  @Test
-  public void ping_failsOnConnectionError() throws Exception {
-    when(channel.isOpen()).thenReturn(true);
-
-    PingCallbackImpl callback = new PingCallbackImpl();
-    sendPing(callback, MoreExecutors.directExecutor());
-    assertEquals(0, callback.invocationCount);
-
-    Status failureStatus = Status.INTERNAL.withDescription("forced failure");
-    handler.onConnectionError(ctx, failureStatus.asRuntimeException(), null);
-    // ping failed on connection error
-    assertEquals(1, callback.invocationCount);
-    assertSame(failureStatus, Status.fromThrowable(callback.failureCause));
   }
 
   private void sendPing(PingCallback callback, Executor executor) {


### PR DESCRIPTION
This series fixes 3 error-propagating failures and removes most unwanted log-spew. Some parts of it we may not want to do, but it is arranged into separate pieces where we can more easily decide the parts we like. Each commit has a useful description.

I have still seen log spew due to [Http2ConnectionHandler](https://github.com/netty/netty/blob/master/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java#L697), but otherwise thinsg are healthier.