### PR TITLE
Removing transport shutdown hooks from channel builder

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -76,7 +76,7 @@ public final class InProcessServerBuilder extends AbstractServerBuilder<InProces
   }
 
   @Override
-  protected ServerEssentials buildEssentials() {
-    return new ServerEssentials(new InProcessServer(name), null);
+  protected InProcessServer buildTransportServer() {
+    return new InProcessServer(name);
   }
 }

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -32,7 +32,7 @@
 package io.grpc.internal;
 
 /** Pre-configured factory for creating {@link ClientTransport} instances. */
-public interface ClientTransportFactory {
+public interface ClientTransportFactory extends ReferenceCounted {
   /** Creates an unstarted transport for exclusive use. */
   ClientTransport newClientTransport();
 }

--- a/core/src/main/java/io/grpc/internal/ReferenceCounted.java
+++ b/core/src/main/java/io/grpc/internal/ReferenceCounted.java
@@ -29,59 +29,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.inprocess;
-
-import com.google.common.base.Preconditions;
-
-import io.grpc.AbstractChannelBuilder;
-import io.grpc.internal.AbstractReferenceCounted;
-import io.grpc.internal.ClientTransport;
-import io.grpc.internal.ClientTransportFactory;
+package io.grpc.internal;
 
 /**
- * Builder for a channel that issues in-process requests. Clients identify the in-process server by
- * its name.
- *
- * <p>The channel is intended to be fully-featured, high performance, and useful in testing.
+ * A reference-counted object that requires explicit deallocation.
  */
-public class InProcessChannelBuilder extends AbstractChannelBuilder<InProcessChannelBuilder> {
+public interface ReferenceCounted {
   /**
-   * Create a channel builder that will connect to the server with the given name.
-   *
-   * @param name the identity of the server to connect to
-   * @return a new builder
+   * Gets the current reference count.
    */
-  public static InProcessChannelBuilder forName(String name) {
-    return new InProcessChannelBuilder(name);
-  }
+  int referenceCount();
 
-  private final String name;
+  /**
+   * Increases the reference count by 1.
+   */
+  ReferenceCounted retain();
 
-  private InProcessChannelBuilder(String name) {
-    this.name = Preconditions.checkNotNull(name);
-  }
-
-  @Override
-  protected ClientTransportFactory buildTransportFactory() {
-    return new InProcessClientTransportFactory(name);
-  }
-
-  private static class InProcessClientTransportFactory extends AbstractReferenceCounted
-          implements ClientTransportFactory {
-    private final String name;
-
-    private InProcessClientTransportFactory(String name) {
-      this.name = name;
-    }
-
-    @Override
-    public ClientTransport newClientTransport() {
-      return new InProcessTransport(name);
-    }
-
-    @Override
-    protected void deallocate() {
-      // Do nothing.
-    }
-  }
+  /**
+   * Decreases the reference count by {@code 1} and deallocates this object if the reference count
+   * reaches at {@code 0}.
+   *
+   * @return {@code true} if and only if the reference count became {@code 0} and this object has
+   *         been deallocated
+   */
+  ReferenceCounted release();
 }

--- a/core/src/test/java/io/grpc/ChannelImplTest.java
+++ b/core/src/test/java/io/grpc/ChannelImplTest.java
@@ -185,7 +185,7 @@ public class ChannelImplTest {
     transportListener.transportTerminated();
     assertTrue(channel.isTerminated());
 
-    verifyNoMoreInteractions(mockTransportFactory);
+    verify(mockTransportFactory).newClientTransport();
     verifyNoMoreInteractions(mockTransport);
     verifyNoMoreInteractions(mockStream);
   }
@@ -260,7 +260,7 @@ public class ChannelImplTest {
     transportListenerCaptor.getValue().transportTerminated();
     assertTrue(channel.isTerminated());
 
-    verifyNoMoreInteractions(mockTransportFactory);
+    verify(mockTransportFactory, times(3)).newClientTransport();
     verifyNoMoreInteractions(mockTransport);
     verifyNoMoreInteractions(mockTransport2);
     verifyNoMoreInteractions(mockTransport3);

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -31,13 +31,14 @@
 
 package io.grpc.netty;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static io.netty.channel.ChannelOption.SO_BACKLOG;
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 
-import com.google.common.base.Preconditions;
-
 import io.grpc.internal.Server;
 import io.grpc.internal.ServerListener;
+import io.grpc.internal.SharedResourceHolder;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -63,36 +64,37 @@ public class NettyServer implements Server {
 
   private final SocketAddress address;
   private final Class<? extends ServerChannel> channelType;
-  private final EventLoopGroup bossGroup;
-  private final EventLoopGroup workerGroup;
   private final SslContext sslContext;
   private final int maxStreamsPerConnection;
+  private final boolean usingSharedBossGroup;
+  private final boolean usingSharedWorkerGroup;
+  private EventLoopGroup bossGroup;
+  private EventLoopGroup workerGroup;
   private ServerListener listener;
   private Channel channel;
   private int flowControlWindow;
 
   NettyServer(SocketAddress address, Class<? extends ServerChannel> channelType,
-      EventLoopGroup bossGroup, EventLoopGroup workerGroup, int maxStreamsPerConnection,
-      int flowControlWindow) {
-    this(address, channelType, bossGroup, workerGroup, null, maxStreamsPerConnection,
-            flowControlWindow);
-  }
-
-  NettyServer(SocketAddress address, Class<? extends ServerChannel> channelType,
-      EventLoopGroup bossGroup, EventLoopGroup workerGroup, @Nullable SslContext sslContext,
-      int maxStreamsPerConnection, int flowControlWindow) {
+              @Nullable EventLoopGroup bossGroup, @Nullable EventLoopGroup workerGroup,
+              @Nullable SslContext sslContext, int maxStreamsPerConnection, int flowControlWindow) {
     this.address = address;
-    this.channelType = Preconditions.checkNotNull(channelType, "channelType");
-    this.bossGroup = Preconditions.checkNotNull(bossGroup, "bossGroup");
-    this.workerGroup = Preconditions.checkNotNull(workerGroup, "workerGroup");
+    this.channelType = checkNotNull(channelType, "channelType");
+    this.bossGroup = bossGroup;
+    this.workerGroup = workerGroup;
     this.sslContext = sslContext;
+    this.usingSharedBossGroup = bossGroup == null;
+    this.usingSharedWorkerGroup = workerGroup == null;
     this.maxStreamsPerConnection = maxStreamsPerConnection;
     this.flowControlWindow = flowControlWindow;
   }
 
   @Override
   public void start(ServerListener serverListener) throws IOException {
-    listener = serverListener;
+    listener = checkNotNull(serverListener, "serverListener");
+
+    // If using the shared groups, get references to them.
+    allocateSharedGroups();
+
     ServerBootstrap b = new ServerBootstrap();
     b.group(bossGroup, workerGroup);
     b.channel(channelType);
@@ -126,6 +128,7 @@ public class NettyServer implements Server {
   @Override
   public void shutdown() {
     if (channel == null || !channel.isOpen()) {
+      // Already closed.
       return;
     }
     channel.close().addListener(new ChannelFutureListener() {
@@ -135,7 +138,34 @@ public class NettyServer implements Server {
           log.log(Level.WARNING, "Error shutting down server", future.cause());
         }
         listener.serverShutdown();
+        releaseSharedGroups();
       }
     });
+  }
+
+  private void allocateSharedGroups() {
+    if (bossGroup == null) {
+      bossGroup = SharedResourceHolder.get(Utils.DEFAULT_BOSS_EVENT_LOOP_GROUP);
+    }
+    if (workerGroup == null) {
+      workerGroup = SharedResourceHolder.get(Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP);
+    }
+  }
+
+  private void releaseSharedGroups() {
+    try {
+      if (usingSharedBossGroup && bossGroup != null) {
+        SharedResourceHolder.release(Utils.DEFAULT_BOSS_EVENT_LOOP_GROUP, bossGroup);
+      }
+    } finally {
+      bossGroup = null;
+      try {
+        if (usingSharedWorkerGroup && workerGroup != null) {
+          SharedResourceHolder.release(Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP, workerGroup);
+        }
+      } finally {
+        workerGroup = null;
+      }
+    }
   }
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -167,17 +167,17 @@ class OkHttpClientTransport implements ClientTransport {
 
   OkHttpClientTransport(String host, int port, String authorityHost, Executor executor,
       @Nullable SSLSocketFactory sslSocketFactory, ConnectionSpec connectionSpec) {
-    this.host = Preconditions.checkNotNull(host);
+    this.host = Preconditions.checkNotNull(host, "host");
     this.port = port;
     this.authorityHost = authorityHost;
     defaultAuthority = authorityHost + ":" + port;
-    this.executor = Preconditions.checkNotNull(executor);
+    this.executor = Preconditions.checkNotNull(executor, "executor");
     serializingExecutor = new SerializingExecutor(executor);
     // Client initiated streams are odd, server initiated ones are even. Server should not need to
     // use it. We start clients at 3 to avoid conflicting with HTTP negotiation.
     nextStreamId = 3;
     this.sslSocketFactory = sslSocketFactory;
-    this.connectionSpec = Preconditions.checkNotNull(connectionSpec);
+    this.connectionSpec = Preconditions.checkNotNull(connectionSpec, "connectionSpec");
     this.ticker = Ticker.systemTicker();
   }
 


### PR DESCRIPTION
The current process of building a channel is a bit complicated in that transports have to provide a own shutdown hook to the channel builder in order to close shared executors. This somewhat entagled creation pattern makes it difficult to separate the process of channel building from transport building. Better separating these two should make the code more readable and maintainable moving forward.