### PR TITLE
Avoid NettyServerBuilder in security documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -165,14 +165,14 @@ Some web containers, such as [Jetty](http://www.eclipse.org/jetty/documentation/
 ```
 ## Enabling TLS on a server
 
-In this example the service owner provides a certificate chain and private key to create an SslContext. This is then bound to the server which is started on a specific port, in this case 443 which is the standard SSL port. Note that the service implementation is also bound while creating the server.
+To use TLS on the server, a certificate chain and private key need to be
+specified in PEM format. The standard TLS port is 443, but we use 8443 below to
+avoid needing extra permissions from the OS.
 
 ```java
-// Load certificate chain and key for SSL server into a Netty SslContext
-SslContext sslContext = GrpcSslContexts.forServer(certChainFile, privateKeyFile);
-// Create a server, bound to port 443 and exposing a service implementation
-ServerImpl server = NettyServerBuilder.forPort(443)
-    .sslContext(sslContext)
+ServerImpl server = ServerBuilder.forPort(8443)
+    // Enable TLS
+    .useTransportSecurity(certChainFile, privateKeyFile)
     .addService(TestServiceGrpc.bindService(serviceImplementation))
     .build();
 server.start();

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -178,7 +178,12 @@ ServerImpl server = ServerBuilder.forPort(8443)
 server.start();
 ```
 
-If the issuing certificate authority for a server is not known to the client then a similar process should be followed on the client to load it so that it may validate the certificate issued to the server. If <a href="http://en.wikipedia.org/wiki/Transport_Layer_Security#Client-authenticated_TLS_handshake">mutual authentication</a> is desired this can also be supported by creating the appropriate SslContext.
+If the issuing certificate authority is not known to the client then a properly
+configured SslContext or SSLSocketFactory should be provided to the
+NettyChannelBuilder or OkHttpChannelBuilder, respectively. [Mutual
+authentication][] can be configured similarly.
+
+[Mutual authentication]: http://en.wikipedia.org/wiki/Transport_Layer_Security#Client-authenticated_TLS_handshake
 
 # gRPC over plaintext
 


### PR DESCRIPTION
The more generic ServerBuilder is all that is necessary.