### PR TITLE
Reduce advertised Netty API

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -50,6 +50,7 @@ import java.util.Set;
 /**
  * Utility for configuring SslContext for gRPC.
  */
+@ExperimentalApi("Only needed with experimental builders")
 public class GrpcSslContexts {
   private GrpcSslContexts() {}
 

--- a/netty/src/main/java/io/grpc/netty/NegotiationType.java
+++ b/netty/src/main/java/io/grpc/netty/NegotiationType.java
@@ -31,9 +31,12 @@
 
 package io.grpc.netty;
 
+import io.grpc.ExperimentalApi;
+
 /**
  * Identifies the negotiation used for starting up HTTP/2.
  */
+@ExperimentalApi("Only used by experimental builders")
 public enum NegotiationType {
   /**
    * Uses TLS ALPN/NPN negotiation, assumes an SSL connection.

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -59,7 +59,7 @@ import javax.annotation.Nullable;
 /**
  * Netty-based server implementation.
  */
-public class NettyServer implements Server {
+class NettyServer implements Server {
   private static final Logger log = Logger.getLogger(Server.class.getName());
 
   private final SocketAddress address;


### PR DESCRIPTION
NettyServer wasn't usable as public, since its constructor was
package-private. So although this reduces our API, it shouldn't actually
impact anyone.

Fixes #1047