### PR TITLE
Add even more coverage

### DIFF
--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
@@ -33,16 +33,22 @@ package io.grpc.okhttp;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
+import io.grpc.okhttp.OkHttpProtocolNegotiator.AndroidNegotiator;
+import io.grpc.okhttp.OkHttpProtocolNegotiator.AndroidNegotiator.TlsExtensionType;
 import io.grpc.okhttp.internal.Platform;
 import io.grpc.okhttp.internal.Protocol;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -51,7 +57,12 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.Provider;
+import java.security.Security;
 
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 
 /**
@@ -61,7 +72,20 @@ import javax.net.ssl.SSLSocket;
 public class OkHttpProtocolNegotiatorTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
-  private SSLSocket sock = mock(SSLSocket.class);
+  private final Provider fakeSecurityProvider = new Provider("GmsCore_OpenSSL", 1.0, "info") {};
+  private final SSLSocket sock = mock(SSLSocket.class);
+  private final Platform platform = mock(Platform.class);
+
+  @Before
+  public void setUp() {
+    // Tests that depend on android need this to know which protocol negotiation to use.
+    Security.addProvider(fakeSecurityProvider);
+  }
+
+  @After
+  public void tearDown() {
+    Security.removeProvider(fakeSecurityProvider.getName());
+  }
 
   @Test
   public void createNegotiator_isAndroid() {
@@ -77,8 +101,7 @@ public class OkHttpProtocolNegotiatorTest {
     };
 
     OkHttpProtocolNegotiator negotiator = OkHttpProtocolNegotiator.createNegotiator(cl);
-
-    assertEquals(OkHttpProtocolNegotiator.AndroidNegotiator.class, negotiator.getClass());
+    assertEquals(AndroidNegotiator.class, negotiator.getClass());
   }
 
   @Test
@@ -96,7 +119,7 @@ public class OkHttpProtocolNegotiatorTest {
 
     OkHttpProtocolNegotiator negotiator = OkHttpProtocolNegotiator.createNegotiator(cl);
 
-    assertEquals(OkHttpProtocolNegotiator.AndroidNegotiator.class, negotiator.getClass());
+    assertEquals(AndroidNegotiator.class, negotiator.getClass());
   }
 
   @Test
@@ -144,7 +167,6 @@ public class OkHttpProtocolNegotiatorTest {
 
   @Test
   public void negotiate_success() throws Exception {
-    Platform platform = mock(Platform.class);
     when(platform.getSelectedProtocol(Mockito.<SSLSocket>any())).thenReturn("h2");
     OkHttpProtocolNegotiator negotiator = new OkHttpProtocolNegotiator(platform);
 
@@ -155,5 +177,219 @@ public class OkHttpProtocolNegotiatorTest {
     verify(platform).getSelectedProtocol(sock);
     verify(platform).afterHandshake(sock);
   }
-}
 
+  @Test
+  public void pickTlsExtensionType_securityProvider() throws Exception {
+    assertNotNull(Security.getProvider(fakeSecurityProvider.getName()));
+
+    AndroidNegotiator.TlsExtensionType tlsExtensionType =
+        AndroidNegotiator.pickTlsExtensionType(getClass().getClassLoader());
+
+    assertEquals(TlsExtensionType.ALPN_AND_NPN, tlsExtensionType);
+  }
+
+  @Test
+  public void pickTlsExtensionType_android50() throws Exception {
+    Security.removeProvider(fakeSecurityProvider.getName());
+    ClassLoader cl = new ClassLoader(this.getClass().getClassLoader()) {
+      @Override
+      protected Class<?> findClass(String name) throws ClassNotFoundException {
+        // Just don't throw.
+        if ("android.net.Network".equals(name)) {
+          return null;
+        }
+        return super.findClass(name);
+      }
+    };
+
+    AndroidNegotiator.TlsExtensionType tlsExtensionType =
+        AndroidNegotiator.pickTlsExtensionType(cl);
+
+    assertEquals(TlsExtensionType.ALPN_AND_NPN, tlsExtensionType);
+  }
+
+  @Test
+  public void pickTlsExtensionType_android41() throws Exception {
+    Security.removeProvider(fakeSecurityProvider.getName());
+    ClassLoader cl = new ClassLoader(this.getClass().getClassLoader()) {
+      @Override
+      protected Class<?> findClass(String name) throws ClassNotFoundException {
+        // Just don't throw.
+        if ("android.app.ActivityOptions".equals(name)) {
+          return null;
+        }
+        return super.findClass(name);
+      }
+    };
+
+    AndroidNegotiator.TlsExtensionType tlsExtensionType =
+        AndroidNegotiator.pickTlsExtensionType(cl);
+
+    assertEquals(TlsExtensionType.NPN, tlsExtensionType);
+  }
+
+  @Test
+  public void pickTlsExtensionType_none() throws Exception {
+    Security.removeProvider(fakeSecurityProvider.getName());
+
+    AndroidNegotiator.TlsExtensionType tlsExtensionType =
+        AndroidNegotiator.pickTlsExtensionType(getClass().getClassLoader());
+
+    assertNull(tlsExtensionType);
+  }
+
+  @Test
+  public void androidNegotiator_failsOnNull() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("Unable to pick a TLS extension");
+
+    new AndroidNegotiator(platform, null);
+  }
+
+  // Checks that the super class is properly invoked.
+  @Test
+  public void negotiate_android_handshakeFails() throws Exception {
+    AndroidNegotiator negotiator = new AndroidNegotiator(platform, TlsExtensionType.ALPN_AND_NPN);
+
+    FakeAndroidSslSocket androidSock = new FakeAndroidSslSocket() {
+      @Override
+      public void startHandshake() throws IOException {
+        throw new IOException("expected");
+      }
+    };
+
+    thrown.expect(IOException.class);
+    thrown.expectMessage("expected");
+
+    negotiator.negotiate(androidSock, "hostname", ImmutableList.of(Protocol.HTTP_2));
+  }
+
+  @VisibleForTesting
+  public static class FakeAndroidSslSocketAlpn extends FakeAndroidSslSocket {
+    @Override
+    public byte[] getAlpnSelectedProtocol() {
+      return "h2".getBytes(StandardCharsets.UTF_8);
+    }
+  }
+
+  @Test
+  public void getSelectedProtocol_alpn() throws Exception {
+    AndroidNegotiator negotiator = new AndroidNegotiator(platform, TlsExtensionType.ALPN_AND_NPN);
+    FakeAndroidSslSocket androidSock = new FakeAndroidSslSocketAlpn();
+
+    String actual = negotiator.getSelectedProtocol(androidSock);
+
+    assertEquals("h2", actual);
+  }
+
+  @VisibleForTesting
+  public static class FakeAndroidSslSocketNpn extends FakeAndroidSslSocket {
+    @Override
+    public byte[] getNpnSelectedProtocol() {
+      return "h2".getBytes(StandardCharsets.UTF_8);
+    }
+  }
+
+  @Test
+  public void getSelectedProtocol_npn() throws Exception {
+    AndroidNegotiator negotiator = new AndroidNegotiator(platform, TlsExtensionType.NPN);
+    FakeAndroidSslSocket androidSock = new FakeAndroidSslSocketNpn();
+
+    String actual = negotiator.getSelectedProtocol(androidSock);
+
+    assertEquals("h2", actual);
+  }
+
+  // A fake of org.conscrypt.OpenSSLSocketImpl
+  @VisibleForTesting // Must be public for reflection to work
+  public static class FakeAndroidSslSocket extends SSLSocket {
+
+    public void setUseSessionTickets(boolean arg) {}
+
+    public void setHostname(String arg) {}
+
+    public byte[] getAlpnSelectedProtocol() {
+      return null;
+    }
+
+    public void setAlpnProtocols(byte[] arg) {}
+
+    public byte[] getNpnSelectedProtocol() {
+      return null;
+    }
+
+    public void setNpnProtocols(byte[] arg) {}
+
+    @Override
+    public void addHandshakeCompletedListener(HandshakeCompletedListener listener) {}
+
+    @Override
+    public boolean getEnableSessionCreation() {
+      return false;
+    }
+
+    @Override
+    public String[] getEnabledCipherSuites() {
+      return null;
+    }
+
+    @Override
+    public String[] getEnabledProtocols() {
+      return null;
+    }
+
+    @Override
+    public boolean getNeedClientAuth() {
+      return false;
+    }
+
+    @Override
+    public SSLSession getSession() {
+      return null;
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+      return null;
+    }
+
+    @Override
+    public String[] getSupportedProtocols() {
+      return null;
+    }
+
+    @Override
+    public boolean getUseClientMode() {
+      return false;
+    }
+
+    @Override
+    public boolean getWantClientAuth() {
+      return false;
+    }
+
+    @Override
+    public void removeHandshakeCompletedListener(HandshakeCompletedListener listener) {}
+
+    @Override
+    public void setEnableSessionCreation(boolean flag) {}
+
+    @Override
+    public void setEnabledCipherSuites(String[] suites) {}
+
+    @Override
+    public void setEnabledProtocols(String[] protocols) {}
+
+    @Override
+    public void setNeedClientAuth(boolean need) {}
+
+    @Override
+    public void setUseClientMode(boolean mode) {}
+
+    @Override
+    public void setWantClientAuth(boolean want) {}
+
+    @Override
+    public void startHandshake() throws IOException {}
+  }
+}


### PR DESCRIPTION
This covers more the the OkHttp Protocol negotiators.  This addition tries to pretend to be at least somewhat Android like, which avoid the need to bring up a full android emulator to ensure test safety.  My hope is that as we find bugs or discrepancies in the okhttp android behavior, they will get added as test cases to this class.  

This testing is not comprehensive, but increases the coverage of the file.  