### PR TITLE
Fixing okhttp hang when TLS nego fails.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpTlsUpgrader.java
@@ -56,6 +56,9 @@ public final class OkHttpTlsUpgrader {
 
   /**
    * Upgrades given Socket to be a SSLSocket.
+   *
+   * @throws IOException if an IO error was encountered during the upgrade handshake.
+   * @throws RuntimeException if the upgrade negotiation failed.
    */
   public static SSLSocket upgrade(SSLSocketFactory sslSocketFactory,
       Socket socket, String host, int port, ConnectionSpec spec) throws IOException {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/OkHttpProtocolNegotiator.java
@@ -75,6 +75,9 @@ public class OkHttpProtocolNegotiator {
 
   /**
    * Start and wait until the negotiation is done, returns the negotiated protocol.
+   *
+   * @throws IOException if an IO error was encountered during the handshake.
+   * @throws RuntimeException if the negotiation completed, but no protocol was selected.
    */
   public String negotiate(
       SSLSocket sslSocket, String hostname, List<Protocol> protocols) throws IOException {

--- a/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
@@ -237,8 +237,8 @@ class AsyncFrameWriter implements FrameWriter {
           throw new IOException("Unable to perform write due to unavailable frameWriter.");
         }
         doRun();
-      } catch (IOException ex) {
-        transport.onIoException(ex);
+      } catch (Exception ex) {
+        transport.onException(ex);
         throw new RuntimeException(ex);
       }
     }

--- a/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
@@ -237,9 +237,12 @@ class AsyncFrameWriter implements FrameWriter {
           throw new IOException("Unable to perform write due to unavailable frameWriter.");
         }
         doRun();
-      } catch (Exception ex) {
-        transport.onException(ex);
-        throw new RuntimeException(ex);
+      } catch (RuntimeException e) {
+        transport.onException(e);
+        throw e;
+      } catch (Exception e) {
+        transport.onException(e);
+        throw new RuntimeException(e);
       }
     }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -357,8 +357,12 @@ class OkHttpClientTransport implements ClientTransport {
           sock.setTcpNoDelay(true);
           source = Okio.buffer(Okio.source(sock));
           sink = Okio.buffer(Okio.sink(sock));
+        } catch (RuntimeException e) {
+          onException(e);
+          throw e;
         } catch (Exception e) {
           onException(e);
+
           // (and probably do all of this work asynchronously instead of in calling thread)
           throw new RuntimeException(e);
         }
@@ -388,7 +392,10 @@ class OkHttpClientTransport implements ClientTransport {
           rawFrameWriter.connectionPreface();
           Settings settings = new Settings();
           rawFrameWriter.settings(settings);
-        } catch (IOException e) {
+        } catch (RuntimeException e) {
+          onException(e);
+          throw e;
+        } catch (Exception e) {
           onException(e);
           throw new RuntimeException(e);
         }
@@ -439,7 +446,7 @@ class OkHttpClientTransport implements ClientTransport {
   /**
    * Finish all active streams due to an IOException, then close the transport.
    */
-  void onException(Exception failureCause) {
+  void onException(Throwable failureCause) {
     log.log(Level.SEVERE, "Transport failed", failureCause);
     onGoAway(0, Status.UNAVAILABLE.withCause(failureCause));
   }
@@ -587,11 +594,15 @@ class OkHttpClientTransport implements ClientTransport {
         // Read until the underlying socket closes.
         while (frameReader.nextFrame(this)) {
         }
-      } catch (IOException ioe) {
+      } catch (IOException e) {
         // We send GoAway here because OkHttp wraps many protocol errors as IOException.
         // TODO(madongfly): Send the exception message to the server.
         frameWriter.goAway(0, ErrorCode.PROTOCOL_ERROR, new byte[0]);
-        onException(ioe);
+        onException(e);
+      } catch (Throwable t) {
+        // For non-IOExceptions, it's not clear if the transport is in a safe state to attempt
+        // writing. Don't send a GO_AWAY, just shutdown the transport.
+        onException(t);
       } finally {
         try {
           frameReader.close();

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -357,8 +357,8 @@ class OkHttpClientTransport implements ClientTransport {
           sock.setTcpNoDelay(true);
           source = Okio.buffer(Okio.source(sock));
           sink = Okio.buffer(Okio.sink(sock));
-        } catch (IOException e) {
-          onIoException(e);
+        } catch (Exception e) {
+          onException(e);
           // (and probably do all of this work asynchronously instead of in calling thread)
           throw new RuntimeException(e);
         }
@@ -389,7 +389,7 @@ class OkHttpClientTransport implements ClientTransport {
           Settings settings = new Settings();
           rawFrameWriter.settings(settings);
         } catch (IOException e) {
-          onIoException(e);
+          onException(e);
           throw new RuntimeException(e);
         }
 
@@ -439,7 +439,7 @@ class OkHttpClientTransport implements ClientTransport {
   /**
    * Finish all active streams due to an IOException, then close the transport.
    */
-  void onIoException(IOException failureCause) {
+  void onException(Exception failureCause) {
     log.log(Level.SEVERE, "Transport failed", failureCause);
     onGoAway(0, Status.UNAVAILABLE.withCause(failureCause));
   }
@@ -591,7 +591,7 @@ class OkHttpClientTransport implements ClientTransport {
         // We send GoAway here because OkHttp wraps many protocol errors as IOException.
         // TODO(madongfly): Send the exception message to the server.
         frameWriter.goAway(0, ErrorCode.PROTOCOL_ERROR, new byte[0]);
-        onIoException(ioe);
+        onException(ioe);
       } finally {
         try {
           frameReader.close();

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -594,7 +594,7 @@ class OkHttpClientTransport implements ClientTransport {
         // Read until the underlying socket closes.
         while (frameReader.nextFrame(this)) {
         }
-      } catch (Throwable t) {
+      } catch (Exception t) {
         // TODO(madongfly): Send the exception message to the server.
         frameWriter.goAway(0, ErrorCode.PROTOCOL_ERROR, new byte[0]);
         onException(t);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -594,14 +594,9 @@ class OkHttpClientTransport implements ClientTransport {
         // Read until the underlying socket closes.
         while (frameReader.nextFrame(this)) {
         }
-      } catch (IOException e) {
-        // We send GoAway here because OkHttp wraps many protocol errors as IOException.
+      } catch (Throwable t) {
         // TODO(madongfly): Send the exception message to the server.
         frameWriter.goAway(0, ErrorCode.PROTOCOL_ERROR, new byte[0]);
-        onException(e);
-      } catch (Throwable t) {
-        // For non-IOExceptions, it's not clear if the transport is in a safe state to attempt
-        // writing. Don't send a GO_AWAY, just shutdown the transport.
         onException(t);
       } finally {
         try {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -1087,7 +1087,7 @@ public class OkHttpClientTransportTest {
     clientTransport.ping(callback, MoreExecutors.directExecutor());
     assertEquals(0, callback.invocationCount);
 
-    clientTransport.onIoException(new IOException());
+    clientTransport.onException(new IOException());
     // ping failed on error
     assertEquals(1, callback.invocationCount);
     assertTrue(callback.failureCause instanceof StatusException);


### PR DESCRIPTION
Negotiation failure results in a RuntimeException, which is not properly  handled by the okhttp code, resulting in the client hanging.

Refactored the code to shutdown the transport when TLS negotiation fails.