### PR TITLE
Support default port in NameResolver.

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -99,8 +99,9 @@ public final class Attributes {
       this.product = new Attributes();
     }
 
-    public <T> void set(Key<T> key, T value) {
+    public <T> Builder set(Key<T> key, T value) {
       product.data.put(key.name, value);
+      return this;
     }
 
     /**

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -72,14 +72,23 @@ public abstract class NameResolver {
 
   public abstract static class Factory {
     /**
+     * The port number used in case the target or the underlying naming system doesn't provide a
+     * port number.
+     */
+    public static final Attributes.Key<Integer> PARAMS_DEFAULT_PORT =
+        new Attributes.Key<Integer>("io.grpc.NameResolverDefaultPort");
+
+    /**
      * Creates a {@link NameResolver} for the given target URI, or {@code null} if the given URI
      * cannot be resolved by this factory. The decision should be solely based on the scheme of the
      * URI.
      *
      * @param targetUri the target URI to be resolved, whose scheme must not be {@code null}
+     * @param params optional parameters. Canonical keys are defined as {@code PARAMS_*} fields in
+     *               {@link Factory}.
      */
     @Nullable
-    public abstract NameResolver newNameResolver(URI targetUri);
+    public abstract NameResolver newNameResolver(URI targetUri, Attributes params);
   }
 
   /**

--- a/core/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/core/src/main/java/io/grpc/NameResolverRegistry.java
@@ -74,9 +74,9 @@ public final class NameResolverRegistry extends NameResolver.Factory {
    * <p>The factory that was registered later has higher priority.
    */
   @Override
-  public NameResolver newNameResolver(URI targetUri) {
+  public NameResolver newNameResolver(URI targetUri, Attributes params) {
     for (NameResolver.Factory factory : registry) {
-      NameResolver resolver = factory.newNameResolver(targetUri);
+      NameResolver resolver = factory.newNameResolver(targetUri, params);
       if (resolver != null) {
         return resolver;
       }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -35,7 +35,6 @@ import com.google.common.base.Preconditions;
 
 import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
-import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.NameResolver;
@@ -165,18 +164,27 @@ public abstract class AbstractManagedChannelImplBuilder
         new ExponentialBackoffPolicy.Provider(),
         nameResolverFactory == null ? NameResolverRegistry.getDefaultRegistry()
             : nameResolverFactory,
+        getNameResolverParams(),
         loadBalancerFactory == null ? SimpleLoadBalancerFactory.getInstance()
             : loadBalancerFactory,
         transportFactory, executor, userAgent, interceptors);
   }
 
   /**
-   * Children of AbstractChannelBuilder should override this method to provide the
-   * {@link ClientTransportFactory} appropriate for this channel.  This method is meant for
-   * Transport implementors and should not be used by normal users.
+   * Subclasses should override this method to provide the {@link ClientTransportFactory}
+   * appropriate for this channel. This method is meant for Transport implementors and should not
+   * be used by normal users.
    */
-  @Internal
   protected abstract ClientTransportFactory buildTransportFactory();
+
+  /**
+   * Subclasses can override this method to provide additional parameters to {@link
+   * NameResolver.Factory#newNameResolver}. The default implementation returns {@link
+   * Attributes.EMPTY}.
+   */
+  protected Attributes getNameResolverParams() {
+    return Attributes.EMPTY;
+  }
 
   private static class AuthorityOverridingTransportFactory implements ClientTransportFactory {
     final ClientTransportFactory factory;
@@ -222,7 +230,7 @@ public abstract class AbstractManagedChannelImplBuilder
     }
 
     @Override
-    public NameResolver newNameResolver(URI notUsedUri) {
+    public NameResolver newNameResolver(URI notUsedUri, Attributes params) {
       return new NameResolver() {
         @Override
         public String getServiceAuthority() {

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -101,6 +101,16 @@ public final class GrpcUtil {
           Metadata.Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER);
 
   /**
+   * The default port for plain-text connections.
+   */
+  public static final int DEFAULT_PORT_PLAINTEXT = 80;
+
+  /**
+   * The default port for SSL connections.
+   */
+  public static final int DEFAULT_PORT_SSL = 443;
+
+  /**
    * Content-Type used for GRPC-over-HTTP/2.
    */
   public static final String CONTENT_TYPE_GRPC = "application/grpc";

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -133,7 +133,8 @@ public final class ManagedChannelImpl extends ManagedChannel {
   };
 
   ManagedChannelImpl(String target, BackoffPolicy.Provider backoffPolicyProvider,
-      NameResolver.Factory nameResolverFactory, LoadBalancer.Factory loadBalancerFactory,
+      NameResolver.Factory nameResolverFactory, Attributes nameResolverParams,
+      LoadBalancer.Factory loadBalancerFactory,
       ClientTransportFactory transportFactory, @Nullable Executor executor,
       @Nullable String userAgent, List<ClientInterceptor> interceptors) {
     if (executor == null) {
@@ -152,7 +153,7 @@ public final class ManagedChannelImpl extends ManagedChannel {
     StringBuilder uriSyntaxErrors = new StringBuilder();
     try {
       targetUri = new URI(target);
-      nameResolver = nameResolverFactory.newNameResolver(targetUri);
+      nameResolver = nameResolverFactory.newNameResolver(targetUri, nameResolverParams);
       // For "localhost:8080" this would likely return null, because "localhost" is parsed as the
       // scheme. Will fall into the next branch and try "dns:///localhost:8080".
     } catch (URISyntaxException e) {
@@ -163,7 +164,7 @@ public final class ManagedChannelImpl extends ManagedChannel {
     if (nameResolver == null) {
       try {
         targetUri = new URI("dns:///" + target);
-        nameResolver = nameResolverFactory.newNameResolver(targetUri);
+        nameResolver = nameResolverFactory.newNameResolver(targetUri, nameResolverParams);
       } catch (URISyntaxException e) {
         if (uriSyntaxErrors.length() > 0) {
           uriSyntaxErrors.append("; ");

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -37,7 +37,9 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
+import io.grpc.NameResolver;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
 import io.grpc.internal.ClientTransport;
@@ -191,6 +193,24 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
   protected ClientTransportFactory buildTransportFactory() {
     return new NettyTransportFactory(channelType, negotiationType, sslContext,
         eventLoopGroup, flowControlWindow, maxMessageSize);
+  }
+
+  @Override
+  protected Attributes getNameResolverParams() {
+    int defaultPort;
+    switch (negotiationType) {
+      case PLAINTEXT:
+      case PLAINTEXT_UPGRADE:
+        defaultPort = GrpcUtil.DEFAULT_PORT_PLAINTEXT;
+        break;
+      case TLS:
+        defaultPort = GrpcUtil.DEFAULT_PORT_SSL;
+        break;
+      default:
+        throw new AssertionError(negotiationType + " not handled");
+    }
+    return Attributes.newBuilder()
+        .set(NameResolver.Factory.PARAMS_DEFAULT_PORT, defaultPort).build();
   }
 
   @VisibleForTesting

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -41,7 +41,9 @@ import com.squareup.okhttp.CipherSuite;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.TlsVersion;
 
+import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
+import io.grpc.NameResolver;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
 import io.grpc.internal.ClientTransport;
@@ -196,6 +198,23 @@ public class OkHttpChannelBuilder extends
   protected final ClientTransportFactory buildTransportFactory() {
     return new OkHttpTransportFactory(transportExecutor,
             createSocketFactory(), connectionSpec, maxMessageSize);
+  }
+
+  @Override
+  protected Attributes getNameResolverParams() {
+    int defaultPort;
+    switch (negotiationType) {
+      case PLAINTEXT:
+        defaultPort = GrpcUtil.DEFAULT_PORT_PLAINTEXT;
+        break;
+      case TLS:
+        defaultPort = GrpcUtil.DEFAULT_PORT_SSL;
+        break;
+      default:
+        throw new AssertionError(negotiationType + " not handled");
+    }
+    return Attributes.newBuilder()
+        .set(NameResolver.Factory.PARAMS_DEFAULT_PORT, defaultPort).build();
   }
 
   private SSLSocketFactory createSocketFactory() {


### PR DESCRIPTION
- Channel builders decide the default port based on whether TLS is used.
- Channel builders populate the default port via an Attributes object
  passed to NameResolver.Factory#newNameResolver

Resolves #1138