### PR TITLE
Update Compression API

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -198,9 +198,23 @@ public abstract class ClientCall<ReqT, RespT> {
   /**
    * Enables per-message compression, if an encoding type has been negotiated.  If no message
    * encoding has been negotiated, this is a no-op.
+   *
+   * @param enabled whether or not subsequent calls to {@link #sendMessage} should be compressed.
    */
   @ExperimentalApi
   public void setMessageCompression(boolean enabled) {
-    // noop
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  /**
+   * Overrides the compression negotiator for this call.  By default calls inherit a negotiator
+   * from their channel.  This method exists to allow per call override of negotiation.  This is an
+   * advanced API call and shouldn't need to be used in normal circumstances.
+   *
+   * @param negotiator the new compression negotiator.
+   */
+  @ExperimentalApi
+  public void overrideCompressionNegotiator(CompressionNegotiator negotiator) {
+    throw new UnsupportedOperationException("unimplemented");
   }
 }

--- a/core/src/main/java/io/grpc/CompressionNegotiator.java
+++ b/core/src/main/java/io/grpc/CompressionNegotiator.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Set;
+
+/**
+ * Compression Negotiators act on behalf of a {@link ClientCall} or {@link ServerCall} to set up
+ * compression between endpoints.  This class provides a default implementation that will try to
+ * advertise all known decoders to the remote end point, and then decide on which
+ * {@link Compressor} or {@link Decompressor} to use when sending and receiving messages.
+ *
+ * <p>This class is also designed to be overriden to provide custom compression negotiation on a
+ * per-call basis.  This means that it is possible to pick a different codec based on service,
+ * method, call, or other criteria.  Because of this, overriding behavior should be done carefully
+ * to ensure that the gRPC protocol is not violated.  Specifically, you MUST only advertise codecs
+ * you are capable of decoding, and you must only pick an encoding that the remote endpoint can
+ * decode.
+ */
+@ExperimentalApi
+public class CompressionNegotiator {
+
+  private final CompressorRegistry compressorRegistry;
+  private final DecompressorRegistry decompressorRegistry;
+
+  public CompressionNegotiator(
+      CompressorRegistry compressorRegistry, DecompressorRegistry decompressorRegistry) {
+    this.compressorRegistry = checkNotNull(compressorRegistry, "compressorRegistry");
+    this.decompressorRegistry = checkNotNull(decompressorRegistry, "decompressorRegistry");
+  }
+
+  public CompressionNegotiator() {
+    this(CompressorRegistry.getDefaultInstance(), DecompressorRegistry.getDefaultInstance());
+  }
+
+  /**
+   * Called after the remote endpoint has provided headers, but before the local headers have been
+   * sent.
+   *
+   * <p>For clients, this is called with the encodings the server has previously sent in other
+   * calls.  Thus for the first call it is possible that the known encodings could be empty.  By
+   * default this method picks the first compressor that the CompressorRegistry supports and that
+   * the remote endpoint supports.  The order is not defined for iteration through the compressor
+   * registry.  The order is not defined for knownRemoteAcceptEncodings, even if the remote
+   * endpoint provided them in an order.
+   *
+   * @param knownRemoteAcceptEncodings encodings the remote endpoint is known to support
+   * @return A compressor that may be used to encode messages.
+   */
+  public Compressor pickCompressor(Set<String> knownRemoteAcceptEncodings) {
+    for (String supportedEncoding : compressorRegistry.getKnownMessageEncodings()) {
+      if (knownRemoteAcceptEncodings.contains(supportedEncoding)) {
+        return compressorRegistry.lookupCompressor(supportedEncoding);
+      }
+    }
+
+    return Codec.Identity.NONE;
+  }
+
+  /**
+   * Returns a set of strings representing what decoders to put in the grpc-accept-encoding header.
+   * The default implementation uses the results from the decompressorRegistry.
+   *
+   * <p>Results are inherently unordered, since most implementations ignore order.  It would be
+   * possible to override this method and return a Set with a specific iteration order.  However,
+   * there is not a substantial benefit to doing so.
+   */
+  public Set<String> advertiseDecompressors() {
+    return decompressorRegistry.getAdvertisedMessageEncodings();
+  }
+
+  /**
+   * Picks a decompressor based on the received grpc-encoding header.  This method may not be
+   * called if the remote end point does not provide an encoding header.
+   *
+   * @param remoteEncoding the encoding of messages to be sent by the remote endpoint
+   * @return a decompressor capable of decoding messages encoded with {@code remoteEncoding}
+   * @throws IllegalArgumentException if a decompressor cannot be found
+   */
+  public Decompressor pickDecompressor(String remoteEncoding) {
+    Decompressor d = decompressorRegistry.lookupDecompressor(remoteEncoding);
+    checkArgument(d != null, "Unabled to find decompressor for %s", remoteEncoding);
+
+    return d;
+  }
+}
+

--- a/core/src/main/java/io/grpc/CompressorRegistry.java
+++ b/core/src/main/java/io/grpc/CompressorRegistry.java
@@ -35,7 +35,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
 
-
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -49,7 +50,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class CompressorRegistry {
   private static final CompressorRegistry DEFAULT_INSTANCE = new CompressorRegistry(
-      new Codec.Gzip());
+      new Codec.Gzip(),
+      Codec.Identity.NONE);
 
   public static CompressorRegistry getDefaultInstance() {
     return DEFAULT_INSTANCE;
@@ -72,6 +74,13 @@ public final class CompressorRegistry {
   @Nullable
   public Compressor lookupCompressor(String compressorName) {
     return compressors.get(compressorName);
+  }
+
+  /**
+   * Provides a list of all message encodings that have compressors available.
+   */
+  public Set<String> getKnownMessageEncodings() {
+    return Collections.unmodifiableSet(compressors.keySet());
   }
 
   /**

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -164,20 +164,11 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory);
 
   /**
-   * Set the decompression registry for use in the channel.  This is an advanced API call and
-   * shouldn't be used unless you are using custom message encoding.   The default supported
-   * decompressors are in {@code DecompressorRegistry.getDefaultInstance}.
+   * Set the compression negotiator for use in the channel.  This is an advanced API call and
+   * shouldn't be used unless you are using custom message encoding.
    */
   @ExperimentalApi
-  public abstract T decompressorRegistry(DecompressorRegistry registry);
-
-  /**
-   * Set the compression registry for use in the channel.  This is an advanced API call and
-   * shouldn't be used unless you are using custom message encoding.   The default supported
-   * compressors are in {@code CompressorRegistry.getDefaultInstance}.
-   */
-  @ExperimentalApi
-  public abstract T compressorRegistry(CompressorRegistry registry);
+  public abstract T compressionNegotiator(CompressionNegotiator cn);
 
   /**
    * Builds a channel using the given parameters.

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -88,20 +88,11 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   public abstract T useTransportSecurity(File certChain, File privateKey);
 
   /**
-   * Set the decompression registry for use in the channel.  This is an advanced API call and
-   * shouldn't be used unless you are using custom message encoding.   The default supported
-   * decompressors are in {@code DecompressorRegistry.getDefaultInstance}.
+   * Set the compression negotiator for use in the server.  This is an advanced API call and
+   * shouldn't be used unless you are using custom message encoding.
    */
   @ExperimentalApi
-  public abstract T decompressorRegistry(DecompressorRegistry registry);
-
-  /**
-   * Set the compression registry for use in the channel.  This is an advanced API call and
-   * shouldn't be used unless you are using custom message encoding.   The default supported
-   * compressors are in {@code CompressorRegistry.getDefaultInstance}.
-   */
-  @ExperimentalApi
-  public abstract T compressorRegistry(CompressorRegistry registry);
+  public abstract T compressionNegotiator(CompressionNegotiator cn);
 
   /**
    * Builds a server using the given parameters.

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -31,7 +31,6 @@
 
 package io.grpc;
 
-
 /**
  * Encapsulates a single call received from a remote client. Calls may not simply be unary
  * request-response even though this is the most common pattern. Calls may stream any number of
@@ -171,9 +170,23 @@ public abstract class ServerCall<RespT> {
   /**
    * Enables per-message compression, if an encoding type has been negotiated.  If no message
    * encoding has been negotiated, this is a no-op.
+   *
+   * @param enabled whether or not subsequent calls to {@link #sendMessage} should be compressed.
    */
   @ExperimentalApi
   public void setMessageCompression(boolean enabled) {
-    // noop
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  /**
+   * Overrides the compression negotiator for this call.  By default calls inherit a negotiator
+   * from their channel.  This method exists to allow per call override of negotiation.  This is an
+   * advanced API call and shouldn't need to be used in normal circumstances.
+   *
+   * @param negotiator the new compression negotiator.
+   */
+  @ExperimentalApi
+  public void overrideCompressionNegotiator(CompressionNegotiator negotiator) {
+    throw new UnsupportedOperationException("unimplemented");
   }
 }

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -34,8 +34,7 @@ package io.grpc.inprocess;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.grpc.Compressor;
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
+import io.grpc.Decompressor;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -231,9 +230,6 @@ class InProcessTransport implements ServerTransport, ClientTransport {
       }
 
       @Override
-      public void setDecompressionRegistry(DecompressorRegistry registry) {}
-
-      @Override
       public void request(int numMessages) {
         clientStream.serverRequested(numMessages);
       }
@@ -340,17 +336,13 @@ class InProcessTransport implements ServerTransport, ClientTransport {
       }
 
       @Override
-      public void setMessageCompression(boolean enable) {
-         // noop
-      }
+      public void setMessageCompression(boolean enable) {}
 
       @Override
-      public Compressor pickCompressor(Iterable<String> messageEncodings) {
-        return null;
-      }
+      public void setCompressor(Compressor c) {}
 
       @Override
-      public void setCompressionRegistry(CompressorRegistry registry) {}
+      public void setDecompressor(Decompressor d) {}
     }
 
     private class InProcessClientStream implements ClientStream {
@@ -458,18 +450,13 @@ class InProcessTransport implements ServerTransport, ClientTransport {
       }
 
       @Override
-      public void setDecompressionRegistry(DecompressorRegistry registry) {}
-
-      @Override
       public void setMessageCompression(boolean enable) {}
 
       @Override
-      public Compressor pickCompressor(Iterable<String> messageEncodings) {
-        return null;
-      }
+      public void setCompressor(Compressor c) {}
 
       @Override
-      public void setCompressionRegistry(CompressorRegistry registry) {}
+      public void setDecompressor(Decompressor d) {}
 
       @Override
       public void start(ClientStreamListener listener) {

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -122,21 +122,6 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
       log.log(Level.INFO, "Received headers on closed stream {0} {1}",
           new Object[]{id(), headers});
     }
-    if (headers.containsKey(GrpcUtil.MESSAGE_ENCODING_KEY)) {
-      String messageEncoding = headers.get(GrpcUtil.MESSAGE_ENCODING_KEY);
-      try {
-        setDecompressor(messageEncoding);
-      } catch (IllegalArgumentException e) {
-        // Don't use INVALID_ARGUMENT since that is for servers to send clients.
-        Status status = Status.INTERNAL.withDescription("Unable to decompress message from server.")
-            .withCause(e);
-        // TODO(carl-mastrangelo): look back into tearing down this stream.  sendCancel() can be
-        // buffered.
-        inboundTransportError(status, headers);
-        sendCancel(status);
-        return;
-      }
-    }
 
     inboundPhase(Phase.MESSAGE);
     listener.headersRead(headers);
@@ -144,7 +129,7 @@ public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
 
   /**
    * Processes the contents of a received data frame from the server.
-   *
+   *T
    * @param frame the received data frame. Its ownership is transferred to this method.
    */
   protected void inboundDataReceived(ReadableBuffer frame) {

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -38,8 +38,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
+import io.grpc.CompressionNegotiator;
 import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
 import io.grpc.ManagedChannelBuilder;
@@ -89,10 +88,7 @@ public abstract class AbstractManagedChannelImplBuilder
   private LoadBalancer.Factory loadBalancerFactory;
 
   @Nullable
-  private DecompressorRegistry decompressorRegistry;
-
-  @Nullable
-  private CompressorRegistry compressorRegistry;
+  private CompressionNegotiator compressionNegotiator;
 
   protected AbstractManagedChannelImplBuilder(String target) {
     this.target = Preconditions.checkNotNull(target);
@@ -147,15 +143,8 @@ public abstract class AbstractManagedChannelImplBuilder
 
   @Override
   @ExperimentalApi
-  public final T decompressorRegistry(DecompressorRegistry registry) {
-    this.decompressorRegistry = registry;
-    return thisT();
-  }
-
-  @Override
-  @ExperimentalApi
-  public final T compressorRegistry(CompressorRegistry registry) {
-    this.compressorRegistry = registry;
+  public final T compressionNegotiator(CompressionNegotiator cn) {
+    this.compressionNegotiator = cn;
     return thisT();
   }
 
@@ -198,8 +187,7 @@ public abstract class AbstractManagedChannelImplBuilder
         getNameResolverParams(),
         firstNonNull(loadBalancerFactory, SimpleLoadBalancerFactory.getInstance()),
         transportFactory,
-        firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
-        firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()),
+        firstNonNull(compressionNegotiator, new CompressionNegotiator()),
         executor, userAgent, interceptors);
   }
 

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -31,12 +31,13 @@
 
 package io.grpc.internal;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 
-import io.grpc.CompressorRegistry;
+import io.grpc.CompressionNegotiator;
 import io.grpc.Context;
-import io.grpc.DecompressorRegistry;
 import io.grpc.HandlerRegistry;
 import io.grpc.Internal;
 import io.grpc.MutableHandlerRegistry;
@@ -61,10 +62,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   private Executor executor;
 
   @Nullable
-  private DecompressorRegistry decompressorRegistry;
-
-  @Nullable
-  private CompressorRegistry compressorRegistry;
+  private CompressionNegotiator compressionNegotiator;
 
   /**
    * Constructs using a given handler registry.
@@ -107,29 +105,20 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   }
 
   @Override
-  public final T decompressorRegistry(DecompressorRegistry registry) {
-    decompressorRegistry = registry;
+  public final T compressionNegotiator(CompressionNegotiator cn) {
+    compressionNegotiator = cn;
     return thisT();
   }
 
-  protected final DecompressorRegistry decompressorRegistry() {
-    return decompressorRegistry;
-  }
-
-  @Override
-  public final T compressorRegistry(CompressorRegistry registry) {
-    compressorRegistry = registry;
-    return thisT();
-  }
-
-  protected final CompressorRegistry compressorRegistry() {
-    return compressorRegistry;
+  protected final CompressionNegotiator compressionNegotiator() {
+    return compressionNegotiator;
   }
 
   @Override
   public ServerImpl build() {
     io.grpc.internal.Server transportServer = buildTransportServer();
-    return new ServerImpl(executor, registry, transportServer, Context.ROOT);
+    return new ServerImpl(executor, registry, transportServer, Context.ROOT,
+        firstNonNull(compressionNegotiator, new CompressionNegotiator()));
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -31,7 +31,6 @@
 
 package io.grpc.internal;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -40,9 +39,7 @@ import com.google.common.base.MoreObjects;
 
 import io.grpc.Codec;
 import io.grpc.Compressor;
-import io.grpc.CompressorRegistry;
 import io.grpc.Decompressor;
-import io.grpc.DecompressorRegistry;
 
 import java.io.InputStream;
 
@@ -101,10 +98,6 @@ public abstract class AbstractStream<IdT> implements Stream {
   private boolean allocated;
 
   private final Object onReadyLock = new Object();
-  private volatile DecompressorRegistry decompressorRegistry =
-      DecompressorRegistry.getDefaultInstance();
-  private volatile CompressorRegistry compressorRegistry =
-      CompressorRegistry.getDefaultInstance();
 
   @VisibleForTesting
   class FramerSink implements MessageFramer.Sink {
@@ -305,47 +298,14 @@ public abstract class AbstractStream<IdT> implements Stream {
     }
   }
 
-  /**
-   * Looks up the decompressor by its message encoding name, and sets it for this stream.
-   * Decompressors are registered with {@link DecompressorRegistry#register}.
-   *
-   * @param messageEncoding the name of the encoding provided by the remote host
-   * @throws IllegalArgumentException if the provided message encoding cannot be found.
-   */
-  protected final void setDecompressor(String messageEncoding) {
-    Decompressor d = decompressorRegistry.lookupDecompressor(messageEncoding);
-    checkArgument(d != null,
-        "Unable to find decompressor for message encoding %s", messageEncoding);
+  @Override
+  public final void setDecompressor(Decompressor d) {
     deframer.setDecompressor(d);
   }
 
   @Override
-  public final void setDecompressionRegistry(DecompressorRegistry registry) {
-    decompressorRegistry = checkNotNull(registry);
-  }
-
-  @Override
-  public final void setCompressionRegistry(CompressorRegistry registry) {
-    compressorRegistry = checkNotNull(registry);
-  }
-
-  @Override
-  public final Compressor pickCompressor(Iterable<String> messageEncodings) {
-    for (String messageEncoding : messageEncodings) {
-      Compressor c = compressorRegistry.lookupCompressor(messageEncoding);
-      if (c != null) {
-        // TODO(carl-mastrangelo): check that headers haven't already been sent.  I can't find where
-        // the client stream changes outbound phase correctly, so I am ignoring it.
-        framer.setCompressor(c);
-        return c;
-      }
-    }
-    return null;
-  }
-
-  // TODO(carl-mastrangelo): this is a hack to get around registry passing.  Remove it.
-  protected final DecompressorRegistry decompressorRegistry() {
-    return decompressorRegistry;
+  public final void setCompressor(Compressor c) {
+    framer.setCompressor(c);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -35,8 +35,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import io.grpc.Compressor;
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
+import io.grpc.Decompressor;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
@@ -68,10 +67,6 @@ class DelayedStream implements ClientStream {
   private Status error;
 
   @GuardedBy("this")
-  private Iterable<String> compressionMessageEncodings;
-  @GuardedBy("this")
-  private DecompressorRegistry decompressionRegistry;
-  @GuardedBy("this")
   private final List<PendingMessage> pendingMessages = new LinkedList<PendingMessage>();
   private boolean messageCompressionEnabled;
   @GuardedBy("this")
@@ -81,7 +76,9 @@ class DelayedStream implements ClientStream {
   @GuardedBy("this")
   private boolean pendingFlush;
   @GuardedBy("this")
-  private CompressorRegistry compressionRegistry;
+  private Compressor compressor;
+  @GuardedBy("this")
+  private Decompressor decompressor;
 
   static final class PendingMessage {
     final InputStream message;
@@ -116,17 +113,14 @@ class DelayedStream implements ClientStream {
   private void startStream() {
     checkState(realStream != null, "realStream");
     checkState(listener != null, "listener");
+    if (compressor != null) {
+      realStream.setCompressor(compressor);
+    }
+    if (decompressor != null) {
+      realStream.setDecompressor(decompressor);
+    }
     realStream.start(listener);
 
-    if (compressionMessageEncodings != null) {
-      realStream.pickCompressor(compressionMessageEncodings);
-    }
-    if (this.decompressionRegistry != null) {
-      realStream.setDecompressionRegistry(this.decompressionRegistry);
-    }
-    if (this.compressionRegistry != null) {
-      realStream.setCompressionRegistry(this.compressionRegistry);
-    }
     for (PendingMessage message : pendingMessages) {
       realStream.setMessageCompression(message.shouldBeCompressed);
       realStream.writeMessage(message.message);
@@ -246,45 +240,29 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public Compressor pickCompressor(Iterable<String> messageEncodings) {
-    if (startedRealStream == null) {
+  public void setDecompressor(Decompressor d) {
+    if (realStream == null) {
       synchronized (this) {
-        if (startedRealStream == null) {
-          compressionMessageEncodings = messageEncodings;
-          // ClientCall never uses this.  Since the stream doesn't exist yet, it can't say what
-          // stream it would pick.  Eventually this will need a cleaner solution.
-          // TODO(carl-mastrangelo): Remove this.
-          return null;
-        }
-      }
-    }
-    return startedRealStream.pickCompressor(messageEncodings);
-  }
-
-  @Override
-  public void setCompressionRegistry(CompressorRegistry registry) {
-    if (startedRealStream == null) {
-      synchronized (this) {
-        if (startedRealStream == null) {
-          compressionRegistry = registry;
+        if (realStream == null) {
+          decompressor = d;
           return;
         }
       }
     }
-    startedRealStream.setCompressionRegistry(registry);
+    realStream.setDecompressor(d);
   }
 
   @Override
-  public void setDecompressionRegistry(DecompressorRegistry registry) {
-    if (startedRealStream == null) {
+  public void setCompressor(Compressor c) {
+    if (realStream == null) {
       synchronized (this) {
-        if (startedRealStream == null) {
-          decompressionRegistry = registry;
+        if (realStream == null) {
+          compressor = c;
           return;
         }
       }
     }
-    startedRealStream.setDecompressionRegistry(registry);
+    realStream.setCompressor(c);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/NoopClientStream.java
+++ b/core/src/main/java/io/grpc/internal/NoopClientStream.java
@@ -32,8 +32,7 @@
 package io.grpc.internal;
 
 import io.grpc.Compressor;
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
+import io.grpc.Decompressor;
 import io.grpc.Status;
 
 import java.io.InputStream;
@@ -68,18 +67,13 @@ public class NoopClientStream implements ClientStream {
   public void halfClose() {}
 
   @Override
-  public void setDecompressionRegistry(DecompressorRegistry registry) {}
-
-  @Override
   public void setMessageCompression(boolean enable) {
     // noop
   }
 
   @Override
-  public Compressor pickCompressor(Iterable<String> messageEncodings) {
-    return null;
-  }
+  public void setCompressor(Compressor c) {}
 
   @Override
-  public void setCompressionRegistry(CompressorRegistry registry) {}
+  public void setDecompressor(Decompressor d) {}
 }

--- a/core/src/main/java/io/grpc/internal/Stream.java
+++ b/core/src/main/java/io/grpc/internal/Stream.java
@@ -32,12 +32,9 @@
 package io.grpc.internal;
 
 import io.grpc.Compressor;
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
+import io.grpc.Decompressor;
 
 import java.io.InputStream;
-
-import javax.annotation.Nullable;
 
 /**
  * A single stream of communication between two end-points within a transport.
@@ -85,43 +82,12 @@ public interface Stream {
   boolean isReady();
 
   /**
-   * Picks a compressor for for this stream.  If no message encodings are acceptable, compression is
-   * not used.  It is undefined if this this method is invoked multiple times.  If the stream has
-   * a {@code start()} method, pickCompressor must be called prior to start.
-   *
-   *
-   * @param messageEncodings a group of message encoding names that the remote endpoint is known
-   *     to support.
-   * @return The compressor chosen for the stream, or null if none selected.
-   */
-  @Nullable
-  Compressor pickCompressor(Iterable<String> messageEncodings);
-
-  /**
    * Enables per-message compression, if an encoding type has been negotiated.  If no message
    * encoding has been negotiated, this is a no-op.
    */
   void setMessageCompression(boolean enable);
 
-  /**
-   * Sets the decompressor registry to use when resolving {@code #setDecompressor(String)}.  If
-   * unset, the default DecompressorRegistry will be used.  If the stream has a {@code start()}
-   * method, setDecompressionRegistry must be called prior to start.
-   *
-   * @see DecompressorRegistry#getDefaultInstance()
-   *
-   * @param registry the decompressors to use.
-   */
-  void setDecompressionRegistry(DecompressorRegistry registry);
+  void setCompressor(Compressor c);
 
-  /**
-   * Sets the compressor registry to use when resolving {@link #pickCompressor}.  If unset, the
-   * default CompressorRegistry will be used.  If the stream has a {@code start()} method,
-   * setCompressionRegistry must be called prior to start.
-   *
-   * @see CompressorRegistry#getDefaultInstance()
-   *
-   * @param registry the compressors to use.
-   */
-  void setCompressionRegistry(CompressorRegistry registry);
+  void setDecompressor(Decompressor d);
 }

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -240,23 +240,6 @@ public class AbstractClientStreamTest {
   }
 
   @Test
-  public void inboundHeadersReceived_notifiesListenerOnBadEncoding() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
-    stream.start(mockListener);
-    Metadata headers = new Metadata();
-    headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, "bad");
-    Metadata.Key<String> randomKey = Metadata.Key.of("random", Metadata.ASCII_STRING_MARSHALLER);
-    headers.put(randomKey, "4");
-
-    stream.inboundHeadersReceived(headers);
-
-    ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass(Metadata.class);
-    verify(mockListener).closed(statusCaptor.capture(), metadataCaptor.capture());
-    assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
-    assertEquals("4", metadataCaptor.getValue().get(randomKey));
-  }
-
-  @Test
   public void rstStreamClosesStream() {
     AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
     stream.start(mockListener);

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -36,8 +36,7 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
+import io.grpc.Codec;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
@@ -77,10 +76,9 @@ public class DelayedStreamTest {
   @Test
   public void setStream_sendsAllMessages() {
     stream.start(listener);
-    DecompressorRegistry decompressors = DecompressorRegistry.newEmptyInstance();
-    CompressorRegistry compressors = CompressorRegistry.newEmptyInstance();
-    stream.setDecompressionRegistry(decompressors);
-    stream.setCompressionRegistry(compressors);
+
+    stream.setCompressor(Codec.Identity.NONE);
+    stream.setDecompressor(Codec.Identity.NONE);
 
     stream.setMessageCompression(true);
     InputStream message = new ByteArrayInputStream(new byte[]{'a'});
@@ -90,8 +88,8 @@ public class DelayedStreamTest {
 
     stream.setStream(realStream);
 
-    verify(realStream).setDecompressionRegistry(decompressors);
-    verify(realStream).setCompressionRegistry(compressors);
+    verify(realStream).setCompressor(Codec.Identity.NONE);
+    verify(realStream).setDecompressor(Codec.Identity.NONE);
 
     // Verify that the order was correct, even though they should be interleaved with the
     // writeMessage calls

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -54,8 +54,8 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
+import io.grpc.CompressionNegotiator;
+import io.grpc.Compressor;
 import io.grpc.IntegerMarshaller;
 import io.grpc.LoadBalancer;
 import io.grpc.ManagedChannel;
@@ -135,8 +135,7 @@ public class ManagedChannelImplTest {
       NameResolver.Factory nameResolverFactory, List<ClientInterceptor> interceptors) {
     return new ManagedChannelImpl(target, new FakeBackoffPolicyProvider(),
         nameResolverFactory, NAME_RESOLVER_PARAMS, loadBalancerFactory,
-        mockTransportFactory, DecompressorRegistry.getDefaultInstance(),
-        CompressorRegistry.getDefaultInstance(), executor, null, interceptors);
+        mockTransportFactory, new CompressionNegotiator(), executor, null, interceptors);
   }
 
   @Before
@@ -194,9 +193,8 @@ public class ManagedChannelImplTest {
     verify(mockTransport, timeout(1000)).start(transportListenerCaptor.capture());
     ClientTransport.Listener transportListener = transportListenerCaptor.getValue();
     verify(mockTransport, timeout(1000)).newStream(same(method), same(headers));
+    verify(mockStream).setCompressor(isA(Compressor.class));
     verify(mockStream).start(streamListenerCaptor.capture());
-    verify(mockStream).setDecompressionRegistry(isA(DecompressorRegistry.class));
-    verify(mockStream).setCompressionRegistry(isA(CompressorRegistry.class));
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
 
     // Second call

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -48,8 +48,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
+import io.grpc.CompressionNegotiator;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.NameResolver;
@@ -126,8 +125,7 @@ public class ManagedChannelImplTransportManagerTest {
 
     channel = new ManagedChannelImpl("fake://target", mockBackoffPolicyProvider,
         nameResolverFactory, Attributes.EMPTY, mockLoadBalancerFactory,
-        mockTransportFactory, DecompressorRegistry.getDefaultInstance(),
-        CompressorRegistry.getDefaultInstance(), executor, null,
+        mockTransportFactory, new CompressionNegotiator(), executor, null,
         Collections.<ClientInterceptor>emptyList());
 
     ArgumentCaptor<TransportManager> tmCaptor = ArgumentCaptor.forClass(TransportManager.class);

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.Futures;
 
+import io.grpc.CompressionNegotiator;
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -89,7 +90,8 @@ public class ServerCallImplTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     context = Context.ROOT.withCancellation();
-    call = new ServerCallImpl<Long, Long>(stream, method, context);
+    call = new ServerCallImpl<Long, Long>(stream, method, context, new CompressionNegotiator(),
+        new Metadata());
   }
 
   @Test

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -41,6 +41,7 @@ import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.Codec;
+import io.grpc.CompressionNegotiator;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.ForwardingClientCall;
@@ -98,8 +99,7 @@ public class TransportCompressionTest extends AbstractTransportTest {
     compressors.register(Fzip.INSTANCE);
     startStaticServer(
         ServerBuilder.forPort(serverPort)
-            .compressorRegistry(compressors)
-            .decompressorRegistry(decompressors),
+            .compressionNegotiator(new CompressionNegotiator(compressors, decompressors){}),
         new ServerInterceptor() {
           @Override
           public <ReqT, RespT> Listener<ReqT> interceptCall(MethodDescriptor<ReqT, RespT> method,
@@ -140,8 +140,7 @@ public class TransportCompressionTest extends AbstractTransportTest {
   @Override
   protected ManagedChannel createChannel() {
     return ManagedChannelBuilder.forAddress("localhost", serverPort)
-        .decompressorRegistry(decompressors)
-        .compressorRegistry(compressors)
+        .compressionNegotiator(new CompressionNegotiator(compressors, decompressors){})
         .intercept(new ClientInterceptor() {
           @Override
           public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -35,8 +35,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.netty.channel.ChannelOption.SO_BACKLOG;
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
 import io.grpc.internal.Server;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.SharedResourceHolder;
@@ -74,8 +72,6 @@ class NettyServer implements Server {
   private EventLoopGroup workerGroup;
   private ServerListener listener;
   private Channel channel;
-  private final DecompressorRegistry decompressorRegistry;
-  private final CompressorRegistry compressorRegistry;
   private final int flowControlWindow;
   private final int maxMessageSize;
   private final int maxHeaderListSize;
@@ -83,8 +79,7 @@ class NettyServer implements Server {
 
   NettyServer(SocketAddress address, Class<? extends ServerChannel> channelType,
               @Nullable EventLoopGroup bossGroup, @Nullable EventLoopGroup workerGroup,
-              ProtocolNegotiator protocolNegotiator, DecompressorRegistry decompressorRegistry,
-              CompressorRegistry compressorRegistry, int maxStreamsPerConnection,
+              ProtocolNegotiator protocolNegotiator, int maxStreamsPerConnection,
               int flowControlWindow, int maxMessageSize, int maxHeaderListSize) {
     this.address = address;
     this.channelType = checkNotNull(channelType, "channelType");
@@ -97,8 +92,6 @@ class NettyServer implements Server {
     this.flowControlWindow = flowControlWindow;
     this.maxMessageSize = maxMessageSize;
     this.maxHeaderListSize = maxHeaderListSize;
-    this.decompressorRegistry = checkNotNull(decompressorRegistry, "decompressorRegistry");
-    this.compressorRegistry = checkNotNull(compressorRegistry, "compressorRegistry");
   }
 
   @Override
@@ -125,10 +118,8 @@ class NettyServer implements Server {
             eventLoopReferenceCounter.release();
           }
         });
-        NettyServerTransport transport
-            = new NettyServerTransport(ch, protocolNegotiator, decompressorRegistry,
-                compressorRegistry, maxStreamsPerConnection, flowControlWindow, maxMessageSize,
-                maxHeaderListSize);
+        NettyServerTransport transport = new NettyServerTransport(ch, protocolNegotiator,
+            maxStreamsPerConnection, flowControlWindow, maxMessageSize, maxHeaderListSize);
         transport.start(listener.transportCreated(transport));
       }
     });

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -31,14 +31,11 @@
 
 package io.grpc.netty;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
 import com.google.common.base.Preconditions;
 
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
 import io.grpc.ExperimentalApi;
 import io.grpc.HandlerRegistry;
 import io.grpc.Internal;
@@ -246,8 +243,6 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
     }
     return new NettyServer(address, channelType, bossEventLoopGroup,
             workerEventLoopGroup, negotiator,
-            firstNonNull(decompressorRegistry(), DecompressorRegistry.getDefaultInstance()),
-            firstNonNull(compressorRegistry(), CompressorRegistry.getDefaultInstance()),
             maxConcurrentCallsPerConnection, flowControlWindow,
             maxMessageSize, maxHeaderListSize);
   }

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -43,8 +43,6 @@ import static io.netty.handler.codec.http2.DefaultHttp2LocalFlowController.DEFAU
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.GrpcUtil;
@@ -97,8 +95,6 @@ class NettyServerHandler extends AbstractNettyHandler {
 
   private static final Status GOAWAY_STATUS = Status.UNAVAILABLE;
 
-  private final DecompressorRegistry decompressorRegistry;
-  private final CompressorRegistry compressorRegistry;
   private final Http2Connection.PropertyKey streamKey;
   private final ServerTransportListener transportListener;
   private final int maxMessageSize;
@@ -107,8 +103,6 @@ class NettyServerHandler extends AbstractNettyHandler {
   private WriteQueue serverWriteQueue;
 
   static NettyServerHandler newHandler(ServerTransportListener transportListener,
-                                       DecompressorRegistry decompressorRegistry,
-                                       CompressorRegistry compressorRegistry,
                                        int maxStreams,
                                        int flowControlWindow,
                                        int maxHeaderListSize,
@@ -121,15 +115,13 @@ class NettyServerHandler extends AbstractNettyHandler {
         new DefaultHttp2FrameReader(headersDecoder), frameLogger);
     Http2FrameWriter frameWriter =
         new Http2OutboundFrameLogger(new DefaultHttp2FrameWriter(), frameLogger);
-    return newHandler(frameReader, frameWriter, transportListener, decompressorRegistry,
-        compressorRegistry, maxStreams, flowControlWindow, maxMessageSize);
+    return newHandler(
+        frameReader, frameWriter, transportListener, maxStreams, flowControlWindow, maxMessageSize);
   }
 
   @VisibleForTesting
   static NettyServerHandler newHandler(Http2FrameReader frameReader, Http2FrameWriter frameWriter,
                                        ServerTransportListener transportListener,
-                                       DecompressorRegistry decompressorRegistry,
-                                       CompressorRegistry compressorRegistry,
                                        int maxStreams,
                                        int flowControlWindow,
                                        int maxMessageSize) {
@@ -151,21 +143,16 @@ class NettyServerHandler extends AbstractNettyHandler {
     settings.initialWindowSize(flowControlWindow);
     settings.maxConcurrentStreams(maxStreams);
 
-    return new NettyServerHandler(transportListener, decoder, encoder, settings,
-        decompressorRegistry, compressorRegistry, maxMessageSize);
+    return new NettyServerHandler(transportListener, decoder, encoder, settings, maxMessageSize);
   }
 
   private NettyServerHandler(ServerTransportListener transportListener,
                              Http2ConnectionDecoder decoder,
                              Http2ConnectionEncoder encoder, Http2Settings settings,
-                             DecompressorRegistry decompressorRegistry,
-                             CompressorRegistry compressorRegistry,
                              int maxMessageSize) {
     super(decoder, encoder, settings);
     checkArgument(maxMessageSize >= 0, "maxMessageSize must be >= 0");
     this.maxMessageSize = maxMessageSize;
-    this.decompressorRegistry = checkNotNull(decompressorRegistry, "decompressorRegistry");
-    this.compressorRegistry = checkNotNull(compressorRegistry, "compressorRegistry");
 
     streamKey = encoder.connection().newKey();
     this.transportListener = checkNotNull(transportListener, "transportListener");
@@ -205,11 +192,6 @@ class NettyServerHandler extends AbstractNettyHandler {
 
       NettyServerStream stream = new NettyServerStream(ctx.channel(), http2Stream, this,
               maxMessageSize);
-
-      // These must be called before inboundHeadersReceived, because the framers depend on knowing
-      // the compression algorithms available before negotiation.
-      stream.setDecompressionRegistry(decompressorRegistry);
-      stream.setCompressionRegistry(compressorRegistry);
 
       Metadata metadata = Utils.convertHeaders(headers);
       stream.inboundHeadersReceived(metadata);

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -31,12 +31,8 @@
 
 package io.grpc.netty;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.Preconditions;
 
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
 import io.grpc.internal.ServerTransport;
 import io.grpc.internal.ServerTransportListener;
 import io.netty.channel.Channel;
@@ -55,8 +51,6 @@ class NettyServerTransport implements ServerTransport {
 
   private final Channel channel;
   private final ProtocolNegotiator protocolNegotiator;
-  private final DecompressorRegistry decompressorRegistry;
-  private final CompressorRegistry compressorRegistry;
   private final int maxStreams;
   private ServerTransportListener listener;
   private boolean terminated;
@@ -64,18 +58,14 @@ class NettyServerTransport implements ServerTransport {
   private final int maxMessageSize;
   private final int maxHeaderListSize;
 
-  NettyServerTransport(Channel channel, ProtocolNegotiator protocolNegotiator,
-                       DecompressorRegistry decompressorRegistry,
-                       CompressorRegistry compressorRegistry, int maxStreams, int flowControlWindow,
-                       int maxMessageSize, int maxHeaderListSize) {
+  NettyServerTransport(Channel channel, ProtocolNegotiator protocolNegotiator, int maxStreams,
+      int flowControlWindow, int maxMessageSize, int maxHeaderListSize) {
     this.channel = Preconditions.checkNotNull(channel, "channel");
     this.protocolNegotiator = Preconditions.checkNotNull(protocolNegotiator, "protocolNegotiator");
     this.maxStreams = maxStreams;
     this.flowControlWindow = flowControlWindow;
     this.maxMessageSize = maxMessageSize;
     this.maxHeaderListSize = maxHeaderListSize;
-    this.decompressorRegistry = checkNotNull(decompressorRegistry, "decompressorRegistry");
-    this.compressorRegistry = checkNotNull(compressorRegistry, "compressorRegistry");
   }
 
   public void start(ServerTransportListener listener) {
@@ -125,7 +115,7 @@ class NettyServerTransport implements ServerTransport {
    * Creates the Netty handler to be used in the channel pipeline.
    */
   private NettyServerHandler createHandler(ServerTransportListener transportListener) {
-    return NettyServerHandler.newHandler(transportListener, decompressorRegistry,
-        compressorRegistry, maxStreams, flowControlWindow, maxHeaderListSize, maxMessageSize);
+    return NettyServerHandler.newHandler(transportListener,  maxStreams, flowControlWindow,
+        maxHeaderListSize, maxMessageSize);
   }
 }

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -43,8 +43,6 @@ import static org.junit.Assert.fail;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.SettableFuture;
 
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
@@ -321,10 +319,8 @@ public class NettyClientTransportTest {
     SslContext serverContext = GrpcSslContexts.forServer(serverCert, key)
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
     ProtocolNegotiator negotiator = ProtocolNegotiators.serverTls(serverContext);
-    server = new NettyServer(address, NioServerSocketChannel.class,
-            group, group, negotiator, DecompressorRegistry.getDefaultInstance(),
-            CompressorRegistry.getDefaultInstance(), maxStreamsPerConnection,
-            DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE, maxHeaderListSize);
+    server = new NettyServer(address, NioServerSocketChannel.class, group, group, negotiator,
+        maxStreamsPerConnection, DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE, maxHeaderListSize);
     server.start(serverListener);
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -54,8 +54,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.io.ByteStreams;
 
-import io.grpc.CompressorRegistry;
-import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -347,7 +345,6 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   @Override
   protected NettyServerHandler newHandler() {
     return NettyServerHandler.newHandler(frameReader(), frameWriter(), transportListener,
-        DecompressorRegistry.getDefaultInstance(), CompressorRegistry.getDefaultInstance(),
         maxConcurrentStreams, flowControlWindow, DEFAULT_MAX_MESSAGE_SIZE);
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -50,9 +50,7 @@ import static org.mockito.Mockito.when;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ServerStreamListener;
-
 import io.netty.buffer.EmptyByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelPromise;
@@ -96,7 +94,6 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     stream.writeHeaders(new Metadata());
     Http2Headers headers = new DefaultHttp2Headers()
         .status(Utils.STATUS_OK)
-        .set(GrpcUtil.MESSAGE_ACCEPT_ENCODING, AsciiString.of("gzip"))
         .set(Utils.CONTENT_TYPE_HEADER, Utils.CONTENT_TYPE_GRPC);
     verify(writeQueue).enqueue(new SendResponseHeadersCommand(STREAM_ID, headers, false), true);
     byte[] msg = smallMessage();


### PR DESCRIPTION
This change adds the ability to control compression behavior from interceptors.  The API has changed significantly, and for the better.  Major improvements:

- Compression decisions are made by a CompressionNegotiator.  It is designed to be overriden to pick compressors, decompressors, and advertise encodings.
- All compression setup is done through the negotiator.  No more need to pass registries around.
- All compression decisions have been moved to the ClientCall and ServerCall.  This allows better control of compression rather than having it in the stream
- API is mirrored between clients and servers, reducing cognative load.  

New use cases previously not possible:
- Per call compression negotiation.  It is possible to pick a compressor based on the Call, the headers, or any other data.