### PR TITLE
Remove proto size restriction when parsing protos.

### DIFF
--- a/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
@@ -31,6 +31,7 @@
 
 package io.grpc.protobuf;
 
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
@@ -73,7 +74,12 @@ public class ProtoUtils {
           }
         }
         try {
-          return parser.parseFrom(stream);
+          // Pre-create the CodedInputStream so that we can remove the size limit restriction
+          // when parsing.
+          CodedInputStream codedInput = CodedInputStream.newInstance(stream);
+          codedInput.setSizeLimit(Integer.MAX_VALUE);
+
+          return parser.parseFrom(codedInput);
         } catch (InvalidProtocolBufferException ipbe) {
           throw Status.INTERNAL.withDescription("Invalid protobuf byte sequence")
             .withCause(ipbe).asRuntimeException();

--- a/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
@@ -78,6 +78,7 @@ public class ProtoUtils {
           // when parsing.
           CodedInputStream codedInput = CodedInputStream.newInstance(stream);
           codedInput.setSizeLimit(Integer.MAX_VALUE);
+          codedInput.checkLastTagWas(0);
 
           return parser.parseFrom(codedInput);
         } catch (InvalidProtocolBufferException ipbe) {

--- a/protobuf/src/test/java/io/grpc/protobuf/ProtoUtilsTest.java
+++ b/protobuf/src/test/java/io/grpc/protobuf/ProtoUtilsTest.java
@@ -35,6 +35,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 import com.google.common.io.ByteStreams;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.Enum;
 import com.google.protobuf.Type;
 
@@ -46,6 +48,7 @@ import org.junit.runners.JUnit4;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Random;
 
 /** Unit tests for {@link ProtoUtils}. */
 @RunWith(JUnit4.class)
@@ -71,5 +74,16 @@ public class ProtoUtilsTest {
     // Enum's name and Type's name are both strings with tag 1.
     Enum altProto = Enum.newBuilder().setName(proto.getName()).build();
     assertEquals(proto, marshaller.parse(enumMarshaller.stream(altProto)));
+  }
+
+  @Test
+  public void marshallerShouldNotLimitProtoSize() throws Exception {
+    byte[] bigName = new byte[100 * 1024 * 1024];
+    new Random().nextBytes(bigName);
+
+    proto = Type.newBuilder().setNameBytes(ByteString.copyFrom(bigName)).build();
+
+    // Just perform a round trip to verify that it works.
+    testRoundtrip();
   }
 }

--- a/protobuf/src/test/java/io/grpc/protobuf/ProtoUtilsTest.java
+++ b/protobuf/src/test/java/io/grpc/protobuf/ProtoUtilsTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertSame;
 
 import com.google.common.io.ByteStreams;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Enum;
 import com.google.protobuf.Type;
 


### PR DESCRIPTION
@ejona86 PTAL .. this is the first part of the change to support maxMessageSize.