### PR TITLE
Prepare codebase for per-platform implementations.

### DIFF
--- a/core/src/main/java/io/grpc/internal/Base64Codec.java
+++ b/core/src/main/java/io/grpc/internal/Base64Codec.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+package io.grpc.internal;
+
+/**
+ * Simple interface for a Base64 encoder/decoder. Used to abstract platform-provided
+ * encoders.
+ */
+interface Base64Codec {
+  public String encode(byte[] bytes);
+  
+  public byte[] decode(String message);
+}
+

--- a/core/src/main/java/io/grpc/internal/DefaultPlatform.java
+++ b/core/src/main/java/io/grpc/internal/DefaultPlatform.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.io.BaseEncoding;
+
+
+/**
+ * Default platform implementation. Provides a base64 codec from the 
+ * Guava library.
+ */
+ // TODO(nnaze): Create specific platorm implementations for different 
+ // platforms (Android, Java SDK, etc).
+class DefaultPlatform implements Platform {
+  
+  private static class DefaultBase64Codec implements Base64Codec {
+    private final BaseEncoding encoding = BaseEncoding.base64();
+    
+    @Override
+    public String encode(byte[] bytes) {
+      return encoding.encode(bytes);
+    }
+
+    @Override
+    public byte[] decode(String message) {
+      return encoding.decode(message);
+    }
+  }
+
+  @Override
+  public Base64Codec getBase64Encoder() {
+    return new DefaultBase64Codec();
+  }
+}

--- a/core/src/main/java/io/grpc/internal/Platform.java
+++ b/core/src/main/java/io/grpc/internal/Platform.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+/**
+ * A number of platform-specific implementation methods that are abstracted
+ * as a common interface here.  A platform-specific implementation is
+ * provided in {@link PlatformProvider}.
+ */
+interface Platform {
+  public Base64Codec getBase64Encoder();
+}

--- a/core/src/main/java/io/grpc/internal/PlatformProvider.java
+++ b/core/src/main/java/io/grpc/internal/PlatformProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+/**
+ * Provides a platform-specific Plaform object.
+ *
+ * <p>For right now, this just returns the default platform object, but
+ * in time Gradle will define this class differently depending on 
+ * the platform (Android, Java SDK, etc).
+ */
+class PlatformProvider {
+  public static Platform getPlatform() {
+    return new DefaultPlatform();
+  }
+}

--- a/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
+++ b/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
@@ -33,8 +33,6 @@ package io.grpc.internal;
 
 import static com.google.common.base.Charsets.US_ASCII;
 
-import com.google.common.io.BaseEncoding;
-
 import io.grpc.Metadata;
 
 import java.util.ArrayList;
@@ -50,6 +48,7 @@ import java.util.logging.Logger;
 public final class TransportFrameUtil {
 
   private static final Logger logger = Logger.getLogger(TransportFrameUtil.class.getName());
+  private static final Base64Codec base64Codec = PlatformProvider.getPlatform().getBase64Encoder();
 
   private static final byte[] binaryHeaderSuffixBytes =
       Metadata.BINARY_HEADER_SUFFIX.getBytes(US_ASCII);
@@ -67,9 +66,10 @@ public final class TransportFrameUtil {
       byte[] key = serializedHeaders[i];
       byte[] value = serializedHeaders[i + 1];
       if (endsWith(key, binaryHeaderSuffixBytes)) {
+        
         // Binary header.
         result.add(key);
-        result.add(BaseEncoding.base64().encode(value).getBytes(US_ASCII));
+        result.add(base64Codec.encode(value).getBytes(US_ASCII));
       } else {
         // Non-binary header.
         // Filter out headers that contain non-spec-compliant ASCII characters.
@@ -102,7 +102,7 @@ public final class TransportFrameUtil {
       result[i] = key;
       if (endsWith(key, binaryHeaderSuffixBytes)) {
         // Binary header
-        result[i + 1] = BaseEncoding.base64().decode(new String(value, US_ASCII));
+        result[i + 1] = base64Codec.decode(new String(value, US_ASCII));
       } else {
         // Non-binary header
         result[i + 1] = value;


### PR DESCRIPTION
Introduce Platform and Base64Codec interfaces.

Implement a default platform implementation that gives a simple
default codec implementation that just calls through to the base64
implementation in Guava.

Introduce a call site in PlatformProvider that gives the correct
platform object for the current platform (different versions of this
file will, in the future, be swapped in for different platforms).

Update TransportFrameUtil to get its base64 code from the platform
object rather than calling Guava directly so that we can later configure
PlatformProvider via a property in Gradle to give us a
implementation specific for a particular platform.