### PR TITLE
Upgrading to Netty 4.1.0.Beta8

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,7 +57,7 @@ In Maven, you can use the [os-maven-plugin](https://github.com/trustin/os-maven-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>1.1.33.Fork7</version>
+      <version>1.1.33.Fork9</version>
       <classifier>${tcnative.classifier}</classifier>
     </dependency>
   </dependencies>
@@ -125,7 +125,7 @@ if (osdetector.os == "linux" && osdetector.release.isLike("fedora")) {
 }
 
 dependencies {
-    compile 'io.netty:netty-tcnative:1.1.33.Fork7:' + tcnative_classifier
+    compile 'io.netty:netty-tcnative:1.1.33.Fork9:' + tcnative_classifier
 }
 ```
 

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -38,7 +38,7 @@ dependencies {
             libraries.mockito,
             libraries.hdrhistogram,
             libraries.netty_tcnative,
-            libraries.netty_transport_native_epoll
+            libraries.netty_epoll
 }
 
 configureProtoCompilation()

--- a/build.gradle
+++ b/build.gradle
@@ -144,9 +144,9 @@ subprojects {
                 protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.7.0',
 
-                netty: 'io.netty:netty-codec-http2:4.1.0.Beta6',
-                netty_tcnative: 'io.netty:netty-tcnative:1.1.33.Fork7:' + tcnative_suffix,
-                netty_transport_native_epoll: 'io.netty:netty-transport-native-epoll:4.1.0.Beta6' + epoll_suffix,
+                netty: 'io.netty:netty-codec-http2:4.1.0.Beta8',
+                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.0.Beta8' + epoll_suffix,
+                netty_tcnative: 'io.netty:netty-tcnative:1.1.33.Fork9:' + tcnative_suffix,
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
@@ -34,7 +34,7 @@ package io.grpc.netty;
 import io.grpc.Internal;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
-import io.netty.util.ByteString;
+import io.netty.util.AsciiString;
 
 /**
  * A class that provides a Netty handler to control protocol negotiation.
@@ -49,7 +49,7 @@ public interface ProtocolNegotiator {
     /**
      * The HTTP/2 scheme to be used when sending {@code HEADERS}.
      */
-    ByteString scheme();
+    AsciiString scheme();
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -59,7 +59,7 @@ import io.netty.handler.ssl.OpenSslEngine;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
-import io.netty.util.ByteString;
+import io.netty.util.AsciiString;
 
 import java.net.URI;
 import java.util.ArrayDeque;
@@ -108,7 +108,7 @@ public final class ProtocolNegotiators {
           }
 
           @Override
-          public ByteString scheme() {
+          public AsciiString scheme() {
             return Utils.HTTP;
           }
         };
@@ -183,7 +183,7 @@ public final class ProtocolNegotiators {
     }
 
     @Override
-    public ByteString scheme() {
+    public AsciiString scheme() {
       return Utils.HTTPS;
     }
   }
@@ -488,7 +488,7 @@ public final class ProtocolNegotiators {
     }
 
     @Override
-    public ByteString scheme() {
+    public AsciiString scheme() {
       return Utils.HTTPS;
     }
 
@@ -527,7 +527,7 @@ public final class ProtocolNegotiators {
     }
 
     @Override
-    public ByteString scheme() {
+    public AsciiString scheme() {
       return Utils.HTTP;
     }
 
@@ -554,7 +554,7 @@ public final class ProtocolNegotiators {
     }
 
     @Override
-    public ByteString scheme() {
+    public AsciiString scheme() {
       return Utils.HTTP;
     }
 

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -34,6 +34,7 @@ package io.grpc.netty;
 import static io.grpc.internal.GrpcUtil.AUTHORITY_KEY;
 import static io.grpc.internal.GrpcUtil.CONTENT_TYPE_KEY;
 import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
+import static io.netty.util.CharsetUtil.US_ASCII;
 import static io.netty.util.CharsetUtil.UTF_8;
 
 import com.google.common.base.Preconditions;
@@ -47,7 +48,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
-import io.netty.util.ByteString;
+import io.netty.util.AsciiString;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
@@ -62,18 +63,20 @@ import java.util.concurrent.TimeUnit;
  */
 class Utils {
 
-  public static final ByteString STATUS_OK = new ByteString("200".getBytes(UTF_8));
-  public static final ByteString HTTP_METHOD = new ByteString(GrpcUtil.HTTP_METHOD.getBytes(UTF_8));
-  public static final ByteString HTTPS = new ByteString("https".getBytes(UTF_8));
-  public static final ByteString HTTP = new ByteString("http".getBytes(UTF_8));
-  public static final ByteString CONTENT_TYPE_HEADER =
-      new ByteString(CONTENT_TYPE_KEY.name().getBytes(UTF_8));
-  public static final ByteString CONTENT_TYPE_GRPC =
-      new ByteString(GrpcUtil.CONTENT_TYPE_GRPC.getBytes(UTF_8));
-  public static final ByteString TE_HEADER = new ByteString("te".getBytes(UTF_8));
-  public static final ByteString TE_TRAILERS = new ByteString(GrpcUtil.TE_TRAILERS.getBytes(UTF_8));
-  public static final ByteString USER_AGENT =
-      new ByteString(USER_AGENT_KEY.name().getBytes(UTF_8));
+  public static final AsciiString STATUS_OK = new AsciiString("200".getBytes(US_ASCII));
+  public static final AsciiString HTTP_METHOD = new AsciiString(
+          GrpcUtil.HTTP_METHOD.getBytes(US_ASCII));
+  public static final AsciiString HTTPS = new AsciiString("https".getBytes(US_ASCII));
+  public static final AsciiString HTTP = new AsciiString("http".getBytes(US_ASCII));
+  public static final AsciiString CONTENT_TYPE_HEADER =
+      new AsciiString(CONTENT_TYPE_KEY.name().getBytes(US_ASCII));
+  public static final AsciiString CONTENT_TYPE_GRPC =
+      new AsciiString(GrpcUtil.CONTENT_TYPE_GRPC.getBytes(US_ASCII));
+  public static final AsciiString TE_HEADER = new AsciiString("te".getBytes(US_ASCII));
+  public static final AsciiString TE_TRAILERS = new AsciiString(
+          GrpcUtil.TE_TRAILERS.getBytes(US_ASCII));
+  public static final AsciiString USER_AGENT =
+      new AsciiString(USER_AGENT_KEY.name().getBytes(US_ASCII));
 
   public static final Resource<EventLoopGroup> DEFAULT_BOSS_EVENT_LOOP_GROUP =
       new DefaultEventLoopGroupResource(1, "grpc-default-boss-ELG");
@@ -90,17 +93,26 @@ class Utils {
     // arbitrary binary data, not just ASCII.
     byte[][] headerValues = new byte[http2Headers.size() * 2][];
     int i = 0;
-    for (Map.Entry<ByteString, ByteString> entry : http2Headers) {
-      headerValues[i++] = entry.getKey().array();
-      headerValues[i++] = entry.getValue().array();
+    for (Map.Entry<CharSequence, CharSequence> entry : http2Headers) {
+      headerValues[i++] = bytes(entry.getKey());
+      headerValues[i++] = bytes(entry.getValue());
     }
     return TransportFrameUtil.toRawSerializedHeaders(headerValues);
   }
 
+  private static byte[] bytes(CharSequence seq) {
+    if (seq instanceof AsciiString) {
+      // Fast path - no copy.
+      return ((AsciiString) seq).array();
+    }
+    // Slow path - copy.
+    return seq.toString().getBytes(UTF_8);
+  }
+
   public static Http2Headers convertClientHeaders(Metadata headers,
-      ByteString scheme,
-      ByteString defaultPath,
-      ByteString defaultAuthority) {
+      AsciiString scheme,
+      AsciiString defaultPath,
+      AsciiString defaultAuthority) {
     Preconditions.checkNotNull(defaultPath, "defaultPath");
     Preconditions.checkNotNull(defaultAuthority, "defaultAuthority");
     // Add any application-provided headers first.
@@ -116,12 +128,12 @@ class Utils {
 
     // Override the default authority and path if provided by the headers.
     if (headers.containsKey(AUTHORITY_KEY)) {
-      http2Headers.authority(new ByteString(headers.get(AUTHORITY_KEY).getBytes(UTF_8)));
+      http2Headers.authority(new AsciiString(headers.get(AUTHORITY_KEY).getBytes(UTF_8)));
     }
 
     // Set the User-Agent header.
     String userAgent = GrpcUtil.getGrpcUserAgent("netty", headers.get(USER_AGENT_KEY));
-    http2Headers.set(USER_AGENT, new ByteString(userAgent.getBytes(UTF_8)));
+    http2Headers.set(USER_AGENT, new AsciiString(userAgent.getBytes(UTF_8)));
 
     return http2Headers;
   }
@@ -151,8 +163,8 @@ class Utils {
     Http2Headers http2Headers = new DefaultHttp2Headers();
     byte[][] serializedHeaders = TransportFrameUtil.toHttp2Headers(headers);
     for (int i = 0; i < serializedHeaders.length; i += 2) {
-      ByteString name = new ByteString(serializedHeaders[i], false);
-      ByteString value = new ByteString(serializedHeaders[i + 1], false);
+      AsciiString name = new AsciiString(serializedHeaders[i], false);
+      AsciiString value = new AsciiString(serializedHeaders[i + 1], false);
       http2Headers.add(name, value);
     }
 

--- a/netty/src/test/java/io/grpc/netty/BufferingHttp2ConnectionEncoderTest.java
+++ b/netty/src/test/java/io/grpc/netty/BufferingHttp2ConnectionEncoderTest.java
@@ -111,9 +111,10 @@ public class BufferingHttp2ConnectionEncoderTest {
         new DefaultHttp2ConnectionEncoder(connection, writer);
     encoder = new BufferingHttp2ConnectionEncoder(defaultEncoder);
     DefaultHttp2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder,
-        new DefaultHttp2FrameReader(), frameListener);
+        new DefaultHttp2FrameReader());
+    decoder.frameListener(frameListener);
 
-    Http2ConnectionHandler handler = new Http2ConnectionHandler(decoder, encoder);
+    Http2ConnectionHandler handler = new Http2ConnectionHandler.Builder().build(decoder, encoder);
     channel = new EmbeddedChannel(handler);
     ctx = channel.pipeline().context(handler);
   }

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -55,14 +55,12 @@ import static org.mockito.Mockito.when;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.util.AsciiString;
-import io.netty.util.ByteString;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -265,10 +263,10 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     // Set stream id to indicate it has been created
     stream().id(STREAM_ID);
     Http2Headers headers = new DefaultHttp2Headers().status(STATUS_OK).set(CONTENT_TYPE_HEADER,
-            new ByteString("application/bad", UTF_8));
+            new AsciiString("application/bad", UTF_8));
     stream().transportHeadersReceived(headers, false);
     Http2Headers trailers = new DefaultHttp2Headers()
-        .set(new ByteString("grpc-status", UTF_8), new ByteString("0", UTF_8));
+        .set(new AsciiString("grpc-status", UTF_8), new AsciiString("0", UTF_8));
     stream().transportHeadersReceived(trailers, true);
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(listener).closed(captor.capture(), any(Metadata.class));

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -80,7 +80,6 @@ import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.AsciiString;
-import io.netty.util.ByteString;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -278,7 +277,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   public void headersWithInvalidContentTypeShouldFail() throws Exception {
     Http2Headers headers = new DefaultHttp2Headers()
             .method(HTTP_METHOD)
-            .set(CONTENT_TYPE_HEADER, new ByteString("application/bad", UTF_8))
+            .set(CONTENT_TYPE_HEADER, new AsciiString("application/bad", UTF_8))
             .set(TE_HEADER, TE_TRAILERS)
             .path(new AsciiString("/foo/bar"));
     ByteBuf headersFrame = headersFrame(STREAM_ID, headers);


### PR DESCRIPTION
A few things to note:

- ByteString has gone away in favor of AsciiString.

- Http2Headers now uses CharSequence for all methods, so there are a few places that we have to explicitly check for AsciiString to get the optimizations.

- We now have to specify a graceful shutdown timeout for our Netty handlers. Using 5 seconds.