### PR TITLE
Add SERVICE_NAME constant to service container

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
@@ -15,6 +15,8 @@ import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 @javax.annotation.Generated("by gRPC proto compiler")
 public class TestServiceGrpc {
 
+  public static final String SERVICE_NAME = "grpc.testing.TestService";
+
   // Static method descriptors that strictly reflect the proto.
   public static final io.grpc.MethodDescriptor<io.grpc.testing.SimpleRequest,
       io.grpc.testing.SimpleResponse> METHOD_UNARY_CALL =
@@ -148,7 +150,7 @@ public class TestServiceGrpc {
 
   public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder("grpc.testing.TestService")
+    return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
       .addMethod(io.grpc.ServerMethodDefinition.create(
           METHOD_UNARY_CALL,
           asyncUnaryCall(

--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
@@ -15,6 +15,8 @@ import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 @javax.annotation.Generated("by gRPC proto compiler")
 public class WorkerGrpc {
 
+  public static final String SERVICE_NAME = "grpc.testing.Worker";
+
   // Static method descriptors that strictly reflect the proto.
   public static final io.grpc.MethodDescriptor<io.grpc.testing.ClientArgs,
       io.grpc.testing.ClientStatus> METHOD_RUN_TEST =
@@ -130,7 +132,7 @@ public class WorkerGrpc {
 
   public static io.grpc.ServerServiceDefinition bindService(
       final Worker serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder("grpc.testing.Worker")
+    return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
       .addMethod(io.grpc.ServerMethodDefinition.create(
           METHOD_RUN_TEST,
           asyncBidiStreamingCall(

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -400,7 +400,7 @@ static void PrintBindServiceMethod(const ServiceDescriptor* service,
   p->Indent();
   p->Print(*vars,
            "return "
-           "$ServerServiceDefinition$.builder(\"$Package$$service_name$\")\n");
+           "$ServerServiceDefinition$.builder(SERVICE_NAME)\n");
   p->Indent();
   for (int i = 0; i < service->method_count(); ++i) {
     const MethodDescriptor* method = service->method(i);
@@ -490,6 +490,11 @@ static void PrintService(const ServiceDescriptor* service,
       "@$Generated$(\"by gRPC proto compiler\")\n"
       "public class $service_class_name$ {\n\n");
   p->Indent();
+
+  p->Print(
+      *vars,
+      "public static final String SERVICE_NAME = "
+      "\"$Package$$service_name$\";\n\n");
 
   PrintMethodFields(service, vars, p, generate_nano);
 

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -15,6 +15,8 @@ import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 @javax.annotation.Generated("by gRPC proto compiler")
 public class GreeterGrpc {
 
+  public static final String SERVICE_NAME = "helloworld.Greeter";
+
   // Static method descriptors that strictly reflect the proto.
   public static final io.grpc.MethodDescriptor<io.grpc.examples.helloworld.HelloRequest,
       io.grpc.examples.helloworld.HelloResponse> METHOD_SAY_HELLO =
@@ -131,7 +133,7 @@ public class GreeterGrpc {
 
   public static io.grpc.ServerServiceDefinition bindService(
       final Greeter serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder("helloworld.Greeter")
+    return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
       .addMethod(io.grpc.ServerMethodDefinition.create(
           METHOD_SAY_HELLO,
           asyncUnaryCall(

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -15,6 +15,8 @@ import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 @javax.annotation.Generated("by gRPC proto compiler")
 public class RouteGuideGrpc {
 
+  public static final String SERVICE_NAME = "routeguide.RouteGuide";
+
   // Static method descriptors that strictly reflect the proto.
   public static final io.grpc.MethodDescriptor<io.grpc.examples.routeguide.Point,
       io.grpc.examples.routeguide.Feature> METHOD_GET_FEATURE =
@@ -192,7 +194,7 @@ public class RouteGuideGrpc {
 
   public static io.grpc.ServerServiceDefinition bindService(
       final RouteGuide serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder("routeguide.RouteGuide")
+    return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
       .addMethod(io.grpc.ServerMethodDefinition.create(
           METHOD_GET_FEATURE,
           asyncUnaryCall(

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -15,6 +15,8 @@ import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 @javax.annotation.Generated("by gRPC proto compiler")
 public class ReconnectServiceGrpc {
 
+  public static final String SERVICE_NAME = "grpc.testing.ReconnectService";
+
   // Static method descriptors that strictly reflect the proto.
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> METHOD_START =
@@ -166,7 +168,7 @@ public class ReconnectServiceGrpc {
 
   public static io.grpc.ServerServiceDefinition bindService(
       final ReconnectService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder("grpc.testing.ReconnectService")
+    return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
       .addMethod(io.grpc.ServerMethodDefinition.create(
           METHOD_START,
           asyncUnaryCall(

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -15,6 +15,8 @@ import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 @javax.annotation.Generated("by gRPC proto compiler")
 public class TestServiceGrpc {
 
+  public static final String SERVICE_NAME = "grpc.testing.TestService";
+
   // Static method descriptors that strictly reflect the proto.
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> METHOD_EMPTY_CALL =
@@ -244,7 +246,7 @@ public class TestServiceGrpc {
 
   public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder("grpc.testing.TestService")
+    return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
       .addMethod(io.grpc.ServerMethodDefinition.create(
           METHOD_EMPTY_CALL,
           asyncUnaryCall(


### PR DESCRIPTION
Extract the fully-qualified service name into a `public static final String SERVICE_NAME` field on the service container type.

This makes the service name accessible as a compile-time constant.