### PR TITLE
Update README to reference 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,23 @@ Download [the JAR][]. Or for Maven, add to your `pom.xml`:
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-all</artifactId>
-  <version>0.9.0</version>
+  <version>0.12.0</version>
 </dependency>
 ```
 
 Or for Gradle, add to your dependencies:
 ```gradle
-compile 'io.grpc:grpc-all:0.9.0'
+compile 'io.grpc:grpc-all:0.12.0'
 ```
 
 For Android client, you only need to depend on the needed sub-projects, such as:
 ```gradle
-compile 'io.grpc:grpc-okhttp:0.9.0'
-compile 'io.grpc:grpc-protobuf-nano:0.9.0'
-compile 'io.grpc:grpc-stub:0.9.0'
+compile 'io.grpc:grpc-okhttp:0.12.0'
+compile 'io.grpc:grpc-protobuf-nano:0.12.0'
+compile 'io.grpc:grpc-stub:0.12.0'
 ```
 
-[the JAR]: https://search.maven.org/remote_content?g=io.grpc&a=grpc-all&v=0.9.0
+[the JAR]: https://search.maven.org/remote_content?g=io.grpc&a=grpc-all&v=0.12.0
 
 Development snapshots are available in [Sonatypes's snapshot
 repository](https://oss.sonatype.org/content/repositories/snapshots/).
@@ -90,9 +90,9 @@ For protobuf-based codegen integrated with the Maven build system, you can use
           protobuf-java directly, you will be transitively depending on the
           protobuf-java version that grpc depends on.
         -->
-        <protocArtifact>com.google.protobuf:protoc:3.0.0-beta-2:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.0.0-beta-1:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
-        <pluginArtifact>io.grpc:protoc-gen-grpc-java:0.9.0:exe:${os.detected.classifier}</pluginArtifact>
+        <pluginArtifact>io.grpc:protoc-gen-grpc-java:0.12.0:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
       <executions>
         <execution>
@@ -129,11 +129,11 @@ protobuf {
     // The version of protoc must match protobuf-java. If you don't depend on
     // protobuf-java directly, you will be transitively depending on the
     // protobuf-java version that grpc depends on.
-    artifact = "com.google.protobuf:protoc:3.0.0-beta-2"
+    artifact = "com.google.protobuf:protoc:3.0.0-beta-1"
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:0.9.0'
+      artifact = 'io.grpc:protoc-gen-grpc-java:0.12.0'
     }
   }
   generateProtoTasks {


### PR DESCRIPTION
The version of protoc to use was bumped prematurely in e2ed2e8, so it is
reverted back to beta-1 here. When 0.13.0 is released then the protoc
version should be bumped.