### PR TITLE
Don't hold channel/server lock when shutting down transport

### DIFF
--- a/core/src/main/java/io/grpc/ServerImpl.java
+++ b/core/src/main/java/io/grpc/ServerImpl.java
@@ -137,10 +137,10 @@ public final class ServerImpl extends Server {
         return this;
       }
       shutdown = true;
-      transportServer.shutdown();
-      SharedResourceHolder.release(TIMER_SERVICE, timeoutService);
-      return this;
     }
+    transportServer.shutdown();
+    SharedResourceHolder.release(TIMER_SERVICE, timeoutService);
+    return this;
   }
 
   /**
@@ -152,10 +152,8 @@ public final class ServerImpl extends Server {
    */
   // TODO(ejona86): cancel preexisting calls.
   public ServerImpl shutdownNow() {
-    synchronized (lock) {
-      shutdown();
-      return this;
-    }
+    shutdown();
+    return this;
   }
 
   /**
@@ -253,12 +251,16 @@ public final class ServerImpl extends Server {
 
     @Override
     public void serverShutdown() {
+      ArrayList<ServerTransport> copiedTransports;
       synchronized (lock) {
         // transports collection can be modified during shutdown(), even if we hold the lock, due
         // to reentrancy.
-        for (ServerTransport transport : new ArrayList<ServerTransport>(transports)) {
-          transport.shutdown();
-        }
+        copiedTransports = new ArrayList<ServerTransport>(transports);
+      }
+      for (ServerTransport transport : copiedTransports) {
+        transport.shutdown();
+      }
+      synchronized (lock) {
         transportServerTerminated = true;
         checkForTermination();
       }


### PR DESCRIPTION
Holding the lock while calling the transport can cause a deadlock, as
shown in #696. In previous auditing for deadlock prevention I considered
heavily Call interactions, but failed to consider shutdown() and realize
it was holding a lock while calling transport.shutdown().

We still hold a lock when calling transport.start(). Although it is
conceivable that this could cause a deadlock as the code evolves over
time, I don't believe it can cause a deadlock today or that the risk is
very high. In addition, it would require more effort to solve.

@dconnelly, I did reproduce the issue by well-placed sleeps. So I have
confirmed that this fixes the problem.