### PR TITLE
Use assertEquals instead of assertTrue(Range.contains)

### DIFF
--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Objects;
-import com.google.common.collect.Range;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -102,11 +101,10 @@ public class CallOptionsTest {
     long deadline = CallOptions.DEFAULT
         .withDeadlineAfter(1, TimeUnit.MINUTES).getDeadlineNanoTime();
     long expected = System.nanoTime() + 1L * 60 * 1000 * 1000 * 1000;
-    long delta = deadline - expected;
     // 10 milliseconds of leeway
     long epsilon = 1000 * 1000 * 10;
 
-    assertTrue(Range.closed(-epsilon, epsilon).contains(delta));
+    assertEquals(expected, deadline, epsilon);
   }
 
   @Test


### PR DESCRIPTION
It likely will produce a better error message and doesn't require using
as large of an API/impl.