### PR TITLE
Android-Interop-test: fix lint errors/warnings, enable proguard.

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -13,10 +13,17 @@ android {
         versionName "1.0"
     }
     buildTypes {
-        release {
-            minifyEnabled false
+        debug {
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    lintOptions {
+        disable 'InvalidPackage', 'HardcodedText'
     }
 }
 

--- a/android-interop-testing/app/proguard-rules.pro
+++ b/android-interop-testing/app/proguard-rules.pro
@@ -15,3 +15,6 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-dontwarn com.google.common.**
+-dontwarn okio.**

--- a/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTester.java
+++ b/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTester.java
@@ -34,8 +34,10 @@ package io.grpc.android.integrationtest;
 import com.google.protobuf.EmptyProtos;
 import com.google.protobuf.nano.MessageNano;
 
+import android.annotation.TargetApi;
 import android.net.SSLCertificateSocketFactory;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
@@ -49,6 +51,7 @@ import junit.framework.Assert;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.RuntimeException;
 import java.lang.reflect.Method;
 import java.security.KeyStore;
 import java.security.cert.CertificateFactory;
@@ -343,8 +346,13 @@ public final class InteropTester extends AsyncTask<Void, Void, String> {
     return context.getSocketFactory();
   }
 
+  @TargetApi(14)
   private SSLCertificateSocketFactory getSslCertificateSocketFactory(
       @Nullable InputStream testCa, String androidSocketFatoryTls) throws Exception {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH /* API level 14 */) {
+      throw new RuntimeException(
+          "android_socket_factory_tls doesn't work with API level less than 14.");
+    }
     SSLCertificateSocketFactory factory = (SSLCertificateSocketFactory)
         SSLCertificateSocketFactory.getDefault(5000 /* Timeout in ms*/);
     // Use HTTP/2.0

--- a/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/TesterInstrumentation.java
+++ b/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/TesterInstrumentation.java
@@ -58,13 +58,15 @@ public class TesterInstrumentation extends Instrumentation {
   public void onCreate(Bundle args) {
     super.onCreate(args);
 
-    testCase = args.getString("test_case", "empty_unary");
-    host = args.getString("server_host", "");
-    port = Integer.parseInt(args.getString("server_port", "8080"));
-    serverHostOverride = args.getString("server_host_override", null);
-    useTls = Boolean.parseBoolean(args.getString("use_tls", "true"));
-    useTestCa = Boolean.parseBoolean(args.getString("use_test_ca", "false"));
-    androidSocketFactoryTls = args.getString("android_socket_factory_tls", null);
+    testCase = args.getString("test_case") != null ? args.getString("test_case") : "empty_unary";
+    host = args.getString("server_host");
+    port = Integer.parseInt(args.getString("server_port"));
+    serverHostOverride = args.getString("server_host_override");
+    useTls = args.getString("use_tls") != null ?
+        Boolean.parseBoolean(args.getString("use_tls")) : true;
+    useTestCa = args.getString("use_test_ca") != null ?
+        Boolean.parseBoolean(args.getString("use_test_ca")) : false;
+    androidSocketFactoryTls = args.getString("android_socket_factory_tls");
 
     InputStream testCa = null;
     if (useTestCa) {

--- a/android-interop-testing/app/src/main/res/layout/activity_tester.xml
+++ b/android-interop-testing/app/src/main/res/layout/activity_tester.xml
@@ -73,7 +73,7 @@
       android:layout_height="wrap_content"
       android:paddingTop="12dp"
       android:paddingBottom="12dp"
-      android:textSize="16dp"
+      android:textSize="16sp"
       android:text="Response:"
       />
 
@@ -89,8 +89,7 @@
         android:id="@+id/grpc_response_text"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:textSize="16dp"
-        android:layout_weight="1.0"
+        android:textSize="16sp"
         />
 
   </ScrollView>


### PR DESCRIPTION
Fixes #693.

@ejona86, please take a look, thanks!