### PR TITLE
okhttp: Update test to demonstrate that pending streams will not be started if…

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -284,6 +284,8 @@ class OkHttpClientTransport implements ClientTransport {
   private boolean startPendingStreams() {
     boolean hasStreamStarted = false;
     synchronized (lock) {
+      // No need to check goAway since the pendingStreams will be cleared when goAway
+      // becomes true.
       while (!pendingStreams.isEmpty() && streams.size() < maxConcurrentStreams) {
         OkHttpClientStream stream = pendingStreams.poll();
         startStream(stream);


### PR DESCRIPTION
… the transport is in goAway status.

Closes #782