### PR TITLE
Enable warnings for rawtypes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ subprojects {
 
 
     [compileJava, compileTestJava].each() {
-        it.options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation", "-Xlint:-options"]
+        it.options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation", "-Xlint:-options",
+            "-Xlint:rawtypes"]
         it.options.encoding = "UTF-8"
     }
 


### PR DESCRIPTION
This would have prevented the missing generics in 31394aa

The date of this commit is actually correct. I've had this commit sitting around on a branch since June. It's time that we should enable rawtypes warnings...