### PR TITLE
OkHttp should use plaintext in TransportBenchmark

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -120,7 +120,8 @@ public class TransportBenchmark {
         int port = pickUnusedPort();
         InetSocketAddress address = new InetSocketAddress("localhost", port);
         serverBuilder = NettyServerBuilder.forAddress(address);
-        channelBuilder = OkHttpChannelBuilder.forAddress("localhost", port);
+        channelBuilder = OkHttpChannelBuilder.forAddress("localhost", port)
+            .negotiationType(io.grpc.transport.okhttp.NegotiationType.PLAINTEXT);
         break;
       }
       default:


### PR DESCRIPTION
Otherwise, OkHttp fails because it is connecting to a plaintext server.