### PR TITLE
DelayedClientTransport and fix TransportSet.shutdown() semantics.

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -36,8 +36,8 @@ import com.google.common.base.Preconditions;
 import io.grpc.ExperimentalApi;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
-import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.ManagedClientTransport;
 
 import java.net.SocketAddress;
 
@@ -89,7 +89,7 @@ public class InProcessChannelBuilder extends
     }
 
     @Override
-    public ClientTransport newClientTransport(SocketAddress addr, String authority) {
+    public ManagedClientTransport newClientTransport(SocketAddress addr, String authority) {
       return new InProcessTransport(name);
     }
 

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -40,7 +40,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
-import io.grpc.internal.ClientTransport;
+import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.NoopClientStream;
 import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
@@ -59,12 +59,12 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
-class InProcessTransport implements ServerTransport, ClientTransport {
+class InProcessTransport implements ServerTransport, ManagedClientTransport {
   private static final Logger log = Logger.getLogger(InProcessTransport.class.getName());
 
   private final String name;
   private ServerTransportListener serverTransportListener;
-  private ClientTransport.Listener clientTransportListener;
+  private ManagedClientTransport.Listener clientTransportListener;
   @GuardedBy("this")
   private boolean shutdown;
   @GuardedBy("this")
@@ -79,7 +79,7 @@ class InProcessTransport implements ServerTransport, ClientTransport {
   }
 
   @Override
-  public synchronized void start(ClientTransport.Listener listener) {
+  public synchronized void start(ManagedClientTransport.Listener listener) {
     this.clientTransportListener = listener;
     InProcessServer server = InProcessServer.findServer(name);
     if (server != null) {
@@ -152,7 +152,7 @@ class InProcessTransport implements ServerTransport, ClientTransport {
 
   @Override
   public synchronized void shutdown() {
-    // Can be called multiple times: once for ClientTransport, once for ServerTransport.
+    // Can be called multiple times: once for ManagedClientTransport, once for ServerTransport.
     if (shutdown) {
       return;
     }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -230,7 +230,8 @@ public abstract class AbstractManagedChannelImplBuilder
     }
 
     @Override
-    public ClientTransport newClientTransport(SocketAddress serverAddress, String authority) {
+    public ManagedClientTransport newClientTransport(SocketAddress serverAddress,
+        String authority) {
       return factory.newClientTransport(
           serverAddress, authorityOverride != null ? authorityOverride : authority);
     }

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -33,7 +33,7 @@ package io.grpc.internal;
 
 import java.net.SocketAddress;
 
-/** Pre-configured factory for creating {@link ClientTransport} instances. */
+/** Pre-configured factory for creating {@link ManagedClientTransport} instances. */
 public interface ClientTransportFactory extends ReferenceCounted {
   /**
    * Creates an unstarted transport for exclusive use.
@@ -41,5 +41,5 @@ public interface ClientTransportFactory extends ReferenceCounted {
    * @param serverAddress the address that the transport is connected to
    * @param authority the HTTP/2 authority of the server
    */
-  ClientTransport newClientTransport(SocketAddress serverAddress, String authority);
+  ManagedClientTransport newClientTransport(SocketAddress serverAddress, String authority);
 }

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.concurrent.Executor;
+
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * A client transport that queues requests before a real transport is available. When a backing
+ * transport is later provided, this class delegates to it.
+ *
+ * <p>This transport owns the streams that it has created before {@link #setTransport} is
+ * called. When {@link #setTransport} is called, the ownership of pending streams and subsequent new
+ * streams are transferred to the given transport, thus this transport won't own any stream.
+ */
+class DelayedClientTransport implements ManagedClientTransport {
+  private final Object lock = new Object();
+
+  private Listener listener;
+  /** 'lock' must be held when assigning to delegate. */
+  private volatile ClientTransport delegate;
+
+  @GuardedBy("lock")
+  private Collection<PendingStream> pendingStreams = new HashSet<PendingStream>();
+  @GuardedBy("lock")
+  private Collection<PendingPing> pendingPings = new ArrayList<PendingPing>();
+  /**
+   * When shutdown == true and pendingStreams == null, then the transport is considered terminated.
+   */
+  @GuardedBy("lock")
+  private boolean shutdown;
+
+  @Override
+  public void start(Listener listener) {
+    this.listener = Preconditions.checkNotNull(listener, "listener");
+  }
+
+  @Override
+  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
+    ClientTransport transport = delegate;
+    if (transport != null) {
+      return transport.newStream(method, headers);
+    }
+    synchronized (lock) {
+      // Check again, since it may have changed while waiting for lock
+      transport = delegate;
+      if (transport != null) {
+        return transport.newStream(method, headers);
+      }
+      if (!shutdown) {
+        PendingStream pendingStream = new PendingStream(method, headers);
+        pendingStreams.add(pendingStream);
+        return pendingStream;
+      }
+    }
+    DelayedStream stream = new DelayedStream();
+    stream.setError(Status.UNAVAILABLE.withDescription("transport shutdown"));
+    return stream;
+  }
+
+  public void ping(final PingCallback callback, Executor executor) {
+    ClientTransport transport = delegate;
+    if (transport != null) {
+      transport.ping(callback, executor);
+      return;
+    }
+    synchronized (lock) {
+      // Check again, since it may have changed while waiting for lock
+      transport = delegate;
+      if (transport != null) {
+        transport.ping(callback, executor);
+        return;
+      }
+      if (!shutdown) {
+        PendingPing pendingPing = new PendingPing(callback, executor);
+        pendingPings.add(pendingPing);
+        return;
+      }
+    }
+    executor.execute(new Runnable() {
+        @Override public void run() {
+          callback.onFailure(
+              Status.UNAVAILABLE.withDescription("transport shutdown").asException());
+        }
+      });
+  }
+
+  /**
+   * Prevents creating any new streams until {@link #setTransport} is called. Buffered streams are
+   * not failed, so if {@link #shutdown} is called when {@link #setTransport} has not been called,
+   * you still need to call {@link setTransport} to make this transport terminated.
+   */
+  @Override
+  public void shutdown() {
+    synchronized (lock) {
+      if (shutdown) {
+        return;
+      }
+      shutdown = true;
+      listener.transportShutdown(
+          Status.OK.withDescription("Channel requested transport to shut down"));
+      if (pendingStreams == null || pendingStreams.isEmpty()) {
+        pendingStreams = null;
+        listener.transportTerminated();
+      }
+    }
+  }
+
+  /**
+   * Shuts down this transport and cancels all streams that it owns, hence immediately terminates
+   * this transport.
+   */
+  public void shutdownNow(Status status) {
+    shutdown();
+    Collection<PendingStream> savedPendingStreams = null;
+    synchronized (lock) {
+      if (pendingStreams != null) {
+        savedPendingStreams = pendingStreams;
+        pendingStreams = null;
+      }
+    }
+    if (savedPendingStreams != null) {
+      for (PendingStream stream : savedPendingStreams) {
+        stream.setError(status);
+      }
+      listener.transportTerminated();
+    }
+    // If savedPendingStreams == null, transportTerminated() has already been called in shutdown().
+  }
+
+  /**
+   * Transfers all the pending and future requests and pings to the given transport.
+   *
+   * <p>May only be called after {@link #start(Listener)}.
+   *
+   * <p>{@code transport} will be used for all future calls to {@link #newStream}, even if this
+   * transport is {@link #shutdown}.
+   */
+  public void setTransport(ClientTransport transport) {
+    Collection<PendingStream> savedPendingStreams;
+    synchronized (lock) {
+      Preconditions.checkState(delegate == null, "setTransport already called");
+      Preconditions.checkState(listener != null, "start() not called");
+      delegate = Preconditions.checkNotNull(transport, "transport");
+      for (PendingPing ping : pendingPings) {
+        ping.createRealPing(transport);
+      }
+      pendingPings = null;
+      if (shutdown && pendingStreams != null) {
+        listener.transportTerminated();
+      }
+      savedPendingStreams = pendingStreams;
+      pendingStreams = null;
+      if (!shutdown) {
+        listener.transportReady();
+      }
+    }
+    // createRealStream may be expensive, so we run it outside of the lock.  It will start real
+    // streams on the transport. If there are pending requests, they will be serialized too, which
+    // may be expensive.
+    // TODO(zhangkun83): may consider doing it in a different thread.
+    if (savedPendingStreams != null) {
+      for (PendingStream stream : savedPendingStreams) {
+        stream.createRealStream(transport);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  int getPendingStreamsCount() {
+    synchronized (lock) {
+      return pendingStreams == null ? 0 : pendingStreams.size();
+    }
+  }
+
+  private class PendingStream extends DelayedStream {
+    private final MethodDescriptor<?, ?> method;
+    private final Metadata headers;
+
+    private PendingStream(MethodDescriptor<?, ?> method, Metadata headers) {
+      this.method = method;
+      this.headers = headers;
+    }
+
+    private void createRealStream(ClientTransport transport) {
+      setStream(transport.newStream(method, headers));
+    }
+
+    // TODO(zhangkun83): DelayedStream.setError() doesn't have a clearly-defined semantic to be
+    // overriden. Make it clear or find another method to override.
+    @Override
+    void setError(Status reason) {
+      synchronized (lock) {
+        if (pendingStreams != null) {
+          pendingStreams.remove(this);
+          if (shutdown && pendingStreams.isEmpty()) {
+            pendingStreams = null;
+            listener.transportTerminated();
+          }
+        }
+      }
+      super.setError(reason);
+    }
+  }
+
+  private static class PendingPing {
+    private final PingCallback callback;
+    private final Executor executor;
+
+    public PendingPing(PingCallback callback, Executor executor) {
+      this.callback = callback;
+      this.executor = executor;
+    }
+
+    public void createRealPing(ClientTransport transport) {
+      try {
+        transport.ping(callback, executor);
+      } catch (final UnsupportedOperationException ex) {
+        executor.execute(new Runnable() {
+          @Override
+          public void run() {
+            callback.onFailure(ex);
+          }
+        });
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -53,6 +53,8 @@ import javax.annotation.concurrent.GuardedBy;
  * DelayedStream} may be internally altered by different threads, thus internal synchronization is
  * necessary.
  */
+// TODO(zhangkun83): merge it with DelayedClientTransport.PendingStream as it will be no longer
+// needed by ClientCallImpl as we move away from ListenableFuture<ClientTransport>
 class DelayedStream implements ClientStream {
 
   // set to non null once both listener and realStream are valid.  After this point it is safe

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.Status;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link ClientTransport} that has life-cycle management.
+ *
+ * <p>{@link #start} must be the first method call to this interface and return before calling other
+ * methods.
+ *
+ * <p>Typically the transport owns the streams it creates through {@link #newStream}, while some
+ * implementations may transfer the streams to somewhere else. Either way they must conform to the
+ * contract defined by {@link #shutdown}, {@link Listener#transportShutdown} and
+ * {@link Listener#transportTerminated}.
+ */
+@ThreadSafe
+public interface ManagedClientTransport extends ClientTransport {
+
+  /**
+   * Starts transport. This method may only be called once.
+   *
+   * <p>Implementations must not call {@code listener} from within {@link #start}; implementations
+   * are expected to notify listener on a separate thread.  This method should not throw any
+   * exceptions.
+   *
+   * @param listener non-{@code null} listener of transport events
+   */
+  void start(Listener listener);
+
+  /**
+   * Initiates an orderly shutdown of the transport.  Existing streams continue, but the transport
+   * will not own any new streams.  New streams will either fail (once
+   * {@link Listener#transportShutdown} callback called), or be transferred off this transport (in
+   * which case they may succeed).  This method may only be called once.
+   */
+  void shutdown();
+
+  /**
+   * Receives notifications for the transport life-cycle events. Implementation does not need to be
+   * thread-safe, so notifications must be properly sychronized externally.
+   */
+  interface Listener {
+    /**
+     * The transport is shutting down. This transport will stop owning new streams, but existing
+     * streams may continue, and the transport may still be able to process {@link #newStream} as
+     * long as it doesn't own the new streams. Shutdown could have been caused by an error or normal
+     * operation.  It is possible that this method is called without {@link #shutdown} being called.
+     * If the argument to this function is {@link Status#isOk}, it is safe to immediately reconnect.
+     *
+     * <p>This is called exactly once, and must be called prior to {@link #transportTerminated}.
+     *
+     * @param s the reason for the shutdown.
+     */
+    void transportShutdown(Status s);
+
+    /**
+     * The transport completed shutting down. All resources have been released. All streams have
+     * either been closed or transferred off this transport. This transport may still be able to
+     * process {@link #newStream} as long as it doesn't own the new streams.
+     *
+     * <p>This is called exactly once, and must be called after {@link #transportShutdown} has been
+     * called.
+     */
+    void transportTerminated();
+
+    /**
+     * The transport is ready to accept traffic, because the connection is established.  This is
+     * called at most once.
+     */
+    void transportReady();
+  }
+}

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.grpc.IntegerMarshaller;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StringMarshaller;
+import io.grpc.internal.ClientTransport;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Unit tests for {@link DelayedClientTransport}.
+ */
+@RunWith(JUnit4.class)
+public class DelayedClientTransportTest {
+  @Mock private ManagedClientTransport.Listener transportListener;
+  @Mock private ClientTransport mockRealTransport;
+  @Mock private ClientStream mockRealStream;
+  @Mock private ClientStreamListener streamListener;
+  @Mock private ClientTransport.PingCallback pingCallback;
+  @Mock private Executor mockExecutor;
+  @Captor private ArgumentCaptor<Status> statusCaptor;
+
+  private final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
+      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
+      new StringMarshaller(), new IntegerMarshaller());
+  private final Metadata headers = new Metadata();
+
+  private final DelayedClientTransport delayedTransport = new DelayedClientTransport();
+
+  @Before public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    when(mockRealTransport.newStream(same(method), same(headers))).thenReturn(mockRealStream);
+    delayedTransport.start(transportListener);
+  }
+
+  @Test public void streamStartThenSetTransport() {
+    ClientStream stream = delayedTransport.newStream(method, headers);
+    stream.start(streamListener);
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    assertTrue(stream instanceof DelayedStream);
+    delayedTransport.setTransport(mockRealTransport);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verify(mockRealTransport).newStream(same(method), same(headers));
+    verify(mockRealStream).start(same(streamListener));
+  }
+
+  @Test public void newStreamThenSetTransportThenShutdown() {
+    ClientStream stream = delayedTransport.newStream(method, headers);
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    assertTrue(stream instanceof DelayedStream);
+    delayedTransport.setTransport(mockRealTransport);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    verify(mockRealTransport).newStream(same(method), same(headers));
+    stream.start(streamListener);
+    verify(mockRealStream).start(same(streamListener));
+  }
+
+  @Test public void transportTerminatedThenSetTransport() {
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    delayedTransport.setTransport(mockRealTransport);
+    verifyNoMoreInteractions(transportListener);
+  }
+
+  @Test public void setTransportThenShutdownThenNewStream() {
+    delayedTransport.setTransport(mockRealTransport);
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    ClientStream stream = delayedTransport.newStream(method, headers);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    stream.start(streamListener);
+    assertFalse(stream instanceof DelayedStream);
+    verify(mockRealTransport).newStream(same(method), same(headers));
+    verify(mockRealStream).start(same(streamListener));
+  }
+
+  @Test public void setTransportThenShutdownNowThenNewStream() {
+    delayedTransport.setTransport(mockRealTransport);
+    delayedTransport.shutdownNow(Status.UNAVAILABLE);
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    ClientStream stream = delayedTransport.newStream(method, headers);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    stream.start(streamListener);
+    assertFalse(stream instanceof DelayedStream);
+    verify(mockRealTransport).newStream(same(method), same(headers));
+    verify(mockRealStream).start(same(streamListener));
+  }
+
+  @Test public void cancelStreamWithoutSetTransport() {
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    stream.cancel(Status.CANCELLED);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verifyNoMoreInteractions(mockRealTransport);
+    verifyNoMoreInteractions(mockRealStream);
+  }
+
+  @Test public void startThenCancelStreamWithoutSetTransport() {
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    stream.start(streamListener);
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    stream.cancel(Status.CANCELLED);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verify(streamListener).closed(same(Status.CANCELLED), any(Metadata.class));
+    verifyNoMoreInteractions(mockRealTransport);
+    verifyNoMoreInteractions(mockRealStream);
+  }
+
+  @Test public void newStreamThenShutdownTransportThenCancelStream() {
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener, times(0)).transportTerminated();
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    stream.cancel(Status.CANCELLED);
+    verify(transportListener).transportTerminated();
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verifyNoMoreInteractions(mockRealTransport);
+    verifyNoMoreInteractions(mockRealStream);
+  }
+
+  @Test public void setTransportThenShutdownThenPing() {
+    delayedTransport.setTransport(mockRealTransport);
+    delayedTransport.shutdown();
+    delayedTransport.ping(pingCallback, mockExecutor);
+    verify(mockRealTransport).ping(same(pingCallback), same(mockExecutor));
+  }
+
+  @Test public void pingThenSetTransport() {
+    delayedTransport.ping(pingCallback, mockExecutor);
+    delayedTransport.setTransport(mockRealTransport);
+    verify(mockRealTransport).ping(same(pingCallback), same(mockExecutor));
+  }
+
+  @Test public void shutdownThenNewStream() {
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    stream.start(streamListener);
+    verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
+  }
+
+  @Test public void startStreamThenShutdownNow() {
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    stream.start(streamListener);
+    delayedTransport.shutdownNow(Status.UNAVAILABLE);
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
+  }
+
+  @Test public void shutdownNowThenNewStream() {
+    delayedTransport.shutdownNow(Status.UNAVAILABLE);
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    stream.start(streamListener);
+    verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
+  }
+}

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -63,7 +63,6 @@ public class DelayedStreamTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Mock private ClientStreamListener listener;
-  @Mock private ClientTransport transport;
   @Mock private ClientStream realStream;
   @Captor private ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
   private DelayedStream stream = new DelayedStream();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -117,7 +117,7 @@ public class ManagedChannelImplTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Mock
-  private ClientTransport mockTransport;
+  private ManagedClientTransport mockTransport;
   @Mock
   private ClientTransportFactory mockTransportFactory;
   @Mock
@@ -127,8 +127,8 @@ public class ManagedChannelImplTest {
   @Mock
   private ClientCall.Listener<Integer> mockCallListener3;
 
-  private ArgumentCaptor<ClientTransport.Listener> transportListenerCaptor =
-      ArgumentCaptor.forClass(ClientTransport.Listener.class);
+  private ArgumentCaptor<ManagedClientTransport.Listener> transportListenerCaptor =
+      ArgumentCaptor.forClass(ManagedClientTransport.Listener.class);
   private ArgumentCaptor<ClientStreamListener> streamListenerCaptor =
       ArgumentCaptor.forClass(ClientStreamListener.class);
 
@@ -183,7 +183,6 @@ public class ManagedChannelImplTest {
     verifyNoMoreInteractions(mockTransportFactory);
 
     // Create transport and call
-    ClientTransport mockTransport = mock(ClientTransport.class);
     ClientStream mockStream = mock(ClientStream.class);
     Metadata headers = new Metadata();
     when(mockTransportFactory.newClientTransport(any(SocketAddress.class), any(String.class)))
@@ -193,7 +192,7 @@ public class ManagedChannelImplTest {
     verify(mockTransportFactory, timeout(1000))
         .newClientTransport(same(socketAddress), eq(authority));
     verify(mockTransport, timeout(1000)).start(transportListenerCaptor.capture());
-    ClientTransport.Listener transportListener = transportListenerCaptor.getValue();
+    ManagedClientTransport.Listener transportListener = transportListenerCaptor.getValue();
     verify(mockTransport, timeout(1000)).newStream(same(method), same(headers));
     verify(mockStream).start(streamListenerCaptor.capture());
     verify(mockStream).setCompressor(isA(Compressor.class));
@@ -277,7 +276,7 @@ public class ManagedChannelImplTest {
     call.cancel();
 
     verify(mockTransport, timeout(1000)).start(transportListenerCaptor.capture());
-    final ClientTransport.Listener transportListener = transportListenerCaptor.getValue();
+    final ManagedClientTransport.Listener transportListener = transportListenerCaptor.getValue();
     final Object lock = new Object();
     final CyclicBarrier barrier = new CyclicBarrier(2);
     new Thread() {
@@ -386,8 +385,8 @@ public class ManagedChannelImplTest {
     final SocketAddress badAddress = new SocketAddress() {};
     final ResolvedServerInfo goodServer = new ResolvedServerInfo(goodAddress, Attributes.EMPTY);
     final ResolvedServerInfo badServer = new ResolvedServerInfo(badAddress, Attributes.EMPTY);
-    final ClientTransport goodTransport = mock(ClientTransport.class);
-    final ClientTransport badTransport = mock(ClientTransport.class);
+    final ManagedClientTransport goodTransport = mock(ManagedClientTransport.class);
+    final ManagedClientTransport badTransport = mock(ManagedClientTransport.class);
     when(mockTransportFactory.newClientTransport(same(goodAddress), any(String.class)))
         .thenReturn(goodTransport);
     when(mockTransportFactory.newClientTransport(same(badAddress), any(String.class)))
@@ -413,8 +412,8 @@ public class ManagedChannelImplTest {
 
     // First try should fail with the bad address.
     call.start(mockCallListener, headers);
-    ArgumentCaptor<ClientTransport.Listener> badTransportListenerCaptor =
-        ArgumentCaptor.forClass(ClientTransport.Listener.class);
+    ArgumentCaptor<ManagedClientTransport.Listener> badTransportListenerCaptor =
+        ArgumentCaptor.forClass(ManagedClientTransport.Listener.class);
     verify(mockCallListener, timeout(1000)).onClose(same(Status.UNAVAILABLE), any(Metadata.class));
     verify(badTransport, timeout(1000)).start(badTransportListenerCaptor.capture());
     badTransportListenerCaptor.getValue().transportShutdown(Status.UNAVAILABLE);

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -43,9 +43,9 @@ import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
-import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.SharedResourceHolder;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
@@ -304,7 +304,8 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
     }
 
     @Override
-    public ClientTransport newClientTransport(SocketAddress serverAddress, String authority) {
+    public ManagedClientTransport newClientTransport(
+        SocketAddress serverAddress, String authority) {
       ProtocolNegotiator negotiator = protocolNegotiator != null ? protocolNegotiator :
           createProtocolNegotiator(authority, negotiationType, sslContext);
       return new NettyClientTransport(serverAddress, channelType, group, negotiator,

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -42,10 +42,10 @@ import com.google.common.base.Ticker;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusException;
-import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransport.PingCallback;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
+import io.grpc.internal.ManagedClientTransport;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -115,7 +115,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   private Throwable goAwayStatusThrowable;
   private int nextStreamId;
 
-  static NettyClientHandler newHandler(ClientTransport.Listener listener,
+  static NettyClientHandler newHandler(ManagedClientTransport.Listener listener,
                                        int flowControlWindow, int maxHeaderListSize,
                                        Ticker ticker) {
     Preconditions.checkArgument(maxHeaderListSize > 0, "maxHeaderListSize must be positive");
@@ -131,7 +131,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   static NettyClientHandler newHandler(Http2Connection connection,
                                        Http2FrameReader frameReader,
                                        Http2FrameWriter frameWriter,
-                                       final ClientTransport.Listener listener,
+                                       final ManagedClientTransport.Listener listener,
                                        int flowControlWindow,
                                        Ticker ticker) {
     Preconditions.checkNotNull(connection, "connection");

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -40,7 +40,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
-import io.grpc.internal.ClientTransport;
+import io.grpc.internal.ManagedClientTransport;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -56,9 +56,9 @@ import java.util.concurrent.Executor;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
- * A Netty-based {@link ClientTransport} implementation.
+ * A Netty-based {@link ManagedClientTransport} implementation.
  */
-class NettyClientTransport implements ClientTransport {
+class NettyClientTransport implements ManagedClientTransport {
   private final SocketAddress address;
   private final Class<? extends Channel> channelType;
   private final EventLoopGroup group;

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -50,8 +50,8 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
-import io.grpc.internal.ClientTransport;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
@@ -92,7 +92,7 @@ import java.util.concurrent.TimeoutException;
 public class NettyClientTransportTest {
 
   @Mock
-  private ClientTransport.Listener clientTransportListener;
+  private ManagedClientTransport.Listener clientTransportListener;
 
   private final List<NettyClientTransport> transports = new ArrayList<NettyClientTransport>();
   private NioEventLoopGroup group;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -46,9 +46,9 @@ import io.grpc.ExperimentalApi;
 import io.grpc.NameResolver;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AbstractReferenceCounted;
-import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.SharedResourceHolder.Resource;
 
@@ -255,7 +255,7 @@ public class OkHttpChannelBuilder extends
     }
 
     @Override
-    public ClientTransport newClientTransport(SocketAddress addr, String authority) {
+    public ManagedClientTransport newClientTransport(SocketAddress addr, String authority) {
       InetSocketAddress inetSocketAddr = (InetSocketAddress) addr;
       return new OkHttpClientTransport(inetSocketAddr, authority, executor, socketFactory,
           Utils.convertSpec(connectionSpec), maxMessageSize);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -44,9 +44,9 @@ import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import io.grpc.Status.Code;
-import io.grpc.internal.ClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
+import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.okhttp.internal.ConnectionSpec;
 import io.grpc.okhttp.internal.framed.ErrorCode;
@@ -84,9 +84,9 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
- * A okhttp-based {@link ClientTransport} implementation.
+ * A okhttp-based {@link ManagedClientTransport} implementation.
  */
-class OkHttpClientTransport implements ClientTransport {
+class OkHttpClientTransport implements ManagedClientTransport {
   private static final Map<ErrorCode, Status> ERROR_CODE_TO_STATUS;
   private static final Logger log = Logger.getLogger(OkHttpClientTransport.class.getName());
   private static final OkHttpClientStream[] EMPTY_STREAM_ARRAY = new OkHttpClientStream[0];

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -73,6 +73,7 @@ import io.grpc.internal.AbstractStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.ManagedClientTransport;
 import io.grpc.okhttp.OkHttpClientTransport.ClientFrameHandler;
 import io.grpc.okhttp.internal.ConnectionSpec;
 import io.grpc.okhttp.internal.framed.ErrorCode;
@@ -131,7 +132,7 @@ public class OkHttpClientTransportTest {
   @Mock
   MethodDescriptor<?, ?> method;
   @Mock
-  private ClientTransport.Listener transportListener;
+  private ManagedClientTransport.Listener transportListener;
   private OkHttpClientTransport clientTransport;
   private MockFrameReader frameReader;
   private ExecutorService executor;
@@ -1323,7 +1324,7 @@ public class OkHttpClientTransportTest {
         ConnectionSpec.CLEARTEXT,
         DEFAULT_MAX_MESSAGE_SIZE);
 
-    ClientTransport.Listener listener = mock(ClientTransport.Listener.class);
+    ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
     clientTransport.start(listener);
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(listener, timeout(TIME_OUT_MS)).transportShutdown(captor.capture());


### PR DESCRIPTION
Always return a completed future from `TransportSet`. If a (real) transport has not been created (e.g., in reconnect back-off), a `DelayedClientTransport` will be returned.

Eventually we will get rid of the transport futures everywhere, and have streams always __owned__ by some transports.

### DelayedClientTransport

After we get rid of the transport future, this is what `ClientCallImpl` and `LoadBalancer` get when a real transport has not been created yet. It buffers new streams and pings until `setTransport()` is called, after which point all buffered and future streams/pings are transferred to the real transport.

If a buffered stream is cancelled, `DelayedClientTransport` will remove it from the buffer list, thus #1342 will be resolved after the larger refactoring is complete.

This PR only makes `TransportSet` use `DelayedClientTransport`. Follow-up changes will be made to allow `LoadBalancer.pickTransport()` to return null, in which case `ManagedChannelImpl` will give `ClientCallImpl` a `DelayedClientTransport`.

### Changes to ClientTransport shutdown semantics

Previously when shutdown() is called, `ClientTransport` should not accept newStream(), and when all existing streams have been closed, `ClientTransport` is terminated. Only when a transport is terminated would a transport owner (e.g., `TransportSet`) remove the reference to it.

`DelayedClientTransport` brings about a new case: when `setTransport()` is called, we switch to the real transport and no longer need the delayed transport. This is achieved by calling `shutdown()` on the delayed transport and letting it terminate. However, as the delayed transport has already been handed out to users, we would like `newStream()` to keep working for them, even though the delayed transport is already shut down and terminated.

In order to make it easy to manage the life-cycle of `DelayedClientTransport`, we redefine the shutdown semantics of transport:
- A transport can own a stream. Typically the transport owns the streams
  it creates, but there may be exceptions. `DelayedClientTransport` DOES
  NOT OWN the streams it returns from `newStream()` after `setTransport()`
  has been called. Instead, the ownership would be transferred to the
  real transport.
- After `shutdown()` has been called, the transport stops owning new
  streams, and `newStream()` may still succeed. With this idea,
  `DelayedClientTransport`, even when terminated, will continue
  passing `newStream()` to the real transport.
- When a transport is in shutdown state, and it doesn't own any stream,
  it then can enter terminated state.


### ManagedClientTransport / ClientTransport

Remove life-cycle interfaces from `ClientTransport`, and put them in its subclass - `ManagedClientTransport`, with the same idea that we have `Channel` and `ManagedChannel`. Only the one who creates the transport will get `ManagedClientTransport` thus is able to start and shutdown the transport. The users of transport, e.g., `LoadBalancer`, can only get `ClientTransport` thus are not alter its state. This change clarifies the responsibility of transport life-cycle management.


### Fix TransportSet shutdown semantics
Currently, if `TransportSet.shutdown()` has been called, it no longer create new transports, which is wrong.

The correct semantics of `TransportSet.shutdown()` should be:
- Shutdown all transports, thus stop new streams being created on them
- Stop `obtainActiveTransport()` from returning transports
- Streams that already created, including those buffered in delayed transport, should continue. That means if delayed transport has buffered streams, we should let the existing reconnect task continue.
