### PR TITLE
Switch to use Executor instead of ExecutorService where we don't need it

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -129,8 +129,8 @@ public class TransportBenchmark {
     }
 
     if (direct) {
-      serverBuilder.executor(MoreExecutors.newDirectExecutorService());
-      channelBuilder.executor(MoreExecutors.newDirectExecutorService());
+      serverBuilder.executor(MoreExecutors.directExecutor());
+      channelBuilder.executor(MoreExecutors.directExecutor());
     }
 
     server = serverBuilder

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -227,10 +227,10 @@ public abstract class AbstractBenchmark {
     }
 
     if (serverExecutor == ExecutorType.DIRECT) {
-      serverBuilder.executor(MoreExecutors.newDirectExecutorService());
+      serverBuilder.executor(MoreExecutors.directExecutor());
     }
     if (clientExecutor == ExecutorType.DIRECT) {
-      channelBuilder.executor(MoreExecutors.newDirectExecutorService());
+      channelBuilder.executor(MoreExecutors.directExecutor());
     }
 
     // Always use a different worker group from the client.

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -174,7 +174,7 @@ public class AsyncServer {
         .channelType(channelType)
         .addService(TestServiceGrpc.bindService(new TestServiceImpl()))
         .sslContext(sslContext)
-        .executor(config.directExecutor ? MoreExecutors.newDirectExecutorService() : null)
+        .executor(config.directExecutor ? MoreExecutors.directExecutor() : null)
         .flowControlWindow(config.flowControlWindow)
         .build();
   }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/Utils.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/Utils.java
@@ -134,7 +134,7 @@ final class Utils {
       InetSocketAddress addr = (InetSocketAddress) config.address;
       OkHttpChannelBuilder builder = OkHttpChannelBuilder
           .forAddress(addr.getHostName(), addr.getPort())
-          .executor(config.directExecutor ? MoreExecutors.newDirectExecutorService() : null);
+          .executor(config.directExecutor ? MoreExecutors.directExecutor() : null);
       builder.negotiationType(config.tls ? io.grpc.okhttp.NegotiationType.TLS
           : io.grpc.okhttp.NegotiationType.PLAINTEXT);
       if (config.tls) {
@@ -201,7 +201,7 @@ final class Utils {
         .eventLoopGroup(group)
         .channelType(channelType)
         .negotiationType(negotiationType)
-        .executor(config.directExecutor ? MoreExecutors.newDirectExecutorService() : null)
+        .executor(config.directExecutor ? MoreExecutors.directExecutor() : null)
         .sslContext(sslContext)
         .flowControlWindow(config.flowControlWindow)
         .build();

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -76,7 +76,7 @@ import java.util.concurrent.ScheduledExecutorService;
 public class ClientCallImplTest {
 
   private final SerializingExecutor executor =
-      new SerializingExecutor(MoreExecutors.newDirectExecutorService());
+      new SerializingExecutor(MoreExecutors.directExecutor());
   private final ScheduledExecutorService deadlineCancellationExecutor =
       Executors.newScheduledThreadPool(0);
   private final DecompressorRegistry decompressorRegistry =


### PR DESCRIPTION
@ejona86 Broken out from headers canonicalization fix