### PR TITLE
Fix missing version bump of protobuf to b1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
           protobuf-java directly, you will be transitively depending on the
           protobuf-java version that grpc depends on.
         -->
-        <protocArtifact>com.google.protobuf:protoc:3.0.0-alpha-3.1:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.0.0-beta-1:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
         <pluginArtifact>io.grpc:protoc-gen-grpc-java:0.9.0:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
@@ -108,7 +108,7 @@ protobuf {
     // The version of protoc must match protobuf-java. If you don't depend on
     // protobuf-java directly, you will be transitively depending on the
     // protobuf-java version that grpc depends on.
-    artifact = "com.google.protobuf:protoc:3.0.0-alpha-3.1"
+    artifact = "com.google.protobuf:protoc:3.0.0-beta-1"
   }
   plugins {
     grpc {


### PR DESCRIPTION
This applies to the v0.9.x branch.