### PR TITLE
Bump Guava to 19.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ subprojects {
             epoll_suffix = ":" + osdetector.classifier
         }
         libraries = [
-                guava: 'com.google.guava:guava:18.0',
+                guava: 'com.google.guava:guava:19.0',
                 // used to collect benchmark results
                 hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.4',
                 hpack: 'com.twitter:hpack:0.10.1',


### PR DESCRIPTION
There isn't a strong reason to to bump this, but it's good to stay up to date.  There are minor bug fixes, but I don't believe they affect us at all.  