### PR TITLE
Negotiation Handlers should implement ChannelHandler

### DIFF
--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
@@ -32,7 +32,7 @@
 package io.grpc.netty;
 
 import io.grpc.Internal;
-import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.util.AsciiString;
 
@@ -45,7 +45,7 @@ public interface ProtocolNegotiator {
   /**
    * The Netty handler to control the protocol negotiation.
    */
-  interface Handler extends ChannelInboundHandler {
+  interface Handler extends ChannelHandler {
     /**
      * The HTTP/2 scheme to be used when sending {@code HEADERS}.
      */

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -89,7 +89,7 @@ public final class ProtocolNegotiators {
     return new ProtocolNegotiator() {
       @Override
       public Handler newHandler(final Http2ConnectionHandler handler) {
-        class PlaintextHandler extends ChannelDuplexHandler implements Handler {
+        class PlaintextHandler extends ChannelHandlerAdapter implements Handler {
           @Override
           public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
             // Just replace this handler with the gRPC handler.


### PR DESCRIPTION
Having Handler implement ChannelInboundHandler is overspecifying and
unnecessary, as the code compiles fine just by changing "implements
ChannelInboundHandler" to "implements ChannelHandler".

PlaintextHandler was swapped to ChannelHandlerAdapter instead of
ChannelDuplexHandler because it just needs the ChannelHandler methods.