### PR TITLE
Fix artifact upload for compiler

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -194,7 +194,7 @@ artifacts {
 [
   install.repositories.mavenInstaller,
   uploadArchives.repositories.mavenDeployer,
-]*.addFilter('all') {artifact, file ->
+]*.setFilter {artifact, file ->
   ! (file.getName().endsWith('jar') || file.getName().endsWith('jar.asc'))
 }
 
@@ -207,6 +207,19 @@ artifacts {
   }
   if (ret.exitValue != 0) {
     throw new GradleException("check-artifact.sh exited with " + ret.exitValue)
+  }
+}
+
+[
+  install.repositories.mavenInstaller,
+  uploadArchives.repositories.mavenDeployer,
+]*.pom*.whenConfigured { pom ->
+  pom.project {
+    // This isn't any sort of Java archive artifact, and OSSRH doesn't enforce
+    // javadoc for 'pom' packages. 'exe' would be a more appropriate packaging
+    // value, but it isn't clear how that will be interpreted. In addition,
+    // 'pom' is typically the value used when building an exe with Maven.
+    packaging = "pom"
   }
 }
 

--- a/compiler/check-artifact.sh
+++ b/compiler/check-artifact.sh
@@ -125,5 +125,5 @@ checkDependencies ()
   echo
 }
 
-FILE="build/artifacts/java_pluginExecutable/protoc-gen-grpc-java.exe"
+FILE="build/artifacts/java_plugin/protoc-gen-grpc-java.exe"
 checkArch "$FILE" && checkDependencies "$FILE"


### PR DESCRIPTION
check-artifact.sh was broken by the update to Gradle 2.10. We think the
update to Gradle 2.8 caused the POM to start being generated, but this
now fixes it to have the correct contents.

Using addFilter _disables_ the normal POM, so we use setFilter instead.

Fixes #1360