### PR TITLE
Move default scheme decision from ManagedChannelImpl to NameResolverFactory.

### DIFF
--- a/core/src/main/java/io/grpc/DnsNameResolverFactory.java
+++ b/core/src/main/java/io/grpc/DnsNameResolverFactory.java
@@ -53,11 +53,12 @@ import java.net.URI;
 @ExperimentalApi
 public final class DnsNameResolverFactory extends NameResolver.Factory {
 
+  private static final String SCHEME = "dns";
   private static final DnsNameResolverFactory instance = new DnsNameResolverFactory();
 
   @Override
   public NameResolver newNameResolver(URI targetUri, Attributes params) {
-    if ("dns".equals(targetUri.getScheme())) {
+    if (SCHEME.equals(targetUri.getScheme())) {
       String targetPath = Preconditions.checkNotNull(targetUri.getPath(), "targetPath");
       Preconditions.checkArgument(targetPath.startsWith("/"),
           "the path component (%s) of the target (%s) must start with '/'", targetPath, targetUri);
@@ -66,6 +67,11 @@ public final class DnsNameResolverFactory extends NameResolver.Factory {
     } else {
       return null;
     }
+  }
+
+  @Override
+  public String getDefaultScheme() {
+    return SCHEME;
   }
 
   private DnsNameResolverFactory() {

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -87,6 +87,13 @@ public abstract class NameResolver {
      */
     @Nullable
     public abstract NameResolver newNameResolver(URI targetUri, Attributes params);
+
+    /**
+     * Returns the default scheme, which will be used to construct a URI when {@link
+     * ManagedChannelBuilder#forTarget(String)} is given an authority string instead of a compliant
+     * URI.
+     */
+    public abstract String getDefaultScheme();
   }
 
   /**

--- a/core/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/core/src/main/java/io/grpc/NameResolverRegistry.java
@@ -31,6 +31,8 @@
 
 package io.grpc;
 
+import com.google.common.base.Preconditions;
+
 import java.net.URI;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -43,21 +45,22 @@ import javax.annotation.concurrent.ThreadSafe;
 @ExperimentalApi
 @ThreadSafe
 public final class NameResolverRegistry extends NameResolver.Factory {
-  private static final NameResolverRegistry defaultRegistry = new NameResolverRegistry();
+  private static final NameResolverRegistry defaultRegistry =
+      new NameResolverRegistry(DnsNameResolverFactory.getInstance());
 
   private final CopyOnWriteArrayList<NameResolver.Factory> registry =
       new CopyOnWriteArrayList<NameResolver.Factory>();
 
-  private NameResolverRegistry() {
-    // To prevent instantiation
-  }
-
-  static {
-    defaultRegistry.register(DnsNameResolverFactory.getInstance());
-  }
-
   public static NameResolverRegistry getDefaultRegistry() {
     return defaultRegistry;
+  }
+
+  private final String defaultScheme;
+
+  private NameResolverRegistry(NameResolver.Factory defaultResolverFactory) {
+    register(defaultResolverFactory);
+    defaultScheme = Preconditions.checkNotNull(
+        defaultResolverFactory.getDefaultScheme(), "defaultScheme");
   }
 
   /**
@@ -82,5 +85,10 @@ public final class NameResolverRegistry extends NameResolver.Factory {
       }
     }
     return null;
+  }
+
+  @Override
+  public String getDefaultScheme() {
+    return defaultScheme;
   }
 }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -65,6 +65,7 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractManagedChannelImplBuilder
         <T extends AbstractManagedChannelImplBuilder<T>> extends ManagedChannelBuilder<T> {
+  private static final String DIRECT_ADDRESS_SCHEME = "directaddress";
 
   @Nullable
   private Executor executor;
@@ -99,7 +100,7 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   protected AbstractManagedChannelImplBuilder(SocketAddress directServerAddress, String authority) {
-    this.target = "directaddress:///" + directServerAddress;
+    this.target = DIRECT_ADDRESS_SCHEME + ":///" + directServerAddress;
     this.directServerAddress = directServerAddress;
     this.nameResolverFactory = new DirectAddressNameResolverFactory(directServerAddress, authority);
   }
@@ -279,6 +280,11 @@ public abstract class AbstractManagedChannelImplBuilder
         @Override
         public void shutdown() {}
       };
+    }
+
+    @Override
+    public String getDefaultScheme() {
+      return DIRECT_ADDRESS_SCHEME;
     }
   }
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -215,9 +215,10 @@ public final class ManagedChannelImpl extends ManagedChannel {
 
     // If we reached here, the targetUri couldn't be used.
     if (!URI_PATTERN.matcher(target).matches()) {
-      // It doesn't look like a URI target. Maybe it's a DNS name.
+      // It doesn't look like a URI target. Maybe it's an authority string. Try with the default
+      // scheme from the factory.
       try {
-        targetUri = new URI("dns", null, "/" + target, null);
+        targetUri = new URI(nameResolverFactory.getDefaultScheme(), null, "/" + target, null);
       } catch (URISyntaxException e) {
         // Should not be possible.
         throw new IllegalArgumentException(e);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -53,21 +53,18 @@ public class ManagedChannelImplGetNameResolverTest {
 
   @Test
   public void invalidUriTarget() {
-    testInvalidTarget("dns:///[invalid]");
+    testInvalidTarget("defaultscheme:///[invalid]");
   }
 
   @Test
   public void validTargetWithInvalidDnsName() throws Exception {
-    // "dns:///[invalid" is a valid URI target, it's just "[invalid" is not a valid DNS name.  Such
-    // error will be handled by DnsNameResolver (tested in DnsNameResolverTest), but not in
-    // getNameResolver().
-    testValidTarget("[invalid]", new URI("dns", null, "/[invalid]", null));
+    testValidTarget("[valid]", new URI("defaultscheme", null, "/[valid]", null));
   }
 
   @Test
   public void validAuthorityTarget() throws Exception {
     testValidTarget("foo.googleapis.com:8080",
-        new URI("dns", null, "/foo.googleapis.com:8080", null));
+        new URI("defaultscheme", null, "/foo.googleapis.com:8080", null));
   }
 
   @Test
@@ -78,7 +75,7 @@ public class ManagedChannelImplGetNameResolverTest {
 
   @Test
   public void validIpv4AuthorityTarget() throws Exception {
-    testValidTarget("127.0.0.1:1234", new URI("dns", null, "/127.0.0.1:1234", null));
+    testValidTarget("127.0.0.1:1234", new URI("defaultscheme", null, "/127.0.0.1:1234", null));
   }
 
   @Test
@@ -88,7 +85,7 @@ public class ManagedChannelImplGetNameResolverTest {
 
   @Test
   public void validIpv6AuthorityTarget() throws Exception {
-    testValidTarget("[::1]:1234", new URI("dns", null, "/[::1]:1234", null));
+    testValidTarget("[::1]:1234", new URI("defaultscheme", null, "/[::1]:1234", null));
   }
 
   @Test
@@ -107,6 +104,11 @@ public class ManagedChannelImplGetNameResolverTest {
       @Override
       public NameResolver newNameResolver(URI targetUri, Attributes params) {
         return null;
+      }
+
+      @Override
+      public String getDefaultScheme() {
+        return "defaultscheme";
       }
     };
     try {
@@ -151,6 +153,11 @@ public class ManagedChannelImplGetNameResolverTest {
         return new FakeNameResolver(targetUri);
       }
       return null;
+    }
+
+    @Override
+    public String getDefaultScheme() {
+      return expectedScheme;
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -434,6 +434,11 @@ public class ManagedChannelImplTest {
       return resolver;
     }
 
+    @Override
+    public String getDefaultScheme() {
+      return "fake";
+    }
+
     void allResolved() {
       for (FakeNameResolver resolver : resolvers) {
         resolver.resolved();
@@ -485,6 +490,11 @@ public class ManagedChannelImplTest {
 
         @Override public void shutdown() {}
       };
+    }
+
+    @Override
+    public String getDefaultScheme() {
+      return "fake";
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -98,6 +98,11 @@ public class ManagedChannelImplTransportManagerTest {
         }
       };
     }
+
+    @Override
+    public String getDefaultScheme() {
+      return "fake";
+    }
   };
 
   private final ExecutorService executor = Executors.newSingleThreadExecutor();


### PR DESCRIPTION
This makes it possible to use an alternative default scheme other than "dns" by installing a custom `NameResolver.Factory` to the channel builder.