### PR TITLE
Clarify specs for target strings, epecially for IPv6

### DIFF
--- a/core/src/main/java/io/grpc/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/DnsNameResolver.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import com.google.common.base.Preconditions;
+
+import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.SharedResourceHolder;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+
+import javax.annotation.Nullable;
+
+/**
+ * A DNS-based {@link NameResolver}.
+ *
+ * @see DnsNameResolverFactory
+ */
+final class DnsNameResolver extends NameResolver {
+  private final String authority;
+  private final String host;
+  private final int port;
+  private ExecutorService executor;
+
+  DnsNameResolver(@Nullable String nsAuthority, String name, Attributes params) {
+    // TODO: if a DNS server is provided as nsAuthority, use it.
+    // https://www.captechconsulting.com/blogs/accessing-the-dusty-corners-of-dns-with-java
+
+    // Must prepend a "//" to the name when constructing a URI, otherwise it will be treated as an
+    // opaque URI, thus the authority and host of the resulted URI would be null.
+    URI nameUri = URI.create("//" + name);
+    authority = Preconditions.checkNotNull(nameUri.getAuthority(),
+        "nameUri (%s) doesn't have an authority", nameUri);
+    host = Preconditions.checkNotNull(nameUri.getHost(), "host");
+    if (nameUri.getPort() == -1) {
+      Integer defaultPort = params.get(NameResolver.Factory.PARAMS_DEFAULT_PORT);
+      if (defaultPort != null) {
+        port = defaultPort;
+      } else {
+        throw new IllegalArgumentException(
+            "name '" + name + "' doesn't contain a port, and default port is not set in params");
+      }
+    } else {
+      port = nameUri.getPort();
+    }
+  }
+
+  @Override
+  public String getServiceAuthority() {
+    return authority;
+  }
+
+  @Override
+  public synchronized void start(final Listener listener) {
+    Preconditions.checkState(executor == null, "already started");
+    executor = SharedResourceHolder.get(GrpcUtil.SHARED_CHANNEL_EXECUTOR);
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        InetAddress[] inetAddrs;
+        try {
+          inetAddrs = InetAddress.getAllByName(host);
+        } catch (Exception e) {
+          listener.onError(Status.UNAVAILABLE.withCause(e));
+          return;
+        }
+        ArrayList<ResolvedServerInfo> servers
+            = new ArrayList<ResolvedServerInfo>(inetAddrs.length);
+        for (int i = 0; i < inetAddrs.length; i++) {
+          InetAddress inetAddr = inetAddrs[i];
+          servers.add(
+              new ResolvedServerInfo(new InetSocketAddress(inetAddr, port), Attributes.EMPTY));
+        }
+        listener.onUpdate(servers, Attributes.EMPTY);
+      }
+    });
+  }
+
+  @Override
+  public synchronized void shutdown() {
+    if (executor != null) {
+      executor = SharedResourceHolder.release(GrpcUtil.SHARED_CHANNEL_EXECUTOR, executor);
+    }
+  }
+
+  int getPort() {
+    return port;
+  }
+}

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -46,19 +46,22 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
 
   /**
    * Creates a channel with a target string, which can be either a valid {@link
-   * NameResolver}-compliant URI, or a HOST:PORT string.
+   * NameResolver}-compliant URI, or an authority string.
    *
-   * <p>Example {@code NameResolver}-compliant URIs:
+   * <p>A {@code NameResolver}-compliant URI is an aboslute hierarchical URI as defined by {@link
+   * java.net.URI}. Example URIs:
    * <ul>
    *   <li>{@code "dns:///foo.googleapis.com:8080"}</li>
    *   <li>{@code "dns:///foo.googleapis.com"}</li>
+   *   <li>{@code "dns:///%5B2001:db8:85a3:8d3:1319:8a2e:370:7348%5D:443"}</li>
    *   <li>{@code "dns://8.8.8.8/foo.googleapis.com:8080"}</li>
    *   <li>{@code "dns://8.8.8.8/foo.googleapis.com"}</li>
    *   <li>{@code "zookeeper://zk.example.com:9900/example_service"}</li>
    * </ul>
    *
-   * <p>Example HOST:PORT strings, which will be converted to {@code NameResolver}-compliant URIs by
-   * prepending {@code "dns:///"}.
+   * <p>An authority string will be converted to a {@code NameResolver}-compliant URI, which has
+   * {@code "dns"} as the scheme, no authority, and the original authority string as its path after
+   * properly escaped. Example authority strings:
    * <ul>
    *   <li>{@code "localhost"}</li>
    *   <li>{@code "127.0.0.1"}</li>

--- a/core/src/test/java/io/grpc/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/DnsNameResolverTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.URI;
+
+/** Unit tests for {@link DnsNameResolver}. */
+@RunWith(JUnit4.class)
+public class DnsNameResolverTest {
+
+  private DnsNameResolverFactory factory = DnsNameResolverFactory.getInstance();
+
+  private static final int DEFAULT_PORT = 887;
+  private static final Attributes NAME_RESOLVER_PARAMS =
+      Attributes.newBuilder().set(NameResolver.Factory.PARAMS_DEFAULT_PORT, DEFAULT_PORT).build();
+
+  @Test
+  public void invalidDnsName() throws Exception {
+    testInvalidUri(new URI("dns", null, "/[invalid]", null));
+  }
+
+  @Test
+  public void validIpv6() throws Exception {
+    testValidUri(new URI("dns", null, "/[::1]", null), "[::1]", DEFAULT_PORT);
+  }
+
+  @Test
+  public void validDnsNameWithoutPort() throws Exception {
+    testValidUri(new URI("dns", null, "/foo.googleapis.com", null),
+        "foo.googleapis.com", DEFAULT_PORT);
+  }
+
+  @Test
+  public void validDnsNameWithPort() throws Exception {
+    testValidUri(new URI("dns", null, "/foo.googleapis.com:456", null),
+        "foo.googleapis.com:456", 456);
+  }
+
+  private void testInvalidUri(URI uri) {
+    try {
+      factory.newNameResolver(uri, NAME_RESOLVER_PARAMS);
+      fail("Should have failed");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  private void testValidUri(URI uri, String exportedAuthority, int expectedPort) {
+    DnsNameResolver resolver = (DnsNameResolver) factory.newNameResolver(uri, NAME_RESOLVER_PARAMS);
+    assertNotNull(resolver);
+    assertEquals(expectedPort, resolver.getPort());
+    assertEquals(exportedAuthority, resolver.getServiceAuthority());
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import io.grpc.Attributes;
+import io.grpc.NameResolver;
+import io.grpc.NameResolver.Factory;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.URI;
+
+/** Unit tests for {@link ManagedChannelImpl#getNameResolver}. */
+@RunWith(JUnit4.class)
+public class ManagedChannelImplGetNameResolverTest {
+  private static final Attributes NAME_RESOLVER_PARAMS =
+      Attributes.newBuilder().set(NameResolver.Factory.PARAMS_DEFAULT_PORT, 447).build();
+
+  @Test
+  public void invalidUriTarget() {
+    testInvalidTarget("dns:///[invalid]");
+  }
+
+  @Test
+  public void validTargetWithInvalidDnsName() throws Exception {
+    // "dns:///[invalid" is a valid URI target, it's just "[invalid" is not a valid DNS name.  Such
+    // error will be handled by DnsNameResolver (tested in DnsNameResolverTest), but not in
+    // getNameResolver().
+    testValidTarget("[invalid]", new URI("dns", null, "/[invalid]", null));
+  }
+
+  @Test
+  public void validAuthorityTarget() throws Exception {
+    testValidTarget("foo.googleapis.com:8080",
+        new URI("dns", null, "/foo.googleapis.com:8080", null));
+  }
+
+  @Test
+  public void validUriTarget() throws Exception {
+    testValidTarget("scheme:///foo.googleapis.com:8080",
+        new URI("scheme", null, "/foo.googleapis.com:8080", null));
+  }
+
+  @Test
+  public void validIpv4AuthorityTarget() throws Exception {
+    testValidTarget("127.0.0.1:1234", new URI("dns", null, "/127.0.0.1:1234", null));
+  }
+
+  @Test
+  public void validIpv4UriTarget() throws Exception {
+    testValidTarget("dns:///127.0.0.1:1234", new URI("dns", null, "/127.0.0.1:1234", null));
+  }
+
+  @Test
+  public void validIpv6AuthorityTarget() throws Exception {
+    testValidTarget("[::1]:1234", new URI("dns", null, "/[::1]:1234", null));
+  }
+
+  @Test
+  public void invalidIpv6UriTarget() throws Exception {
+    testInvalidTarget("dns:///[::1]:1234");
+  }
+
+  @Test
+  public void validIpv6UriTarget() throws Exception {
+    testValidTarget("dns:///%5B::1%5D:1234", new URI("dns", null, "/[::1]:1234", null));
+  }
+
+  @Test
+  public void validTargetNoResovler() {
+    Factory nameResolverFactory = new NameResolver.Factory() {
+      @Override
+      public NameResolver newNameResolver(URI targetUri, Attributes params) {
+        return null;
+      }
+    };
+    try {
+      ManagedChannelImpl.getNameResolver(
+          "foo.googleapis.com:8080", nameResolverFactory, NAME_RESOLVER_PARAMS);
+      fail("Should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  private void testValidTarget(String target, URI expectedUri) {
+    Factory nameResolverFactory = new FakeNameResolverFactory(expectedUri.getScheme());
+    FakeNameResolver nameResolver = (FakeNameResolver) ManagedChannelImpl.getNameResolver(
+        target, nameResolverFactory, NAME_RESOLVER_PARAMS);
+    assertNotNull(nameResolver);
+    assertEquals(expectedUri, nameResolver.uri);
+  }
+
+  private void testInvalidTarget(String target) {
+    Factory nameResolverFactory = new FakeNameResolverFactory("dns");
+
+    try {
+      FakeNameResolver nameResolver = (FakeNameResolver) ManagedChannelImpl.getNameResolver(
+          target, nameResolverFactory, NAME_RESOLVER_PARAMS);
+      fail("Should have failed, but got resolver with " + nameResolver.uri);
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  private static class FakeNameResolverFactory extends NameResolver.Factory {
+    final String expectedScheme;
+
+    FakeNameResolverFactory(String expectedScheme) {
+      this.expectedScheme = expectedScheme;
+    }
+
+    @Override
+    public NameResolver newNameResolver(URI targetUri, Attributes params) {
+      if (expectedScheme.equals(targetUri.getScheme())) {
+        return new FakeNameResolver(targetUri);
+      }
+      return null;
+    }
+  }
+
+  private static class FakeNameResolver extends NameResolver {
+    final URI uri;
+
+    FakeNameResolver(URI uri) {
+      this.uri = uri;
+    }
+
+    @Override public String getServiceAuthority() {
+      return uri.getAuthority();
+    }
+
+    @Override public void start(final Listener listener) {}
+
+    @Override public void shutdown() {}
+  }
+}


### PR DESCRIPTION
See the javadocs of `ManagedChannelBuilder.forTarget()`.

The most interesting case is passing an IPv6 address as target. It can be either be passed as an authority, where brackets should not be escaped (`[::1]`), or as a path of a full URI, where brackets must be escaped (`dns:///%5B::1%5D`).

Previously, `dns:///[::1]`, being an invalid URI (brackets not allowed in path), would be converted to `dns:////dns:///%5B::1%5D` and passed to DnsNameResolver. Though it would fail eventually, the error would be very confusing to users. I changed the logic so that it would try with `dns:///` only if the target string doesn't look like an intended URI target. 

I have restricted the "URI target" to be absolute and hierarchical, i.e., must start with `scheme://`. I couldn't find a way to better tell if a string is intended to be a URI, but I am open to other options.

Refactored tests (@carl-mastrangelo FYI)
- Move the tests for `getNameResolver()` into a separate file `ManagedChannelImplGetNameResolverTest`, because those tests are not quite compatible with the facility provided by `ManagedChannelImplTest`.
- Create `DnsNameResolverTest`. Move `DnsNameResolver` out of the factory class to accommodate for the test.