### PR TITLE
Update gradle to 2.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
     ext {
         def exeSuffix = osdetector.os == 'windows' ? ".exe" : ""
         protocPluginBaseName = 'protoc-gen-grpc-java'
-        javaPluginPath = "$rootDir/compiler/build/binaries/java_pluginExecutable/$protocPluginBaseName$exeSuffix"
+        javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         protobufVersion = '3.0.0-beta-1'
         protobufNanoVersion = '3.0.0-alpha-4'

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -71,6 +71,41 @@ model {
       baseName "$protocPluginBaseName"
     }
   }
+
+  binaries {
+    all {
+      if (toolChain in Gcc || toolChain in Clang) {
+        cppCompiler.args "--std=c++0x"
+        addEnvArgs("CXXFLAGS", cppCompiler.args)
+        addEnvArgs("CPPFLAGS", cppCompiler.args)
+        if (osdetector.os == "osx") {
+          cppCompiler.args "-mmacosx-version-min=10.7", "-stdlib=libc++"
+          addLibraryIfNotLinked('protoc', linker.args)
+          addLibraryIfNotLinked('protobuf', linker.args)
+        } else if (osdetector.os == "windows") {
+          linker.args "-static", "-lprotoc", "-lprotobuf", "-static-libgcc", "-static-libstdc++",
+                      "-s"
+        } else {
+          // Link protoc, protobuf, libgcc and libstdc++ statically.
+          // Link other (system) libraries dynamically.
+          // Clang under OSX doesn't support these options.
+          linker.args "-Wl,-Bstatic", "-lprotoc", "-lprotobuf", "-static-libgcc",
+                      "-static-libstdc++",
+                      "-Wl,-Bdynamic", "-lpthread", "-s"
+        }
+        addEnvArgs("LDFLAGS", linker.args)
+      } else if (toolChain in VisualCpp) {
+        cppCompiler.args "/EHsc", "/MT"
+        if (rootProject.hasProperty('vcProtobufInclude')) {
+          cppCompiler.args "/I${rootProject.vcProtobufInclude}"
+        }
+        linker.args "libprotobuf.lib", "libprotoc.lib"
+        if (rootProject.hasProperty('vcProtobufLibs')) {
+          linker.args "/LIBPATH:${rootProject.vcProtobufLibs}"
+        }
+      }
+    }
+  }
 }
 
 configurations {
@@ -132,37 +167,6 @@ checkstyleTestNano {
 
 println "*** Building codegen requires Protobuf version ${protobufVersion}"
 println "*** Please refer to https://github.com/grpc/grpc-java/blob/master/COMPILING.md#how-to-build-code-generation-plugin"
-
-binaries.all {
-  if (toolChain in Gcc || toolChain in Clang) {
-    cppCompiler.args "--std=c++0x"
-    addEnvArgs("CXXFLAGS", cppCompiler.args)
-    addEnvArgs("CPPFLAGS", cppCompiler.args)
-    if (osdetector.os == "osx") {
-      cppCompiler.args "-mmacosx-version-min=10.7", "-stdlib=libc++"
-      addLibraryIfNotLinked('protoc', linker.args)
-      addLibraryIfNotLinked('protobuf', linker.args)
-    } else if (osdetector.os == "windows") {
-      linker.args "-static", "-lprotoc", "-lprotobuf", "-static-libgcc", "-static-libstdc++", "-s"
-    } else {
-      // Link protoc, protobuf, libgcc and libstdc++ statically.
-      // Link other (system) libraries dynamically.
-      // Clang under OSX doesn't support these options.
-      linker.args "-Wl,-Bstatic", "-lprotoc", "-lprotobuf", "-static-libgcc", "-static-libstdc++",
-                  "-Wl,-Bdynamic", "-lpthread", "-s"
-    }
-    addEnvArgs("LDFLAGS", linker.args)
-  } else if (toolChain in VisualCpp) {
-    cppCompiler.args "/EHsc", "/MT"
-    if (rootProject.hasProperty('vcProtobufInclude')) {
-      cppCompiler.args "/I${rootProject.vcProtobufInclude}"
-    }
-    linker.args "libprotobuf.lib", "libprotoc.lib"
-    if (rootProject.hasProperty('vcProtobufLibs')) {
-      linker.args "/LIBPATH:${rootProject.vcProtobufLibs}"
-    }
-  }
-}
 
 task buildArtifacts(type: Copy) {
   dependsOn 'java_pluginExecutable'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 23 10:41:33 PDT 2015
+#Tue Jan 26 12:09:52 PST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip


### PR DESCRIPTION
Gets us past some minor DSL changes and should get increased build
performance. Will make it easier to update to 2.11 and other future
versions.