### PR TITLE
Move the pick-first logic from SimpleLoadBalancer to TransportSet.

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -35,7 +35,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import io.grpc.internal.ClientTransport;
 
-import java.net.SocketAddress;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -83,12 +82,13 @@ public abstract class LoadBalancer {
   /**
    * Called when a transport is fully connected and ready to accept traffic.
    */
-  public void transportReady(SocketAddress addr, ClientTransport transport) { }
+  public void transportReady(EquivalentAddressGroup addressGroup, ClientTransport transport) { }
 
   /**
    * Called when a transport is shutting down.
    */
-  public void transportShutdown(SocketAddress addr, ClientTransport transport, Status s) { }
+  public void transportShutdown(
+      EquivalentAddressGroup addressGroup, ClientTransport transport, Status s) { }
 
   public abstract static class Factory {
     /**

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import io.grpc.Attributes;
+import io.grpc.ClientInterceptor;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.NameResolver;
+import io.grpc.Status;
+import io.grpc.TransportManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Unit tests for {@link ManagedChannelImpl}'s {@link TransportManager} implementation as well as
+ * {@link TransportSet}.
+ */
+@RunWith(JUnit4.class)
+public class ManagedChannelImplTransportManagerTest {
+
+  private static final String authority = "fakeauthority";
+  private static final NameResolver.Factory nameResolverFactory = new NameResolver.Factory() {
+    @Override
+    public NameResolver newNameResolver(final URI targetUri, Attributes params) {
+      return new NameResolver() {
+        @Override public void start(final Listener listener) {
+        }
+
+        @Override public String getServiceAuthority() {
+          return authority;
+        }
+
+        @Override public void shutdown() {
+        }
+      };
+    }
+  };
+
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  private ManagedChannelImpl channel;
+
+  @Mock private ClientTransportFactory mockTransportFactory;
+  @Mock private LoadBalancer.Factory mockLoadBalancerFactory;
+  @Mock private BackoffPolicy.Provider mockBackoffPolicyProvider;
+  @Mock private BackoffPolicy mockBackoffPolicy;
+
+  private TransportManager tm;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    when(mockBackoffPolicyProvider.get()).thenReturn(mockBackoffPolicy);
+    when(mockLoadBalancerFactory.newLoadBalancer(anyString(), any(TransportManager.class)))
+        .thenReturn(mock(LoadBalancer.class));
+
+    channel = new ManagedChannelImpl("fake://target", mockBackoffPolicyProvider,
+        nameResolverFactory, Attributes.EMPTY, mockLoadBalancerFactory,
+        mockTransportFactory, executor, null, Collections.<ClientInterceptor>emptyList());
+
+    ArgumentCaptor<TransportManager> tmCaptor = ArgumentCaptor.forClass(TransportManager.class);
+    verify(mockLoadBalancerFactory).newLoadBalancer(anyString(), tmCaptor.capture());
+    tm = tmCaptor.getValue();
+  }
+
+  @After
+  public void tearDown() {
+    channel.shutdown();
+    executor.shutdown();
+  }
+
+  @Test
+  public void createAndReuseTransport() throws Exception {
+    doAnswer(new Answer<ClientTransport>() {
+      @Override
+      public ClientTransport answer(InvocationOnMock invocation) throws Throwable {
+        return mock(ClientTransport.class);
+      }
+    }).when(mockTransportFactory).newClientTransport(any(SocketAddress.class), any(String.class));
+
+    SocketAddress addr = mock(SocketAddress.class);
+    EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(addr);
+    ListenableFuture<ClientTransport> future1 = tm.getTransport(addressGroup);
+    verify(mockTransportFactory).newClientTransport(addr, authority);
+    ListenableFuture<ClientTransport> future2 = tm.getTransport(addressGroup);
+    assertNotNull(future1.get());
+    assertSame(future1.get(), future2.get());
+    verify(mockBackoffPolicyProvider).get();
+    verify(mockBackoffPolicy, times(0)).nextBackoffMillis();
+    verifyNoMoreInteractions(mockTransportFactory);
+  }
+
+  @Test
+  public void reconnect() throws Exception {
+    SocketAddress addr1 = mock(SocketAddress.class);
+    SocketAddress addr2 = mock(SocketAddress.class);
+    EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(Arrays.asList(addr1, addr2));
+
+    LinkedList<ClientTransport.Listener> listeners =
+        TestUtils.captureListeners(mockTransportFactory);
+
+    // Invocation counters
+    int backoffReset = 0;
+
+    // Pick the first transport
+    ListenableFuture<ClientTransport> future1 = tm.getTransport(addressGroup);
+    assertNotNull(future1.get());
+    verify(mockTransportFactory).newClientTransport(addr1, authority);
+    verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    // Fail the first transport, without setting it to ready
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Subsequent getTransport() will use the next address
+    ListenableFuture<ClientTransport> future2a = tm.getTransport(addressGroup);
+    assertNotNull(future2a.get());
+    // Will keep the previous back-off policy, and not consult back-off policy
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    verify(mockTransportFactory).newClientTransport(addr2, authority);
+    ListenableFuture<ClientTransport> future2b = tm.getTransport(addressGroup);
+    assertSame(future2a.get(), future2b.get());
+    assertNotSame(future1.get(), future2a.get());
+    // Make the second transport ready
+    listeners.peek().transportReady();
+    // Disconnect the second transport
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Subsequent getTransport() will use the next address, which is the first one since we have run
+    // out of addresses.
+    ListenableFuture<ClientTransport> future3 = tm.getTransport(addressGroup);
+    assertNotSame(future1.get(), future3.get());
+    assertNotSame(future2a.get(), future3.get());
+    // This time back-off policy was reset, because previous transport was succesfully connected.
+    verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    // Back-off policy was never consulted.
+    verify(mockBackoffPolicy, times(0)).nextBackoffMillis();
+    verify(mockTransportFactory, times(2)).newClientTransport(addr1, authority);
+    verifyNoMoreInteractions(mockTransportFactory);
+    assertEquals(1, listeners.size());
+  }
+
+  @Test
+  public void reconnectWithBackoff() throws Exception {
+    SocketAddress addr1 = mock(SocketAddress.class);
+    SocketAddress addr2 = mock(SocketAddress.class);
+    EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(Arrays.asList(addr1, addr2));
+
+    LinkedList<ClientTransport.Listener> listeners =
+        TestUtils.captureListeners(mockTransportFactory);
+
+    // Invocation counters
+    int transportsAddr1 = 0;
+    int transportsAddr2 = 0;
+    int backoffConsulted = 0;
+    int backoffReset = 0;
+
+    // First pick succeeds
+    ListenableFuture<ClientTransport> future1 = tm.getTransport(addressGroup);
+    assertNotNull(future1.get());
+    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+    // Back-off policy was set initially.
+    verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    listeners.peek().transportReady();
+    // Then close it
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Second pick fails. This is the beginning of a series of failures.
+    ListenableFuture<ClientTransport> future2 = tm.getTransport(addressGroup);
+    assertNotNull(future2.get());
+    verify(mockTransportFactory, times(++transportsAddr2)).newClientTransport(addr2, authority);
+    // Back-off policy was reset.
+    verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Third pick fails too
+    ListenableFuture<ClientTransport> future3 = tm.getTransport(addressGroup);
+    assertNotNull(future3.get());
+    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+    // Back-off policy was not reset.
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Forth pick is on addr2, back-off policy kicks in.
+    ListenableFuture<ClientTransport> future4 = tm.getTransport(addressGroup);
+    assertNotNull(future4.get());
+    verify(mockTransportFactory, times(++transportsAddr2)).newClientTransport(addr2, authority);
+    // Back-off policy was not reset, but was consulted.
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    verify(mockBackoffPolicy, times(++backoffConsulted)).nextBackoffMillis();
+  }
+
+}

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.Status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.SocketAddress;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for {@link TransportSet}.
+ *
+ * <p>It only tests the logic that is not covered by {@link ManagedChannelImplTransportManagerTest}.
+ */
+@RunWith(JUnit4.class)
+public class TransportSetTest {
+
+  private static final String authority = "fakeauthority";
+
+  private long currentTimeMillis;
+
+  @Mock private LoadBalancer mockLoadBalancer;
+  @Mock private BackoffPolicy mockBackoffPolicy1;
+  @Mock private BackoffPolicy mockBackoffPolicy2;
+  @Mock private BackoffPolicy mockBackoffPolicy3;
+  @Mock private BackoffPolicy.Provider mockBackoffPolicyProvider;
+  @Mock private ClientTransportFactory mockTransportFactory;
+  @Mock private TransportSet.Callback mockTransportSetCallback;
+  @Mock private ScheduledExecutorService mockScheduledExecutorService;
+
+  private final PriorityQueue<Task> tasks = new PriorityQueue<Task>();
+
+  private TransportSet transportSet;
+  private EquivalentAddressGroup addressGroup;
+  private LinkedList<ClientTransport.Listener> listeners;
+
+  @Before public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    when(mockBackoffPolicyProvider.get())
+        .thenReturn(mockBackoffPolicy1, mockBackoffPolicy2, mockBackoffPolicy3);
+    when(mockBackoffPolicy1.nextBackoffMillis()).thenReturn(10L, 100L);
+    when(mockBackoffPolicy2.nextBackoffMillis()).thenReturn(10L, 100L);
+    when(mockBackoffPolicy3.nextBackoffMillis()).thenReturn(10L, 100L);
+    doAnswer(new Answer<ScheduledFuture<?>>() {
+      @Override public ScheduledFuture<?> answer(InvocationOnMock invocation) throws Throwable {
+        Object[] args = invocation.getArguments();
+        Runnable task = (Runnable) args[0];
+        long delay = (Long) args[1];
+        TimeUnit unit = (TimeUnit) args[2];
+        tasks.add(new Task(currentTimeMillis + unit.toMillis(delay), task));
+        return null;
+      }
+    }).when(mockScheduledExecutorService)
+        .schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+    listeners = TestUtils.captureListeners(mockTransportFactory);
+  }
+
+  @Test public void singleAddressBackoff() {
+    SocketAddress addr = mock(SocketAddress.class);
+    createTransortSet(addr);
+
+    // Invocation counters
+    int transportsCreated = 0;
+    int backoff1Consulted = 0;
+    int backoff2Consulted = 0;
+    int backoffReset = 0;
+
+    // First attempt happens immediately (TransportSet aggressively maintains a transport)
+    verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    verify(mockTransportFactory, times(++transportsCreated)).newClientTransport(addr, authority);
+    // Fail this one
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Second attempt uses the first back-off value interval.
+    verify(mockBackoffPolicy1, times(++backoff1Consulted)).nextBackoffMillis();
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    // Transport creation doesn't happen until time is due
+    forwardTime(9);
+    verify(mockTransportFactory, times(transportsCreated)).newClientTransport(addr, authority);
+    forwardTime(1);
+    verify(mockTransportFactory, times(++transportsCreated)).newClientTransport(addr, authority);
+    // Fail this one too
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Third attempt uses the second back-off interval.
+    verify(mockBackoffPolicy1, times(++backoff1Consulted)).nextBackoffMillis();
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    // Transport creation doesn't happen until time is due
+    forwardTime(99);
+    verify(mockTransportFactory, times(transportsCreated)).newClientTransport(addr, authority);
+    forwardTime(1);
+    verify(mockTransportFactory, times(++transportsCreated)).newClientTransport(addr, authority);
+    // Let this one succeed
+    listeners.peek().transportReady();
+    // And close it
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Back-off is reset, and the next attempt will happen immediately
+    verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    verify(mockTransportFactory, times(++transportsCreated)).newClientTransport(addr, authority);
+
+    // Final checks for consultations on back-off policies
+    verify(mockBackoffPolicy1, times(backoff1Consulted)).nextBackoffMillis();
+    verify(mockBackoffPolicy2, times(backoff2Consulted)).nextBackoffMillis();
+  }
+
+  @Test public void twoAddressesBackoff() {
+    SocketAddress addr1 = mock(SocketAddress.class);
+    SocketAddress addr2 = mock(SocketAddress.class);
+    createTransortSet(addr1, addr2);
+
+    // Invocation counters
+    int transportsAddr1 = 0;
+    int transportsAddr2 = 0;
+    int backoff1Consulted = 0;
+    int backoff2Consulted = 0;
+    int backoff3Consulted = 0;
+    int backoffReset = 0;
+
+    // Connection happens immediately (TransportSet aggressively maintains a transport)
+    verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+    // Let this one through
+    listeners.peek().transportReady();
+    // Then shut it down
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+
+    ////// Now start a series of failing attempts, where addr2 is the head.
+    // First attempt after a connection closed. Reset back-off policy.
+    verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    verify(mockTransportFactory, times(++transportsAddr2)).newClientTransport(addr2, authority);
+    // Fail this one
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Second attempt will happen immediately. Keep back-off policy.
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+    // Fail this one too
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Third attempt is on head, thus controlled by the first back-off interval.
+    verify(mockBackoffPolicy2, times(++backoff2Consulted)).nextBackoffMillis();
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    forwardTime(9);
+    verify(mockTransportFactory, times(transportsAddr2)).newClientTransport(addr2, authority);
+    forwardTime(1);
+    verify(mockTransportFactory, times(++transportsAddr2)).newClientTransport(addr2, authority);
+    // Fail this one too
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Forth attempt will happen immediately. Keep back-off policy.
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+    // Fail this one too
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Fifth attempt is on head, thus controlled by the second back-off interval.
+    verify(mockBackoffPolicy2, times(++backoff2Consulted)).nextBackoffMillis();
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    forwardTime(99);
+    verify(mockTransportFactory, times(transportsAddr2)).newClientTransport(addr2, authority);
+    forwardTime(1);
+    verify(mockTransportFactory, times(++transportsAddr2)).newClientTransport(addr2, authority);
+    // Let it through
+    listeners.peek().transportReady();
+    // Then close it.
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+
+    ////// Now start a series of failing attempts, where addr1 is the head.
+    // First attempt after a connection closed. Reset back-off policy.
+    verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+    // Fail this one
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Second attempt will happen immediately. Keep back-off policy.
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    verify(mockTransportFactory, times(++transportsAddr2)).newClientTransport(addr2, authority);
+    // Fail this one too
+    listeners.poll().transportShutdown(Status.UNAVAILABLE);
+
+    // Third attempt is on head, thus controlled by the first back-off interval.
+    verify(mockBackoffPolicy3, times(++backoff3Consulted)).nextBackoffMillis();
+    verify(mockBackoffPolicyProvider, times(backoffReset)).get();
+    forwardTime(9);
+    verify(mockTransportFactory, times(transportsAddr1)).newClientTransport(addr1, authority);
+    forwardTime(1);
+    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+
+    // Final checks on invocations on back-off policies
+    verify(mockBackoffPolicy1, times(backoff1Consulted)).nextBackoffMillis();
+    verify(mockBackoffPolicy2, times(backoff2Consulted)).nextBackoffMillis();
+    verify(mockBackoffPolicy3, times(backoff3Consulted)).nextBackoffMillis();
+  }
+
+  private static class Task implements Comparable<Task> {
+    final long dueTimeMillis;
+    final Runnable command;
+
+    Task(long dueTimeMillis, Runnable command) {
+      this.dueTimeMillis = dueTimeMillis;
+      this.command = command;
+    }
+
+    @Override public int compareTo(Task other) {
+      if (dueTimeMillis < other.dueTimeMillis) {
+        return -1;
+      } else if (dueTimeMillis > other.dueTimeMillis) {
+        return 1;
+      } else {
+        return 0;
+      }
+    }
+  }
+
+  private void runDueTasks() {
+    while (true) {
+      Task task = tasks.peek();
+      if (task == null || task.dueTimeMillis > currentTimeMillis) {
+        break;
+      }
+      tasks.poll();
+      task.command.run();
+    }
+  }
+
+  private void forwardTime(long millis) {
+    currentTimeMillis += millis;
+    runDueTasks();
+  }
+
+  private void createTransortSet(SocketAddress ... addrs) {
+    addressGroup = new EquivalentAddressGroup(Arrays.asList(addrs));
+    transportSet = new TransportSet(addressGroup, authority, mockLoadBalancer,
+        mockBackoffPolicyProvider, mockTransportFactory, mockScheduledExecutorService,
+        mockTransportSetCallback);
+  }
+}


### PR DESCRIPTION
`TransportSet` (as well as `TransportManager`) accepts a group of equivalent addresses (`EquivalentAddressGroup`) instead of a single address. `TransportSet` will move down the address list when reconnecting, and thus the back-off is applied across all the addresses, instead of on each
address individually.

Main benefits:
- It will stop channel from trying to reconnect addresses that have been failed to connect to and moved away from. (#1212)
- It will make future implementation of Happy Eyeballs possible, inside TransportSet.

Tested in `ManagedChannelImplTransportManagerTest`