### PR TITLE
Add transport-level test suite

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,6 +7,7 @@ description = 'gRPC: Core'
 dependencies {
     compile libraries.guava,
             libraries.jsr305
+    testCompile project(':grpc-testing')
 }
 
 // Configure the animal sniffer plugin

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -100,6 +100,7 @@ class InProcessTransport implements ServerTransport, ManagedClientTransport {
       shutdownThread.setDaemon(true);
       shutdownThread.setName("grpc-inprocess-shutdown");
       shutdownThread.start();
+      return;
     }
     Thread readyThread = new Thread(new Runnable() {
       @Override

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.inprocess;
+
+import io.grpc.internal.ManagedClientTransport;
+import io.grpc.internal.Server;
+import io.grpc.internal.testing.AbstractTransportTest;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link InProcessTransport}. */
+@RunWith(JUnit4.class)
+public class InProcessTransportTest extends AbstractTransportTest {
+  private static final String transportName = "perfect-for-testing";
+
+  @Override
+  protected Server newServer() {
+    return new InProcessServer(transportName);
+  }
+
+  @Override
+  protected ManagedClientTransport newClientTransport() {
+    return new InProcessTransport(transportName);
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+/** A command to trigger close. It is buffered differently than normal close. */
+class GracefulCloseCommand {}

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -177,7 +177,7 @@ class NettyClientTransport implements ManagedClientTransport {
     notifyShutdown(Status.OK.withDescription("Channel requested transport to shut down"));
     // Notifying of termination is automatically done when the channel closes.
     if (channel != null && channel.isOpen()) {
-      channel.close();
+      handler.getWriteQueue().enqueue(new GracefulCloseCommand(), true);
     }
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import static org.junit.Assert.assertEquals;
+
+import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.ManagedClientTransport;
+import io.grpc.internal.Server;
+import io.grpc.internal.testing.AbstractTransportTest;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for Netty transport. */
+@RunWith(JUnit4.class)
+public class NettyTransportTest extends AbstractTransportTest {
+  private static final String TRANSPORT_NAME = "perfect-for-testing";
+  private ClientTransportFactory clientFactory = NettyChannelBuilder
+      // Although specified here, address is ignored because we never call build.
+      .forAddress(new LocalAddress(TRANSPORT_NAME))
+      .flowControlWindow(65 * 1024)
+      .negotiationType(NegotiationType.PLAINTEXT)
+      .channelType(LocalChannel.class)
+      .buildTransportFactory();
+
+  @After
+  public void releaseClientFactory() {
+    clientFactory.release();
+    assertEquals(0, clientFactory.referenceCount());
+  }
+
+  @Override
+  protected Server newServer() {
+    return NettyServerBuilder
+        .forAddress(new LocalAddress(TRANSPORT_NAME))
+        .flowControlWindow(65 * 1024)
+        .channelType(LocalServerChannel.class)
+        .buildTransportServer();
+  }
+
+  @Override
+  protected ManagedClientTransport newClientTransport() {
+    return clientFactory.newClientTransport(new LocalAddress(TRANSPORT_NAME), TRANSPORT_NAME);
+  }
+
+  // TODO(ejona): Netty fails to use UNAVAILABLE for the status.
+  @Test
+  @Ignore
+  @Override
+  public void serverNotListening() {}
+
+  // TODO(ejona): Flaky
+  @Test
+  @Ignore
+  @Override
+  public void flowControlPushBack() {}
+}

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -9,7 +9,9 @@ dependencies {
             libraries.okio
 
     // Tests depend on base class defined by core module.
-    testCompile project(':grpc-core').sourceSets.test.output
+    testCompile project(':grpc-core').sourceSets.test.output,
+                project(':grpc-testing'),
+                project(':grpc-netty')
 }
 
 project.sourceSets {

--- a/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
@@ -238,10 +238,8 @@ class AsyncFrameWriter implements FrameWriter {
         doRun();
       } catch (RuntimeException e) {
         transport.onException(e);
-        throw e;
       } catch (Exception e) {
         transport.onException(e);
-        throw new RuntimeException(e);
       }
     }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -262,8 +262,6 @@ class OkHttpClientStream extends Http2ClientStream {
       }
       cancelSent = true;
       if (pendingData != null) {
-        // stream is pending.
-        transport.removePendingStream(this);
         // release holding data, so they can be GCed or returned to pool earlier.
         requestHeaders = null;
         for (PendingData data : pendingData) {
@@ -271,6 +269,8 @@ class OkHttpClientStream extends Http2ClientStream {
         }
         pendingData = null;
         transportReportStatus(reason, true, new Metadata());
+        // stream is pending.
+        transport.removePendingStream(this);
       } else {
         // If pendingData is null, start must have already been called, which means synStream has
         // been called as well.

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -63,6 +63,8 @@ import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.ByteString;
 import okio.Okio;
+import okio.Source;
+import okio.Timeout;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -141,16 +143,14 @@ class OkHttpClientTransport implements ManagedClientTransport {
   private final int maxMessageSize;
   private int connectionUnacknowledgedBytesRead;
   private ClientFrameHandler clientFrameHandler;
-  // Indicates the transport is in go-away state: no new streams will be processed,
-  // but existing streams may continue.
-  @GuardedBy("lock")
-  private boolean goAway;
-  // Used to indicate the special phase while we are going to enter go-away state but before
-  // goAway is turned to true, see the comment at where this is set about why it is needed.
-  @GuardedBy("lock")
-  private boolean startedGoAway;
+  /**
+   * Indicates the transport is in go-away state: no new streams will be processed, but existing
+   * streams may continue.
+   */
   @GuardedBy("lock")
   private Status goAwayStatus;
+  @GuardedBy("lock")
+  private boolean goAwaySent;
   @GuardedBy("lock")
   private Http2Ping ping;
   @GuardedBy("lock")
@@ -253,7 +253,7 @@ class OkHttpClientTransport implements ManagedClientTransport {
   @GuardedBy("lock")
   void streamReadyToStart(OkHttpClientStream clientStream) {
     synchronized (lock) {
-      if (goAway) {
+      if (goAwayStatus != null) {
         clientStream.transportReportStatus(goAwayStatus, true, new Metadata());
       } else if (streams.size() >= maxConcurrentStreams) {
         pendingStreams.add(clientStream);
@@ -278,7 +278,8 @@ class OkHttpClientTransport implements ManagedClientTransport {
       // Make sure nextStreamId greater than all used id, so that mayHaveCreatedStream() performs
       // correctly.
       nextStreamId = Integer.MAX_VALUE;
-      startGoAway(Integer.MAX_VALUE, Status.INTERNAL.withDescription("Stream ids exhausted"));
+      startGoAway(Integer.MAX_VALUE, ErrorCode.NO_ERROR,
+          Status.UNAVAILABLE.withDescription("Stream ids exhausted"));
     } else {
       nextStreamId += 2;
     }
@@ -287,16 +288,13 @@ class OkHttpClientTransport implements ManagedClientTransport {
   /**
    * Starts pending streams, returns true if at least one pending stream is started.
    */
+  @GuardedBy("lock")
   private boolean startPendingStreams() {
     boolean hasStreamStarted = false;
-    synchronized (lock) {
-      // No need to check goAway since the pendingStreams will be cleared when goAway
-      // becomes true.
-      while (!pendingStreams.isEmpty() && streams.size() < maxConcurrentStreams) {
-        OkHttpClientStream stream = pendingStreams.poll();
-        startStream(stream);
-        hasStreamStarted = true;
-      }
+    while (!pendingStreams.isEmpty() && streams.size() < maxConcurrentStreams) {
+      OkHttpClientStream stream = pendingStreams.poll();
+      startStream(stream);
+      hasStreamStarted = true;
     }
     return hasStreamStarted;
   }
@@ -329,14 +327,29 @@ class OkHttpClientTransport implements ManagedClientTransport {
           executor.execute(clientFrameHandler);
           synchronized (lock) {
             maxConcurrentStreams = Integer.MAX_VALUE;
+            startPendingStreams();
           }
           frameWriter.becomeConnected(testFrameWriter, socket);
-          startPendingStreams();
           connectedFuture.set(null);
           return;
         }
 
-        BufferedSource source;
+        // Use closed source on failure so that the reader immediately shuts down.
+        BufferedSource source = Okio.buffer(new Source() {
+          @Override
+          public long read(Buffer sink, long byteCount) {
+            return -1;
+          }
+
+          @Override
+          public Timeout timeout() {
+            return Timeout.NONE;
+          }
+
+          @Override
+          public void close() {}
+        });
+        Variant variant = new Http2();
         BufferedSink sink;
         Socket sock;
         try {
@@ -348,32 +361,21 @@ class OkHttpClientTransport implements ManagedClientTransport {
           sock.setTcpNoDelay(true);
           source = Okio.buffer(Okio.source(sock));
           sink = Okio.buffer(Okio.sink(sock));
-        } catch (RuntimeException e) {
-          onException(e);
-          throw e;
         } catch (Exception e) {
           onException(e);
-
-          // (and probably do all of this work asynchronously instead of in calling thread)
-          throw new RuntimeException(e);
+          return;
+        } finally {
+          clientFrameHandler = new ClientFrameHandler(variant.newReader(source, true));
+          executor.execute(clientFrameHandler);
         }
 
         FrameWriter rawFrameWriter;
         synchronized (lock) {
-          if (stopped) {
-            // In case user called shutdown() during the connecting.
-            try {
-              sock.close();
-            } catch (IOException e) {
-              log.log(Level.WARNING, "Failed closing socket", e);
-            }
-            return;
-          }
           socket = sock;
           maxConcurrentStreams = Integer.MAX_VALUE;
+          startPendingStreams();
         }
 
-        Variant variant = new Http2();
         rawFrameWriter = variant.newWriter(sink, true);
         frameWriter.becomeConnected(rawFrameWriter, socket);
 
@@ -385,15 +387,11 @@ class OkHttpClientTransport implements ManagedClientTransport {
           rawFrameWriter.settings(settings);
         } catch (RuntimeException e) {
           onException(e);
-          throw e;
+          return;
         } catch (Exception e) {
           onException(e);
-          throw new RuntimeException(e);
+          return;
         }
-
-        clientFrameHandler = new ClientFrameHandler(variant.newReader(source, true));
-        executor.execute(clientFrameHandler);
-        startPendingStreams();
       }
     });
   }
@@ -439,16 +437,14 @@ class OkHttpClientTransport implements ManagedClientTransport {
   @Override
   public void shutdown() {
     synchronized (lock) {
-      if (goAway) {
+      if (goAwayStatus != null) {
         return;
       }
+
+      goAwayStatus = Status.UNAVAILABLE.withDescription("Transport stopped");
+      listener.transportShutdown(goAwayStatus);
+      stopIfNecessary();
     }
-
-    // Send GOAWAY with lastGoodStreamId of 0, since we don't expect any server-initiated streams.
-    // The GOAWAY is part of graceful shutdown.
-    frameWriter.goAway(0, ErrorCode.NO_ERROR, new byte[0]);
-
-    startGoAway(Integer.MAX_VALUE, Status.UNAVAILABLE.withDescription("Transport stopped"));
   }
 
   /**
@@ -476,35 +472,29 @@ class OkHttpClientTransport implements ManagedClientTransport {
    * Finish all active streams due to an IOException, then close the transport.
    */
   void onException(Throwable failureCause) {
-    log.log(Level.WARNING, "Transport failed", failureCause);
-    startGoAway(0, Status.UNAVAILABLE.withCause(failureCause));
+    startGoAway(0, ErrorCode.INTERNAL_ERROR, Status.UNAVAILABLE.withCause(failureCause));
   }
 
   /**
    * Send GOAWAY to the server, then finish all active streams and close the transport.
    */
   private void onError(ErrorCode errorCode, String moreDetail) {
-    frameWriter.goAway(0, errorCode, new byte[0]);
-    startGoAway(0, toGrpcStatus(errorCode).augmentDescription(moreDetail));
+    startGoAway(0, errorCode, toGrpcStatus(errorCode).augmentDescription(moreDetail));
   }
 
-  private void startGoAway(int lastKnownStreamId, Status status) {
+  private void startGoAway(int lastKnownStreamId, ErrorCode errorCode, Status status) {
     synchronized (lock) {
-      if (startedGoAway) {
-        // Another go-away is in progress, ignore this one.
-        return;
+      if (goAwayStatus == null) {
+        goAwayStatus = status;
+        listener.transportShutdown(status);
       }
-      // We use startedGoAway here instead of goAway, because once the goAway becomes true, other
-      // thread in stopIfNecessary() may stop the transport and cause the
-      // listener.transportTerminated() be called before listener.transportShutdown().
-      startedGoAway = true;
-    }
+      if (errorCode != null) {
+        // Send GOAWAY with lastGoodStreamId of 0, since we don't expect any server-initiated
+        // streams. The GOAWAY is part of graceful shutdown.
+        goAwaySent = true;
+        frameWriter.goAway(0, errorCode, new byte[0]);
+      }
 
-    listener.transportShutdown(status);
-
-    synchronized (lock) {
-      goAway = true;
-      goAwayStatus = status;
       Iterator<Map.Entry<Integer, OkHttpClientStream>> it = streams.entrySet().iterator();
       while (it.hasNext()) {
         Map.Entry<Integer, OkHttpClientStream> entry = it.next();
@@ -518,9 +508,9 @@ class OkHttpClientTransport implements ManagedClientTransport {
         stream.transportReportStatus(status, true, new Metadata());
       }
       pendingStreams.clear();
-    }
 
-    stopIfNecessary();
+      stopIfNecessary();
+    }
   }
 
   /**
@@ -558,22 +548,31 @@ class OkHttpClientTransport implements ManagedClientTransport {
   /**
    * When the transport is in goAway state, we should stop it once all active streams finish.
    */
+  @GuardedBy("lock")
   void stopIfNecessary() {
-    synchronized (lock) {
-      if (goAway && streams.size() == 0) {
-        if (!stopped) {
-          stopped = true;
-          // We will close the underlying socket in the writing thread to break out the reader
-          // thread, which will close the frameReader and notify the listener.
-          frameWriter.close();
-
-          if (ping != null) {
-            ping.failed(getPingFailure());
-            ping = null;
-          }
-        }
-      }
+    if (!(goAwayStatus != null && streams.isEmpty() && pendingStreams.isEmpty())) {
+      return;
     }
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+
+    if (ping != null) {
+      ping.failed(getPingFailure());
+      ping = null;
+    }
+
+    if (!goAwaySent) {
+      // Send GOAWAY with lastGoodStreamId of 0, since we don't expect any server-initiated
+      // streams. The GOAWAY is part of graceful shutdown.
+      goAwaySent = true;
+      frameWriter.goAway(0, ErrorCode.NO_ERROR, new byte[0]);
+    }
+
+    // We will close the underlying socket in the writing thread to break out the reader
+    // thread, which will close the frameReader and notify the listener.
+    frameWriter.close();
   }
 
   private Throwable getPingFailure() {
@@ -631,13 +630,11 @@ class OkHttpClientTransport implements ManagedClientTransport {
         // frameReader.nextFrame() returns false when the underlying read encounters an IOException,
         // it may be triggered by the socket closing, in such case, the startGoAway() will do
         // nothing, otherwise, we finish all streams since it's a real IO issue.
-        // We don't call onException() here since we don't want to log the warning in case this is
-        // triggered by socket closing.
-        startGoAway(0, Status.UNAVAILABLE);
+        startGoAway(0, ErrorCode.INTERNAL_ERROR,
+            Status.UNAVAILABLE.withDescription("Socket closed"));
       } catch (Exception t) {
         // TODO(madongfly): Send the exception message to the server.
-        frameWriter.goAway(0, ErrorCode.PROTOCOL_ERROR, new byte[0]);
-        onException(t);
+        startGoAway(0, ErrorCode.PROTOCOL_ERROR, Status.UNAVAILABLE.withCause(t));
       } finally {
         try {
           frameReader.close();
@@ -736,6 +733,7 @@ class OkHttpClientTransport implements ManagedClientTransport {
           listener.transportReady();
           firstSettings = false;
         }
+        startPendingStreams();
       }
 
       frameWriter.ackSettings(settings);
@@ -780,7 +778,7 @@ class OkHttpClientTransport implements ManagedClientTransport {
         // If a debug message was provided, use it.
         status.augmentDescription(debugData.utf8());
       }
-      startGoAway(lastGoodStreamId, status);
+      startGoAway(lastGoodStreamId, null, status);
     }
 
     @Override

--- a/okhttp/src/test/java/io/grpc/internal/AccessProtectedHack.java
+++ b/okhttp/src/test/java/io/grpc/internal/AccessProtectedHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,42 +29,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.okhttp;
+package io.grpc.internal;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import io.grpc.ManagedChannelProvider;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-import java.util.ServiceLoader;
-
-/** Unit tests for {@link OkHttpChannelProvider}. */
-@RunWith(JUnit4.class)
-public class OkHttpChannelProviderTest {
-  private OkHttpChannelProvider provider = new OkHttpChannelProvider();
-
-  @Test
-  public void provided() {
-    for (ManagedChannelProvider current : ServiceLoader.load(ManagedChannelProvider.class)) {
-      if (current instanceof OkHttpChannelProvider) {
-        return;
-      }
-    }
-    fail("ServiceLoader unable to load OkHttpChannelProvider");
+/** A hack to access protected methods from io.grpc.internal. */
+public final class AccessProtectedHack {
+  public static Server serverBuilderBuildTransportServer(AbstractServerImplBuilder<?> builder) {
+    return builder.buildTransportServer();
   }
 
-  @Test
-  public void isAvailable() {
-    assertTrue(provider.isAvailable());
-  }
-
-  @Test
-  public void builderIsAOkHttpBuilder() {
-    assertSame(OkHttpChannelBuilder.class, provider.builderForAddress("localhost", 443).getClass());
-  }
+  private AccessProtectedHack() {}
 }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -660,7 +660,6 @@ public class OkHttpClientTransportTest {
     stream2.start(listener2);
     assertEquals(2, activeStreamCount());
     clientTransport.shutdown();
-    verify(frameWriter, timeout(TIME_OUT_MS)).goAway(eq(0), eq(ErrorCode.NO_ERROR), (byte[]) any());
 
     assertEquals(2, activeStreamCount());
     verify(transportListener).transportShutdown(isA(Status.class));
@@ -672,6 +671,7 @@ public class OkHttpClientTransportTest {
     assertEquals(0, activeStreamCount());
     assertEquals(Status.CANCELLED.getCode(), listener1.status.getCode());
     assertEquals(Status.CANCELLED.getCode(), listener2.status.getCode());
+    verify(frameWriter, timeout(TIME_OUT_MS)).goAway(eq(0), eq(ErrorCode.NO_ERROR), (byte[]) any());
     verify(transportListener, timeout(TIME_OUT_MS)).transportTerminated();
     shutdownAndVerify();
   }
@@ -853,7 +853,7 @@ public class OkHttpClientTransportTest {
   }
 
   @Test
-  public void pendingStreamFailedByShutdown() throws Exception {
+  public void pendingStreamSucceedAfterShutdown() throws Exception {
     initTransport();
     setMaxConcurrentStreams(0);
     final MockStreamListener listener = new MockStreamListener();
@@ -863,10 +863,11 @@ public class OkHttpClientTransportTest {
     waitForStreamPending(1);
 
     clientTransport.shutdown();
-
-    listener.waitUntilStreamClosed();
-    assertEquals(Status.UNAVAILABLE.getCode(), listener.status.getCode());
-    assertEquals(0, clientTransport.getPendingStreamSize());
+    setMaxConcurrentStreams(1);
+    verify(frameWriter, timeout(TIME_OUT_MS))
+        .synStream(anyBoolean(), anyBoolean(), eq(3), anyInt(), anyListHeader());
+    assertEquals(1, activeStreamCount());
+    stream.sendCancel(Status.CANCELLED);
     shutdownAndVerify();
   }
 
@@ -897,7 +898,7 @@ public class OkHttpClientTransportTest {
     stream1.cancel(Status.CANCELLED);
     listener1.waitUntilStreamClosed();
     listener3.waitUntilStreamClosed();
-    assertEquals(Status.INTERNAL.getCode(), listener3.status.getCode());
+    assertEquals(Status.UNAVAILABLE.getCode(), listener3.status.getCode());
     assertEquals(0, clientTransport.getPendingStreamSize());
     assertEquals(1, activeStreamCount());
     stream2 = getStream(startId + 2);
@@ -1290,10 +1291,14 @@ public class OkHttpClientTransportTest {
     clientTransport.shutdown();
     allowTransportConnected();
 
-    // The new stream should be failed, as well as the pending stream.
+    // The new stream should be failed, but not the pending stream.
     assertNewStreamFail();
+    verify(frameWriter, timeout(TIME_OUT_MS))
+        .synStream(anyBoolean(), anyBoolean(), eq(3), anyInt(), anyListHeader());
+    assertEquals(1, activeStreamCount());
+    stream.cancel(Status.CANCELLED);
     listener.waitUntilStreamClosed();
-    assertEquals(Status.UNAVAILABLE.getCode(), listener.status.getCode());
+    assertEquals(Status.CANCELLED.getCode(), listener.status.getCode());
     shutdownAndVerify();
   }
 
@@ -1408,6 +1413,10 @@ public class OkHttpClientTransportTest {
         new Header(Status.CODE_KEY.name(), "0"),
         // Adding Content-Type for testing responses with only a single HEADERS frame.
         CONTENT_TYPE_HEADER);
+  }
+
+  private static List<Header> anyListHeader() {
+    return any();
   }
 
   private static class MockFrameReader implements FrameReader {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,40 +31,57 @@
 
 package io.grpc.okhttp;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 
-import io.grpc.ManagedChannelProvider;
+import io.grpc.internal.AccessProtectedHack;
+import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.ManagedClientTransport;
+import io.grpc.internal.Server;
+import io.grpc.internal.testing.AbstractTransportTest;
+import io.grpc.netty.NettyServerBuilder;
+import io.grpc.testing.TestUtils;
 
+import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.ServiceLoader;
+import java.net.InetSocketAddress;
 
-/** Unit tests for {@link OkHttpChannelProvider}. */
+/** Unit tests for OkHttp transport. */
 @RunWith(JUnit4.class)
-public class OkHttpChannelProviderTest {
-  private OkHttpChannelProvider provider = new OkHttpChannelProvider();
+public class OkHttpTransportTest extends AbstractTransportTest {
+  private static final int SERVER_PORT = TestUtils.pickUnusedPort();
+  private ClientTransportFactory clientFactory = OkHttpChannelBuilder
+      // Although specified here, address is ignored because we never call build.
+      .forAddress("127.0.0.1", SERVER_PORT)
+      .negotiationType(NegotiationType.PLAINTEXT)
+      .buildTransportFactory();
 
-  @Test
-  public void provided() {
-    for (ManagedChannelProvider current : ServiceLoader.load(ManagedChannelProvider.class)) {
-      if (current instanceof OkHttpChannelProvider) {
-        return;
-      }
-    }
-    fail("ServiceLoader unable to load OkHttpChannelProvider");
+  @After
+  public void releaseClientFactory() {
+    clientFactory.release();
+    assertEquals(0, clientFactory.referenceCount());
   }
 
-  @Test
-  public void isAvailable() {
-    assertTrue(provider.isAvailable());
+  @Override
+  protected Server newServer() {
+    return AccessProtectedHack.serverBuilderBuildTransportServer(
+        NettyServerBuilder
+          .forPort(SERVER_PORT)
+          .flowControlWindow(65 * 1024));
   }
 
-  @Test
-  public void builderIsAOkHttpBuilder() {
-    assertSame(OkHttpChannelBuilder.class, provider.builderForAddress("localhost", 443).getClass());
+  @Override
+  protected ManagedClientTransport newClientTransport() {
+    return clientFactory.newClientTransport(
+        new InetSocketAddress("127.0.0.1", SERVER_PORT), "127.0.0.1:" + SERVER_PORT);
   }
+
+  // TODO(ejona): Flaky/Broken
+  @Test
+  @Ignore
+  @Override
+  public void flowControlPushBack() {}
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,5 +1,7 @@
 description = "gRPC: Testing"
 dependencies {
-    compile project(':grpc-core')
-    compile project(':grpc-stub')
+    compile project(':grpc-core'),
+            project(':grpc-stub'),
+            libraries.junit,
+            libraries.mockito
 }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -1,0 +1,905 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal.testing;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.internal.ClientStream;
+import io.grpc.internal.ClientStreamListener;
+import io.grpc.internal.ClientTransport;
+import io.grpc.internal.ManagedClientTransport;
+import io.grpc.internal.Server;
+import io.grpc.internal.ServerListener;
+import io.grpc.internal.ServerStream;
+import io.grpc.internal.ServerStreamListener;
+import io.grpc.internal.ServerTransport;
+import io.grpc.internal.ServerTransportListener;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/** Standard unit tests for {@link ClientTransport}s and {@link ServerTransport}s. */
+@RunWith(JUnit4.class)
+public abstract class AbstractTransportTest {
+  /**
+   * Returns a new server that when started will be able to be connected to from the client. Each
+   * returned instance should be new and yet be accessible by new client transports. This
+   * effectively means that each instance should listen on the same port, or similar.
+   */
+  protected abstract Server newServer();
+
+  /**
+   * Returns a new transport that when started will be able to connect to the server.
+   */
+  protected abstract ManagedClientTransport newClientTransport();
+
+  /**
+   * When non-null, will be shut down during tearDown(). However, it _must_ have been started with
+   * {@code serverListener}, otherwise tearDown() can't wait for shutdown which can put following
+   * tests in an indeterminate state.
+   */
+  private Server server;
+  private ServerTransport serverTransport;
+  private ManagedClientTransport client;
+  private MethodDescriptor<String, String> methodDescriptor = MethodDescriptor.create(
+      MethodDescriptor.MethodType.UNKNOWN, "service/method", StringMarshaller.INSTANCE,
+      StringMarshaller.INSTANCE);
+  private Metadata.Key<String> asciiKey = Metadata.Key.of(
+      "ascii-key", Metadata.ASCII_STRING_MARSHALLER);
+  private Metadata.Key<String> binaryKey = Metadata.Key.of(
+      "key-bin", StringBinaryMarshaller.INSTANCE);
+
+  private ManagedClientTransport.Listener mockClientTransportListener
+      = mock(ManagedClientTransport.Listener.class);
+  private ClientStreamListener mockClientStreamListener = mock(ClientStreamListener.class);
+  private MockServerListener serverListener = new MockServerListener();
+  private ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+  private ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
+  private ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass(Metadata.class);
+  private ArgumentCaptor<InputStream> inputStreamCaptor
+      = ArgumentCaptor.forClass(InputStream.class);
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setUp() {
+    server = newServer();
+    client = newClientTransport();
+  }
+
+  @After
+  public void tearDown() throws InterruptedException {
+    if (client != null) {
+      // TODO(ejona): swap to shutdownNow
+      client.shutdown();
+    }
+    if (serverTransport != null) {
+      // TODO(ejona): swap to shutdownNow
+      serverTransport.shutdown();
+    }
+    if (server != null) {
+      server.shutdown();
+      assertTrue(serverListener.waitForShutdown(1000, TimeUnit.MILLISECONDS));
+    }
+  }
+
+  // TODO(ejona):
+  //   multiple streams on same transport
+  //   multiple client transports to same server
+  //   halfClose to trigger flush (client and server)
+  //   flow control pushes back (client and server)
+  //   flow control provides precisely number of messages requested (client and server)
+  //   onReady called when buffer drained (on server and client)
+  //   test no start reentrancy (esp. during failure) (transport and call)
+  //   multiple requests/responses (verifying contents received)
+  //   server transport shutdown triggers client shutdown (via GOAWAY)
+
+  @Test
+  public void serverNotListening() {
+    server = null;
+    InOrder inOrder = inOrder(mockClientTransportListener);
+    client.start(mockClientTransportListener);
+    verify(mockClientTransportListener, timeout(1000)).transportTerminated();
+    inOrder.verify(mockClientTransportListener).transportShutdown(statusCaptor.capture());
+    assertCodeEquals(Status.UNAVAILABLE, statusCaptor.getValue());
+    inOrder.verify(mockClientTransportListener).transportTerminated();
+    verify(mockClientTransportListener, never()).transportReady();
+  }
+
+  @Test
+  public void clientStartStop() throws Exception {
+    server.start(serverListener);
+    InOrder inOrder = inOrder(mockClientTransportListener);
+    client.start(mockClientTransportListener);
+    client.shutdown();
+    verify(mockClientTransportListener, timeout(1000)).transportTerminated();
+    inOrder.verify(mockClientTransportListener).transportShutdown(any(Status.class));
+    inOrder.verify(mockClientTransportListener).transportTerminated();
+    server.shutdown();
+    assertTrue(serverListener.waitForShutdown(1000, TimeUnit.MILLISECONDS));
+    server = null;
+  }
+
+  @Test
+  public void clientStartAndStopOnceConnected() throws Exception {
+    server.start(serverListener);
+    InOrder inOrder = inOrder(mockClientTransportListener);
+    client.start(mockClientTransportListener);
+    verify(mockClientTransportListener, timeout(1000)).transportReady();
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    client.shutdown();
+    verify(mockClientTransportListener, timeout(1000)).transportTerminated();
+    inOrder.verify(mockClientTransportListener).transportShutdown(any(Status.class));
+    inOrder.verify(mockClientTransportListener).transportTerminated();
+    assertTrue(serverTransportListener.waitForTermination(1000, TimeUnit.MILLISECONDS));
+    server.shutdown();
+    assertTrue(serverListener.waitForShutdown(1000, TimeUnit.MILLISECONDS));
+    server = null;
+  }
+
+  @Test
+  public void serverAlreadyListening() throws Exception {
+    client = null;
+    server.start(serverListener);
+    Server server2 = newServer();
+    thrown.expect(IOException.class);
+    server2.start(new MockServerListener());
+  }
+
+  @Test
+  public void openStreamPreventsTermination() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    clientStream.start(mockClientStreamListener);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+
+    client.shutdown();
+    client = null;
+    server.shutdown();
+    server = null;
+    serverTransport.shutdown();
+    serverTransport = null;
+
+    verify(mockClientTransportListener, timeout(1000)).transportShutdown(any(Status.class));
+    assertTrue(serverListener.waitForShutdown(1000, TimeUnit.MILLISECONDS));
+
+    // A new server should be able to start listening, since the current server has given up
+    // resources. There may be cases this is impossible in the future, but for now it is a useful
+    // property.
+    serverListener = new MockServerListener();
+    server = newServer();
+    server.start(serverListener);
+
+    // Try to "flush" out any listener notifications on client and server. This also ensures that
+    // the stream still functions.
+    serverStream.writeHeaders(new Metadata());
+    clientStream.halfClose();
+    verify(mockClientStreamListener, timeout(1000)).headersRead(any(Metadata.class));
+    verify(mockServerStreamListener, timeout(1000)).halfClosed();
+
+    verify(mockClientTransportListener, never()).transportTerminated();
+    assertFalse(serverTransportListener.isTerminated());
+
+    clientStream.cancel(Status.CANCELLED);
+
+    verify(mockClientTransportListener, timeout(1000)).transportTerminated();
+    assertTrue(serverTransportListener.waitForTermination(1000, TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void ping() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    ClientTransport.PingCallback mockPingCallback = mock(ClientTransport.PingCallback.class);
+    try {
+      client.ping(mockPingCallback, MoreExecutors.directExecutor());
+    } catch (UnsupportedOperationException ex) {
+      assumeTrue(false);
+    }
+    verify(mockPingCallback, timeout(1000)).onSuccess(Matchers.anyInt());
+  }
+
+  @Test
+  public void ping_duringShutdown() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    // Stream prevents termination
+    ClientStream stream = client.newStream(methodDescriptor, new Metadata());
+    stream.start(mockClientStreamListener);
+    client.shutdown();
+    ClientTransport.PingCallback mockPingCallback = mock(ClientTransport.PingCallback.class);
+    try {
+      client.ping(mockPingCallback, MoreExecutors.directExecutor());
+    } catch (UnsupportedOperationException ex) {
+      assumeTrue(false);
+    }
+    verify(mockPingCallback, timeout(1000)).onSuccess(Matchers.anyInt());
+    stream.cancel(Status.CANCELLED);
+  }
+
+  @Test
+  public void ping_afterTermination() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    client.shutdown();
+    ClientTransport.PingCallback mockPingCallback = mock(ClientTransport.PingCallback.class);
+    try {
+      client.ping(mockPingCallback, MoreExecutors.directExecutor());
+    } catch (UnsupportedOperationException ex) {
+      assumeTrue(false);
+    }
+    verify(mockPingCallback, timeout(1000)).onFailure(throwableCaptor.capture());
+    Status status = Status.fromThrowable(throwableCaptor.getValue());
+    assertCodeEquals(Status.UNAVAILABLE, status);
+  }
+
+  @Test
+  public void newStream_duringShutdown() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    // Stream prevents termination
+    ClientStream stream = client.newStream(methodDescriptor, new Metadata());
+    stream.start(mockClientStreamListener);
+    client.shutdown();
+    ClientStream stream2 = client.newStream(methodDescriptor, new Metadata());
+    ClientStreamListener mockClientStreamListener2 = mock(ClientStreamListener.class);
+    stream2.start(mockClientStreamListener2);
+    verify(mockClientStreamListener2, timeout(1000))
+        .closed(statusCaptor.capture(), any(Metadata.class));
+    assertCodeEquals(Status.UNAVAILABLE, statusCaptor.getValue());
+
+    // Make sure earlier stream works.
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    serverStreamCreation.stream.close(Status.OK, new Metadata());
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(statusCaptor.capture(), any(Metadata.class));
+    assertCodeEquals(Status.OK, statusCaptor.getValue());
+  }
+
+  @Test
+  public void basicStream() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    Metadata clientHeaders = new Metadata();
+    clientHeaders.put(asciiKey, "client");
+    clientHeaders.put(asciiKey, "dupvalue");
+    clientHeaders.put(asciiKey, "dupvalue");
+    clientHeaders.put(binaryKey, "äbinaryclient");
+    ClientStream clientStream = client.newStream(methodDescriptor, clientHeaders);
+    clientStream.start(mockClientStreamListener);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    assertEquals(methodDescriptor.getFullMethodName(), serverStreamCreation.method);
+    assertEquals(Lists.newArrayList(clientHeaders.getAll(asciiKey)),
+        Lists.newArrayList(serverStreamCreation.headers.getAll(asciiKey)));
+    assertEquals(Lists.newArrayList(clientHeaders.getAll(binaryKey)),
+        Lists.newArrayList(serverStreamCreation.headers.getAll(binaryKey)));
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+
+    serverStream.request(1);
+    verify(mockClientStreamListener, timeout(1000)).onReady();
+    assertTrue(clientStream.isReady());
+    clientStream.writeMessage(methodDescriptor.streamRequest("Hello!"));
+    clientStream.flush();
+    verify(mockServerStreamListener, timeout(1000)).messageRead(inputStreamCaptor.capture());
+    assertEquals("Hello!", methodDescriptor.parseRequest(inputStreamCaptor.getValue()));
+    inputStreamCaptor.getValue().close();
+
+    clientStream.halfClose();
+    verify(mockServerStreamListener, timeout(1000)).halfClosed();
+
+    Metadata serverHeaders = new Metadata();
+    serverHeaders.put(asciiKey, "server");
+    serverHeaders.put(asciiKey, "dupvalue");
+    serverHeaders.put(asciiKey, "dupvalue");
+    serverHeaders.put(binaryKey, "äbinaryserver");
+    serverStream.writeHeaders(serverHeaders);
+    verify(mockClientStreamListener, timeout(1000)).headersRead(metadataCaptor.capture());
+    assertEquals(Lists.newArrayList(serverHeaders.getAll(asciiKey)),
+        Lists.newArrayList(metadataCaptor.getValue().getAll(asciiKey)));
+    assertEquals(Lists.newArrayList(serverHeaders.getAll(binaryKey)),
+        Lists.newArrayList(metadataCaptor.getValue().getAll(binaryKey)));
+
+    clientStream.request(1);
+    verify(mockServerStreamListener, timeout(1000)).onReady();
+    assertTrue(serverStream.isReady());
+    serverStream.writeMessage(methodDescriptor.streamResponse("Hi. Who are you?"));
+    serverStream.flush();
+    verify(mockClientStreamListener, timeout(1000)).messageRead(inputStreamCaptor.capture());
+    assertEquals("Hi. Who are you?", methodDescriptor.parseResponse(inputStreamCaptor.getValue()));
+    inputStreamCaptor.getValue().close();
+
+    Status status = Status.OK.withDescription("That was normal");
+    Metadata trailers = new Metadata();
+    trailers.put(asciiKey, "trailers");
+    trailers.put(asciiKey, "dupvalue");
+    trailers.put(asciiKey, "dupvalue");
+    trailers.put(binaryKey, "äbinarytrailers");
+    serverStream.close(status, trailers);
+    verify(mockServerStreamListener, timeout(1000)).closed(statusCaptor.capture());
+    assertCodeEquals(Status.OK, statusCaptor.getValue());
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(statusCaptor.capture(), metadataCaptor.capture());
+    assertEquals(status.getCode(), statusCaptor.getValue().getCode());
+    assertEquals(status.getDescription(), statusCaptor.getValue().getDescription());
+    assertEquals(Lists.newArrayList(trailers.getAll(asciiKey)),
+        Lists.newArrayList(metadataCaptor.getValue().getAll(asciiKey)));
+    assertEquals(Lists.newArrayList(trailers.getAll(binaryKey)),
+        Lists.newArrayList(metadataCaptor.getValue().getAll(binaryKey)));
+  }
+
+  @Test
+  public void zeroMessageStream() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    clientStream.start(mockClientStreamListener);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+
+    clientStream.halfClose();
+    verify(mockServerStreamListener, timeout(1000)).halfClosed();
+
+    serverStream.writeHeaders(new Metadata());
+    verify(mockClientStreamListener, timeout(1000)).headersRead(any(Metadata.class));
+
+    Status status = Status.OK.withDescription("Nice talking to you");
+    serverStream.close(status, new Metadata());
+    verify(mockServerStreamListener, timeout(1000)).closed(statusCaptor.capture());
+    assertCodeEquals(Status.OK, statusCaptor.getValue());
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(status.getCode(), statusCaptor.getValue().getCode());
+    assertEquals(status.getDescription(), statusCaptor.getValue().getDescription());
+  }
+
+  @Test
+  public void earlyServerClose_withServerHeaders() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    clientStream.start(mockClientStreamListener);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+
+    serverStream.writeHeaders(new Metadata());
+    verify(mockClientStreamListener, timeout(1000)).headersRead(any(Metadata.class));
+
+    Status status = Status.OK.withDescription("Hello. Goodbye.");
+    serverStream.close(status, new Metadata());
+    verify(mockServerStreamListener, timeout(1000)).closed(statusCaptor.capture());
+    assertCodeEquals(Status.OK, statusCaptor.getValue());
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(status.getCode(), statusCaptor.getValue().getCode());
+  }
+
+  @Test
+  public void earlyServerClose_noServerHeaders() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    clientStream.start(mockClientStreamListener);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+
+    Status status = Status.OK.withDescription("Hellogoodbye");
+    Metadata trailers = new Metadata();
+    trailers.put(asciiKey, "trailers");
+    trailers.put(asciiKey, "dupvalue");
+    trailers.put(asciiKey, "dupvalue");
+    trailers.put(binaryKey, "äbinarytrailers");
+    serverStream.close(status, trailers);
+    verify(mockServerStreamListener, timeout(1000)).closed(statusCaptor.capture());
+    assertCodeEquals(Status.OK, statusCaptor.getValue());
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(statusCaptor.capture(), metadataCaptor.capture());
+    assertEquals(status.getCode(), statusCaptor.getValue().getCode());
+    assertEquals(Lists.newArrayList(trailers.getAll(asciiKey)),
+        Lists.newArrayList(metadataCaptor.getValue().getAll(asciiKey)));
+    assertEquals(Lists.newArrayList(trailers.getAll(binaryKey)),
+        Lists.newArrayList(metadataCaptor.getValue().getAll(binaryKey)));
+  }
+
+  @Test
+  public void earlyServerClose_serverFailure() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    clientStream.start(mockClientStreamListener);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+
+    Status status = Status.INVALID_ARGUMENT.withDescription("I'm not listening");
+    serverStream.close(status, new Metadata());
+    verify(mockServerStreamListener, timeout(1000)).closed(statusCaptor.capture());
+    assertCodeEquals(Status.OK, statusCaptor.getValue());
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(status.getCode(), statusCaptor.getValue().getCode());
+  }
+
+  @Test
+  public void clientCancel() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    clientStream.start(mockClientStreamListener);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+
+    Status status = Status.CANCELLED.withDescription("Nevermind");
+    clientStream.cancel(status);
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(Matchers.same(status), any(Metadata.class));
+    verify(mockServerStreamListener, timeout(1000)).closed(statusCaptor.capture());
+    assertNotEquals(Status.Code.OK, statusCaptor.getValue().getCode());
+
+    reset(mockServerStreamListener);
+    reset(mockClientStreamListener);
+    clientStream.cancel(status);
+    verify(mockServerStreamListener, never()).closed(any(Status.class));
+    verify(mockClientStreamListener, never()).closed(any(Status.class), any(Metadata.class));
+  }
+
+  @Test
+  public void serverCancel() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    clientStream.start(mockClientStreamListener);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+
+    Status status = Status.DEADLINE_EXCEEDED.withDescription("It was bound to happen");
+    serverStream.cancel(status);
+    verify(mockServerStreamListener, timeout(1000)).closed(Matchers.same(status));
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(statusCaptor.capture(), any(Metadata.class));
+    // Presently we can't sent much back to the client in this case. Verify that is the current
+    // behavior for consistency between transports.
+    assertCodeEquals(Status.CANCELLED, statusCaptor.getValue());
+
+    // Second cancellation shouldn't trigger additional callbacks
+    reset(mockServerStreamListener);
+    reset(mockClientStreamListener);
+    serverStream.cancel(status);
+    verify(mockServerStreamListener, never()).closed(any(Status.class));
+    verify(mockClientStreamListener, never()).closed(any(Status.class), any(Metadata.class));
+  }
+
+  @Test
+  public void flowControlPushBack() throws Exception {
+    server.start(serverListener);
+    client.start(mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    clientStream.start(mockClientStreamListener);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    assertEquals(methodDescriptor.getFullMethodName(), serverStreamCreation.method);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+    serverStream.writeHeaders(new Metadata());
+
+    Answer<Void> closeStream = new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Exception {
+        Object[] args = invocation.getArguments();
+        ((InputStream) args[0]).close();
+        return null;
+      }
+    };
+
+    String largeMessage;
+    {
+      int size = 1 * 1024;
+      StringBuffer sb = new StringBuffer(size);
+      for (int i = 0; i < size; i++) {
+        sb.append('a');
+      }
+      largeMessage = sb.toString();
+    }
+
+    doAnswer(closeStream).when(mockServerStreamListener).messageRead(any(InputStream.class));
+    serverStream.request(1);
+    verify(mockClientStreamListener, timeout(1000)).onReady();
+    assertTrue(clientStream.isReady());
+    final int maxToSend = 10 * 1024;
+    int clientSent;
+    for (clientSent = 0; clientStream.isReady(); clientSent++) {
+      if (clientSent > maxToSend) {
+        fail("Too many messages sent before isReady() returned false");
+      }
+      clientStream.writeMessage(methodDescriptor.streamRequest(largeMessage));
+      clientStream.flush();
+    }
+    assertTrue(clientSent > 0);
+    for (; clientSent < 5; clientSent++) {
+      clientStream.writeMessage(methodDescriptor.streamResponse(largeMessage));
+      clientStream.flush();
+    }
+    doPingPong(serverListener);
+    verify(mockServerStreamListener, timeout(1000)).messageRead(any(InputStream.class));
+
+    doAnswer(closeStream).when(mockClientStreamListener).messageRead(any(InputStream.class));
+    clientStream.request(1);
+    verify(mockServerStreamListener, timeout(1000)).onReady();
+    assertTrue(serverStream.isReady());
+    int serverSent;
+    for (serverSent = 0; serverStream.isReady(); serverSent++) {
+      if (serverSent > maxToSend) {
+        fail("Too many messages sent before isReady() returned false");
+      }
+      serverStream.writeMessage(methodDescriptor.streamResponse(largeMessage));
+      serverStream.flush();
+    }
+    assertTrue(clientSent > 0);
+    for (; serverSent < 5; serverSent++) {
+      serverStream.writeMessage(methodDescriptor.streamResponse(largeMessage));
+      serverStream.flush();
+    }
+    doPingPong(serverListener);
+    verify(mockClientStreamListener, timeout(1000)).messageRead(any(InputStream.class));
+
+    serverStream.request(3);
+    clientStream.request(3);
+    doPingPong(serverListener);
+    // times() is total number throughout the entire test
+    verify(mockClientStreamListener, timeout(1000).times(4)).messageRead(any(InputStream.class));
+    verify(mockServerStreamListener, timeout(1000).times(4)).messageRead(any(InputStream.class));
+
+    // Request four extra
+    serverStream.request(clientSent);
+    clientStream.request(serverSent);
+    verify(mockClientStreamListener, timeout(1000).times(clientSent))
+        .messageRead(any(InputStream.class));
+    verify(mockServerStreamListener, timeout(1000).times(serverSent))
+        .messageRead(any(InputStream.class));
+
+    verify(mockClientStreamListener, timeout(1000).times(2)).onReady();
+    assertTrue(clientStream.isReady());
+    verify(mockServerStreamListener, timeout(1000).times(2)).onReady();
+    assertTrue(serverStream.isReady());
+
+    for (int i = 0; i < 5; i++) {
+      clientStream.writeMessage(methodDescriptor.streamRequest(largeMessage));
+      clientStream.flush();
+      serverStream.writeMessage(methodDescriptor.streamResponse(largeMessage));
+      serverStream.flush();
+    }
+    doPingPong(serverListener);
+    verify(mockClientStreamListener, timeout(1000).times(clientSent + 4))
+        .messageRead(any(InputStream.class));
+    verify(mockServerStreamListener, timeout(1000).times(serverSent + 4))
+        .messageRead(any(InputStream.class));
+
+    // Drain exactly how many messages are left
+    serverStream.request(1);
+    clientStream.request(1);
+    verify(mockServerStreamListener, timeout(1000).times(serverSent + 5))
+        .messageRead(any(InputStream.class));
+    verify(mockClientStreamListener, timeout(1000).times(clientSent + 5))
+        .messageRead(any(InputStream.class));
+
+    clientStream.writeMessage(methodDescriptor.streamRequest(largeMessage));
+    clientStream.flush();
+    clientStream.halfClose();
+    doPingPong(serverListener);
+    verify(mockServerStreamListener, never()).halfClosed();
+
+    serverStream.request(1);
+    verify(mockServerStreamListener, timeout(1000).times(serverSent + 6))
+        .messageRead(any(InputStream.class));
+    verify(mockServerStreamListener, timeout(1000)).halfClosed();
+
+    serverStream.writeMessage(methodDescriptor.streamResponse(largeMessage));
+    serverStream.flush();
+    Status status = Status.OK.withDescription("... quite a lengthy discussion");
+    serverStream.close(status, new Metadata());
+    doPingPong(serverListener);
+    verify(mockClientStreamListener, never()).closed(any(Status.class), any(Metadata.class));
+
+    clientStream.request(1);
+    verify(mockClientStreamListener, timeout(1000).times(clientSent + 6))
+        .messageRead(any(InputStream.class));
+    verify(mockServerStreamListener, timeout(1000)).closed(statusCaptor.capture());
+    assertCodeEquals(Status.OK, statusCaptor.getValue());
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(status.getCode(), statusCaptor.getValue().getCode());
+    assertEquals(status.getDescription(), statusCaptor.getValue().getDescription());
+  }
+
+  private void doPingPong(MockServerListener serverListener) throws InterruptedException {
+    ManagedClientTransport client = newClientTransport();
+    client.start(mock(ManagedClientTransport.Listener.class));
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStreamListener mockClientStreamListener = mock(ClientStreamListener.class);
+    clientStream.start(mockClientStreamListener);
+
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(1000, TimeUnit.MILLISECONDS);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(1000, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
+
+    serverStream.close(Status.OK, new Metadata());
+    verify(mockClientStreamListener, timeout(1000))
+        .closed(any(Status.class), any(Metadata.class));
+    verify(mockServerStreamListener, timeout(1000)).closed(any(Status.class));
+    client.shutdown();
+  }
+
+  /**
+   * Only assert that the Status.Code matches, but provide the entire actual result in case the
+   * assertion fails.
+   */
+  private static void assertCodeEquals(Status expected, Status actual) {
+    if (expected == null) {
+      fail("expected should not be null");
+    }
+    if (actual == null || !expected.getCode().equals(actual.getCode())) {
+      assertEquals(expected, actual);
+    }
+  }
+
+  private static boolean waitForFuture(Future<?> future, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    try {
+      future.get(timeout, unit);
+    } catch (ExecutionException ex) {
+      throw new AssertionError(ex);
+    } catch (TimeoutException ex) {
+      return false;
+    }
+    return true;
+  }
+
+  private static class MockServerListener implements ServerListener {
+    public final BlockingQueue<MockServerTransportListener> listeners
+        = new LinkedBlockingQueue<MockServerTransportListener>();
+    private final SettableFuture<?> shutdown = SettableFuture.create();
+
+    @Override
+    public ServerTransportListener transportCreated(ServerTransport transport) {
+      MockServerTransportListener listener = new MockServerTransportListener(transport);
+      listeners.add(listener);
+      return listener;
+    }
+
+    @Override
+    public void serverShutdown() {
+      assertTrue(shutdown.set(null));
+    }
+
+    public boolean waitForShutdown(long timeout, TimeUnit unit) throws InterruptedException {
+      return waitForFuture(shutdown, timeout, unit);
+    }
+
+    public MockServerTransportListener takeListenerOrFail(long timeout, TimeUnit unit)
+        throws InterruptedException {
+      MockServerTransportListener listener = listeners.poll(timeout, unit);
+      if (listener == null) {
+        fail("Timed out waiting for server transport");
+      }
+      return listener;
+    }
+  }
+
+  private static class MockServerTransportListener implements ServerTransportListener {
+    public final ServerTransport transport;
+    public final BlockingQueue<StreamCreation> streams = new LinkedBlockingQueue<StreamCreation>();
+    private final SettableFuture<?> terminated = SettableFuture.create();
+
+    public MockServerTransportListener(ServerTransport transport) {
+      this.transport = transport;
+    }
+
+    @Override
+    public ServerStreamListener streamCreated(ServerStream stream, String method,
+        Metadata headers) {
+      ServerStreamListener listener = mock(ServerStreamListener.class);
+      streams.add(new StreamCreation(stream, method, headers, listener));
+      return listener;
+    }
+
+    @Override
+    public void transportTerminated() {
+      assertTrue(terminated.set(null));
+    }
+
+    public boolean waitForTermination(long timeout, TimeUnit unit) throws InterruptedException {
+      return waitForFuture(terminated, timeout, unit);
+    }
+
+    public boolean isTerminated() {
+      return terminated.isDone();
+    }
+
+    public StreamCreation takeStreamOrFail(long timeout, TimeUnit unit)
+        throws InterruptedException {
+      StreamCreation stream = streams.poll(timeout, unit);
+      if (stream == null) {
+        fail("Timed out waiting for server stream");
+      }
+      return stream;
+    }
+  }
+
+  private static class StreamCreation {
+    public final ServerStream stream;
+    public final String method;
+    public final Metadata headers;
+    public final ServerStreamListener listener;
+
+    public StreamCreation(ServerStream stream, String method,
+        Metadata headers, ServerStreamListener listener) {
+      this.stream = stream;
+      this.method = method;
+      this.headers = headers;
+      this.listener = listener;
+    }
+  }
+
+  private static class StringMarshaller implements MethodDescriptor.Marshaller<String> {
+    public static final StringMarshaller INSTANCE = new StringMarshaller();
+
+    @Override
+    public InputStream stream(String value) {
+      return new ByteArrayInputStream(value.getBytes(UTF_8));
+    }
+
+    @Override
+    public String parse(InputStream stream) {
+      try {
+        return new String(ByteStreams.toByteArray(stream), UTF_8);
+      } catch (IOException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+  }
+
+  private static class StringBinaryMarshaller implements Metadata.BinaryMarshaller<String> {
+    public static final StringBinaryMarshaller INSTANCE = new StringBinaryMarshaller();
+
+    @Override
+    public byte[] toBytes(String value) {
+      return value.getBytes(UTF_8);
+    }
+
+    @Override
+    public String parseBytes(byte[] serialized) {
+      return new String(serialized, UTF_8);
+    }
+  }
+}


### PR DESCRIPTION
This only produces about a 1% total code coverage gain mainly because the code coverage includes the interop tests. If you ignore coverage provided by the interop tests this increases overall coverage from 75% to 80%.

| Component | Before | After |
| ------ | ------ | ------- |
| netty | 78.82% | 84.82% |
| okhttp | 80.36% | 86.35% |
| inprocess | 0% | 79.54% |
| all minus interop | 75.68% | 80.91% |
| all | 87.28% | 88.24% |

Each commit is intended to be reviewed individually. I can send them out separately, but each commit depends on the commit before it.