### PR TITLE
Mark ChannelHandler.exceptionCaught implementation deprecated to fix warning

### DIFF
--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -102,6 +102,7 @@ public final class ProtocolNegotiators {
           }
 
           @Override
+          @Deprecated
           public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             // Should never happen.
             ctx.fireExceptionCaught(cause);


### PR DESCRIPTION
This just propagates the deprecated annotation from ChannelHandler. Note
that exceptionCaught is _not_ deprecated for ChannelInboundHandler and
ChannelDuplexHandler.