### PR TITLE
Update Windows building instructions for proto3b1

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -48,8 +48,8 @@ environment variables will be used when building grpc-java.
 
 Protobuf installs to ``/usr/local`` by default.
 
-For Visual C++, please refer to the [Protobuf README](https://github.com/google/protobuf/blob/master/vsprojects/readme.txt)
-for how to compile Protobuf.
+For Visual C++, please refer to the [Protobuf README](https://github.com/google/protobuf/blob/master/cmake/README.md)
+for how to compile Protobuf. gRPC-java assumes a Release build.
 
 #### Linux and MinGW
 If ``/usr/local/lib`` is not in your library search path, you can add it by running:
@@ -73,7 +73,8 @@ Gradle to find protobuf:
 ```
 .\gradlew install ^
     -PvcProtobufInclude=C:\path\to\protobuf-3.0.0-beta-1\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.0.0-beta-1\vsprojects\Release
+    -PvcProtobufLibs=C:\path\to\protobuf-3.0.0-beta-1\vsprojects\Release ^
+    -PtargetArch=x86_32
 ```
 
 Since specifying those properties every build is bothersome, you can instead
@@ -81,11 +82,13 @@ create ``<project-root>\gradle.properties`` with contents like:
 ```
 vcProtobufInclude=C:\\path\\to\\protobuf-3.0.0-beta-1\\src
 vcProtobufLibs=C:\\path\\to\\protobuf-3.0.0-beta-1\\vsprojects\\Release
+targetArch=x86_32
 ```
 
-The build script will build the codegen for the same architecture as the Java
-runtime installed on your system. If you are using 64-bit JVM, the codegen will
-be compiled for 64-bit, that means you must have compiled Protobuf in 64-bit.
+By default, the build script will build the codegen for the same architecture as
+the Java runtime installed on your system. If you are using 64-bit JVM, the
+codegen will be compiled for 64-bit. Since Protobuf is only built for 32-bit by
+default, the `targetArch=x86_32` is necessary.
 
 ### Notes for MinGW on Windows
 If you have both MinGW and VC++ installed on Windows, VC++ will be used by

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,0 +1,43 @@
+REM installer http://www.7-zip.org/a/7z1507-x64.exe
+REM 7za is in http://www.7-zip.org/a/7z1507-extra.7z
+
+REM Prerequisite: 7za.exe in current directory or PATH
+
+set PROTOBUF_VER=3.0.0-beta-1
+set CMAKE_NAME=cmake-3.3.2-win32-x86
+
+if not exist "protobuf-%PROTOBUF_VER%\cmake\Release\" (
+  call :installProto
+)
+set PROTOCDIR=%cd%\protobuf-%PROTOBUF_VER%\cmake\Release\
+goto :eof
+
+
+:installProto
+
+if not exist "%CMAKE_NAME%" (
+  call :installCmake
+)
+set PATH=%PATH%;%cd%\%CMAKE_NAME%\bin
+powershell -command "& { iwr https://github.com/google/protobuf/archive/v%PROTOBUF_VER%.zip -OutFile protobuf.zip }"
+7za X protobuf.zip
+del protobuf.zip
+pushd protobuf-3.0.0-beta-1\cmake
+mkdir build
+cd build
+cmake -DBUILD_TESTING=OFF ..
+msbuild /maxcpucount /p:Configuration=Release libprotoc.vcxproj
+call extract_includes.bat
+popd
+goto :eof
+
+
+:installCmake
+
+powershell -command "& { iwr https://cmake.org/files/v3.3/%CMAKE_NAME%.zip -OutFile cmake.zip }"
+7za X cmake.zip
+del cmake.zip
+goto :eof
+
+REM Compile gRPC-Java with something like:
+REM -PtargetArch=x86_32 -PvcProtobufLibs=%cd%\protobuf-3.0.0-beta-1\cmake\build\Release -PvcProtobufInclude=%cd%\protobuf-3.0.0-beta-1\cmake\build\include

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -153,7 +153,7 @@ binaries.all {
     }
     addEnvArgs("LDFLAGS", linker.args)
   } else if (toolChain in VisualCpp) {
-    cppCompiler.args "/EHsc", "/MD"
+    cppCompiler.args "/EHsc", "/MT"
     if (rootProject.hasProperty('vcProtobufInclude')) {
       cppCompiler.args "/I${rootProject.vcProtobufInclude}"
     }


### PR DESCRIPTION
This is an unmodified cherry-pick of d04994f0

The Windows build is failing on the v0.9.x branch. This makes sense to backport since you use protobuf beta-1 in the v0.9.x branch.