### PR TITLE
Raise visibility of Netty Channel Builder Ctor

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -104,7 +104,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
     this(GrpcUtil.authorityFromHostAndPort(host, port));
   }
 
-  private NettyChannelBuilder(String target) {
+  protected NettyChannelBuilder(String target) {
     super(target);
   }
 


### PR DESCRIPTION
The constructor masks AMCB constructor that makes the name resolver used.