### PR TITLE
In blocking stubs, throw Status.CANCELLED on interruption

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -135,7 +135,7 @@ public class ClientCalls {
           executor.waitAndDrain();
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
-          throw new RuntimeException(e);
+          throw Status.CANCELLED.withCause(e).asRuntimeException();
         }
       }
       return getUnchecked(responseFuture);
@@ -436,7 +436,7 @@ public class ClientCalls {
           last = waitForNext();
         } catch (InterruptedException ie) {
           Thread.interrupted();
-          throw new RuntimeException(ie);
+          throw Status.CANCELLED.withCause(ie).asRuntimeException();
         }
       }
       if (last instanceof Status) {


### PR DESCRIPTION
This was already being done in one case, but should have been done for
the other occurrances of InterruptedException. Before the
RuntimeException is just asking to be a bug since application code will
commonly only catch StatusRuntimeException.