### PR TITLE
Add transport test for OkHttp

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -644,8 +644,8 @@ public abstract class AbstractInteropTest {
                .setIntervalUs(20000))
                .build()).next();
       fail("Expected deadline to be exceeded");
-    } catch (Throwable t) {
-      assertEquals(Status.DEADLINE_EXCEEDED.getCode(), Status.fromThrowable(t).getCode());
+    } catch (StatusRuntimeException ex) {
+      assertEquals(Status.DEADLINE_EXCEEDED.getCode(), ex.getStatus().getCode());
     }
   }
 

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -10,7 +10,8 @@ dependencies {
 
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
-                project(":grpc-testing")
+                project(':grpc-testing'),
+                project(':grpc-netty')
 }
 
 project.sourceSets {

--- a/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
@@ -238,10 +238,8 @@ class AsyncFrameWriter implements FrameWriter {
         doRun();
       } catch (RuntimeException e) {
         transport.onException(e);
-        throw e;
       } catch (Exception e) {
         transport.onException(e);
-        throw new RuntimeException(e);
       }
     }
 

--- a/okhttp/src/test/java/io/grpc/internal/AccessProtectedHack.java
+++ b/okhttp/src/test/java/io/grpc/internal/AccessProtectedHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,42 +29,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.okhttp;
+package io.grpc.internal;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import io.grpc.ManagedChannelProvider;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-import java.util.ServiceLoader;
-
-/** Unit tests for {@link OkHttpChannelProvider}. */
-@RunWith(JUnit4.class)
-public class OkHttpChannelProviderTest {
-  private OkHttpChannelProvider provider = new OkHttpChannelProvider();
-
-  @Test
-  public void provided() {
-    for (ManagedChannelProvider current : ServiceLoader.load(ManagedChannelProvider.class)) {
-      if (current instanceof OkHttpChannelProvider) {
-        return;
-      }
-    }
-    fail("ServiceLoader unable to load OkHttpChannelProvider");
+/** A hack to access protected methods from io.grpc.internal. */
+public final class AccessProtectedHack {
+  public static InternalServer serverBuilderBuildTransportServer(
+      AbstractServerImplBuilder<?> builder) {
+    return builder.buildTransportServer();
   }
 
-  @Test
-  public void isAvailable() {
-    assertTrue(provider.isAvailable());
-  }
-
-  @Test
-  public void builderIsAOkHttpBuilder() {
-    assertSame(OkHttpChannelBuilder.class, provider.builderForAddress("localhost", 443).getClass());
-  }
+  private AccessProtectedHack() {}
 }


### PR DESCRIPTION
OkHttpClientTransport has a fix for shutdown during start which
prevented transportTerminated from being called. It also no longer fails
pending streams during shutdown. Lifecycle management in general was
revamped to be hopefully simpler and more precise. In the process GOAWAY
handling (both sending and receiving) was improved.

With some of the changes, the log spam generated was immense and
unhelpful (since many exceptions are part of normal operation on
shutdown). This change reduces the amount of log spam to nothing.

This was split out from #1397.

@nmittler, @zhangkun83, @carl-mastrangelo, @zsurocking anyone want to
review this? :smile: The test itself is straight-forward (other than the hack!),
but I don't know who makes most sense to come up-to-speed with OkHttp.