### PR TITLE
Rename HttpUtil to GrpcUtil.

### DIFF
--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -42,7 +42,7 @@ import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransport.PingCallback;
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.internal.SharedResourceHolder;
 
@@ -394,11 +394,11 @@ public final class ChannelImpl extends Channel {
   // TODO(johnbcoughlin) make this package private when we can do so with the tests.
   @VisibleForTesting
   public static final Metadata.Key<Long> TIMEOUT_KEY =
-      Metadata.Key.of(HttpUtil.TIMEOUT, new TimeoutMarshaller());
+      Metadata.Key.of(GrpcUtil.TIMEOUT, new TimeoutMarshaller());
 
   // TODO(carl-mastrangelo): move this to internal
   public static final Metadata.Key<String> MESSAGE_ENCODING_KEY =
-      Metadata.Key.of(HttpUtil.MESSAGE_ENCODING, Metadata.ASCII_STRING_MARSHALLER);
+      Metadata.Key.of(GrpcUtil.MESSAGE_ENCODING, Metadata.ASCII_STRING_MARSHALLER);
 
   /**
    * Marshals a microseconds representation of the timeout to and from a string representation,

--- a/core/src/main/java/io/grpc/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/ClientCallImpl.java
@@ -41,7 +41,7 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SerializingExecutor;
 
 import java.io.InputStream;
@@ -124,9 +124,9 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     }
 
     // Fill out the User-Agent header.
-    headers.removeAll(HttpUtil.USER_AGENT_KEY);
+    headers.removeAll(GrpcUtil.USER_AGENT_KEY);
     if (userAgent != null) {
-      headers.put(HttpUtil.USER_AGENT_KEY, userAgent);
+      headers.put(GrpcUtil.USER_AGENT_KEY, userAgent);
     }
 
     headers.removeAll(ChannelImpl.MESSAGE_ENCODING_KEY);

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -39,9 +39,9 @@ import java.net.HttpURLConnection;
 import javax.annotation.Nullable;
 
 /**
- * Constants for GRPC-over-HTTP (or HTTP/2).
+ * Common utilities for GRPC.
  */
-public final class HttpUtil {
+public final class GrpcUtil {
 
   /**
    * {@link io.grpc.Metadata.Key} for the Content-Type request/response header.
@@ -204,7 +204,7 @@ public final class HttpUtil {
   public static String getGrpcUserAgent(String transportName,
                                         @Nullable String applicationUserAgent) {
     StringBuilder builder = new StringBuilder("grpc-java-").append(transportName);
-    String version = HttpUtil.class.getPackage().getImplementationVersion();
+    String version = GrpcUtil.class.getPackage().getImplementationVersion();
     if (version != null) {
       builder.append("/");
       builder.append(version);
@@ -216,5 +216,5 @@ public final class HttpUtil {
     return builder.toString();
   }
 
-  private HttpUtil() {}
+  private GrpcUtil() {}
 }

--- a/core/src/main/java/io/grpc/internal/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStream.java
@@ -166,7 +166,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
   private static Status statusFromHttpStatus(Metadata metadata) {
     Integer httpStatus = metadata.get(HTTP2_STATUS);
     if (httpStatus != null) {
-      Status status = HttpUtil.httpStatusToGrpcStatus(httpStatus);
+      Status status = GrpcUtil.httpStatusToGrpcStatus(httpStatus);
       return status.isOk() ? status
           : status.augmentDescription("extracted status from HTTP :status " + httpStatus);
     }
@@ -204,8 +204,8 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
       return null;
     }
     contentTypeChecked = true;
-    String contentType = headers.get(HttpUtil.CONTENT_TYPE_KEY);
-    if (TEMP_CHECK_CONTENT_TYPE && !HttpUtil.CONTENT_TYPE_GRPC.equalsIgnoreCase(contentType)) {
+    String contentType = headers.get(GrpcUtil.CONTENT_TYPE_KEY);
+    if (TEMP_CHECK_CONTENT_TYPE && !GrpcUtil.CONTENT_TYPE_GRPC.equalsIgnoreCase(contentType)) {
       // Malformed content-type so report an error
       return Status.INTERNAL.withDescription("invalid content-type " + contentType);
     }
@@ -216,7 +216,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
    * Inspect the raw metadata and figure out what charset is being used.
    */
   private static Charset extractCharset(Metadata headers) {
-    String contentType = headers.get(HttpUtil.CONTENT_TYPE_KEY);
+    String contentType = headers.get(GrpcUtil.CONTENT_TYPE_KEY);
     if (contentType != null) {
       String[] split = contentType.split("charset=");
       try {

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -35,15 +35,15 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import io.grpc.Status;
-import io.grpc.internal.HttpUtil.Http2Error;
+import io.grpc.internal.GrpcUtil.Http2Error;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link HttpUtil}. */
+/** Unit tests for {@link GrpcUtil}. */
 @RunWith(JUnit4.class)
-public class HttpUtilTest {
+public class GrpcUtilTest {
   @Test
   public void http2ErrorForCode() {
     // Try edge cases manually, to make the test obviously correct for important cases.

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -7,6 +7,7 @@ import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
@@ -20,14 +21,16 @@ public class ReconnectServiceGrpc {
       com.google.protobuf.EmptyProtos.Empty> METHOD_START =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
-          "grpc.testing.ReconnectService", "Start",
+          generateFullMethodName(
+              "grpc.testing.ReconnectService", "Start"),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()));
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       io.grpc.testing.integration.Messages.ReconnectInfo> METHOD_STOP =
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
-          "grpc.testing.ReconnectService", "Stop",
+          generateFullMethodName(
+              "grpc.testing.ReconnectService", "Stop"),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.ReconnectInfo.parser()));
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -42,8 +42,9 @@ import com.google.common.base.Ticker;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientTransport.PingCallback;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
-import io.grpc.internal.HttpUtil;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -215,7 +216,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
    */
   private void onRstStreamRead(int streamId, long errorCode) throws Http2Exception {
     NettyClientStream stream = clientStream(requireHttp2Stream(streamId));
-    Status status = HttpUtil.Http2Error.statusForCode((int) errorCode);
+    Status status = GrpcUtil.Http2Error.statusForCode((int) errorCode);
     stream.transportReportStatus(status, false, new Metadata());
   }
 
@@ -439,7 +440,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
   }
 
   private Status statusFromGoAway(long errorCode, ByteBuf debugData) {
-    Status status = HttpUtil.Http2Error.statusForCode((int) errorCode);
+    Status status = GrpcUtil.Http2Error.statusForCode((int) errorCode);
     if (debugData.isReadable()) {
       // If a debug message was provided, use it.
       String msg = debugData.toString(UTF_8);

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -31,15 +31,15 @@
 
 package io.grpc.netty;
 
-import static io.grpc.internal.HttpUtil.CONTENT_TYPE_KEY;
-import static io.grpc.internal.HttpUtil.USER_AGENT_KEY;
+import static io.grpc.internal.GrpcUtil.CONTENT_TYPE_KEY;
+import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 import static io.netty.util.CharsetUtil.UTF_8;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.grpc.Metadata;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.internal.TransportFrameUtil;
 import io.netty.channel.EventLoopGroup;
@@ -62,15 +62,15 @@ import java.util.concurrent.TimeUnit;
 class Utils {
 
   public static final ByteString STATUS_OK = new ByteString("200".getBytes(UTF_8));
-  public static final ByteString HTTP_METHOD = new ByteString(HttpUtil.HTTP_METHOD.getBytes(UTF_8));
+  public static final ByteString HTTP_METHOD = new ByteString(GrpcUtil.HTTP_METHOD.getBytes(UTF_8));
   public static final ByteString HTTPS = new ByteString("https".getBytes(UTF_8));
   public static final ByteString HTTP = new ByteString("http".getBytes(UTF_8));
   public static final ByteString CONTENT_TYPE_HEADER = new ByteString(CONTENT_TYPE_KEY.name()
       .getBytes(UTF_8));
   public static final ByteString CONTENT_TYPE_GRPC = new ByteString(
-      HttpUtil.CONTENT_TYPE_GRPC.getBytes(UTF_8));
+      GrpcUtil.CONTENT_TYPE_GRPC.getBytes(UTF_8));
   public static final ByteString TE_HEADER = new ByteString("te".getBytes(UTF_8));
-  public static final ByteString TE_TRAILERS = new ByteString(HttpUtil.TE_TRAILERS.getBytes(UTF_8));
+  public static final ByteString TE_TRAILERS = new ByteString(GrpcUtil.TE_TRAILERS.getBytes(UTF_8));
   public static final ByteString USER_AGENT = new ByteString(USER_AGENT_KEY.name().getBytes(UTF_8));
 
   public static final Resource<EventLoopGroup> DEFAULT_BOSS_EVENT_LOOP_GROUP =
@@ -129,7 +129,7 @@ class Utils {
     }
 
     // Set the User-Agent header.
-    String userAgent = HttpUtil.getGrpcUserAgent("netty", headers.get(USER_AGENT_KEY));
+    String userAgent = GrpcUtil.getGrpcUserAgent("netty", headers.get(USER_AGENT_KEY));
     http2Headers.set(USER_AGENT, new ByteString(userAgent.getBytes(UTF_8)));
 
     return http2Headers;

--- a/netty/src/test/java/io/grpc/netty/BufferingHttp2ConnectionEncoderTest.java
+++ b/netty/src/test/java/io/grpc/netty/BufferingHttp2ConnectionEncoderTest.java
@@ -31,7 +31,7 @@
 
 package io.grpc.netty;
 
-import static io.grpc.internal.HttpUtil.Http2Error.CANCEL;
+import static io.grpc.internal.GrpcUtil.Http2Error.CANCEL;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_FRAME_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
 import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL;

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -32,7 +32,7 @@
 package io.grpc.netty;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static io.grpc.internal.HttpUtil.USER_AGENT_KEY;
+import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -48,7 +48,7 @@ import io.grpc.StatusException;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
@@ -130,7 +130,7 @@ public class NettyClientTransportTest {
     assertEquals(1, serverListener.streamListeners.size());
 
     Metadata.Headers headers = serverListener.streamListeners.get(0).headers;
-    assertEquals(HttpUtil.getGrpcUserAgent("netty", null), headers.get(USER_AGENT_KEY));
+    assertEquals(GrpcUtil.getGrpcUserAgent("netty", null), headers.get(USER_AGENT_KEY));
   }
 
   @Test
@@ -148,7 +148,7 @@ public class NettyClientTransportTest {
     // Verify that the received headers contained the User-Agent.
     assertEquals(1, serverListener.streamListeners.size());
     Metadata.Headers receivedHeaders = serverListener.streamListeners.get(0).headers;
-    assertEquals(HttpUtil.getGrpcUserAgent("netty", userAgent),
+    assertEquals(GrpcUtil.getGrpcUserAgent("netty", userAgent),
             receivedHeaders.get(USER_AGENT_KEY));
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/Headers.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Headers.java
@@ -31,15 +31,15 @@
 
 package io.grpc.okhttp;
 
-import static io.grpc.internal.HttpUtil.CONTENT_TYPE_KEY;
-import static io.grpc.internal.HttpUtil.USER_AGENT_KEY;
+import static io.grpc.internal.GrpcUtil.CONTENT_TYPE_KEY;
+import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 
 import com.google.common.base.Preconditions;
 
 import com.squareup.okhttp.internal.spdy.Header;
 
 import io.grpc.Metadata;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.TransportFrameUtil;
 
 import okio.ByteString;
@@ -53,10 +53,10 @@ import java.util.List;
 public class Headers {
 
   public static final Header SCHEME_HEADER = new Header(Header.TARGET_SCHEME, "https");
-  public static final Header METHOD_HEADER = new Header(Header.TARGET_METHOD, HttpUtil.HTTP_METHOD);
+  public static final Header METHOD_HEADER = new Header(Header.TARGET_METHOD, GrpcUtil.HTTP_METHOD);
   public static final Header CONTENT_TYPE_HEADER =
-      new Header(CONTENT_TYPE_KEY.name(), HttpUtil.CONTENT_TYPE_GRPC);
-  public static final Header TE_HEADER = new Header("te", HttpUtil.TE_TRAILERS);
+      new Header(CONTENT_TYPE_KEY.name(), GrpcUtil.CONTENT_TYPE_GRPC);
+  public static final Header TE_HEADER = new Header("te", GrpcUtil.TE_TRAILERS);
 
   /**
    * Serializes the given headers and creates a list of OkHttp {@link Header}s to be used when
@@ -79,8 +79,8 @@ public class Headers {
     String path = headers.getPath() != null ? headers.getPath() : defaultPath;
     okhttpHeaders.add(new Header(Header.TARGET_PATH, path));
 
-    String userAgent = HttpUtil.getGrpcUserAgent("okhttp", headers.get(USER_AGENT_KEY));
-    okhttpHeaders.add(new Header(HttpUtil.USER_AGENT_KEY.name(), userAgent));
+    String userAgent = GrpcUtil.getGrpcUserAgent("okhttp", headers.get(USER_AGENT_KEY));
+    okhttpHeaders.add(new Header(GrpcUtil.USER_AGENT_KEY.name(), userAgent));
 
     // All non-pseudo headers must come after pseudo headers.
     okhttpHeaders.add(CONTENT_TYPE_HEADER);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -58,8 +58,8 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
-import io.grpc.internal.HttpUtil;
 import io.grpc.internal.SerializingExecutor;
 
 import okio.Buffer;
@@ -717,7 +717,7 @@ class OkHttpClientTransport implements ClientTransport {
 
     @Override
     public void goAway(int lastGoodStreamId, ErrorCode errorCode, ByteString debugData) {
-      Status status = HttpUtil.Http2Error.statusForCode(errorCode.httpCode);
+      Status status = GrpcUtil.Http2Error.statusForCode(errorCode.httpCode);
       if (debugData != null && debugData.size() > 0) {
         // If a debug message was provided, use it.
         status.augmentDescription(debugData.utf8());

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -77,7 +77,7 @@ import io.grpc.StatusException;
 import io.grpc.internal.AbstractStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
-import io.grpc.internal.HttpUtil;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.okhttp.OkHttpClientTransport.ClientFrameHandler;
 
 import okio.Buffer;
@@ -316,8 +316,8 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     clientTransport.newStream(method, new Metadata.Headers(), listener);
-    Header userAgentHeader = new Header(HttpUtil.USER_AGENT_KEY.name(),
-            HttpUtil.getGrpcUserAgent("okhttp", null));
+    Header userAgentHeader = new Header(GrpcUtil.USER_AGENT_KEY.name(),
+            GrpcUtil.getGrpcUserAgent("okhttp", null));
     List<Header> expectedHeaders = Arrays.asList(SCHEME_HEADER, METHOD_HEADER,
             new Header(Header.TARGET_AUTHORITY, "notarealauthority:80"),
             new Header(Header.TARGET_PATH, "/fakemethod"),
@@ -333,13 +333,13 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener = new MockStreamListener();
     String userAgent = "fakeUserAgent";
     Metadata.Headers metadata = new Metadata.Headers();
-    metadata.put(HttpUtil.USER_AGENT_KEY, userAgent);
+    metadata.put(GrpcUtil.USER_AGENT_KEY, userAgent);
     clientTransport.newStream(method, metadata, listener);
     List<Header> expectedHeaders = Arrays.asList(SCHEME_HEADER, METHOD_HEADER,
         new Header(Header.TARGET_AUTHORITY, "notarealauthority:80"),
         new Header(Header.TARGET_PATH, "/fakemethod"),
-        new Header(HttpUtil.USER_AGENT_KEY.name(),
-            HttpUtil.getGrpcUserAgent("okhttp", userAgent)),
+        new Header(GrpcUtil.USER_AGENT_KEY.name(),
+            GrpcUtil.getGrpcUserAgent("okhttp", userAgent)),
         CONTENT_TYPE_HEADER, TE_HEADER);
     verify(frameWriter, timeout(TIME_OUT_MS))
         .synStream(eq(false), eq(false), eq(3), eq(0), eq(expectedHeaders));


### PR DESCRIPTION
It's not really just for HTTP, it has becoming a dumping ground for many internal constants/utilities.