### PR TITLE
Put nano generated code into nano package, unless option javanano_use…

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -33,7 +33,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.9.0-SNAPSHOT'
+            artifact = 'io.grpc:protoc-gen-grpc-java:0.10.0-SNAPSHOT'
         }
     }
     generateProtoTasks {
@@ -64,10 +64,10 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     testCompile 'junit:junit:4.12'
     // You need to build grpc-java to obtain these libraries below.
-    compile 'io.grpc:grpc-core:0.9.0-SNAPSHOT'
-    compile 'io.grpc:grpc-protobuf-nano:0.9.0-SNAPSHOT'
-    compile 'io.grpc:grpc-okhttp:0.9.0-SNAPSHOT'
-    compile 'io.grpc:grpc-stub:0.9.0-SNAPSHOT'
-    compile 'io.grpc:grpc-testing:0.9.0-SNAPSHOT'
+    compile 'io.grpc:grpc-core:0.10.0-SNAPSHOT'
+    compile 'io.grpc:grpc-protobuf-nano:0.10.0-SNAPSHOT'
+    compile 'io.grpc:grpc-okhttp:0.10.0-SNAPSHOT'
+    compile 'io.grpc:grpc-stub:0.10.0-SNAPSHOT'
+    compile 'io.grpc:grpc-testing:0.10.0-SNAPSHOT'
     compile 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTester.java
+++ b/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTester.java
@@ -60,6 +60,8 @@ import io.grpc.android.integrationtest.nano.Messages.StreamingInputCallRequest;
 import io.grpc.android.integrationtest.nano.Messages.StreamingInputCallResponse;
 import io.grpc.android.integrationtest.nano.Messages.StreamingOutputCallRequest;
 import io.grpc.android.integrationtest.nano.Messages.StreamingOutputCallResponse;
+import io.grpc.android.integrationtest.nano.TestServiceGrpc;
+import io.grpc.android.integrationtest.nano.UnimplementedServiceGrpc;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.StreamRecorder;

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -208,7 +208,7 @@ artifacts {
 
 test.dependsOn('testGolden', 'testNanoGolden')
 
-def configureTestTask(Task task, String suffix) {
+def configureTestTask(Task task, String suffix, String extraPackage) {
   task.dependsOn "generateTest${suffix}Proto"
   if (osdetector.os != 'windows') {
     task.executable "diff"
@@ -217,11 +217,11 @@ def configureTestTask(Task task, String suffix) {
   }
   // File isn't found on Windows if last slash is forward-slash
   def slash = System.getProperty("file.separator")
-  task.args "$buildDir/generated/source/proto/test${suffix}/grpc/io/grpc/testing/integration${slash}TestServiceGrpc.java",
+  task.args "$buildDir/generated/source/proto/test${suffix}/grpc/io/grpc/testing/integration${extraPackage}${slash}TestServiceGrpc.java",
        "$projectDir/src/test/golden/TestService${suffix}.java.txt"
 }
 
 task testGolden(type: Exec)
 task testNanoGolden(type: Exec)
-configureTestTask(testGolden, '')
-configureTestTask(testNanoGolden, 'Nano')
+configureTestTask(testGolden, '', '')
+configureTestTask(testNanoGolden, 'Nano', '/nano')

--- a/compiler/src/java_plugin/cpp/java_generator.h
+++ b/compiler/src/java_plugin/cpp/java_generator.h
@@ -39,7 +39,7 @@ using namespace std;
 namespace java_grpc_generator {
 
 // Returns the package name of the gRPC services defined in the given file.
-string ServiceJavaPackage(const google::protobuf::FileDescriptor* file);
+string ServiceJavaPackage(const google::protobuf::FileDescriptor* file, bool nano);
 
 // Returns the name of the outer class that wraps in all the generated code for
 // the given service.

--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -8,8 +8,8 @@
 #include "java_generator.h"
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/plugin.h>
-#include <google/protobuf/io/zero_copy_stream.h>
 #include <google/protobuf/descriptor.h>
+#include <google/protobuf/io/zero_copy_stream.h>
 
 static string JavaPackageToDir(const string& package_name) {
   string package_dir = package_name;
@@ -41,7 +41,7 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
       }
     }
 
-    string package_name = java_grpc_generator::ServiceJavaPackage(file);
+    string package_name = java_grpc_generator::ServiceJavaPackage(file, generate_nano);
     string package_filename = JavaPackageToDir(package_name);
     for (int i = 0; i < file->service_count(); ++i) {
       const google::protobuf::ServiceDescriptor* service = file->service(i);

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -1,4 +1,4 @@
-package io.grpc.testing.integration;
+package io.grpc.testing.integration.nano;
 
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
 import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;


### PR DESCRIPTION
…_deprecated_package is set to true.

Also fixes the behavior while java_package is set to empty (although it's a rare case, we should keep the behavior consistent with protobuf):
Previously, the outer class name would be used as package name, such as Test.TestServiceGrpc, and the reference to nano messages would be something like Test.nano.SimpleRequest.
After this change, either no package (unnamed package in Java) or "nano" will be applied if java_package is set to empty.

Fixes #1038

@zhangkun83 @ejona86  Please take a look, thanks!