### PR TITLE
Change some error status usages to be consistent with other gRPC impl…

### DIFF
--- a/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
+++ b/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
@@ -137,7 +137,7 @@ public class ClientAuthInterceptorTests {
     Mockito.verify(listener).onClose(statusCaptor.capture(), isA(Metadata.Trailers.class));
     Assert.assertNull(headers.getAll(AUTHORIZATION));
     Mockito.verify(call, never()).start(listener, headers);
-    Assert.assertEquals(Status.Code.UNKNOWN, statusCaptor.getValue().getCode());
+    Assert.assertEquals(Status.Code.UNAUTHENTICATED, statusCaptor.getValue().getCode());
     Assert.assertNotNull(statusCaptor.getValue().getCause());
   }
 

--- a/core/src/main/java/io/grpc/internal/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStream.java
@@ -181,7 +181,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
     if (status == null) {
       status = statusFromHttpStatus(trailers);
       if (status == null || status.isOk()) {
-        status = Status.INTERNAL.withDescription("missing GRPC status in response");
+        status = Status.UNKNOWN.withDescription("missing GRPC status in response");
       } else {
         status = status.withDescription(
             "missing GRPC status, inferred error from HTTP status code");

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -39,6 +39,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipException;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -352,11 +353,14 @@ public class MessageDeframer implements Closeable {
     }
 
     if (compression != Compression.GZIP) {
-      throw new AssertionError("Unknown compression type");
+      throw Status.INVALID_ARGUMENT.withDescription("Unknown compression type")
+          .asRuntimeException();
     }
 
     try {
       return new GZIPInputStream(ReadableBuffers.openStream(nextFrame, true));
+    } catch (ZipException e) {
+      throw Status.INTERNAL.withDescription("Decompression failed").asRuntimeException();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -437,7 +437,7 @@ class OkHttpClientTransport implements ClientTransport {
    */
   void onIoException(IOException failureCause) {
     log.log(Level.SEVERE, "Transport failed", failureCause);
-    onGoAway(0, Status.INTERNAL.withCause(failureCause));
+    onGoAway(0, Status.UNAVAILABLE.withCause(failureCause));
   }
 
   /**

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -1058,7 +1058,7 @@ public class OkHttpClientTransportTest {
     // ping failed on error
     assertEquals(1, callback.invocationCount);
     assertTrue(callback.failureCause instanceof StatusException);
-    assertEquals(Status.Code.INTERNAL,
+    assertEquals(Status.Code.UNAVAILABLE,
         ((StatusException) callback.failureCause).getStatus().getCode());
 
     // now that handler is in terminal state, all future pings fail immediately
@@ -1066,7 +1066,7 @@ public class OkHttpClientTransportTest {
     clientTransport.ping(callback, MoreExecutors.directExecutor());
     assertEquals(1, callback.invocationCount);
     assertTrue(callback.failureCause instanceof StatusException);
-    assertEquals(Status.Code.INTERNAL,
+    assertEquals(Status.Code.UNAVAILABLE,
         ((StatusException) callback.failureCause).getStatus().getCode());
   }
 


### PR DESCRIPTION
…ementations.

The first PR for #608

Changes includes:
* Use UNAVAILABLE for network issue on OkHttp connecting/writing path (reading path remains INTERNAL since OkHttp throws IOException for http2 protocol issue, so we can not distinguish it from real network issue).
* Use INTERNAL for `Could not decompress, but compression algorithm supported (both directions)`.
* Use GRPC_STATUS_INVALID_ARGUMENT for unsupported Compression algorithm is specified.
* Use UNKNOWN for `Error parsing returned status`.
* Use GRPC_STATUS_UNAUTHENTICATED for `Credentials failed to get metadata`.


@ejona86, @nmittler Please take a look, thanks.