### PR TITLE
Help steer new users away from copying our build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,6 @@ subprojects {
                 // used to collect benchmark results
                 hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.4',
                 hpack: 'com.twitter:hpack:0.10.1',
-                jsonp: 'org.glassfish:javax.json:1.0.4',
                 jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
                 oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.3.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,3 +1,14 @@
+// Don't consider this build file part of the example! It is much more complex
+// than yours needs to be. For your own build file, please follow ../README.md
+// instead. For a starting point you can make a build.gradle file with:
+//
+//   apply plugin: 'java'
+//   repositories {
+//     mavenCentral()
+//   }
+//
+// Then copy the snippets from README.md.
+
 apply plugin: 'application'
 
 description = "grpc Examples"
@@ -18,7 +29,7 @@ dependencies {
             project(':grpc-netty'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
-            libraries.jsonp
+            'org.glassfish:javax.json:1.0.4'
 }
 
 configureProtoCompilation()


### PR DESCRIPTION
The jsonp dependency string is no longer shared because it was only used
in one place and someone trying to compile the examples using a new
build.gradle will need to add that dependency. It was a bit complex to
follow how libraries.jsonp worked and it wasn't really adding any value
in this particular case.