### PR TITLE
Map IOException during connecting to UNAVAILABLE

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -300,7 +300,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   protected void onConnectionError(ChannelHandlerContext ctx, Throwable cause,
       Http2Exception http2Ex) {
     logger.log(Level.FINE, "Caught a connection error", cause);
-    goAwayStatus(statusFromError(cause));
+    goAwayStatus(Utils.statusFromThrowable(cause));
     super.onConnectionError(ctx, cause, http2Ex);
   }
 
@@ -310,16 +310,11 @@ class NettyClientHandler extends AbstractNettyHandler {
     // Close the stream with a status that contains the cause.
     NettyClientStream stream = clientStream(connection().stream(http2Ex.streamId()));
     if (stream != null) {
-      stream.transportReportStatus(statusFromError(cause), false, new Metadata());
+      stream.transportReportStatus(Utils.statusFromThrowable(cause), false, new Metadata());
     }
 
     // Delegate to the base class to send a RST_STREAM.
     super.onStreamError(ctx, cause, http2Ex);
-  }
-
-  private Status statusFromError(Throwable cause) {
-    return cause instanceof Http2Exception ? Status.INTERNAL.withCause(cause)
-        : Status.fromThrowable(cause);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -127,7 +127,7 @@ class NettyClientTransport implements ClientTransport {
       public void operationComplete(ChannelFuture future) throws Exception {
         if (!future.isSuccess()) {
           // Stream creation failed. Close the stream if not already closed.
-          stream.transportReportStatus(Status.fromThrowable(future.cause()), true,
+          stream.transportReportStatus(Utils.statusFromThrowable(future.cause()), true,
                   new Metadata());
         }
       }
@@ -184,7 +184,7 @@ class NettyClientTransport implements ClientTransport {
         if (!future.isSuccess()) {
           // Need to notify of this failure, because handler.connectionError() is not guaranteed to
           // have seen this cause.
-          notifyTerminated(Status.fromThrowable(future.cause()));
+          notifyTerminated(Utils.statusFromThrowable(future.cause()));
         }
       }
     });

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -249,8 +249,7 @@ class NettyServerHandler extends AbstractNettyHandler {
         connection().stream(Http2Exception.streamId(http2Ex)));
     if (serverStream != null) {
       // Abort the stream with a status to help the client with debugging.
-      serverStream.abortStream(cause instanceof Http2Exception
-          ? Status.INTERNAL.withCause(cause) : Status.fromThrowable(cause), true);
+      serverStream.abortStream(Utils.statusFromThrowable(cause), true);
     } else {
       // Delegate to the base class to send a RST_STREAM.
       super.onStreamError(ctx, cause, http2Ex);

--- a/netty/src/test/java/io/grpc/netty/UtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/UtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import io.grpc.Status;
+import io.netty.channel.ConnectTimeoutException;
+import io.netty.handler.codec.http2.Http2Error;
+import io.netty.handler.codec.http2.Http2Exception;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Utils}. */
+@RunWith(JUnit4.class)
+public class UtilsTest {
+  @Test
+  public void testStatusFromThrowable() {
+    Status s = Status.CANCELLED.withDescription("msg");
+    assertSame(s, Utils.statusFromThrowable(new Exception(s.asException())));
+    Throwable t;
+    t = new ConnectTimeoutException("msg");
+    assertStatusEquals(Status.UNAVAILABLE.withCause(t), Utils.statusFromThrowable(t));
+    t = new Http2Exception(Http2Error.INTERNAL_ERROR, "msg");
+    assertStatusEquals(Status.INTERNAL.withCause(t), Utils.statusFromThrowable(t));
+    t = new Exception("msg");
+    assertStatusEquals(Status.UNKNOWN.withCause(t), Utils.statusFromThrowable(t));
+  }
+
+  private static void assertStatusEquals(Status expected, Status actual) {
+    assertEquals(expected.getCode(), actual.getCode());
+    assertEquals(expected.getDescription(), actual.getDescription());
+    assertEquals(expected.getCause(), actual.getCause());
+  }
+}


### PR DESCRIPTION
This isn't expected to have much impact once the connection is
established because AbstractNettyHandler.exceptionCaught() wraps all
unknown exceptions with Http2Exception. Fixing that is future work.

Some cases we may now be unwrapping a StatusException, such as one
thrown by MessageDeframer. In general, that seems a Good Thing™, but it
is unclear exactly if it would be perceivable.

Fixes #1181