### PR TITLE
request() is thread-safe

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -140,6 +140,8 @@ public abstract class ClientCall<ReqT, RespT> {
    * <p>If called multiple times, the number of messages able to delivered will be the sum of the
    * calls.
    *
+   * <p>This method is safe to call from multiple threads without external synchronizaton.
+   *
    * @param numMessages the requested number of messages to be delivered to the listener. Must be
    *                    non-negative.
    */

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -109,6 +109,8 @@ public abstract class ServerCall<RespT> {
    *
    * <p>Servers use this mechanism to provide back-pressure to the client for flow-control.
    *
+   * <p>This method is safe to call from multiple threads without external synchronizaton.
+   *
    * @param numMessages the requested number of messages to be delivered to the listener.
    */
   public abstract void request(int numMessages);


### PR DESCRIPTION
It is typically used for receiving, but is on the sending object. It
would be a pain for users to coordinate, and the implementation is
already thread-safe because we always thought it would be thread-safe.
So make it part of the documentation.

This is for both v0.9.x and master.