### PR TITLE
Propagate headers/trailers if response isn't gRPC

### DIFF
--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -245,11 +245,15 @@ public class AbstractClientStreamTest {
     stream.start(mockListener);
     Metadata headers = new Metadata();
     headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, "bad");
+    Metadata.Key<String> randomKey = Metadata.Key.of("random", Metadata.ASCII_STRING_MARSHALLER);
+    headers.put(randomKey, "4");
 
     stream.inboundHeadersReceived(headers);
 
-    verify(mockListener).closed(statusCaptor.capture(), isA(Metadata.class));
+    ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass(Metadata.class);
+    verify(mockListener).closed(statusCaptor.capture(), metadataCaptor.capture());
     assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
+    assertEquals("4", metadataCaptor.getValue().get(randomKey));
   }
 
   @Test


### PR DESCRIPTION
This provides more structured data into the application for it to do
special handling.

In general, we would hope most people don't need this functionality, but
it is a good escape hatch to allow users to workaround infrastructure
problems.

I do think there needs to be some discussion on whether we think this is
a good idea, since currently we are only delivering metadata if it was sent
from a gRPC client/server.