### PR TITLE
Remove extraneous shutdown condition in NettyClientTransport

### DIFF
--- a/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/transport/netty/NettyClientTransport.java
@@ -227,9 +227,7 @@ class NettyClientTransport implements ClientTransport {
     boolean notifyShutdown;
     synchronized (this) {
       notifyShutdown = !shutdown;
-      if (!shutdown) {
-        shutdown = true;
-      }
+      shutdown = true;
     }
     if (notifyShutdown) {
       listener.transportShutdown(status);


### PR DESCRIPTION
We didn't do the extraneous check in notifyTerminated()...