### PR TITLE
Replace Parser in proto utils to instance-based API

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
@@ -26,8 +26,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "grpc.testing.TestService", "UnaryCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.SimpleRequest,
       io.grpc.testing.SimpleResponse> METHOD_STREAMING_CALL =
@@ -35,8 +35,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
               "grpc.testing.TestService", "StreamingCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.SimpleResponse.getDefaultInstance()));
 
   public static TestServiceStub newStub(io.grpc.Channel channel) {
     return new TestServiceStub(channel);

--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
@@ -26,8 +26,8 @@ public class WorkerGrpc {
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
               "grpc.testing.Worker", "RunTest"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientArgs.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientStatus.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientArgs.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ClientStatus.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.ServerArgs,
       io.grpc.testing.ServerStatus> METHOD_RUN_SERVER =
@@ -35,8 +35,8 @@ public class WorkerGrpc {
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
               "grpc.testing.Worker", "RunServer"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerArgs.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerStatus.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerArgs.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.ServerStatus.getDefaultInstance()));
 
   public static WorkerStub newStub(io.grpc.Channel channel) {
     return new WorkerStub(channel);

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -113,19 +113,17 @@ static void PrintMethodFields(
           "        generateFullMethodName(\n"
           "            \"$Package$$service_name$\", \"$method_name$\"),\n"
           "        $NanoUtils$.<$input_type$>marshaller(\n"
-          "            new io.grpc.protobuf.nano.Parser<$input_type$>() {\n"
+          "            new io.grpc.protobuf.nano.MessageNanoFactory<$input_type$>() {\n"
           "                @Override\n"
-          "                public $input_type$ parse("
-          "$CodedInputByteBufferNano$ input) throws IOException {\n"
-          "                    return $input_type$.parseFrom(input);\n"
+          "                public $input_type$ newInstance() {\n"
+          "                    return new $input_type$();\n"
           "                }\n"
           "        }),\n"
           "        $NanoUtils$.<$output_type$>marshaller(\n"
-          "            new io.grpc.protobuf.nano.Parser<$output_type$>() {\n"
+          "            new io.grpc.protobuf.nano.MessageNanoFactory<$output_type$>() {\n"
           "                @Override\n"
-          "                public $output_type$ parse("
-          "$CodedInputByteBufferNano$ input) throws IOException {\n"
-          "                    return $output_type$.parseFrom(input);\n"
+          "                public $output_type$ newInstance() {\n"
+          "                    return new $output_type$();\n"
           "                }\n"
           "        }));\n");
     } else {
@@ -622,8 +620,6 @@ void GenerateService(const ServiceDescriptor* service,
   vars["Immutable"] = "javax.annotation.concurrent.Immutable";
   vars["ListenableFuture"] =
       "com.google.common.util.concurrent.ListenableFuture";
-  vars["CodedInputByteBufferNano"] = 
-      "com.google.protobuf.nano.CodedInputByteBufferNano";
   vars["ExperimentalApi"] = "io.grpc.ExperimentalApi";
 
   Printer printer(out, '$');

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -138,8 +138,8 @@ static void PrintMethodFields(
           "        $MethodType$.$method_type$,\n"
           "        generateFullMethodName(\n"
           "            \"$Package$$service_name$\", \"$method_name$\"),\n"
-          "        $ProtoUtils$.marshaller($input_type$.parser()),\n"
-          "        $ProtoUtils$.marshaller($output_type$.parser()));\n");
+          "        $ProtoUtils$.marshaller($input_type$.getDefaultInstance()),\n"
+          "        $ProtoUtils$.marshaller($output_type$.getDefaultInstance()));\n");
     }
   }
   p->Print("\n");

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -26,8 +26,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "grpc.testing.TestService", "UnaryCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.SimpleResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
@@ -35,8 +35,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
           generateFullMethodName(
               "grpc.testing.TestService", "StreamingOutputCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
@@ -44,8 +44,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
           generateFullMethodName(
               "grpc.testing.TestService", "StreamingInputCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL =
@@ -53,8 +53,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
               "grpc.testing.TestService", "FullBidiCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL =
@@ -62,8 +62,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
               "grpc.testing.TestService", "HalfBidiCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()));
 
   public static TestServiceStub newStub(io.grpc.Channel channel) {
     return new TestServiceStub(channel);

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -29,17 +29,17 @@ public class TestServiceGrpc {
           generateFullMethodName(
               "grpc.testing.TestService", "UnaryCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.SimpleRequest>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.SimpleRequest>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.SimpleRequest>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.SimpleRequest parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.SimpleRequest.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.SimpleRequest newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.SimpleRequest();
                   }
           }),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.SimpleResponse>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.SimpleResponse>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.SimpleResponse>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.SimpleResponse parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.SimpleResponse.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.SimpleResponse newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.SimpleResponse();
                   }
           }));
   @io.grpc.ExperimentalApi
@@ -50,17 +50,17 @@ public class TestServiceGrpc {
           generateFullMethodName(
               "grpc.testing.TestService", "StreamingOutputCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest();
                   }
           }),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse();
                   }
           }));
   @io.grpc.ExperimentalApi
@@ -71,17 +71,17 @@ public class TestServiceGrpc {
           generateFullMethodName(
               "grpc.testing.TestService", "StreamingInputCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.StreamingInputCallRequest parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.StreamingInputCallRequest.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.StreamingInputCallRequest newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.StreamingInputCallRequest();
                   }
           }),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.StreamingInputCallResponse parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.StreamingInputCallResponse.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.StreamingInputCallResponse newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.StreamingInputCallResponse();
                   }
           }));
   @io.grpc.ExperimentalApi
@@ -92,17 +92,17 @@ public class TestServiceGrpc {
           generateFullMethodName(
               "grpc.testing.TestService", "FullBidiCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest();
                   }
           }),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse();
                   }
           }));
   @io.grpc.ExperimentalApi
@@ -113,17 +113,17 @@ public class TestServiceGrpc {
           generateFullMethodName(
               "grpc.testing.TestService", "HalfBidiCall"),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest();
                   }
           }),
           io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
-              new io.grpc.protobuf.nano.Parser<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
+              new io.grpc.protobuf.nano.MessageNanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
                   @Override
-                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse parse(com.google.protobuf.nano.CodedInputByteBufferNano input) throws IOException {
-                      return io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse.parseFrom(input);
+                  public io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse newInstance() {
+                      return new io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse();
                   }
           }));
 

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -26,8 +26,8 @@ public class GreeterGrpc {
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "helloworld.Greeter", "SayHello"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.helloworld.HelloResponse.getDefaultInstance()));
 
   public static GreeterStub newStub(io.grpc.Channel channel) {
     return new GreeterStub(channel);

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -26,8 +26,8 @@ public class RouteGuideGrpc {
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "routeguide.RouteGuide", "GetFeature"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.examples.routeguide.Rectangle,
       io.grpc.examples.routeguide.Feature> METHOD_LIST_FEATURES =
@@ -35,8 +35,8 @@ public class RouteGuideGrpc {
           io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
           generateFullMethodName(
               "routeguide.RouteGuide", "ListFeatures"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Rectangle.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Rectangle.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Feature.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.examples.routeguide.Point,
       io.grpc.examples.routeguide.RouteSummary> METHOD_RECORD_ROUTE =
@@ -44,8 +44,8 @@ public class RouteGuideGrpc {
           io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
           generateFullMethodName(
               "routeguide.RouteGuide", "RecordRoute"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteSummary.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.Point.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteSummary.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.examples.routeguide.RouteNote,
       io.grpc.examples.routeguide.RouteNote> METHOD_ROUTE_CHAT =
@@ -53,8 +53,8 @@ public class RouteGuideGrpc {
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
               "routeguide.RouteGuide", "RouteChat"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.examples.routeguide.RouteNote.getDefaultInstance()));
 
   public static RouteGuideStub newStub(io.grpc.Channel channel) {
     return new RouteGuideStub(channel);

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -26,8 +26,8 @@ public class ReconnectServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "grpc.testing.ReconnectService", "Start"),
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       io.grpc.testing.integration.Messages.ReconnectInfo> METHOD_STOP =
@@ -35,8 +35,8 @@ public class ReconnectServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "grpc.testing.ReconnectService", "Stop"),
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.ReconnectInfo.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.ReconnectInfo.getDefaultInstance()));
 
   public static ReconnectServiceStub newStub(io.grpc.Channel channel) {
     return new ReconnectServiceStub(channel);

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -26,8 +26,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "grpc.testing.TestService", "EmptyCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
       io.grpc.testing.integration.Messages.SimpleResponse> METHOD_UNARY_CALL =
@@ -35,8 +35,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "grpc.testing.TestService", "UnaryCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
@@ -44,8 +44,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
           generateFullMethodName(
               "grpc.testing.TestService", "StreamingOutputCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
       io.grpc.testing.integration.Messages.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
@@ -53,8 +53,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
           generateFullMethodName(
               "grpc.testing.TestService", "StreamingInputCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL =
@@ -62,8 +62,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
               "grpc.testing.TestService", "FullDuplexCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL =
@@ -71,8 +71,8 @@ public class TestServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
               "grpc.testing.TestService", "HalfDuplexCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()));
 
   public static TestServiceStub newStub(io.grpc.Channel channel) {
     return new TestServiceStub(channel);

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -26,8 +26,8 @@ public class UnimplementedServiceGrpc {
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
               "grpc.testing.UnimplementedService", "UnimplementedCall"),
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()),
-          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.parser()));
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()));
 
   public static UnimplementedServiceStub newStub(io.grpc.Channel channel) {
     return new UnimplementedServiceStub(channel);

--- a/protobuf-nano/src/main/java/io/grpc/protobuf/nano/MessageNanoFactory.java
+++ b/protobuf-nano/src/main/java/io/grpc/protobuf/nano/MessageNanoFactory.java
@@ -31,16 +31,13 @@
 
 package io.grpc.protobuf.nano;
 
-import com.google.protobuf.nano.CodedInputByteBufferNano;
 import com.google.protobuf.nano.MessageNano;
 
-import java.io.IOException;
-
 /**
- * Parser for parsing nano proto messages.
+ * Produce new message instances. Used by a marshaller to deserialize incoming messages.
  *
  * <p>Should be implemented by generated code.
  */
-public interface Parser<T extends MessageNano> {
-  T parse(CodedInputByteBufferNano input) throws IOException;
+public interface MessageNanoFactory<T extends MessageNano> {
+  T newInstance();
 }

--- a/protobuf-nano/src/main/java/io/grpc/protobuf/nano/NanoUtils.java
+++ b/protobuf-nano/src/main/java/io/grpc/protobuf/nano/NanoUtils.java
@@ -49,7 +49,8 @@ public class NanoUtils {
   private NanoUtils() {}
 
   /** Adapt {@code parser} to a {@code Marshaller}. */
-  public static <T extends MessageNano> Marshaller<T> marshaller(final Parser<T> parser) {
+  public static <T extends MessageNano> Marshaller<T> marshaller(
+      final MessageNanoFactory<T> factory) {
     return new Marshaller<T>() {
       @Override
       public InputStream stream(T value) {
@@ -63,7 +64,9 @@ public class NanoUtils {
           CodedInputByteBufferNano input =
               CodedInputByteBufferNano.newInstance(ByteStreams.toByteArray(stream));
           input.setSizeLimit(Integer.MAX_VALUE);
-          return parser.parse(input);
+          T message = factory.newInstance();
+          message.mergeFrom(input);
+          return message;
         } catch (IOException ipbe) {
           throw Status.INTERNAL.withDescription("Failed parsing nano proto message").withCause(ipbe)
               .asRuntimeException();

--- a/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
@@ -48,8 +48,11 @@ import java.io.InputStream;
  */
 public class ProtoUtils {
 
-  /** Adapt a {@code Parser} to a {@code Marshaller}. */
-  public static <T extends MessageLite> Marshaller<T> marshaller(final Parser<T> parser) {
+  /** Create a {@code Marshaller} for protos of the same type as {@code defaultInstance}. */
+  public static <T extends MessageLite> Marshaller<T> marshaller(final T defaultInstance) {
+    Parser<?> parserGeneric = defaultInstance.getParserForType();
+    @SuppressWarnings("unchecked")
+    final Parser<T> parser = (Parser<T>) parserGeneric;
     return new Marshaller<T>() {
       @Override
       public InputStream stream(T value) {

--- a/protobuf/src/test/java/io/grpc/protobuf/ProtoUtilsTest.java
+++ b/protobuf/src/test/java/io/grpc/protobuf/ProtoUtilsTest.java
@@ -52,7 +52,7 @@ import java.util.Arrays;
 /** Unit tests for {@link ProtoUtils}. */
 @RunWith(JUnit4.class)
 public class ProtoUtilsTest {
-  private Marshaller<Type> marshaller = ProtoUtils.marshaller(Type.parser());
+  private Marshaller<Type> marshaller = ProtoUtils.marshaller(Type.getDefaultInstance());
   private Type proto = Type.newBuilder().setName("name").build();
 
   @Test
@@ -69,7 +69,7 @@ public class ProtoUtilsTest {
 
   @Test
   public void testMismatch() throws Exception {
-    Marshaller<Enum> enumMarshaller = ProtoUtils.marshaller(Enum.parser());
+    Marshaller<Enum> enumMarshaller = ProtoUtils.marshaller(Enum.getDefaultInstance());
     // Enum's name and Type's name are both strings with tag 1.
     Enum altProto = Enum.newBuilder().setName(proto.getName()).build();
     assertEquals(proto, marshaller.parse(enumMarshaller.stream(altProto)));


### PR DESCRIPTION
This gives us much greater freedom to tweak how we handle marshalling, as the instance-based API can be adapted to most other forms of API. This makes it much easier to make changes optimizing Android performance while not adding parallel code paths. (Resolves #936)

@zhangkun83 