### PR TITLE
Fix a bug ByteReadableBufferWrapper. We should set new buffer's limit…

### DIFF
--- a/core/src/main/java/io/grpc/internal/ReadableBuffers.java
+++ b/core/src/main/java/io/grpc/internal/ReadableBuffers.java
@@ -288,8 +288,8 @@ public final class ReadableBuffers {
     public ByteReadableBufferWrapper readBytes(int length) {
       checkReadable(length);
       ByteBuffer buffer = bytes.duplicate();
-      bytes.position(bytes.position() + length);
       buffer.limit(bytes.position() + length);
+      bytes.position(bytes.position() + length);
       return new ByteReadableBufferWrapper(buffer);
     }
 

--- a/core/src/test/java/io/grpc/internal/ReadableBufferTestBase.java
+++ b/core/src/test/java/io/grpc/internal/ReadableBufferTestBase.java
@@ -121,6 +121,17 @@ public abstract class ReadableBufferTestBase {
     assertEquals(msg.length() - 2, buffer.readableBytes());
   }
 
+  @Test
+  public void partialReadToReadableBufferShouldSucceed() {
+    ReadableBuffer buffer = buffer();
+    ReadableBuffer newBuffer = buffer.readBytes(2);
+    assertEquals(2, newBuffer.readableBytes());
+    assertEquals(msg.length() - 2, buffer.readableBytes());
+    byte[] array = new byte[2];
+    newBuffer.readBytes(array, 0, 2);
+    assertArrayEquals(new byte[] {'h', 'e'}, Arrays.copyOfRange(array, 0, 2));     
+  }
+
   protected abstract ReadableBuffer buffer();
 
   private static String repeatUntilLength(String toRepeat, int length) {


### PR DESCRIPTION
… before changing the original buffer's position