### PR TITLE
Add test to prove RST closes stream, and remove hack from transport to force closure.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -45,7 +45,6 @@ import io.grpc.StatusException;
 import io.grpc.internal.ClientTransport.PingCallback;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -226,11 +225,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
   private void onRstStreamRead(int streamId, long errorCode) throws Http2Exception {
     NettyClientStream stream = clientStream(requireHttp2Stream(streamId));
     Status status = GrpcUtil.Http2Error.statusForCode((int) errorCode);
-    // TODO(carl-mastrangelo): This is a hack!  Currently, due to a bug in the deframer, the stream
-    // listener might not be closed if the stream is stopped while in the middle of a recieving a
-    // message.   This is a quick work around to get things working again, but should be changed
-    // back to not stopping delivery once a proper, thought-out fix is in place in the Deframer.
-    stream.transportReportStatus(status, true /*stop delivery*/, new Metadata());
+    stream.transportReportStatus(status, false /*stop delivery*/, new Metadata());
   }
 
   @Override


### PR DESCRIPTION
This adds a test proving that 0d9ac41bdd1a480047c1ec57f4ac499d3a801457 resolves the RST issue.