### PR TITLE
Add transport test for Netty

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -158,7 +158,7 @@ class InProcessTransport implements ServerTransport, ManagedClientTransport {
       return;
     }
     shutdownStatus = Status.UNAVAILABLE.withDescription("transport was requested to shut down");
-    notifyShutdown(Status.OK.withDescription(shutdownStatus.getDescription()));
+    notifyShutdown(shutdownStatus);
     if (streams.isEmpty()) {
       notifyTerminated();
     }

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -139,7 +139,7 @@ class DelayedClientTransport implements ManagedClientTransport {
       }
       shutdown = true;
       listener.transportShutdown(
-          Status.OK.withDescription("Channel requested transport to shut down"));
+          Status.UNAVAILABLE.withDescription("Channel requested transport to shut down"));
       if (pendingStreams == null || pendingStreams.isEmpty()) {
         pendingStreams = null;
         listener.transportTerminated();

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -78,7 +78,6 @@ public interface ManagedClientTransport extends ClientTransport {
      * streams may continue, and the transport may still be able to process {@link #newStream} as
      * long as it doesn't own the new streams. Shutdown could have been caused by an error or normal
      * operation.  It is possible that this method is called without {@link #shutdown} being called.
-     * If the argument to this function is {@link Status#isOk}, it is safe to immediately reconnect.
      *
      * <p>This is called exactly once, and must be called prior to {@link #transportTerminated}.
      *

--- a/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+/** A command to trigger close. It is buffered differently than normal close. */
+class GracefulCloseCommand {}

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -193,6 +193,11 @@ class NettyClientHandler extends AbstractNettyHandler {
     });
   }
 
+  /**
+   * Return the reason the handler failed. Only intended to be used by {@link NettyClientTransport}.
+   * Most other classes should retrieve the transport's shutdown status, since it may be more
+   * complete.
+   */
   @Nullable
   public Status errorStatus() {
     return goAwayStatus;
@@ -214,6 +219,11 @@ class NettyClientHandler extends AbstractNettyHandler {
       ((RequestMessagesCommand) msg).requestMessages();
     } else if (msg instanceof SendPingCommand) {
       sendPingFrame(ctx, (SendPingCommand) msg, promise);
+    } else if (msg instanceof GracefulCloseCommand) {
+      // Explicitly flush to create any buffered streams before sending GOAWAY.
+      // TODO(ejona): determine if the need to flush is a bug in Netty
+      flush(ctx);
+      close(ctx, promise);
     } else if (msg == NOOP_MESSAGE) {
       ctx.write(Unpooled.EMPTY_BUFFER, promise);
     } else {
@@ -268,6 +278,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   @Override
   public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
     logger.fine("Network channel being closed by the application.");
+    goAwayStatus(Status.UNAVAILABLE.withDescription("Channel requested transport shutdown"));
     super.close(ctx, promise);
   }
 
@@ -331,6 +342,12 @@ class NettyClientHandler extends AbstractNettyHandler {
    */
   private void createStream(CreateStreamCommand command, final ChannelPromise promise)
           throws Exception {
+    if (goAwayStatus != null) {
+      // The connection is going away, just terminate the stream now.
+      promise.setFailure(goAwayStatusThrowable);
+      return;
+    }
+
     // Get the stream ID for the new stream.
     final int streamId;
     try {
@@ -351,12 +368,6 @@ class NettyClientHandler extends AbstractNettyHandler {
     final NettyClientStream stream = command.stream();
     final Http2Headers headers = command.headers();
     stream.id(streamId);
-
-    if (goAwayStatus != null) {
-      // The connection is going away, just terminate the stream now.
-      promise.setFailure(goAwayStatusThrowable);
-      return;
-    }
 
     // Create an intermediate promise so that we can intercept the failure reported back to the
     // application.
@@ -423,20 +434,25 @@ class NettyClientHandler extends AbstractNettyHandler {
    */
   private void sendPingFrame(ChannelHandlerContext ctx, SendPingCommand msg,
       ChannelPromise promise) {
+    // Don't check goAwayStatus since we want to allow pings after shutdown but before termination.
+    // After termination, messages will no longer arrive because the pipeline clears all handlers on
+    // channel close.
+
     PingCallback callback = msg.callback();
     Executor executor = msg.executor();
-    if (!ctx.channel().isOpen()) {
-      Http2Ping.notifyFailed(callback, executor, goAwayStatus().asException());
-      return;
-    }
-
     // we only allow one outstanding ping at a time, so just add the callback to
     // any outstanding operation
     if (ping != null) {
+      promise.setSuccess();
       ping.addCallback(callback, executor);
       return;
     }
 
+    // Use a new promise to prevent calling the callback twice on write failure: here and in
+    // NettyClientTransport.ping(). It may appear strange, but it will behave the same as if
+    // ping != null above.
+    promise.setSuccess();
+    promise = ctx().newPromise();
     // set outstanding operation
     long data = random.nextLong();
     ByteBuf buffer = ctx.alloc().buffer(8);

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -53,6 +53,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -166,6 +167,12 @@ class Utils {
     Status s = Status.fromThrowable(t);
     if (s.getCode() != Status.Code.UNKNOWN) {
       return s;
+    }
+    if (t instanceof ClosedChannelException) {
+      // ClosedChannelException is used any time the Netty channel is closed. Proper error
+      // processing requires remembering the error that occurred before this one and using it
+      // instead.
+      return Status.UNKNOWN.withCause(t);
     }
     if (t instanceof IOException) {
       return Status.UNAVAILABLE.withCause(t);

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import static org.junit.Assert.assertEquals;
+
+import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.ManagedClientTransport;
+import io.grpc.internal.Server;
+import io.grpc.internal.testing.AbstractTransportTest;
+import io.grpc.testing.TestUtils;
+
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.InetSocketAddress;
+
+/** Unit tests for Netty transport. */
+@RunWith(JUnit4.class)
+public class NettyTransportTest extends AbstractTransportTest {
+  private static final int SERVER_PORT = TestUtils.pickUnusedPort();
+  // Avoid LocalChannel for testing because LocalChannel can fail with
+  // io.netty.channel.ChannelException instead of java.net.ConnectException which breaks
+  // serverNotListening test.
+  private ClientTransportFactory clientFactory = NettyChannelBuilder
+      // Although specified here, address is ignored because we never call build.
+      .forAddress("localhost", SERVER_PORT)
+      .flowControlWindow(65 * 1024)
+      .negotiationType(NegotiationType.PLAINTEXT)
+      .buildTransportFactory();
+
+  @After
+  public void releaseClientFactory() {
+    clientFactory.release();
+    assertEquals(0, clientFactory.referenceCount());
+  }
+
+  @Override
+  protected Server newServer() {
+    return NettyServerBuilder
+        .forPort(SERVER_PORT)
+        .flowControlWindow(65 * 1024)
+        .buildTransportServer();
+  }
+
+  @Override
+  protected ManagedClientTransport newClientTransport() {
+    return clientFactory.newClientTransport(
+        new InetSocketAddress("localhost", SERVER_PORT), "localhost:" + SERVER_PORT);
+  }
+
+  // TODO(ejona): Flaky
+  @Test
+  @Ignore
+  @Override
+  public void flowControlPushBack() {}
+}


### PR DESCRIPTION
Netty client shutdown would race with the negotiation handling and
circumvent AbstractBufferingHandler. Use a new command in order to
leave channel.close() available for abrupt killing of the connection
when connecting.

This was split out from #1397.