### PR TITLE
Use getClassLoader() instead of Thread.currentThread().getContextClas…

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
@@ -47,16 +47,6 @@ public class OkHttpChannelProvider extends ManagedChannelProvider {
     return isAndroid() ? 8 : 3;
   }
 
-  private static boolean isAndroid() {
-    try {
-      Class.forName("android.app.Application", /*initialize=*/ false, null);
-      return true;
-    } catch (Exception e) {
-      // If Application isn't loaded, it might as well not be Android.
-      return false;
-    }
-  }
-
   @Override
   protected OkHttpChannelBuilder builderForAddress(String name, int port) {
     return OkHttpChannelBuilder.forAddress(name, port);


### PR DESCRIPTION
…sLoader() for android.

See #1272 for more details.

Fixes #1272.

@ejona86 Please take a look, thanks!