### PR TITLE
Add directExecutor() to Channel and Server Builders. Fixes #368.

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -33,7 +33,6 @@ package io.grpc.benchmarks;
 
 import static io.grpc.testing.TestUtils.pickUnusedPort;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 
 import io.grpc.ManagedChannel;
@@ -129,8 +128,8 @@ public class TransportBenchmark {
     }
 
     if (direct) {
-      serverBuilder.executor(MoreExecutors.directExecutor());
-      channelBuilder.executor(MoreExecutors.directExecutor());
+      serverBuilder.directExecutor();
+      channelBuilder.directExecutor();
     }
 
     server = serverBuilder

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -31,8 +31,6 @@
 
 package io.grpc.benchmarks.netty;
 
-import com.google.common.util.concurrent.MoreExecutors;
-
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Drainable;
@@ -227,10 +225,10 @@ public abstract class AbstractBenchmark {
     }
 
     if (serverExecutor == ExecutorType.DIRECT) {
-      serverBuilder.executor(MoreExecutors.directExecutor());
+      serverBuilder.directExecutor();
     }
     if (clientExecutor == ExecutorType.DIRECT) {
-      channelBuilder.executor(MoreExecutors.directExecutor());
+      channelBuilder.directExecutor();
     }
 
     // Always use a different worker group from the client.

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -31,7 +31,6 @@
 
 package io.grpc.benchmarks.qps;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 
 import io.grpc.Server;
@@ -167,16 +166,19 @@ public class AsyncServer {
       }
     }
 
-    return NettyServerBuilder
+    NettyServerBuilder builder = NettyServerBuilder
         .forAddress(config.address)
         .bossEventLoopGroup(boss)
         .workerEventLoopGroup(worker)
         .channelType(channelType)
         .addService(TestServiceGrpc.bindService(new TestServiceImpl()))
         .sslContext(sslContext)
-        .executor(config.directExecutor ? MoreExecutors.directExecutor() : null)
-        .flowControlWindow(config.flowControlWindow)
-        .build();
+        .flowControlWindow(config.flowControlWindow);
+    if (config.directExecutor) {
+      builder.directExecutor();
+    }
+
+    return builder.build();
   }
 
   public static class TestServiceImpl implements TestServiceGrpc.TestService {

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -75,6 +75,19 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
+   * Execute application code directly in the transport thread.
+   *
+   * <p>Depending on the underlying transport, using a direct executor may lead to substantial
+   * performance improvements. However, it also requires the application to not block under
+   * any circumstances.
+   *
+   * <p>Calling this method is semantically equivalent to calling {@link #executor(Executor)} and
+   * passing in a direct executor. However, this is the preferred way as it may allow the transport
+   * to perform special optimizations.
+   */
+  public abstract T directExecutor();
+
+  /**
    * Provides a custom executor.
    *
    * <p>It's an optional parameter. If the user has not provided an executor when the channel is

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -48,6 +48,19 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   }
 
   /**
+   * Execute application code directly in the transport thread.
+   *
+   * <p>Depending on the underlying transport, using a direct executor may lead to substantial
+   * performance improvements. However, it also requires the application to not block under
+   * any circumstances.
+   *
+   * <p>Calling this method is semantically equivalent to calling {@link #executor(Executor)} and
+   * passing in a direct executor. However, this is the preferred way as it may allow the transport
+   * to perform special optimizations.
+   */
+  public abstract T directExecutor();
+
+  /**
    * Provides a custom executor.
    *
    * <p>It's an optional parameter. If the user has not provided an executor when the server is

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -32,6 +32,7 @@
 package io.grpc.internal;
 
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
@@ -90,6 +91,11 @@ public abstract class AbstractManagedChannelImplBuilder
     this.target = "directaddress:///" + directServerAddress;
     this.directServerAddress = directServerAddress;
     this.nameResolverFactory = new DirectAddressNameResolverFactory(directServerAddress, authority);
+  }
+
+  @Override
+  public final T directExecutor() {
+    return executor(MoreExecutors.directExecutor());
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -32,6 +32,7 @@
 package io.grpc.internal;
 
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.HandlerRegistry;
 import io.grpc.Internal;
@@ -68,6 +69,11 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
    */
   protected AbstractServerImplBuilder() {
     this.registry = new MutableHandlerRegistryImpl();
+  }
+
+  @Override
+  public final T directExecutor() {
+    return executor(MoreExecutors.directExecutor());
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -318,7 +318,7 @@ public final class ManagedChannelImpl extends ManagedChannel {
         CallOptions callOptions) {
       return new ClientCallImpl<ReqT, RespT>(
           method,
-          new SerializingExecutor(executor),
+          executor,
           callOptions,
           transportProvider,
           scheduledExecutor)

--- a/core/src/main/java/io/grpc/internal/SerializeReentrantCallsDirectExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SerializeReentrantCallsDirectExecutor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.Preconditions;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.Executor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Executes a task directly in the calling thread, unless it's a reentrant call in which case the
+ * task is enqueued and executed once the calling task completes.
+ *
+ * <p> The {@code Executor} assumes that reentrant calls are rare and its fast path is thus
+ * optimized for that - avoiding queuing and additional object creation altogether.
+ *
+ * <p> This class is not thread-safe.
+ */
+class SerializeReentrantCallsDirectExecutor implements Executor {
+
+  private static final Logger log =
+      Logger.getLogger(SerializeReentrantCallsDirectExecutor.class.getName());
+
+  private boolean executing;
+  // Lazily initialized if a reentrant call is detected.
+  private ArrayDeque<Runnable> taskQueue;
+
+  @Override
+  public void execute(Runnable task) {
+    Preconditions.checkNotNull(task, "'task' must not be null.");
+    if (!executing) {
+      executing = true;
+      try {
+        task.run();
+      } catch (Throwable t) {
+        log.log(Level.SEVERE, "Exception while executing runnable " + task, t);
+      } finally {
+        if (taskQueue != null) {
+          completeQueuedTasks();
+        }
+        executing = false;
+      }
+    } else {
+      enqueue(task);
+    }
+  }
+
+  private void completeQueuedTasks() {
+    Runnable task = null;
+    while ((task = taskQueue.poll()) != null) {
+      try {
+        task.run();
+      } catch (Throwable t) {
+        // Log it and keep going
+        log.log(Level.SEVERE, "Exception while executing runnable " + task, t);
+      }
+    }
+  }
+
+  private void enqueue(Runnable r) {
+    if (taskQueue == null) {
+      taskQueue = new ArrayDeque<Runnable>(4);
+    }
+    taskQueue.add(r);
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -75,8 +75,6 @@ import java.util.concurrent.ScheduledExecutorService;
 @RunWith(JUnit4.class)
 public class ClientCallImplTest {
 
-  private final SerializingExecutor executor =
-      new SerializingExecutor(MoreExecutors.directExecutor());
   private final ScheduledExecutorService deadlineCancellationExecutor =
       Executors.newScheduledThreadPool(0);
   private final DecompressorRegistry decompressorRegistry =
@@ -106,7 +104,7 @@ public class ClientCallImplTest {
           any(ClientStreamListener.class))).thenReturn(stream);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         descriptor,
-        executor,
+        MoreExecutors.directExecutor(),
         CallOptions.DEFAULT,
         provider,
         deadlineCancellationExecutor)

--- a/core/src/test/java/io/grpc/internal/SerializeReentrantCallsDirectExecutorTest.java
+++ b/core/src/test/java/io/grpc/internal/SerializeReentrantCallsDirectExecutorTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SerializeReentrantCallsDirectExecutorTest {
+
+  SerializeReentrantCallsDirectExecutor executor;
+
+  @Before
+  public void setup() {
+    executor = new SerializeReentrantCallsDirectExecutor();
+  }
+
+  @Test public void reentrantCallsShouldBeSerialized() {
+    final List<Integer> callOrder = new ArrayList<Integer>(4);
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        executor.execute(new Runnable() {
+          @Override
+          public void run() {
+            executor.execute(new Runnable() {
+              @Override public void run() {
+                callOrder.add(3);
+              }
+            });
+
+            callOrder.add(2);
+
+            executor.execute(new Runnable() {
+              @Override public void run() {
+                callOrder.add(4);
+              }
+            });
+          }
+        });
+        callOrder.add(1);
+      }
+    });
+
+    assertEquals(asList(1, 2, 3, 4), callOrder);
+  }
+
+  @Test
+  public void exceptionShouldNotCancelQueuedTasks() {
+    final AtomicBoolean executed1 = new AtomicBoolean();
+    final AtomicBoolean executed2 = new AtomicBoolean();
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        executor.execute(new Runnable() {
+          @Override
+          public void run() {
+            executed1.set(true);
+            throw new RuntimeException("Two");
+          }
+        });
+        executor.execute(new Runnable() {
+          @Override
+          public void run() {
+            executed2.set(true);
+          }
+        });
+
+        throw new RuntimeException("One");
+      }
+    });
+
+    assertTrue(executed1.get());
+    assertTrue(executed2.get());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void executingNullShouldFail() {
+    executor.execute(null);
+  }
+
+  @Test
+  public void executeCanBeRepeated() {
+    final List<Integer> executes = new ArrayList<Integer>();
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        executes.add(1);
+      }
+    });
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        executes.add(2);
+      }
+    });
+
+    assertEquals(asList(1,2), executes);
+  }
+
+  @Test
+  public void interruptDoesNotAffectExecution() {
+    final AtomicInteger callsExecuted = new AtomicInteger();
+
+    Thread.currentThread().interrupt();
+
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        Thread.currentThread().interrupt();
+        callsExecuted.incrementAndGet();
+      }
+    });
+
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        callsExecuted.incrementAndGet();
+      }
+    });
+
+    // clear interrupted flag
+    Thread.interrupted();
+  }
+}


### PR DESCRIPTION
When using a direct executor we don't need to wrap calls in a
serializing executor and can thus also avoid the overhead that
comes with it.

Benchmarks show that throughput can be improved substantially.
On my MBP I get a 24% improvement in throughput with also
significantly better latency throughout all percentiles.

(running qps_client and qps_server with --address=localhost:1234 --directexecutor)

```
=== BEFORE ===
Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     452
90%ile Latency (in micros):     600
95%ile Latency (in micros):     726
99%ile Latency (in micros):     1314
99.9%ile Latency (in micros):   5663
Maximum Latency (in micros):    136447
QPS:                            78498

=== AFTER ===
Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     399
90%ile Latency (in micros):     429
95%ile Latency (in micros):     453
99%ile Latency (in micros):     650
99.9%ile Latency (in micros):   1265
Maximum Latency (in micros):    33855
QPS:                            97552
```