### PR TITLE
Resolve Netty hostname when connecting.

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -180,7 +180,7 @@ public abstract class AbstractManagedChannelImplBuilder
   /**
    * Subclasses can override this method to provide additional parameters to {@link
    * NameResolver.Factory#newNameResolver}. The default implementation returns {@link
-   * Attributes.EMPTY}.
+   * Attributes#EMPTY}.
    */
   protected Attributes getNameResolverParams() {
     return Attributes.EMPTY;

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -32,6 +32,7 @@
 package io.grpc.testing.integration;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -76,11 +77,13 @@ public class Http2NettyTest extends AbstractTransportTest {
   protected ManagedChannel createChannel() {
     try {
       return NettyChannelBuilder
-          .forAddress(TestUtils.testServerAddress(serverPort))
+          .forAddress("127.0.0.1", serverPort)
           .sslContext(GrpcSslContexts.forClient()
               .trustManager(TestUtils.loadCert("ca.pem"))
               .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
               .build())
+          .overrideAuthority(GrpcUtil.authorityFromHostAndPort(
+              TestUtils.TEST_SERVER_HOST, serverPort))
           .build();
     } catch (Exception ex) {
       throw new RuntimeException(ex);

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -79,14 +79,18 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
    * noticing changes to DNS.
    */
   public static NettyChannelBuilder forAddress(SocketAddress serverAddress) {
-    return new NettyChannelBuilder(serverAddress);
+    if (serverAddress instanceof InetSocketAddress) {
+      return forTarget(getAuthorityFromAddress(serverAddress));
+    } else {
+      return new NettyChannelBuilder(serverAddress);
+    }
   }
 
   /**
    * Creates a new builder with the given host and port.
    */
   public static NettyChannelBuilder forAddress(String host, int port) {
-    return forAddress(new InetSocketAddress(host, port));
+    return forTarget(GrpcUtil.authorityFromHostAndPort(host, port));
   }
 
   /**


### PR DESCRIPTION
Depending on which construction method is used for the Netty channel, we can potentially only resolve the hostname once when creating the channel. This means that we'll always use the same IP address for a given server. This can cause issues with load balancing as well as stale IPs.