### PR TITLE
Enable Animal Sniffer for protobuf projects

### DIFF
--- a/protobuf-nano/build.gradle
+++ b/protobuf-nano/build.gradle
@@ -1,7 +1,15 @@
+plugins {
+    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
+}
+
 description = 'gRPC: Protobuf Nano'
 
 dependencies {
     compile project(':grpc-core'),
             libraries.protobuf_nano,
             libraries.guava
+}
+
+animalsniffer {
+    signature = "org.codehaus.mojo.signature:java16:+@signature"
 }

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -1,7 +1,15 @@
+plugins {
+    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
+}
+
 description = 'gRPC: Protobuf'
 
 dependencies {
     compile project(':grpc-core'),
             libraries.protobuf,
             libraries.guava
+}
+
+animalsniffer {
+    signature = "org.codehaus.mojo.signature:java16:+@signature"
 }


### PR DESCRIPTION
This ensures that we remain JDK6/Android-compatible.