### PR TITLE
Remove the use of MoreObjects/Objects from CallOptions.

### DIFF
--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -31,8 +31,6 @@
 
 package io.grpc;
 
-import com.google.common.base.Objects;
-
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -180,18 +178,18 @@ public final class CallOptions {
     requestKey = other.requestKey;
   }
 
-  @SuppressWarnings("deprecation") // guava 14.0
   @Override
   public String toString() {
-    Objects.ToStringHelper toStringHelper = Objects.toStringHelper(this);
-    toStringHelper.add("deadlineNanoTime", deadlineNanoTime);
+    StringBuilder out = new StringBuilder();
+    out.append("CallOptions{");
+    out.append("deadlineNanoTime=").append(deadlineNanoTime);
     if (deadlineNanoTime != null) {
       long remainingNanos = deadlineNanoTime - System.nanoTime();
-      toStringHelper.addValue(remainingNanos + " ns from now");
+      out.append(" (").append(remainingNanos + " ns from now)");
     }
-    toStringHelper.add("compressor", compressor);
-    toStringHelper.add("authority", authority);
-
-    return toStringHelper.toString();
+    out.append(", compressor=").append(compressor);
+    out.append(", authority=").append(authority);
+    out.append("}");
+    return out.toString();
   }
 }

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -130,7 +130,7 @@ public class CallOptionsTest {
     // Deadline makes it hard to check string for equality.
     assertEquals("CallOptions{deadlineNanoTime=null, compressor=GziP, authority=authority}",
         allSet.withCompressor(gzip).withDeadlineNanoTime(null).toString());
-    assertTrue(allSet.toString().contains("deadlineNanoTime=" + sampleDeadlineNanoTime + ","));
+    assertTrue(allSet.toString().contains("deadlineNanoTime=" + sampleDeadlineNanoTime + " ("));
   }
 
   private static boolean equal(CallOptions o1, CallOptions o2) {


### PR DESCRIPTION
Guava is renaming its Objects to MoreObjects because Java 7 also has a
class named Objects. Such migration is happening inside Google. Although
gRPC depends on Guava 18, Google internally was stuck using Guava 14.0
for legacy reasons (#879) so gRPC cannot migrate to MoreObjects which is
not available in Guava 14, and it should not stick to Objects because
this would conflict with the internal migration work. To make our lives
easier, we could just drop the use of MoreObjects/Objects.

@ejona86 @carl-mastrangelo 