### PR TITLE
Release commits

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -32,7 +32,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.13.0'
+            artifact = 'io.grpc:protoc-gen-grpc-java:0.13.1-SNAPSHOT'
         }
     }
     generateProtoTasks {
@@ -63,9 +63,9 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     testCompile 'junit:junit:4.12'
     // You need to build grpc-java to obtain these libraries below.
-    compile 'io.grpc:grpc-protobuf-nano:0.13.0'
-    compile 'io.grpc:grpc-okhttp:0.13.0'
-    compile 'io.grpc:grpc-stub:0.13.0'
-    compile 'io.grpc:grpc-testing:0.13.0'
+    compile 'io.grpc:grpc-protobuf-nano:0.13.1-SNAPSHOT'
+    compile 'io.grpc:grpc-okhttp:0.13.1-SNAPSHOT'
+    compile 'io.grpc:grpc-stub:0.13.1-SNAPSHOT'
+    compile 'io.grpc:grpc-testing:0.13.1-SNAPSHOT'
     compile 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -32,7 +32,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.13.0-SNAPSHOT'
+            artifact = 'io.grpc:protoc-gen-grpc-java:0.13.0'
         }
     }
     generateProtoTasks {
@@ -63,9 +63,9 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     testCompile 'junit:junit:4.12'
     // You need to build grpc-java to obtain these libraries below.
-    compile 'io.grpc:grpc-protobuf-nano:0.13.0-SNAPSHOT'
-    compile 'io.grpc:grpc-okhttp:0.13.0-SNAPSHOT'
-    compile 'io.grpc:grpc-stub:0.13.0-SNAPSHOT'
-    compile 'io.grpc:grpc-testing:0.13.0-SNAPSHOT'
+    compile 'io.grpc:grpc-protobuf-nano:0.13.0'
+    compile 'io.grpc:grpc-okhttp:0.13.0'
+    compile 'io.grpc:grpc-stub:0.13.0'
+    compile 'io.grpc:grpc-testing:0.13.0'
     compile 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ subprojects {
     apply plugin: "com.google.osdetector"
 
     group = "io.grpc"
-    version = "0.13.0-SNAPSHOT"
+    version = "0.13.0"
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ subprojects {
     apply plugin: "com.google.osdetector"
 
     group = "io.grpc"
-    version = "0.13.0"
+    version = "0.13.1-SNAPSHOT"
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6


### PR DESCRIPTION
Note that these are against the (brand new!) 0.13.x branch. There are two commits here. Please review them separately. The "bump version to v0.13.0" will become our v0.13.0 release tag.