### PR TITLE
Fix executor propagation in CallOptions.

### DIFF
--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -171,6 +171,7 @@ public final class CallOptions {
     deadlineNanoTime = other.deadlineNanoTime;
     authority = other.authority;
     requestKey = other.requestKey;
+    executor = other.executor;
   }
 
   @Override


### PR DESCRIPTION
This fixes a minor race condition if interceptors modify the call options since different executors will be used to wait on. 