### PR TITLE
Refactoring channel API.

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -36,13 +36,13 @@ import static io.grpc.testing.TestUtils.pickUnusedPort;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 
-import io.grpc.AbstractChannelBuilder;
-import io.grpc.AbstractServerBuilder;
-import io.grpc.ChannelImpl;
-import io.grpc.ServerImpl;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
 import io.grpc.benchmarks.qps.AsyncServer;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.internal.AbstractManagedChannelImplBuilder;
+import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -80,14 +80,14 @@ public class TransportBenchmark {
   @Param({"true", "false"})
   public boolean direct;
 
-  private ChannelImpl channel;
-  private ServerImpl server;
+  private ManagedChannel channel;
+  private Server server;
   private TestServiceGrpc.TestServiceBlockingStub stub;
 
   @Setup
   public void setUp() throws Exception {
-    AbstractServerBuilder serverBuilder;
-    AbstractChannelBuilder channelBuilder;
+    AbstractServerImplBuilder serverBuilder;
+    AbstractManagedChannelImplBuilder channelBuilder;
     switch (transport) {
       case INPROCESS:
       {

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
@@ -50,7 +50,7 @@ import java.util.List;
 import java.util.Random;
 
 /**
- * Benchmark for {@link io.grpc.MutableHandlerRegistryImpl}.
+ * Benchmark for {@link MutableHandlerRegistryImpl}.
  */
 @State(Scope.Benchmark)
 @Fork(1)
@@ -94,7 +94,7 @@ public class HandlerRegistryBenchmark {
   }
 
   /**
-   * Benchmark the {@link io.grpc.HandlerRegistry#lookupMethod(String)} throughput.
+   * Benchmark the {@link MutableHandlerRegistryImpl#lookupMethod(String)} throughput.
    */
   @Benchmark
   public void lookupMethod(Blackhole bh) {

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -34,7 +34,7 @@ package io.grpc.benchmarks.qps;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 
-import io.grpc.ServerImpl;
+import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
@@ -81,7 +81,7 @@ public class AsyncServer {
       return;
     }
 
-    final ServerImpl server = newServer(config);
+    final Server server = newServer(config);
     server.start();
 
     System.out.println("QPS Server started on " + config.address);
@@ -100,7 +100,7 @@ public class AsyncServer {
     });
   }
 
-  static ServerImpl newServer(ServerConfiguration config) throws IOException {
+  static Server newServer(ServerConfiguration config) throws IOException {
     SslContext sslContext = null;
     if (config.tls) {
       System.out.println("Using fake CA for TLS certificate.\n"

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
@@ -50,7 +50,7 @@ import static io.grpc.benchmarks.qps.Utils.newRequest;
 import static io.grpc.benchmarks.qps.Utils.saveHistogram;
 
 import io.grpc.Channel;
-import io.grpc.ChannelImpl;
+import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.SimpleRequest;
@@ -108,7 +108,7 @@ public class OpenLoopClient {
     }
     config.channels = 1;
     config.directExecutor = true;
-    Channel ch = newClientChannel(config);
+    ManagedChannel ch = newClientChannel(config);
     SimpleRequest req = newRequest(config);
     LoadGenerationWorker worker =
         new LoadGenerationWorker(ch, req, config.targetQps, config.duration);
@@ -119,7 +119,7 @@ public class OpenLoopClient {
     if (config.histogramFile != null) {
       saveHistogram(histogram, config.histogramFile);
     }
-    ((ChannelImpl) ch).shutdown();
+    ch.shutdown();
   }
 
   private void printStats(Histogram histogram, long elapsedTime) {

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/Utils.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/Utils.java
@@ -34,7 +34,7 @@ package io.grpc.benchmarks.qps;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 
-import io.grpc.Channel;
+import io.grpc.ManagedChannel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -128,7 +128,7 @@ final class Utils {
         .build();
   }
 
-  static Channel newClientChannel(ClientConfiguration config) throws IOException {
+  static ManagedChannel newClientChannel(ClientConfiguration config) throws IOException {
     if (config.transport == ClientConfiguration.Transport.OK_HTTP) {
       InetSocketAddress addr = (InetSocketAddress) config.address;
       OkHttpChannelBuilder builder = OkHttpChannelBuilder

--- a/core/src/main/java/io/grpc/HandlerRegistry.java
+++ b/core/src/main/java/io/grpc/HandlerRegistry.java
@@ -38,6 +38,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Registry of services and their methods used by servers to dispatching incoming calls.
  */
 @ThreadSafe
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/933")
 public abstract class HandlerRegistry {
 
   /**

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2015, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,28 +31,15 @@
 
 package io.grpc;
 
-import io.grpc.internal.ClientTransportFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import javax.annotation.Nullable;
-
 /**
- * The base class for channel builders.
+ * A builder for {@link ManagedChannel} instances.
  *
- * @param <BuilderT> The concrete type of this builder.
+ * @param <T> The concrete type of this builder.
  */
-public abstract class AbstractChannelBuilder<BuilderT extends AbstractChannelBuilder<BuilderT>> {
-
-  @Nullable
-  private ExecutorService executor;
-  private final List<ClientInterceptor> interceptors = new ArrayList<ClientInterceptor>();
-
-  @Nullable
-  private String userAgent;
+public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> {
 
   /**
    * Provides a custom executor.
@@ -63,61 +50,17 @@ public abstract class AbstractChannelBuilder<BuilderT extends AbstractChannelBui
    * <p>The channel won't take ownership of the given executor. It's caller's responsibility to
    * shut down the executor when it's desired.
    */
-  public final BuilderT executor(ExecutorService executor) {
-    this.executor = executor;
-    return thisT();
-  }
+  public abstract T executor(ExecutorService executor);
 
   /**
    * Adds interceptors that will be called before the channel performs its real work. This is
    * functionally equivalent to using {@link ClientInterceptors#intercept(Channel, List)}, but while
    * still having access to the original {@code ChannelImpl}.
    */
-  public final BuilderT intercept(List<ClientInterceptor> interceptors) {
-    this.interceptors.addAll(interceptors);
-    return thisT();
-  }
-
-  /**
-   * Adds interceptors that will be called before the channel performs its real work. This is
-   * functionally equivalent to using {@link ClientInterceptors#intercept(Channel,
-   * ClientInterceptor...)}, but while still having access to the original {@code ChannelImpl}.
-   */
-  public final BuilderT intercept(ClientInterceptor... interceptors) {
-    return intercept(Arrays.asList(interceptors));
-  }
-
-  private BuilderT thisT() {
-    @SuppressWarnings("unchecked")
-    BuilderT thisT = (BuilderT) this;
-    return thisT;
-  }
-
-  /**
-   * Provides a custom {@code User-Agent} for the application.
-   *
-   * <p>It's an optional parameter. If provided, the given agent will be prepended by the
-   * grpc {@code User-Agent}.
-   */
-  @SuppressWarnings("unchecked")
-  public final BuilderT userAgent(String userAgent) {
-    this.userAgent = userAgent;
-    return (BuilderT) this;
-  }
+  public abstract T intercept(List<ClientInterceptor> interceptors);
 
   /**
    * Builds a channel using the given parameters.
    */
-  public ChannelImpl build() {
-    ClientTransportFactory transportFactory = buildTransportFactory();
-    return new ChannelImpl(transportFactory, executor, userAgent, interceptors);
-  }
-
-  /**
-   * Children of AbstractChannelBuilder should override this method to provide the
-   * {@link ClientTransportFactory} appropriate for this channel.  This method is meant for
-   * Transport implementors and should not be used by normal users.
-   */
-  @Internal
-  protected abstract ClientTransportFactory buildTransportFactory();
+  public abstract ManagedChannel build();
 }

--- a/core/src/main/java/io/grpc/MutableHandlerRegistry.java
+++ b/core/src/main/java/io/grpc/MutableHandlerRegistry.java
@@ -41,6 +41,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @see MutableHandlerRegistryImpl
  */
 @ThreadSafe
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/933")
 public abstract class MutableHandlerRegistry extends HandlerRegistry {
   /**
    * Returns {@code null}, or previous service if {@code service} replaced an existing service.
@@ -51,6 +52,5 @@ public abstract class MutableHandlerRegistry extends HandlerRegistry {
   /**
    * Returns {@code false} if {@code service} was not registered.
    */
-  @Nullable
   public abstract boolean removeService(ServerServiceDefinition service);
 }

--- a/core/src/main/java/io/grpc/MutableHandlerRegistryImpl.java
+++ b/core/src/main/java/io/grpc/MutableHandlerRegistryImpl.java
@@ -44,6 +44,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * blocking method lookup.
  */
 @ThreadSafe
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/933")
 public final class MutableHandlerRegistryImpl extends MutableHandlerRegistry {
   private final ConcurrentMap<String, ServerServiceDefinition> services
       = new ConcurrentHashMap<String, ServerServiceDefinition>();

--- a/core/src/main/java/io/grpc/Server.java
+++ b/core/src/main/java/io/grpc/Server.java
@@ -31,6 +31,9 @@
 
 package io.grpc;
 
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -38,4 +41,54 @@ import javax.annotation.concurrent.ThreadSafe;
  * application code or interceptors.
  */
 @ThreadSafe
-public abstract class Server {}
+public abstract class Server {
+  /**
+   * Bind and start the server.
+   *
+   * @return {@code this} object
+   * @throws IllegalStateException if already started
+   * @throws IOException if unable to bind
+   */
+  public abstract Server start() throws IOException;
+
+  /**
+   * Initiates an orderly shutdown in which preexisting calls continue but new calls are rejected.
+   */
+  public abstract Server shutdown();
+
+  /**
+   * Initiates a forceful shutdown in which preexisting and new calls are rejected. Although
+   * forceful, the shutdown process is still not instantaneous; {@link #isTerminated()} will likely
+   * return {@code false} immediately after this method returns.
+   */
+  public abstract Server shutdownNow();
+
+  /**
+   * Returns whether the server is shutdown. Shutdown servers reject any new calls, but may still
+   * have some calls being processed.
+   *
+   * @see #shutdown()
+   * @see #isTerminated()
+   */
+  public abstract boolean isShutdown();
+
+  /**
+   * Returns whether the server is terminated. Terminated servers have no running calls and
+   * relevant resources released (like TCP connections).
+   *
+   * @see #isShutdown()
+   */
+  public abstract boolean isTerminated();
+
+  /**
+   * Waits for the server to become terminated, giving up if the timeout is reached.
+   *
+   * @return whether the server is terminated, as would be done by {@link #isTerminated()}.
+   */
+  public abstract boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException;
+
+  /**
+   * Waits for the server to become terminated.
+   */
+  public abstract void awaitTermination() throws InterruptedException;
+}

--- a/core/src/main/java/io/grpc/ServerMethodDefinition.java
+++ b/core/src/main/java/io/grpc/ServerMethodDefinition.java
@@ -32,8 +32,7 @@
 package io.grpc;
 
 /**
- * Definition of a method bound by a {@link io.grpc.HandlerRegistry} and exposed
- * by a {@link Server}.
+ * Definition of a method exposed by a {@link Server}.
  */
 public final class ServerMethodDefinition<RequestT, ResponseT> {
   private final MethodDescriptor<RequestT, ResponseT> method;

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -33,7 +33,8 @@ package io.grpc.inprocess;
 
 import com.google.common.base.Preconditions;
 
-import io.grpc.AbstractChannelBuilder;
+import io.grpc.ExperimentalApi;
+import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransportFactory;
@@ -44,7 +45,9 @@ import io.grpc.internal.ClientTransportFactory;
  *
  * <p>The channel is intended to be fully-featured, high performance, and useful in testing.
  */
-public class InProcessChannelBuilder extends AbstractChannelBuilder<InProcessChannelBuilder> {
+@ExperimentalApi("There is no plan to make this API stable.")
+public class InProcessChannelBuilder extends
+        AbstractManagedChannelImplBuilder<InProcessChannelBuilder> {
   /**
    * Create a channel builder that will connect to the server with the given name.
    *

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -33,8 +33,9 @@ package io.grpc.inprocess;
 
 import com.google.common.base.Preconditions;
 
-import io.grpc.AbstractServerBuilder;
+import io.grpc.ExperimentalApi;
 import io.grpc.HandlerRegistry;
+import io.grpc.internal.AbstractServerImplBuilder;
 
 /**
  * Builder for a server that services in-process requests. Clients identify the in-process server by
@@ -42,7 +43,9 @@ import io.grpc.HandlerRegistry;
  *
  * <p>The server is intended to be fully-featured, high performance, and useful in testing.
  */
-public final class InProcessServerBuilder extends AbstractServerBuilder<InProcessServerBuilder> {
+@ExperimentalApi("There is no plan to make this API stable.")
+public final class InProcessServerBuilder
+        extends AbstractServerImplBuilder<InProcessServerBuilder> {
   /**
    * Create a server builder that will bind with the given name.
    *

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.ClientInterceptor;
+import io.grpc.Internal;
+import io.grpc.ManagedChannelBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import javax.annotation.Nullable;
+
+/**
+ * The base class for channel builders.
+ *
+ * @param <T> The concrete type of this builder.
+ */
+public abstract class AbstractManagedChannelImplBuilder
+        <T extends AbstractManagedChannelImplBuilder<T>> extends ManagedChannelBuilder<T> {
+
+  @Nullable
+  private ExecutorService executor;
+  private final List<ClientInterceptor> interceptors = new ArrayList<ClientInterceptor>();
+
+  @Nullable
+  private String userAgent;
+
+  /**
+   * Provides a custom executor.
+   *
+   * <p>It's an optional parameter. If the user has not provided an executor when the channel is
+   * built, the builder will use a static cached thread pool.
+   *
+   * <p>The channel won't take ownership of the given executor. It's caller's responsibility to
+   * shut down the executor when it's desired.
+   */
+  public final T executor(ExecutorService executor) {
+    this.executor = executor;
+    return thisT();
+  }
+
+  /**
+   * Adds interceptors that will be called before the channel performs its real work. This is
+   * functionally equivalent to using {@link io.grpc.ClientInterceptors#intercept(io.grpc.Channel,
+   * List)}, but while still having access to the original {@code ChannelImpl}.
+   */
+  public final T intercept(List<ClientInterceptor> interceptors) {
+    this.interceptors.addAll(interceptors);
+    return thisT();
+  }
+
+  /**
+   * Adds interceptors that will be called before the channel performs its real work. This is
+   * functionally equivalent to using {@link io.grpc.ClientInterceptors#intercept(io.grpc.Channel,
+   * ClientInterceptor...)}, but while still having access to the original {@code ChannelImpl}.
+   */
+  public final T intercept(ClientInterceptor... interceptors) {
+    return intercept(Arrays.asList(interceptors));
+  }
+
+  private T thisT() {
+    @SuppressWarnings("unchecked")
+    T thisT = (T) this;
+    return thisT;
+  }
+
+  /**
+   * Provides a custom {@code User-Agent} for the application.
+   *
+   * <p>It's an optional parameter. If provided, the given agent will be prepended by the
+   * grpc {@code User-Agent}.
+   */
+  public final T userAgent(String userAgent) {
+    this.userAgent = userAgent;
+    return thisT();
+  }
+
+  /**
+   * Builds a channel using the given parameters.
+   */
+  public ManagedChannelImpl build() {
+    ClientTransportFactory transportFactory = buildTransportFactory();
+    return new ManagedChannelImpl(transportFactory, executor, userAgent, interceptors);
+  }
+
+  /**
+   * Children of AbstractChannelBuilder should override this method to provide the
+   * {@link ClientTransportFactory} appropriate for this channel.  This method is meant for
+   * Transport implementors and should not be used by normal users.
+   */
+  @Internal
+  protected abstract ClientTransportFactory buildTransportFactory();
+}

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.Preconditions;
+
+import io.grpc.HandlerRegistry;
+import io.grpc.Internal;
+import io.grpc.MutableHandlerRegistry;
+import io.grpc.MutableHandlerRegistryImpl;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerServiceDefinition;
+
+import java.util.concurrent.ExecutorService;
+
+import javax.annotation.Nullable;
+
+/**
+ * The base class for server builders.
+ *
+ * @param <T> The concrete type for this builder.
+ */
+public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuilder<T>>
+        extends ServerBuilder<T> {
+
+  private final HandlerRegistry registry;
+  @Nullable
+  private ExecutorService executor;
+
+  /**
+   * Constructs using a given handler registry.
+   */
+  protected AbstractServerImplBuilder(HandlerRegistry registry) {
+    this.registry = Preconditions.checkNotNull(registry);
+  }
+
+  /**
+   * Constructs with a MutableHandlerRegistry created internally.
+   */
+  protected AbstractServerImplBuilder() {
+    this.registry = new MutableHandlerRegistryImpl();
+  }
+
+  @Override
+  public final T executor(@Nullable ExecutorService executor) {
+    this.executor = executor;
+    return thisT();
+  }
+
+  /**
+   * Adds a service implementation to the handler registry.
+   *
+   * <p>This is supported only if the user didn't provide a handler registry, or the provided one is
+   * a {@link MutableHandlerRegistry}. Otherwise it throws an UnsupportedOperationException.
+   */
+  @Override
+  public final T addService(ServerServiceDefinition service) {
+    if (registry instanceof MutableHandlerRegistry) {
+      ((MutableHandlerRegistry) registry).addService(service);
+      return thisT();
+    }
+    throw new UnsupportedOperationException("Underlying HandlerRegistry is not mutable");
+  }
+
+  @Override
+  public ServerImpl build() {
+    io.grpc.internal.Server transportServer = buildTransportServer();
+    return new ServerImpl(executor, registry, transportServer);
+  }
+
+  /**
+   * Children of AbstractServerBuilder should override this method to provide transport specific
+   * information for the server.  This method is mean for Transport implementors and should not be
+   * used by normal users.
+   */
+  @Internal
+  protected abstract io.grpc.internal.Server buildTransportServer();
+
+  private T thisT() {
+    @SuppressWarnings("unchecked")
+    T thisT = (T) this;
+    return thisT;
+  }
+}

--- a/core/src/main/java/io/grpc/internal/BackoffPolicy.java
+++ b/core/src/main/java/io/grpc/internal/BackoffPolicy.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc;
+package io.grpc.internal;
 
 /**
  * Determines how long to wait before doing some action (typically a retry, or a reconnect).

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc;
+package io.grpc.internal;
 
 import static io.grpc.internal.GrpcUtil.AUTHORITY_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
@@ -39,12 +39,14 @@ import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.MessageEncoding;
 import io.grpc.MessageEncoding.Compressor;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
-import io.grpc.internal.ClientStream;
-import io.grpc.internal.ClientStreamListener;
-import io.grpc.internal.ClientTransport;
-import io.grpc.internal.SerializingExecutor;
+import io.grpc.Status;
 
 import java.io.InputStream;
 import java.util.concurrent.ScheduledExecutorService;

--- a/core/src/main/java/io/grpc/internal/ExponentialBackoffPolicy.java
+++ b/core/src/main/java/io/grpc/internal/ExponentialBackoffPolicy.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc;
+package io.grpc.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
 

--- a/core/src/test/java/io/grpc/IntegerMarshaller.java
+++ b/core/src/test/java/io/grpc/IntegerMarshaller.java
@@ -34,7 +34,7 @@ package io.grpc;
 import java.io.InputStream;
 
 /** Marshalls decimal-encoded integers. */
-class IntegerMarshaller implements MethodDescriptor.Marshaller<Integer> {
+public class IntegerMarshaller implements MethodDescriptor.Marshaller<Integer> {
   public static IntegerMarshaller INSTANCE = new IntegerMarshaller();
 
   @Override

--- a/core/src/test/java/io/grpc/StringMarshaller.java
+++ b/core/src/test/java/io/grpc/StringMarshaller.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /** Marshalls UTF-8 encoded strings. */
-class StringMarshaller implements MethodDescriptor.Marshaller<String> {
+public class StringMarshaller implements MethodDescriptor.Marshaller<String> {
   public static StringMarshaller INSTANCE = new StringMarshaller();
 
   @Override

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc;
+package io.grpc.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -47,10 +47,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import io.grpc.internal.ClientStream;
-import io.grpc.internal.ClientStreamListener;
-import io.grpc.internal.ClientTransport;
-import io.grpc.internal.ClientTransportFactory;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.IntegerMarshaller;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StringMarshaller;
 
 import org.junit.After;
 import org.junit.Before;
@@ -70,9 +76,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 
-/** Unit tests for {@link ChannelImpl}. */
+/** Unit tests for {@link ManagedChannelImpl}. */
 @RunWith(JUnit4.class)
-public class ChannelImplTest {
+public class ManagedChannelImplTest {
   private MethodDescriptor<String, Integer> method = MethodDescriptor.create(
       MethodDescriptor.MethodType.UNKNOWN, "/service/method",
       new StringMarshaller(), new IntegerMarshaller());
@@ -82,7 +88,7 @@ public class ChannelImplTest {
   private ClientTransport mockTransport;
   @Mock
   private ClientTransportFactory mockTransportFactory;
-  private ChannelImpl channel;
+  private ManagedChannel channel;
 
   @Mock
   private ClientCall.Listener<Integer> mockCallListener;
@@ -99,7 +105,7 @@ public class ChannelImplTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    channel = new ChannelImpl(mockTransportFactory, executor, null,
+    channel = new ManagedChannelImpl(mockTransportFactory, executor, null,
         Collections.<ClientInterceptor>emptyList());
     when(mockTransportFactory.newClientTransport()).thenReturn(mockTransport);
   }
@@ -280,7 +286,8 @@ public class ChannelImplTest {
         return next.newCall(method, callOptions);
       }
     };
-    channel = new ChannelImpl(mockTransportFactory, executor, null, Arrays.asList(interceptor));
+    channel = new ManagedChannelImpl(mockTransportFactory, executor, null,
+            Arrays.asList(interceptor));
     assertNotNull(channel.newCall(method, CallOptions.DEFAULT));
     assertEquals(1, atomic.get());
   }

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc;
+package io.grpc.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -44,12 +44,17 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import io.grpc.IntegerMarshaller;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
-import io.grpc.internal.ServerListener;
-import io.grpc.internal.ServerStream;
-import io.grpc.internal.ServerStreamListener;
-import io.grpc.internal.ServerTransport;
-import io.grpc.internal.ServerTransportListener;
+import io.grpc.MutableHandlerRegistry;
+import io.grpc.MutableHandlerRegistryImpl;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.StringMarshaller;
 
 import org.junit.After;
 import org.junit.Before;

--- a/examples/android/app/src/main/java/io/grpc/helloworldexample/HelloworldActivity.java
+++ b/examples/android/app/src/main/java/io/grpc/helloworldexample/HelloworldActivity.java
@@ -11,12 +11,12 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import java.util.concurrent.TimeUnit;
-
-import io.grpc.ChannelImpl;
+import io.grpc.ManagedChannel;
 import io.grpc.helloworldexample.Helloworld.HelloReply;
 import io.grpc.helloworldexample.Helloworld.HelloRequest;
 import io.grpc.transport.okhttp.OkHttpChannelBuilder;
+
+import java.util.concurrent.TimeUnit;
 
 public class HelloworldActivity extends ActionBarActivity {
     private Button mSendButton;
@@ -47,7 +47,7 @@ public class HelloworldActivity extends ActionBarActivity {
         private String mHost;
         private String mMessage;
         private int mPort;
-        private ChannelImpl mChannel;
+        private ManagedChannel mChannel;
 
         @Override
         protected void onPreExecute() {
@@ -58,7 +58,7 @@ public class HelloworldActivity extends ActionBarActivity {
             mResultText.setText("");
         }
 
-        private String sayHello(ChannelImpl channel) {
+        private String sayHello(ManagedChannel channel) {
             GreeterGrpc.GreeterBlockingStub stub = GreeterGrpc.newBlockingStub(channel);
             HelloRequest message = new HelloRequest();
             message.name = mMessage;

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderClient.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderClient.java
@@ -32,9 +32,9 @@
 package io.grpc.examples.header;
 
 import io.grpc.Channel;
-import io.grpc.ChannelImpl;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
+import io.grpc.ManagedChannel;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloResponse;
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
 public class CustomHeaderClient {
   private static final Logger logger = Logger.getLogger(CustomHeaderClient.class.getName());
 
-  private final ChannelImpl originChannel;
+  private final ManagedChannel originChannel;
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
   /**

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
@@ -31,7 +31,7 @@
 
 package io.grpc.examples.header;
 
-import io.grpc.ServerImpl;
+import io.grpc.Server;
 import io.grpc.ServerInterceptors;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloRequest;
@@ -50,7 +50,7 @@ public class CustomHeaderServer {
 
   /* The port on which the server should run */
   private static final int port = 50051;
-  private ServerImpl server;
+  private Server server;
 
   private void start() throws Exception {
     server = NettyServerBuilder.forPort(port).addService(ServerInterceptors

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
@@ -31,7 +31,7 @@
 
 package io.grpc.examples.helloworld;
 
-import io.grpc.ChannelImpl;
+import io.grpc.ManagedChannel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
 public class HelloWorldClient {
   private static final Logger logger = Logger.getLogger(HelloWorldClient.class.getName());
 
-  private final ChannelImpl channel;
+  private final ManagedChannel channel;
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
   /** Construct client connecting to HelloWorld server at {@code host:port}. */

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
@@ -31,7 +31,7 @@
 
 package io.grpc.examples.helloworld;
 
-import io.grpc.ServerImpl;
+import io.grpc.Server;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 
@@ -45,7 +45,7 @@ public class HelloWorldServer {
 
   /* The port on which the server should run */
   private int port = 50051;
-  private ServerImpl server;
+  private Server server;
 
   private void start() throws Exception {
     server = NettyServerBuilder.forPort(port)

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideClient.java
@@ -33,7 +33,7 @@ package io.grpc.examples.routeguide;
 
 import com.google.common.util.concurrent.SettableFuture;
 
-import io.grpc.ChannelImpl;
+import io.grpc.ManagedChannel;
 import io.grpc.examples.routeguide.RouteGuideGrpc.RouteGuideBlockingStub;
 import io.grpc.examples.routeguide.RouteGuideGrpc.RouteGuideStub;
 import io.grpc.netty.NegotiationType;
@@ -53,7 +53,7 @@ import java.util.logging.Logger;
 public class RouteGuideClient {
   private static final Logger logger = Logger.getLogger(RouteGuideClient.class.getName());
 
-  private final ChannelImpl channel;
+  private final ManagedChannel channel;
   private final RouteGuideBlockingStub blockingStub;
   private final RouteGuideStub asyncStub;
 

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -40,7 +40,7 @@ import static java.lang.Math.sqrt;
 import static java.lang.Math.toRadians;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
-import io.grpc.ServerImpl;
+import io.grpc.Server;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 
@@ -63,7 +63,7 @@ public class RouteGuideServer {
 
   private final int port;
   private final Collection<Feature> features;
-  private ServerImpl grpcServer;
+  private Server grpcServer;
 
   public RouteGuideServer(int port) {
     this(port, RouteGuideUtil.getDefaultFeaturesFile());

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -32,7 +32,6 @@
 package io.grpc.testing.integration;
 
 import static io.grpc.testing.integration.Messages.PayloadType.COMPRESSABLE;
-import static io.grpc.testing.integration.Util.assertEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -52,16 +51,16 @@ import com.google.auth.oauth2.ServiceAccountJwtAccessCredentials;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.EmptyProtos.Empty;
 
-import io.grpc.AbstractServerBuilder;
 import io.grpc.CallOptions;
-import io.grpc.ChannelImpl;
 import io.grpc.ClientCall;
+import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
-import io.grpc.ServerImpl;
+import io.grpc.Server;
 import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.auth.ClientAuthInterceptor;
+import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.protobuf.ProtoUtils;
 import io.grpc.stub.MetadataUtils;
@@ -104,10 +103,10 @@ public abstract class AbstractTransportTest {
   private static final AtomicReference<Metadata> requestHeadersCapture =
       new AtomicReference<Metadata>();
   private static ScheduledExecutorService testServiceExecutor;
-  private static ServerImpl server;
+  private static Server server;
   private static int OPERATION_TIMEOUT = 5000;
 
-  protected static void startStaticServer(AbstractServerBuilder<?> builder) {
+  protected static void startStaticServer(AbstractServerImplBuilder<?> builder) {
     testServiceExecutor = Executors.newScheduledThreadPool(2);
 
     builder.addService(ServerInterceptors.intercept(
@@ -126,7 +125,7 @@ public abstract class AbstractTransportTest {
     testServiceExecutor.shutdown();
   }
 
-  protected ChannelImpl channel;
+  protected ManagedChannel channel;
   protected TestServiceGrpc.TestServiceBlockingStub blockingStub;
   protected TestServiceGrpc.TestService asyncStub;
 
@@ -149,7 +148,7 @@ public abstract class AbstractTransportTest {
     }
   }
 
-  protected abstract ChannelImpl createChannel();
+  protected abstract ManagedChannel createChannel();
 
   @Test(timeout = 10000)
   public void emptyUnary() throws Exception {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/ReconnectTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/ReconnectTestClient.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.EmptyProtos.Empty;
 
-import io.grpc.ChannelImpl;
+import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -53,8 +53,8 @@ public class ReconnectTestClient {
   private int serverControlPort = 8080;
   private int serverRetryPort = 8081;
   private boolean useOkhttp = false;
-  private ChannelImpl controlChannel;
-  private ChannelImpl retryChannel;
+  private ManagedChannel controlChannel;
+  private ManagedChannel retryChannel;
   private ReconnectServiceGrpc.ReconnectServiceBlockingStub controlStub;
   private ReconnectServiceGrpc.ReconnectServiceBlockingStub retryStub;
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -33,7 +33,7 @@ package io.grpc.testing.integration;
 
 import com.google.common.io.Files;
 
-import io.grpc.ChannelImpl;
+import io.grpc.ManagedChannel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -253,7 +253,7 @@ public class TestServiceClient {
 
   private class Tester extends AbstractTransportTest {
     @Override
-    protected ChannelImpl createChannel() {
+    protected ManagedChannel createChannel() {
       if (!useOkHttp) {
         InetAddress address;
         try {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -33,7 +33,7 @@ package io.grpc.testing.integration;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
-import io.grpc.ServerImpl;
+import io.grpc.Server;
 import io.grpc.ServerInterceptors;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
@@ -80,7 +80,7 @@ public class TestServiceServer {
   private boolean useTls = true;
 
   private ScheduledExecutorService executor;
-  private ServerImpl server;
+  private Server server;
 
   private void parseArgs(String[] args) {
     boolean usage = false;

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -31,7 +31,7 @@
 
 package io.grpc.testing.integration;
 
-import io.grpc.ChannelImpl;
+import io.grpc.ManagedChannel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -67,7 +67,7 @@ public class Http2NettyLocalChannelTest extends AbstractTransportTest {
   }
 
   @Override
-  protected ChannelImpl createChannel() {
+  protected ManagedChannel createChannel() {
     return NettyChannelBuilder
         .forAddress(new LocalAddress("in-process-1"))
         .negotiationType(NegotiationType.PLAINTEXT)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -31,7 +31,7 @@
 
 package io.grpc.testing.integration;
 
-import io.grpc.ChannelImpl;
+import io.grpc.ManagedChannel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -73,7 +73,7 @@ public class Http2NettyTest extends AbstractTransportTest {
   }
 
   @Override
-  protected ChannelImpl createChannel() {
+  protected ManagedChannel createChannel() {
     try {
       return NettyChannelBuilder
           .forAddress(TestUtils.testServerAddress(serverPort))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -34,7 +34,7 @@ package io.grpc.testing.integration;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.TlsVersion;
 
-import io.grpc.ChannelImpl;
+import io.grpc.ManagedChannel;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
@@ -75,7 +75,7 @@ public class Http2OkHttpTest extends AbstractTransportTest {
   }
 
   @Override
-  protected ChannelImpl createChannel() {
+  protected ManagedChannel createChannel() {
     OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("127.0.0.1", serverPort)
         .connectionSpec(new ConnectionSpec.Builder(OkHttpChannelBuilder.DEFAULT_CONNECTION_SPEC)
             .cipherSuites(TestUtils.preferredTestCiphers().toArray(new String[0]))

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -36,12 +36,12 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
 import com.google.common.base.Preconditions;
 
-import io.grpc.AbstractChannelBuilder;
+import io.grpc.ExperimentalApi;
+import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.SharedResourceHolder;
-
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -56,7 +56,9 @@ import javax.net.ssl.SSLException;
 /**
  * A builder to help simplify construction of channels using the Netty transport.
  */
-public final class NettyChannelBuilder extends AbstractChannelBuilder<NettyChannelBuilder> {
+@ExperimentalApi("There is no plan to make this API stable, given transport API instability")
+public final class NettyChannelBuilder
+        extends AbstractManagedChannelImplBuilder<NettyChannelBuilder> {
   public static final int DEFAULT_FLOW_CONTROL_WINDOW = 1048576; // 1MiB
 
   private final SocketAddress serverAddress;

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -36,9 +36,9 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
 import com.google.common.base.Preconditions;
 
-import io.grpc.AbstractServerBuilder;
+import io.grpc.ExperimentalApi;
 import io.grpc.HandlerRegistry;
-
+import io.grpc.internal.AbstractServerImplBuilder;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -52,7 +52,8 @@ import javax.annotation.Nullable;
 /**
  * A builder to help simplify the construction of a Netty-based GRPC server.
  */
-public final class NettyServerBuilder extends AbstractServerBuilder<NettyServerBuilder> {
+@ExperimentalApi("There is no plan to make this API stable, given transport API instability")
+public final class NettyServerBuilder extends AbstractServerImplBuilder<NettyServerBuilder> {
   public static final int DEFAULT_FLOW_CONTROL_WINDOW = 1048576; // 1MiB
 
   private final SocketAddress address;
@@ -128,13 +129,13 @@ public final class NettyServerBuilder extends AbstractServerBuilder<NettyServerB
    * <p>The server won't take ownership of the given EventLoopGroup. It's caller's responsibility
    * to shut it down when it's desired.
    *
-   * <p>Grpc uses non-daemon {@link Thread}s by default and thus a {@link io.grpc.ServerImpl} will
+   * <p>Grpc uses non-daemon {@link Thread}s by default and thus a {@link io.grpc.Server} will
    * continue to run even after the main thread has terminated. However, users have to be cautious
    * when providing their own {@link EventLoopGroup}s.
    * For example, Netty's {@link EventLoopGroup}s use daemon threads by default
    * and thus an application with only daemon threads running besides the main thread will exit as
    * soon as the main thread completes.
-   * A simple solution to this problem is to call {@link io.grpc.ServerImpl#awaitTermination()} to
+   * A simple solution to this problem is to call {@link io.grpc.Server#awaitTermination()} to
    * keep the main thread alive until the server has terminated.
    */
   public NettyServerBuilder bossEventLoopGroup(EventLoopGroup group) {
@@ -151,13 +152,13 @@ public final class NettyServerBuilder extends AbstractServerBuilder<NettyServerB
    * <p>The server won't take ownership of the given EventLoopGroup. It's caller's responsibility
    * to shut it down when it's desired.
    *
-   * <p>Grpc uses non-daemon {@link Thread}s by default and thus a {@link io.grpc.ServerImpl} will
+   * <p>Grpc uses non-daemon {@link Thread}s by default and thus a {@link io.grpc.Server} will
    * continue to run even after the main thread has terminated. However, users have to be cautious
    * when providing their own {@link EventLoopGroup}s.
    * For example, Netty's {@link EventLoopGroup}s use daemon threads by default
    * and thus an application with only daemon threads running besides the main thread will exit as
    * soon as the main thread completes.
-   * A simple solution to this problem is to call {@link io.grpc.ServerImpl#awaitTermination()} to
+   * A simple solution to this problem is to call {@link io.grpc.Server#awaitTermination()} to
    * keep the main thread alive until the server has terminated.
    */
   public NettyServerBuilder workerEventLoopGroup(EventLoopGroup group) {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -41,7 +41,8 @@ import com.squareup.okhttp.CipherSuite;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.TlsVersion;
 
-import io.grpc.AbstractChannelBuilder;
+import io.grpc.ExperimentalApi;
+import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransportFactory;
@@ -55,7 +56,9 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLSocketFactory;
 
 /** Convenience class for building channels with the OkHttp transport. */
-public final class OkHttpChannelBuilder extends AbstractChannelBuilder<OkHttpChannelBuilder> {
+@ExperimentalApi("There is no plan to make this API stable, given transport API instability")
+public final class OkHttpChannelBuilder extends
+        AbstractManagedChannelImplBuilder<OkHttpChannelBuilder> {
 
   public static final ConnectionSpec DEFAULT_CONNECTION_SPEC =
       new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)


### PR DESCRIPTION
Client:
* New ManagedChannel abstract class.
* Adding ping to Channel.
* Moving builders and implementations to internal.

Server:
* Added lifecycle management API to Server (mirroring ManagedChannel).
* Moved ServerImpl, AbstractServerBuilder and handler registries to internal.
* New ServerBuilder abstract class (mirroring ManagedChannelBuilder).

Fixes #545