### PR TITLE
Automated readability/efficiency tweaks

### DIFF
--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -557,8 +557,10 @@ public final class Metadata {
      */
     private AsciiKey(String name, AsciiMarshaller<T> marshaller) {
       super(name);
-      Preconditions.checkArgument(!name.endsWith(BINARY_HEADER_SUFFIX),
-          "ASCII header is named " + name + ". It must not end with " + BINARY_HEADER_SUFFIX);
+      Preconditions.checkArgument(
+          !name.endsWith(BINARY_HEADER_SUFFIX),
+          "ASCII header is named %s. It must not end with %s",
+          name, BINARY_HEADER_SUFFIX);
       this.marshaller = Preconditions.checkNotNull(marshaller);
     }
 

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -233,7 +233,7 @@ public class MethodDescriptor<ReqT, RespT> {
   @ExperimentalApi
   @Nullable
   public static String extractFullServiceName(String fullMethodName) {
-    int index = fullMethodName.lastIndexOf("/");
+    int index = fullMethodName.lastIndexOf('/');
     if (index == -1) {
       return null;
     }

--- a/core/src/main/java/io/grpc/internal/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStream.java
@@ -100,7 +100,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
     if (transportError != null) {
       // Note we don't immediately report the transport error, instead we wait for more data on the
       // stream so we can accumulate more detail into the error before reporting it.
-      transportError = transportError.augmentDescription("\n" + headers.toString());
+      transportError = transportError.augmentDescription("\n" + headers);
       transportErrorMetadata = headers;
       errorCharset = extractCharset(headers);
     } else {

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -217,7 +217,7 @@ public final class ManagedChannelImpl extends ManagedChannel {
     }
     throw new IllegalArgumentException(String.format(
         "cannot find a NameResolver for %s%s",
-        target, uriSyntaxErrors.length() > 0 ? " (" + uriSyntaxErrors.toString() + ")" : ""));
+        target, uriSyntaxErrors.length() > 0 ? " (" + uriSyntaxErrors + ")" : ""));
   }
 
   /**

--- a/core/src/test/java/io/grpc/internal/ByteWritableBufferTest.java
+++ b/core/src/test/java/io/grpc/internal/ByteWritableBufferTest.java
@@ -51,6 +51,6 @@ public class ByteWritableBufferTest extends WritableBufferTestBase {
 
   @Override
   protected byte[] writtenBytes() {
-    return Arrays.copyOfRange(buffer.data, 0, buffer.readableBytes());
+    return Arrays.copyOf(buffer.data, buffer.readableBytes());
   }
 }

--- a/core/src/test/java/io/grpc/internal/ReadableBufferTestBase.java
+++ b/core/src/test/java/io/grpc/internal/ReadableBufferTestBase.java
@@ -124,7 +124,7 @@ public abstract class ReadableBufferTestBase {
   protected abstract ReadableBuffer buffer();
 
   private static String repeatUntilLength(String toRepeat, int length) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     while (buf.length() < length) {
       buf.append(toRepeat);
     }

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -521,6 +521,7 @@ public class ServerImplTest {
         try {
           barrier.await();
         } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(ex);
         } catch (BrokenBarrierException ex) {
           throw new RuntimeException(ex);

--- a/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
+++ b/examples/src/main/java/io/grpc/examples/header/HeaderClientInterceptor.java
@@ -69,7 +69,7 @@ public class HeaderClientInterceptor implements ClientInterceptor {
              * you can use {@link io.grpc.stub.MetadataUtils attachHeaders}
              * directly to send header
              */
-            logger.info("header received from server:" + headers.toString());
+            logger.info("header received from server:" + headers);
             super.onHeaders(headers);
           }
         }, headers);

--- a/examples/src/main/java/io/grpc/examples/header/HeaderServerInterceptor.java
+++ b/examples/src/main/java/io/grpc/examples/header/HeaderServerInterceptor.java
@@ -57,7 +57,7 @@ public class HeaderServerInterceptor implements ServerInterceptor {
       ServerCall<RespT> call,
       final Metadata requestHeaders,
       ServerCallHandler<ReqT, RespT> next) {
-    logger.info("header received from client:" + requestHeaders.toString());
+    logger.info("header received from client:" + requestHeaders);
     return next.startCall(method, new SimpleForwardingServerCall<RespT>(call) {
       @Override
       public void sendHeaders(Metadata responseHeaders) {

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -34,6 +34,7 @@ package io.grpc.grpclb;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -351,13 +352,7 @@ class GrpclbLoadBalancer<T> extends LoadBalancer<T> {
           directTransport = transportFuture = Futures.immediateFuture(lbTransport);
           pendingPicksFulfillmentBatch = pendingPicks.createFulfillmentBatch();
         }
-        pendingPicksFulfillmentBatch.link(
-            new Supplier<ListenableFuture<T>>() {
-              @Override
-              public ListenableFuture<T> get() {
-                return transportFuture;
-              }
-            });
+        pendingPicksFulfillmentBatch.link(Suppliers.ofInstance(transportFuture));
       } else {
         handleError(status);
         synchronized (lock) {

--- a/grpclb/src/main/java/io/grpc/grpclb/RoundRobinServerList.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/RoundRobinServerList.java
@@ -34,7 +34,7 @@ package io.grpc.grpclb;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import io.grpc.EquivalentAddressGroup;
@@ -62,7 +62,7 @@ class RoundRobinServerList<T> {
   private RoundRobinServerList(TransportManager<T> tm, List<EquivalentAddressGroup> list) {
     this.tm = tm;
     this.list = list;
-    this.cyclingIter = Iterables.cycle(list).iterator();
+    this.cyclingIter = Iterators.cycle(list);
   }
 
   ListenableFuture<T> getTransportForNextServer() {

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -97,8 +97,7 @@ public class GrpclbLoadBalancerTest {
         new ArrayList<SettableFuture<Transport>>(servers.size());
 
     for (ResolvedServerInfo server : servers) {
-      transports.add(
-          mock(Transport.class, withSettings().name("Transport for "  + server.toString())));
+      transports.add(mock(Transport.class, withSettings().name("Transport for "  + server)));
       SettableFuture<Transport> future = SettableFuture.create();
       transportFutures.add(future);
       when(mockTransportManager.getTransport(eq(new EquivalentAddressGroup(server.getAddress()))))

--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -32,7 +32,6 @@
 package io.grpc.netty;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.getEmbeddedHttp2Exception;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -49,7 +48,7 @@ import io.netty.handler.codec.http2.Http2Stream;
  * shutdown the connection) as well as sending the initial connection window at startup.
  */
 abstract class AbstractNettyHandler extends Http2ConnectionHandler {
-  private static long GRACEFUL_SHUTDOWN_TIMEOUT = MILLISECONDS.convert(5, SECONDS);
+  private static long GRACEFUL_SHUTDOWN_TIMEOUT = SECONDS.toMillis(5);
   private int initialConnectionWindow;
   private ChannelHandlerContext ctx;
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -46,7 +46,7 @@ import io.grpc.okhttp.internal.framed.Header;
 
 import okio.Buffer;
 
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 
@@ -83,7 +83,7 @@ class OkHttpClientStream extends Http2ClientStream {
    * {@link #start(Integer)} have been called.
    */
   @GuardedBy("lock")
-  private Queue<PendingData> pendingData = new LinkedList<PendingData>();
+  private Queue<PendingData> pendingData = new ArrayDeque<PendingData>();
   @GuardedBy("lock")
   private boolean cancelSent = false;
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -69,6 +69,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -92,7 +93,7 @@ class OkHttpClientTransport implements ManagedClientTransport {
   private static final OkHttpClientStream[] EMPTY_STREAM_ARRAY = new OkHttpClientStream[0];
 
   static {
-    Map<ErrorCode, Status> errorToStatus = new HashMap<ErrorCode, Status>();
+    Map<ErrorCode, Status> errorToStatus = new EnumMap<ErrorCode, Status>(ErrorCode.class);
     errorToStatus.put(ErrorCode.NO_ERROR,
         Status.INTERNAL.withDescription("No error: A GRPC status of OK should have been sent"));
     errorToStatus.put(ErrorCode.PROTOCOL_ERROR,

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -1398,18 +1398,16 @@ public class OkHttpClientTransportTest {
   }
 
   private List<Header> grpcResponseHeaders() {
-    return ImmutableList.<Header>builder()
-        .add(new Header(":status", "200"))
-        .add(CONTENT_TYPE_HEADER)
-        .build();
+    return ImmutableList.of(
+        new Header(":status", "200"),
+        CONTENT_TYPE_HEADER);
   }
 
   private List<Header> grpcResponseTrailers() {
-    return ImmutableList.<Header>builder()
-        .add(new Header(Status.CODE_KEY.name(), "0"))
+    return ImmutableList.of(
+        new Header(Status.CODE_KEY.name(), "0"),
         // Adding Content-Type for testing responses with only a single HEADERS frame.
-        .add(CONTENT_TYPE_HEADER)
-        .build();
+        CONTENT_TYPE_HEADER);
   }
 
   private static class MockFrameReader implements FrameReader {
@@ -1428,6 +1426,7 @@ public class OkHttpClientTransportTest {
           fail("Failed waiting frame reader to be closed.");
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         fail("Interrupted while waiting for frame reader to be closed.");
       }
     }
@@ -1443,6 +1442,7 @@ public class OkHttpClientTransportTest {
       try {
         wait();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new IOException(e);
       }
       if (throwExceptionForNextFrame) {

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -435,7 +435,7 @@ public class ClientCalls {
           // hangs here as the call will become closed.
           last = waitForNext();
         } catch (InterruptedException ie) {
-          Thread.interrupted();
+          Thread.currentThread().interrupt();
           throw Status.CANCELLED.withCause(ie).asRuntimeException();
         }
       }


### PR DESCRIPTION
Although the changes were determined automatically, they were manually
applied to the codebase.

ClientCalls actually has a bug fix, since the suggestion to add
interrupt() made it obvious that interrupted() was inappropriate.

We can pick and choose which changes we like, but these all seemed pretty reasonable.