### PR TITLE
Pull the latest Protobuf sources before checking out the release.

### DIFF
--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,6 +1,7 @@
 FROM protoc-artifacts:latest
 
 RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
+    git fetch && \
     git checkout v3.0.0-alpha-3.1 && \
     ./autogen.sh && \
     CXXFLAGS=-m32 ./configure --disable-shared --prefix=/protobuf-32 && \


### PR DESCRIPTION
The protoc-artifacts may have been created at previous release, which
may not contain the latest Protobuf release.

@ejona86 @carl-mastrangelo 