### PR TITLE
Defer explicit flushing of messages written during the onReady callback.

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -109,6 +109,19 @@ public abstract class ClientCall<RequestT, ResponseT> {
      * {@link #sendMessage}) without requiring excessive buffering internally. This event is
      * just a suggestion and the application is free to ignore it, however doing so may
      * result in excessive buffering within the ClientCall.
+     *
+     * <p>Any calls to {@link ClientCall#sendMessage(Object)} made by an implementation of this
+     * method may have their writes to the underlying transport deferred until completion of this
+     * method to improve throughput.
+     *
+     * <p>Typical use:
+     * <pre>
+     * public void onReady() {
+     *   while (haveMoreData() && call.isReady()) {
+     *     call.sendMessage(nextData());
+     *   }
+     * }
+     * </pre>
      */
     public void onReady() {}
   }

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -97,6 +97,10 @@ public abstract class ServerCall<ResponseT> {
      * {@link #sendMessage}) without requiring excessive buffering internally. This event is
      * just a suggestion and the application is free to ignore it, however doing so may
      * result in excessive buffering within the call.
+     *
+     * <p>Any calls to {@link ServerCall#sendMessage(Object)} made by an implementation of this
+     * method may have their writes to the underlying transport deferred until completion of this
+     * method to improve throughput.
      */
     public void onReady() {}
   }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -453,6 +453,7 @@ public final class ServerImpl extends io.grpc.Server {
     private boolean sendHeadersCalled;
     private boolean closeCalled;
     private boolean sendMessageCalled;
+    private volatile boolean inOnReady;
 
     public ServerCallImpl(ServerStream stream, MethodDescriptor<ReqT, RespT> method) {
       this.stream = stream;
@@ -480,7 +481,9 @@ public final class ServerImpl extends io.grpc.Server {
       try {
         InputStream resp = method.streamResponse(message);
         stream.writeMessage(resp);
-        stream.flush();
+        if (!inOnReady) {
+          stream.flush();
+        }
       } catch (Throwable t) {
         close(Status.fromThrowable(t), new Metadata());
         throw Throwables.propagate(t);
@@ -564,7 +567,16 @@ public final class ServerImpl extends io.grpc.Server {
         if (cancelled) {
           return;
         }
-        listener.onReady();
+        if (inOnReady) {
+          throw new IllegalStateException("Re-entrant call to onReady not allowed");
+        }
+        try {
+          inOnReady = true;
+          listener.onReady();
+          stream.flush();
+        } finally {
+          inOnReady = false;
+        }
       }
     }
   }

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -1,0 +1,94 @@
+package io.grpc.internal;
+
+import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.InputStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.IntegerMarshaller;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.StringMarshaller;
+
+/**
+ * Tests for {@link io.grpc.internal.ClientCallImpl}.
+ */
+@RunWith(JUnit4.class)
+public class ClientCallImplTest {
+
+  private MethodDescriptor<String, Integer> method = MethodDescriptor.create(
+      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
+      new StringMarshaller(), new IntegerMarshaller());
+  private ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  @Mock
+  private ClientTransport mockTransport;
+
+  @Mock
+  private ClientStream mockStream;
+
+  @Captor
+  private ArgumentCaptor<ClientStreamListener> listener;
+
+  private ClientCallImpl<String, Integer> clientCall;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    clientCall = new ClientCallImpl<String, Integer>(method, new SerializingExecutor(executor),
+        CallOptions.DEFAULT, new ClientCallImpl.ClientTransportProvider() {
+      @Override
+      public ClientTransport get() {
+        return mockTransport;
+      }
+    }, SharedResourceHolder.get(TIMER_SERVICE));
+    when(mockTransport.newStream(any(MethodDescriptor.class), any(Metadata.class),
+        listener.capture())).thenReturn(mockStream);
+  }
+
+  @Test
+  public void testOnReadyBatchesFlush() {
+    clientCall.start(new ClientCall.Listener<Integer>() {
+      @Override
+      public void onReady() {
+        clientCall.sendMessage("a");
+        clientCall.sendMessage("b");
+        clientCall.sendMessage("c");
+      }
+    }, new Metadata());
+
+    listener.getValue().onReady();
+
+    verify(mockStream, times(3)).writeMessage(any(InputStream.class));
+    verify(mockStream, times(1)).flush();
+  }
+
+  @Test
+  public void testOutsideOnReadyDoesNotBatchFlush() {
+    clientCall.start(new ClientCall.Listener<Integer>() {
+    }, new Metadata());
+
+    clientCall.sendMessage("a");
+    clientCall.sendMessage("b");
+    clientCall.sendMessage("c");
+
+    verify(mockStream, times(3)).writeMessage(any(InputStream.class));
+    verify(mockStream, times(3)).flush();
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package io.grpc.internal;
 
 import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
@@ -5,6 +36,13 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.IntegerMarshaller;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.StringMarshaller;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,15 +54,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import io.grpc.CallOptions;
-import io.grpc.ClientCall;
-import io.grpc.IntegerMarshaller;
-import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
-import io.grpc.StringMarshaller;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link io.grpc.internal.ClientCallImpl}.
@@ -53,27 +86,32 @@ public class ClientCallImplTest {
     MockitoAnnotations.initMocks(this);
     clientCall = new ClientCallImpl<String, Integer>(method, new SerializingExecutor(executor),
         CallOptions.DEFAULT, new ClientCallImpl.ClientTransportProvider() {
-      @Override
-      public ClientTransport get() {
-        return mockTransport;
-      }
-    }, SharedResourceHolder.get(TIMER_SERVICE));
+          @Override
+          public ClientTransport get() {
+            return mockTransport;
+          }
+        },
+        SharedResourceHolder.get(TIMER_SERVICE));
     when(mockTransport.newStream(any(MethodDescriptor.class), any(Metadata.class),
         listener.capture())).thenReturn(mockStream);
   }
 
   @Test
-  public void testOnReadyBatchesFlush() {
+  public void testOnReadyBatchesFlush() throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
     clientCall.start(new ClientCall.Listener<Integer>() {
       @Override
       public void onReady() {
         clientCall.sendMessage("a");
         clientCall.sendMessage("b");
         clientCall.sendMessage("c");
+        latch.countDown();
       }
     }, new Metadata());
 
     listener.getValue().onReady();
+
+    latch.await(5, TimeUnit.SECONDS);
 
     verify(mockStream, times(3)).writeMessage(any(InputStream.class));
     verify(mockStream, times(1)).flush();

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -74,7 +74,6 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /** Unit tests for {@link ServerImpl}. */


### PR DESCRIPTION
@ejona86 @nmittler @zhangkun83 

This significantly improves throughput in streaming message production cases
where the message producer can respond quickly to changes in flow-control
availability.

For FlowControlMessagesPerSecondBenchmark 
before
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                       1           SMALL  thrpt   20  839455.355 ± 22566.188  ops/s

after
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                       1           SMALL  thrpt   20  2439197.246 ± 57983.247  ops/s

so roughly a 3x improvement in throughput. Will provide full benchmark results later...
