### PR TITLE
Implementation of context binding for servers and clients

### DIFF
--- a/core/src/main/java/io/grpc/Context.java
+++ b/core/src/main/java/io/grpc/Context.java
@@ -786,6 +786,11 @@ public class Context {
     public int hashCode() {
       return name.hashCode();
     }
+
+    @Override
+    public String toString() {
+      return name;
+    }
   }
 
   /**

--- a/core/src/main/java/io/grpc/Contexts.java
+++ b/core/src/main/java/io/grpc/Contexts.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+/**
+ * Utility methods for working with {@link Context}s in GRPC.
+ */
+public class Contexts {
+
+  /**
+   * Make the provided {@link Context} {@link Context#current()} for the creation of a listener
+   * to a received call and for all events received by that listener.
+   *
+   * <p>This utility is expected to be used by {@link ServerInterceptor} implementations that need
+   * to augment the {@link Context} in which the application does work when receiving events from
+   * the client.
+   *
+   * @param context to make {@link Context#current()}.
+   * @param method being requested by the client.
+   * @param call used to send responses to client.
+   * @param headers received from client.
+   * @param next handler used to create the listener to be wrapped.
+   * @return listener that will receive events in the scope of the provided context.
+   */
+  public static <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        Context context,
+        MethodDescriptor<ReqT, RespT> method,
+        ServerCall<RespT> call,
+        Metadata headers,
+        ServerCallHandler<ReqT, RespT> next) {
+    Context previous = context.attach();
+    try {
+      return new ContextualizedServerCallListener<ReqT>(
+          next.startCall(method, call, headers),
+          context);
+    } finally {
+      context.detach(previous);
+    }
+  }
+
+  /**
+   * Implementation of {@link io.grpc.ForwardingServerCallListener} that attaches a context before
+   * dispatching calls to the delegate and detaches them after the call completes.
+   */
+  private static class ContextualizedServerCallListener<ReqT> extends
+      ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
+    private final Context context;
+
+    public ContextualizedServerCallListener(ServerCall.Listener<ReqT> delegate, Context context) {
+      super(delegate);
+      this.context = context;
+    }
+
+    @Override
+    public void onMessage(ReqT message) {
+      Context previous = context.attach();
+      try {
+        super.onMessage(message);
+      } finally {
+        context.detach(previous);
+      }
+    }
+
+    @Override
+    public void onHalfClose() {
+      Context previous = context.attach();
+      try {
+        super.onHalfClose();
+      } finally {
+        context.detach(previous);
+      }
+    }
+
+    @Override
+    public void onCancel() {
+      Context previous = context.attach();
+      try {
+        super.onCancel();
+      } finally {
+        context.detach(previous);
+      }
+    }
+
+    @Override
+    public void onComplete() {
+      Context previous = context.attach();
+      try {
+        super.onComplete();
+      } finally {
+        context.detach(previous);
+      }
+    }
+
+    @Override
+    public void onReady() {
+      Context previous = context.attach();
+      try {
+        super.onReady();
+      } finally {
+        context.detach(previous);
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -34,6 +34,7 @@ package io.grpc.internal;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 
+import io.grpc.Context;
 import io.grpc.HandlerRegistry;
 import io.grpc.Internal;
 import io.grpc.MutableHandlerRegistry;
@@ -100,7 +101,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   @Override
   public ServerImpl build() {
     io.grpc.internal.Server transportServer = buildTransportServer();
-    return new ServerImpl(executor, registry, transportServer);
+    return new ServerImpl(executor, registry, transportServer, Context.ROOT);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ContextRunnable.java
+++ b/core/src/main/java/io/grpc/internal/ContextRunnable.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.Context;
+import io.grpc.ExperimentalApi;
+
+/**
+ * Utility base implementation of {@link Runnable} that performs the same function as
+ * {@link Context#wrap(Runnable)} without requiring the construction of an additional object.
+ */
+@ExperimentalApi
+abstract class ContextRunnable implements Runnable {
+
+  private final Context context;
+
+  public ContextRunnable(Context context) {
+    this.context = context;
+  }
+
+  @Override
+  public final void run() {
+    Context previous = context.attach();
+    try {
+      runInContext();
+    } finally {
+      context.detach(previous);
+    }
+  }
+
+  public abstract void runInContext();
+}

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -34,6 +34,7 @@ package io.grpc.testing.integration;
 import static io.grpc.testing.integration.Messages.PayloadType.COMPRESSABLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -517,11 +518,11 @@ public abstract class AbstractTransportTest {
   }
 
   @Test(timeout = 10000)
-  public void exchangeContextUnaryCall() throws Exception {
+  public void exchangeMetadataUnaryCall() throws Exception {
     TestServiceGrpc.TestServiceBlockingStub stub =
         TestServiceGrpc.newBlockingStub(channel);
 
-    // Capture the context exchange
+    // Capture the metadata exchange
     Metadata fixedHeaders = new Metadata();
     // Send a context proto (as it's in the default extension registry)
     Messages.SimpleContext contextValue =
@@ -533,7 +534,7 @@ public abstract class AbstractTransportTest {
     AtomicReference<Metadata> headersCapture = new AtomicReference<Metadata>();
     stub = MetadataUtils.captureMetadata(stub, headersCapture, trailersCapture);
 
-    Assert.assertNotNull(stub.emptyCall(Empty.getDefaultInstance()));
+    assertNotNull(stub.emptyCall(Empty.getDefaultInstance()));
 
     // Assert that our side channel object is echoed back in both headers and trailers
     Assert.assertEquals(contextValue, headersCapture.get().get(METADATA_KEY));
@@ -541,10 +542,10 @@ public abstract class AbstractTransportTest {
   }
 
   @Test(timeout = 10000)
-  public void exchangeContextStreamingCall() throws Exception {
+  public void exchangeMetadataStreamingCall() throws Exception {
     TestServiceGrpc.TestServiceStub stub = TestServiceGrpc.newStub(channel);
 
-    // Capture the context exchange
+    // Capture the metadata exchange
     Metadata fixedHeaders = new Metadata();
     // Send a context proto (as it's in the default extension registry)
     Messages.SimpleContext contextValue =

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -360,6 +360,14 @@ class NettyClientHandler extends AbstractNettyHandler {
                   Http2Stream http2Stream = connection().stream(streamId);
                   if (http2Stream != null) {
                     http2Stream.setProperty(streamKey, stream);
+                  } else if (stream.isClosed()) {
+                    // The stream has been cancelled and Netty is sending a RST_STREAM frame which
+                    // causes it to purge pending writes from the flow-controller and delete the
+                    // http2Stream. The stream listener has already been notified of cancellation
+                    // so there is nothing to do.
+                    return;
+                  } else {
+                    throw new IllegalStateException("Stream closed but http2 stream not defined");
                   }
                   // Attach the client stream to the HTTP/2 stream object as user data.
                   stream.setHttp2Stream(http2Stream);


### PR DESCRIPTION
Continues work on https://github.com/grpc/grpc-java/issues/262

For clients the context used to initiate a call will be propagated to the callbacks receiving data from the server.

For servers a CancellableContext is created and associated with each call and is bound for all invocations into application listeners.

For inprocess connectors we guarantee that client contexts do not bleed into server threads