### PR TITLE
Limit memory during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: java
 
 env:
   global:
+    - GRADLE_OPTS=-Xmx512m
     - PROTOBUF_VERSION=3.0.0-beta-2
     - LDFLAGS=-L/tmp/protobuf-${PROTOBUF_VERSION}/lib
     - CXXFLAGS=-I/tmp/protobuf-${PROTOBUF_VERSION}/include

--- a/build.gradle
+++ b/build.gradle
@@ -280,5 +280,6 @@ subprojects {
             showCauses true
             showStackTraces true
         }
+        maxHeapSize = '1500m'
     }
 }


### PR DESCRIPTION
When running :grcp-interop-testing:test, Travis has been hanging on OS X
or flaking on Linux with:
> Process 'Gradle Test Executor 4' finished with non-zero exit value 137

Exit code 137 indicates SIGKILL (128 + 9) and is most likely caused by
the JVM being killed by the kernel's OOM killer.

The limit in .travis.yml is 2x what was necessary to do a parallel
build. The main test memory limit in build.gradle is well above 16m
which is necessary for the tests. Interop-testing is well above 64m
which is necessary for interop-testing, but we use 1.5g to help prevent
timeouts on Travis.

Protobuf and protobuf-nano each have one tests that decodes a proto >64M
in size, which prevents them from running with less than 512m and 768m,
respectively.