### PR TITLE
Introduces the grpc-callable sub-project. 

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -16,6 +16,7 @@ configurations.compile.transitive = false
 
 def subprojects = [
   project(':grpc-auth'),
+  project(':grpc-callable'),
   project(':grpc-core'),
   project(':grpc-netty'),
   project(':grpc-okhttp'),

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,8 @@ subprojects {
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',
-                mockito: 'org.mockito:mockito-core:1.10.19'
+                mockito: 'org.mockito:mockito-core:1.10.19',
+                truth: 'com.google.truth:truth:0.27'
         ]
 
         // Determine the correct version of Jetty ALPN boot to use based
@@ -162,7 +163,8 @@ subprojects {
 
     dependencies {
         testCompile libraries.junit,
-                    libraries.mockito
+                    libraries.mockito,
+                    libraries.truth
 
         // Configuration for modules that use Jetty ALPN
         alpnboot alpnboot_package_name

--- a/callable/build.gradle
+++ b/callable/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
+}
+
+description = "gRPC: Callable"
+dependencies {
+    compile project(':grpc-core'),\
+            project(':grpc-stub')
+}
+
+// Configure the animal sniffer plugin
+animalsniffer {
+    signature = "org.codehaus.mojo.signature:java16:+@signature"
+}
+
+javadoc.options.links 'http://docs.guava-libraries.googlecode.com/git-history/release/javadoc/'

--- a/callable/src/main/java/io/grpc/callable/Callable.java
+++ b/callable/src/main/java/io/grpc/callable/Callable.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.callable;
+
+import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ExperimentalApi;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusException;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.StreamObserver;
+
+import java.util.Iterator;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
+/**
+ * A callable is an object which represents one or more rpc calls. Various operators on callables
+ * produce new callables, representing common API programming patterns. Callables can be used to
+ * directly operate against an api, or to efficiently implement wrappers for apis which add
+ * additional functionality and processing.
+ *
+ * <p>Technically, callables are a factory for grpc {@link ClientCall} objects, and can be executed
+ * by methods of the {@link ClientCalls} class. They also provide shortcuts for direct execution of
+ * the callable instance.
+ */
+@ExperimentalApi
+public abstract class Callable<RequestT, ResponseT> {
+
+  // TODO(wrwg): Support interceptors and method option configurations.
+  // TODO(wrwg): gather more feedback whether the overload with java.util.Concurrent hurts that
+  //             much that we want to rename this into ClientCallable or such.
+
+  // Subclass Contract
+  // =================
+
+  /**
+   * Creates a new GRPC call from this callable. A channel may or may not be provided.
+   * If a channel is not provided, the callable must be bound to a channel.
+   */
+  public abstract ClientCall<RequestT, ResponseT> newCall(@Nullable Channel channel);
+
+  /**
+   * Return a descriptor for this callable, or null if none available.
+   */
+  @Nullable public CallableDescriptor<RequestT, ResponseT> getDescriptor() {
+    return null;
+  }
+
+  /**
+   * Gets the channel bound to this callable, or null, if none is bound to it.
+   */
+  @Nullable public Channel getBoundChannel() {
+    return null;
+  }
+
+  // Binding Callables
+  // =================
+
+  /**
+   * Returns a callable which is bound to the given channel. Operations on the result can
+   * omit the channel. If a channel is provided anyway, it overrides the bound channel.
+   */
+  public Callable<RequestT, ResponseT> bind(final Channel boundChannel) {
+    return new Callable<RequestT, ResponseT>() {
+      @Override
+      public ClientCall<RequestT, ResponseT> newCall(@Nullable Channel channel) {
+        if (channel == null) {
+          // If the caller does not provide a channel, we use the bound one.
+          channel = boundChannel;
+        }
+        return Callable.this.newCall(channel);
+      }
+
+      @Override
+      @Nullable
+      public CallableDescriptor<RequestT, ResponseT> getDescriptor() {
+        return Callable.this.getDescriptor();
+      }
+
+      @Override
+      @Nullable
+      public Channel getBoundChannel() {
+        return boundChannel;
+      }
+    };
+  }
+
+  // Running Callables
+  // =================
+
+  /**
+   * Convenience method to run a unary callable synchronously. If no channel is provided,
+   * the callable must be bound to one.
+   */
+  public ResponseT call(@Nullable Channel channel, RequestT request) {
+    return ClientCalls.blockingUnaryCall(newCall(channel), request);
+  }
+
+  /**
+   * Convenience method to run a unary callable synchronously, without channel. Requires a callable
+   * which is bound to a channel.
+   */
+  public ResponseT call(RequestT request) {
+    return call(null, request);
+  }
+
+  /**
+   * Convenience method to run a unary callable asynchronously. If no channel is provided,
+   * the callable must be bound to one.
+   */
+  public void asyncCall(@Nullable Channel channel, RequestT request,
+      StreamObserver<ResponseT> responseObserver) {
+    ClientCalls.asyncUnaryCall(newCall(channel), request, responseObserver);
+  }
+
+  /**
+   * Convenience method to run a unary callable asynchronously, without channel. Requires a callable
+   * which is bound to a channel.
+   */
+  public void asyncCall(RequestT request, StreamObserver<ResponseT> responseObserver) {
+    asyncCall(null, request, responseObserver);
+  }
+
+  /**
+   * Convenience method to run a unary callable returning a future. If no channel is provided,
+   * the callable must be bound to one.
+   */
+  public ListenableFuture<ResponseT> futureCall(@Nullable Channel channel, RequestT request) {
+    return ClientCalls.futureUnaryCall(newCall(channel), request);
+  }
+
+  /**
+   * Convenience method to run a unary callable returning a future, without a channel. Requires a
+   * callable which is bound to a channel.
+   */
+  public ListenableFuture<ResponseT> futureCall(RequestT request) {
+    return futureCall(null, request);
+  }
+
+  /**
+   * Convenience method for a blocking server streaming call. If no channel is provided,
+   * the callable must be bound to one.
+   *
+   * <p>Returns an iterable for the responses. Note the returned iterable can be used only once.
+   * Returning an Iterator would be more precise, but iterators cannot be used in Java for loops.
+   */
+  public Iterable<ResponseT> iterableResponseStreamCall(@Nullable Channel channel,
+      RequestT request) {
+    final Iterator<ResponseT> result =
+        ClientCalls.blockingServerStreamingCall(newCall(channel), request);
+    return new Iterable<ResponseT>() {
+      @Override
+      public Iterator<ResponseT> iterator() {
+        return result;
+      }
+    };
+  }
+
+  /**
+   * Convenience method for a blocking server streaming call, without a channel. Requires a
+   * callable which is bound to a channel.
+   *
+   * <p>Returns an iterable for the responses. Note the returned iterable can be used only once.
+   * Returning an Iterator would be more precise, but iterators cannot be used in Java for loops.
+   */
+  public Iterable<ResponseT> iterableResponseStreamCall(RequestT request) {
+    return iterableResponseStreamCall(null, request);
+  }
+
+  // Creation
+  // ========
+
+  /**
+   * Returns a callable which executes the described method.
+   *
+   * <pre>
+   *  Response response = Callable.create(SerivceGrpc.CONFIG.myMethod).call(channel, request);
+   * </pre>
+   */
+  public static <RequestT, ResponseT> Callable<RequestT, ResponseT>
+      create(MethodDescriptor<RequestT, ResponseT> descriptor) {
+    return create(CallableDescriptor.create(descriptor));
+  }
+
+  /**
+   * Returns a callable which executes the method described by a {@link CallableDescriptor}.
+   */
+  public static <RequestT, ResponseT> Callable<RequestT, ResponseT>
+      create(final CallableDescriptor<RequestT, ResponseT> descriptor) {
+    return new Callable<RequestT, ResponseT>() {
+      @Override public ClientCall<RequestT, ResponseT> newCall(Channel channel) {
+        if (channel == null) {
+          throw new IllegalStateException(String.format(
+              "unbound callable for method '%s' requires a channel for execution",
+              descriptor.getMethodDescriptor().getFullMethodName()));
+        }
+        return channel.newCall(descriptor.getMethodDescriptor(), CallOptions.DEFAULT);
+      }
+
+      @Override public CallableDescriptor<RequestT, ResponseT> getDescriptor() {
+        return descriptor;
+      }
+
+      @Override public String toString() {
+        return descriptor.getMethodDescriptor().getFullMethodName();
+      }
+    };
+  }
+
+  /**
+   * Returns a callable which executes the given function asynchronously on each provided
+   * input. The supplied executor is used for creating tasks for each input. Example:
+   *
+   * <pre>
+   *  Callable.Transformer&lt;RequestT, ResponseT> transformer = ...;
+   *  Response response = Callable.create(transformer, executor).call(channel, request);
+   * </pre>
+   */
+  public static <RequestT, ResponseT> Callable<RequestT, ResponseT>
+      create(Transformer<? super RequestT, ? extends ResponseT> transformer, Executor executor) {
+    return new TransformingCallable<RequestT, ResponseT>(transformer, executor);
+  }
+
+
+  /**
+   * Returns a callable which executes the given function immediately on each provided input.
+   * Similar as {@link #create(Transformer, Executor)} but does not operate asynchronously and does
+   * not require an executor.
+   *
+   * <p>Note that the callable returned by this method does not respect flow control. Some
+   * operations applied to it may deadlock because of this. However, it is safe to use this
+   * callable in the context of a {@link #followedBy(Callable)} operation, which is the major
+   * use cases for transformers. But if you use a transformer to simulate a real rpc
+   * you should use {@link #create(Transformer, Executor)} instead.
+   */
+  public static <RequestT, ResponseT> Callable<RequestT, ResponseT>
+      create(Transformer<? super RequestT, ? extends ResponseT> transformer) {
+    return new TransformingCallable<RequestT, ResponseT>(transformer, null);
+  }
+
+  /**
+   * Interface for a transformer. It can throw a {@link StatusException} to indicate an error.
+   */
+  public interface Transformer<RequestT, ResponseT> {
+    ResponseT apply(RequestT request) throws StatusException;
+  }
+
+  /**
+   * Returns a callable which echos its input.
+   */
+  public static <RequestT> Callable<RequestT, RequestT>
+      identity() {
+    return new TransformingCallable<RequestT, RequestT>(new Transformer<RequestT, RequestT>() {
+      @Override public RequestT apply(RequestT request) throws StatusException {
+        return request;
+      }
+    }, null);
+  }
+
+  /**
+   * Returns a callable which always returns the given constant.
+   */
+  public static <RequestT, ResponseT> Callable<RequestT, ResponseT>
+      constant(final ResponseT result) {
+    return new TransformingCallable<RequestT, ResponseT>(new Transformer<RequestT, ResponseT>() {
+      @Override public ResponseT apply(RequestT request) throws StatusException {
+        return result;
+      }
+    }, null);
+  }
+
+  // Followed-By
+  // ===========
+
+  /**
+   * Returns a callable which forwards the responses from this callable as requests into the other
+   * callable. Works both for unary and streaming operands. Example:
+   *
+   * <pre>
+   * String bookName = ...;
+   * Callable.Transformer&lt;Book, GetAuthorRequest> bookToGetAuthorRequest = ...;
+   * Author response =
+   *     Callable.create(LibraryGrpc.CONFIG.getBook)
+   *             .followedBy(Callable.create(bookToGetAuthorRequest))
+   *             .followedBy(Callable.create(LibraryGrpc.CONFIG.getAuthor))
+   *             .call(channel, new GetBookRequest().setName(bookName).build());
+   * </pre>
+   *
+   * <p>For streaming calls, each output of the first callable will be forwarded to the second
+   * one as it arrives, allowing for streaming pipelines.
+   */
+  public <FinalResT> Callable<RequestT, FinalResT>
+      followedBy(Callable<ResponseT, FinalResT> callable) {
+    return new FollowedByCallable<RequestT, ResponseT, FinalResT>(this, callable);
+  }
+
+  // Channel Redirection
+  // ===================
+
+  /**
+   * Returns a callable which redirects the execution of this callable to a channel determined at
+   * call execution time, via a supplier. This can be used for creating batches which target
+   * different services. Example:
+   *
+   * <pre>
+   * Author response =
+   *     Callable.redirect(
+   *       Suppliers.ofInstance(bookChannel),
+   *       Callable.create(LibraryGrpc.CONFIG.getBook))
+   *     .followedBy(Callable.create(LibraryGrpc.CONFIG.getAuthor))
+   *     .call(authorChannel, new GetBookRequest().setName(bookName));
+   * </pre>
+   */
+  public static <RequestT, ResponseT> Callable<RequestT, ResponseT>
+      redirect(final Supplier<Channel> channelSupplier,
+               final Callable<RequestT, ResponseT> scoped) {
+    return new Callable<RequestT, ResponseT>() {
+      @Override
+      public ClientCall<RequestT, ResponseT> newCall(Channel channel) {
+        return scoped.newCall(channelSupplier.get());
+      }
+    };
+  }
+
+  // Retrying
+  // ========
+
+  /**
+   * Returns a callable which retries using exponential back-off on transient errors. Example:
+   *
+   * <pre>
+   * Response response = Callable.create(METHOD).retrying().call(channel, request);
+   * </pre>
+   *
+   * <p>The call will be retried if and only if the returned status code is {@code UNAVAILABLE}.
+   *
+   * <p>No output will be produced until the underlying callable has succeeded. Applied to compound
+   * callables, this can be used to implement simple transactions supposed the underlying callables
+   * are either side-effect free or idempotent.
+   *
+   * <p>Note that the retry callable requires to buffer all inputs and outputs of the underlying
+   * callable, and should be used with care when applied to streaming calls.
+   */
+  public Callable<RequestT, ResponseT> retrying() {
+    return new RetryingCallable<RequestT, ResponseT>(this);
+  }
+
+  // Page Streaming
+  // ==============
+
+  /**
+   * Returns a callable which streams the resources obtained from a series of calls to a method
+   * implementing the pagination pattern. Example:
+   *
+   * <pre>
+   *  for (Resource resource :
+   *       Callable.create(listBooksDescriptor)
+   *               .pageStreaming(pageDescriptor)
+   *               .iterableResponseStreamCall(channel, request)) {
+   *    doSomething(resource);
+   *  }
+   *</pre>
+   *
+   * <p>The returned stream does not buffer results; if it is traversed again, the API will be
+   * called again.
+   */
+  public <ResourceT> Callable<RequestT, ResourceT>
+      pageStreaming(PageDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor) {
+    return new PageStreamingCallable<RequestT, ResponseT, ResourceT>(this, pageDescriptor);
+  }
+
+  /**
+   * Returns a callable which behaves the same as {@link #pageStreaming(PageDescriptor)}, with
+   * the page descriptor attempted to derive from the callable descriptor.
+   *
+   * @throws IllegalArgumentException if a page descriptor is not derivable.
+   */
+  public <ResourceT> Callable<RequestT, ResourceT>
+      pageStreaming(Class<ResourceT> resourceType) {
+    PageDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor =
+        getDescriptor() != null ? getDescriptor().getPageDescriptor(resourceType) : null;
+    if (pageDescriptor == null) {
+      throw new IllegalArgumentException(String.format(
+          "cannot derive page descriptor for '%s'", this));
+    }
+    return pageStreaming(pageDescriptor);
+  }
+}

--- a/callable/src/main/java/io/grpc/callable/CallableDescriptor.java
+++ b/callable/src/main/java/io/grpc/callable/CallableDescriptor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.callable;
+
+import com.google.common.base.Preconditions;
+
+import io.grpc.ExperimentalApi;
+import io.grpc.MethodDescriptor;
+
+import javax.annotation.Nullable;
+
+/**
+ * Describes meta data for a {@link Callable}.
+ */
+@ExperimentalApi
+class CallableDescriptor<RequestT, ResponseT> {
+
+  /**
+   * Constructs a descriptor from grpc descriptor.
+   */
+  public static <RequestT, ResponseT> CallableDescriptor<RequestT, ResponseT>
+      create(MethodDescriptor<RequestT, ResponseT> grpcDescriptor) {
+    return new CallableDescriptor<RequestT, ResponseT>(grpcDescriptor);
+  }
+
+  private final MethodDescriptor<RequestT, ResponseT> descriptor;
+
+  private CallableDescriptor(MethodDescriptor<RequestT, ResponseT> descriptor) {
+    this.descriptor = Preconditions.checkNotNull(descriptor);
+  }
+
+  /**
+   * Returns the grpc method descriptor.
+   */
+  public MethodDescriptor<RequestT, ResponseT> getMethodDescriptor() {
+    return descriptor;
+  }
+
+  /**
+   * Returns a page descriptor if one is derivable from the callable descriptor, null if not.
+   * By default, this returns null, but sub-classes may override this.
+   */
+  @Nullable public <ResourceT> PageDescriptor<RequestT, ResponseT, ResourceT>
+  getPageDescriptor(@SuppressWarnings("unused") Class<ResourceT> resourceType) {
+    return null;
+  }
+}

--- a/callable/src/main/java/io/grpc/callable/CompoundClientCall.java
+++ b/callable/src/main/java/io/grpc/callable/CompoundClientCall.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.callable;
+
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+/**
+ * A helper to implement compound calls which is used for the implementation of other callables in
+ * this package. This allows to have the listener and call types being implemented from one class,
+ * which is not possible out-of-the-box because {@link ClientCall} is a class, not an interface.
+ * (Note that in Java8 ClientCall could be an interface, because it does not has instance data.)
+ */
+abstract class CompoundClientCall<RequestT, ResponseT, InnerResT>
+    extends ClientCall<RequestT, ResponseT> {
+
+  private final InnerListener listener = new InnerListener();
+
+  void onHeaders(@SuppressWarnings("unused") Metadata headers) {
+    // We typically ignore response headers in compound calls.
+  }
+
+  abstract void onMessage(InnerResT message);
+
+  abstract void onClose(Status status, Metadata trailers);
+
+  final ClientCall.Listener<InnerResT> listener() {
+    return listener;
+  }
+
+  class InnerListener extends ClientCall.Listener<InnerResT> {
+
+    @Override
+    public void onHeaders(Metadata headers) {
+      CompoundClientCall.this.onHeaders(headers);
+    }
+
+    @Override
+    public void onMessage(InnerResT message) {
+      CompoundClientCall.this.onMessage(message);
+    }
+
+    @Override
+    public void onClose(Status status, Metadata trailers) {
+      CompoundClientCall.this.onClose(status, trailers);
+    }
+  }
+}

--- a/callable/src/main/java/io/grpc/callable/FollowedByCallable.java
+++ b/callable/src/main/java/io/grpc/callable/FollowedByCallable.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.callable;
+
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper type for the implementation of {@link Callable} methods. Please see there first for the
+ * specification of what this is doing. This class is concerned with the how.
+ *
+ * <p>Implements the followedBy callable, which executes two callables in parallel, piping output
+ * from the first to the second.
+ */
+class FollowedByCallable<RequestT, InterT, ResponseT> extends Callable<RequestT, ResponseT> {
+
+  private final Callable<RequestT, InterT> first;
+  private final Callable<InterT, ResponseT> second;
+
+  FollowedByCallable(Callable<RequestT, InterT> first, Callable<InterT, ResponseT> second) {
+    this.first = first;
+    this.second = second;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("followedBy(%s, %s)", first, second);
+  }
+
+  @Override
+  @Nullable
+  public Channel getBoundChannel() {
+    // Inherit a bound channel from operands.
+    Channel channel = first.getBoundChannel();
+    if (channel != null) {
+      return channel;
+    }
+    return second.getBoundChannel();
+  }
+
+  @Override
+  public ClientCall<RequestT, ResponseT> newCall(Channel channel) {
+    return new FollowedByCall(channel);
+  }
+
+  /**
+   * Both calls are started in parallel, and the output from the first is immediately piped as input
+   * into the second. As we don't know the required input for the second call, we request all output
+   * from the first as soon as some output for the composite is requested.
+   */
+  private class FollowedByCall extends CompoundClientCall<RequestT, ResponseT, InterT> {
+
+    private Channel channel;
+    private ClientCall<RequestT, InterT> firstCall;
+    private ClientCall<InterT, ResponseT> secondCall;
+    private ClientCall.Listener<ResponseT> listener;
+
+    private FollowedByCall(Channel channel) {
+      this.channel = channel;
+    }
+
+    @Override
+    public void start(ClientCall.Listener<ResponseT> listener, Metadata headers) {
+      this.listener = listener;
+      this.firstCall = first.newCall(channel);
+      this.secondCall = second.newCall(channel);
+
+      // This instance's listener will receive output from the first call.
+      this.firstCall.start(this.listener(), headers);
+
+      // The ForwardingCallable listener will receive output from the second call.
+      this.secondCall.start(listener, headers);
+    }
+
+    @Override
+    public void request(int numMessages) {
+      // We don't know how much inputs the second call needs, so we request all what is available.
+      firstCall.request(Integer.MAX_VALUE);
+      secondCall.request(numMessages);
+    }
+
+    @Override
+    public void cancel() {
+      firstCall.cancel();
+      secondCall.cancel();
+    }
+
+    @Override
+    public void sendMessage(RequestT message) {
+      firstCall.sendMessage(message);
+    }
+
+    @Override
+    public void halfClose() {
+      firstCall.halfClose();
+    }
+
+    @Override
+    public void onMessage(InterT message) {
+      secondCall.sendMessage(message);
+    }
+
+    @Override
+    public void onClose(Status status, Metadata trailers) {
+      if (status.isOk()) {
+        secondCall.halfClose();
+        return;
+      }
+      secondCall.cancel();
+      listener.onClose(status, trailers);
+    }
+  }
+}

--- a/callable/src/main/java/io/grpc/callable/PageDescriptor.java
+++ b/callable/src/main/java/io/grpc/callable/PageDescriptor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.callable;
+
+import io.grpc.ExperimentalApi;
+
+/**
+ * An interface which describes the paging pattern.
+ */
+@ExperimentalApi
+public interface PageDescriptor<RequestT, ResponseT, ResourceT> {
+
+  /**
+   * Delivers the empty page token.
+   */
+  Object emptyToken();
+
+  /**
+   * Injects a page token into the request.
+   */
+  RequestT injectToken(RequestT payload, Object token);
+
+  /**
+   * Extracts the next token from the response. Returns the empty token if there are
+   * no more pages.
+   */
+  Object extractNextToken(ResponseT payload);
+
+  /**
+   * Extracts an iterable of resources from the response.
+   */
+  Iterable<ResourceT> extractResources(ResponseT payload);
+}

--- a/callable/src/main/java/io/grpc/callable/PageStreamingCallable.java
+++ b/callable/src/main/java/io/grpc/callable/PageStreamingCallable.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.callable;
+
+import com.google.common.base.Preconditions;
+
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+import java.util.concurrent.Semaphore;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper type for the implementation of {@link Callable} methods. Please see there first for the
+ * specification of what this is doing. This class is concerned with the how.
+ *
+ * <p>Implementation of the pageStreaming callable.
+ */
+class PageStreamingCallable<RequestT, ResponseT, ResourceT> extends Callable<RequestT, ResourceT> {
+
+  private final Callable<RequestT, ResponseT> callable;
+  private final PageDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor;
+
+
+  PageStreamingCallable(Callable<RequestT, ResponseT> callable,
+      PageDescriptor<RequestT, ResponseT, ResourceT> pageDescriptor) {
+    this.callable = Preconditions.checkNotNull(callable);
+    this.pageDescriptor = Preconditions.checkNotNull(pageDescriptor);
+  }
+
+  @Override public String toString() {
+    return String.format("pageStreaming(%s)", callable.toString());
+  }
+
+  @Override
+  @Nullable
+  public Channel getBoundChannel() {
+    return callable.getBoundChannel();
+  }
+
+  @Override
+  public ClientCall<RequestT, ResourceT> newCall(Channel channel) {
+    return new PageStreamingCall(channel);
+  }
+
+  /**
+   * Class which handles both the call logic for the callable and listens to page call responses.
+   *
+   * <p>The implementation uses a semaphore to handle flow control, since the callable level flow
+   * control via request() doesn't map 1:1 to the page call flow control. The semaphore holds at any
+   * time the number of requested messages on callable level. Blocking on the semaphore happens
+   * exclusively in onMessage() calls for pages. Apart of the first page call which is scheduled at
+   * the time the caller half-closes, all future page calls will be triggered from onMessage() as
+   * well. This avoids thread safety issues, assuming the ClientCall concurrency contract.
+   */
+  private class PageStreamingCall extends CompoundClientCall<RequestT, ResourceT, ResponseT> {
+
+    private final Channel channel;
+    private ClientCall.Listener<ResourceT> outerListener;
+    private Metadata headers;
+    private RequestT request;
+    private Semaphore requestedSemaphore = new Semaphore(0);
+    private ClientCall<RequestT, ResponseT> currentCall;
+    private Object nextPageToken = pageDescriptor.emptyToken();
+    private boolean sentClose;
+
+    private PageStreamingCall(Channel channel) {
+      this.channel = channel;
+    }
+
+    @Override
+    public void start(ClientCall.Listener<ResourceT> responseListener, Metadata headers) {
+      this.outerListener = responseListener;
+      this.headers = headers;
+      currentCall = callable.newCall(channel);
+      currentCall.start(listener(), headers);
+    }
+
+    @Override
+    public void request(int numMessages) {
+      requestedSemaphore.release(numMessages);
+    }
+
+    @Override
+    public void sendMessage(RequestT request) {
+      Preconditions.checkState(this.request == null);
+      this.request = request;
+    }
+
+    @Override
+    public void halfClose() {
+      // Trigger the call for the first page.
+      requestNextPage();
+    }
+
+    @Override
+    public void cancel() {
+      currentCall.cancel();
+      if (!sentClose) {
+        outerListener.onClose(Status.CANCELLED, new Metadata());
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void requestNextPage() {
+      currentCall.request(1);
+      currentCall.sendMessage(pageDescriptor.injectToken(request, nextPageToken));
+      currentCall.halfClose();
+    }
+
+    @Override
+    public void onMessage(ResponseT response) {
+      // Extract the token for the next page. If empty, there are no more pages,
+      // and we set the token to null.
+      Object token = pageDescriptor.extractNextToken(response);
+      nextPageToken = token.equals(pageDescriptor.emptyToken()) ? null : token;
+
+      // Deliver as much resources as have been requested. This may block via
+      // our semaphore, and while we are delivering, more requests may come in.
+      for (ResourceT resource : pageDescriptor.extractResources(response)) {
+        try {
+          requestedSemaphore.acquire();
+        } catch (InterruptedException e) {
+          outerListener.onClose(Status.fromThrowable(e), new Metadata());
+          sentClose = true;
+          currentCall.cancel();
+          return;
+        }
+        outerListener.onMessage(resource);
+      }
+
+      // If there is a next page, create a new call and request it.
+      if (nextPageToken != null) {
+        currentCall = callable.newCall(channel);
+        currentCall.start(listener(), headers);
+        requestNextPage();
+      } else {
+        outerListener.onClose(Status.OK, new Metadata());
+        sentClose = true;
+      }
+    }
+
+    @Override
+    public void onClose(Status status, Metadata trailers) {
+      if (!status.isOk()) {
+        // If there is an error, propagate it. Otherwise let onMessage determine how to continue.
+        outerListener.onClose(status, trailers);
+        sentClose = true;
+      }
+    }
+  }
+}
+

--- a/callable/src/main/java/io/grpc/callable/RetryingCallable.java
+++ b/callable/src/main/java/io/grpc/callable/RetryingCallable.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.callable;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+import java.util.List;
+import java.util.Random;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper type for the implementation of {@link Callable} methods. Please see there first for the
+ * specification of what this is doing. This class is concerned with the how.
+ *
+ * <p>Implementation of the retrying callable.
+ */
+class RetryingCallable<RequestT, ResponseT> extends Callable<RequestT, ResponseT> {
+
+  // TODO(wgg): make the parameters below configurable. They are currently taken from
+  // http://en.wikipedia.org/wiki/Exponential_backoff.
+
+  private static final int SLOT_TIME_MILLIS = 2;
+  private static final int TRUNCATE_AFTER = 10;
+  private static final int MAX_ATTEMPTS = 16;
+  private static final Random randomGenerator = new Random(0);
+
+  private final Callable<RequestT, ResponseT> callable;
+
+  RetryingCallable(Callable<RequestT, ResponseT> callable) {
+    this.callable = callable;
+  }
+
+  @Override public String toString() {
+    return String.format("retrying(%s)", callable.toString());
+  }
+
+  @Override
+  @Nullable
+  public CallableDescriptor<RequestT, ResponseT> getDescriptor() {
+    return callable.getDescriptor();
+  }
+
+  @Override
+  @Nullable
+  public Channel getBoundChannel() {
+    return callable.getBoundChannel();
+  }
+
+  @Override public ClientCall<RequestT, ResponseT> newCall(Channel channel) {
+    return new RetryingCall(channel);
+  }
+
+  private static boolean canRetry(Status status) {
+    return status.getCode() == Status.Code.UNAVAILABLE;
+  }
+
+  /**
+   * Class implementing the call for retry.
+   *
+   * <p>This remembers all actions from the caller in order to replay the call if needed. No output
+   * will be produced until the call has successfully ended. Thus this call requires full buffering
+   * of inputs and outputs,
+   */
+  private class RetryingCall extends CompoundClientCall<RequestT, ResponseT, ResponseT> {
+
+    private final Channel channel;
+    private ClientCall.Listener<ResponseT> listener;
+    private int requested;
+    private Metadata requestHeaders;
+    private final List<RequestT> requestPayloads = Lists.newArrayList();
+    private final List<ResponseT> responsePayloads = Lists.newArrayList();
+    private Metadata responseHeaders;
+    private int attempt;
+    private ClientCall<RequestT, ResponseT> currentCall;
+
+    private RetryingCall(Channel channel) {
+      this.channel = channel;
+    }
+
+    @Override
+    public void start(ClientCall.Listener<ResponseT> listener, Metadata headers) {
+      this.listener = listener;
+      requestHeaders = headers;
+      currentCall = callable.newCall(channel);
+      currentCall.start(listener(), headers);
+    }
+
+    @Override
+    public void request(int numMessages) {
+      requested += numMessages;
+      currentCall.request(numMessages);
+    }
+
+    @Override
+    public void cancel() {
+      currentCall.cancel();
+    }
+
+    @Override
+    public void halfClose() {
+      currentCall.halfClose();
+    }
+
+    @Override
+    public void sendMessage(RequestT message) {
+      requestPayloads.add(message);
+      currentCall.sendMessage(message);
+    }
+
+    @Override
+    public void onHeaders(Metadata headers) {
+      responseHeaders = headers;
+    }
+
+    @Override
+    void onMessage(ResponseT message) {
+      responsePayloads.add(message);
+    }
+
+    @Override
+    public void onClose(Status status, Metadata trailers) {
+      if (status.isOk() || !canRetry(status) || attempt >= MAX_ATTEMPTS) {
+        // Call succeeded or failed non-transiently or failed too often; feed underlying listener
+        // with the result.
+        if (status.isOk()) {
+          if (responseHeaders != null) {
+            listener.onHeaders(responseHeaders);
+          }
+          for (ResponseT response : responsePayloads) {
+            listener.onMessage(response);
+          }
+        }
+        listener.onClose(status, trailers);
+        return;
+      }
+
+      // Sleep using duration calculated by exponential backoff algorithm.
+      attempt++;
+      int slots = 1 << (attempt - 1 > TRUNCATE_AFTER ? TRUNCATE_AFTER : attempt - 1);
+      int slot = randomGenerator.nextInt(slots);
+      if (slot > 0) {
+        try {
+          Thread.sleep(SLOT_TIME_MILLIS * slot);
+        } catch (InterruptedException e) {
+          throw Throwables.propagate(e);
+        }
+      }
+
+      // Start call again.
+      responseHeaders = null;
+      responsePayloads.clear();
+      currentCall = callable.newCall(channel);
+      currentCall.start(listener(), requestHeaders);
+      currentCall.request(requested);
+      for (RequestT request : requestPayloads) {
+        currentCall.sendMessage(request);
+      }
+      currentCall.halfClose();
+    }
+  }
+}

--- a/callable/src/main/java/io/grpc/callable/TransformingCallable.java
+++ b/callable/src/main/java/io/grpc/callable/TransformingCallable.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.callable;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.internal.SerializingExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper type for the implementation of {@link Callable} methods. Please see there first for the
+ * specification of what this is doing. This class is concerned with the how.
+ *
+ * <p>Implements the transform callable, which executes a function to produce a stream of responses
+ * from a stream of requests.
+ */
+class TransformingCallable<RequestT, ResponseT> extends Callable<RequestT, ResponseT> {
+
+  private final Transformer<? super RequestT, ? extends ResponseT> transformer;
+  @Nullable private final Executor executor;
+
+  TransformingCallable(Transformer<? super RequestT, ? extends ResponseT> transformer,
+      Executor executor) {
+    this.transformer = Preconditions.checkNotNull(transformer);
+    this.executor = executor;
+  }
+
+  @Override
+  public String toString() {
+    return "transforming(...)";
+  }
+
+  @Override
+  public ClientCall<RequestT, ResponseT> newCall(Channel channel) {
+    return new TransformCall();
+  }
+
+  /**
+   * Implements the transforming call. If an executor is provided, delivery of results will
+   * happen asynchronously and flow control is respected. If not, results will be delivered
+   * to the listener immediately on sendMessage(). This violates the ClientCall contract as
+   * methods on Call are supposed to be non-blocking, whereas methods on Listener can block.
+   * In most practical cases, this should not matter (see also high-level documentation in
+   * Callable).
+   *
+   * <p>Note that this class does not need to be thread-safe since (a) the contract for
+   * ClientCall does not require thread-safeness (b) we use a SerializingExecutor for
+   * asynchronous callbacks which is guaranteed to run not more than one thread.
+   */
+  private class TransformCall extends ClientCall<RequestT, ResponseT> {
+
+    private final SerializingExecutor callExecutor =
+        executor == null ? null : new SerializingExecutor(executor);
+    private final Semaphore semaphore = new Semaphore(0);
+    private ClientCall.Listener<ResponseT> listener;
+    private boolean sentClose;
+
+    @Override
+    public void start(ClientCall.Listener<ResponseT> listener, Metadata headers) {
+      this.listener = listener;
+    }
+
+    @Override
+    public void request(int numMessages) {
+      if (callExecutor != null) {
+        semaphore.release(numMessages);
+      }
+    }
+
+    @Override
+    public void cancel() {
+      if (!sentClose) {
+        listener.onClose(Status.CANCELLED, new Metadata());
+        sentClose = true;
+      }
+    }
+
+    @Override
+    public void sendMessage(final RequestT message) {
+      if (callExecutor == null) {
+        doSend(message);
+        return;
+      }
+      callExecutor.execute(new Runnable() {
+        @Override public void run() {
+          try {
+            semaphore.acquire();
+            doSend(message);
+          } catch (Throwable t) {
+            cancel();
+            throw Throwables.propagate(t);
+          }
+        }
+      });
+    }
+
+    @SuppressWarnings("deprecation") // e.getStatus()
+    private void doSend(RequestT message) {
+      try {
+        listener.onMessage(transformer.apply(message));
+      } catch (StatusException e) {
+        sentClose = true;
+        listener.onClose(e.getStatus(), new Metadata());
+      } catch (Throwable t) {
+        // TODO(wgg): should we throw anything else here, or catch like below? Catching might
+        // be an issue for debugging.
+        sentClose = true;
+        listener.onClose(Status.fromThrowable(t), new Metadata());
+      }
+    }
+
+    @Override
+    public void halfClose() {
+      if (callExecutor == null) {
+        doClose();
+        return;
+      }
+      callExecutor.execute(new Runnable() {
+        @Override public void run() {
+          doClose();
+        }
+      });
+    }
+
+    private void doClose() {
+      if (!sentClose) {
+        sentClose = true;
+        listener.onClose(Status.OK, new Metadata());
+      }
+    }
+  }
+}

--- a/callable/src/test/java/io/grpc/callable/CallableTest.java
+++ b/callable/src/test/java/io/grpc/callable/CallableTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.callable;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.truth.Truth;
+
+import io.grpc.Channel;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.callable.Callable.Transformer;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.StreamObserver;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Executors;
+
+/**
+ * Tests for {@link Callable}.
+ */
+@RunWith(JUnit4.class)
+public class CallableTest {
+
+  private static final Transformer<Integer, Integer> PLUS_ONE =
+      new Transformer<Integer, Integer>() {
+        @Override public Integer apply(Integer request) throws StatusException {
+          return request + 1;
+        }
+      };
+
+  private static final Transformer<Object, String> TO_STRING =
+      new Transformer<Object, String>() {
+        @Override public String apply(Object request) throws StatusException {
+          return request.toString();
+        }
+      };
+
+  private static final Transformer<String, Integer> TO_INT =
+      new Transformer<String, Integer>() {
+        @Override public Integer apply(String request) throws StatusException {
+          return Integer.parseInt(request);
+        }
+      };
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Mock Channel channel;
+
+  // Creation and Chaining
+  // =====================
+
+  @Mock StreamObserver<Integer> output;
+  @Mock Transformer<Integer, Integer> transformIntToInt;
+
+  @Test public void transformAndFollowedBy() {
+    Callable<Object, Integer> callable =
+        Callable.create(TO_STRING)
+                .followedBy(Callable.create(TO_INT))
+                .followedBy(Callable.create(PLUS_ONE));
+
+    // Unary call
+    Truth.assertThat(callable.call(channel, 1)).isEqualTo(2);
+
+    // Streaming call
+    StreamObserver<Object> input =
+        ClientCalls.asyncBidiStreamingCall(callable.newCall(channel), output);
+    input.onNext(1);
+    input.onNext(2);
+    input.onNext(3);
+    input.onCompleted();
+
+    InOrder inOrder = Mockito.inOrder(output);
+    inOrder.verify(output).onNext(2);
+    inOrder.verify(output).onNext(3);
+    inOrder.verify(output).onNext(4);
+  }
+
+  // Retry
+  // =====
+
+  @Test public void retry() throws StatusException {
+    Mockito.when(transformIntToInt.apply(Mockito.anyInt()))
+        .thenThrow(new StatusException(Status.UNAVAILABLE))
+        .thenThrow(new StatusException(Status.UNAVAILABLE))
+        .thenThrow(new StatusException(Status.UNAVAILABLE))
+        .thenReturn(2);
+    Callable<Integer, Integer> callable = Callable.create(transformIntToInt).retrying();
+    Truth.assertThat(callable.call(channel, 1)).isEqualTo(2);
+  }
+
+
+  // Page Streaming
+  // ==============
+
+  /**
+   * Request message.
+   */
+  private static class Request {
+    String pageToken;
+  }
+
+  /**
+   * Response message.
+   */
+  private static class Response {
+    String nextPageToken;
+    List<String> books;
+  }
+
+  /**
+   * A page producer fake which uses a seeded random generator to produce different page
+   * sizes.
+   */
+  private static class PageProducer implements Transformer<Request, Response>  {
+    List<String> collection;
+    Random random = new Random(0);
+
+    PageProducer() {
+      collection = new ArrayList<String>();
+      for (int i = 1; i < 20; i++) {
+        collection.add("book #" + i);
+      }
+    }
+
+    @Override
+    public Response apply(Request request) {
+      int start = 0;
+      if (!Strings.isNullOrEmpty(request.pageToken)) {
+        start = Integer.parseInt(request.pageToken);
+      }
+      int end = start + random.nextInt(3);
+      String nextToken;
+      if (end >= collection.size()) {
+        end = collection.size();
+        nextToken = "";
+      } else {
+        nextToken = end + "";
+      }
+      Response response = new Response();
+      response.nextPageToken = nextToken;
+      response.books = collection.subList(start, end);
+      return response;
+    }
+  }
+
+  private static class BooksPageDescriptor implements PageDescriptor<Request, Response, String> {
+
+    @Override
+    public Object emptyToken() {
+      return "";
+    }
+
+    @Override
+    public Request injectToken(Request payload, Object token) {
+      payload.pageToken = (String) token;
+      return payload;
+    }
+
+    @Override
+    public Object extractNextToken(Response payload) {
+      return payload.nextPageToken;
+    }
+
+    @Override
+    public Iterable<String> extractResources(Response payload) {
+      return payload.books;
+    }
+  }
+
+  @Test public void pageStreaming() {
+
+    // Create a callable.
+    PageProducer producer = new PageProducer();
+    Callable<Request, String> callable =
+        Callable.create(producer, Executors.newCachedThreadPool())
+                .pageStreaming(new BooksPageDescriptor());
+
+    // Emit the call and check the result.
+    Truth.assertThat(Lists.newArrayList(
+        callable.iterableResponseStreamCall(channel, new Request())))
+      .isEqualTo(producer.collection);
+  }
+
+  // Binding
+  // =======
+
+  @Mock
+  MethodDescriptor<Request, Response> method;
+
+  @Test public void testUnboundFailure() {
+    Mockito.stub(method.getFullMethodName()).toReturn("mocked method");
+    thrown.expectMessage(
+        "unbound callable for method 'mocked method' requires "
+        + "a channel for execution");
+
+    Callable<Request, Response> callable = Callable.create(method);
+    callable.call(new Request());
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = "grpc"
 include ":grpc-core"
 include ":grpc-stub"
 include ":grpc-auth"
+include ":grpc-callable"
 include ":grpc-okhttp"
 include ":grpc-protobuf"
 include ":grpc-protobuf-nano"
@@ -15,6 +16,7 @@ include ":grpc-examples"
 project(':grpc-core').projectDir = "$rootDir/core" as File
 project(':grpc-stub').projectDir = "$rootDir/stub" as File
 project(':grpc-auth').projectDir = "$rootDir/auth" as File
+project(':grpc-callable').projectDir = "$rootDir/callable" as File
 project(':grpc-okhttp').projectDir = "$rootDir/okhttp" as File
 project(':grpc-protobuf').projectDir = "$rootDir/protobuf" as File
 project(':grpc-protobuf-nano').projectDir = "$rootDir/protobuf-nano" as File


### PR DESCRIPTION
Implements #510.

Callables provide a composition mechanism for rpcs. They are a factory for client calls, and support sequential composition (parallel to come later), as well as programming patterns like retry and page streamining.

This introduces a new subproject for callables and places them in package io.grpc.callable.

@ejona86 @louiscryan @nmittler @anthmgoogle 