### PR TITLE
Ease use of JWT by passing URI to auth library

### DIFF
--- a/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
+++ b/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
@@ -42,8 +42,11 @@ import io.grpc.ClientInterceptors.CheckedForwardingClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import io.grpc.StatusException;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -70,22 +73,27 @@ public class ClientAuthInterceptor implements ClientInterceptor {
   }
 
   @Override
-  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
-      CallOptions callOptions, Channel next) {
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      final MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, final Channel next) {
     // TODO(ejona86): If the call fails for Auth reasons, this does not properly propagate info that
     // would be in WWW-Authenticate, because it does not yet have access to the header.
     return new CheckedForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
       @Override
       protected void checkedStart(Listener<RespT> responseListener, Metadata headers)
-          throws Exception {
+          throws StatusException {
         Metadata cachedSaved;
+        URI uri = serviceUri(next, method);
         synchronized (ClientAuthInterceptor.this) {
           // TODO(louiscryan): This is icky but the current auth library stores the same
           // metadata map until the next refresh cycle. This will be fixed once
           // https://github.com/google/google-auth-library-java/issues/3
           // is resolved.
-          if (lastMetadata == null || lastMetadata != getRequestMetadata()) {
-            lastMetadata = getRequestMetadata();
+          // getRequestMetadata() may return a different map based on the provided URI, i.e., for
+          // JWT. However, today it does not cache JWT and so we won't bother tring to cache its
+          // return value based on the URI.
+          Map<String, List<String>> latestMetadata = getRequestMetadata(uri);
+          if (lastMetadata == null || lastMetadata != latestMetadata) {
+            lastMetadata = latestMetadata;
             cached = toHeaders(lastMetadata);
           }
           cachedSaved = cached;
@@ -96,11 +104,37 @@ public class ClientAuthInterceptor implements ClientInterceptor {
     };
   }
 
-  private Map<String, List<String>> getRequestMetadata() {
+  /**
+   * Generate a JWT-specific service URI. The URI is simply an identifier with enough information
+   * for a service to know that the JWT was intended for it. The URI will commonly be verified with
+   * a simple string equality check.
+   */
+  private URI serviceUri(Channel channel, MethodDescriptor<?, ?> method) throws StatusException {
+    String authority = channel.authority();
+    if (authority == null) {
+      throw Status.UNAUTHENTICATED.withDescription("Channel has no authority").asException();
+    }
+    // Always use HTTPS, by definition.
+    final String scheme = "https";
+    // The default port must not be present. Alternative ports should be present.
+    final String suffixToStrip = ":443";
+    if (authority.endsWith(suffixToStrip)) {
+      authority = authority.substring(0, authority.length() - suffixToStrip.length());
+    }
+    String path = "/" + MethodDescriptor.extractFullServiceName(method.getFullMethodName());
     try {
-      return credentials.getRequestMetadata();
+      return new URI(scheme, authority, path, null, null);
+    } catch (URISyntaxException e) {
+      throw Status.UNAUTHENTICATED.withDescription("Unable to construct service URI for auth")
+          .withCause(e).asException();
+    }
+  }
+
+  private Map<String, List<String>> getRequestMetadata(URI uri) throws StatusException {
+    try {
+      return credentials.getRequestMetadata(uri);
     } catch (IOException e) {
-      throw Status.UNAUTHENTICATED.withCause(e).asRuntimeException();
+      throw Status.UNAUTHENTICATED.withCause(e).asException();
     }
   }
 

--- a/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
+++ b/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
@@ -34,6 +34,7 @@ package io.grpc.auth;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,6 +52,7 @@ import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.Status;
 
 import org.junit.Assert;
@@ -64,6 +66,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Date;
 import java.util.concurrent.Executors;
 
@@ -82,6 +85,11 @@ public class ClientAuthInterceptorTests {
   Credentials credentials;
 
   @Mock
+  Marshaller<String> stringMarshaller;
+
+  @Mock
+  Marshaller<Integer> intMarshaller;
+
   MethodDescriptor<String, Integer> descriptor;
 
   @Mock
@@ -99,7 +107,10 @@ public class ClientAuthInterceptorTests {
   @Before
   public void startUp() throws IOException {
     MockitoAnnotations.initMocks(this);
+    descriptor = MethodDescriptor.create(
+        MethodDescriptor.MethodType.UNKNOWN, "a.service/method", stringMarshaller, intMarshaller);
     when(channel.newCall(same(descriptor), any(CallOptions.class))).thenReturn(call);
+    doReturn("localhost:443").when(channel).authority();
     interceptor = new ClientAuthInterceptor(credentials,
         Executors.newSingleThreadExecutor());
   }
@@ -111,7 +122,7 @@ public class ClientAuthInterceptorTests {
     values.put("Authorization", "token2");
     values.put("Extra-Authorization", "token3");
     values.put("Extra-Authorization", "token4");
-    when(credentials.getRequestMetadata()).thenReturn(Multimaps.asMap(values));
+    when(credentials.getRequestMetadata(any(URI.class))).thenReturn(Multimaps.asMap(values));
     ClientCall<String, Integer> interceptedCall =
         interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
     Metadata headers = new Metadata();
@@ -128,7 +139,7 @@ public class ClientAuthInterceptorTests {
 
   @Test
   public void testCredentialsThrows() throws IOException {
-    when(credentials.getRequestMetadata()).thenThrow(new IOException("Broken"));
+    when(credentials.getRequestMetadata(any(URI.class))).thenThrow(new IOException("Broken"));
     ClientCall<String, Integer> interceptedCall =
         interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
     Metadata headers = new Metadata();
@@ -159,5 +170,22 @@ public class ClientAuthInterceptorTests {
     Iterable<String> authorization = headers.getAll(AUTHORIZATION);
     Assert.assertArrayEquals(new String[]{"Bearer allyourbase"},
         Iterables.toArray(authorization, String.class));
+  }
+
+  @Test
+  public void verifyServiceUri() throws IOException {
+    ClientCall<String, Integer> interceptedCall;
+
+    doReturn("example.com:443").when(channel).authority();
+    interceptedCall = interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
+    interceptedCall.start(listener, new Metadata());
+    verify(credentials).getRequestMetadata(URI.create("https://example.com/a.service"));
+    interceptedCall.cancel();
+
+    doReturn("example.com:123").when(channel).authority();
+    interceptedCall = interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
+    interceptedCall.start(listener, new Metadata());
+    verify(credentials).getRequestMetadata(URI.create("https://example.com:123/a.service"));
+    interceptedCall.cancel();
   }
 }

--- a/core/src/main/java/io/grpc/Channel.java
+++ b/core/src/main/java/io/grpc/Channel.java
@@ -59,4 +59,12 @@ public abstract class Channel {
    */
   public abstract <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
       MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions);
+
+  /**
+   * The authority of the destination this channel connects to. Typically this is in the format
+   * {@code host:port}.
+   *
+   * @return authority of remote, or {@code null}
+   */
+  public abstract String authority();
 }

--- a/core/src/main/java/io/grpc/ChannelImpl.java
+++ b/core/src/main/java/io/grpc/ChannelImpl.java
@@ -283,6 +283,11 @@ public final class ChannelImpl extends Channel {
     return interceptorChannel.newCall(method, callOptions);
   }
 
+  @Override
+  public String authority() {
+    return interceptorChannel.authority();
+  }
+
   private ClientTransport obtainActiveTransport() {
     ClientTransport savedActiveTransport = activeTransport;
     // If we know there is an active transport and we are not in backoff mode, return quickly.
@@ -343,6 +348,11 @@ public final class ChannelImpl extends Channel {
           transportProvider,
           scheduledExecutor)
               .setUserAgent(userAgent);
+    }
+
+    @Override
+    public String authority() {
+      return transportFactory.authority();
     }
   }
 

--- a/core/src/main/java/io/grpc/ClientInterceptors.java
+++ b/core/src/main/java/io/grpc/ClientInterceptors.java
@@ -88,6 +88,11 @@ public class ClientInterceptors {
         MethodDescriptor<ReqT, RespT> method, CallOptions callOptions) {
       return interceptor.interceptCall(method, callOptions, channel);
     }
+
+    @Override
+    public String authority() {
+      return channel.authority();
+    }
   }
 
   private static final ClientCall<Object, Object> NOOP_CALL = new ClientCall<Object, Object>() {

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -80,6 +80,11 @@ public class InProcessChannelBuilder extends AbstractChannelBuilder<InProcessCha
     }
 
     @Override
+    public String authority() {
+      return null;
+    }
+
+    @Override
     protected void deallocate() {
       // Do nothing.
     }

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -35,4 +35,10 @@ package io.grpc.internal;
 public interface ClientTransportFactory extends ReferenceCounted {
   /** Creates an unstarted transport for exclusive use. */
   ClientTransport newClientTransport();
+
+  /**
+   * Returns the authority of the channel. Typically, this should be in the form {@code host:port}.
+   * Note that since there is not a scheme, there can't be a default port.
+   */
+  String authority();
 }

--- a/core/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -168,6 +168,11 @@ public class ClientInterceptorsTest {
         order.add("channel");
         return (ClientCall<ReqT, RespT>) call;
       }
+
+      @Override
+      public String authority() {
+        return null;
+      }
     };
     ClientInterceptor interceptor1 = new ClientInterceptor() {
       @Override

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -186,6 +186,7 @@ public final class NettyChannelBuilder extends AbstractChannelBuilder<NettyChann
     private final int flowControlWindow;
     private final ProtocolNegotiator negotiator;
     private final int maxMessageSize;
+    private final String authority;
 
     private NettyTransportFactory(SocketAddress serverAddress,
                                   Class<? extends Channel> channelType,
@@ -198,6 +199,14 @@ public final class NettyChannelBuilder extends AbstractChannelBuilder<NettyChann
       this.flowControlWindow = flowControlWindow;
       this.negotiator = negotiator;
       this.maxMessageSize = maxMessageSize;
+      if (serverAddress instanceof InetSocketAddress) {
+        InetSocketAddress address = (InetSocketAddress) serverAddress;
+        this.authority = address.getHostString() + ":" + address.getPort();
+      } else {
+        // Specialized address types are allowed to support custom Channel types so just assume
+        // their toString() values are valid :authority values
+        this.authority = serverAddress.toString();
+      }
 
       usingSharedGroup = group == null;
       if (usingSharedGroup) {
@@ -211,7 +220,12 @@ public final class NettyChannelBuilder extends AbstractChannelBuilder<NettyChann
     @Override
     public ClientTransport newClientTransport() {
       return new NettyClientTransport(serverAddress, channelType, group, negotiator,
-              flowControlWindow, maxMessageSize);
+              flowControlWindow, maxMessageSize, authority);
+    }
+
+    @Override
+    public String authority() {
+      return authority;
     }
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -64,7 +64,6 @@ import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
 import io.netty.handler.logging.LogLevel;
 import io.netty.util.AsciiString;
 
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.Executor;
 
@@ -95,22 +94,14 @@ class NettyClientTransport implements ClientTransport {
 
   NettyClientTransport(SocketAddress address, Class<? extends Channel> channelType,
                        EventLoopGroup group, ProtocolNegotiator negotiator,
-                       int flowControlWindow, int maxMessageSize) {
+                       int flowControlWindow, int maxMessageSize, String authority) {
     Preconditions.checkNotNull(negotiator, "negotiator");
     this.address = Preconditions.checkNotNull(address, "address");
     this.group = Preconditions.checkNotNull(group, "group");
     this.channelType = Preconditions.checkNotNull(channelType, "channelType");
     this.flowControlWindow = flowControlWindow;
     this.maxMessageSize = maxMessageSize;
-
-    if (address instanceof InetSocketAddress) {
-      InetSocketAddress inetAddress = (InetSocketAddress) address;
-      authority = new AsciiString(inetAddress.getHostString() + ":" + inetAddress.getPort());
-    } else {
-      // Specialized address types are allowed to support custom Channel types so just assume their
-      // toString() values are valid :authority values
-      authority = new AsciiString(address.toString());
-    }
+    this.authority = new AsciiString(authority);
 
     handler = newHandler();
     negotiationHandler = negotiator.newHandler(handler);

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -245,7 +245,8 @@ public class NettyClientTransportTest {
 
   private NettyClientTransport newTransport(ProtocolNegotiator negotiator, int maxMsgSize) {
     NettyClientTransport transport = new NettyClientTransport(address, NioSocketChannel.class,
-            group, negotiator, DEFAULT_WINDOW_SIZE, maxMsgSize);
+            group, negotiator, DEFAULT_WINDOW_SIZE, maxMsgSize,
+            address.getHostString() + ":" + address.getPort());
     transports.add(transport);
     return transport;
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -201,6 +201,7 @@ public final class OkHttpChannelBuilder extends AbstractChannelBuilder<OkHttpCha
     private final SSLSocketFactory socketFactory;
     private final ConnectionSpec connectionSpec;
     private final int maxMessageSize;
+    private final String authority;
 
     private OkHttpTransportFactory(String host,
                                    int port,
@@ -215,6 +216,7 @@ public final class OkHttpChannelBuilder extends AbstractChannelBuilder<OkHttpCha
       this.socketFactory = socketFactory;
       this.connectionSpec = connectionSpec;
       this.maxMessageSize = maxMessageSize;
+      this.authority = authorityHost + ":" + port;
 
       usingSharedExecutor = executor == null;
       if (usingSharedExecutor) {
@@ -229,6 +231,11 @@ public final class OkHttpChannelBuilder extends AbstractChannelBuilder<OkHttpCha
     public ClientTransport newClientTransport() {
       return new OkHttpClientTransport(host, port, authorityHost, executor, socketFactory,
               connectionSpec, maxMessageSize);
+    }
+
+    @Override
+    public String authority() {
+      return authority;
     }
 
     @Override


### PR DESCRIPTION
The URI no longer needs to be provided to the Credential explicitly,
which prevents needing to know a magic string and allows using the same
Credential with multiple services.

I'd like to add 1-2 tests before pushing, but I wanted to start the review process while I'm doing that.