### PR TITLE
Implement per_rpc_creds test

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -593,9 +593,9 @@ public abstract class AbstractTransportTest {
         requestHeadersCapture.get().get(GrpcUtil.TIMEOUT_KEY));
     Assert.assertTrue(
         "configuredTimeoutMinutes=" + configuredTimeoutMinutes
-        + ", transferredTimeoutMinutes=" + transferredTimeoutMinutes,
+            + ", transferredTimeoutMinutes=" + transferredTimeoutMinutes,
         configuredTimeoutMinutes - transferredTimeoutMinutes >= 0
-        && configuredTimeoutMinutes - transferredTimeoutMinutes <= 1);
+            && configuredTimeoutMinutes - transferredTimeoutMinutes <= 1);
   }
 
   @Test
@@ -845,6 +845,15 @@ public abstract class AbstractTransportTest {
     assertFalse(response.getOauthScope().isEmpty());
     assertTrue("Received oauth scope: " + response.getOauthScope(),
         authScope.contains(response.getOauthScope()));
+  }
+
+  /** Sends a unary rpc with "per rpc" raw oauth2 access token credentials. */
+  public void perRpcCreds(String jsonKey, InputStream credentialsStream, String oauthScope)
+      throws Exception {
+    // In gRpc Java, we don't have per Rpc credentials, user can use an intercepted stub only once
+    // for that purpose.
+    // So, this test is identical to oauth2_auth_token test.
+    oauth2AuthToken(jsonKey, credentialsStream, oauthScope);
   }
 
   protected static void assertSuccess(StreamRecorder<?> recorder) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -168,6 +168,7 @@ public class TestServiceClient {
           + "\n      service_account_creds: large_unary with service_account auth"
           + "\n      compute_engine_creds: large_unary with compute engine auth"
           + "\n      oauth2_auth_token: raw oauth2 access token auth"
+          + "\n      per_rpc_creds: per rpc raw oauth2 access token auth"
           + "\n      cancel_after_begin: cancel stream after starting it"
           + "\n      cancel_after_first_response: cancel on first response"
           + "\n  --use_tls=true|false        Whether to use TLS. Default " + c.useTls
@@ -233,6 +234,10 @@ public class TestServiceClient {
       String jsonKey = Files.toString(new File(serviceAccountKeyFile), Charset.forName("UTF-8"));
       FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));
       tester.oauth2AuthToken(jsonKey, credentialsStream, oauthScope);
+    } else if ("per_rpc_creds".equals(testCase)) {
+      String jsonKey = Files.toString(new File(serviceAccountKeyFile), Charset.forName("UTF-8"));
+      FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));
+      tester.perRpcCreds(jsonKey, credentialsStream, oauthScope);
     } else if ("cancel_after_begin".equals(testCase)) {
       tester.cancelAfterBegin();
     } else if ("cancel_after_first_response".equals(testCase)) {


### PR DESCRIPTION
Manually tested by:
```
./run-test-client.sh --server_port=443 --server_host=grpc-test.sandbox.google.com --server_host_override=grpc-test.sandbox.google.com --service_account_key_file=/usr/local/google/home/simonma/gce_cred.json --oauth_scope=https://www.googleapis.com/auth/xapi.zoo --test_case=per_rpc_creds
```

Fixes #704
