### PR TITLE
Add simple BINARY_BYTE_MARSHALLER for processing raw headers

### DIFF
--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -69,6 +69,29 @@ public final class Metadata {
   public static final String BINARY_HEADER_SUFFIX = "-bin";
 
   /**
+   * Simple metadata marshaller that encodes bytes as is.
+   *
+   * <p>This should be used when raw bytes are favored over un-serialized version of object. Can be
+   * helpful in situations where more processing to bytes is needed on application side, avoids
+   * double encoding/decoding.</p>
+   *
+   * <p>Both #toBytes and #parseBytes methods return copy of the byte array</p>
+   */
+  public static final BinaryMarshaller<byte[]> BINARY_BYTE_MARSHALLER =
+      new BinaryMarshaller<byte[]>() {
+
+    @Override
+    public byte[] toBytes(byte[] value) {
+      return value.clone();
+    }
+
+    @Override
+    public byte[] parseBytes(byte[] serialized) {
+      return serialized.clone();
+    }
+  };
+
+  /**
    * Simple metadata marshaller that encodes strings as is.
    *
    * <p>This should be used with ASCII strings that only contain the characters listed in the class


### PR DESCRIPTION
In a similar way to `ASCII_STRING_MARSHALLER`, I think it might be helpful to have its binary counterpart - `BINARY_BYTE_MARSHALLER`.

We are currently using such marshaller to avoid double serialization and are encoding/decoding protos on our own on app side, only when needed. I can imagine that this might be a common case for people dealing with `-bin` headers and it's not proto-specific - applies to all binary headers in general, despite the "format" they're in.

That said, maybe it's worth including in core?
