### PR TITLE
Private ServerMethodDefinition constructor; avoid create() in codegen

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
@@ -158,30 +158,30 @@ public class TestServiceGrpc {
   public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_UNARY_CALL,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                io.grpc.testing.SimpleRequest,
-                io.grpc.testing.SimpleResponse>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.testing.SimpleRequest request,
-                  io.grpc.stub.StreamObserver<io.grpc.testing.SimpleResponse> responseObserver) {
-                serviceImpl.unaryCall(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_STREAMING_CALL,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.testing.SimpleRequest,
-                io.grpc.testing.SimpleResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.SimpleRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.SimpleResponse> responseObserver) {
-                return serviceImpl.streamingCall(responseObserver);
-              }
-            }))).build();
+      .addMethod(
+        METHOD_UNARY_CALL,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              io.grpc.testing.SimpleRequest,
+              io.grpc.testing.SimpleResponse>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.testing.SimpleRequest request,
+                io.grpc.stub.StreamObserver<io.grpc.testing.SimpleResponse> responseObserver) {
+              serviceImpl.unaryCall(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_STREAMING_CALL,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.testing.SimpleRequest,
+              io.grpc.testing.SimpleResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.SimpleRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.SimpleResponse> responseObserver) {
+              return serviceImpl.streamingCall(responseObserver);
+            }
+          })).build();
   }
 }

--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
@@ -140,29 +140,29 @@ public class WorkerGrpc {
   public static io.grpc.ServerServiceDefinition bindService(
       final Worker serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_RUN_TEST,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.testing.ClientArgs,
-                io.grpc.testing.ClientStatus>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.ClientArgs> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.ClientStatus> responseObserver) {
-                return serviceImpl.runTest(responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_RUN_SERVER,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.testing.ServerArgs,
-                io.grpc.testing.ServerStatus>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.ServerArgs> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.ServerStatus> responseObserver) {
-                return serviceImpl.runServer(responseObserver);
-              }
-            }))).build();
+      .addMethod(
+        METHOD_RUN_TEST,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.testing.ClientArgs,
+              io.grpc.testing.ClientStatus>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.ClientArgs> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.ClientStatus> responseObserver) {
+              return serviceImpl.runTest(responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_RUN_SERVER,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.testing.ServerArgs,
+              io.grpc.testing.ServerStatus>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.ServerArgs> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.ServerStatus> responseObserver) {
+              return serviceImpl.runServer(responseObserver);
+            }
+          })).build();
   }
 }

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -452,8 +452,7 @@ static void PrintBindServiceMethod(const ServiceDescriptor* service,
             "io.grpc.stub.ServerCalls.UnaryMethod";
       }
     }
-    p->Print(*vars, ".addMethod($ServerMethodDefinition$.create(\n");
-    p->Indent();
+    p->Print(*vars, ".addMethod(\n");
     p->Indent();
     p->Print(
         *vars,
@@ -486,12 +485,11 @@ static void PrintBindServiceMethod(const ServiceDescriptor* service,
           "}\n");
     }
     p->Outdent();
-    p->Print("})))");
+    p->Print("}))");
     if (i == service->method_count() - 1) {
       p->Print(".build();");
     }
     p->Print("\n");
-    p->Outdent();
     p->Outdent();
     p->Outdent();
   }

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -225,67 +225,67 @@ public class TestServiceGrpc {
   public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_UNARY_CALL,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                io.grpc.testing.integration.Test.SimpleRequest,
-                io.grpc.testing.integration.Test.SimpleResponse>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.testing.integration.Test.SimpleRequest request,
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
-                serviceImpl.unaryCall(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_STREAMING_OUTPUT_CALL,
-          asyncServerStreamingCall(
-            new io.grpc.stub.ServerCalls.ServerStreamingMethod<
-                io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-                io.grpc.testing.integration.Test.StreamingOutputCallResponse>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-                serviceImpl.streamingOutputCall(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_STREAMING_INPUT_CALL,
-          asyncClientStreamingCall(
-            new io.grpc.stub.ServerCalls.ClientStreamingMethod<
-                io.grpc.testing.integration.Test.StreamingInputCallRequest,
-                io.grpc.testing.integration.Test.StreamingInputCallResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
-                return serviceImpl.streamingInputCall(responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_FULL_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-                io.grpc.testing.integration.Test.StreamingOutputCallResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-                return serviceImpl.fullBidiCall(responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_HALF_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-                io.grpc.testing.integration.Test.StreamingOutputCallResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-                return serviceImpl.halfBidiCall(responseObserver);
-              }
-            }))).build();
+      .addMethod(
+        METHOD_UNARY_CALL,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              io.grpc.testing.integration.Test.SimpleRequest,
+              io.grpc.testing.integration.Test.SimpleResponse>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.testing.integration.Test.SimpleRequest request,
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
+              serviceImpl.unaryCall(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_STREAMING_OUTPUT_CALL,
+        asyncServerStreamingCall(
+          new io.grpc.stub.ServerCalls.ServerStreamingMethod<
+              io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+              io.grpc.testing.integration.Test.StreamingOutputCallResponse>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+              serviceImpl.streamingOutputCall(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_STREAMING_INPUT_CALL,
+        asyncClientStreamingCall(
+          new io.grpc.stub.ServerCalls.ClientStreamingMethod<
+              io.grpc.testing.integration.Test.StreamingInputCallRequest,
+              io.grpc.testing.integration.Test.StreamingInputCallResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
+              return serviceImpl.streamingInputCall(responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_FULL_BIDI_CALL,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+              io.grpc.testing.integration.Test.StreamingOutputCallResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+              return serviceImpl.fullBidiCall(responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_HALF_BIDI_CALL,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+              io.grpc.testing.integration.Test.StreamingOutputCallResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+              return serviceImpl.halfBidiCall(responseObserver);
+            }
+          })).build();
   }
 }

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -287,67 +287,67 @@ public class TestServiceGrpc {
   public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_UNARY_CALL,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                io.grpc.testing.integration.nano.Test.SimpleRequest,
-                io.grpc.testing.integration.nano.Test.SimpleResponse>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.testing.integration.nano.Test.SimpleRequest request,
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver) {
-                serviceImpl.unaryCall(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_STREAMING_OUTPUT_CALL,
-          asyncServerStreamingCall(
-            new io.grpc.stub.ServerCalls.ServerStreamingMethod<
-                io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-                io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request,
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-                serviceImpl.streamingOutputCall(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_STREAMING_INPUT_CALL,
-          asyncClientStreamingCall(
-            new io.grpc.stub.ServerCalls.ClientStreamingMethod<
-                io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
-                io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
-                return serviceImpl.streamingInputCall(responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_FULL_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-                io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-                return serviceImpl.fullBidiCall(responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_HALF_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-                io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-                return serviceImpl.halfBidiCall(responseObserver);
-              }
-            }))).build();
+      .addMethod(
+        METHOD_UNARY_CALL,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              io.grpc.testing.integration.nano.Test.SimpleRequest,
+              io.grpc.testing.integration.nano.Test.SimpleResponse>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.testing.integration.nano.Test.SimpleRequest request,
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver) {
+              serviceImpl.unaryCall(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_STREAMING_OUTPUT_CALL,
+        asyncServerStreamingCall(
+          new io.grpc.stub.ServerCalls.ServerStreamingMethod<
+              io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+              io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request,
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
+              serviceImpl.streamingOutputCall(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_STREAMING_INPUT_CALL,
+        asyncClientStreamingCall(
+          new io.grpc.stub.ServerCalls.ClientStreamingMethod<
+              io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+              io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
+              return serviceImpl.streamingInputCall(responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_FULL_BIDI_CALL,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+              io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
+              return serviceImpl.fullBidiCall(responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_HALF_BIDI_CALL,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+              io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
+              return serviceImpl.halfBidiCall(responseObserver);
+            }
+          })).build();
   }
 }

--- a/core/src/main/java/io/grpc/ServerMethodDefinition.java
+++ b/core/src/main/java/io/grpc/ServerMethodDefinition.java
@@ -33,14 +33,14 @@ package io.grpc;
 
 /**
  * Definition of a method exposed by a {@link Server}.
+ *
+ * @see ServerServiceDefinition
  */
 public final class ServerMethodDefinition<ReqT, RespT> {
   private final MethodDescriptor<ReqT, RespT> method;
   private final ServerCallHandler<ReqT, RespT> handler;
 
-  // ServerMethodDefinition has no form of public construction. It is only created within the
-  // context of a ServerServiceDefinition.Builder.
-  ServerMethodDefinition(MethodDescriptor<ReqT, RespT> method,
+  private ServerMethodDefinition(MethodDescriptor<ReqT, RespT> method,
       ServerCallHandler<ReqT, RespT> handler) {
     this.method = method;
     this.handler = handler;

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -139,18 +139,18 @@ public class GreeterGrpc {
   public static io.grpc.ServerServiceDefinition bindService(
       final Greeter serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_SAY_HELLO,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                io.grpc.examples.helloworld.HelloRequest,
-                io.grpc.examples.helloworld.HelloResponse>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.examples.helloworld.HelloRequest request,
-                  io.grpc.stub.StreamObserver<io.grpc.examples.helloworld.HelloResponse> responseObserver) {
-                serviceImpl.sayHello(request, responseObserver);
-              }
-            }))).build();
+      .addMethod(
+        METHOD_SAY_HELLO,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              io.grpc.examples.helloworld.HelloRequest,
+              io.grpc.examples.helloworld.HelloResponse>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.examples.helloworld.HelloRequest request,
+                io.grpc.stub.StreamObserver<io.grpc.examples.helloworld.HelloResponse> responseObserver) {
+              serviceImpl.sayHello(request, responseObserver);
+            }
+          })).build();
   }
 }

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -206,55 +206,55 @@ public class RouteGuideGrpc {
   public static io.grpc.ServerServiceDefinition bindService(
       final RouteGuide serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_GET_FEATURE,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                io.grpc.examples.routeguide.Point,
-                io.grpc.examples.routeguide.Feature>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.examples.routeguide.Point request,
-                  io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
-                serviceImpl.getFeature(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_LIST_FEATURES,
-          asyncServerStreamingCall(
-            new io.grpc.stub.ServerCalls.ServerStreamingMethod<
-                io.grpc.examples.routeguide.Rectangle,
-                io.grpc.examples.routeguide.Feature>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.examples.routeguide.Rectangle request,
-                  io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
-                serviceImpl.listFeatures(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_RECORD_ROUTE,
-          asyncClientStreamingCall(
-            new io.grpc.stub.ServerCalls.ClientStreamingMethod<
-                io.grpc.examples.routeguide.Point,
-                io.grpc.examples.routeguide.RouteSummary>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Point> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteSummary> responseObserver) {
-                return serviceImpl.recordRoute(responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_ROUTE_CHAT,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.examples.routeguide.RouteNote,
-                io.grpc.examples.routeguide.RouteNote>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> responseObserver) {
-                return serviceImpl.routeChat(responseObserver);
-              }
-            }))).build();
+      .addMethod(
+        METHOD_GET_FEATURE,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              io.grpc.examples.routeguide.Point,
+              io.grpc.examples.routeguide.Feature>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.examples.routeguide.Point request,
+                io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
+              serviceImpl.getFeature(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_LIST_FEATURES,
+        asyncServerStreamingCall(
+          new io.grpc.stub.ServerCalls.ServerStreamingMethod<
+              io.grpc.examples.routeguide.Rectangle,
+              io.grpc.examples.routeguide.Feature>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.examples.routeguide.Rectangle request,
+                io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
+              serviceImpl.listFeatures(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_RECORD_ROUTE,
+        asyncClientStreamingCall(
+          new io.grpc.stub.ServerCalls.ClientStreamingMethod<
+              io.grpc.examples.routeguide.Point,
+              io.grpc.examples.routeguide.RouteSummary>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Point> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteSummary> responseObserver) {
+              return serviceImpl.recordRoute(responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_ROUTE_CHAT,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.examples.routeguide.RouteNote,
+              io.grpc.examples.routeguide.RouteNote>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> responseObserver) {
+              return serviceImpl.routeChat(responseObserver);
+            }
+          })).build();
   }
 }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -176,31 +176,31 @@ public class ReconnectServiceGrpc {
   public static io.grpc.ServerServiceDefinition bindService(
       final ReconnectService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_START,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                com.google.protobuf.EmptyProtos.Empty,
-                com.google.protobuf.EmptyProtos.Empty>() {
-              @java.lang.Override
-              public void invoke(
-                  com.google.protobuf.EmptyProtos.Empty request,
-                  io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-                serviceImpl.start(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_STOP,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                com.google.protobuf.EmptyProtos.Empty,
-                io.grpc.testing.integration.Messages.ReconnectInfo>() {
-              @java.lang.Override
-              public void invoke(
-                  com.google.protobuf.EmptyProtos.Empty request,
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.ReconnectInfo> responseObserver) {
-                serviceImpl.stop(request, responseObserver);
-              }
-            }))).build();
+      .addMethod(
+        METHOD_START,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              com.google.protobuf.EmptyProtos.Empty,
+              com.google.protobuf.EmptyProtos.Empty>() {
+            @java.lang.Override
+            public void invoke(
+                com.google.protobuf.EmptyProtos.Empty request,
+                io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
+              serviceImpl.start(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_STOP,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              com.google.protobuf.EmptyProtos.Empty,
+              io.grpc.testing.integration.Messages.ReconnectInfo>() {
+            @java.lang.Override
+            public void invoke(
+                com.google.protobuf.EmptyProtos.Empty request,
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.ReconnectInfo> responseObserver) {
+              serviceImpl.stop(request, responseObserver);
+            }
+          })).build();
   }
 }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -262,80 +262,80 @@ public class TestServiceGrpc {
   public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_EMPTY_CALL,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                com.google.protobuf.EmptyProtos.Empty,
-                com.google.protobuf.EmptyProtos.Empty>() {
-              @java.lang.Override
-              public void invoke(
-                  com.google.protobuf.EmptyProtos.Empty request,
-                  io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-                serviceImpl.emptyCall(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_UNARY_CALL,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                io.grpc.testing.integration.Messages.SimpleRequest,
-                io.grpc.testing.integration.Messages.SimpleResponse>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.testing.integration.Messages.SimpleRequest request,
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
-                serviceImpl.unaryCall(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_STREAMING_OUTPUT_CALL,
-          asyncServerStreamingCall(
-            new io.grpc.stub.ServerCalls.ServerStreamingMethod<
-                io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-                io.grpc.testing.integration.Messages.StreamingOutputCallResponse>() {
-              @java.lang.Override
-              public void invoke(
-                  io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-                serviceImpl.streamingOutputCall(request, responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_STREAMING_INPUT_CALL,
-          asyncClientStreamingCall(
-            new io.grpc.stub.ServerCalls.ClientStreamingMethod<
-                io.grpc.testing.integration.Messages.StreamingInputCallRequest,
-                io.grpc.testing.integration.Messages.StreamingInputCallResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
-                return serviceImpl.streamingInputCall(responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_FULL_DUPLEX_CALL,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-                io.grpc.testing.integration.Messages.StreamingOutputCallResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-                return serviceImpl.fullDuplexCall(responseObserver);
-              }
-            })))
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_HALF_DUPLEX_CALL,
-          asyncBidiStreamingCall(
-            new io.grpc.stub.ServerCalls.BidiStreamingMethod<
-                io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-                io.grpc.testing.integration.Messages.StreamingOutputCallResponse>() {
-              @java.lang.Override
-              public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> invoke(
-                  io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-                return serviceImpl.halfDuplexCall(responseObserver);
-              }
-            }))).build();
+      .addMethod(
+        METHOD_EMPTY_CALL,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              com.google.protobuf.EmptyProtos.Empty,
+              com.google.protobuf.EmptyProtos.Empty>() {
+            @java.lang.Override
+            public void invoke(
+                com.google.protobuf.EmptyProtos.Empty request,
+                io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
+              serviceImpl.emptyCall(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_UNARY_CALL,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              io.grpc.testing.integration.Messages.SimpleRequest,
+              io.grpc.testing.integration.Messages.SimpleResponse>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.testing.integration.Messages.SimpleRequest request,
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
+              serviceImpl.unaryCall(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_STREAMING_OUTPUT_CALL,
+        asyncServerStreamingCall(
+          new io.grpc.stub.ServerCalls.ServerStreamingMethod<
+              io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+              io.grpc.testing.integration.Messages.StreamingOutputCallResponse>() {
+            @java.lang.Override
+            public void invoke(
+                io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
+              serviceImpl.streamingOutputCall(request, responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_STREAMING_INPUT_CALL,
+        asyncClientStreamingCall(
+          new io.grpc.stub.ServerCalls.ClientStreamingMethod<
+              io.grpc.testing.integration.Messages.StreamingInputCallRequest,
+              io.grpc.testing.integration.Messages.StreamingInputCallResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
+              return serviceImpl.streamingInputCall(responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_FULL_DUPLEX_CALL,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+              io.grpc.testing.integration.Messages.StreamingOutputCallResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
+              return serviceImpl.fullDuplexCall(responseObserver);
+            }
+          }))
+      .addMethod(
+        METHOD_HALF_DUPLEX_CALL,
+        asyncBidiStreamingCall(
+          new io.grpc.stub.ServerCalls.BidiStreamingMethod<
+              io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+              io.grpc.testing.integration.Messages.StreamingOutputCallResponse>() {
+            @java.lang.Override
+            public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> invoke(
+                io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
+              return serviceImpl.halfDuplexCall(responseObserver);
+            }
+          })).build();
   }
 }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -139,18 +139,18 @@ public class UnimplementedServiceGrpc {
   public static io.grpc.ServerServiceDefinition bindService(
       final UnimplementedService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(SERVICE_NAME)
-      .addMethod(io.grpc.ServerMethodDefinition.create(
-          METHOD_UNIMPLEMENTED_CALL,
-          asyncUnaryCall(
-            new io.grpc.stub.ServerCalls.UnaryMethod<
-                com.google.protobuf.EmptyProtos.Empty,
-                com.google.protobuf.EmptyProtos.Empty>() {
-              @java.lang.Override
-              public void invoke(
-                  com.google.protobuf.EmptyProtos.Empty request,
-                  io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-                serviceImpl.unimplementedCall(request, responseObserver);
-              }
-            }))).build();
+      .addMethod(
+        METHOD_UNIMPLEMENTED_CALL,
+        asyncUnaryCall(
+          new io.grpc.stub.ServerCalls.UnaryMethod<
+              com.google.protobuf.EmptyProtos.Empty,
+              com.google.protobuf.EmptyProtos.Empty>() {
+            @java.lang.Override
+            public void invoke(
+                com.google.protobuf.EmptyProtos.Empty request,
+                io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
+              serviceImpl.unimplementedCall(request, responseObserver);
+            }
+          })).build();
   }
 }


### PR DESCRIPTION
There is no need to use ServerMethodDefinition in codegen. The create()
method itself could be helpful to a dynamic HandlerRegistry
implementation, so we won't remove it.

This has mostly no impact on our public API, so could be delayed after beta. But it
does fix a missing check in one of the addMethod() overloads, which could break
broken code if we added it later.