### PR TITLE
Change version to 0.10.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ subprojects {
     apply plugin: "jacoco"
 
     group = "io.grpc"
-    version = "1.0.0-SNAPSHOT"
+    version = "0.10.0-SNAPSHOT"
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6


### PR DESCRIPTION
We aren't 100% certain the next release is 1.0, so swap to a more
conservative number for snapshots.