### PR TITLE
NameResolver can now produce addresses without ports

### DIFF
--- a/core/src/main/java/io/grpc/DnsNameResolverFactory.java
+++ b/core/src/main/java/io/grpc/DnsNameResolverFactory.java
@@ -49,8 +49,8 @@ import javax.annotation.Nullable;
  *
  * <p>It resolves a target URI whose scheme is {@code "dns"}. The (optional) authority of the target
  * URI is reserved for the address of alternative DNS server (not implemented yet). The path of the
- * target URI, exluding the leading slash {@code '/'}, is treated as the host name to be resolved by
- * DNS. Example target URIs:
+ * target URI, exluding the leading slash {@code '/'}, is treated as the host name and the optional
+ * port to be resolved by DNS. Example target URIs:
  * <ul>
  *   <li>{@code "dns:///foo.googleapis.com:8080"} (using default DNS)</li>
  *   <li>{@code "dns://8.8.8.8/foo.googleapis.com:8080"} (using alternative DNS (not implemented
@@ -99,8 +99,7 @@ public final class DnsNameResolverFactory extends NameResolver.Factory {
       authority = Preconditions.checkNotNull(nameUri.getAuthority(),
           "nameUri (%s) doesn't have an authority", nameUri);
       host = Preconditions.checkNotNull(nameUri.getHost(), "host");
-      port = nameUri.getPort();
-      Preconditions.checkArgument(port > 0, "port (%s) must be positive", port);
+      port = nameUri.getPort() == -1 ? 0 : nameUri.getPort();
     }
 
     @Override

--- a/core/src/main/java/io/grpc/ResolvedServerInfo.java
+++ b/core/src/main/java/io/grpc/ResolvedServerInfo.java
@@ -57,6 +57,10 @@ public final class ResolvedServerInfo {
 
   /**
    * Returns the address.
+   *
+   * <p>For address types (e.g., {@link java.net.InetSocketAddress}) that carry port numbers, the
+   * port being 0 means undefined, in which case the channel will use an appropriate default port to
+   * make connections.
    */
   public SocketAddress getAddress() {
     return address;

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -38,6 +38,7 @@ import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.GrpcUtil;
 
 import java.net.SocketAddress;
 
@@ -78,6 +79,12 @@ public class InProcessChannelBuilder extends
   @Override
   protected ClientTransportFactory buildTransportFactory() {
     return new InProcessClientTransportFactory(name);
+  }
+
+  @Override
+  protected int getDefaultPort() {
+    // Not used
+    return GrpcUtil.DEFAULT_PORT_PLAINTEXT;
   }
 
   private static class InProcessClientTransportFactory extends AbstractReferenceCounted

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -38,7 +38,6 @@ import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.GrpcUtil;
 
 import java.net.SocketAddress;
 
@@ -83,8 +82,8 @@ public class InProcessChannelBuilder extends
 
   @Override
   protected int getDefaultPort() {
-    // Not used
-    return GrpcUtil.DEFAULT_PORT_PLAINTEXT;
+    // port is not applicable
+    return -1;
   }
 
   private static class InProcessClientTransportFactory extends AbstractReferenceCounted

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -35,7 +35,6 @@ import com.google.common.base.Preconditions;
 
 import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
-import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.NameResolver;
@@ -165,6 +164,7 @@ public abstract class AbstractManagedChannelImplBuilder
         new ExponentialBackoffPolicy.Provider(),
         nameResolverFactory == null ? NameResolverRegistry.getDefaultRegistry()
             : nameResolverFactory,
+        getDefaultPort(),
         loadBalancerFactory == null ? SimpleLoadBalancerFactory.getInstance()
             : loadBalancerFactory,
         transportFactory, executor, userAgent, interceptors);
@@ -175,8 +175,13 @@ public abstract class AbstractManagedChannelImplBuilder
    * {@link ClientTransportFactory} appropriate for this channel.  This method is meant for
    * Transport implementors and should not be used by normal users.
    */
-  @Internal
   protected abstract ClientTransportFactory buildTransportFactory();
+
+  /**
+   * Children of AbstractChannelBuilder should override this method to provide the default port for
+   * creating outgoing connections in case the {@link NameResolver} not provide a port.
+   */
+  protected abstract int getDefaultPort();
 
   private static class AuthorityOverridingTransportFactory implements ClientTransportFactory {
     final ClientTransportFactory factory;

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -180,6 +180,9 @@ public abstract class AbstractManagedChannelImplBuilder
   /**
    * Children of AbstractChannelBuilder should override this method to provide the default port for
    * creating outgoing connections in case the {@link NameResolver} not provide a port.
+   *
+   * <p>If the port is not applicable, for example, in the case of in-process channel builder, this
+   * method may return -1.
    */
   protected abstract int getDefaultPort();
 

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -101,6 +101,16 @@ public final class GrpcUtil {
           Metadata.Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER);
 
   /**
+   * The default port for plain-text connections.
+   */
+  public static final int DEFAULT_PORT_PLAINTEXT = 80;
+
+  /**
+   * The default port for SSL connections.
+   */
+  public static final int DEFAULT_PORT_SSL = 443;
+
+  /**
    * Content-Type used for GRPC-over-HTTP/2.
    */
   public static final String CONTENT_TYPE_GRPC = "application/grpc";

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -56,6 +56,7 @@ import io.grpc.Status;
 import io.grpc.TransportManager;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -104,6 +105,7 @@ public final class ManagedChannelImpl extends ManagedChannel {
   private final Channel interceptorChannel;
 
   private final NameResolver nameResolver;
+  private final int defaultPort;
   private final LoadBalancer loadBalancer;
 
   /**
@@ -133,7 +135,8 @@ public final class ManagedChannelImpl extends ManagedChannel {
   };
 
   ManagedChannelImpl(String target, BackoffPolicy.Provider backoffPolicyProvider,
-      NameResolver.Factory nameResolverFactory, LoadBalancer.Factory loadBalancerFactory,
+      NameResolver.Factory nameResolverFactory, int defaultPort,
+      LoadBalancer.Factory loadBalancerFactory,
       ClientTransportFactory transportFactory, @Nullable Executor executor,
       @Nullable String userAgent, List<ClientInterceptor> interceptors) {
     if (executor == null) {
@@ -175,6 +178,8 @@ public final class ManagedChannelImpl extends ManagedChannel {
         "cannot find a NameResolver for %s%s", target,
         uriSyntaxErrors.length() > 0 ? " (" + uriSyntaxErrors.toString() + ")" : "");
     this.nameResolver = nameResolver;
+    Preconditions.checkArgument(defaultPort > 0, "defaultPort is %s, must > 0", defaultPort);
+    this.defaultPort = defaultPort;
 
     this.loadBalancer = loadBalancerFactory.newLoadBalancer(nameResolver.getServiceAuthority(), tm);
     this.transportFactory = transportFactory;
@@ -185,7 +190,21 @@ public final class ManagedChannelImpl extends ManagedChannel {
     this.nameResolver.start(new NameResolver.Listener() {
       @Override
       public void onUpdate(List<ResolvedServerInfo> servers, Attributes config) {
-        loadBalancer.handleResolvedAddresses(servers, config);
+        ArrayList<ResolvedServerInfo> effectiveServers = new ArrayList<ResolvedServerInfo>();
+        for (ResolvedServerInfo server : servers) {
+          SocketAddress address = server.getAddress();
+          if (address instanceof InetSocketAddress) {
+            InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
+            if (inetSocketAddress.getPort() == 0) {
+              server = new ResolvedServerInfo(
+                  new InetSocketAddress(
+                      inetSocketAddress.getAddress(), ManagedChannelImpl.this.defaultPort),
+                  server.getAttributes());
+            }
+          }
+          effectiveServers.add(server);
+        }
+        loadBalancer.handleResolvedAddresses(effectiveServers, config);
       }
 
       @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -178,7 +178,6 @@ public final class ManagedChannelImpl extends ManagedChannel {
         "cannot find a NameResolver for %s%s", target,
         uriSyntaxErrors.length() > 0 ? " (" + uriSyntaxErrors.toString() + ")" : "");
     this.nameResolver = nameResolver;
-    Preconditions.checkArgument(defaultPort > 0, "defaultPort is %s, must > 0", defaultPort);
     this.defaultPort = defaultPort;
 
     this.loadBalancer = loadBalancerFactory.newLoadBalancer(nameResolver.getServiceAuthority(), tm);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -121,7 +121,7 @@ public class ManagedChannelImplTest {
   private ManagedChannel createChannel(
       NameResolver.Factory nameResolverFactory, List<ClientInterceptor> interceptors) {
     return new ManagedChannelImpl(target, new FakeBackoffPolicyProvider(),
-        nameResolverFactory, SimpleLoadBalancerFactory.getInstance(),
+        nameResolverFactory, 80, SimpleLoadBalancerFactory.getInstance(),
         mockTransportFactory, executor, null, interceptors);
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -193,6 +193,19 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
         eventLoopGroup, flowControlWindow, maxMessageSize);
   }
 
+  @Override
+  protected int getDefaultPort() {
+    switch (negotiationType) {
+      case PLAINTEXT:
+      case PLAINTEXT_UPGRADE:
+        return GrpcUtil.DEFAULT_PORT_PLAINTEXT;
+      case TLS:
+        return GrpcUtil.DEFAULT_PORT_SSL;
+      default:
+        throw new AssertionError(negotiationType + " not handled");
+    }
+  }
+
   @VisibleForTesting
   static ProtocolNegotiator createProtocolNegotiator(
       String authority,

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -198,6 +198,18 @@ public class OkHttpChannelBuilder extends
             createSocketFactory(), connectionSpec, maxMessageSize);
   }
 
+  @Override
+  protected int getDefaultPort() {
+    switch (negotiationType) {
+      case PLAINTEXT:
+        return GrpcUtil.DEFAULT_PORT_PLAINTEXT;
+      case TLS:
+        return GrpcUtil.DEFAULT_PORT_SSL;
+      default:
+        throw new AssertionError(negotiationType + " not handled");
+    }
+  }
+
   private SSLSocketFactory createSocketFactory() {
     switch (negotiationType) {
       case TLS:


### PR DESCRIPTION
- InetSocketAddress with port 0 means port not specified, in which case
  ManagedChannelImpl will use the default port passed from channel
  builders.
- Channel builders decide the default port based on whether TLS is used.
- Channel builders for which port is not applicable, e.g., InProcessChannelBuilder, will return -1 as the default port.

Resolves #1138