### PR TITLE
Call ClientStreamListener directly from current thread

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -196,7 +196,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
     }
     if (stream == null) {
       DelayedStream delayed;
-      stream = delayed = new DelayedStream(listener, callExecutor);
+      stream = delayed = new DelayedStream(listener);
       addListener(transportFuture,
           new StreamCreationTask(delayed, headers, method, callOptions, listener));
     }

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -43,7 +43,6 @@ import io.grpc.Status;
 import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.Executor;
 
 import javax.annotation.concurrent.GuardedBy;
 
@@ -56,8 +55,6 @@ import javax.annotation.concurrent.GuardedBy;
  * necessary.
  */
 class DelayedStream implements ClientStream {
-  private final Executor callExecutor;
-
   private final ClientStreamListener listener;
 
   private final Object lock = new Object();
@@ -93,11 +90,8 @@ class DelayedStream implements ClientStream {
     }
   }
 
-  DelayedStream(
-      ClientStreamListener listener,
-      Executor callExecutor) {
+  DelayedStream(ClientStreamListener listener) {
     this.listener = listener;
-    this.callExecutor = callExecutor;
   }
 
   /**
@@ -143,12 +137,7 @@ class DelayedStream implements ClientStream {
     synchronized (lock) {
       if (realStream == null) {
         realStream = NOOP_CLIENT_STREAM;
-        callExecutor.execute(new Runnable() {
-          @Override
-          public void run() {
-            listener.closed(reason, new Metadata());
-          }
-        });
+        listener.closed(reason, new Metadata());
       }
     }
   }

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -36,8 +36,6 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.util.concurrent.MoreExecutors;
-
 import io.grpc.Codec;
 import io.grpc.DecompressorRegistry;
 import io.grpc.IntegerMarshaller;
@@ -59,7 +57,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.concurrent.Executor;
 
 /**
  * Tests for {@link DelayedStream}.  Most of the state checking is enforced by
@@ -67,8 +64,6 @@ import java.util.concurrent.Executor;
  */
 @RunWith(JUnit4.class)
 public class DelayedStreamTest {
-  private static final Executor executor = MoreExecutors.directExecutor();
-
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Mock private ClientStreamListener listener;
@@ -85,7 +80,7 @@ public class DelayedStreamTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
 
-    stream = new DelayedStream(listener, executor);
+    stream = new DelayedStream(listener);
   }
 
   @Test


### PR DESCRIPTION
ClientStreamListener is intended to be called directly from the
transport, so it is safe to hold locks during the call and run on the
network thread.