### PR TITLE
This checks the make sure that the negotiated application protocol is one that GRPC supports ("h2").

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -55,6 +55,10 @@ public class GrpcSslContexts {
 
   static final Set<String> HTTP2_VERSIONS = ImmutableSet.of("h2");
 
+  /*
+   * These configs use ACCEPT due to limited support in OpenSSL.  Actual protocol enforcement is
+   * done in ProtocolNegotiators.
+   */
   private static ApplicationProtocolConfig ALPN = new ApplicationProtocolConfig(
       Protocol.ALPN,
       SelectorFailureBehavior.NO_ADVERTISE,

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -31,6 +31,8 @@
 
 package io.grpc.netty;
 
+import com.google.common.collect.ImmutableSet;
+
 import io.grpc.ExperimentalApi;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
@@ -43,6 +45,7 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 import java.io.File;
+import java.util.Set;
 
 /**
  * Utility for configuring SslContext for gRPC.
@@ -50,7 +53,7 @@ import java.io.File;
 public class GrpcSslContexts {
   private GrpcSslContexts() {}
 
-  private static String[] HTTP2_VERSIONS = {"h2"};
+  static final Set<String> HTTP2_VERSIONS = ImmutableSet.of("h2");
 
   private static ApplicationProtocolConfig ALPN = new ApplicationProtocolConfig(
       Protocol.ALPN,

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -31,6 +31,8 @@
 
 package io.grpc.netty;
 
+import static io.grpc.netty.GrpcSslContexts.HTTP2_VERSIONS;
+
 import com.google.common.base.Preconditions;
 
 import io.grpc.Status;
@@ -100,7 +102,7 @@ public final class ProtocolNegotiators {
         if (evt instanceof SslHandshakeCompletionEvent) {
           SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
           if (handshakeEvent.isSuccess()) {
-            if (GrpcSslContexts.HTTP2_VERSIONS.contains(sslHandler(ctx).applicationProtocol())) {
+            if (HTTP2_VERSIONS.contains(sslHandler(ctx).applicationProtocol())) {
               // Successfully negotiated the protocol. Replace this handler with
               // the GRPC handler.
               ctx.pipeline().replace(this, null, grpcHandler);

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -395,7 +395,7 @@ public final class ProtocolNegotiators {
         SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
         if (handshakeEvent.isSuccess()) {
           SslHandler handler = ctx.pipeline().get(SslHandler.class);
-          if (handler.applicationProtocol() != null) {
+          if (HTTP2_VERSIONS.contains(handler.applicationProtocol())) {
             // Successfully negotiated the protocol.
             logSslEngineDetails(Level.FINER, ctx, "TLS negotiation succeeded.", null);
             writeBufferedAndRemove(ctx);

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -81,6 +81,7 @@ public final class ProtocolNegotiators {
   public static ChannelHandler serverTls(SSLEngine sslEngine, final ChannelHandler grpcHandler) {
     Preconditions.checkNotNull(sslEngine, "sslEngine");
 
+
     final SslHandler sslHandler = new SslHandler(sslEngine, false);
     return new ChannelInboundHandlerAdapter() {
       @Override
@@ -99,7 +100,7 @@ public final class ProtocolNegotiators {
         if (evt instanceof SslHandshakeCompletionEvent) {
           SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
           if (handshakeEvent.isSuccess()) {
-            if (sslHandler(ctx).applicationProtocol() != null) {
+            if ("h2".equals(sslHandler(ctx).applicationProtocol())) {
               // Successfully negotiated the protocol. Replace this handler with
               // the GRPC handler.
               ctx.pipeline().replace(this, null, grpcHandler);

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -100,7 +100,7 @@ public final class ProtocolNegotiators {
         if (evt instanceof SslHandshakeCompletionEvent) {
           SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
           if (handshakeEvent.isSuccess()) {
-            if ("h2".equals(sslHandler(ctx).applicationProtocol())) {
+            if (GrpcSslContexts.HTTP2_VERSIONS.contains(sslHandler(ctx).applicationProtocol())) {
               // Successfully negotiated the protocol. Replace this handler with
               // the GRPC handler.
               ctx.pipeline().replace(this, null, grpcHandler);


### PR DESCRIPTION
This checks the make sure that the negotiated application protocol is one that GRPC supports ("h2").  Currently, the netty server just accepts whatever the client picked, regardless of what it is.  Effectively, this change forces some kind of *PN.  See #1081. 