### PR TITLE
Fix issues discovered by internal GRPCLB integration test.

### DIFF
--- a/core/src/main/java/io/grpc/internal/SingleTransportChannel.java
+++ b/core/src/main/java/io/grpc/internal/SingleTransportChannel.java
@@ -41,6 +41,9 @@ import io.grpc.ClientCall;
 import io.grpc.MethodDescriptor;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -53,6 +56,8 @@ public final class SingleTransportChannel extends Channel {
   private final Executor executor;
   private final String authority;
   private final ScheduledExecutorService deadlineCancellationExecutor;
+  private final Set<String> knownAcceptEncodingRegistry =
+      Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
   private final ClientTransportProvider transportProvider = new ClientTransportProvider() {
     @Override
@@ -78,7 +83,7 @@ public final class SingleTransportChannel extends Channel {
       MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
     return new ClientCallImpl<RequestT, ResponseT>(methodDescriptor,
         new SerializingExecutor(executor), callOptions, transportProvider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor).setKnownMessageEncodingRegistry(knownAcceptEncodingRegistry);
   }
 
   @Override

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -18,7 +18,7 @@ public class LoadBalancerGrpc {
 
   private LoadBalancerGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.lb.v1.LoadBalancer";
+  public static final String SERVICE_NAME = "loadbalancer_gslb.client.grpc.LoadBalancer";
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi
@@ -27,7 +27,7 @@ public class LoadBalancerGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
-              "grpc.lb.v1.LoadBalancer", "BalanceLoad"),
+              "loadbalancer_gslb.client.grpc.LoadBalancer", "BalanceLoad"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.grpclb.LoadBalanceRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.grpclb.LoadBalanceResponse.getDefaultInstance()));
 

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/ClientStats.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/ClientStats.java
@@ -4,7 +4,7 @@
 package io.grpc.grpclb;
 
 /**
- * Protobuf type {@code grpc.lb.v1.ClientStats}
+ * Protobuf type {@code loadbalancer_gslb.client.grpc.ClientStats}
  *
  * <pre>
  * Contains client level statistics that are useful to load balancing. Each
@@ -13,7 +13,7 @@ package io.grpc.grpclb;
  */
 public  final class ClientStats extends
     com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:grpc.lb.v1.ClientStats)
+    // @@protoc_insertion_point(message_implements:loadbalancer_gslb.client.grpc.ClientStats)
     ClientStatsOrBuilder {
   // Use ClientStats.newBuilder() to construct.
   private ClientStats(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -78,12 +78,12 @@ public  final class ClientStats extends
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ClientStats_descriptor;
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ClientStats_descriptor;
   }
 
   protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ClientStats_fieldAccessorTable
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ClientStats_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             io.grpc.grpclb.ClientStats.class, io.grpc.grpclb.ClientStats.Builder.class);
   }
@@ -244,7 +244,7 @@ public  final class ClientStats extends
     return builder;
   }
   /**
-   * Protobuf type {@code grpc.lb.v1.ClientStats}
+   * Protobuf type {@code loadbalancer_gslb.client.grpc.ClientStats}
    *
    * <pre>
    * Contains client level statistics that are useful to load balancing. Each
@@ -253,16 +253,16 @@ public  final class ClientStats extends
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:grpc.lb.v1.ClientStats)
+      // @@protoc_insertion_point(builder_implements:loadbalancer_gslb.client.grpc.ClientStats)
       io.grpc.grpclb.ClientStatsOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ClientStats_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ClientStats_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ClientStats_fieldAccessorTable
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ClientStats_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.grpclb.ClientStats.class, io.grpc.grpclb.ClientStats.Builder.class);
     }
@@ -294,7 +294,7 @@ public  final class ClientStats extends
 
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ClientStats_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ClientStats_descriptor;
     }
 
     public io.grpc.grpclb.ClientStats getDefaultInstanceForType() {
@@ -488,10 +488,10 @@ public  final class ClientStats extends
     }
 
 
-    // @@protoc_insertion_point(builder_scope:grpc.lb.v1.ClientStats)
+    // @@protoc_insertion_point(builder_scope:loadbalancer_gslb.client.grpc.ClientStats)
   }
 
-  // @@protoc_insertion_point(class_scope:grpc.lb.v1.ClientStats)
+  // @@protoc_insertion_point(class_scope:loadbalancer_gslb.client.grpc.ClientStats)
   private static final io.grpc.grpclb.ClientStats DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new io.grpc.grpclb.ClientStats();

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/ClientStatsOrBuilder.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/ClientStatsOrBuilder.java
@@ -4,7 +4,7 @@
 package io.grpc.grpclb;
 
 public interface ClientStatsOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:grpc.lb.v1.ClientStats)
+    // @@protoc_insertion_point(interface_extends:loadbalancer_gslb.client.grpc.ClientStats)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/InitialLoadBalanceRequest.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/InitialLoadBalanceRequest.java
@@ -4,11 +4,11 @@
 package io.grpc.grpclb;
 
 /**
- * Protobuf type {@code grpc.lb.v1.InitialLoadBalanceRequest}
+ * Protobuf type {@code loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest}
  */
 public  final class InitialLoadBalanceRequest extends
     com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:grpc.lb.v1.InitialLoadBalanceRequest)
+    // @@protoc_insertion_point(message_implements:loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest)
     InitialLoadBalanceRequestOrBuilder {
   // Use InitialLoadBalanceRequest.newBuilder() to construct.
   private InitialLoadBalanceRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -62,12 +62,12 @@ public  final class InitialLoadBalanceRequest extends
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceRequest_descriptor;
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_descriptor;
   }
 
   protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceRequest_fieldAccessorTable
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             io.grpc.grpclb.InitialLoadBalanceRequest.class, io.grpc.grpclb.InitialLoadBalanceRequest.Builder.class);
   }
@@ -216,20 +216,20 @@ public  final class InitialLoadBalanceRequest extends
     return builder;
   }
   /**
-   * Protobuf type {@code grpc.lb.v1.InitialLoadBalanceRequest}
+   * Protobuf type {@code loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:grpc.lb.v1.InitialLoadBalanceRequest)
+      // @@protoc_insertion_point(builder_implements:loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest)
       io.grpc.grpclb.InitialLoadBalanceRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceRequest_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceRequest_fieldAccessorTable
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.grpclb.InitialLoadBalanceRequest.class, io.grpc.grpclb.InitialLoadBalanceRequest.Builder.class);
     }
@@ -257,7 +257,7 @@ public  final class InitialLoadBalanceRequest extends
 
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceRequest_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_descriptor;
     }
 
     public io.grpc.grpclb.InitialLoadBalanceRequest getDefaultInstanceForType() {
@@ -419,10 +419,10 @@ public  final class InitialLoadBalanceRequest extends
     }
 
 
-    // @@protoc_insertion_point(builder_scope:grpc.lb.v1.InitialLoadBalanceRequest)
+    // @@protoc_insertion_point(builder_scope:loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:grpc.lb.v1.InitialLoadBalanceRequest)
+  // @@protoc_insertion_point(class_scope:loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest)
   private static final io.grpc.grpclb.InitialLoadBalanceRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new io.grpc.grpclb.InitialLoadBalanceRequest();

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/InitialLoadBalanceRequestOrBuilder.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/InitialLoadBalanceRequestOrBuilder.java
@@ -4,7 +4,7 @@
 package io.grpc.grpclb;
 
 public interface InitialLoadBalanceRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:grpc.lb.v1.InitialLoadBalanceRequest)
+    // @@protoc_insertion_point(interface_extends:loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/InitialLoadBalanceResponse.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/InitialLoadBalanceResponse.java
@@ -4,11 +4,11 @@
 package io.grpc.grpclb;
 
 /**
- * Protobuf type {@code grpc.lb.v1.InitialLoadBalanceResponse}
+ * Protobuf type {@code loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse}
  */
 public  final class InitialLoadBalanceResponse extends
     com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:grpc.lb.v1.InitialLoadBalanceResponse)
+    // @@protoc_insertion_point(message_implements:loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse)
     InitialLoadBalanceResponseOrBuilder {
   // Use InitialLoadBalanceResponse.newBuilder() to construct.
   private InitialLoadBalanceResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -74,12 +74,12 @@ public  final class InitialLoadBalanceResponse extends
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceResponse_descriptor;
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_descriptor;
   }
 
   protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceResponse_fieldAccessorTable
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             io.grpc.grpclb.InitialLoadBalanceResponse.class, io.grpc.grpclb.InitialLoadBalanceResponse.Builder.class);
   }
@@ -318,20 +318,20 @@ public  final class InitialLoadBalanceResponse extends
     return builder;
   }
   /**
-   * Protobuf type {@code grpc.lb.v1.InitialLoadBalanceResponse}
+   * Protobuf type {@code loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:grpc.lb.v1.InitialLoadBalanceResponse)
+      // @@protoc_insertion_point(builder_implements:loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse)
       io.grpc.grpclb.InitialLoadBalanceResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceResponse_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceResponse_fieldAccessorTable
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.grpclb.InitialLoadBalanceResponse.class, io.grpc.grpclb.InitialLoadBalanceResponse.Builder.class);
     }
@@ -365,7 +365,7 @@ public  final class InitialLoadBalanceResponse extends
 
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_InitialLoadBalanceResponse_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_descriptor;
     }
 
     public io.grpc.grpclb.InitialLoadBalanceResponse getDefaultInstanceForType() {
@@ -757,10 +757,10 @@ public  final class InitialLoadBalanceResponse extends
     }
 
 
-    // @@protoc_insertion_point(builder_scope:grpc.lb.v1.InitialLoadBalanceResponse)
+    // @@protoc_insertion_point(builder_scope:loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:grpc.lb.v1.InitialLoadBalanceResponse)
+  // @@protoc_insertion_point(class_scope:loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse)
   private static final io.grpc.grpclb.InitialLoadBalanceResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new io.grpc.grpclb.InitialLoadBalanceResponse();

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/InitialLoadBalanceResponseOrBuilder.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/InitialLoadBalanceResponseOrBuilder.java
@@ -4,7 +4,7 @@
 package io.grpc.grpclb;
 
 public interface InitialLoadBalanceResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:grpc.lb.v1.InitialLoadBalanceResponse)
+    // @@protoc_insertion_point(interface_extends:loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalanceRequest.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalanceRequest.java
@@ -4,11 +4,11 @@
 package io.grpc.grpclb;
 
 /**
- * Protobuf type {@code grpc.lb.v1.LoadBalanceRequest}
+ * Protobuf type {@code loadbalancer_gslb.client.grpc.LoadBalanceRequest}
  */
 public  final class LoadBalanceRequest extends
     com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:grpc.lb.v1.LoadBalanceRequest)
+    // @@protoc_insertion_point(message_implements:loadbalancer_gslb.client.grpc.LoadBalanceRequest)
     LoadBalanceRequestOrBuilder {
   // Use LoadBalanceRequest.newBuilder() to construct.
   private LoadBalanceRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -83,12 +83,12 @@ public  final class LoadBalanceRequest extends
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceRequest_descriptor;
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_descriptor;
   }
 
   protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceRequest_fieldAccessorTable
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             io.grpc.grpclb.LoadBalanceRequest.class, io.grpc.grpclb.LoadBalanceRequest.Builder.class);
   }
@@ -126,7 +126,7 @@ public  final class LoadBalanceRequest extends
 
   public static final int INITIAL_REQUEST_FIELD_NUMBER = 1;
   /**
-   * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
    *
    * <pre>
    * This message should be sent on the first request to the load balancer.
@@ -139,7 +139,7 @@ public  final class LoadBalanceRequest extends
     return io.grpc.grpclb.InitialLoadBalanceRequest.getDefaultInstance();
   }
   /**
-   * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
    *
    * <pre>
    * This message should be sent on the first request to the load balancer.
@@ -154,7 +154,7 @@ public  final class LoadBalanceRequest extends
 
   public static final int CLIENT_STATS_FIELD_NUMBER = 2;
   /**
-   * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
    *
    * <pre>
    * The client stats should be periodically reported to the load balancer
@@ -168,7 +168,7 @@ public  final class LoadBalanceRequest extends
     return io.grpc.grpclb.ClientStats.getDefaultInstance();
   }
   /**
-   * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
    *
    * <pre>
    * The client stats should be periodically reported to the load balancer
@@ -292,20 +292,20 @@ public  final class LoadBalanceRequest extends
     return builder;
   }
   /**
-   * Protobuf type {@code grpc.lb.v1.LoadBalanceRequest}
+   * Protobuf type {@code loadbalancer_gslb.client.grpc.LoadBalanceRequest}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:grpc.lb.v1.LoadBalanceRequest)
+      // @@protoc_insertion_point(builder_implements:loadbalancer_gslb.client.grpc.LoadBalanceRequest)
       io.grpc.grpclb.LoadBalanceRequestOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceRequest_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceRequest_fieldAccessorTable
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.grpclb.LoadBalanceRequest.class, io.grpc.grpclb.LoadBalanceRequest.Builder.class);
     }
@@ -333,7 +333,7 @@ public  final class LoadBalanceRequest extends
 
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceRequest_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_descriptor;
     }
 
     public io.grpc.grpclb.LoadBalanceRequest getDefaultInstanceForType() {
@@ -437,7 +437,7 @@ public  final class LoadBalanceRequest extends
     private com.google.protobuf.SingleFieldBuilder<
         io.grpc.grpclb.InitialLoadBalanceRequest, io.grpc.grpclb.InitialLoadBalanceRequest.Builder, io.grpc.grpclb.InitialLoadBalanceRequestOrBuilder> initialRequestBuilder_;
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
      *
      * <pre>
      * This message should be sent on the first request to the load balancer.
@@ -457,7 +457,7 @@ public  final class LoadBalanceRequest extends
       }
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
      *
      * <pre>
      * This message should be sent on the first request to the load balancer.
@@ -477,7 +477,7 @@ public  final class LoadBalanceRequest extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
      *
      * <pre>
      * This message should be sent on the first request to the load balancer.
@@ -495,7 +495,7 @@ public  final class LoadBalanceRequest extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
      *
      * <pre>
      * This message should be sent on the first request to the load balancer.
@@ -521,7 +521,7 @@ public  final class LoadBalanceRequest extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
      *
      * <pre>
      * This message should be sent on the first request to the load balancer.
@@ -544,7 +544,7 @@ public  final class LoadBalanceRequest extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
      *
      * <pre>
      * This message should be sent on the first request to the load balancer.
@@ -554,7 +554,7 @@ public  final class LoadBalanceRequest extends
       return getInitialRequestFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
      *
      * <pre>
      * This message should be sent on the first request to the load balancer.
@@ -571,7 +571,7 @@ public  final class LoadBalanceRequest extends
       }
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
      *
      * <pre>
      * This message should be sent on the first request to the load balancer.
@@ -599,7 +599,7 @@ public  final class LoadBalanceRequest extends
     private com.google.protobuf.SingleFieldBuilder<
         io.grpc.grpclb.ClientStats, io.grpc.grpclb.ClientStats.Builder, io.grpc.grpclb.ClientStatsOrBuilder> clientStatsBuilder_;
     /**
-     * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
      *
      * <pre>
      * The client stats should be periodically reported to the load balancer
@@ -620,7 +620,7 @@ public  final class LoadBalanceRequest extends
       }
     }
     /**
-     * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
      *
      * <pre>
      * The client stats should be periodically reported to the load balancer
@@ -641,7 +641,7 @@ public  final class LoadBalanceRequest extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
      *
      * <pre>
      * The client stats should be periodically reported to the load balancer
@@ -660,7 +660,7 @@ public  final class LoadBalanceRequest extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
      *
      * <pre>
      * The client stats should be periodically reported to the load balancer
@@ -687,7 +687,7 @@ public  final class LoadBalanceRequest extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
      *
      * <pre>
      * The client stats should be periodically reported to the load balancer
@@ -711,7 +711,7 @@ public  final class LoadBalanceRequest extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
      *
      * <pre>
      * The client stats should be periodically reported to the load balancer
@@ -722,7 +722,7 @@ public  final class LoadBalanceRequest extends
       return getClientStatsFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
      *
      * <pre>
      * The client stats should be periodically reported to the load balancer
@@ -740,7 +740,7 @@ public  final class LoadBalanceRequest extends
       }
     }
     /**
-     * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
      *
      * <pre>
      * The client stats should be periodically reported to the load balancer
@@ -776,10 +776,10 @@ public  final class LoadBalanceRequest extends
     }
 
 
-    // @@protoc_insertion_point(builder_scope:grpc.lb.v1.LoadBalanceRequest)
+    // @@protoc_insertion_point(builder_scope:loadbalancer_gslb.client.grpc.LoadBalanceRequest)
   }
 
-  // @@protoc_insertion_point(class_scope:grpc.lb.v1.LoadBalanceRequest)
+  // @@protoc_insertion_point(class_scope:loadbalancer_gslb.client.grpc.LoadBalanceRequest)
   private static final io.grpc.grpclb.LoadBalanceRequest DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new io.grpc.grpclb.LoadBalanceRequest();

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalanceRequestOrBuilder.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalanceRequestOrBuilder.java
@@ -4,11 +4,11 @@
 package io.grpc.grpclb;
 
 public interface LoadBalanceRequestOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:grpc.lb.v1.LoadBalanceRequest)
+    // @@protoc_insertion_point(interface_extends:loadbalancer_gslb.client.grpc.LoadBalanceRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
    *
    * <pre>
    * This message should be sent on the first request to the load balancer.
@@ -16,7 +16,7 @@ public interface LoadBalanceRequestOrBuilder extends
    */
   io.grpc.grpclb.InitialLoadBalanceRequest getInitialRequest();
   /**
-   * <code>optional .grpc.lb.v1.InitialLoadBalanceRequest initial_request = 1;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceRequest initial_request = 1;</code>
    *
    * <pre>
    * This message should be sent on the first request to the load balancer.
@@ -25,7 +25,7 @@ public interface LoadBalanceRequestOrBuilder extends
   io.grpc.grpclb.InitialLoadBalanceRequestOrBuilder getInitialRequestOrBuilder();
 
   /**
-   * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
    *
    * <pre>
    * The client stats should be periodically reported to the load balancer
@@ -34,7 +34,7 @@ public interface LoadBalanceRequestOrBuilder extends
    */
   io.grpc.grpclb.ClientStats getClientStats();
   /**
-   * <code>optional .grpc.lb.v1.ClientStats client_stats = 2;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.ClientStats client_stats = 2;</code>
    *
    * <pre>
    * The client stats should be periodically reported to the load balancer

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalanceResponse.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalanceResponse.java
@@ -4,11 +4,11 @@
 package io.grpc.grpclb;
 
 /**
- * Protobuf type {@code grpc.lb.v1.LoadBalanceResponse}
+ * Protobuf type {@code loadbalancer_gslb.client.grpc.LoadBalanceResponse}
  */
 public  final class LoadBalanceResponse extends
     com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:grpc.lb.v1.LoadBalanceResponse)
+    // @@protoc_insertion_point(message_implements:loadbalancer_gslb.client.grpc.LoadBalanceResponse)
     LoadBalanceResponseOrBuilder {
   // Use LoadBalanceResponse.newBuilder() to construct.
   private LoadBalanceResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -83,12 +83,12 @@ public  final class LoadBalanceResponse extends
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceResponse_descriptor;
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_descriptor;
   }
 
   protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceResponse_fieldAccessorTable
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             io.grpc.grpclb.LoadBalanceResponse.class, io.grpc.grpclb.LoadBalanceResponse.Builder.class);
   }
@@ -126,7 +126,7 @@ public  final class LoadBalanceResponse extends
 
   public static final int INITIAL_RESPONSE_FIELD_NUMBER = 1;
   /**
-   * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
    *
    * <pre>
    * This message should be sent on the first response to the client.
@@ -139,7 +139,7 @@ public  final class LoadBalanceResponse extends
     return io.grpc.grpclb.InitialLoadBalanceResponse.getDefaultInstance();
   }
   /**
-   * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
    *
    * <pre>
    * This message should be sent on the first response to the client.
@@ -154,7 +154,7 @@ public  final class LoadBalanceResponse extends
 
   public static final int SERVER_LIST_FIELD_NUMBER = 2;
   /**
-   * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
    *
    * <pre>
    * Contains the list of servers selected by the load balancer. The client
@@ -168,7 +168,7 @@ public  final class LoadBalanceResponse extends
     return io.grpc.grpclb.ServerList.getDefaultInstance();
   }
   /**
-   * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
    *
    * <pre>
    * Contains the list of servers selected by the load balancer. The client
@@ -292,20 +292,20 @@ public  final class LoadBalanceResponse extends
     return builder;
   }
   /**
-   * Protobuf type {@code grpc.lb.v1.LoadBalanceResponse}
+   * Protobuf type {@code loadbalancer_gslb.client.grpc.LoadBalanceResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:grpc.lb.v1.LoadBalanceResponse)
+      // @@protoc_insertion_point(builder_implements:loadbalancer_gslb.client.grpc.LoadBalanceResponse)
       io.grpc.grpclb.LoadBalanceResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceResponse_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceResponse_fieldAccessorTable
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.grpclb.LoadBalanceResponse.class, io.grpc.grpclb.LoadBalanceResponse.Builder.class);
     }
@@ -333,7 +333,7 @@ public  final class LoadBalanceResponse extends
 
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_LoadBalanceResponse_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_descriptor;
     }
 
     public io.grpc.grpclb.LoadBalanceResponse getDefaultInstanceForType() {
@@ -437,7 +437,7 @@ public  final class LoadBalanceResponse extends
     private com.google.protobuf.SingleFieldBuilder<
         io.grpc.grpclb.InitialLoadBalanceResponse, io.grpc.grpclb.InitialLoadBalanceResponse.Builder, io.grpc.grpclb.InitialLoadBalanceResponseOrBuilder> initialResponseBuilder_;
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
      *
      * <pre>
      * This message should be sent on the first response to the client.
@@ -457,7 +457,7 @@ public  final class LoadBalanceResponse extends
       }
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
      *
      * <pre>
      * This message should be sent on the first response to the client.
@@ -477,7 +477,7 @@ public  final class LoadBalanceResponse extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
      *
      * <pre>
      * This message should be sent on the first response to the client.
@@ -495,7 +495,7 @@ public  final class LoadBalanceResponse extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
      *
      * <pre>
      * This message should be sent on the first response to the client.
@@ -521,7 +521,7 @@ public  final class LoadBalanceResponse extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
      *
      * <pre>
      * This message should be sent on the first response to the client.
@@ -544,7 +544,7 @@ public  final class LoadBalanceResponse extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
      *
      * <pre>
      * This message should be sent on the first response to the client.
@@ -554,7 +554,7 @@ public  final class LoadBalanceResponse extends
       return getInitialResponseFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
      *
      * <pre>
      * This message should be sent on the first response to the client.
@@ -571,7 +571,7 @@ public  final class LoadBalanceResponse extends
       }
     }
     /**
-     * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
      *
      * <pre>
      * This message should be sent on the first response to the client.
@@ -599,7 +599,7 @@ public  final class LoadBalanceResponse extends
     private com.google.protobuf.SingleFieldBuilder<
         io.grpc.grpclb.ServerList, io.grpc.grpclb.ServerList.Builder, io.grpc.grpclb.ServerListOrBuilder> serverListBuilder_;
     /**
-     * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
      *
      * <pre>
      * Contains the list of servers selected by the load balancer. The client
@@ -620,7 +620,7 @@ public  final class LoadBalanceResponse extends
       }
     }
     /**
-     * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
      *
      * <pre>
      * Contains the list of servers selected by the load balancer. The client
@@ -641,7 +641,7 @@ public  final class LoadBalanceResponse extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
      *
      * <pre>
      * Contains the list of servers selected by the load balancer. The client
@@ -660,7 +660,7 @@ public  final class LoadBalanceResponse extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
      *
      * <pre>
      * Contains the list of servers selected by the load balancer. The client
@@ -687,7 +687,7 @@ public  final class LoadBalanceResponse extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
      *
      * <pre>
      * Contains the list of servers selected by the load balancer. The client
@@ -711,7 +711,7 @@ public  final class LoadBalanceResponse extends
       return this;
     }
     /**
-     * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
      *
      * <pre>
      * Contains the list of servers selected by the load balancer. The client
@@ -722,7 +722,7 @@ public  final class LoadBalanceResponse extends
       return getServerListFieldBuilder().getBuilder();
     }
     /**
-     * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
      *
      * <pre>
      * Contains the list of servers selected by the load balancer. The client
@@ -740,7 +740,7 @@ public  final class LoadBalanceResponse extends
       }
     }
     /**
-     * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+     * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
      *
      * <pre>
      * Contains the list of servers selected by the load balancer. The client
@@ -776,10 +776,10 @@ public  final class LoadBalanceResponse extends
     }
 
 
-    // @@protoc_insertion_point(builder_scope:grpc.lb.v1.LoadBalanceResponse)
+    // @@protoc_insertion_point(builder_scope:loadbalancer_gslb.client.grpc.LoadBalanceResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:grpc.lb.v1.LoadBalanceResponse)
+  // @@protoc_insertion_point(class_scope:loadbalancer_gslb.client.grpc.LoadBalanceResponse)
   private static final io.grpc.grpclb.LoadBalanceResponse DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new io.grpc.grpclb.LoadBalanceResponse();

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalanceResponseOrBuilder.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalanceResponseOrBuilder.java
@@ -4,11 +4,11 @@
 package io.grpc.grpclb;
 
 public interface LoadBalanceResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:grpc.lb.v1.LoadBalanceResponse)
+    // @@protoc_insertion_point(interface_extends:loadbalancer_gslb.client.grpc.LoadBalanceResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
    *
    * <pre>
    * This message should be sent on the first response to the client.
@@ -16,7 +16,7 @@ public interface LoadBalanceResponseOrBuilder extends
    */
   io.grpc.grpclb.InitialLoadBalanceResponse getInitialResponse();
   /**
-   * <code>optional .grpc.lb.v1.InitialLoadBalanceResponse initial_response = 1;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.InitialLoadBalanceResponse initial_response = 1;</code>
    *
    * <pre>
    * This message should be sent on the first response to the client.
@@ -25,7 +25,7 @@ public interface LoadBalanceResponseOrBuilder extends
   io.grpc.grpclb.InitialLoadBalanceResponseOrBuilder getInitialResponseOrBuilder();
 
   /**
-   * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
    *
    * <pre>
    * Contains the list of servers selected by the load balancer. The client
@@ -34,7 +34,7 @@ public interface LoadBalanceResponseOrBuilder extends
    */
   io.grpc.grpclb.ServerList getServerList();
   /**
-   * <code>optional .grpc.lb.v1.ServerList server_list = 2;</code>
+   * <code>optional .loadbalancer_gslb.client.grpc.ServerList server_list = 2;</code>
    *
    * <pre>
    * Contains the list of servers selected by the load balancer. The client

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalancerProto.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/LoadBalancerProto.java
@@ -9,40 +9,40 @@ public final class LoadBalancerProto {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_lb_v1_LoadBalanceRequest_descriptor;
+    internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_descriptor;
   static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_lb_v1_LoadBalanceRequest_fieldAccessorTable;
+      internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_fieldAccessorTable;
   static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_lb_v1_InitialLoadBalanceRequest_descriptor;
+    internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_descriptor;
   static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_lb_v1_InitialLoadBalanceRequest_fieldAccessorTable;
+      internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_fieldAccessorTable;
   static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_lb_v1_ClientStats_descriptor;
+    internal_static_loadbalancer_gslb_client_grpc_ClientStats_descriptor;
   static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_lb_v1_ClientStats_fieldAccessorTable;
+      internal_static_loadbalancer_gslb_client_grpc_ClientStats_fieldAccessorTable;
   static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_lb_v1_LoadBalanceResponse_descriptor;
+    internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_descriptor;
   static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_lb_v1_LoadBalanceResponse_fieldAccessorTable;
+      internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_fieldAccessorTable;
   static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_lb_v1_InitialLoadBalanceResponse_descriptor;
+    internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_descriptor;
   static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_lb_v1_InitialLoadBalanceResponse_fieldAccessorTable;
+      internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_fieldAccessorTable;
   static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_lb_v1_ServerList_descriptor;
+    internal_static_loadbalancer_gslb_client_grpc_ServerList_descriptor;
   static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_lb_v1_ServerList_fieldAccessorTable;
+      internal_static_loadbalancer_gslb_client_grpc_ServerList_fieldAccessorTable;
   static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_lb_v1_Server_descriptor;
+    internal_static_loadbalancer_gslb_client_grpc_Server_descriptor;
   static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_lb_v1_Server_fieldAccessorTable;
+      internal_static_loadbalancer_gslb_client_grpc_Server_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -52,32 +52,36 @@ public final class LoadBalancerProto {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\023load_balancer.proto\022\ngrpc.lb.v1\032\036googl" +
-      "e/protobuf/duration.proto\"\244\001\n\022LoadBalanc" +
-      "eRequest\022@\n\017initial_request\030\001 \001(\0132%.grpc" +
-      ".lb.v1.InitialLoadBalanceRequestH\000\022/\n\014cl" +
-      "ient_stats\030\002 \001(\0132\027.grpc.lb.v1.ClientStat" +
-      "sH\000B\033\n\031load_balance_request_type\")\n\031Init" +
-      "ialLoadBalanceRequest\022\014\n\004name\030\001 \001(\t\"Z\n\013C" +
-      "lientStats\022\026\n\016total_requests\030\001 \001(\003\022\031\n\021cl" +
-      "ient_rpc_errors\030\002 \001(\003\022\030\n\020dropped_request" +
-      "s\030\003 \001(\003\"\246\001\n\023LoadBalanceResponse\022B\n\020initi",
-      "al_response\030\001 \001(\0132&.grpc.lb.v1.InitialLo" +
-      "adBalanceResponseH\000\022-\n\013server_list\030\002 \001(\013" +
-      "2\026.grpc.lb.v1.ServerListH\000B\034\n\032load_balan" +
-      "ce_response_type\"\230\001\n\032InitialLoadBalanceR" +
-      "esponse\022 \n\026load_balancer_delegate\030\002 \001(\tH" +
-      "\000\022?\n\034client_stats_report_interval\030\003 \001(\0132" +
-      "\031.google.protobuf.DurationB\027\n\025initial_re" +
-      "sponse_type\"i\n\nServerList\022#\n\007servers\030\001 \003" +
-      "(\0132\022.grpc.lb.v1.Server\0226\n\023expiration_int" +
-      "erval\030\003 \001(\0132\031.google.protobuf.Duration\"\\",
-      "\n\006Server\022\022\n\nip_address\030\001 \001(\t\022\014\n\004port\030\002 \001" +
-      "(\005\022\032\n\022load_balance_token\030\003 \001(\t\022\024\n\014drop_r" +
-      "equest\030\004 \001(\0102b\n\014LoadBalancer\022R\n\013BalanceL" +
-      "oad\022\036.grpc.lb.v1.LoadBalanceRequest\032\037.gr" +
-      "pc.lb.v1.LoadBalanceResponse(\0010\001B%\n\016io.g" +
-      "rpc.grpclbB\021LoadBalancerProtoP\001b\006proto3"
+      "\n\023load_balancer.proto\022\035loadbalancer_gslb" +
+      ".client.grpc\032\036google/protobuf/duration.p" +
+      "roto\"\312\001\n\022LoadBalanceRequest\022S\n\017initial_r" +
+      "equest\030\001 \001(\01328.loadbalancer_gslb.client." +
+      "grpc.InitialLoadBalanceRequestH\000\022B\n\014clie" +
+      "nt_stats\030\002 \001(\0132*.loadbalancer_gslb.clien" +
+      "t.grpc.ClientStatsH\000B\033\n\031load_balance_req" +
+      "uest_type\")\n\031InitialLoadBalanceRequest\022\014" +
+      "\n\004name\030\001 \001(\t\"Z\n\013ClientStats\022\026\n\016total_req" +
+      "uests\030\001 \001(\003\022\031\n\021client_rpc_errors\030\002 \001(\003\022\030",
+      "\n\020dropped_requests\030\003 \001(\003\"\314\001\n\023LoadBalance" +
+      "Response\022U\n\020initial_response\030\001 \001(\01329.loa" +
+      "dbalancer_gslb.client.grpc.InitialLoadBa" +
+      "lanceResponseH\000\022@\n\013server_list\030\002 \001(\0132).l" +
+      "oadbalancer_gslb.client.grpc.ServerListH" +
+      "\000B\034\n\032load_balance_response_type\"\230\001\n\032Init" +
+      "ialLoadBalanceResponse\022 \n\026load_balancer_" +
+      "delegate\030\002 \001(\tH\000\022?\n\034client_stats_report_" +
+      "interval\030\003 \001(\0132\031.google.protobuf.Duratio" +
+      "nB\027\n\025initial_response_type\"|\n\nServerList",
+      "\0226\n\007servers\030\001 \003(\0132%.loadbalancer_gslb.cl" +
+      "ient.grpc.Server\0226\n\023expiration_interval\030" +
+      "\003 \001(\0132\031.google.protobuf.Duration\"\\\n\006Serv" +
+      "er\022\022\n\nip_address\030\001 \001(\t\022\014\n\004port\030\002 \001(\005\022\032\n\022" +
+      "load_balance_token\030\003 \001(\t\022\024\n\014drop_request" +
+      "\030\004 \001(\0102\210\001\n\014LoadBalancer\022x\n\013BalanceLoad\0221" +
+      ".loadbalancer_gslb.client.grpc.LoadBalan" +
+      "ceRequest\0322.loadbalancer_gslb.client.grp" +
+      "c.LoadBalanceResponse(\0010\001B%\n\016io.grpc.grp" +
+      "clbB\021LoadBalancerProtoP\001b\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -92,47 +96,47 @@ public final class LoadBalancerProto {
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.protobuf.DurationProto.getDescriptor(),
         }, assigner);
-    internal_static_grpc_lb_v1_LoadBalanceRequest_descriptor =
+    internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_grpc_lb_v1_LoadBalanceRequest_fieldAccessorTable = new
+    internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_lb_v1_LoadBalanceRequest_descriptor,
+        internal_static_loadbalancer_gslb_client_grpc_LoadBalanceRequest_descriptor,
         new java.lang.String[] { "InitialRequest", "ClientStats", "LoadBalanceRequestType", });
-    internal_static_grpc_lb_v1_InitialLoadBalanceRequest_descriptor =
+    internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_grpc_lb_v1_InitialLoadBalanceRequest_fieldAccessorTable = new
+    internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_lb_v1_InitialLoadBalanceRequest_descriptor,
+        internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceRequest_descriptor,
         new java.lang.String[] { "Name", });
-    internal_static_grpc_lb_v1_ClientStats_descriptor =
+    internal_static_loadbalancer_gslb_client_grpc_ClientStats_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_grpc_lb_v1_ClientStats_fieldAccessorTable = new
+    internal_static_loadbalancer_gslb_client_grpc_ClientStats_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_lb_v1_ClientStats_descriptor,
+        internal_static_loadbalancer_gslb_client_grpc_ClientStats_descriptor,
         new java.lang.String[] { "TotalRequests", "ClientRpcErrors", "DroppedRequests", });
-    internal_static_grpc_lb_v1_LoadBalanceResponse_descriptor =
+    internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_grpc_lb_v1_LoadBalanceResponse_fieldAccessorTable = new
+    internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_lb_v1_LoadBalanceResponse_descriptor,
+        internal_static_loadbalancer_gslb_client_grpc_LoadBalanceResponse_descriptor,
         new java.lang.String[] { "InitialResponse", "ServerList", "LoadBalanceResponseType", });
-    internal_static_grpc_lb_v1_InitialLoadBalanceResponse_descriptor =
+    internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_descriptor =
       getDescriptor().getMessageTypes().get(4);
-    internal_static_grpc_lb_v1_InitialLoadBalanceResponse_fieldAccessorTable = new
+    internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_lb_v1_InitialLoadBalanceResponse_descriptor,
+        internal_static_loadbalancer_gslb_client_grpc_InitialLoadBalanceResponse_descriptor,
         new java.lang.String[] { "LoadBalancerDelegate", "ClientStatsReportInterval", "InitialResponseType", });
-    internal_static_grpc_lb_v1_ServerList_descriptor =
+    internal_static_loadbalancer_gslb_client_grpc_ServerList_descriptor =
       getDescriptor().getMessageTypes().get(5);
-    internal_static_grpc_lb_v1_ServerList_fieldAccessorTable = new
+    internal_static_loadbalancer_gslb_client_grpc_ServerList_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_lb_v1_ServerList_descriptor,
+        internal_static_loadbalancer_gslb_client_grpc_ServerList_descriptor,
         new java.lang.String[] { "Servers", "ExpirationInterval", });
-    internal_static_grpc_lb_v1_Server_descriptor =
+    internal_static_loadbalancer_gslb_client_grpc_Server_descriptor =
       getDescriptor().getMessageTypes().get(6);
-    internal_static_grpc_lb_v1_Server_fieldAccessorTable = new
+    internal_static_loadbalancer_gslb_client_grpc_Server_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_lb_v1_Server_descriptor,
+        internal_static_loadbalancer_gslb_client_grpc_Server_descriptor,
         new java.lang.String[] { "IpAddress", "Port", "LoadBalanceToken", "DropRequest", });
     com.google.protobuf.DurationProto.getDescriptor();
   }

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/Server.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/Server.java
@@ -4,11 +4,11 @@
 package io.grpc.grpclb;
 
 /**
- * Protobuf type {@code grpc.lb.v1.Server}
+ * Protobuf type {@code loadbalancer_gslb.client.grpc.Server}
  */
 public  final class Server extends
     com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:grpc.lb.v1.Server)
+    // @@protoc_insertion_point(message_implements:loadbalancer_gslb.client.grpc.Server)
     ServerOrBuilder {
   // Use Server.newBuilder() to construct.
   private Server(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -81,12 +81,12 @@ public  final class Server extends
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_Server_descriptor;
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_Server_descriptor;
   }
 
   protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_Server_fieldAccessorTable
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_Server_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             io.grpc.grpclb.Server.class, io.grpc.grpclb.Server.Builder.class);
   }
@@ -326,20 +326,20 @@ public  final class Server extends
     return builder;
   }
   /**
-   * Protobuf type {@code grpc.lb.v1.Server}
+   * Protobuf type {@code loadbalancer_gslb.client.grpc.Server}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:grpc.lb.v1.Server)
+      // @@protoc_insertion_point(builder_implements:loadbalancer_gslb.client.grpc.Server)
       io.grpc.grpclb.ServerOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_Server_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_Server_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_Server_fieldAccessorTable
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_Server_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.grpclb.Server.class, io.grpc.grpclb.Server.Builder.class);
     }
@@ -373,7 +373,7 @@ public  final class Server extends
 
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_Server_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_Server_descriptor;
     }
 
     public io.grpc.grpclb.Server getDefaultInstanceForType() {
@@ -719,10 +719,10 @@ public  final class Server extends
     }
 
 
-    // @@protoc_insertion_point(builder_scope:grpc.lb.v1.Server)
+    // @@protoc_insertion_point(builder_scope:loadbalancer_gslb.client.grpc.Server)
   }
 
-  // @@protoc_insertion_point(class_scope:grpc.lb.v1.Server)
+  // @@protoc_insertion_point(class_scope:loadbalancer_gslb.client.grpc.Server)
   private static final io.grpc.grpclb.Server DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new io.grpc.grpclb.Server();

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/ServerList.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/ServerList.java
@@ -4,11 +4,11 @@
 package io.grpc.grpclb;
 
 /**
- * Protobuf type {@code grpc.lb.v1.ServerList}
+ * Protobuf type {@code loadbalancer_gslb.client.grpc.ServerList}
  */
 public  final class ServerList extends
     com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:grpc.lb.v1.ServerList)
+    // @@protoc_insertion_point(message_implements:loadbalancer_gslb.client.grpc.ServerList)
     ServerListOrBuilder {
   // Use ServerList.newBuilder() to construct.
   private ServerList(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -80,12 +80,12 @@ public  final class ServerList extends
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ServerList_descriptor;
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ServerList_descriptor;
   }
 
   protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ServerList_fieldAccessorTable
+    return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ServerList_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
             io.grpc.grpclb.ServerList.class, io.grpc.grpclb.ServerList.Builder.class);
   }
@@ -94,7 +94,7 @@ public  final class ServerList extends
   public static final int SERVERS_FIELD_NUMBER = 1;
   private java.util.List<io.grpc.grpclb.Server> servers_;
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will
@@ -107,7 +107,7 @@ public  final class ServerList extends
     return servers_;
   }
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will
@@ -121,7 +121,7 @@ public  final class ServerList extends
     return servers_;
   }
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will
@@ -134,7 +134,7 @@ public  final class ServerList extends
     return servers_.size();
   }
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will
@@ -147,7 +147,7 @@ public  final class ServerList extends
     return servers_.get(index);
   }
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will
@@ -313,20 +313,20 @@ public  final class ServerList extends
     return builder;
   }
   /**
-   * Protobuf type {@code grpc.lb.v1.ServerList}
+   * Protobuf type {@code loadbalancer_gslb.client.grpc.ServerList}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:grpc.lb.v1.ServerList)
+      // @@protoc_insertion_point(builder_implements:loadbalancer_gslb.client.grpc.ServerList)
       io.grpc.grpclb.ServerListOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ServerList_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ServerList_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ServerList_fieldAccessorTable
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ServerList_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.grpclb.ServerList.class, io.grpc.grpclb.ServerList.Builder.class);
     }
@@ -365,7 +365,7 @@ public  final class ServerList extends
 
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return io.grpc.grpclb.LoadBalancerProto.internal_static_grpc_lb_v1_ServerList_descriptor;
+      return io.grpc.grpclb.LoadBalancerProto.internal_static_loadbalancer_gslb_client_grpc_ServerList_descriptor;
     }
 
     public io.grpc.grpclb.ServerList getDefaultInstanceForType() {
@@ -483,7 +483,7 @@ public  final class ServerList extends
         io.grpc.grpclb.Server, io.grpc.grpclb.Server.Builder, io.grpc.grpclb.ServerOrBuilder> serversBuilder_;
 
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -500,7 +500,7 @@ public  final class ServerList extends
       }
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -517,7 +517,7 @@ public  final class ServerList extends
       }
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -534,7 +534,7 @@ public  final class ServerList extends
       }
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -558,7 +558,7 @@ public  final class ServerList extends
       return this;
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -579,7 +579,7 @@ public  final class ServerList extends
       return this;
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -602,7 +602,7 @@ public  final class ServerList extends
       return this;
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -626,7 +626,7 @@ public  final class ServerList extends
       return this;
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -647,7 +647,7 @@ public  final class ServerList extends
       return this;
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -668,7 +668,7 @@ public  final class ServerList extends
       return this;
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -690,7 +690,7 @@ public  final class ServerList extends
       return this;
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -710,7 +710,7 @@ public  final class ServerList extends
       return this;
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -730,7 +730,7 @@ public  final class ServerList extends
       return this;
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -744,7 +744,7 @@ public  final class ServerList extends
       return getServersFieldBuilder().getBuilder(index);
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -761,7 +761,7 @@ public  final class ServerList extends
       }
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -779,7 +779,7 @@ public  final class ServerList extends
       }
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -793,7 +793,7 @@ public  final class ServerList extends
           io.grpc.grpclb.Server.getDefaultInstance());
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -808,7 +808,7 @@ public  final class ServerList extends
           index, io.grpc.grpclb.Server.getDefaultInstance());
     }
     /**
-     * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+     * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
      *
      * <pre>
      * Contains a list of servers selected by the load balancer. The list will
@@ -1026,10 +1026,10 @@ public  final class ServerList extends
     }
 
 
-    // @@protoc_insertion_point(builder_scope:grpc.lb.v1.ServerList)
+    // @@protoc_insertion_point(builder_scope:loadbalancer_gslb.client.grpc.ServerList)
   }
 
-  // @@protoc_insertion_point(class_scope:grpc.lb.v1.ServerList)
+  // @@protoc_insertion_point(class_scope:loadbalancer_gslb.client.grpc.ServerList)
   private static final io.grpc.grpclb.ServerList DEFAULT_INSTANCE;
   static {
     DEFAULT_INSTANCE = new io.grpc.grpclb.ServerList();

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/ServerListOrBuilder.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/ServerListOrBuilder.java
@@ -4,11 +4,11 @@
 package io.grpc.grpclb;
 
 public interface ServerListOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:grpc.lb.v1.ServerList)
+    // @@protoc_insertion_point(interface_extends:loadbalancer_gslb.client.grpc.ServerList)
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will
@@ -20,7 +20,7 @@ public interface ServerListOrBuilder extends
   java.util.List<io.grpc.grpclb.Server> 
       getServersList();
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will
@@ -31,7 +31,7 @@ public interface ServerListOrBuilder extends
    */
   io.grpc.grpclb.Server getServers(int index);
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will
@@ -42,7 +42,7 @@ public interface ServerListOrBuilder extends
    */
   int getServersCount();
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will
@@ -54,7 +54,7 @@ public interface ServerListOrBuilder extends
   java.util.List<? extends io.grpc.grpclb.ServerOrBuilder> 
       getServersOrBuilderList();
   /**
-   * <code>repeated .grpc.lb.v1.Server servers = 1;</code>
+   * <code>repeated .loadbalancer_gslb.client.grpc.Server servers = 1;</code>
    *
    * <pre>
    * Contains a list of servers selected by the load balancer. The list will

--- a/grpclb/src/generated/main/java/io/grpc/grpclb/ServerOrBuilder.java
+++ b/grpclb/src/generated/main/java/io/grpc/grpclb/ServerOrBuilder.java
@@ -4,7 +4,7 @@
 package io.grpc.grpclb;
 
 public interface ServerOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:grpc.lb.v1.Server)
+    // @@protoc_insertion_point(interface_extends:loadbalancer_gslb.client.grpc.Server)
     com.google.protobuf.MessageOrBuilder {
 
   /**

--- a/grpclb/src/main/proto/load_balancer.proto
+++ b/grpclb/src/main/proto/load_balancer.proto
@@ -4,7 +4,7 @@ syntax = "proto3";
 
 import "google/protobuf/duration.proto";
 
-package grpc.lb.v1;
+package loadbalancer_gslb.client.grpc;
 
 option java_multiple_files = true;
 option java_package = "io.grpc.grpclb";


### PR DESCRIPTION
- Set knownAcceptEncodingRegistry in SingleTransportChannel
- Change the package name of load_balancer.proto to be consistent with
  what is used internally.