### PR TITLE
Netty: Use status INTERNAL instead of UNKNOWN for underlying Http2Exception.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -203,7 +203,8 @@ class NettyServerHandler extends Http2ConnectionHandler {
       // Abort the stream with a status to help the client with debugging.
       // Don't need to send a RST_STREAM since the end-of-stream flag will
       // be sent.
-      serverStream(stream).abortStream(Status.fromThrowable(cause), true);
+      serverStream(stream).abortStream(cause instanceof Http2Exception
+          ? Status.INTERNAL.withCause(cause) : Status.fromThrowable(cause), true);
     } else {
       // Delegate to the base class to send a RST_STREAM.
       super.onStreamError(ctx, cause, http2Ex);


### PR DESCRIPTION
Another effort for #608.

@nmittler @ejona86

