### PR TITLE
Update README to point to protobuf-gradle-plugin 0.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.6.1'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.4'
   }
 }
 


### PR DESCRIPTION
We've been using 0.7.0 since 5df6ab0 and 0.7.4 since d3d253e, but hadn't
updated the README. 0.6.1 wouldn't work in Java 7, so using a newer
version can prevent users from hitting that bump.