### PR TITLE
Supporting OpenSSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,9 +142,9 @@ subprojects {
                 protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.7.0',
 
-                netty: 'io.netty:netty-codec-http2:4.1.0.Beta5',
+                netty: 'io.netty:netty-codec-http2:4.1.0.Beta6',
                 netty_tcnative: 'io.netty:netty-tcnative:1.1.33.Fork6' + tcnative_suffix,
-                netty_transport_native_epoll: 'io.netty:netty-transport-native-epoll:4.1.0.Beta5' + epoll_suffix,
+                netty_transport_native_epoll: 'io.netty:netty-transport-native-epoll:4.1.0.Beta6' + epoll_suffix,
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -37,6 +37,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
@@ -53,20 +54,20 @@ public class GrpcSslContexts {
 
   private static ApplicationProtocolConfig ALPN = new ApplicationProtocolConfig(
       Protocol.ALPN,
-      SelectorFailureBehavior.FATAL_ALERT,
-      SelectedListenerFailureBehavior.FATAL_ALERT,
+      SelectorFailureBehavior.NO_ADVERTISE,
+      SelectedListenerFailureBehavior.ACCEPT,
       HTTP2_VERSIONS);
 
   private static ApplicationProtocolConfig NPN = new ApplicationProtocolConfig(
       Protocol.NPN,
-      SelectorFailureBehavior.FATAL_ALERT,
-      SelectedListenerFailureBehavior.FATAL_ALERT,
+      SelectorFailureBehavior.NO_ADVERTISE,
+      SelectedListenerFailureBehavior.ACCEPT,
       HTTP2_VERSIONS);
 
   private static ApplicationProtocolConfig NPN_AND_ALPN = new ApplicationProtocolConfig(
       Protocol.NPN_AND_ALPN,
-      SelectorFailureBehavior.FATAL_ALERT,
-      SelectedListenerFailureBehavior.FATAL_ALERT,
+      SelectorFailureBehavior.NO_ADVERTISE,
+      SelectedListenerFailureBehavior.ACCEPT,
       HTTP2_VERSIONS);
 
   /**
@@ -123,9 +124,7 @@ public class GrpcSslContexts {
    * Returns OpenSSL if available, otherwise returns the JDK provider.
    */
   private static SslProvider defaultSslProvider() {
-    return SslProvider.JDK;
-    // TODO(nmittler): use this once we support OpenSSL.
-    // return OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
+    return OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK;
   }
 
   /**
@@ -144,9 +143,7 @@ public class GrpcSslContexts {
         throw new IllegalArgumentException("Jetty ALPN/NPN has not been properly configured.");
       }
       case OPENSSL: {
-        throw new IllegalArgumentException("OpenSSL is not currently supported.");
-        // TODO(nmittler): use this once we support OpenSSL.
-        /*if (!OpenSsl.isAvailable()) {
+        if (!OpenSsl.isAvailable()) {
           throw new IllegalArgumentException("OpenSSL is not installed on the system.");
         }
 
@@ -154,7 +151,7 @@ public class GrpcSslContexts {
           return NPN_AND_ALPN;
         } else {
           return NPN;
-        }*/
+        }
       }
       default:
         throw new IllegalArgumentException("Unsupported provider: " + provider);

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -195,7 +195,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
    */
   void returnProcessedBytes(Http2Stream stream, int bytes) {
     try {
-      decoder().flowController().consumeBytes(ctx, stream, bytes);
+      decoder().flowController().consumeBytes(stream, bytes);
     } catch (Http2Exception e) {
       throw new RuntimeException(e);
     }
@@ -523,7 +523,7 @@ class NettyClientHandler extends Http2ConnectionHandler {
       Http2Stream connectionStream = connection().connectionStream();
       int currentSize = connection().local().flowController().windowSize(connectionStream);
       int delta = flowControlWindow - currentSize;
-      decoder().flowController().incrementWindowSize(ctx, connectionStream, delta);
+      decoder().flowController().incrementWindowSize(connectionStream, delta);
       flowControlWindow = -1;
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -270,7 +270,7 @@ class NettyServerHandler extends Http2ConnectionHandler {
    */
   void returnProcessedBytes(Http2Stream http2Stream, int bytes) {
     try {
-      decoder().flowController().consumeBytes(ctx, http2Stream, bytes);
+      decoder().flowController().consumeBytes(http2Stream, bytes);
     } catch (Http2Exception e) {
       throw new RuntimeException(e);
     }
@@ -396,7 +396,7 @@ class NettyServerHandler extends Http2ConnectionHandler {
       Http2Stream connectionStream = connection().connectionStream();
       int currentSize = connection().local().flowController().windowSize(connectionStream);
       int delta = flowControlWindow - currentSize;
-      decoder().flowController().incrementWindowSize(ctx, connectionStream, delta);
+      decoder().flowController().incrementWindowSize(connectionStream, delta);
       flowControlWindow = -1;
     }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -39,6 +39,7 @@ import static io.grpc.netty.Utils.HTTP_METHOD;
 import static io.grpc.netty.Utils.STATUS_OK;
 import static io.grpc.netty.Utils.TE_HEADER;
 import static io.grpc.netty.Utils.TE_TRAILERS;
+import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,11 +49,8 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.calls;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Ticker;
@@ -60,7 +58,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.Status.Code;
 import io.grpc.StatusException;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransport.PingCallback;
@@ -69,24 +66,17 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
 import io.netty.handler.codec.http2.DefaultHttp2ConnectionEncoder;
-import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
-import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
-import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2FlowController;
-import io.netty.handler.codec.http2.Http2FrameReader;
-import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.AsciiString;
-import io.netty.util.concurrent.ImmediateEventExecutor;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -96,43 +86,31 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link NettyClientHandler}.
  */
 @RunWith(JUnit4.class)
-public class NettyClientHandlerTest extends NettyHandlerTestBase {
-
-  private NettyClientHandler handler;
+public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHandler> {
 
   // TODO(zhangkun83): mocking concrete classes is not safe. Consider making NettyClientStream an
   // interface.
   @Mock
   private NettyClientStream stream;
-
-  private ByteBuf content;
   private Http2Headers grpcHeaders;
-  private WriteQueue writeQueue;
   private long nanoTime; // backs a ticker, for testing ping round-trip time measurement
+  private int flowControlWindow = DEFAULT_WINDOW_SIZE;
+  private int streamId = 3;
 
   /** Set up for test. */
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    frameWriter = new DefaultHttp2FrameWriter();
-    frameReader = new DefaultHttp2FrameReader();
-    handler = newHandler(DEFAULT_WINDOW_SIZE);
-    content = Unpooled.copiedBuffer("hello world", UTF_8);
-
-    when(channel.isActive()).thenReturn(true);
-    mockContext();
+    super.setUp();
 
     grpcHeaders = new DefaultHttp2Headers()
         .scheme(HTTPS)
@@ -143,27 +121,9 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
         .add(CONTENT_TYPE_HEADER, CONTENT_TYPE_GRPC)
         .add(TE_HEADER, TE_TRAILERS);
 
-    // Simulate activation of the handler to force writing of the initial settings
-    handler.startWriteQueue(channel);
-    writeQueue = handler.getWriteQueue();
-    // Delegate writes on the channel to the handler
-    doAnswer(new Answer<ChannelFuture>() {
-      @Override
-      public ChannelFuture answer(InvocationOnMock invocation) throws Throwable {
-        ChannelPromise promise = (ChannelPromise) invocation.getArguments()[1];
-        handler.write(ctx, invocation.getArguments()[0], promise);
-        return promise;
-      }
-    }).when(channel).write(any(), any(ChannelPromise.class));
-    handler.handlerAdded(ctx);
-
     // Simulate receipt of initial remote settings.
     ByteBuf serializedSettings = serializeSettings(new Http2Settings());
     handler.channelRead(ctx, serializedSettings);
-
-    // Reset the context to clear any interactions resulting from the HTTP/2
-    // connection preface handshake.
-    mockContext();
   }
 
   @Test
@@ -171,78 +131,53 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     // Force the stream to be buffered.
     receiveMaxConcurrentStreams(0);
     // Create a new stream with id 3.
-    ChannelPromise createPromise =
-            new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
-    writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), createPromise, true);
+    ChannelFuture createFuture = enqueue(new CreateStreamCommand(grpcHeaders, stream));
     verify(stream).id(eq(3));
     when(stream.id()).thenReturn(3);
     // Cancel the stream.
-    writeQueue.enqueue(new CancelClientStreamCommand(stream, Status.CANCELLED), true);
+    cancelStream(Status.CANCELLED);
 
-    assertTrue(createPromise.isSuccess());
+    assertTrue(createFuture.isSuccess());
     verify(stream).transportReportStatus(eq(Status.CANCELLED), eq(true),
         any(Metadata.class));
   }
 
   @Test
   public void createStreamShouldSucceed() throws Exception {
-    writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), true);
-    verify(channel, times(1)).flush();
-    verify(stream).id(eq(3));
-
-    // Capture and verify the written headers frame.
-    ByteBuf serializedHeaders = captureWrite(ctx);
-    ChannelHandlerContext ctx = newContext();
-    frameReader.readFrame(ctx, serializedHeaders, frameListener);
-    ArgumentCaptor<Http2Headers> captor = ArgumentCaptor.forClass(Http2Headers.class);
-    verify(frameListener).onHeadersRead(eq(ctx), eq(3), captor.capture(), eq(0),
-            eq(Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(false));
-    Http2Headers headers = captor.getValue();
-    assertEquals("https", headers.scheme().toString());
-    assertEquals(HTTP_METHOD, headers.method());
-    assertEquals("www.fake.com", headers.authority().toString());
-    assertEquals(CONTENT_TYPE_GRPC, headers.get(CONTENT_TYPE_HEADER));
-    assertEquals(TE_TRAILERS, headers.get(TE_HEADER));
-    assertEquals("/fakemethod", headers.path().toString());
-    assertEquals("sometoken", headers.get(as("auth")).toString());
+    createStream();
+    verify(frameWriter).writeHeaders(eq(ctx), eq(3), eq(grpcHeaders), eq(0),
+        eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(false), any(ChannelPromise.class));
   }
 
   @Test
   public void cancelShouldSucceed() throws Exception {
     createStream();
-    verify(channel, times(1)).flush();
-    writeQueue.enqueue(new CancelClientStreamCommand(stream, Status.CANCELLED), true);
+    cancelStream(Status.CANCELLED);
 
-    ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
-    verify(ctx).write(eq(expected), any(ChannelPromise.class));
-    verify(channel, times(2)).flush();
+    verify(frameWriter).writeRstStream(eq(ctx), eq(3), eq(Http2Error.CANCEL.code()),
+        any(ChannelPromise.class));
   }
 
   @Test
   public void cancelDeadlineExceededShouldSucceed() throws Exception {
     createStream();
-    verify(channel, times(1)).flush();
-    writeQueue.enqueue(new CancelClientStreamCommand(stream, Status.DEADLINE_EXCEEDED), true);
+    cancelStream(Status.DEADLINE_EXCEEDED);
 
-    ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
-    verify(ctx).write(eq(expected), any(ChannelPromise.class));
-    verify(channel, times(2)).flush();
+    verify(frameWriter).writeRstStream(eq(ctx), eq(3), eq(Http2Error.CANCEL.code()),
+        any(ChannelPromise.class));
   }
 
   @Test
   public void cancelWhileBufferedShouldSucceed() throws Exception {
     handler.connection().local().maxActiveStreams(0);
-    writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), true);
-    verify(channel, times(1)).flush();
-    mockContext();
-    ArgumentCaptor<Integer> idCaptor = ArgumentCaptor.forClass(Integer.class);
-    verify(stream).id(idCaptor.capture());
-    when(stream.id()).thenReturn(idCaptor.getValue());
-    ChannelFuture future = writeQueue.enqueue(new CancelClientStreamCommand(stream,
-            Status.CANCELLED), newPromise(), true);
-    assertTrue(future.isSuccess());
-    verify(channel, times(2)).flush();
-    verifyNoMoreInteractions(ctx);
+
+    ChannelFuture createFuture = createStream();
+    assertFalse(createFuture.isDone());
+
+    ChannelFuture cancelFuture = cancelStream(Status.CANCELLED);
+    assertTrue(cancelFuture.isSuccess());
+    assertTrue(createFuture.isDone());
+    assertTrue(createFuture.isSuccess());
   }
 
   /**
@@ -254,13 +189,12 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
   public void cancelTwiceShouldSucceed() throws Exception {
     createStream();
 
-    writeQueue.enqueue(new CancelClientStreamCommand(stream, Status.CANCELLED), newPromise(), true);
+    cancelStream(Status.CANCELLED);
 
-    ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
-    verify(ctx).write(eq(expected), any(ChannelPromise.class));
+    verify(frameWriter).writeRstStream(any(ChannelHandlerContext.class), eq(3),
+        eq(Http2Error.CANCEL.code()), any(ChannelPromise.class));
 
-    ChannelFuture future = writeQueue.enqueue(new CancelClientStreamCommand(stream,
-            Status.CANCELLED), newPromise(), true);
+    ChannelFuture future = cancelStream(Status.CANCELLED);
     assertTrue(future.isSuccess());
   }
 
@@ -268,39 +202,31 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
   public void cancelTwiceDifferentReasons() throws Exception {
     createStream();
 
-    writeQueue.enqueue(new CancelClientStreamCommand(stream, Status.DEADLINE_EXCEEDED),
-            newPromise(), true);
+    cancelStream(Status.DEADLINE_EXCEEDED);
 
-    ByteBuf expected = rstStreamFrame(3, (int) Http2Error.CANCEL.code());
-    verify(ctx).write(eq(expected), any(ChannelPromise.class));
+    verify(frameWriter).writeRstStream(eq(ctx), eq(3), eq(Http2Error.CANCEL.code()),
+        any(ChannelPromise.class));
 
-    ChannelFuture future = writeQueue.enqueue(new CancelClientStreamCommand(stream,
-            Status.CANCELLED), newPromise(), true);
+    ChannelFuture future = cancelStream(Status.CANCELLED);
     assertTrue(future.isSuccess());
   }
 
   @Test
   public void sendFrameShouldSucceed() throws Exception {
     createStream();
-    verify(channel, times(1)).flush();
+
     // Send a frame and verify that it was written.
-    ChannelFuture future = writeQueue.enqueue(
-            new SendGrpcFrameCommand(stream, content, true), true);
-    verify(channel, times(2)).flush();
+    ChannelFuture future = enqueue(new SendGrpcFrameCommand(stream, content, true));
+
     assertTrue(future.isSuccess());
-    ByteBuf bufWritten = captureWrite(ctx);
-    int startIndex = bufWritten.readerIndex() + Http2CodecUtil.FRAME_HEADER_LENGTH;
-    int length = bufWritten.writerIndex() - startIndex;
-    ByteBuf writtenContent = bufWritten.slice(startIndex, length);
-    assertEquals(content, writtenContent);
+    verify(frameWriter).writeData(eq(ctx), eq(3), eq(content), eq(0), eq(true),
+        any(ChannelPromise.class));
   }
 
   @Test
   public void sendForUnknownStreamShouldFail() throws Exception {
     when(stream.id()).thenReturn(3);
-    ChannelFuture future = writeQueue.enqueue(
-            new SendGrpcFrameCommand(stream, content, true), true);
-    verify(channel, times(1)).flush();
+    ChannelFuture future = enqueue(new SendGrpcFrameCommand(stream, content, true));
     assertTrue(future.isDone());
     assertFalse(future.isSuccess());
   }
@@ -332,25 +258,24 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
   public void receivedGoAwayShouldCancelBufferedStream() throws Exception {
     // Force the stream to be buffered.
     receiveMaxConcurrentStreams(0);
-    ChannelPromise promise = new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
-    writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), promise, true);
+    ChannelFuture future = enqueue(new CreateStreamCommand(grpcHeaders, stream));
     handler.channelRead(ctx, goAwayFrame(0));
-    assertTrue(promise.isDone());
-    assertFalse(promise.isSuccess());
+    assertTrue(future.isDone());
+    assertFalse(future.isSuccess());
     verify(stream).transportReportStatus(any(Status.class), eq(false),
-            notNull(Metadata.class));
+        notNull(Metadata.class));
   }
 
   @Test
   public void receivedGoAwayShouldFailUnknownStreams() throws Exception {
-    writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), true);
+    enqueue(new CreateStreamCommand(grpcHeaders, stream));
 
     // Read a GOAWAY that indicates our stream was never processed by the server.
     handler.channelRead(ctx,
-            goAwayFrame(0, 8 /* Cancel */, Unpooled.copiedBuffer("this is a test", UTF_8)));
+        goAwayFrame(0, 8 /* Cancel */, Unpooled.copiedBuffer("this is a test", UTF_8)));
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(stream).transportReportStatus(captor.capture(), eq(false),
-            notNull(Metadata.class));
+        notNull(Metadata.class));
     assertEquals(Status.CANCELLED.getCode(), captor.getValue().getCode());
     assertEquals("HTTP/2 error code: CANCEL\nthis is a test",
         captor.getValue().getDescription());
@@ -360,8 +285,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
   public void receivedGoAwayShouldFailUnknownBufferedStreams() throws Exception {
     receiveMaxConcurrentStreams(0);
 
-    ChannelPromise promise1 = new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
-    writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), promise1, true);
+    enqueue(new CreateStreamCommand(grpcHeaders, stream));
 
     // Read a GOAWAY that indicates our stream was never processed by the server.
     handler.channelRead(ctx,
@@ -377,19 +301,19 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
   @Test
   public void cancelStreamShouldCreateAndThenFailBufferedStream() throws Exception {
     receiveMaxConcurrentStreams(0);
-    writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), true);
+    enqueue(new CreateStreamCommand(grpcHeaders, stream));
     verify(stream).id(3);
     when(stream.id()).thenReturn(3);
-    writeQueue.enqueue(new CancelClientStreamCommand(stream, Status.CANCELLED), true);
+    cancelStream(Status.CANCELLED);
     verify(stream).transportReportStatus(eq(Status.CANCELLED), eq(true),
-            any(Metadata.class));
+        any(Metadata.class));
   }
 
   @Test
   public void channelShutdownShouldCancelBufferedStreams() throws Exception {
     // Force a stream to get added to the pending queue.
     receiveMaxConcurrentStreams(0);
-    ChannelFuture future = writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), true);
+    ChannelFuture future = enqueue(new CreateStreamCommand(grpcHeaders, stream));
 
     handler.channelInactive(ctx);
     assertTrue(future.isDone());
@@ -404,39 +328,39 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     InOrder inOrder = inOrder(stream);
     inOrder.verify(stream, calls(1)).transportReportStatus(captor.capture(), eq(false),
-            notNull(Metadata.class));
+        notNull(Metadata.class));
     assertEquals(Status.UNAVAILABLE.getCode(), captor.getValue().getCode());
   }
 
   @Test
   public void connectionWindowShouldBeOverridden() throws Exception {
-    int connectionWindow = 1048576; // 1MiB
-    handler = newHandler(connectionWindow);
-    handler.handlerAdded(ctx);
+    flowControlWindow = 1048576; // 1MiB
+    setUp();
+
     Http2Stream connectionStream = handler.connection().connectionStream();
     Http2FlowController localFlowController = handler.connection().local().flowController();
     int actualInitialWindowSize = localFlowController.initialWindowSize(connectionStream);
     int actualWindowSize = localFlowController.windowSize(connectionStream);
-    assertEquals(connectionWindow, actualWindowSize);
-    assertEquals(connectionWindow, actualInitialWindowSize);
+    assertEquals(flowControlWindow, actualWindowSize);
+    assertEquals(flowControlWindow, actualInitialWindowSize);
   }
 
   @Test
   public void createIncrementsIdsForActualAndBufferdStreams() throws Exception {
     receiveMaxConcurrentStreams(2);
     CreateStreamCommand command = new CreateStreamCommand(grpcHeaders, stream);
-    writeQueue.enqueue(command, true);
+    enqueue(command);
     verify(stream).id(eq(3));
-    writeQueue.enqueue(command, true);
+    enqueue(command);
     verify(stream).id(eq(5));
-    writeQueue.enqueue(command, true);
+    enqueue(command);
     verify(stream).id(eq(7));
   }
 
   @Test
   public void exhaustedStreamsShouldFail() throws Exception {
-    handler = newHandler(DEFAULT_WINDOW_SIZE, Integer.MAX_VALUE);
-    handler.handlerAdded(ctx);
+    streamId = Integer.MAX_VALUE;
+    setUp();
 
     // Create the MAX_INT stream.
     ChannelFuture future = createStream();
@@ -450,21 +374,15 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
 
   @Test
   public void ping() throws Exception {
-    when(channel.isOpen()).thenReturn(true);
-
     PingCallbackImpl callback1 = new PingCallbackImpl();
-    sendPing(callback1, MoreExecutors.directExecutor());
+    sendPing(callback1);
     // add'l ping will be added as listener to outstanding operation
     PingCallbackImpl callback2 = new PingCallbackImpl();
-    sendPing(callback2, MoreExecutors.directExecutor());
+    sendPing(callback2);
 
-    ByteBuf ping = captureWrite(ctx);
-    frameReader.readFrame(ctx, ping, frameListener);
     ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
-    verify(frameListener).onPingRead(eq(ctx), captor.capture());
-    // callback not invoked until we see acknowledgement
-    assertEquals(0, callback1.invocationCount);
-    assertEquals(0, callback2.invocationCount);
+    verify(frameWriter).writePing(eq(ctx), eq(false), captor.capture(),
+        any(ChannelPromise.class));
 
     // getting a bad ack won't cause the callback to be invoked
     ByteBuf pingPayload = captor.getValue();
@@ -490,31 +408,14 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
 
     // now that previous ping is done, next request starts a new operation
     callback1 = new PingCallbackImpl();
-    sendPing(callback1, MoreExecutors.directExecutor());
+    sendPing(callback1);
     assertEquals(0, callback1.invocationCount);
   }
 
   @Test
-  public void ping_failsIfChannelClosed() throws Exception {
-    // channel already closed
-    when(channel.isOpen()).thenReturn(false);
-
-    PingCallbackImpl callback = new PingCallbackImpl();
-    sendPing(callback, MoreExecutors.directExecutor());
-
-    // ping immediately fails because channel is closed
-    assertEquals(1, callback.invocationCount);
-    assertTrue(callback.failureCause instanceof StatusException);
-    assertEquals(Code.UNAVAILABLE,
-        ((StatusException) callback.failureCause).getStatus().getCode());
-  }
-
-  @Test
   public void ping_failsWhenChannelCloses() throws Exception {
-    when(channel.isOpen()).thenReturn(true);
-
     PingCallbackImpl callback = new PingCallbackImpl();
-    sendPing(callback, MoreExecutors.directExecutor());
+    sendPing(callback);
     assertEquals(0, callback.invocationCount);
 
     handler.channelInactive(ctx);
@@ -525,65 +426,56 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase {
         ((StatusException) callback.failureCause).getStatus().getCode());
   }
 
-  private void sendPing(PingCallback callback, Executor executor) {
-    writeQueue.enqueue(new SendPingCommand(callback, executor), true);
+  private ChannelFuture sendPing(PingCallback callback) {
+    return enqueue(new SendPingCommand(callback, MoreExecutors.directExecutor()));
   }
 
   private void receiveMaxConcurrentStreams(int max) throws Exception {
     ByteBuf serializedSettings = serializeSettings(new Http2Settings().maxConcurrentStreams(max));
     handler.channelRead(ctx, serializedSettings);
-    // Reset the context to clear this write.
-    mockContext();
   }
 
   private ByteBuf dataFrame(int streamId, boolean endStream) {
-    // Need to retain the content since the frameWriter releases it.
-    content.retain();
-    ChannelHandlerContext ctx = newContext();
-    frameWriter.writeData(ctx, streamId, content, 0, endStream, newPromise());
-    return captureWrite(ctx);
-  }
-
-  private ByteBuf pingFrame(boolean ack, ByteBuf payload) {
-    // Need to retain the content since the frameWriter releases it.
-    content.retain();
-    ChannelHandlerContext ctx = newContext();
-    frameWriter.writePing(ctx, ack, payload, newPromise());
-    return captureWrite(ctx);
+    return dataFrame(streamId, endStream, content);
   }
 
   private ChannelFuture createStream() throws Exception {
-    ChannelFuture future = writeQueue.enqueue(new CreateStreamCommand(grpcHeaders, stream), true);
+    ChannelFuture future = enqueue(new CreateStreamCommand(grpcHeaders, stream));
     when(stream.id()).thenReturn(3);
-    // Reset the context mock to clear recording of sent headers frame.
-    mockContext();
     return future;
   }
 
-  private NettyClientHandler newHandler(int connectionWindowSize)
-          throws Http2Exception {
-    return newHandler(connectionWindowSize, 3);
+  private ChannelFuture cancelStream(Status status) throws Exception {
+    return enqueue(new CancelClientStreamCommand(stream, status));
   }
 
-  private NettyClientHandler newHandler(int connectionWindowSize, int streamId)
-          throws Http2Exception {
+  @Override
+  protected NettyClientHandler newHandler() throws Http2Exception {
     Http2Connection connection = new DefaultHttp2Connection(false);
 
     // Create and close a stream previous to the nextStreamId.
     Http2Stream stream = connection.local().createStream(streamId - 2, true);
     stream.close();
 
-    Http2FrameReader frameReader = new DefaultHttp2FrameReader();
-    Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
     BufferingHttp2ConnectionEncoder encoder = new BufferingHttp2ConnectionEncoder(
-            new DefaultHttp2ConnectionEncoder(connection, frameWriter));
+        new DefaultHttp2ConnectionEncoder(connection, frameWriter));
     Ticker ticker = new Ticker() {
       @Override
       public long read() {
         return nanoTime;
       }
     };
-    return new NettyClientHandler(encoder, connection, frameReader, connectionWindowSize, ticker);
+    return new NettyClientHandler(encoder, connection, frameReader, flowControlWindow, ticker);
+  }
+
+  @Override
+  protected void initWriteQueue() {
+    handler.startWriteQueue(channel);
+  }
+
+  @Override
+  protected WriteQueue writeQueue() {
+    return handler.getWriteQueue();
   }
 
   private AsciiString as(String string) {

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -31,9 +31,10 @@
 
 package io.grpc.netty;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,38 +42,37 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoop;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
+import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2FrameListener;
 import io.netty.handler.codec.http2.Http2FrameReader;
 import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.util.concurrent.ImmediateEventExecutor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 /**
  * Base class for Netty handler unit tests.
  */
 @RunWith(JUnit4.class)
-public abstract class NettyHandlerTestBase {
+public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
 
-  @Mock
-  protected Channel channel;
+  protected ByteBuf content;
 
-  @Mock
+  protected EmbeddedChannel channel;
+
   protected ChannelHandlerContext ctx;
 
   @Mock
@@ -81,16 +81,46 @@ public abstract class NettyHandlerTestBase {
   @Mock
   protected Http2FrameListener frameListener;
 
-  @Mock
-  protected EventLoop eventLoop;
-  private boolean inEventLoop;
-
   protected Http2FrameWriter frameWriter;
+
   protected Http2FrameReader frameReader;
 
+  protected T handler;
+
+  protected void setUp() throws Exception {
+    content = Unpooled.copiedBuffer("hello world", UTF_8);
+    frameWriter = spy(new DefaultHttp2FrameWriter());
+    frameReader = new DefaultHttp2FrameReader();
+
+    handler = newHandler();
+
+    channel = new EmbeddedChannel(handler);
+    ctx = channel.pipeline().context(handler);
+
+    initWriteQueue();
+  }
+
+  protected final ByteBuf dataFrame(int streamId, boolean endStream, ByteBuf content) {
+    // Need to retain the content since the frameWriter releases it.
+    content.retain();
+
+    ChannelHandlerContext ctx = newMockContext();
+    new DefaultHttp2FrameWriter().writeData(ctx, streamId, content, 0, endStream, newPromise());
+    return captureWrite(ctx);
+  }
+
+  protected final ByteBuf pingFrame(boolean ack, ByteBuf payload) {
+    // Need to retain the content since the frameWriter releases it.
+    payload.retain();
+
+    ChannelHandlerContext ctx = newMockContext();
+    new DefaultHttp2FrameWriter().writePing(ctx, ack, payload, newPromise());
+    return captureWrite(ctx);
+  }
+
   protected final ByteBuf headersFrame(int streamId, Http2Headers headers) {
-    ChannelHandlerContext ctx = newContext();
-    frameWriter.writeHeaders(ctx, streamId, headers, 0, false, newPromise());
+    ChannelHandlerContext ctx = newMockContext();
+    new DefaultHttp2FrameWriter().writeHeaders(ctx, streamId, headers, 0, false, newPromise());
     return captureWrite(ctx);
   }
 
@@ -99,32 +129,39 @@ public abstract class NettyHandlerTestBase {
   }
 
   protected final ByteBuf goAwayFrame(int lastStreamId, int errorCode, ByteBuf data) {
-    ChannelHandlerContext ctx = newContext();
-    frameWriter.writeGoAway(ctx, lastStreamId, errorCode, data, newPromise());
+    ChannelHandlerContext ctx = newMockContext();
+    new DefaultHttp2FrameWriter().writeGoAway(ctx, lastStreamId, errorCode, data, newPromise());
     return captureWrite(ctx);
   }
 
   protected final ByteBuf rstStreamFrame(int streamId, int errorCode) {
-    ChannelHandlerContext ctx = newContext();
-    frameWriter.writeRstStream(ctx, streamId, errorCode, newPromise());
+    ChannelHandlerContext ctx = newMockContext();
+    new DefaultHttp2FrameWriter().writeRstStream(ctx, streamId, errorCode, newPromise());
     return captureWrite(ctx);
   }
 
   protected final ByteBuf serializeSettings(Http2Settings settings) {
-    ChannelHandlerContext ctx = newContext();
-    frameWriter.writeSettings(ctx, settings, newPromise());
+    ChannelHandlerContext ctx = newMockContext();
+    new DefaultHttp2FrameWriter().writeSettings(ctx, settings, newPromise());
     return captureWrite(ctx);
   }
 
-  protected final ChannelHandlerContext newContext() {
-    ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
-    when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
-    when(ctx.executor()).thenReturn(eventLoop);
-    return ctx;
+  protected final ChannelPromise newPromise() {
+    return channel.newPromise();
   }
 
-  protected final ChannelPromise newPromise() {
-    return new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
+  protected final ChannelFuture enqueue(Object command) {
+    ChannelFuture future = writeQueue().enqueue(command, newPromise(), true);
+    channel.runPendingTasks();
+    return future;
+  }
+
+  protected final ChannelHandlerContext newMockContext() {
+    ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+    when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+    EventLoop eventLoop = Mockito.mock(EventLoop.class);
+    when(ctx.executor()).thenReturn(eventLoop);
+    return ctx;
   }
 
   protected final ByteBuf captureWrite(ChannelHandlerContext ctx) {
@@ -138,83 +175,9 @@ public abstract class NettyHandlerTestBase {
     return composite;
   }
 
-  protected final void mockContext() {
-    Mockito.reset(ctx);
+  protected abstract T newHandler() throws Http2Exception;
 
-    when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
-    when(ctx.channel()).thenReturn(channel);
-    when(ctx.newSucceededFuture()).thenReturn(succeededFuture);
-    when(ctx.executor()).thenReturn(eventLoop);
-    when(channel.eventLoop()).thenReturn(eventLoop);
+  protected abstract void initWriteQueue();
 
-    Answer<ChannelPromise> newPromiseAnswer = new Answer<ChannelPromise>() {
-      @Override
-      public ChannelPromise answer(InvocationOnMock invocation) throws Throwable {
-        return newPromise();
-      }
-    };
-    doAnswer(newPromiseAnswer).when(channel).newPromise();
-    doAnswer(newPromiseAnswer).when(ctx).newPromise();
-
-    when(eventLoop.inEventLoop()).thenAnswer(new Answer<Boolean>() {
-      @Override
-      public Boolean answer(InvocationOnMock invocation) throws Throwable {
-        return inEventLoop;
-      }
-    });
-
-    mockFuture(succeededFuture, true);
-
-    doAnswer(new Answer<Void>() {
-      @Override
-      public Void answer(InvocationOnMock invocation) throws Throwable {
-        try {
-          inEventLoop = true;
-          Runnable runnable = (Runnable) invocation.getArguments()[0];
-          runnable.run();
-          return null;
-        } finally {
-          inEventLoop = false;
-        }
-      }
-    }).when(eventLoop).execute(any(Runnable.class));
-
-    Answer<ChannelFuture> writeOneArgAnswer = new Answer<ChannelFuture>() {
-      @Override
-      public ChannelFuture answer(InvocationOnMock in) throws Throwable {
-        return ctx.writeAndFlush(in.getArguments()[0], newPromise());
-      }
-    };
-    Answer<ChannelFuture> writeTwoArgAnswer = new Answer<ChannelFuture>() {
-      @Override
-      public ChannelFuture answer(InvocationOnMock in) throws Throwable {
-        ChannelPromise promise = (ChannelPromise) in.getArguments()[1];
-        promise.trySuccess();
-        return promise;
-      }
-    };
-    // Make all writes complete immediately.
-    doAnswer(writeTwoArgAnswer).when(ctx).write(any(), any(ChannelPromise.class));
-    doAnswer(writeTwoArgAnswer).when(ctx).writeAndFlush(any(), any(ChannelPromise.class));
-    doAnswer(writeOneArgAnswer).when(ctx).write(any());
-    doAnswer(writeOneArgAnswer).when(ctx).writeAndFlush(any());
-  }
-
-  protected final void mockFuture(final ChannelFuture future, boolean succeeded) {
-    when(future.isDone()).thenReturn(true);
-    when(future.isCancelled()).thenReturn(false);
-    when(future.isSuccess()).thenReturn(succeeded);
-    if (!succeeded) {
-      when(future.cause()).thenReturn(new Exception("fake"));
-    }
-
-    doAnswer(new Answer<ChannelFuture>() {
-      @Override
-      public ChannelFuture answer(InvocationOnMock invocation) throws Throwable {
-        ChannelFutureListener listener = (ChannelFutureListener) invocation.getArguments()[0];
-        listener.operationComplete(future);
-        return future;
-      }
-    }).when(future).addListener(any(ChannelFutureListener.class));
-  }
+  protected abstract WriteQueue writeQueue();
 }

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -43,13 +43,12 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.toByteBuf;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -66,26 +65,20 @@ import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.ServerTransportListener;
 import io.grpc.internal.WritableBuffer;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
-import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
-import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
 import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2FlowController;
-import io.netty.handler.codec.http2.Http2FrameReader;
-import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2Stream;
@@ -99,19 +92,18 @@ import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
 
-/** Unit tests for {@link NettyServerHandler}. */
+/**
+ * Unit tests for {@link NettyServerHandler}.
+ */
 @RunWith(JUnit4.class)
-public class NettyServerHandlerTest extends NettyHandlerTestBase {
+public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHandler> {
 
   private static final int STREAM_ID = 3;
-  private static final byte[] CONTENT = "hello world".getBytes(UTF_8);
 
   @Mock
   private ServerTransportListener transportListener;
@@ -121,10 +113,9 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
 
   private NettyServerStream stream;
 
-  private NettyServerHandler handler;
-  private WriteQueue writeQueue;
+  private int flowControlWindow = DEFAULT_WINDOW_SIZE;
+  private int maxConcurrentStreams = Integer.MAX_VALUE;
 
-  /** Set up for test. */
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
@@ -133,62 +124,25 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
         any(String.class),
         any(Metadata.class)))
         .thenReturn(streamListener);
-    handler = newHandler(transportListener);
-    frameWriter = new DefaultHttp2FrameWriter();
-    frameReader = new DefaultHttp2FrameReader();
 
-    when(channel.isActive()).thenReturn(true);
-    mockContext();
-    // Delegate writes on the channel to the handler
-    doAnswer(new Answer<ChannelFuture>() {
-      @Override
-      public ChannelFuture answer(InvocationOnMock invocation) throws Throwable {
-        ChannelPromise promise = newPromise();
-        handler.write(ctx, invocation.getArguments()[0], promise);
-        return promise;
-      }
-    }).when(channel).write(any());
-    doAnswer(new Answer<ChannelFuture>() {
-      @Override
-      public ChannelFuture answer(InvocationOnMock invocation) throws Throwable {
-        ChannelPromise promise = (ChannelPromise) invocation.getArguments()[1];
-        handler.write(ctx, invocation.getArguments()[0], promise);
-        return promise;
-      }
-    }).when(channel).write(any(), any(ChannelPromise.class));
-
-    when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
-
-    // Simulate activation of the handler to force writing of the initial settings
-    handler.handlerAdded(ctx);
-    writeQueue = handler.getWriteQueue();
+    super.setUp();
 
     // Simulate receipt of the connection preface
     handler.channelRead(ctx, Http2CodecUtil.connectionPrefaceBuf());
     // Simulate receipt of initial remote settings.
     ByteBuf serializedSettings = serializeSettings(new Http2Settings());
     handler.channelRead(ctx, serializedSettings);
-
-    // Reset the context to clear any interactions resulting from the HTTP/2
-    // connection preface handshake.
-    mockContext();
   }
 
   @Test
   public void sendFrameShouldSucceed() throws Exception {
     createStream();
-    ByteBuf content = Unpooled.copiedBuffer(CONTENT);
 
     // Send a frame and verify that it was written.
-    ChannelFuture future = writeQueue.enqueue(
-            new SendGrpcFrameCommand(stream, content, false), true);
+    ChannelFuture future = enqueue(new SendGrpcFrameCommand(stream, content, false));
     assertTrue(future.isSuccess());
-    ByteBuf bufWritten = captureWrite(ctx);
-    verify(channel, times(1)).flush();
-    int startIndex = bufWritten.readerIndex() + Http2CodecUtil.FRAME_HEADER_LENGTH;
-    int length = bufWritten.writerIndex() - startIndex;
-    ByteBuf writtenContent = bufWritten.slice(startIndex, length);
-    assertEquals(content, writtenContent);
+    verify(frameWriter).writeData(eq(ctx), eq(STREAM_ID), eq(content), eq(0), eq(false),
+        any(ChannelPromise.class));
   }
 
   @Test
@@ -210,7 +164,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
     handler.channelRead(ctx, frame);
     ArgumentCaptor<InputStream> captor = ArgumentCaptor.forClass(InputStream.class);
     verify(streamListener).messageRead(captor.capture());
-    assertArrayEquals(CONTENT, ByteStreams.toByteArray(captor.getValue()));
+    assertArrayEquals(ByteBufUtil.getBytes(content), ByteStreams.toByteArray(captor.getValue()));
 
     if (endStream) {
       verify(streamListener).halfClosed();
@@ -257,8 +211,8 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
     // Read a DATA frame to trigger the exception.
     handler.channelRead(ctx, emptyGrpcFrame(STREAM_ID, true));
 
-    // Verify that the context was NOT closed.
-    verify(ctx, never()).close();
+    // Verify that the channel was NOT closed.
+    assertTrue(channel.isOpen());
 
     // Verify the stream was closed.
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
@@ -277,48 +231,29 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
     // Verify the expected GO_AWAY frame was written.
     Exception e = connectionError(Http2Error.PROTOCOL_ERROR,
         "Frame length 0 incorrect size for ping.");
-    ByteBuf expected =
-        goAwayFrame(STREAM_ID, (int) Http2Error.FRAME_SIZE_ERROR.code(), toByteBuf(ctx, e));
-    ByteBuf actual = captureWrite(ctx);
-    assertEquals(expected, actual);
+    verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(Http2Error.FRAME_SIZE_ERROR.code()),
+        eq(toByteBuf(ctx, e)), any(ChannelPromise.class));
 
     // Verify that the context was closed.
-    verify(ctx).close();
+    assertFalse(channel.isOpen());
   }
 
   @Test
   public void closeShouldCloseChannel() throws Exception {
     handler.close(ctx, newPromise());
 
-    // Verify the expected GO_AWAY frame was written.
-    ByteBuf expected = goAwayFrame(0, (int) Http2Error.NO_ERROR.code(), Unpooled.EMPTY_BUFFER);
-    ByteBuf actual = captureWrite(ctx);
-    assertEquals(expected, actual);
+    verify(frameWriter).writeGoAway(eq(ctx), eq(0), eq(Http2Error.NO_ERROR.code()),
+        eq(Unpooled.EMPTY_BUFFER), any(ChannelPromise.class));
 
-    // Verify that the context was closed.
-    verify(ctx).close(any(ChannelPromise.class));
+    // Verify that the channel was closed.
+    assertFalse(channel.isOpen());
   }
 
   @Test
   public void shouldAdvertiseMaxConcurrentStreams() throws Exception {
-    final int maxConcurrentStreams = 314;
-    channel = mock(Channel.class);
-    Http2FrameWriter frameWriter = mock(Http2FrameWriter.class);
-    Http2Connection connection = new DefaultHttp2Connection(true);
-    handler =
-        new NettyServerHandler(transportListener, connection, new DefaultHttp2FrameReader(),
-            frameWriter, maxConcurrentStreams, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE);
+    maxConcurrentStreams = 314;
+    setUp();
 
-    when(channel.isActive()).thenReturn(true);
-    mockContext();
-
-    when(frameWriter.writeSettings(
-        any(ChannelHandlerContext.class), any(Http2Settings.class), any(ChannelPromise.class)))
-          .thenReturn(new DefaultChannelPromise(channel).setSuccess());
-    when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
-
-    // Simulate activation of the handler to force writing of the initial settings
-    handler.handlerAdded(ctx);
     ArgumentCaptor<Http2Settings> captor = ArgumentCaptor.forClass(Http2Settings.class);
     verify(frameWriter, times(2)).writeSettings(
         any(ChannelHandlerContext.class), captor.capture(), any(ChannelPromise.class));
@@ -329,9 +264,9 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
 
   @Test
   public void connectionWindowShouldBeOverridden() throws Exception {
-    int flowControlWindow = 1048576; // 1MiB
-    handler = newHandler(transportListener, flowControlWindow);
-    handler.handlerAdded(ctx);
+    flowControlWindow = 1048576; // 1MiB
+    setUp();
+
     Http2Stream connectionStream = handler.connection().connectionStream();
     Http2FlowController localFlowController = handler.connection().local().flowController();
     int actualInitialWindowSize = localFlowController.initialWindowSize(connectionStream);
@@ -343,10 +278,9 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
   @Test
   public void cancelShouldSendRstStream() throws Exception {
     createStream();
-    writeQueue.enqueue(new CancelServerStreamCommand(stream, Status.DEADLINE_EXCEEDED), true);
-    ByteBuf expected = rstStreamFrame(stream.id(), (int) Http2Error.CANCEL.code());
-    ByteBuf actual = captureWrite(ctx);
-    assertEquals(expected, actual);
+    enqueue(new CancelServerStreamCommand(stream, Status.DEADLINE_EXCEEDED));
+    verify(frameWriter).writeRstStream(eq(ctx), eq(stream.id()), eq(Http2Error.CANCEL.code()),
+        any(ChannelPromise.class));
   }
 
   @Test
@@ -358,12 +292,8 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
             .path(new AsciiString("/foo/bar"));
     ByteBuf headersFrame = headersFrame(STREAM_ID, headers);
     handler.channelRead(ctx, headersFrame);
-    ByteBuf expectedFrame = rstStreamFrame(STREAM_ID, (int) Http2Error.REFUSED_STREAM.code());
-    try {
-      verify(ctx).write(eq(expectedFrame), any(ChannelPromise.class));
-    } finally {
-      expectedFrame.release();
-    }
+    verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), eq(Http2Error.REFUSED_STREAM.code()),
+        any(ChannelPromise.class));
   }
 
   private void createStream() throws Exception {
@@ -384,7 +314,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
   }
 
   private ByteBuf dataFrame(int streamId, boolean endStream) {
-    final ByteBuf compressionFrame = Unpooled.buffer(CONTENT.length);
+    final ByteBuf compressionFrame = Unpooled.buffer(content.readableBytes());
     MessageFramer framer = new MessageFramer(new MessageFramer.Sink() {
       @Override
       public void deliverFrame(WritableBuffer frame, boolean endOfStream, boolean flush) {
@@ -394,40 +324,45 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase {
         }
       }
     }, new NettyWritableBufferAllocator(ByteBufAllocator.DEFAULT));
-    framer.writePayload(new ByteArrayInputStream(CONTENT));
+    framer.writePayload(new ByteArrayInputStream(ByteBufUtil.getBytes(content)));
     framer.flush();
     if (endStream) {
       framer.close();
     }
-    ChannelHandlerContext ctx = newContext();
-    frameWriter.writeData(ctx, streamId, compressionFrame, 0, endStream, newPromise());
+    ChannelHandlerContext ctx = newMockContext();
+    new DefaultHttp2FrameWriter().writeData(ctx, streamId, compressionFrame, 0, endStream,
+        newPromise());
     return captureWrite(ctx);
   }
 
   private ByteBuf emptyGrpcFrame(int streamId, boolean endStream) throws Exception {
-    ChannelHandlerContext ctx = newContext();
     ByteBuf buf = NettyTestUtil.messageFrame("");
-    frameWriter.writeData(ctx, streamId, buf, 0, endStream, newPromise());
-    return captureWrite(ctx);
+    try {
+      return super.dataFrame(streamId, endStream, buf);
+    } finally {
+      buf.release();
+    }
   }
 
   private ByteBuf badFrame() throws Exception {
-    ChannelHandlerContext ctx = newContext();
     // Write an empty PING frame - this is invalid.
-    frameWriter.writePing(ctx, false, Unpooled.EMPTY_BUFFER, newPromise());
-    return captureWrite(ctx);
+    return super.pingFrame(false, Unpooled.EMPTY_BUFFER);
   }
 
-  private static NettyServerHandler newHandler(ServerTransportListener transportListener,
-                                               int flowControlWindow) {
+  @Override
+  protected NettyServerHandler newHandler() {
     Http2Connection connection = new DefaultHttp2Connection(true);
-    Http2FrameReader frameReader = new DefaultHttp2FrameReader();
-    Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
     return new NettyServerHandler(transportListener, connection, frameReader, frameWriter,
-        Integer.MAX_VALUE, flowControlWindow, DEFAULT_MAX_MESSAGE_SIZE);
+        maxConcurrentStreams, flowControlWindow, DEFAULT_MAX_MESSAGE_SIZE);
   }
 
-  private static NettyServerHandler newHandler(ServerTransportListener transportListener) {
-    return newHandler(transportListener, DEFAULT_WINDOW_SIZE);
+  @Override
+  protected void initWriteQueue() {
+    // Nothing to do.
+  }
+
+  @Override
+  protected WriteQueue writeQueue() {
+    return handler.getWriteQueue();
   }
 }


### PR DESCRIPTION
- Upgrading to Netty 4.1.0.Beta6
- enabling OpenSSL in negotiation codepaths