### PR TITLE
Don't leak streams and avoid creating cancelled streams

### DIFF
--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -448,6 +448,16 @@ public class ClientCallImplTest {
   }
 
   @Test
+  public void streamCreationTask_alreadyCancelled() {
+    StreamCreationTask task = new StreamCreationTask(
+        delayedStream, new Metadata(), method, CallOptions.DEFAULT, streamListener);
+
+    when(delayedStream.cancelledPrematurely()).thenReturn(true);
+    task.onSuccess(clientTransport);
+    verifyZeroInteractions(clientTransport);
+  }
+
+  @Test
   public void streamCreationTask_transportShutdown() {
     StreamCreationTask task = new StreamCreationTask(
         delayedStream, new Metadata(), method, CallOptions.DEFAULT, streamListener);

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -150,10 +150,9 @@ public class DelayedStreamTest {
   @Test
   public void streamCancelled() {
     stream.cancel(Status.CANCELLED);
-
-    // Should be a no op, and not fail due to transport not returning a newStream
-    stream.setStream(realStream);
-
     verify(listener).closed(eq(Status.CANCELLED), isA(Metadata.class));
+
+    thrown.expect(IllegalStateException.class);
+    stream.setStream(realStream);
   }
 }


### PR DESCRIPTION
There is an inherent race with setStream since the application may be
calling cancel() in another thread. We fix the race with proper locking,
but also avoid creating a to-be-cancelled stream since there is a large
window between creating the transportFuture and it being completed.