### PR TITLE
Temporarily ignore content type

### DIFF
--- a/core/src/main/java/io/grpc/internal/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStream.java
@@ -204,8 +204,10 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
       return null;
     }
     contentTypeChecked = true;
+    // Temporarily disable content type checking due to lacking content-type from C servers (#1021).
+    final boolean contentTypeChecking = false;
     String contentType = headers.get(GrpcUtil.CONTENT_TYPE_KEY);
-    if (!GrpcUtil.isGrpcContentType(contentType)) {
+    if (contentTypeChecking && !GrpcUtil.isGrpcContentType(contentType)) {
       return Status.INTERNAL.withDescription("Invalid content-type: " + contentType);
     }
     return null;

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -261,18 +261,22 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
   }
 
   @Test
-  public void invalidInboundContentTypeShouldCancelStream() {
+  public void invalidInboundContentTypeShouldBeIgnored/*CancelStream*/() {
     // Set stream id to indicate it has been created
     stream().id(STREAM_ID);
     Http2Headers headers = new DefaultHttp2Headers().status(STATUS_OK).set(CONTENT_TYPE_HEADER,
             new ByteString("application/bad", UTF_8));
     stream().transportHeadersReceived(headers, false);
-    stream().transportHeadersReceived(new DefaultHttp2Headers(), true);
+    Http2Headers trailers = new DefaultHttp2Headers()
+        .set(new ByteString("grpc-status", UTF_8), new ByteString("0", UTF_8));
+    stream().transportHeadersReceived(trailers, true);
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(listener).closed(captor.capture(), any(Metadata.class));
     Status status = captor.getValue();
-    assertEquals(status.getCode(), Status.Code.INTERNAL);
-    assertTrue(status.getDescription().contains("content-type"));
+    // Temporarily consider this OK, for compatibility with C-based servers
+    //assertEquals(status.getCode(), Status.Code.INTERNAL);
+    assertEquals(status.getCode(), Status.Code.OK);
+    //assertTrue(status.getDescription().contains("content-type"));
   }
 
   @Test


### PR DESCRIPTION
Note that this is _only_ for v0.9.x. Master will continue with the current behavior.