### PR TITLE
Have OpenSSL v1.0.2 available to unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ language: java
 env:
   global:
     - PROTOBUF_VERSION=3.0.0-beta-1
+    - OPENSSL_VERSION=1.0.2d
     - LDFLAGS=-L/tmp/protobuf-${PROTOBUF_VERSION}/lib
     - CXXFLAGS=-I/tmp/protobuf-${PROTOBUF_VERSION}/include
-    - LD_LIBRARY_PATH=/tmp/protobuf-${PROTOBUF_VERSION}/lib
+    - LD_LIBRARY_PATH=/tmp/protobuf-${PROTOBUF_VERSION}/lib:/tmp/openssl-${OPENSSL_VERSION}/lib
 
 before_install:
   - buildscripts/make_dependencies.sh # build protoc into /tmp/protobuf-${PROTOBUF_VERSION}
@@ -32,6 +33,7 @@ notifications:
 cache:
   directories:
     - /tmp/protobuf-${PROTOBUF_VERSION}
+    - /tmp/openssl-${OPENSSL_VERSION}
     - $HOME/.m2/repository/io/netty
     - $HOME/.gradle/caches/modules-2
     - $HOME/.gradle/wrapper

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,7 +1,9 @@
 REM installer http://www.7-zip.org/a/7z1507-x64.exe
 REM 7za is in http://www.7-zip.org/a/7z1507-extra.7z
 
-REM Prerequisite: 7za.exe in current directory or PATH
+REM Prerequisite:
+REM   7za.exe in current directory or PATH
+REM   Install http://slproweb.com/download/Win64OpenSSL_Light-1_0_2d.exe
 
 set PROTOBUF_VER=3.0.0-beta-1
 set CMAKE_NAME=cmake-3.3.2-win32-x86
@@ -9,7 +11,9 @@ set CMAKE_NAME=cmake-3.3.2-win32-x86
 if not exist "protobuf-%PROTOBUF_VER%\cmake\Release\" (
   call :installProto
 )
-set PROTOCDIR=%cd%\protobuf-%PROTOBUF_VER%\cmake\Release\
+
+echo Compile gRPC-Java with something like:
+echo -PtargetArch=x86_32 -PvcProtobufLibs=%cd%\protobuf-%PROTOBUF_VER%\cmake\build\Release -PvcProtobufInclude=%cd%\protobuf-%PROTOBUF_VER%\cmake\build\include
 goto :eof
 
 
@@ -38,6 +42,3 @@ powershell -command "& { iwr https://cmake.org/files/v3.3/%CMAKE_NAME%.zip -OutF
 7za X cmake.zip
 del cmake.zip
 goto :eof
-
-REM Compile gRPC-Java with something like:
-REM -PtargetArch=x86_32 -PvcProtobufLibs=%cd%\protobuf-3.0.0-beta-1\cmake\build\Release -PvcProtobufInclude=%cd%\protobuf-3.0.0-beta-1\cmake\build\include

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Build protoc & netty
+# Build protoc & openssl
 set -ev
 
 DOWNLOAD_DIR=/tmp/source
@@ -17,7 +17,20 @@ else
   ./autogen.sh
   # install here so we don't need sudo
   ./configure --prefix=${INSTALL_DIR}
-  make -j2
+  make -j$(nproc)
+  make install
+  popd
+fi
+
+INSTALL_DIR=/tmp/openssl-${OPENSSL_VERSION}
+
+if [ -f ${INSTALL_DIR}/lib/libssl.so ]; then
+  echo "Not building openssl. Already built"
+else
+  wget -O - https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | tar xz -C $DOWNLOAD_DIR
+  pushd $DOWNLOAD_DIR/openssl-${OPENSSL_VERSION}
+  ./Configure linux-x86_64 shared no-ssl2 no-comp --prefix=${INSTALL_DIR}
+  make -j$(nproc)
   make install
   popd
 fi


### PR DESCRIPTION
Verify it is working on Windows and Travis, even with tcnative enabled: https://travis-ci.org/grpc/grpc-java/builds/83210175

Fixes #1091