### PR TITLE
0.9.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Download [the JAR][]. Or for Maven, add to your `pom.xml`:
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-all</artifactId>
-  <version>0.8.0</version>
+  <version>0.9.0</version>
 </dependency>
 ```
 
 Or for Gradle, add to your dependencies:
 ```gradle
-compile 'io.grpc:grpc-all:0.8.0'
+compile 'io.grpc:grpc-all:0.9.0'
 ```
 
-[the JAR]: https://search.maven.org/remote_content?g=io.grpc&a=grpc-all&v=0.8.0
+[the JAR]: https://search.maven.org/remote_content?g=io.grpc&a=grpc-all&v=0.9.0
 
 Development snapshots are available in [Sonatypes's snapshot
 repository](https://oss.sonatype.org/content/repositories/snapshots/).
@@ -71,7 +71,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
         -->
         <protocArtifact>com.google.protobuf:protoc:3.0.0-alpha-3.1:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
-        <pluginArtifact>io.grpc:protoc-gen-grpc-java:0.8.0:exe:${os.detected.classifier}</pluginArtifact>
+        <pluginArtifact>io.grpc:protoc-gen-grpc-java:0.9.0:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
       <executions>
         <execution>
@@ -112,7 +112,7 @@ protobuf {
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:0.8.0'
+      artifact = 'io.grpc:protoc-gen-grpc-java:0.9.0'
     }
   }
   generateProtoTasks {

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -33,7 +33,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.9.0'
+            artifact = 'io.grpc:protoc-gen-grpc-java:0.9.1-SNAPSHOT'
         }
     }
     generateProtoTasks {
@@ -64,10 +64,10 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     testCompile 'junit:junit:4.12'
     // You need to build grpc-java to obtain these libraries below.
-    compile 'io.grpc:grpc-core:0.9.0'
-    compile 'io.grpc:grpc-protobuf-nano:0.9.0'
-    compile 'io.grpc:grpc-okhttp:0.9.0'
-    compile 'io.grpc:grpc-stub:0.9.0'
-    compile 'io.grpc:grpc-testing:0.9.0'
+    compile 'io.grpc:grpc-core:0.9.1-SNAPSHOT'
+    compile 'io.grpc:grpc-protobuf-nano:0.9.1-SNAPSHOT'
+    compile 'io.grpc:grpc-okhttp:0.9.1-SNAPSHOT'
+    compile 'io.grpc:grpc-stub:0.9.1-SNAPSHOT'
+    compile 'io.grpc:grpc-testing:0.9.1-SNAPSHOT'
     compile 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -33,7 +33,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.9.0-SNAPSHOT'
+            artifact = 'io.grpc:protoc-gen-grpc-java:0.9.0'
         }
     }
     generateProtoTasks {
@@ -64,10 +64,10 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     testCompile 'junit:junit:4.12'
     // You need to build grpc-java to obtain these libraries below.
-    compile 'io.grpc:grpc-core:0.9.0-SNAPSHOT'
-    compile 'io.grpc:grpc-protobuf-nano:0.9.0-SNAPSHOT'
-    compile 'io.grpc:grpc-okhttp:0.9.0-SNAPSHOT'
-    compile 'io.grpc:grpc-stub:0.9.0-SNAPSHOT'
-    compile 'io.grpc:grpc-testing:0.9.0-SNAPSHOT'
+    compile 'io.grpc:grpc-core:0.9.0'
+    compile 'io.grpc:grpc-protobuf-nano:0.9.0'
+    compile 'io.grpc:grpc-okhttp:0.9.0'
+    compile 'io.grpc:grpc-stub:0.9.0'
+    compile 'io.grpc:grpc-testing:0.9.0'
     compile 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
     osdetector.classifierWithLikes = ['fedora']
 
     group = "io.grpc"
-    version = "0.9.0-SNAPSHOT"
+    version = "0.9.0"
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
     osdetector.classifierWithLikes = ['fedora']
 
     group = "io.grpc"
-    version = "0.9.0"
+    version = "0.9.1-SNAPSHOT"
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6


### PR DESCRIPTION
There are two commits here. Both need to be reviewed. The first one will become the 'v0.9.0' tag.