### PR TITLE
Cancel the transport future when the call is cancelled.

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -55,6 +55,10 @@ public abstract class LoadBalancer {
   /**
    * Pick a transport that Channel will use for next RPC.
    *
+   * <p>If the caller gives up before the futrue is done, it should call either {@code cancel(true)}
+   * or {@code cancel(false)} (they have the same effect) on the future to avoid leaking of
+   * resources.
+   *
    * @param requestKey for affinity-based routing
    */
   public abstract ListenableFuture<ClientTransport> pickTransport(

--- a/core/src/main/java/io/grpc/TransportManager.java
+++ b/core/src/main/java/io/grpc/TransportManager.java
@@ -52,6 +52,8 @@ public abstract class TransportManager {
    * Returns the future of a transport for any of the addresses from the given address group.
    *
    * <p>If the channel has been shut down, the value of the future will be {@code null}.
+   *
+   * <p>Cancelling the returned future has no effect.
    */
   // TODO(zhangkun83): GrpcLoadBalancer will use this to get transport to connect to LB servers,
   // which would have a different authority than the primary servers. We need to figure out how to

--- a/core/src/main/java/io/grpc/internal/ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ClientStream.java
@@ -44,7 +44,7 @@ public interface ClientStream extends Stream {
    * Abnormally terminates the stream. After calling this method, no further messages will be
    * sent or received, however it may still be possible to receive buffered messages for a brief
    * period until {@link ClientStreamListener#closed} is called. This method is safe to be called
-   * at any time and multiple times.
+   * at any time and multiple times and from any thread.
    *
    * @param reason must have {@link io.grpc.Status.Code#CANCELLED},
    *     {@link io.grpc.Status.Code#DEADLINE_EXCEEDED}, {@link io.grpc.Status.Code#INTERNAL},

--- a/core/src/test/java/io/grpc/internal/BlankFutureProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/BlankFutureProviderTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import io.grpc.internal.BlankFutureProvider.FulfillmentBatch;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+
+/** Unit tests for {@link BlankFutureProvider}. */
+@RunWith(JUnit4.class)
+public class BlankFutureProviderTest {
+
+  private final BlankFutureProvider<String> provider = new BlankFutureProvider<String>();
+
+  @Test public void fulfillWithFinishedFutures() throws Exception {
+    ListenableFuture<String> f1 = provider.newBlankFuture();
+    ListenableFuture<String> f2 = provider.newBlankFuture();
+    FulfillmentBatch<String> batch = provider.createFulfillmentBatch();
+    ListenableFuture<String> f3 = provider.newBlankFuture();
+    batch.link(new Supplier<ListenableFuture<String>>() {
+      int index;
+      @Override public ListenableFuture<String> get() {
+        return Futures.immediateFuture("value" + (index++));
+      }
+    });
+    assertTrue(f1.isDone());
+    assertTrue(f2.isDone());
+    assertNotEquals(f1.get(), f2.get());
+    assertTrue(f1.get().startsWith("value"));
+    assertTrue(f2.get().startsWith("value"));
+    assertFalse(f3.isDone());
+  }
+
+  @Test public void fulfillWithLaterSuccessfulFutures() throws Exception {
+    ListenableFuture<String> f1 = provider.newBlankFuture();
+    ListenableFuture<String> f2 = provider.newBlankFuture();
+    FulfillmentBatch<String> batch = provider.createFulfillmentBatch();
+    ListenableFuture<String> f3 = provider.newBlankFuture();
+    final ArrayList<SettableFuture<String>> fulfillingFutures =
+        new ArrayList<SettableFuture<String>>();
+    batch.link(new Supplier<ListenableFuture<String>>() {
+      @Override public ListenableFuture<String> get() {
+        SettableFuture<String> future = SettableFuture.create();
+        fulfillingFutures.add(future);
+        return future;
+      }
+    });
+    assertFalse(f1.isDone());
+    assertFalse(f2.isDone());
+    for (int i = 0; i < fulfillingFutures.size(); i++) {
+      fulfillingFutures.get(i).set("value" + i);
+    }
+    assertNotEquals(f1.get(), f2.get());
+    assertTrue(f1.get().startsWith("value"));
+    assertTrue(f2.get().startsWith("value"));
+    assertFalse(f3.isDone());
+  }
+
+  @Test public void fulfillWithLaterFailedFutures() throws Exception {
+    ListenableFuture<String> f1 = provider.newBlankFuture();
+    ListenableFuture<String> f2 = provider.newBlankFuture();
+    FulfillmentBatch<String> batch = provider.createFulfillmentBatch();
+    ListenableFuture<String> f3 = provider.newBlankFuture();
+    final ArrayList<SettableFuture<String>> fulfillingFutures =
+        new ArrayList<SettableFuture<String>>();
+    batch.link(new Supplier<ListenableFuture<String>>() {
+      @Override public ListenableFuture<String> get() {
+        SettableFuture<String> future = SettableFuture.create();
+        fulfillingFutures.add(future);
+        return future;
+      }
+    });
+    assertFalse(f1.isDone());
+    assertFalse(f2.isDone());
+    for (int i = 0; i < fulfillingFutures.size(); i++) {
+      fulfillingFutures.get(i).setException(new Exception("simulated" + i));
+    }
+    assertTrue(f1.isDone());
+    assertTrue(f2.isDone());
+    Throwable e1 = null;
+    Throwable e2 = null;
+    try {
+      f1.get();
+      fail("Should have thrown");
+    } catch (ExecutionException e) {
+      e1 = e.getCause();
+    }
+    try {
+      f2.get();
+      fail("Should have thrown");
+    } catch (ExecutionException e) {
+      e2 = e.getCause();
+    }
+    assertNotEquals(e1.getMessage(), e2.getMessage());
+    assertTrue(e1.getMessage().startsWith("simulated"));
+    assertTrue(e2.getMessage().startsWith("simulated"));
+    assertFalse(f3.isDone());
+  }
+
+  @Test public void fulfillWithError() throws Exception {
+    ListenableFuture<String> f1 = provider.newBlankFuture();
+    ListenableFuture<String> f2 = provider.newBlankFuture();
+    FulfillmentBatch<String> batch = provider.createFulfillmentBatch();
+    ListenableFuture<String> f3 = provider.newBlankFuture();
+    Exception error = new Exception("simulated");
+    batch.fail(error);
+    assertTrue(f1.isDone());
+    assertTrue(f2.isDone());
+    Throwable e1 = null;
+    Throwable e2 = null;
+    try {
+      f1.get();
+      fail("Should have thrown");
+    } catch (ExecutionException e) {
+      e1 = e.getCause();
+    }
+    try {
+      f2.get();
+      fail("Should have thrown");
+    } catch (ExecutionException e) {
+      e2 = e.getCause();
+    }
+    assertSame(error, e1);
+    assertSame(error, e2);
+    assertFalse(f3.isDone());
+  }
+
+  @Test public void cancellingFutureRemovesItFromSet() {
+    SettableFuture<String> f1 = (SettableFuture<String>) provider.newBlankFuture();
+    SettableFuture<String> f2 = (SettableFuture<String>) provider.newBlankFuture();
+    assertTrue(provider.getBlankFutureSet().contains(f1));
+    assertTrue(provider.getBlankFutureSet().contains(f2));
+    f1.cancel(false);
+    assertTrue(f1.isCancelled());
+    assertFalse(provider.getBlankFutureSet().contains(f1));
+    assertTrue(provider.getBlankFutureSet().contains(f2));
+    assertFalse(f2.isDone());
+  }
+}

--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.Ticker;
+import com.google.common.util.concurrent.AbstractFuture;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A manipulated clock that exports a {@link Ticker} and a {@link ScheduledExecutorService}.
+ */
+final class FakeClock {
+
+  final ScheduledExecutorService scheduledExecutorService = new ScheduledExecutorImpl();
+  final Ticker ticker = new Ticker() {
+      @Override public long read() {
+        return TimeUnit.MILLISECONDS.toNanos(currentTimeNanos);
+      }
+    };
+
+  private final PriorityQueue<ScheduledTask> tasks = new PriorityQueue<ScheduledTask>();
+  private long currentTimeNanos;
+
+  private class ScheduledTask extends AbstractFuture<Void> implements ScheduledFuture<Void> {
+    final Runnable command;
+    final long dueTimeNanos;
+
+    ScheduledTask(long dueTimeNanos, Runnable command) {
+      this.dueTimeNanos = dueTimeNanos;
+      this.command = command;
+    }
+
+    @Override public boolean cancel(boolean mayInterruptIfRunning) {
+      tasks.remove(this);
+      return super.cancel(mayInterruptIfRunning);
+    }
+
+    @Override public long getDelay(TimeUnit unit) {
+      return unit.convert(dueTimeNanos - currentTimeNanos, TimeUnit.NANOSECONDS);
+    }
+
+    @Override public int compareTo(Delayed other) {
+      ScheduledTask otherTask = (ScheduledTask) other;
+      if (dueTimeNanos > otherTask.dueTimeNanos) {
+        return 1;
+      } else if (dueTimeNanos < otherTask.dueTimeNanos) {
+        return -1;
+      } else {
+        return 0;
+      }
+    }
+
+    void complete() {
+      set(null);
+    }
+  }
+
+  private class ScheduledExecutorImpl implements ScheduledExecutorService {
+    @Override public <V> ScheduledFuture<V> schedule(
+        Callable<V> callable, long delay, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public ScheduledFuture<?> schedule(Runnable cmd, long delay, TimeUnit unit) {
+      ScheduledTask task = new ScheduledTask(currentTimeNanos + unit.toNanos(delay), cmd);
+      tasks.add(task);
+      return task;
+    }
+
+    @Override public ScheduledFuture<?> scheduleAtFixedRate(
+        Runnable command, long initialDelay, long period, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public ScheduledFuture<?> scheduleWithFixedDelay(
+        Runnable command, long initialDelay, long delay, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public boolean awaitTermination(long timeout, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public <T> List<Future<T>> invokeAll(
+        Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public <T> T invokeAny(Collection<? extends Callable<T>> tasks) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public <T> T invokeAny(
+        Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public boolean isShutdown() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public boolean isTerminated() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public void shutdown() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public List<Runnable> shutdownNow() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public <T> Future<T> submit(Callable<T> task) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public Future<?> submit(Runnable task) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public <T> Future<T> submit(Runnable task, T result) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public void execute(Runnable command) {
+      command.run();
+    }
+  }
+
+  private void runDueTasks() {
+    while (true) {
+      ScheduledTask task = tasks.peek();
+      if (task == null || task.dueTimeNanos > currentTimeNanos) {
+        break;
+      }
+      tasks.poll();
+      task.command.run();
+      task.complete();
+    }
+  }
+
+  void forwardTime(long value, TimeUnit unit) {
+    currentTimeNanos += unit.toNanos(value);
+    runDueTasks();
+  }
+
+  void forwardMillis(long millis) {
+    forwardTime(millis, TimeUnit.MILLISECONDS);
+  }
+}


### PR DESCRIPTION
This is to prevent leaking future objects in BlankFutureProvider.
Resolves #1188