### PR TITLE
Netty authority override

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -34,6 +34,7 @@ package io.grpc.netty;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import io.grpc.ExperimentalApi;
@@ -193,9 +194,11 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
         eventLoopGroup, flowControlWindow, maxMessageSize);
   }
 
-  private static ProtocolNegotiator createProtocolNegotiator(
-      String authority, NegotiationType negotiationType, SslContext sslContext) {
-    ProtocolNegotiator negotiator;
+  @VisibleForTesting
+  static ProtocolNegotiator createProtocolNegotiator(
+      String authority,
+      NegotiationType negotiationType,
+      SslContext sslContext) {
     switch (negotiationType) {
       case PLAINTEXT:
         return ProtocolNegotiators.plaintext();
@@ -247,9 +250,9 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
 
     @Override
     public ClientTransport newClientTransport(SocketAddress serverAddress, String authority) {
-      GrpcUtil.checkAuthority(authority);
-      return new NettyClientTransport(serverAddress, channelType, group,
-          createProtocolNegotiator(authority, negotiationType, sslContext),
+      ProtocolNegotiator negotiator =
+          createProtocolNegotiator(authority, negotiationType, sslContext);
+      return new NettyClientTransport(serverAddress, channelType, group, negotiator,
           flowControlWindow, maxMessageSize, authority);
     }
 


### PR DESCRIPTION
Sorry for the large change, this got slightly bigger than I wanted it to make it easier to test.  Netty is a little more difficult to string the host / port fallback, and a little more convoluted.  The idea here is to provide the host, port, and authority, and let the Channel Builder put the pieces together.  Normally the authority is a derivation of the host and port, so they are typically identical and don't result in any behavior change.  In cases where the authority has been overridden, the derived host and port will be null and -1, so the former host and port (from the socket addr) will be used.  

This is different than the way OkHttp does it, so it was hard to share anything between them.  I don't *think* ProtocolNegotiators is used out side of netty, but I opted to keep the existing API present for tls(), incase anyone was.  If I can change its method signature, this code becomes a little simpler.

One last thing: I didn't add any tests to PN because I have another PR to add them and didn't want to cause myself a merge conflict.  I will add them later.  Trust me man, I'm good for it!

