### PR TITLE
Add code coverage badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-[![Build Status](https://travis-ci.org/grpc/grpc-java.svg?branch=master)](https://travis-ci.org/grpc/grpc-java)
-
 gRPC-Java - An RPC library and framework
 ========================================
+
+[![Build Status](https://travis-ci.org/grpc/grpc-java.svg?branch=master)](https://travis-ci.org/grpc/grpc-java)
+[![Coverage Status](https://coveralls.io/repos/grpc/grpc-java/badge.svg?branch=master&service=github)](https://coveralls.io/github/grpc/grpc-java?branch=master)
 
 gRPC-Java works with JDK 6. TLS usage typically requires using Java 8, or Play
 Services Dynamic Security Provider on Android. Please see the [Security


### PR DESCRIPTION
Moving to below the header reduces the amount of whitespace between them
and the rest of the text.