### PR TITLE
Use status UNAVAILABLE for IOException thrown by OkHttp reading path,…

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -580,9 +580,10 @@ class OkHttpClientTransport implements ClientTransport {
         while (frameReader.nextFrame(this)) {
         }
       } catch (IOException ioe) {
-        // We call onError instead of onIoException here, because OkHttp wraps many protocol errors
-        // as IOException, we should send GoAway for such errors.
-        onError(ErrorCode.PROTOCOL_ERROR, ioe.getMessage());
+        // We send GoAway here because OkHttp wraps many protocol errors as IOException.
+        // TODO(madongfly): Send the exception message to the server.
+        frameWriter.goAway(0, ErrorCode.PROTOCOL_ERROR, new byte[0]);
+        onIoException(ioe);
       } finally {
         try {
           frameReader.close();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -205,10 +205,10 @@ public class OkHttpClientTransportTest {
     listener1.waitUntilStreamClosed();
     listener2.waitUntilStreamClosed();
     assertEquals(0, activeStreamCount());
-    assertEquals(Status.INTERNAL.getCode(), listener1.status.getCode());
-    assertEquals("Protocol error\n" + NETWORK_ISSUE_MESSAGE, listener1.status.getDescription());
-    assertEquals(Status.INTERNAL.getCode(), listener2.status.getCode());
-    assertEquals("Protocol error\n" + NETWORK_ISSUE_MESSAGE, listener2.status.getDescription());
+    assertEquals(Status.UNAVAILABLE.getCode(), listener1.status.getCode());
+    assertEquals(NETWORK_ISSUE_MESSAGE, listener1.status.getCause().getMessage());
+    assertEquals(Status.UNAVAILABLE.getCode(), listener2.status.getCode());
+    assertEquals(NETWORK_ISSUE_MESSAGE, listener2.status.getCause().getMessage());
     verify(transportListener, timeout(TIME_OUT_MS)).transportShutdown(isA(Status.class));
     verify(transportListener, timeout(TIME_OUT_MS)).transportTerminated();
   }


### PR DESCRIPTION
… which can also be triggered by HTTP/2 issues.

Fixes #608