### PR TITLE
Remove outdated and misleading JavaDoc

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -75,8 +75,6 @@ public abstract class ClientCall<ReqT, RespT> {
 
     /**
      * The response headers have been received. Headers always precede messages.
-     * This method is always called, if no headers were received then an empty {@link Metadata}
-     * is passed.
      *
      * @param headers containing metadata sent by the server at the start of the response.
      */

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -169,9 +169,6 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
       callExecutor.execute(new ContextRunnable(context) {
         @Override
         public void runInContext() {
-          // Must call onHeaders per API contract
-          observer.onHeaders(new Metadata());
-          // then notify of immediate closure.
           observer.onClose(Status.CANCELLED.withCause(context.cause()), new Metadata());
         }
       });

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -414,21 +414,9 @@ public class ClientCallImplTest {
 
     final SettableFuture<Status> statusFuture = SettableFuture.create();
     call.start(new ClientCall.Listener<Void>() {
-      boolean headersCalled;
-      @Override
-      public void onHeaders(Metadata headers) {
-        headersCalled = true;
-      }
-
       @Override
       public void onClose(Status status, Metadata trailers) {
-        if (headersCalled) {
-          statusFuture.set(status);
-        } else {
-          statusFuture.setException(
-              new AssertionError("Headers must be called before close"));
-        }
-
+        statusFuture.set(status);
       }
     }, new Metadata());
 


### PR DESCRIPTION
"onHeaders always is called" is from the initial gRPC design where
0-many context frames were sent before the first message. That is why it
was possible for "no headers were received". That has long-since not
been true, but in the various refactorings this language was
accidentally left. The language "Headers always precede messages" is
correct since headers are only guaranteed if messages were sent.