### PR TITLE
Upgrade maven-os-plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
     <extension>
       <groupId>kr.motd.maven</groupId>
       <artifactId>os-maven-plugin</artifactId>
-      <version>1.2.3.Final</version>
+      <version>1.4.0.Final</version>
     </extension>
   </extensions>
   <plugins>


### PR DESCRIPTION
Upgrade `os-maven-plugin` to 1.4.0, which fixes a bug with
running in Intellij IDEA with a bundled Maven version (3.0.5).

See https://github.com/trustin/os-maven-plugin/issues/5