### PR TITLE
Remove double-"brew update" as now unnecessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ env:
 before_install:
     # Work around https://github.com/travis-ci/travis-ci/issues/2317
   - if \[ "$TRAVIS_OS_NAME" = linux \]; then jdk_switcher use oraclejdk8; fi
-    # Update twice to work around https://github.com/Homebrew/homebrew/issues/45616
-  - if \[ "$TRAVIS_OS_NAME" = osx \]; then brew update || brew update; fi
+  - if \[ "$TRAVIS_OS_NAME" = osx \]; then brew update; fi
   - buildscripts/make_dependencies.sh # build protoc into /tmp/protobuf-${PROTOBUF_VERSION}
   - mkdir -p $HOME/.gradle
   - echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties


### PR DESCRIPTION
The issue is closed and our latest runs on Travis are only needing to
run brew update once.