### PR TITLE
Add test oauth2_auth_token.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ subprojects {
                 javaee_api: 'javax:javaee-api:7.0',
                 jsonp: 'org.glassfish:javax.json:1.0.4',
                 jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
-                oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.1.0',
+                oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.2.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.4.0',
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufVersion}",

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -158,6 +158,18 @@ public class TestServiceClient {
           + "\n                              Defaults to server host"
           + "\n  --server_port=PORT          Port to connect to. Default " + c.serverPort
           + "\n  --test_case=TESTCASE        Test case to run. Default " + c.testCase
+          + "\n    Valid options:"
+          + "\n      empty_unary: empty (zero bytes) request and response"
+          + "\n      large_unary: single request and (large) response"
+          + "\n      client_streaming: request streaming with single response"
+          + "\n      server_streaming: single request with response streaming"
+          + "\n      ping_pong: full-duplex ping-pong streaming"
+          + "\n      empty_stream: A stream that has zero-messages in both directions"
+          + "\n      service_account_creds: large_unary with service_account auth"
+          + "\n      compute_engine_creds: large_unary with compute engine auth"
+          + "\n      oauth2_auth_token: raw oauth2 access token auth"
+          + "\n      cancel_after_begin: cancel stream after starting it"
+          + "\n      cancel_after_first_response: cancel on first response"
           + "\n  --use_tls=true|false        Whether to use TLS. Default " + c.useTls
           + "\n  --use_test_ca=true|false    Whether to trust our fake CA. Default " + c.useTestCa
           + "\n  --use_okhttp=true|false     Whether to use OkHttp instead of Netty. Default "
@@ -211,16 +223,20 @@ public class TestServiceClient {
       tester.pingPong();
     } else if ("empty_stream".equals(testCase)) {
       tester.emptyStream();
-    } else if ("cancel_after_begin".equals(testCase)) {
-      tester.cancelAfterBegin();
-    } else if ("cancel_after_first_response".equals(testCase)) {
-      tester.cancelAfterFirstResponse();
     } else if ("compute_engine_creds".equals(testCase)) {
       tester.computeEngineCreds(defaultServiceAccount, oauthScope);
     } else if ("service_account_creds".equals(testCase)) {
       String jsonKey = Files.toString(new File(serviceAccountKeyFile), Charset.forName("UTF-8"));
       FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));
       tester.serviceAccountCreds(jsonKey, credentialsStream, oauthScope);
+    } else if ("oauth2_auth_token".equals(testCase)) {
+      String jsonKey = Files.toString(new File(serviceAccountKeyFile), Charset.forName("UTF-8"));
+      FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));
+      tester.oauth2AuthToken(jsonKey, credentialsStream, oauthScope);
+    } else if ("cancel_after_begin".equals(testCase)) {
+      tester.cancelAfterBegin();
+    } else if ("cancel_after_first_response".equals(testCase)) {
+      tester.cancelAfterFirstResponse();
     } else {
       throw new IllegalArgumentException("Unknown test case: " + testCase);
     }


### PR DESCRIPTION
Manually tested by:
`./run-test-client.sh --server_port=443 --server_host=grpc-test.sandbox.google.com --server_host_override=grpc-test.sandbox.google.com --service_account_key_file=/usr/local/google/home/simonma/gce_cred.json --oauth_scope=https://www.googleapis.com/auth/xapi.zoo --test_case=oauth2_auth_token`

Fixes #650.

Note: should be checked in after confirmed the auth library 0.2.0 is pushed to the [maven central](http://search.maven.org/#search%7Cga%7C1%7Cgoogle-auth-library-oauth2-http).