### PR TITLE
hpack is no longer a direct dependency

### DIFF
--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -1,7 +1,6 @@
 description = "gRPC: Netty"
 dependencies {
     compile project(':grpc-core'),
-            libraries.hpack,
             libraries.netty
 
     // Tests depend on base class defined by core module.


### PR DESCRIPTION
It isn't even a dependency of Netty, now that Netty has forked the code.