### PR TITLE
Deprecate OkHttpChannelBuilder#overrideHostForAuthority

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/Utils.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/Utils.java
@@ -35,6 +35,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -139,7 +140,8 @@ final class Utils {
       if (config.tls) {
         SSLSocketFactory factory;
         if (config.testca) {
-          builder.overrideHostForAuthority(TestUtils.TEST_SERVER_HOST);
+          builder.overrideAuthority(
+              GrpcUtil.authorityFromHostAndPort(TestUtils.TEST_SERVER_HOST, addr.getPort()));
           try {
             factory = TestUtils.newSslSocketFactoryForCa(TestUtils.loadCert("ca.pem"));
           } catch (Exception e) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -34,6 +34,7 @@ package io.grpc.testing.integration;
 import com.google.common.io.Files;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -283,7 +284,8 @@ public class TestServiceClient {
         OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress(serverHost, serverPort);
         if (serverHostOverride != null) {
           // Force the hostname to match the cert the server uses.
-          builder.overrideHostForAuthority(serverHostOverride);
+          builder.overrideAuthority(
+              GrpcUtil.authorityFromHostAndPort(serverHostOverride, serverPort));
         }
         if (useTls) {
           try {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -35,13 +35,13 @@ import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.TlsVersion;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.StreamRecorder;
 import io.grpc.testing.TestUtils;
-
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 import org.junit.AfterClass;
@@ -85,7 +85,8 @@ public class Http2OkHttpTest extends AbstractTransportTest {
             .cipherSuites(TestUtils.preferredTestCiphers().toArray(new String[0]))
             .tlsVersions(ConnectionSpec.MODERN_TLS.tlsVersions().toArray(new TlsVersion[0]))
             .build())
-        .overrideHostForAuthority(TestUtils.TEST_SERVER_HOST);
+        .overrideAuthority(GrpcUtil.authorityFromHostAndPort(
+            TestUtils.TEST_SERVER_HOST, serverPort));
     try {
       builder.sslSocketFactory(TestUtils.newSslSocketFactoryForCa(
           TestUtils.loadCert("ca.pem")));

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -130,7 +130,10 @@ public final class OkHttpChannelBuilder extends
    * appends the port number to the host provided.
    *
    * <p>Should only used by tests.
+   *
+   * @deprecated use {@link #overrideAuthority} instead
    */
+  @Deprecated
   public OkHttpChannelBuilder overrideHostForAuthority(String host) {
     this.authority = GrpcUtil.authorityFromHostAndPort(host, this.port);
     return this;


### PR DESCRIPTION
It is a duplication of overrideAuthority().

@madongfly 