### PR TITLE
Only link delayed transport AFTER real transport has called transportReady()

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.concurrent.Executor;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
@@ -230,6 +231,12 @@ class DelayedClientTransport implements ManagedClientTransport {
   @Override
   public String getLogId() {
     return GrpcUtil.getLogId(this);
+  }
+
+  @VisibleForTesting
+  @Nullable
+  Supplier<ClientTransport> getTransportSupplier() {
+    return transportSupplier;
   }
 
   private class PendingStream extends DelayedStream {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -165,13 +165,12 @@ public class ManagedChannelImplTransportManagerTest {
     ClientTransport t1 = tm.getTransport(addressGroup);
     verify(mockTransportFactory, timeout(1000)).newClientTransport(addr, authority);
     // The real transport
-    ClientTransport rt = transports.poll(1, TimeUnit.SECONDS).transport;
+    MockClientTransportInfo transportInfo = transports.poll(1, TimeUnit.SECONDS);
+    transportInfo.listener.transportReady();
     ClientTransport t2 = tm.getTransport(addressGroup);
-    // Make sure the first transport is always a real transport. This promise is especially made for
-    // InProcessTransport, because it may run into deadlock if it works under a delayed transport
-    // (https://github.com/grpc/grpc-java/issues/1510).
-    assertSame(rt, t1);
-    assertSame(rt, t2);
+    assertTrue(t1 instanceof DelayedClientTransport);
+    assertFalse(t2 instanceof DelayedClientTransport);
+    assertSame(transportInfo.transport, t2);
     verify(mockBackoffPolicyProvider).get();
     verify(mockBackoffPolicy, times(0)).nextBackoffMillis();
     verifyNoMoreInteractions(mockTransportFactory);


### PR DESCRIPTION
Resolves #1477

If TransportSet fails to connect a transport (i.e., transportShutdown()
called without transportReady()), TransportSet will automatically
schedule reconnection for the next address, unless it has reached the end
of the address list, in which case it will fail the delayed transport.

This will avoid stream errors caused by bad addresses appearing before
good addresses in the resolved address list.

@ejona86 Please review this PR as a whole. I will squash all commits upon check-in.