### PR TITLE
Revert minor grammar tweaks to avoid syncing readme

### DIFF
--- a/testing/src/main/resources/certs/README
+++ b/testing/src/main/resources/certs/README
@@ -10,7 +10,7 @@ $ openssl req -x509 -newkey rsa:1024 -keyout badserver.key -out badserver.pem \
   -days 3650 -nodes
 
 When prompted for certificate information, everything is default except the
-common name, which is set to badserver.test.google.com.
+common name which is set to badserver.test.google.com.
 
 
 Valid test credentials:
@@ -31,7 +31,7 @@ $ rm client.key.rsa
 $ openssl req -new -key client.key -out client.csr
 
 When prompted for certificate information, everything is default except the
-common name, which is set to testclient.
+common name which is set to testclient.
 
 $ openssl ca -in client.csr -out client.pem -keyfile ca.key -cert ca.pem -verbose -config openssl.cnf -days 3650 -updatedb
 $ openssl x509 -in client.pem -out client.pem -outform PEM
@@ -45,7 +45,7 @@ $ rm server0.key.rsa
 $ openssl req -new -key server0.key -out server0.csr
 
 When prompted for certificate information, everything is default except the
-common name, which is set to *.test.google.com.au.
+common name which is set to *.test.google.com.au.
 
 $ openssl ca -in server0.csr -out server0.pem -keyfile ca.key -cert ca.pem -verbose -config openssl.cnf -days 3650 -updatedb
 $ openssl x509 -in server0.pem -out server0.pem -outform PEM
@@ -59,7 +59,7 @@ $ rm server1.key.rsa
 $ openssl req -new -key server1.key -out server1.csr -config server1-openssl.cnf
 
 When prompted for certificate information, everything is default except the
-common name, which is set to *.test.google.com.
+common name which is set to *.test.google.com.
 
 $ openssl ca -in server1.csr -out server1.pem -keyfile ca.key -cert ca.pem -verbose -config server1-openssl.cnf -days 3650 -extensions v3_req -updatedb
 $ openssl x509 -in server1.pem -out server1.pem -outform PEM


### PR DESCRIPTION
The certs are used a lot of places, and we would prefer they stay
identical. This small grammar changes from 95d7bfd don't seem to
contribute enough for the effort envolved to sync.