### PR TITLE
Mark Status*Exception.getStatus() final

### DIFF
--- a/core/src/main/java/io/grpc/StatusException.java
+++ b/core/src/main/java/io/grpc/StatusException.java
@@ -47,7 +47,7 @@ public class StatusException extends Exception {
     this.status = status;
   }
 
-  public Status getStatus() {
+  public final Status getStatus() {
     return status;
   }
 }

--- a/core/src/main/java/io/grpc/StatusRuntimeException.java
+++ b/core/src/main/java/io/grpc/StatusRuntimeException.java
@@ -46,7 +46,7 @@ public class StatusRuntimeException extends RuntimeException {
     this.status = status;
   }
 
-  public Status getStatus() {
+  public final Status getStatus() {
     return status;
   }
 }


### PR DESCRIPTION
This further limits our API.

This is for both v0.9.x and master.