### PR TITLE
Use generics for LoadBalancer to avoid ClientTransport exposure

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -33,8 +33,6 @@ package io.grpc;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-import io.grpc.internal.ClientTransport;
-
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -46,12 +44,14 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>Note to implementations: all methods are expected to return quickly. Any work that may block
  * should be done asynchronously.
+ *
+ * @param T the transport type to balance
  */
 // TODO(zhangkun83): since it's also used for non-loadbalancing cases like pick-first,
 // "RequestRouter" might be a better name.
 @ExperimentalApi
 @ThreadSafe
-public abstract class LoadBalancer {
+public abstract class LoadBalancer<T> {
   /**
    * Pick a transport that Channel will use for next RPC.
    *
@@ -61,8 +61,7 @@ public abstract class LoadBalancer {
    *
    * @param requestKey for affinity-based routing
    */
-  public abstract ListenableFuture<ClientTransport> pickTransport(
-      @Nullable RequestKey requestKey);
+  public abstract ListenableFuture<T> pickTransport(@Nullable RequestKey requestKey);
 
   /**
    * Shuts down this {@code LoadBalancer}.
@@ -86,13 +85,12 @@ public abstract class LoadBalancer {
   /**
    * Called when a transport is fully connected and ready to accept traffic.
    */
-  public void transportReady(EquivalentAddressGroup addressGroup, ClientTransport transport) { }
+  public void transportReady(EquivalentAddressGroup addressGroup, T transport) { }
 
   /**
    * Called when a transport is shutting down.
    */
-  public void transportShutdown(
-      EquivalentAddressGroup addressGroup, ClientTransport transport, Status s) { }
+  public void transportShutdown(EquivalentAddressGroup addressGroup, T transport, Status s) { }
 
   public abstract static class Factory {
     /**
@@ -102,6 +100,6 @@ public abstract class LoadBalancer {
      * @param tm the interface where an {@code LoadBalancer} implementation gets connected
      *               transports from
      */
-    public abstract LoadBalancer newLoadBalancer(String serviceName, TransportManager tm);
+    public abstract <T> LoadBalancer<T> newLoadBalancer(String serviceName, TransportManager<T> tm);
   }
 }

--- a/core/src/main/java/io/grpc/TransportManager.java
+++ b/core/src/main/java/io/grpc/TransportManager.java
@@ -33,15 +33,13 @@ package io.grpc;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
-import io.grpc.internal.ClientTransport;
-
 import java.util.Collection;
 
 /**
  * Manages transport life-cycles and provide ready-to-use transports.
  */
 @ExperimentalApi
-public abstract class TransportManager {
+public abstract class TransportManager<T> {
   /**
    * Advises this {@code TransportManager} to retain transports only to these servers, for warming
    * up connections and discarding unused connections.
@@ -59,6 +57,10 @@ public abstract class TransportManager {
   // TODO(zhangkun83): GrpcLoadBalancer will use this to get transport to connect to LB servers,
   // which would have a different authority than the primary servers. We need to figure out how to
   // do it.
-  public abstract ListenableFuture<ClientTransport> getTransport(
-      EquivalentAddressGroup addressGroup);
+  public abstract ListenableFuture<T> getTransport(EquivalentAddressGroup addressGroup);
+
+  /**
+   * Returns a channel that uses {@code transport}; useful for issuing RPCs on a transport.
+   */
+  public abstract Channel makeChannel(T transport);
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -125,7 +125,7 @@ public final class ManagedChannelImpl extends ManagedChannel {
   private final Channel interceptorChannel;
 
   private final NameResolver nameResolver;
-  private final LoadBalancer loadBalancer;
+  private final LoadBalancer<ClientTransport> loadBalancer;
 
   /**
    * Maps EquivalentAddressGroups to transports for that server.
@@ -357,7 +357,7 @@ public final class ManagedChannelImpl extends ManagedChannel {
     transportFactory.release();
   }
 
-  private final TransportManager tm = new TransportManager() {
+  private final TransportManager<ClientTransport> tm = new TransportManager<ClientTransport>() {
     @Override
     public void updateRetainedTransports(Collection<EquivalentAddressGroup> addrs) {
       // TODO(zhangkun83): warm-up new servers and discard removed servers.
@@ -395,6 +395,12 @@ public final class ManagedChannelImpl extends ManagedChannel {
         }
       }
       return ts.obtainActiveTransport();
+    }
+
+    @Override
+    public Channel makeChannel(ClientTransport transport) {
+      return new SingleTransportChannel(
+          transport, executor, scheduledExecutor, authority());
     }
   };
 }

--- a/core/src/main/java/io/grpc/internal/SingleTransportChannel.java
+++ b/core/src/main/java/io/grpc/internal/SingleTransportChannel.java
@@ -50,7 +50,7 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * A {@link Channel} that wraps a {@link ClientTransport}.
  */
-public final class SingleTransportChannel extends Channel {
+final class SingleTransportChannel extends Channel {
 
   private final ClientTransport transport;
   private final Executor executor;

--- a/core/src/main/java/io/grpc/internal/TransportSet.java
+++ b/core/src/main/java/io/grpc/internal/TransportSet.java
@@ -105,7 +105,7 @@ final class TransportSet {
   @GuardedBy("lock")
   private final Collection<ClientTransport> transports = new ArrayList<ClientTransport>();
 
-  private final LoadBalancer loadBalancer;
+  private final LoadBalancer<ClientTransport> loadBalancer;
 
   @GuardedBy("lock")
   private boolean shutdown;
@@ -117,17 +117,19 @@ final class TransportSet {
   @Nullable
   private volatile UncancellableTransportFuture activeTransportFuture;
 
-  TransportSet(EquivalentAddressGroup addressGroup, String authority, LoadBalancer loadBalancer,
-      BackoffPolicy.Provider backoffPolicyProvider, ClientTransportFactory transportFactory,
-      ScheduledExecutorService scheduledExecutor, Callback callback) {
+  TransportSet(EquivalentAddressGroup addressGroup, String authority,
+      LoadBalancer<ClientTransport> loadBalancer, BackoffPolicy.Provider backoffPolicyProvider,
+      ClientTransportFactory transportFactory, ScheduledExecutorService scheduledExecutor,
+      Callback callback) {
     this(addressGroup, authority, loadBalancer, backoffPolicyProvider, transportFactory,
         scheduledExecutor, callback, Stopwatch.createUnstarted());
   }
 
   @VisibleForTesting
-  TransportSet(EquivalentAddressGroup addressGroup, String authority, LoadBalancer loadBalancer,
-      BackoffPolicy.Provider backoffPolicyProvider, ClientTransportFactory transportFactory,
-      ScheduledExecutorService scheduledExecutor, Callback callback, Stopwatch backoffWatch) {
+  TransportSet(EquivalentAddressGroup addressGroup, String authority,
+      LoadBalancer<ClientTransport> loadBalancer, BackoffPolicy.Provider backoffPolicyProvider,
+      ClientTransportFactory transportFactory, ScheduledExecutorService scheduledExecutor,
+      Callback callback, Stopwatch backoffWatch) {
     this.addressGroup = Preconditions.checkNotNull(addressGroup, "addressGroup");
     this.authority = authority;
     this.loadBalancer = loadBalancer;

--- a/core/src/test/java/io/grpc/SimpleLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/SimpleLoadBalancerTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -46,8 +45,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-
-import io.grpc.internal.ClientTransport;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -62,13 +59,13 @@ import java.util.ArrayList;
 /** Unit test for {@link SimpleLoadBalancerFactory}. */
 @RunWith(JUnit4.class)
 public class SimpleLoadBalancerTest {
-  private LoadBalancer loadBalancer;
+  private LoadBalancer<Transport> loadBalancer;
 
   private ArrayList<ResolvedServerInfo> servers;
   private EquivalentAddressGroup addressGroup;
 
   @Mock
-  private TransportManager mockTransportManager;
+  private TransportManager<Transport> mockTransportManager;
 
   @Before
   public void setUp() {
@@ -87,12 +84,12 @@ public class SimpleLoadBalancerTest {
 
   @Test
   public void pickBeforeResolved() throws Exception {
-    ClientTransport mockTransport = mock(ClientTransport.class);
-    SettableFuture<ClientTransport> sourceFuture = SettableFuture.create();
+    Transport mockTransport = new Transport();
+    SettableFuture<Transport> sourceFuture = SettableFuture.create();
     when(mockTransportManager.getTransport(eq(addressGroup)))
         .thenReturn(sourceFuture);
-    ListenableFuture<ClientTransport> f1 = loadBalancer.pickTransport(null);
-    ListenableFuture<ClientTransport> f2 = loadBalancer.pickTransport(null);
+    ListenableFuture<Transport> f1 = loadBalancer.pickTransport(null);
+    ListenableFuture<Transport> f2 = loadBalancer.pickTransport(null);
     assertNotNull(f1);
     assertNotNull(f2);
     assertNotSame(f1, f2);
@@ -113,12 +110,12 @@ public class SimpleLoadBalancerTest {
 
   @Test
   public void pickAfterResolved() throws Exception {
-    ClientTransport mockTransport = mock(ClientTransport.class);
-    SettableFuture<ClientTransport> sourceFuture = SettableFuture.create();
+    Transport mockTransport = new Transport();
+    SettableFuture<Transport> sourceFuture = SettableFuture.create();
     when(mockTransportManager.getTransport(eq(addressGroup)))
         .thenReturn(sourceFuture);
     loadBalancer.handleResolvedAddresses(servers, Attributes.EMPTY);
-    ListenableFuture<ClientTransport> f = loadBalancer.pickTransport(null);
+    ListenableFuture<Transport> f = loadBalancer.pickTransport(null);
     assertSame(sourceFuture, f);
     assertFalse(f.isDone());
     sourceFuture.set(mockTransport);
@@ -139,4 +136,5 @@ public class SimpleLoadBalancerTest {
     }
   }
 
+  private static class Transport {}
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -529,15 +529,15 @@ public class ManagedChannelImplTest {
 
   private class SpyingLoadBalancerFactory extends LoadBalancer.Factory {
     private final LoadBalancer.Factory delegate;
-    private final List<LoadBalancer> balancers = new ArrayList<LoadBalancer>();
+    private final List<LoadBalancer<?>> balancers = new ArrayList<LoadBalancer<?>>();
 
     private SpyingLoadBalancerFactory(LoadBalancer.Factory delegate) {
       this.delegate = delegate;
     }
 
     @Override
-    public LoadBalancer newLoadBalancer(String serviceName, TransportManager tm) {
-      LoadBalancer lb = spy(delegate.newLoadBalancer(serviceName, tm));
+    public <T> LoadBalancer<T> newLoadBalancer(String serviceName, TransportManager<T> tm) {
+      LoadBalancer<T> lb = spy(delegate.newLoadBalancer(serviceName, tm));
       balancers.add(lb);
       return lb;
     }

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -70,7 +70,7 @@ public class TransportSetTest {
 
   private FakeClock fakeClock;
 
-  @Mock private LoadBalancer mockLoadBalancer;
+  @Mock private LoadBalancer<ClientTransport> mockLoadBalancer;
   @Mock private BackoffPolicy mockBackoffPolicy1;
   @Mock private BackoffPolicy mockBackoffPolicy2;
   @Mock private BackoffPolicy mockBackoffPolicy3;

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerFactory.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerFactory.java
@@ -56,7 +56,7 @@ public class GrpclbLoadBalancerFactory extends LoadBalancer.Factory {
   }
 
   @Override
-  public LoadBalancer newLoadBalancer(String serviceName, TransportManager tm) {
-    return new GrpclbLoadBalancer(serviceName, tm);
+  public <T> LoadBalancer<T> newLoadBalancer(String serviceName, TransportManager<T> tm) {
+    return new GrpclbLoadBalancer<T>(serviceName, tm);
   }
 }


### PR DESCRIPTION
Is this an improvement?