### PR TITLE
Optimize blocking calls to avoid app thread pool

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
@@ -126,7 +126,7 @@ public class TestServiceGrpc {
     @java.lang.Override
     public io.grpc.testing.SimpleResponse unaryCall(io.grpc.testing.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
+          getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
     }
   }
 

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -129,6 +129,7 @@ public class TransportBenchmark {
 
     if (direct) {
       serverBuilder.directExecutor();
+      // Because blocking stubs avoid the executor, this doesn't do much.
       channelBuilder.directExecutor();
     }
 

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -407,7 +407,7 @@ static void PrintStub(
           p->Print(
               *vars,
               "return $calls_method$(\n"
-              "    getChannel().newCall($method_field_name$, getCallOptions()), $params$);\n");
+              "    getChannel(), $method_field_name$, getCallOptions(), $params$);\n");
           break;
         case ASYNC_CALL:
           if (server_streaming) {

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -186,14 +186,14 @@ public class TestServiceGrpc {
     @java.lang.Override
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
+          getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request);
+          getChannel(), METHOD_STREAMING_OUTPUT_CALL, getCallOptions(), request);
     }
   }
 

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -264,14 +264,14 @@ public class TestServiceGrpc {
     @java.lang.Override
     public io.grpc.testing.integration.nano.Test.SimpleResponse unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
+          getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request);
+          getChannel(), METHOD_STREAMING_OUTPUT_CALL, getCallOptions(), request);
     }
   }
 

--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -33,6 +33,7 @@ package io.grpc;
 
 import com.google.common.base.MoreObjects;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -54,6 +55,7 @@ public final class CallOptions {
   // them outside of constructor. Otherwise the constructor will have a potentially long list of
   // unnamed arguments, which is undesirable.
   private Long deadlineNanoTime;
+  private Executor executor;
 
   @Nullable
   private String authority;
@@ -142,6 +144,21 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/67")
   public String getAuthority() {
     return authority;
+  }
+
+  /**
+   * Returns a new {@code CallOptions} with {@code executor} to be used instead of the default
+   * executor specified with {@link ManagedChannelBuilder#executor}.
+   */
+  public CallOptions withExecutor(Executor executor) {
+    CallOptions newOptions = new CallOptions(this);
+    newOptions.executor = executor;
+    return newOptions;
+  }
+
+  @Nullable
+  public Executor getExecutor() {
+    return executor;
   }
 
   private CallOptions() {

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -323,6 +323,10 @@ public final class ManagedChannelImpl extends ManagedChannel {
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(MethodDescriptor<ReqT, RespT> method,
         CallOptions callOptions) {
+      Executor executor = callOptions.getExecutor();
+      if (executor == null) {
+        executor = ManagedChannelImpl.this.executor;
+      }
       return new ClientCallImpl<ReqT, RespT>(
           method,
           executor,

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -37,11 +37,13 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Objects;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /** Unit tests for {@link CallOptions}. */
@@ -60,6 +62,7 @@ public class CallOptionsTest {
     assertNull(CallOptions.DEFAULT.getDeadlineNanoTime());
     assertNull(CallOptions.DEFAULT.getAuthority());
     assertNull(CallOptions.DEFAULT.getRequestKey());
+    assertNull(CallOptions.DEFAULT.getExecutor());
   }
 
   @Test
@@ -87,6 +90,17 @@ public class CallOptionsTest {
     CallOptions options2 = options1.withDeadlineNanoTime(null);
     assertEquals(10L, (long) options1.getDeadlineNanoTime());
     assertNull(options2.getDeadlineNanoTime());
+  }
+
+  @Test
+  public void mutateExecutor() {
+    Executor executor = MoreExecutors.directExecutor();
+    CallOptions options1 = CallOptions.DEFAULT.withExecutor(executor);
+    assertNull(CallOptions.DEFAULT.getExecutor());
+    assertSame(executor, options1.getExecutor());
+    CallOptions options2 = options1.withExecutor(null);
+    assertSame(executor, options1.getExecutor());
+    assertNull(options2.getExecutor());
   }
 
   @Test

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -107,7 +107,7 @@ public class GreeterGrpc {
     @java.lang.Override
     public io.grpc.examples.helloworld.HelloResponse sayHello(io.grpc.examples.helloworld.HelloRequest request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_SAY_HELLO, getCallOptions()), request);
+          getChannel(), METHOD_SAY_HELLO, getCallOptions(), request);
     }
   }
 

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -167,14 +167,14 @@ public class RouteGuideGrpc {
     @java.lang.Override
     public io.grpc.examples.routeguide.Feature getFeature(io.grpc.examples.routeguide.Point request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_GET_FEATURE, getCallOptions()), request);
+          getChannel(), METHOD_GET_FEATURE, getCallOptions(), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.examples.routeguide.Feature> listFeatures(
         io.grpc.examples.routeguide.Rectangle request) {
       return blockingServerStreamingCall(
-          getChannel().newCall(METHOD_LIST_FEATURES, getCallOptions()), request);
+          getChannel(), METHOD_LIST_FEATURES, getCallOptions(), request);
     }
   }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -131,13 +131,13 @@ public class ReconnectServiceGrpc {
     @java.lang.Override
     public com.google.protobuf.EmptyProtos.Empty start(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_START, getCallOptions()), request);
+          getChannel(), METHOD_START, getCallOptions(), request);
     }
 
     @java.lang.Override
     public io.grpc.testing.integration.Messages.ReconnectInfo stop(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_STOP, getCallOptions()), request);
+          getChannel(), METHOD_STOP, getCallOptions(), request);
     }
   }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -210,20 +210,20 @@ public class TestServiceGrpc {
     @java.lang.Override
     public com.google.protobuf.EmptyProtos.Empty emptyCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_EMPTY_CALL, getCallOptions()), request);
+          getChannel(), METHOD_EMPTY_CALL, getCallOptions(), request);
     }
 
     @java.lang.Override
     public io.grpc.testing.integration.Messages.SimpleResponse unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
+          getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
     }
 
     @java.lang.Override
     public java.util.Iterator<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Messages.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request);
+          getChannel(), METHOD_STREAMING_OUTPUT_CALL, getCallOptions(), request);
     }
   }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -107,7 +107,7 @@ public class UnimplementedServiceGrpc {
     @java.lang.Override
     public com.google.protobuf.EmptyProtos.Empty unimplementedCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel().newCall(METHOD_UNIMPLEMENTED_CALL, getCallOptions()), request);
+          getChannel(), METHOD_UNIMPLEMENTED_CALL, getCallOptions(), request);
     }
   }
 


### PR DESCRIPTION
This reduces the necessary number of threads in the application executor
and provides a small improvement in latency (~15μs, which is normally in
the noise, but would be a 5% improvement).

```
Benchmark                         (direct)  (transport)  Mode  Cnt       Score        Error  Units
Before:
TransportBenchmark.unaryCall1024      true    INPROCESS  avgt   10    1566.168 ±     13.677  ns/op
TransportBenchmark.unaryCall1024     false    INPROCESS  avgt   10   35769.532 ±   2358.967  ns/op
After:
TransportBenchmark.unaryCall1024      true    INPROCESS  avgt   10    1813.778 ±     19.995  ns/op
TransportBenchmark.unaryCall1024     false    INPROCESS  avgt   10   18568.223 ±   1679.306  ns/op
```

The benchmark results are exactly what we would expect, assuming that
half of the benefit of direct is on server and half on client:
1566 + (35769 - 1566) / 2 = 18668 ns --vs-- 18568 ns

It is expected that direct=true would get worse, because
SerializingExecutor is now used instead of
SerializeReentrantCallsDirectExecutor plus the additional cost of
ThreadlessExecutor.

In the future we could try to detect the ThreadlessExecutor and ellide
Serializ*Executor completely (as is possible for any single-threaded
executor). We could also optimize the queue used in ThreadlessExecutor
to be single-producer, single-consumer. I don't expect to do those
optimizations soon, however.

There are two separate commits for easier review.

Fixes #461 