### PR TITLE
Remove the first MethodDescriptor constructor.

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -20,14 +21,16 @@ public class TestServiceGrpc {
       io.grpc.testing.SimpleResponse> METHOD_UNARY_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
-          "grpc.testing.TestService", "UnaryCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "UnaryCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.SimpleRequest,
       io.grpc.testing.SimpleResponse> METHOD_STREAMING_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "grpc.testing.TestService", "StreamingCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "StreamingCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.parser()));
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -20,14 +21,16 @@ public class WorkerGrpc {
       io.grpc.testing.ClientStatus> METHOD_RUN_TEST =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "grpc.testing.Worker", "RunTest",
+          generateFullMethodName(
+              "grpc.testing.Worker", "RunTest"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientArgs.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientStatus.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.ServerArgs,
       io.grpc.testing.ServerStatus> METHOD_RUN_SERVER =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "grpc.testing.Worker", "RunServer",
+          generateFullMethodName(
+              "grpc.testing.Worker", "RunServer"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerArgs.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerStatus.parser()));
 

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -221,15 +221,15 @@ public abstract class AbstractBenchmark {
 
     // Simple method that sends and receives NettyByteBuf
     unaryMethod = MethodDescriptor.create(MethodType.UNARY,
-        "benchmark", "unary",
+        "benchmark/unary",
         new ByteBufOutputMarshaller(),
         new ByteBufOutputMarshaller());
     pingPongMethod = MethodDescriptor.create(MethodType.BIDI_STREAMING,
-        "benchmark", "pingPong",
+        "benchmark/pingPong",
         new ByteBufOutputMarshaller(),
         new ByteBufOutputMarshaller());
     flowControlledStreaming = MethodDescriptor.create(MethodType.BIDI_STREAMING,
-        "benchmark", "flowControlledStreaming",
+        "benchmark/flowControlledStreaming",
         new ByteBufOutputMarshaller(),
         new ByteBufOutputMarshaller());
 

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
@@ -84,7 +84,8 @@ public class HandlerRegistryBenchmark {
       for (int methodIndex = 0; methodIndex < methodCountPerService; ++methodIndex) {
         String methodName = randomString();
         MethodDescriptor<?, ?> methodDescriptor = MethodDescriptor.create(
-            MethodDescriptor.MethodType.UNKNOWN, serviceName, methodName, null, null);
+            MethodDescriptor.MethodType.UNKNOWN,
+            MethodDescriptor.generateFullMethodName(serviceName, methodName), null, null);
         serviceBuilder.addMethod(ServerMethodDefinition.create(methodDescriptor, null));
         fullMethodNames.add(methodDescriptor.getFullMethodName());
       }

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -96,7 +96,8 @@ static void PrintMethodFields(
           "    $output_type$> $method_field_name$ =\n"
           "    $MethodDescriptor$.create(\n"
           "        $MethodType$.$method_type$,\n"
-          "        \"$Package$$service_name$\", \"$method_name$\",\n"
+          "        generateFullMethodName(\n"
+          "            \"$Package$$service_name$\", \"$method_name$\"),\n"
           "        $NanoUtils$.<$input_type$>marshaller(\n"
           "            new io.grpc.protobuf.nano.Parser<$input_type$>() {\n"
           "                @Override\n"
@@ -120,7 +121,8 @@ static void PrintMethodFields(
           "    $output_type$> $method_field_name$ =\n"
           "    $MethodDescriptor$.create(\n"
           "        $MethodType$.$method_type$,\n"
-          "        \"$Package$$service_name$\", \"$method_name$\",\n"
+          "        generateFullMethodName(\n"
+          "            \"$Package$$service_name$\", \"$method_name$\"),\n"
           "        $ProtoUtils$.marshaller($input_type$.parser()),\n"
           "        $ProtoUtils$.marshaller($output_type$.parser()));\n");
     }
@@ -550,6 +552,8 @@ void PrintImports(Printer* p, bool generate_nano) {
       "io.grpc.stub.ClientCalls.blockingServerStreamingCall;\n"
       "import static "
       "io.grpc.stub.ClientCalls.futureUnaryCall;\n"
+      "import static "
+      "io.grpc.MethodDescriptor.generateFullMethodName;\n"
       "import static "
       "io.grpc.stub.ServerCalls.asyncUnaryCall;\n"
       "import static "

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -7,6 +7,7 @@ import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -20,35 +21,40 @@ public class TestServiceGrpc {
       io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
-          "grpc.testing.TestService", "UnaryCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "UnaryCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleResponse.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
-          "grpc.testing.TestService", "StreamingOutputCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "StreamingOutputCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
-          "grpc.testing.TestService", "StreamingInputCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "StreamingInputCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallResponse.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "grpc.testing.TestService", "FullBidiCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "FullBidiCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "grpc.testing.TestService", "HalfBidiCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "HalfBidiCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
 

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -7,6 +7,7 @@ import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -22,7 +23,8 @@ public class TestServiceGrpc {
       io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
-          "grpc.testing.TestService", "UnaryCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "UnaryCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.Test.SimpleRequest>marshaller(
               new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.Test.SimpleRequest>() {
                   @Override
@@ -41,7 +43,8 @@ public class TestServiceGrpc {
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
-          "grpc.testing.TestService", "StreamingOutputCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "StreamingOutputCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.Test.StreamingOutputCallRequest>marshaller(
               new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.Test.StreamingOutputCallRequest>() {
                   @Override
@@ -60,7 +63,8 @@ public class TestServiceGrpc {
       io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
-          "grpc.testing.TestService", "StreamingInputCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "StreamingInputCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.Test.StreamingInputCallRequest>marshaller(
               new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.Test.StreamingInputCallRequest>() {
                   @Override
@@ -79,7 +83,8 @@ public class TestServiceGrpc {
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "grpc.testing.TestService", "FullBidiCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "FullBidiCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.Test.StreamingOutputCallRequest>marshaller(
               new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.Test.StreamingOutputCallRequest>() {
                   @Override
@@ -98,7 +103,8 @@ public class TestServiceGrpc {
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "grpc.testing.TestService", "HalfBidiCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "HalfBidiCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.Test.StreamingOutputCallRequest>marshaller(
               new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.Test.StreamingOutputCallRequest>() {
                   @Override

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -136,24 +136,6 @@ public class MethodDescriptor<RequestT, ResponseT> {
    * Creates a new {@code MethodDescriptor}.
    *
    * @param type the call type of this method
-   * @param fullServiceName the fully qualified service name
-   * @param methodName the short-form method name
-   * @param requestMarshaller the marshaller used to encode and decode requests
-   * @param responseMarshaller the marshaller used to encode and decode responses
-   */
-  public static <RequestT, ResponseT> MethodDescriptor<RequestT, ResponseT> create(
-      MethodType type, String fullServiceName, String methodName,
-      Marshaller<RequestT> requestMarshaller,
-      Marshaller<ResponseT> responseMarshaller) {
-    return new MethodDescriptor<RequestT, ResponseT>(
-        type, generateFullMethodName(fullServiceName, methodName), requestMarshaller,
-        responseMarshaller);
-  }
-
-  /**
-   * Creates a new {@code MethodDescriptor}.
-   *
-   * @param type the call type of this method
    * @param fullMethodName the fully qualified name of this method
    * @param requestMarshaller the marshaller used to encode and decode requests
    * @param responseMarshaller the marshaller used to encode and decode responses

--- a/core/src/test/java/io/grpc/MutableHandlerRegistryImplTest.java
+++ b/core/src/test/java/io/grpc/MutableHandlerRegistryImplTest.java
@@ -62,7 +62,7 @@ public class MutableHandlerRegistryImplTest {
   private ServerCallHandler<String, Integer> handler = mock(ServerCallHandler.class);
   private ServerServiceDefinition basicServiceDefinition = ServerServiceDefinition.builder("basic")
       .addMethod(
-          MethodDescriptor.create(MethodType.UNKNOWN, "basic", "flow",
+          MethodDescriptor.create(MethodType.UNKNOWN, "basic/flow",
               requestMarshaller, responseMarshaller),
           handler).build();
   @SuppressWarnings("rawtypes")
@@ -70,12 +70,12 @@ public class MutableHandlerRegistryImplTest {
       getOnlyElement(basicServiceDefinition.getMethods());
   private ServerServiceDefinition multiServiceDefinition = ServerServiceDefinition.builder("multi")
       .addMethod(
-          MethodDescriptor.create(MethodType.UNKNOWN, "multi", "couple",
-            requestMarshaller, responseMarshaller),
+          MethodDescriptor.create(MethodType.UNKNOWN, "multi/couple",
+              requestMarshaller, responseMarshaller),
           handler)
       .addMethod(
-          MethodDescriptor.create(MethodType.UNKNOWN, "multi", "few",
-            requestMarshaller, responseMarshaller),
+          MethodDescriptor.create(MethodType.UNKNOWN, "multi/few",
+              requestMarshaller, responseMarshaller),
           handler).build();
   @SuppressWarnings("rawtypes")
   private ServerMethodDefinition coupleMethodDefinition =
@@ -142,7 +142,7 @@ public class MutableHandlerRegistryImplTest {
     assertNull(registry.addService(basicServiceDefinition));
     assertNotNull(registry.lookupMethod("basic/flow"));
     ServerServiceDefinition replaceServiceDefinition = ServerServiceDefinition.builder("basic")
-        .addMethod(MethodDescriptor.create(MethodType.UNKNOWN, "basic", "another",
+        .addMethod(MethodDescriptor.create(MethodType.UNKNOWN, "basic/another",
               requestMarshaller, responseMarshaller), handler).build();
     ServerMethodDefinition<?, ?> anotherMethodDefinition =
         replaceServiceDefinition.getMethod("basic/another");

--- a/core/src/test/java/io/grpc/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/ServerImplTest.java
@@ -180,7 +180,7 @@ public class ServerImplTest {
     registry.addService(ServerServiceDefinition.builder("Waiter")
         .addMethod(
             MethodDescriptor.create(
-                MethodType.UNKNOWN, "Waiter", "serve", STRING_MARSHALLER, INTEGER_MARSHALLER),
+                MethodType.UNKNOWN, "Waiter/serve", STRING_MARSHALLER, INTEGER_MARSHALLER),
             new ServerCallHandler<String, Integer>() {
               @Override
               public ServerCall.Listener<String> startCall(
@@ -247,7 +247,7 @@ public class ServerImplTest {
     final Status status = Status.ABORTED.withDescription("Oh, no!");
     registry.addService(ServerServiceDefinition.builder("Waiter")
         .addMethod(
-            MethodDescriptor.create(MethodType.UNKNOWN, "Waiter", "serve",
+            MethodDescriptor.create(MethodType.UNKNOWN, "Waiter/serve",
               STRING_MARSHALLER, INTEGER_MARSHALLER),
             new ServerCallHandler<String, Integer>() {
               @Override

--- a/core/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -71,14 +71,14 @@ public class ServerInterceptorsTest {
   @Mock private ServerCall.Listener<String> listener;
   private MethodDescriptor<String, Integer> method = MethodDescriptor.create(
       MethodType.UNKNOWN,
-      "/someRandom.Name",
+      "someRandom/Name",
       requestMarshaller,
       responseMarshaller);
   @Mock private ServerCall<Integer> call;
   private ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("basic")
       .addMethod(
           MethodDescriptor.create(
-            MethodType.UNKNOWN, "basic", "flow", requestMarshaller, responseMarshaller),
+            MethodType.UNKNOWN, "basic/flow", requestMarshaller, responseMarshaller),
           handler).build();
   private Headers headers = new Headers();
 
@@ -146,9 +146,9 @@ public class ServerInterceptorsTest {
     @SuppressWarnings("unchecked")
     ServerCallHandler<String, Integer> handler2 = mock(ServerCallHandler.class);
     serviceDefinition = ServerServiceDefinition.builder("basic")
-        .addMethod(MethodDescriptor.create(MethodType.UNKNOWN, "basic", "flow",
+        .addMethod(MethodDescriptor.create(MethodType.UNKNOWN, "basic/flow",
               requestMarshaller, responseMarshaller), handler)
-        .addMethod(MethodDescriptor.create(MethodType.UNKNOWN, "basic", "flow2",
+        .addMethod(MethodDescriptor.create(MethodType.UNKNOWN, "basic/flow2",
               requestMarshaller, responseMarshaller), handler2).build();
     ServerServiceDefinition intercepted = ServerInterceptors.intercept(
         serviceDefinition, Arrays.<ServerInterceptor>asList(new NoopInterceptor()));
@@ -223,7 +223,7 @@ public class ServerInterceptorsTest {
           }
         };
     ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("basic")
-        .addMethod(MethodDescriptor.create(MethodType.UNKNOWN, "basic", "flow",
+        .addMethod(MethodDescriptor.create(MethodType.UNKNOWN, "basic/flow",
               requestMarshaller, responseMarshaller), handler).build();
     ServerServiceDefinition intercepted = ServerInterceptors.intercept(
         serviceDefinition, Arrays.asList(interceptor1, interceptor2));
@@ -235,7 +235,7 @@ public class ServerInterceptorsTest {
   @Test
   public void argumentsPassed() {
     final MethodDescriptor<String, Integer> method2 =
-        MethodDescriptor.create(MethodType.UNKNOWN, "/someOtherRandom.Method", null, null);
+        MethodDescriptor.create(MethodType.UNKNOWN, "someOtherRandom/Method", null, null);
     @SuppressWarnings("unchecked")
     final ServerCall<Integer> call2 = mock(ServerCall.class);
     @SuppressWarnings("unchecked")

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -20,7 +21,8 @@ public class GreeterGrpc {
       io.grpc.examples.helloworld.HelloResponse> METHOD_SAY_HELLO =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
-          "helloworld.Greeter", "SayHello",
+          generateFullMethodName(
+              "helloworld.Greeter", "SayHello"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloResponse.parser()));
 

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -20,28 +21,32 @@ public class RouteGuideGrpc {
       io.grpc.examples.routeguide.Feature> METHOD_GET_FEATURE =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
-          "routeguide.RouteGuide", "GetFeature",
+          generateFullMethodName(
+              "routeguide.RouteGuide", "GetFeature"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.examples.routeguide.Rectangle,
       io.grpc.examples.routeguide.Feature> METHOD_LIST_FEATURES =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
-          "routeguide.RouteGuide", "ListFeatures",
+          generateFullMethodName(
+              "routeguide.RouteGuide", "ListFeatures"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Rectangle.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.examples.routeguide.Point,
       io.grpc.examples.routeguide.RouteSummary> METHOD_RECORD_ROUTE =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
-          "routeguide.RouteGuide", "RecordRoute",
+          generateFullMethodName(
+              "routeguide.RouteGuide", "RecordRoute"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteSummary.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.examples.routeguide.RouteNote,
       io.grpc.examples.routeguide.RouteNote> METHOD_ROUTE_CHAT =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "routeguide.RouteGuide", "RouteChat",
+          generateFullMethodName(
+              "routeguide.RouteGuide", "RouteChat"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.parser()));
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -20,42 +21,48 @@ public class TestServiceGrpc {
       com.google.protobuf.EmptyProtos.Empty> METHOD_EMPTY_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
-          "grpc.testing.TestService", "EmptyCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "EmptyCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
       io.grpc.testing.integration.Messages.SimpleResponse> METHOD_UNARY_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
-          "grpc.testing.TestService", "UnaryCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "UnaryCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleResponse.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
-          "grpc.testing.TestService", "StreamingOutputCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "StreamingOutputCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
       io.grpc.testing.integration.Messages.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
-          "grpc.testing.TestService", "StreamingInputCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "StreamingInputCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallResponse.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "grpc.testing.TestService", "FullDuplexCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "FullDuplexCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
-          "grpc.testing.TestService", "HalfDuplexCall",
+          generateFullMethodName(
+              "grpc.testing.TestService", "HalfDuplexCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
 

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -349,7 +349,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
         .method(HTTP_METHOD)
         .set(CONTENT_TYPE_HEADER, CONTENT_TYPE_GRPC)
         .set(TE_HEADER, TE_TRAILERS)
-        .path(new AsciiString("/foo.bar"));
+        .path(new AsciiString("/foo/bar"));
     ByteBuf headersFrame = headersFrame(STREAM_ID, headers);
     handler.channelRead(ctx, headersFrame);
 


### PR DESCRIPTION
that takes the service name and method name separately.

Also fix tests that are still using the old full qualified method name format `/ServiceName.MethodName` to use the new format `ServiceName/MethodName`.

Resolves #743 