### PR TITLE
Enable LB and Naming for Netty.forAddress(String,int)

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -89,7 +89,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
    * Creates a new builder with the given host and port.
    */
   public static NettyChannelBuilder forAddress(String host, int port) {
-    return forAddress(new InetSocketAddress(host, port));
+    return new NettyChannelBuilder(host, port);
   }
 
   /**
@@ -98,6 +98,10 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
    */
   public static NettyChannelBuilder forTarget(String target) {
     return new NettyChannelBuilder(target);
+  }
+
+  protected NettyChannelBuilder(String host, int port) {
+    this(GrpcUtil.authorityFromHostAndPort(host, port));
   }
 
   private NettyChannelBuilder(String target) {


### PR DESCRIPTION
This swaps to the forTarget() codepath. The constructor is to make it
more convenient when extending the builder to disable checkAuthority.