### PR TITLE
Skip io.grpc.internal in javadoc.

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -55,6 +55,7 @@ javadoc {
         source subproject.javadoc.source
         options.links subproject.javadoc.options.links.toArray(new String[0])
     }
+    exclude 'io/grpc/internal/**'
 }
 
 task jacocoMerge(type: JacocoMerge) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,3 +13,5 @@ dependencies {
 animalsniffer {
     signature = "org.codehaus.mojo.signature:java16:+@signature"
 }
+
+javadoc.exclude 'io/grpc/internal/**'

--- a/core/src/main/java/io/grpc/AbstractChannelBuilder.java
+++ b/core/src/main/java/io/grpc/AbstractChannelBuilder.java
@@ -35,7 +35,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.Internal;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.SharedResourceHolder.Resource;
 

--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -42,7 +42,6 @@ import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransport.PingCallback;
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.ExperimentalApi;
 import io.grpc.internal.HttpUtil;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.internal.SharedResourceHolder;

--- a/core/src/main/java/io/grpc/Context.java
+++ b/core/src/main/java/io/grpc/Context.java
@@ -35,7 +35,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import io.grpc.internal.ExperimentalApi;
 import io.grpc.internal.SharedResourceHolder;
 
 import java.io.Closeable;

--- a/core/src/main/java/io/grpc/ExperimentalApi.java
+++ b/core/src/main/java/io/grpc/ExperimentalApi.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.internal;
+package io.grpc;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -38,9 +38,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotates a program element which is internal to gRPC, not part of the public API, and should not
- * be used outside of gRPC codebase.
+ * Indicates a public API that can change at any time, and has no guarantee of API stability and
+ * backward-compatibility.
+ *
+ * <p>Usage guidelines:
+ * <ol>
+ * <li>This annotation is used only on public API. Internal interfaces should not use it.</li>
+ * <li>After gRPC has gained API stability, this annotation can only be added to new API. Adding it
+ * to an existing API is considered API-breaking.</li>
+ * <li>Removing this annotation from an API gives it stable status.</li>
+ * </ol>
  */
+@Internal
 @Retention(RetentionPolicy.SOURCE)
 @Target({
     ElementType.ANNOTATION_TYPE,
@@ -50,5 +59,5 @@ import java.lang.annotation.Target;
     ElementType.PACKAGE,
     ElementType.TYPE})
 @Documented
-public @interface Internal {
+public @interface ExperimentalApi {
 }

--- a/core/src/main/java/io/grpc/Internal.java
+++ b/core/src/main/java/io/grpc/Internal.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.internal;
+package io.grpc;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -38,17 +38,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates a public API that can change at any time, and has no guarantee of API stability and
- * backward-compatibility.
- *
- * <p>Usage guidelines:
- * <ol>
- * <li>This annotation is used only on public API. Internal interfaces should not use it.</li>
- * <li>After gRPC has gained API stability, this annotation can only be added to new API. Adding it
- * to an existing API is considered API-breaking.</li>
- * <li>Removing this annotation from an API gives it stable status.</li>
- * </ol>
+ * Annotates a program element which is internal to gRPC, not part of the public API, and should not
+ * be used outside of gRPC codebase.
  */
+@Internal
 @Retention(RetentionPolicy.SOURCE)
 @Target({
     ElementType.ANNOTATION_TYPE,
@@ -58,5 +51,5 @@ import java.lang.annotation.Target;
     ElementType.PACKAGE,
     ElementType.TYPE})
 @Documented
-public @interface ExperimentalApi {
+public @interface Internal {
 }

--- a/core/src/main/java/io/grpc/internal/package-info.java
+++ b/core/src/main/java/io/grpc/internal/package-info.java
@@ -34,5 +34,5 @@
  *
  * <p>All interfaces under this package are not public API, and should not be used outside of gRPC.
  */
-@Internal
+@io.grpc.Internal
 package io.grpc.internal;

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -31,7 +31,7 @@
 
 package io.grpc.netty;
 
-import io.grpc.internal.ExperimentalApi;
+import io.grpc.ExperimentalApi;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;


### PR DESCRIPTION
Also move ExperimentalApi and Internal to io.grpc, so that they appear
in javadoc.

Resolves #802 