### PR TITLE
Allow host authority override.

### DIFF
--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import static org.junit.Assert.assertEquals;
+
+import io.grpc.internal.ClientTransportFactory;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+@RunWith(JUnit4.class)
+public class NettyChannelBuilderTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void overrideAllowsInvalidAuthority() {
+    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){}, "") {
+      @Override
+      protected String checkAuthority(String authority) {
+        return authority;
+      }
+    };
+
+    ClientTransportFactory factory = builder.overrideAuthority("invalid_authority")
+        .negotiationType(NegotiationType.PLAINTEXT)
+        .buildTransportFactory();
+
+    assertEquals("invalid_authority", factory.authority());
+  }
+
+  @Test
+  public void failInvalidAuthority() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid host or port");
+
+    NettyChannelBuilder.forAddress(new InetSocketAddress("invalid_authority", 1234));
+  }
+}
+


### PR DESCRIPTION
This allows invalid authorities to be specified (according to java.net.URI) in the Netty Channel Builder.  

Background: Some TLS certs allow funny characters in the common name, which, while technically valid, are rejected by URI parsing them.  In general, URI is correct to prevent these odd looking host names, since they are far more likely to be an error than a valid use.  This change provides the means to bypass the restriction if clients really want to.  

There are a number of things this doesn't address, specifically supporting OkHttp (though it's possible) or allowing the actual certificate validation to bypass the restriction.  I expect this to be changed in the future, and do not expect this to be exactly correct on the first try.  Everything in NettyChannelBuilder is experimental, and subject to change.