### PR TITLE
Fix documentation on ClientCall.request().

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -142,7 +142,6 @@ public abstract class ClientCall<RequestT, ResponseT> {
    *
    * @param numMessages the requested number of messages to be delivered to the listener. Must be
    *                    non-negative.
-   * @throws IllegalStateException if call is already {@code halfClose()}d or {@link #cancel}ed
    */
   public abstract void request(int numMessages);
 


### PR DESCRIPTION
`request()` is allowed after `halfClose()`, and is not necessarily forbidden after `cancel()` (current implementation does not).

Resolves #290 
