### PR TITLE
Fixing flaky test Http2NettyTest.deadlineExceeded()

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -60,6 +60,7 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
   private Status status;
   private Metadata trailers;
   private Runnable closeListenerTask;
+  private volatile boolean cancelled;
 
   protected AbstractClientStream(WritableBufferAllocator bufferAllocator,
                                  ClientStreamListener listener,
@@ -293,9 +294,14 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
   @Override
   public final void cancel(Status reason) {
     checkArgument(CANCEL_REASONS.contains(reason.getCode()), "Invalid cancellation reason");
-    outboundPhase(Phase.STATUS);
+    cancelled = true;
     sendCancel(reason);
     dispose();
+  }
+
+  @Override
+  public final boolean isReady() {
+    return !cancelled && super.isReady();
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -176,7 +176,7 @@ public abstract class AbstractStream<IdT> implements Stream {
   }
 
   @Override
-  public final boolean isReady() {
+  public boolean isReady() {
     if (listener() != null && outboundPhase() != Phase.STATUS) {
       synchronized (onReadyLock) {
         return allocated && numSentBytesQueued < onReadyThreshold;


### PR DESCRIPTION
This test occasionally flakes due to the way the deadline timer cancels the stream. Stream cancellation immediately closes the outbound status, disallowing the sending of further messages.  The true cancellation is done sometime later in the transport thread in Netty. So there is a race between closing the outbound status and performing the actual cancellation where sent messages will fail with the wrong status.