### PR TITLE
Load-balancing ManagedChannelImpl.

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import com.google.common.base.Preconditions;
+
+import java.util.HashMap;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * An immutable type-safe container of attributes.
+ */
+@ExperimentalApi
+@Immutable
+public final class Attributes {
+
+  private final HashMap<String, Object> data = new HashMap<String, Object>();
+
+  public static final Attributes EMPTY = new Attributes();
+
+  private Attributes() {
+  }
+
+  /**
+   * Gets the value for the key, or {@code null} if it's not present.
+   */
+  @SuppressWarnings("unchecked")
+  @Nullable
+  public <T> T get(Key<T> key) {
+    return (T) data.get(key.name);
+  }
+
+  /**
+   * Create a new builder.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Key<T> {
+    private final String name;
+
+    /**
+     * Construct the key.
+     *
+     * @param name the name, which should be namespaced like com.foo.BarAttribute to avoid
+     *             collision.
+     */
+    public Key(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return data.toString();
+  }
+
+  public static final class Builder {
+    private Attributes product;
+
+    private Builder() {
+      this.product = new Attributes();
+    }
+
+    public <T> void set(Key<T> key, T value) {
+      product.data.put(key.name, value);
+    }
+
+    /**
+     * Build the attributes. Can only be called once.
+     */
+    public Attributes build() {
+      Preconditions.checkState(product != null, "Already built");
+      Attributes result = product;
+      product = null;
+      return result;
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -62,6 +62,9 @@ public final class CallOptions {
   @Nullable
   private String authority;
 
+  @Nullable
+  private RequestKey requestKey;
+
   /**
    * Override the HTTP/2 authority the channel claims to be connecting to. <em>This is not
    * generally safe.</em> Overriding allows advanced users to re-use a single Channel for multiple
@@ -131,6 +134,25 @@ public final class CallOptions {
   }
 
   /**
+   * Returns a new {@code CallOptions} with a request key for affinity-based routing.
+   */
+  @ExperimentalApi
+  public CallOptions withRequestKey(@Nullable RequestKey requestKey) {
+    CallOptions newOptions = new CallOptions(this);
+    newOptions.requestKey = requestKey;
+    return newOptions;
+  }
+
+  /**
+   * Returns the request key for affinity-based routing.
+   */
+  @ExperimentalApi
+  @Nullable
+  public RequestKey getRequestKey() {
+    return requestKey;
+  }
+
+  /**
    * Override the HTTP/2 authority the channel claims to be connecting to. <em>This is not
    * generally safe.</em> Overriding allows advanced users to re-use a single Channel for multiple
    * services, even if those services are hosted on different domain names. That assumes the
@@ -155,6 +177,7 @@ public final class CallOptions {
     deadlineNanoTime = other.deadlineNanoTime;
     compressor = other.compressor;
     authority = other.authority;
+    requestKey = other.requestKey;
   }
 
   @SuppressWarnings("deprecation") // guava 14.0

--- a/core/src/main/java/io/grpc/DnsNameResolverFactory.java
+++ b/core/src/main/java/io/grpc/DnsNameResolverFactory.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import com.google.common.base.Preconditions;
+
+import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.SharedResourceHolder;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+
+import javax.annotation.Nullable;
+
+/**
+ * A factory for DNS-based {@link NameResolver}s.
+ *
+ * <p>The format of the target URI is {@code "[dns://[<DNS_server_address>]/]<name>"}.
+ */
+@ExperimentalApi
+public final class DnsNameResolverFactory extends NameResolver.Factory {
+
+  private static final DnsNameResolverFactory instance = new DnsNameResolverFactory();
+
+  @Override
+  public NameResolver newNameResolver(URI targetUri) {
+    String scheme = targetUri.getScheme();
+    if (scheme == null) {
+      return new DnsNameResolver(null, targetUri.toString());
+    } else if (scheme.equals("dns")) {
+      String targetPath = Preconditions.checkNotNull(targetUri.getPath(), "targetPath");
+      Preconditions.checkArgument(targetPath.startsWith("/"),
+          "the path component (%s) of the target (%s) must start with '/'", targetPath, targetUri);
+      String name = targetPath.substring(1);
+      return new DnsNameResolver(targetUri.getAuthority(), name);
+    } else {
+      return null;
+    }
+  }
+
+  private DnsNameResolverFactory() {
+  }
+
+  public static DnsNameResolverFactory getInstance() {
+    return instance;
+  }
+
+  private static class DnsNameResolver extends NameResolver {
+    private final String authority;
+    private final String host;
+    private final int port;
+    private ExecutorService executor;
+
+    DnsNameResolver(@Nullable String nsAuthority, String name) {
+      // TODO: if a DNS server is provided as nsAuthority, use it.
+      // https://www.captechconsulting.com/blogs/accessing-the-dusty-corners-of-dns-with-java
+
+      // Must prepend a "//" to the name when constructing a URI, otherwise
+      // the authority and host of the resulted URI would be null.
+      URI nameUri = URI.create("//" + name);
+      authority = Preconditions.checkNotNull(nameUri.getAuthority(),
+          "nameUri (%s) doesn't have an authority", nameUri);
+      host = Preconditions.checkNotNull(nameUri.getHost(), "host");
+      port = nameUri.getPort();
+      Preconditions.checkArgument(port > 0, "port (%s) must be positive", port);
+    }
+
+    @Override
+    public String getServiceAuthority() {
+      return authority;
+    }
+
+    @Override
+    public synchronized void start(final Listener listener) {
+      Preconditions.checkState(executor == null, "already started");
+      executor = SharedResourceHolder.get(GrpcUtil.SHARED_CHANNEL_EXECUTOR);
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          InetAddress[] inetAddrs;
+          try {
+            inetAddrs = InetAddress.getAllByName(host);
+          } catch (Exception e) {
+            listener.onError(Status.UNAVAILABLE.withCause(e));
+            return;
+          }
+          ArrayList<ResolvedServerInfo> servers
+              = new ArrayList<ResolvedServerInfo>(inetAddrs.length);
+          for (int i = 0; i < inetAddrs.length; i++) {
+            InetAddress inetAddr = inetAddrs[i];
+            servers.add(
+                new ResolvedServerInfo(new InetSocketAddress(inetAddr, port), Attributes.EMPTY));
+          }
+          listener.onUpdate(servers, Attributes.EMPTY);
+        }
+      });
+    }
+
+    @Override
+    public synchronized void shutdown() {
+      if (executor != null) {
+        executor = SharedResourceHolder.release(GrpcUtil.SHARED_CHANNEL_EXECUTOR, executor);
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import io.grpc.internal.ClientTransport;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A pluggable component that receives resolved addresses from {@link NameResolver} and provides the
+ * channel a usable transport when asked.
+ *
+ * <p>Note to implementations: all methods are expected to return quickly. Any work that may block
+ * should be done asynchronously.
+ */
+// TODO(zhangkun83): since it's also used for non-loadbalancing cases like pick-first,
+// "RequestRouter" might be a better name.
+@ExperimentalApi
+@ThreadSafe
+public abstract class LoadBalancer {
+  /**
+   * Pick a transport that Channel will use for next RPC.
+   *
+   * @param requestKey for affinity-based routing
+   */
+  public abstract ListenableFuture<ClientTransport> pickTransport(
+      @Nullable RequestKey requestKey);
+
+  /**
+   * Shuts down this {@code LoadBalancer}.
+   */
+  public void shutdown() { }
+
+  /**
+   * Handles newly resolved addresses and service config from name resolution system.
+   *
+   * <p>Implementations should not modify the given {@code servers}.
+   */
+  public void handleResolvedAddresses(List<ResolvedServerInfo> servers, Attributes config) { }
+
+  /**
+   * Handles an error from the name resolution system.
+   *
+   * @param error a non-OK status
+   */
+  public void handleNameResolutionError(Status error) { }
+
+  /**
+   * Called when a transport is fully connected and ready to accept traffic.
+   */
+  public void transportReady(SocketAddress addr, ClientTransport transport) { }
+
+  /**
+   * Called when a transport is shutting down.
+   */
+  public void transportShutdown(SocketAddress addr, ClientTransport transport, Status s) { }
+
+  public abstract static class Factory {
+    /**
+     * Creates a {@link LoadBalancer} that will be used inside a channel.
+     *
+     * @param serviceName the DNS-style service name, which is also the authority
+     * @param tm the interface where an {@code LoadBalancer} implementation gets connected
+     *               transports from
+     */
+    public abstract LoadBalancer newLoadBalancer(String serviceName, TransportManager tm);
+  }
+}

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -44,6 +44,11 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
     return ManagedChannelProvider.provider().builderForAddress(name, port);
   }
 
+  @ExperimentalApi
+  public static ManagedChannelBuilder<?> forTarget(String target) {
+    return ManagedChannelProvider.provider().builderForTarget(target);
+  }
+
   /**
    * Provides a custom executor.
    *
@@ -98,6 +103,24 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    */
   @ExperimentalApi("primarily for testing")
   public abstract T usePlaintext(boolean skipNegotiation);
+
+  /*
+   * Provides a custom {@link NameResolver.Factory} for the channel.
+   *
+   * <p>If this method is not called, the builder will look up in the global resolver registry for
+   * a factory for the provided target.
+   */
+  @ExperimentalApi
+  public abstract T nameResolverFactory(NameResolver.Factory resolverFactory);
+
+  /**
+   * Provides a custom {@link LoadBalancer.Factory} for the channel.
+   *
+   * <p>If this method is not called, the builder will use {@link SimpleLoadBalancerFactory} for the
+   * channel.
+   */
+  @ExperimentalApi
+  public abstract T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory);
 
   /**
    * Builds a channel using the given parameters.

--- a/core/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/core/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -106,6 +106,12 @@ public abstract class ManagedChannelProvider {
    */
   protected abstract ManagedChannelBuilder<?> builderForAddress(String name, int port);
 
+  /**
+   * Creates a new builder with the given target URI.
+   */
+  @ExperimentalApi
+  protected abstract ManagedChannelBuilder<?> builderForTarget(String target);
+
   public static final class ProviderNotFoundException extends RuntimeException {
     public ProviderNotFoundException(String msg) {
       super(msg);

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A pluggable component that resolves a target URI (which is broken down into 3 parts as described
+ * below) and return addresses to the caller.
+ *
+ * <p>The format of the target URI is {@code "[<scheme>:]<scheme-specific-string>"}
+ *
+ * <p>{@code NameResolver} has no knowledge of load-balancing. The addresses of a target may be
+ * changed over time, thus the caller registers a {@link Listener} to receive continuous updates.
+ */
+@ExperimentalApi
+@ThreadSafe
+public abstract class NameResolver {
+  /**
+   * Returns the authority, which is also the name of the service.
+   *
+   * <p>An implementation must generate it locally and must keep it unchanged.
+   */
+  public abstract String getServiceAuthority();
+
+  /**
+   * Starts the resolution.
+   *
+   * @param listener used to receive updates on the target
+   */
+  public abstract void start(Listener listener);
+
+  /**
+   * Stops the resolution. Updates to the Listener will stop.
+   */
+  public abstract void shutdown();
+
+  public abstract static class Factory {
+    /**
+     * Creates a {@link NameResolver} for the given target URI, or {@code null} if the given URI
+     * cannot be resolved by this factory.
+     */
+    @Nullable
+    public abstract NameResolver newNameResolver(URI targetUri);
+  }
+
+  /**
+   * Receives address updates.
+   *
+   * <p>All methods are expected to return quickly.
+   */
+  @ThreadSafe
+  public interface Listener {
+    /**
+     * Handles updates on resolved addresses and config.
+     *
+     * <p>Implementations will not modify the given {@code servers}.
+     */
+    void onUpdate(List<ResolvedServerInfo> servers, Attributes config);
+
+    /**
+     * Handles an error from the resolver.
+     *
+     * @param error a non-OK status
+     */
+    void onError(Status error);
+  }
+}

--- a/core/src/main/java/io/grpc/RequestKey.java
+++ b/core/src/main/java/io/grpc/RequestKey.java
@@ -29,56 +29,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.netty;
+package io.grpc;
 
-import io.grpc.internal.ClientTransportFactory;
+/**
+ * A key generated from an RPC request, and to be used for affinity-based
+ * routing.
+ */
+@ExperimentalApi
+public final class RequestKey {
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-
-@RunWith(JUnit4.class)
-public class NettyChannelBuilderTest {
-
-  @Rule public final ExpectedException thrown = ExpectedException.none();
-
-  @Test
-  public void overrideAllowsInvalidAuthority() {
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){}) {
-      @Override
-      protected String checkAuthority(String authority) {
-        return authority;
-      }
-    };
-
-    ClientTransportFactory factory = builder.overrideAuthority("[invalidauthority")
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .buildTransportFactory();
-  }
-
-  @Test
-  public void failOverrideInvalidAuthority() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid authority:");
-
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
-
-    ClientTransportFactory factory = builder.overrideAuthority("[invalidauthority")
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .buildTransportFactory();
-  }
-
-  @Test
-  public void failInvalidAuthority() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid host or port");
-
-    NettyChannelBuilder.forAddress(new InetSocketAddress("invalid_authority", 1234));
+  // TODO(zhangkun83): materialize this class once we decide the form of the affinity key.
+  private RequestKey() {
   }
 }
-

--- a/core/src/main/java/io/grpc/ResolvedServerInfo.java
+++ b/core/src/main/java/io/grpc/ResolvedServerInfo.java
@@ -29,56 +29,48 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.netty;
+package io.grpc;
 
-import io.grpc.internal.ClientTransportFactory;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-@RunWith(JUnit4.class)
-public class NettyChannelBuilderTest {
+import javax.annotation.concurrent.Immutable;
 
-  @Rule public final ExpectedException thrown = ExpectedException.none();
+/**
+ * The information about a server from a {@link NameResolver}.
+ */
+@ExperimentalApi
+@Immutable
+public final class ResolvedServerInfo {
+  private final SocketAddress address;
+  private final Attributes attributes;
 
-  @Test
-  public void overrideAllowsInvalidAuthority() {
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){}) {
-      @Override
-      protected String checkAuthority(String authority) {
-        return authority;
-      }
-    };
-
-    ClientTransportFactory factory = builder.overrideAuthority("[invalidauthority")
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .buildTransportFactory();
+  /**
+   * Constructor.
+   *
+   * @param address the address object
+   * @param attributes attributes associated with this address.
+   */
+  public ResolvedServerInfo(SocketAddress address, Attributes attributes) {
+    this.address = address;
+    this.attributes = attributes;
   }
 
-  @Test
-  public void failOverrideInvalidAuthority() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid authority:");
-
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
-
-    ClientTransportFactory factory = builder.overrideAuthority("[invalidauthority")
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .buildTransportFactory();
+  /**
+   * Returns the address.
+   */
+  public SocketAddress getAddress() {
+    return address;
   }
 
-  @Test
-  public void failInvalidAuthority() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid host or port");
+  /**
+   * Returns the associated attributes.
+   */
+  public Attributes getAttributes() {
+    return attributes;
+  }
 
-    NettyChannelBuilder.forAddress(new InetSocketAddress("invalid_authority", 1234));
+  @Override
+  public String toString() {
+    return "[address=" + address + ", attrs=" + attributes + "]";
   }
 }
-

--- a/core/src/main/java/io/grpc/SimpleLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/SimpleLoadBalancerFactory.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2014, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import io.grpc.internal.ClientTransport;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * A {@link LoadBalancer} that provides simple round-robin and pick-first routing mechanism over the
+ * addresses from the {@link NameResolver}.
+ */
+// TODO(zhangkun83): Only pick-first is implemented. We need to implement round-robin.
+public final class SimpleLoadBalancerFactory extends LoadBalancer.Factory {
+
+  private static final SimpleLoadBalancerFactory instance = new SimpleLoadBalancerFactory();
+
+  private SimpleLoadBalancerFactory() {
+  }
+
+  public static SimpleLoadBalancerFactory getInstance() {
+    return instance;
+  }
+
+  @Override
+  public LoadBalancer newLoadBalancer(String serviceName, TransportManager tm) {
+    return new SimpleLoadBalancer(tm);
+  }
+
+  private static class SimpleLoadBalancer extends LoadBalancer {
+    @GuardedBy("servers")
+    private final List<ResolvedServerInfo> servers = new ArrayList<ResolvedServerInfo>();
+    @GuardedBy("servers")
+    private int currentServerIndex;
+    // TODO(zhangkun83): virtually any LoadBalancer would need to handle picks before name
+    // resolution is done, we may want to move the related logic into ManagedChannelImpl.
+    @GuardedBy("servers")
+    private List<SettableFuture<ClientTransport>> pendingPicks;
+    @GuardedBy("servers")
+    private StatusException nameResolutionError;
+
+    private final TransportManager tm;
+
+    private SimpleLoadBalancer(TransportManager tm) {
+      this.tm = tm;
+    }
+
+    @Override
+    public ListenableFuture<ClientTransport> pickTransport(@Nullable RequestKey requestKey) {
+      ResolvedServerInfo currentServer;
+      synchronized (servers) {
+        if (servers.isEmpty()) {
+          if (nameResolutionError != null) {
+            return Futures.immediateFailedFuture(nameResolutionError);
+          }
+          SettableFuture<ClientTransport> future = SettableFuture.create();
+          if (pendingPicks == null) {
+            pendingPicks = new ArrayList<SettableFuture<ClientTransport>>();
+          }
+          pendingPicks.add(future);
+          return future;
+        }
+        currentServer = servers.get(currentServerIndex);
+      }
+      return tm.getTransport(currentServer.getAddress());
+    }
+
+    @Override
+    public void handleResolvedAddresses(
+        List<ResolvedServerInfo> updatedServers, Attributes config) {
+      List<SettableFuture<ClientTransport>> pendingPicksCopy = null;
+      ResolvedServerInfo currentServer = null;
+      synchronized (servers) {
+        nameResolutionError = null;
+        servers.clear();
+        for (ResolvedServerInfo addr : updatedServers) {
+          servers.add(addr);
+        }
+        if (!servers.isEmpty()) {
+          pendingPicksCopy = pendingPicks;
+          pendingPicks = null;
+          if (currentServerIndex >= servers.size()) {
+            currentServerIndex = 0;
+          }
+          currentServer = servers.get(currentServerIndex);
+        }
+      }
+      if (pendingPicksCopy != null) {
+        // If pendingPicksCopy != null, then servers.isEmpty() == false, then
+        // currentServer must have been assigned.
+        Preconditions.checkState(currentServer != null, "currentServer is null");
+        for (final SettableFuture<ClientTransport> pendingPick : pendingPicksCopy) {
+          ListenableFuture<ClientTransport> future = tm.getTransport(currentServer.getAddress());
+          Futures.addCallback(future, new FutureCallback<ClientTransport>() {
+            @Override public void onSuccess(ClientTransport result) {
+              pendingPick.set(result);
+            }
+
+            @Override public void onFailure(Throwable t) {
+              pendingPick.setException(t);
+            }
+          });
+        }
+      }
+    }
+
+    @Override
+    public void handleNameResolutionError(Status error) {
+      List<SettableFuture<ClientTransport>> pendingPicksCopy = null;
+      StatusException statusException = error.asException();
+      synchronized (servers) {
+        pendingPicksCopy = pendingPicks;
+        pendingPicks = null;
+        nameResolutionError = statusException;
+      }
+      if (pendingPicksCopy != null) {
+        for (SettableFuture<ClientTransport> pendingPick : pendingPicksCopy) {
+          pendingPick.setException(statusException);
+        }
+      }
+    }
+
+    @Override
+    public void transportShutdown(SocketAddress addr, ClientTransport transport, Status s) {
+      if (!s.isOk()) {
+        // If the current transport is shut down due to error, move on to the next address in the
+        // list
+        synchronized (servers) {
+          if (addr.equals(servers.get(currentServerIndex).getAddress())) {
+            currentServerIndex++;
+            if (currentServerIndex >= servers.size()) {
+              currentServerIndex = 0;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -96,7 +96,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
      * @return a future for client transport. If no more transports can be created, e.g., channel is
      *         shut down, the future's value will be {@code null}.
      */
-    ListenableFuture<ClientTransport> get();
+    ListenableFuture<ClientTransport> get(CallOptions callOptions);
   }
 
 
@@ -139,7 +139,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     }
 
     ClientStreamListener listener = new ClientStreamListenerImpl(observer);
-    ListenableFuture<ClientTransport> transportFuture = clientTransportProvider.get();
+    ListenableFuture<ClientTransport> transportFuture = clientTransportProvider.get(callOptions);
     if (transportFuture.isDone()) {
       // Try to skip DelayedStream when possible to avoid the overhead of a volatile read in the
       // fast path. If that fails, stream will stay null and DelayedStream will be created.
@@ -409,7 +409,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
 
       StreamCreationTask() {
         this.transportFuture = Preconditions.checkNotNull(
-            clientTransportProvider.get(), "transportFuture");
+            clientTransportProvider.get(callOptions), "transportFuture");
       }
 
       @Override

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -108,6 +108,8 @@ public interface ClientTransport {
      * that this method is called without {@link #shutdown} being called.  If the argument to this
      * function is {@link Status#isOk}, it is safe to immediately reconnect.
      *
+     * <p>This is called exactly once, and must be called prior to {@link #transportTerminated}.
+     *
      * @param s the reason for the shutdown.
      */
     void transportShutdown(Status s);
@@ -115,7 +117,8 @@ public interface ClientTransport {
     /**
      * The transport completed shutting down. All resources have been released.
      *
-     * <p> {@link #transportShutdown(Status)} must be called before calling this method.
+     * <p>This is called exactly once, and must be called after {@link #transportShutdown} has been
+     * called.
      */
     void transportTerminated();
 

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -31,14 +31,15 @@
 
 package io.grpc.internal;
 
+import java.net.SocketAddress;
+
 /** Pre-configured factory for creating {@link ClientTransport} instances. */
 public interface ClientTransportFactory extends ReferenceCounted {
-  /** Creates an unstarted transport for exclusive use. */
-  ClientTransport newClientTransport();
-
   /**
-   * Returns the authority of the channel. Typically, this should be in the form {@code host:port}.
-   * Note that since there is not a scheme, there can't be a default port.
+   * Creates an unstarted transport for exclusive use.
+   *
+   * @param serverAddress the address that the transport is connected to
+   * @param authority the HTTP/2 authority of the server
    */
-  String authority();
+  ClientTransport newClientTransport(SocketAddress serverAddress, String authority);
 }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -351,7 +351,7 @@ public final class GrpcUtil {
   /**
    * Shared executor for channels.
    */
-  static final Resource<ExecutorService> SHARED_CHANNEL_EXECUTOR =
+  public static final Resource<ExecutorService> SHARED_CHANNEL_EXECUTOR =
       new Resource<ExecutorService>() {
         private static final String name = "grpc-default-executor";
         @Override

--- a/core/src/test/java/io/grpc/ManagedChannelProviderTest.java
+++ b/core/src/test/java/io/grpc/ManagedChannelProviderTest.java
@@ -113,6 +113,11 @@ public class ManagedChannelProviderTest {
     protected ManagedChannelBuilder<?> builderForAddress(String host, int port) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    protected ManagedChannelBuilder<?> builderForTarget(String target) {
+      throw new UnsupportedOperationException();
+    }
   }
 
   public static class Available0Provider extends BaseProvider {

--- a/core/src/test/java/io/grpc/SimpleLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/SimpleLoadBalancerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import io.grpc.internal.ClientTransport;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+
+/** Unit test for {@link SimpleLoadBalancerFactory}. */
+@RunWith(JUnit4.class)
+public class SimpleLoadBalancerTest {
+  private LoadBalancer loadBalancer;
+
+  private ArrayList<ResolvedServerInfo> servers;
+
+  @Mock
+  private TransportManager mockTransportManager;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    loadBalancer = SimpleLoadBalancerFactory.getInstance().newLoadBalancer(
+        "fakeservice", mockTransportManager);
+    servers = new ArrayList<ResolvedServerInfo>();
+    for (int i = 0; i < 3; i++) {
+      servers.add(new ResolvedServerInfo(new FakeSocketAddress("server" + i), Attributes.EMPTY));
+    }
+  }
+
+  @Test
+  public void pickBeforeResolved() throws Exception {
+    ClientTransport mockTransport = mock(ClientTransport.class);
+    SettableFuture<ClientTransport> sourceFuture = SettableFuture.create();
+    when(mockTransportManager.getTransport(same(servers.get(0).getAddress())))
+        .thenReturn(sourceFuture);
+    ListenableFuture<ClientTransport> f1 = loadBalancer.pickTransport(null);
+    ListenableFuture<ClientTransport> f2 = loadBalancer.pickTransport(null);
+    assertNotNull(f1);
+    assertNotNull(f2);
+    assertNotSame(f1, f2);
+    assertFalse(f1.isDone());
+    assertFalse(f2.isDone());
+    verify(mockTransportManager, never()).getTransport(any(SocketAddress.class));
+    loadBalancer.handleResolvedAddresses(servers, Attributes.EMPTY);
+    verify(mockTransportManager, times(2)).getTransport(same(servers.get(0).getAddress()));
+    assertFalse(f1.isDone());
+    assertFalse(f2.isDone());
+    assertNotSame(sourceFuture, f1);
+    assertNotSame(sourceFuture, f2);
+    sourceFuture.set(mockTransport);
+    assertSame(mockTransport, f1.get());
+    assertSame(mockTransport, f2.get());
+    ListenableFuture<ClientTransport> f3 = loadBalancer.pickTransport(null);
+    assertSame(sourceFuture, f3);
+    verify(mockTransportManager, times(3)).getTransport(same(servers.get(0).getAddress()));
+    verifyNoMoreInteractions(mockTransportManager);
+  }
+
+  @Test
+  public void transportFailed() throws Exception {
+    ClientTransport mockTransport1 = mock(ClientTransport.class);
+    ClientTransport mockTransport2 = mock(ClientTransport.class);
+    when(mockTransportManager.getTransport(same(servers.get(0).getAddress()))).thenReturn(
+        Futures.immediateFuture(mockTransport1));
+    when(mockTransportManager.getTransport(same(servers.get(1).getAddress()))).thenReturn(
+        Futures.immediateFuture(mockTransport2));
+    loadBalancer.handleResolvedAddresses(servers, Attributes.EMPTY);
+    ListenableFuture<ClientTransport> f1 = loadBalancer.pickTransport(null);
+    ListenableFuture<ClientTransport> f2 = loadBalancer.pickTransport(null);
+    assertSame(mockTransport1, f1.get());
+    assertSame(mockTransport1, f2.get());
+    loadBalancer.transportShutdown(servers.get(0).getAddress(), mockTransport1, Status.INTERNAL);
+    ListenableFuture<ClientTransport> f3 = loadBalancer.pickTransport(null);
+    assertSame(mockTransport2, f3.get());
+  }
+
+  private static class FakeSocketAddress extends SocketAddress {
+    final String name;
+
+    FakeSocketAddress(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return "FakeSocketAddress-" + name;
+    }
+  }
+
+}

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -94,7 +94,7 @@ public class ClientCallImplTest {
     final ClientStream stream = mock(ClientStream.class);
     ClientTransportProvider provider = new ClientTransportProvider() {
       @Override
-      public ListenableFuture<ClientTransport> get() {
+      public ListenableFuture<ClientTransport> get(CallOptions callOptions) {
         return Futures.immediateFuture(transport);
       }
     };

--- a/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
@@ -51,4 +51,9 @@ public class NettyChannelProvider extends ManagedChannelProvider {
   protected NettyChannelBuilder builderForAddress(String name, int port) {
     return NettyChannelBuilder.forAddress(name, port);
   }
+
+  @Override
+  protected NettyChannelBuilder builderForTarget(String target) {
+    return NettyChannelBuilder.forTarget(target);
+  }
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
@@ -61,4 +61,9 @@ public class OkHttpChannelProvider extends ManagedChannelProvider {
   protected OkHttpChannelBuilder builderForAddress(String name, int port) {
     return OkHttpChannelBuilder.forAddress(name, port);
   }
+
+  @Override
+  protected OkHttpChannelBuilder builderForTarget(String target) {
+    return OkHttpChannelBuilder.forTarget(target);
+  }
 }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -31,8 +31,6 @@
 
 package io.grpc.okhttp;
 
-import static org.junit.Assert.assertEquals;
-
 import io.grpc.internal.ClientTransportFactory;
 
 import org.junit.Rule;
@@ -55,11 +53,20 @@ public class OkHttpChannelBuilderTest {
       }
     };
 
-    ClientTransportFactory factory = builder.overrideAuthority("invalid_authority")
+    ClientTransportFactory factory = builder.overrideAuthority("[invalidauthority")
         .negotiationType(NegotiationType.PLAINTEXT)
         .buildTransportFactory();
+  }
 
-    assertEquals("invalid_authority", factory.authority());
+  @Test
+  public void failOverrideInvalidAuthority() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid authority:");
+    OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234);
+
+    ClientTransportFactory factory = builder.overrideAuthority("[invalidauthority")
+        .negotiationType(NegotiationType.PLAINTEXT)
+        .buildTransportFactory();
   }
 
   @Test


### PR DESCRIPTION
For #428 

- Add NameResolver and LoadBalancer interfaces.
- ManagedChannelImpl now uses NameResolver and LoadBalancer for
  transport selection, which may return transports to multiple
  addresses.
- Transports are still owned by ManagedChannelImpl, which implements
  TransportManager interface that is provided to LoadBalancer, so that
  LoadBalancer doesn't worry about Transport lifecycles.
- Channel builders can be created by forTarget() that accepts the fully
  qualified target name, which is a URI.
- The old address-based construction pattern is supported by using
  AbstractManagedChannelImplBuilder.DirectAddressNameResolver.
- Implemented DnsNameResolver and SimpleLoadBalancer. However, they currently
  merely work for the single-address scenario. They will be completed in follow-up changes.

/cc @nmittler @carl-mastrangelo 