### PR TITLE
WIP: Affinity based load balancer

### DIFF
--- a/loadbalancers/build.gradle
+++ b/loadbalancers/build.gradle
@@ -1,0 +1,15 @@
+description = "LoadBalancer"
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+dependencies {
+    compile project(':grpc-core'),
+            project(':grpc-protobuf'),
+            project(':grpc-stub')
+
+    testCompile project(':grpc-netty')
+}

--- a/loadbalancers/src/main/java/io/grpc/loadbalancers/AffinityLoadBalancer.java
+++ b/loadbalancers/src/main/java/io/grpc/loadbalancers/AffinityLoadBalancer.java
@@ -1,0 +1,188 @@
+package io.grpc.loadbalancers;
+
+import io.grpc.Attributes;
+import io.grpc.ExperimentalApi;
+import io.grpc.LoadBalancer;
+import io.grpc.RequestKey;
+import io.grpc.ResolvedServerInfo;
+import io.grpc.Status;
+import io.grpc.TransportManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Logger;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+
+/**
+ * Decorator for any LoadBalancer that adds simple server affinity functionality in
+ * the form of simple key-value label matching. A default affinity is provided by the 
+ * NameResolver using the ATTR_CORE_AFFINITY attribute.  Per request affinity
+ * may also be provided for each request using the RequestKey.
+ * 
+ * Affinity can be used to partition servers in a service by,
+ * 1. Consistent hashing (ex. each server has a label for the start token of the data it owns)
+ * 2. Redirect a percentage of traffic to a subset of servers for testing or debugging
+ * 3. Control shifting traffic to a new service deployment
+ * 4. Logical grouping of servers based on SLA or rate limiting
+ * 
+ * TODO: Ensure we don't thrash connections when the server list is updated
+ * TODO: Handle LoadBalancer shutdown
+ */
+@ExperimentalApi
+public final class AffinityLoadBalancer<T> extends LoadBalancer<T> {
+  private final static Logger LOG = Logger.getLogger(AffinityLoadBalancer.class.getName());
+
+  public static final Attributes.Key<RequestKey> ATTR_CORE_AFFINITY = new Attributes.Key<>(
+      "io.grpc.AffinityLoadBalancer.Affinity");
+
+  public static final class Factory extends LoadBalancer.Factory {
+    private final LoadBalancer.Factory delegate;
+
+    public Factory(final LoadBalancer.Factory delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public <T> LoadBalancer<T> newLoadBalancer(final String serviceName,
+        final TransportManager<T> tm) {
+      return new AffinityLoadBalancer<T>(serviceName, tm, delegate);
+    }
+  }
+
+  final class FailingLoadBalancer extends LoadBalancer<T> {
+    private final Status errorStatus;
+
+    public FailingLoadBalancer(final Status errorStatus) {
+      this.errorStatus = errorStatus;
+    }
+    
+    @Override
+    public T pickTransport(final RequestKey requestKey) {
+      return transportManager.createFailingTransport(errorStatus);
+    }
+  }
+  
+  final class CachingLoaderBalancer extends LoadBalancer<T> {
+    private final List<ResolvedServerInfo> servers;
+    private final RequestKey coreAffinity;
+
+    public CachingLoaderBalancer(final List<ResolvedServerInfo> servers, final Attributes config) {
+      this.servers = servers;
+      this.coreAffinity = MoreObjects.firstNonNull(config.get(ATTR_CORE_AFFINITY), RequestKey.NONE);
+    }
+
+    @Override
+    public T pickTransport(final RequestKey requestKey) {
+      Preconditions.checkNotNull(requestKey);
+      final RequestKey affinity;
+      if (requestKey != null && requestKey.hasAffinity()) {
+        if (requestKey.isAdditive() && coreAffinity != null) {
+          affinity = coreAffinity.extendWith(requestKey);
+        } else {
+          affinity = requestKey;
+        }
+      } else {
+        affinity = coreAffinity;
+      }
+
+      try {
+        return partitionCache.get(affinity, new Callable<LoadBalancer<T>>() {
+          @Override
+          public LoadBalancer<T> call() throws Exception {
+            LOG.info(String.format("Generating load balancer for '%s'", affinity));
+            List<ResolvedServerInfo> matchedServers = new ArrayList<ResolvedServerInfo>();
+            for (ResolvedServerInfo server : servers) {
+              Labels serverLabels = server.getAttributes().get(Labels.ATTRIBUTE);
+              if (serverLabels != null) {
+                for (Entry<String, String> affinity : affinity.getAffinities()
+                    .entrySet()) {
+                  if (!serverLabels.matches(affinity.getKey(),
+                      affinity.getValue())) {
+                    continue;
+                  }
+                }
+              }
+              matchedServers.add(server);
+            }
+
+            LoadBalancer<T> loadBalancer = loadBalancerFactory.newLoadBalancer(serviceName, transportManager);
+            LOG.info(String.format("Load balancer for '%s' has servers %s",
+                affinity, matchedServers));
+            loadBalancer.handleResolvedAddresses(matchedServers, Attributes.EMPTY);
+            return loadBalancer;
+          }
+        }).pickTransport(affinity);
+      } catch (ExecutionException e) {
+        return transportManager.createFailingTransport(Status.INTERNAL.withCause(e));
+      }
+    }
+  }
+
+  /**
+   * Current 'LoadBalancer' wrapper based on the last set of servers received 
+   * from the NameResolver
+   */
+  private volatile LoadBalancer<T> delegate;
+  
+  /**
+   * Cache of partitioned LoadBalancer instances with each partition matching a unique affinity.
+   * The cache is cleared after each update via handleResolvedAddresses.
+   */
+  private final Cache<RequestKey, LoadBalancer<T>> partitionCache;
+  
+  /**
+   * Factory to the real LoadBalancer algorithm with the factory being called for each
+   * update to handleResolvedAddresses.
+   */
+  private final LoadBalancer.Factory loadBalancerFactory;
+  
+  private final TransportManager<T> transportManager;
+  
+  private final String serviceName;
+
+  public AffinityLoadBalancer(final String serviceName,
+      final TransportManager<T> transportManager,
+      final LoadBalancer.Factory loadBalancerFactory) {
+    
+    LOG.info(String.format("Creating for %s", serviceName));
+    this.delegate = new FailingLoadBalancer(Status.UNAVAILABLE);
+    this.loadBalancerFactory = Preconditions.checkNotNull(loadBalancerFactory);
+    this.transportManager = Preconditions.checkNotNull(transportManager);
+    this.serviceName = Preconditions.checkNotNull(serviceName);
+    
+    this.partitionCache = CacheBuilder.newBuilder()
+        .removalListener(new RemovalListener<RequestKey, LoadBalancer<T>>() {
+          @Override
+          public void onRemoval(RemovalNotification<RequestKey, LoadBalancer<T>> notification) {
+            LOG.info(String.format("Clearing load balancer for %s", notification.getKey()));
+            notification.getValue().shutdown();
+          }
+        }).build();
+  }
+
+  @Override
+  public T pickTransport(final RequestKey requestKey) {
+    return delegate.pickTransport(requestKey);
+  }
+
+  @Override
+  public void handleResolvedAddresses(final List<ResolvedServerInfo> servers, Attributes config) {
+    this.delegate = new CachingLoaderBalancer(servers, config);
+    this.partitionCache.invalidateAll();
+    // TODO: Will this cause all open connections to terminate?
+  }
+
+  @Override
+  public void handleNameResolutionError(Status error) {
+    this.delegate = new FailingLoadBalancer(error);
+  }
+}

--- a/loadbalancers/src/main/java/io/grpc/loadbalancers/Labels.java
+++ b/loadbalancers/src/main/java/io/grpc/loadbalancers/Labels.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 @ExperimentalApi
 public final class Labels {
 
-  public static final Attributes.Key<Labels> ATTRIBUTE = new Attributes.Key<>("io.grpc.NameResolver.Labels");
+  public static final Attributes.Key<Labels> ATTRIBUTE = new Attributes.Key<Labels>("io.grpc.NameResolver.Labels");
   
   public static class Builder {
     private Map<String, Set<String>> labels = new LinkedHashMap<>();

--- a/loadbalancers/src/main/java/io/grpc/loadbalancers/Labels.java
+++ b/loadbalancers/src/main/java/io/grpc/loadbalancers/Labels.java
@@ -1,0 +1,69 @@
+package io.grpc.loadbalancers;
+
+import io.grpc.Attributes;
+import io.grpc.ExperimentalApi;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Labels associated with a {@link ResolvedServerAddress}.  Labels are passed from the NameResolver
+ * to the LoadBalancer in the attribute Labels.ATTRIBUTE.  Labels are modeled as key value
+ * pairs where a label key can be associated with multiple values.
+ * 
+ * @see AffinityLoadBalancer
+ */
+@ExperimentalApi
+public final class Labels {
+
+  public static final Attributes.Key<Labels> ATTRIBUTE = new Attributes.Key<>("io.grpc.NameResolver.Labels");
+  
+  public static class Builder {
+    private Map<String, Set<String>> labels = new LinkedHashMap<>();
+
+    public Builder add(String key, String value) {
+      Preconditions.checkNotNull(labels, "build() already called");
+      Set<String> values = labels.get(key);
+      if (values == null) {
+        values = new LinkedHashSet<>();
+        labels.put(key, values);
+      }
+      values.add(value);
+      return this;
+    }
+
+    public Labels build() {
+      Preconditions.checkNotNull(labels, "build() already called");
+      try {
+        return new Labels(labels);
+      } finally {
+        labels = null;
+      }
+    }
+  }
+
+  private final Map<String, Set<String>> labels;
+
+  private Labels(Map<String, Set<String>> labels) {
+    this.labels = labels;
+  }
+  
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public boolean matches(String key, String value) {
+    Set<String> values = labels.get(key);
+    return values == null ? false : values.contains(value);
+  }
+
+  @Override
+  public String toString() {
+    return "Labels [" + labels + "]";
+  }
+
+}

--- a/loadbalancers/src/test/java/io/grpc/loadbalancers/AffinityLoadBalancerTest.java
+++ b/loadbalancers/src/test/java/io/grpc/loadbalancers/AffinityLoadBalancerTest.java
@@ -1,0 +1,151 @@
+package io.grpc.loadbalancers;
+
+import io.grpc.Attributes;
+import io.grpc.Channel;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.RequestKey;
+import io.grpc.ResolvedServerInfo;
+import io.grpc.Status;
+import io.grpc.TransportManager;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import com.google.common.base.Supplier;
+
+// TODO: This is a basic test just to verify basic functionality.  A more robust test
+// suite will be provided once the overall approach is accepted
+public class AffinityLoadBalancerTest {
+  private final static Logger LOG = Logger.getLogger(AffinityLoadBalancerTest.class.getName());
+
+  public static class StringTransportManager extends TransportManager<String> {
+    @Override
+    public void updateRetainedTransports(Collection<EquivalentAddressGroup> addrs) {
+    }
+
+    @Override
+    public String getTransport(EquivalentAddressGroup addressGroup) {
+      return addressGroup.getAddresses().get(0).toString();
+    }
+
+    @Override
+    public Channel makeChannel(String transport) {
+      return null;
+    }
+
+    @Override
+    public String createFailingTransport(Status error) {
+      return "Failed";
+    }
+
+    @Override
+    public InterimTransport<String> createInterimTransport() {
+      return new InterimTransport<String>() {
+        @Override
+        public String transport() {
+          return "foo";
+        }
+
+        @Override
+        public void closeWithRealTransports(Supplier<String> realTransports) {
+          System.out.println("Closing: " + realTransports);
+        }
+
+        @Override
+        public void closeWithError(Status error) {
+          System.out.println("closeWithError: " + error);
+        }
+      };
+    }
+  }
+
+  public static class RoundRobinLoadBalancer extends LoadBalancer.Factory {
+    @Override
+    public <T> LoadBalancer<T> newLoadBalancer(String serviceName, TransportManager<T> tm) {
+      return new LoadBalancer<T>() {
+        private volatile List<ResolvedServerInfo> servers = Collections.emptyList();
+        private AtomicInteger counter = new AtomicInteger();
+
+        @Override
+        public void handleResolvedAddresses(List<ResolvedServerInfo> servers, Attributes config) {
+          this.servers = servers;
+        }
+
+        @Override
+        public T pickTransport(RequestKey requestKey) {
+          List<ResolvedServerInfo> servers = this.servers;
+          LOG.info(String.format("Pick transport for %s from servers %s ", requestKey, servers));
+          if (servers.isEmpty()) {
+            return tm.createFailingTransport(Status.UNAVAILABLE);
+          }
+          ResolvedServerInfo pickedServer = servers.get(counter.incrementAndGet() % servers.size());
+          return tm.getTransport(new EquivalentAddressGroup(pickedServer.getAddress()));
+        }
+      };
+    }
+  }
+
+  @Test
+  public void test() throws InterruptedException, ExecutionException {
+    LoadBalancer.Factory factory = new AffinityLoadBalancer.Factory(new RoundRobinLoadBalancer());
+
+    LoadBalancer<String> loadBalancer = factory
+        .newLoadBalancer("foo", new StringTransportManager());
+
+    List<ResolvedServerInfo> servers = Arrays.asList(
+        new ResolvedServerInfo(new InetSocketAddress("localhost", 80), Attributes.newBuilder()
+              .set(Labels.ATTRIBUTE, Labels.newBuilder()
+                  .add("vip", "vipA").build()).build()),
+        new ResolvedServerInfo(new InetSocketAddress("localhost", 81), Attributes.newBuilder()
+              .set(Labels.ATTRIBUTE, Labels.newBuilder()
+                  .add("vip", "vipB")
+                  .add("stack", "staging").build()).build()),
+        new ResolvedServerInfo(new InetSocketAddress("localhost", 82), Attributes.newBuilder()
+            .set(Labels.ATTRIBUTE, Labels.newBuilder()
+                  .add("vip", "vipA").build()).build()),
+        new ResolvedServerInfo(new InetSocketAddress("localhost", 83), Attributes.newBuilder()
+            .set(Labels.ATTRIBUTE, Labels.newBuilder()
+                  .add("vip", "vipA").build()).build()));
+
+    loadBalancer.handleResolvedAddresses(
+        servers,
+        Attributes
+            .newBuilder()
+            .set(AffinityLoadBalancer.ATTR_CORE_AFFINITY,
+                RequestKey.newBuilder().affinityTo("vip", "vipA").build()).build());
+
+    for (int i = 0; i < 10; i++) {
+      LOG.info(String.format("Picked : %s", loadBalancer.pickTransport(RequestKey.NONE)));
+    }
+
+    for (int i = 0; i < 10; i++) {
+      LOG.info(String.format("Picked : %s",
+          loadBalancer.pickTransport(RequestKey.newBuilder().affinityTo("vip", "vipA").build())));
+    }
+
+    for (int i = 0; i < 10; i++) {
+      LOG.info(String.format("Picked : %s",
+          loadBalancer.pickTransport(RequestKey.newBuilder().affinityTo("vip", "vipB").build())));
+    }
+
+    for (int i = 0; i < 10; i++) {
+      LOG.info(String.format(
+          "Picked : %s",
+          loadBalancer.pickTransport(RequestKey.newBuilder().affinityTo("vip", "vipB")
+              .affinityTo("stack", "staging").build())));
+    }
+
+    loadBalancer.handleResolvedAddresses(servers, Attributes.EMPTY);
+
+    LOG.info(String.format("Picked : %s", loadBalancer.pickTransport(RequestKey.NONE)));
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ include ":grpc-interop-testing"
 include ":grpc-all"
 include ":grpc-benchmarks"
 include ":grpc-examples"
+include ":grpc-loadbalancers"
 
 project(':grpc-core').projectDir = "$rootDir/core" as File
 project(':grpc-stub').projectDir = "$rootDir/stub" as File
@@ -21,6 +22,7 @@ project(':grpc-protobuf').projectDir = "$rootDir/protobuf" as File
 project(':grpc-protobuf-nano').projectDir = "$rootDir/protobuf-nano" as File
 project(':grpc-netty').projectDir = "$rootDir/netty" as File
 project(':grpc-grpclb').projectDir = "$rootDir/grpclb" as File
+project(':grpc-loadbalancers').projectDir = "$rootDir/loadbalancers" as File
 project(':grpc-testing').projectDir = "$rootDir/testing" as File
 project(':grpc-interop-testing').projectDir = "$rootDir/interop-testing" as File
 project(':grpc-all').projectDir = "$rootDir/all" as File


### PR DESCRIPTION
Many of our services are partitioned into groups of servers based on logical labels that are assigned to each server.  A client request may have an affinity to a group based on matching one or more labels.  

Some example use cases,

1.  Consistent hashing of requests to improve latency and cache hit ratio.  The server label would be "startHash"="1234", where the value represents the starting hash of the range of hash keys owned by the server.  For each request we assign an affinity based on hashing some request identifier (ex. customer id) that can be translated to one of the start hashes in the ring of servers.
2.  When canary-ing new deployments we may route a percentage of traffic to canary instances with label "stack"="canary" and once all tests have passed we remove the label to enable all traffic to the new instances without having to terminate the canary instances and spin up new instances.

The proposed implementation is for a LoadBalancer that uses these labels and affinity keys to filter out matching groups of servers to be passed to a real LoadBalancer implementation, one for each affinity key.  Labels are assigned to the ResolvedServerInfo instances in a NameResolver, the implementation of which is outside the scope of this PR.  As an optimization these groups are cached so that they only need to be resolved once per affinity key per snapshot list of servers.  This cache is cleared whenever the list of servers changes.  

Please provide us with feedback on this approach.  If acceptable I can work on adding a proper test suite.

