### PR TITLE
Fix test checking for invalid content type

### DIFF
--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -267,11 +267,13 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     Http2Headers headers = new DefaultHttp2Headers().status(STATUS_OK).set(CONTENT_TYPE_HEADER,
             new ByteString("application/bad", UTF_8));
     stream().transportHeadersReceived(headers, false);
-    stream().transportHeadersReceived(new DefaultHttp2Headers(), true);
+    Http2Headers trailers = new DefaultHttp2Headers()
+        .set(new ByteString("grpc-status", UTF_8), new ByteString("0", UTF_8));
+    stream().transportHeadersReceived(trailers, true);
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(listener).closed(captor.capture(), any(Metadata.class));
     Status status = captor.getValue();
-    assertEquals(status.getCode(), Status.Code.INTERNAL);
+    assertEquals(Status.Code.INTERNAL, status.getCode());
     assertTrue(status.getDescription().contains("content-type"));
   }
 


### PR DESCRIPTION
Previously, if the content type was being ignored the error code would
have been UNKNOWN since there was no grpc-status. That seems very to
accidentally pass, so now if the content type is ignored it would get
OK.

Note that this is _only_ for master.