### PR TITLE
Fix a NPE in ManagedChannelImpl.

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -340,7 +340,7 @@ public final class ManagedChannelImpl extends ManagedChannel {
       TransportSet ts;
       synchronized (lock) {
         if (shutdown) {
-          return null;
+          return NULL_VALUE_TRANSPORT_FUTURE;
         }
         ts = transports.get(addr);
         if (ts == null) {


### PR DESCRIPTION
The error occurs when name resolution completes after the channel is
shut down. What ManagedChannelImpl doing right now is violating the
TransportManager interface, because TransportManager.getTransport()
should never return null.