### PR TITLE
Spell SNAPSHOT correctly, for full effect

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ subprojects {
     apply plugin: "jacoco"
 
     group = "io.grpc"
-    version = "0.7.3-SNAPHSOT"
+    version = "0.7.3-SNAPSHOT"
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6


### PR DESCRIPTION
Note that this applies only to v0.7.x branch