### PR TITLE
Expose message compression on Server Call

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingServerCall.java
+++ b/core/src/main/java/io/grpc/ForwardingServerCall.java
@@ -70,6 +70,12 @@ public abstract class ForwardingServerCall<RespT> extends ServerCall<RespT> {
     return delegate().isCancelled();
   }
 
+  @Override
+  @ExperimentalApi
+  public void setMessageCompression(boolean enabled) {
+    delegate().setMessageCompression(enabled);
+  }
+
   /**
    * A simplified version of {@link ForwardingServerCall} where subclasses can pass in a {@link
    * ServerCall} as the delegate.

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -167,4 +167,13 @@ public abstract class ServerCall<RespT> {
    * <p>This method may safely be called concurrently from multiple threads.
    */
   public abstract boolean isCancelled();
+
+  /**
+   * Enables per-message compression, if an encoding type has been negotiated.  If no message
+   * encoding has been negotiated, this is a no-op.
+   */
+  @ExperimentalApi
+  public void setMessageCompression(boolean enabled) {
+    // noop
+  }
 }

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -328,6 +328,11 @@ class InProcessTransport implements ServerTransport, ClientTransport {
         clientStreamListener.closed(status, new Metadata());
         return true;
       }
+
+      @Override
+      public void setMessageCompression(boolean enable) {
+        // noop
+      }
     }
 
     private class InProcessClientStream implements ClientStream {
@@ -441,7 +446,13 @@ class InProcessTransport implements ServerTransport, ClientTransport {
 
       @Override
       public void setDecompressionRegistry(DecompressorRegistry registry) {}
+
+      @Override
+      public void setMessageCompression(boolean enable) {
+        // noop
+      }
     }
+
   }
 
   private static class NoopClientStream implements ClientStream {
@@ -472,5 +483,10 @@ class InProcessTransport implements ServerTransport, ClientTransport {
 
     @Override
     public void setDecompressionRegistry(DecompressorRegistry registry) {}
+
+    @Override
+    public void setMessageCompression(boolean enable) {
+      // noop
+    }
   }
 }

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -88,6 +88,11 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<RespT> {
   }
 
   @Override
+  public void setMessageCompression(boolean enable) {
+    stream.setMessageCompression(enable);
+  }
+
+  @Override
   public boolean isReady() {
     return stream.isReady();
   }

--- a/core/src/main/java/io/grpc/internal/Stream.java
+++ b/core/src/main/java/io/grpc/internal/Stream.java
@@ -86,6 +86,12 @@ public interface Stream {
   void setCompressor(Compressor c);
 
   /**
+   * Enables per-message compression, if an encoding type has been negotiated.  If no message
+   * encoding has been negotiated, this is a no-op.
+   */
+  void setMessageCompression(boolean enable);
+
+  /**
    * Sets the decompressor registry to use when resolving {@link #setDecompressor(String)}.  If
    * unset, the default DecompressorRegistry will be used.
    *

--- a/core/src/test/java/io/grpc/internal/AbstractStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractStreamTest.java
@@ -56,6 +56,9 @@ import javax.annotation.Nullable;
 public class AbstractStreamTest {
   @Mock private StreamListener streamListener;
 
+  @Mock MessageFramer framer;
+  @Mock MessageDeframer deframer;
+
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
@@ -68,6 +71,14 @@ public class AbstractStreamTest {
     stream.onStreamAllocated();
 
     verify(streamListener).onReady();
+  }
+
+  @Test
+  public void setMessageCompression() {
+    AbstractStream<?> as = new AbstractStreamBase<Void>(framer, deframer);
+    as.setMessageCompression(true);
+
+    verify(framer).setMessageCompression(true);
   }
 
   @Test
@@ -104,6 +115,10 @@ public class AbstractStreamTest {
   private class AbstractStreamBase<IdT> extends AbstractStream<IdT> {
     private AbstractStreamBase(WritableBufferAllocator bufferAllocator) {
       super(bufferAllocator, DEFAULT_MAX_MESSAGE_SIZE);
+    }
+
+    private AbstractStreamBase(MessageFramer framer, MessageDeframer deframer) {
+      super(framer, deframer);
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -160,6 +160,12 @@ public class ServerCallImplTest {
     assertTrue(call.isReady());
   }
 
+  @Test
+  public void setMessageCompression() {
+    call.setMessageCompression(true);
+
+    verify(stream).setMessageCompression(true);
+  }
 
   private static class LongMarshaller implements Marshaller<Long> {
     @Override


### PR DESCRIPTION
The general Idea of this PR is to make ServerCall the entry point for setting compression, which all Streams will need to implement.  This moves compression in a slightly different direction, notably:

* Setting compressors and decompressors will no longer be explicit.  It should happen automatically in the stream initialization
* A compressor registry will need to be created, and passed along same ad decompressor registry.
* Compression negotiation should always happen, and a preferred compression should be selected.  This means registries will need to support some idea of ordering between codecs 
* Even if a compression method is selected, by default messages will not be compressed!  This seems to go against the above, but it nicely solves the problem clients not needing to worry that messages are accidentally being compressed when they shouldn't be.  It also fits in nicely with allowing clients to selectively enable compression.  This simplifies negotiation.
* Compression is stateful on the call.  Individual messages need to be compressed, but the sendMessage() function should not be changed or overloaded.
* Looking more long term, this fits well into the possible future of having whole stream compression.  The moniker "messageCompression" is explicit, to indicate that individual messages are compressed.

This change is small, in order to try out the new api and see how to string the values along.  The changes I have listed above will be coming down the pipe.  

@ejona86  && @nmittler 