### PR TITLE
Inlcude the file that was used to generate service descriptors

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/TestServiceGrpc.java
@@ -13,7 +13,9 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: qpstest.proto")
 public class TestServiceGrpc {
 
   private TestServiceGrpc() {}

--- a/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/testing/WorkerGrpc.java
@@ -13,7 +13,9 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: qpstest.proto")
 public class WorkerGrpc {
 
   private WorkerGrpc() {}

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -639,10 +639,13 @@ static void PrintService(const ServiceDescriptor* service,
                          Printer* p,
                          bool generate_nano) {
   (*vars)["service_name"] = service->name();
+  (*vars)["file_name"] = service->file()->name();
   (*vars)["service_class_name"] = ServiceClassName(service);
   p->Print(
       *vars,
-      "@$Generated$(\"by gRPC proto compiler\")\n"
+      "@$Generated$(\n"
+      "    value = \"by gRPC proto compiler\",\n"
+      "    comments = \"Source: $file_name$\")\n"
       "public class $service_class_name$ {\n\n");
   p->Indent();
   p->Print(

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -13,7 +13,9 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: test.proto")
 public class TestServiceGrpc {
 
   private TestServiceGrpc() {}

--- a/compiler/src/test/golden/TestServiceNano.java.txt
+++ b/compiler/src/test/golden/TestServiceNano.java.txt
@@ -15,7 +15,9 @@ import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 import java.io.IOException;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: test.proto")
 public class TestServiceGrpc {
 
   private TestServiceGrpc() {}

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -13,7 +13,9 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: helloworld.proto")
 public class GreeterGrpc {
 
   private GreeterGrpc() {}

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -13,7 +13,9 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: route_guide.proto")
 public class RouteGuideGrpc {
 
   private RouteGuideGrpc() {}

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -13,7 +13,9 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: load_balancer.proto")
 public class LoadBalancerGrpc {
 
   private LoadBalancerGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -13,7 +13,9 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: io/grpc/testing/integration/test.proto")
 public class ReconnectServiceGrpc {
 
   private ReconnectServiceGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -13,7 +13,9 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: io/grpc/testing/integration/test.proto")
 public class TestServiceGrpc {
 
   private TestServiceGrpc() {}

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -13,7 +13,9 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-@javax.annotation.Generated("by gRPC proto compiler")
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: io/grpc/testing/integration/test.proto")
 public class UnimplementedServiceGrpc {
 
   private UnimplementedServiceGrpc() {}


### PR DESCRIPTION
This makes it easier to see quickly what source file was used to generate code.