### PR TITLE
Split newCall from starting a call

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -441,6 +441,11 @@ class InProcessTransport implements ServerTransport, ClientTransport {
 
       @Override
       public void setDecompressionRegistry(DecompressorRegistry registry) {}
+
+      @Override
+      public void start() {
+        // Currently a no op
+      }
     }
   }
 
@@ -472,5 +477,10 @@ class InProcessTransport implements ServerTransport, ClientTransport {
 
     @Override
     public void setDecompressionRegistry(DecompressorRegistry registry) {}
+
+    @Override
+    public void start() {
+      // Currently a no op
+    }
   }
 }

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -166,19 +166,23 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       closeCallPrematurely(listener, Status.fromThrowable(ex));
     }
 
-    if (stream != null) {
-      // TODO: this can race with the callbacks.  Fix the race ~eventually~ by decoupling stream
-      // creation and stream starting.
-      stream.setDecompressionRegistry(decompressorRegistry);
-      if (compressor != null) {
-        stream.setCompressor(compressor);
-      }
+    if (stream == null) {
+      return;
+    }
+
+    // TODO: this can race with the callbacks.  Fix the race ~eventually~ by decoupling stream
+    // creation and stream starting.
+    stream.setDecompressionRegistry(decompressorRegistry);
+    if (compressor != null) {
+      stream.setCompressor(compressor);
     }
 
     // Start the deadline timer after stream creation because it will close the stream
     if (deadlineNanoTime != null) {
       deadlineCancellationFuture = startDeadlineTimer(timeoutMicros);
     }
+
+    stream.start();
   }
 
   @Override
@@ -372,6 +376,10 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
 
     @Override
     public void setDecompressionRegistry(DecompressorRegistry registry) {}
+
+    @Override
+    public void start() {}
+
   }
 }
 

--- a/core/src/main/java/io/grpc/internal/ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ClientStream.java
@@ -58,4 +58,9 @@ public interface ClientStream extends Stream {
    * the remote end-point is closed. This method may only be called once.
    */
   void halfClose();
+
+  /**
+   * Begins this client stream.
+   */
+  void start();
 }

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -281,6 +281,9 @@ public class AbstractClientStreamTest {
     }
 
     @Override
+    public void start() {}
+
+    @Override
     protected void returnProcessedBytes(int processedBytes) {}
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -341,7 +341,9 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
   @Test
   public void setHttp2StreamShouldNotifyReady() {
     listener = mock(ClientStreamListener.class);
-    stream = new NettyClientStream(listener, channel, handler, DEFAULT_MAX_MESSAGE_SIZE);
+    Http2Headers headers = mock(Http2Headers.class);
+    stream = new NettyClientStream(
+        listener, channel, handler, DEFAULT_MAX_MESSAGE_SIZE, headers, true);
     stream().id(STREAM_ID);
     verify(listener, never()).onReady();
     assertFalse(stream.isReady());
@@ -363,8 +365,9 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
       }
     }).when(writeQueue).enqueue(any(), any(ChannelPromise.class), anyBoolean());
     when(writeQueue.enqueue(any(), anyBoolean())).thenReturn(future);
-    NettyClientStream stream = new NettyClientStream(listener, channel, handler,
-            DEFAULT_MAX_MESSAGE_SIZE);
+    Http2Headers headers = mock(Http2Headers.class);
+    NettyClientStream stream = new NettyClientStream(
+        listener, channel, handler, DEFAULT_MAX_MESSAGE_SIZE, headers, true);
     assertTrue(stream.canSend());
     assertTrue(stream.canReceive());
     stream.id(STREAM_ID);
@@ -386,7 +389,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
   }
 
   private NettyClientStream stream() {
-    return (NettyClientStream) stream;
+    return stream;
   }
 
   private Http2Headers grpcResponseHeaders() {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -80,12 +80,16 @@ class OkHttpClientStream extends Http2ClientStream {
   @GuardedBy("lock")
   private boolean cancelSent = false;
 
+  // This depends on the internals of the transport.
+  private final Runnable startCallback;
+
   OkHttpClientStream(ClientStreamListener listener,
       AsyncFrameWriter frameWriter,
       OkHttpClientTransport transport,
       OutboundFlowController outboundFlow,
       MethodType type,
       Object lock,
+      Runnable startCallback,
       List<Header> requestHeaders,
       int maxMessageSize) {
     super(new OkHttpWritableBufferAllocator(), listener, maxMessageSize);
@@ -95,6 +99,7 @@ class OkHttpClientStream extends Http2ClientStream {
     this.type = type;
     this.lock = lock;
     this.requestHeaders = requestHeaders;
+    this.startCallback = startCallback;
   }
 
   /**
@@ -115,6 +120,11 @@ class OkHttpClientStream extends Http2ClientStream {
   @Nullable
   public Integer id() {
     return id;
+  }
+
+  @Override
+  public void start() {
+    startCallback.run();
   }
 
   @GuardedBy("lock")


### PR DESCRIPTION
This change allows fixing a race condition between creating a new call and starting it.  Currently, any code that touches a Stream has to do so after it has already started.  Notably, the deadline cancellation races with the start call.

/cc @madongfly & @zhangkun83 