### PR TITLE
Add support for codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,12 @@ install:
 before_script:
   - test -z "$(git status --porcelain)" || (git status && echo Error Working directory is not clean. Forget to commit generated files? && false)
 
+script:
+  - ./gradlew check :grpc-all:jacocoTestReport
+
 after_success:
   - if \[ "$TRAVIS_OS_NAME" = linux \]; then ./gradlew :grpc-all:coveralls; fi
+  - bash <(curl -s https://codecov.io/bash)
 
 os:
   - linux

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -59,6 +59,8 @@ javadoc {
 }
 
 task jacocoMerge(type: JacocoMerge) {
+    dependsOn(subprojects.jacocoTestReport.dependsOn)
+    mustRunAfter(subprojects.jacocoTestReport.mustRunAfter)
     destinationFile = file("${buildDir}/jacoco/test.exec")
     executionData = files(subprojects.jacocoTestReport.executionData)
         .plus(project(':grpc-interop-testing').jacocoTestReport.executionData)


### PR DESCRIPTION
Codecov.io provides patch-based code coverage, so you can easily know
how many of the added lines are covered. It also has a more useful UI.

Unfortunately, the percentage it reports does not include partially-
covered lines--those with uncovered conditions. Thus the reported
percentage is about 6% lower than the coverage we've been looking at
previously. Because of this alone, I don't expect to remove coveralls
support soon.

Use the bash script instead of python module since pip isn't available
by default on Travis OS X.

jacocoTestReport uses mustRunAfter (contrary to the docs; see
https://issues.gradle.org/browse/GRADLE-2960) to make sure it runs after
all tests, only if testing is taking place. We would like
:grpc-all:jacocoTestReport to behave the same way. Without it, we would
need two separate invocations of gradle (adding ~1m to Travis run) in
order to prevent getting random results depending on what tests just so
happened to have been run.