### PR TITLE
Update Android test build to use current grpc snapshot and support Gradle 2.10

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -32,7 +32,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.10.0-SNAPSHOT'
+            artifact = 'io.grpc:protoc-gen-grpc-java:0.13.0-SNAPSHOT'
         }
     }
     generateProtoTasks {
@@ -63,9 +63,9 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     testCompile 'junit:junit:4.12'
     // You need to build grpc-java to obtain these libraries below.
-    compile 'io.grpc:grpc-protobuf-nano:0.10.0-SNAPSHOT'
-    compile 'io.grpc:grpc-okhttp:0.10.0-SNAPSHOT'
-    compile 'io.grpc:grpc-stub:0.10.0-SNAPSHOT'
-    compile 'io.grpc:grpc-testing:0.10.0-SNAPSHOT'
+    compile 'io.grpc:grpc-protobuf-nano:0.13.0-SNAPSHOT'
+    compile 'io.grpc:grpc-okhttp:0.13.0-SNAPSHOT'
+    compile 'io.grpc:grpc-stub:0.13.0-SNAPSHOT'
+    compile 'io.grpc:grpc-testing:0.13.0-SNAPSHOT'
     compile 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.6.1"
+        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.7.4"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
com.android.tools.build:gradle:1.1.0 doesn't work with Gradle 2.10, but
1.5.0 does.

I also bumped the protobuf-gradle-plugin to be the same as the version
used in the README and our primary build.gradle.