### PR TITLE
Add getter for metadata store

### DIFF
--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -174,6 +175,15 @@ public final class Metadata {
           });
     }
     return null;
+  }
+
+  /**
+   * Returns set of all keys in store.
+   *
+   * @return unmodifiable Set of keys
+   */
+  public Set<String> keys() {
+    return Collections.unmodifiableSet(store.keySet());
   }
 
   /**


### PR DESCRIPTION
We have a use case in which we want to iterate through all `*-bin` entries in metadata store, something that is currently impossible to do without reflection (which is what we're doing at the moment).

This simple getter would allow for iterating over whole metadata store without knowing metadata keys in advance.