### PR TITLE
okhttp: Remove stream id check for writing path, it breaks the starting of pe…

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -272,6 +272,9 @@ class OkHttpClientTransport implements ClientTransport {
       frameWriter.flush();
     }
     if (nextStreamId >= Integer.MAX_VALUE - 2) {
+      // Make sure nextStreamId greater than all used id, so that mayHaveCreatedStream() performs
+      // correctly.
+      nextStreamId = Integer.MAX_VALUE;
       onGoAway(Integer.MAX_VALUE, Status.INTERNAL.withDescription("Stream ids exhausted"));
     } else {
       nextStreamId += 2;

--- a/okhttp/src/main/java/io/grpc/okhttp/OutboundFlowController.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OutboundFlowController.java
@@ -119,9 +119,6 @@ class OutboundFlowController {
    */
   void data(boolean outFinished, int streamId, Buffer source, boolean flush) {
     Preconditions.checkNotNull(source, "source");
-    if (streamId <= 0 || !transport.mayHaveCreatedStream(streamId)) {
-      throw new IllegalArgumentException("Invalid streamId: " + streamId);
-    }
 
     OkHttpClientStream stream = transport.getStream(streamId);
     if (stream == null) {


### PR DESCRIPTION
…nding streams.

And fixes OkHttpClientTransport.mayHaveCreatedStream() for the case that streamId is Integer.MAX_VALUE - 2.

Fixes #786