### PR TITLE
Check that zero length messages don't get the compression bit set.

### DIFF
--- a/core/src/test/java/io/grpc/internal/AbstractStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractStreamTest.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
 import io.grpc.internal.AbstractStream.Phase;
+import io.grpc.internal.MessageFramerTest.ByteWritableBuffer;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -58,6 +59,13 @@ public class AbstractStreamTest {
 
   @Mock MessageFramer framer;
   @Mock MessageDeframer deframer;
+
+  private final WritableBufferAllocator allocator = new WritableBufferAllocator() {
+    @Override
+    public WritableBuffer allocate(int capacityHint) {
+      return new ByteWritableBuffer(capacityHint);
+    }
+  };
 
   @Before
   public void setUp() {
@@ -114,7 +122,7 @@ public class AbstractStreamTest {
    */
   private class AbstractStreamBase<IdT> extends AbstractStream<IdT> {
     private AbstractStreamBase(WritableBufferAllocator bufferAllocator) {
-      super(bufferAllocator, DEFAULT_MAX_MESSAGE_SIZE);
+      super(allocator, DEFAULT_MAX_MESSAGE_SIZE);
     }
 
     private AbstractStreamBase(MessageFramer framer, MessageDeframer deframer) {


### PR DESCRIPTION
This also changes the error messages from the framer is a StatusException.  This mirrors what the deframer does on failure.  The benefit of this is that errors in the encoding process show up as a more specific error.  For example, Nano proto throws a message-less NPE if a proto field isn't set.  