### PR TITLE
Always schedule createTransportRunnable in the executor.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -279,6 +279,7 @@ subprojects {
             showExceptions true
             showCauses true
             showStackTraces true
+            events 'standard_error'
         }
         maxHeapSize = '1500m'
     }

--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -102,6 +102,7 @@ final class FakeClock {
     @Override public ScheduledFuture<?> schedule(Runnable cmd, long delay, TimeUnit unit) {
       ScheduledTask task = new ScheduledTask(currentTimeNanos + unit.toNanos(delay), cmd);
       tasks.add(task);
+      runDueTasks();
       return task;
     }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -197,7 +198,11 @@ public class ManagedChannelImplTest {
     verify(mockTransport, timeout(1000)).newStream(same(method), same(headers));
     verify(mockStream).start(streamListenerCaptor.capture());
     verify(mockStream).setCompressor(isA(Compressor.class));
-    verify(mockStream).setMessageCompression(anyBoolean());
+    // Depends on how quick the real transport is created, ClientCallImpl may start on mockStream
+    // directly, or on a DelayedStream which later starts mockStream. In the former case,
+    // setMessageCompression() is not called. In the latter case, it is (in
+    // DelayedStream.startStream()).
+    verify(mockStream, atMost(1)).setMessageCompression(anyBoolean());
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
 
     // Second call

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
@@ -196,6 +197,7 @@ public class ManagedChannelImplTest {
     verify(mockTransport, timeout(1000)).newStream(same(method), same(headers));
     verify(mockStream).start(streamListenerCaptor.capture());
     verify(mockStream).setCompressor(isA(Compressor.class));
+    verify(mockStream).setMessageCompression(anyBoolean());
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
 
     // Second call

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -43,7 +43,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.net.SocketAddress;
-import java.util.LinkedList;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Common utility methods for tests.
@@ -74,9 +75,10 @@ final class TestUtils {
    * returns a list of {@link MockClientTransportInfo}, each of which is a started mock transport
    * and its listener.
    */
-  static LinkedList<MockClientTransportInfo> captureTransports(
+  static BlockingQueue<MockClientTransportInfo> captureTransports(
       ClientTransportFactory mockTransportFactory) {
-    final LinkedList<MockClientTransportInfo> captor = new LinkedList<MockClientTransportInfo>();
+    final BlockingQueue<MockClientTransportInfo> captor =
+        new LinkedBlockingQueue<MockClientTransportInfo>();
 
     doAnswer(new Answer<ManagedClientTransport>() {
       @Override

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -62,7 +62,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.net.SocketAddress;
 import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.concurrent.BlockingQueue;
 
 /**
  * Unit tests for {@link TransportSet}.
@@ -92,7 +92,7 @@ public class TransportSetTest {
 
   private TransportSet transportSet;
   private EquivalentAddressGroup addressGroup;
-  private LinkedList<MockClientTransportInfo> transports;
+  private BlockingQueue<MockClientTransportInfo> transports;
 
   @Before public void setUp() {
     MockitoAnnotations.initMocks(this);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractTransportTest.java
@@ -70,6 +70,7 @@ import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.StreamRecorder;
 import io.grpc.testing.TestUtils;
+import io.grpc.testing.TestWatchDog;
 import io.grpc.testing.integration.Messages.Payload;
 import io.grpc.testing.integration.Messages.PayloadType;
 import io.grpc.testing.integration.Messages.ResponseParameters;
@@ -137,12 +138,14 @@ public abstract class AbstractTransportTest {
   protected ManagedChannel channel;
   protected TestServiceGrpc.TestServiceBlockingStub blockingStub;
   protected TestServiceGrpc.TestService asyncStub;
+  protected TestWatchDog watchDog;
 
   /**
    * Must be called by the subclass setup method if overridden.
    */
   @Before
   public void setUp() {
+    watchDog = new TestWatchDog(9, TimeUnit.SECONDS);
     channel = createChannel();
     blockingStub = TestServiceGrpc.newBlockingStub(channel);
     asyncStub = TestServiceGrpc.newStub(channel);
@@ -155,6 +158,7 @@ public abstract class AbstractTransportTest {
     if (channel != null) {
       channel.shutdown();
     }
+    watchDog.close();
   }
 
   protected abstract ManagedChannel createChannel();

--- a/testing/src/main/java/io/grpc/testing/StackTraces.java
+++ b/testing/src/main/java/io/grpc/testing/StackTraces.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Copyright 2011 The Bazel Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.testing;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.io.PrintStream;
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.Set;
+
+/**
+ * Utilities for stack traces.
+ */
+public class StackTraces {
+
+  /**
+   * Prints all stack traces to the given stream.
+   *
+   * @param out Stream to print to
+   */
+  public static void printAll(PrintStream out) {
+    out.println("Starting full thread dump ...\n");
+    ThreadMXBean mb = ManagementFactory.getThreadMXBean();
+
+    // ThreadInfo has comprehensive information such as locks.
+    ThreadInfo[] threadInfos = mb.dumpAllThreads(true, true);
+
+    // But we can know whether a thread is daemon only from Thread
+    Set<Thread> threads = Thread.getAllStackTraces().keySet();
+    ImmutableMap<Long, Thread> threadMap = Maps.uniqueIndex(
+        threads, new Function<Thread, Long>() {
+          @Override public Long apply(Thread thread) {
+            return thread.getId();
+          }
+        });
+
+    // Dump non-daemon threads first
+    for (ThreadInfo threadInfo : threadInfos) {
+      Thread thread = threadMap.get(threadInfo.getThreadId());
+      if (thread != null && !thread.isDaemon()) {
+        dumpThreadInfo(threadInfo, thread, out);
+      }
+    }
+
+    // Dump daemon threads
+    for (ThreadInfo threadInfo : threadInfos) {
+      Thread thread = threadMap.get(threadInfo.getThreadId());
+      if (thread != null && thread.isDaemon()) {
+        dumpThreadInfo(threadInfo, thread, out);
+      }
+    }
+
+    long[] deadlockedThreads = mb.findDeadlockedThreads();
+    if (deadlockedThreads != null) {
+      out.println("Detected deadlocked threads: " + Arrays.toString(deadlockedThreads));
+    }
+    long[] monitorDeadlockedThreads = mb.findMonitorDeadlockedThreads();
+    if (monitorDeadlockedThreads != null) {
+      out.println("Detected monitor deadlocked threads: "
+          + Arrays.toString(monitorDeadlockedThreads));
+    }
+    out.println("\nDone full thread dump.");
+    out.flush();
+  }
+
+  // Adopted from ThreadInfo.toString(), without MAX_FRAMES limit
+  private static void dumpThreadInfo(ThreadInfo t, Thread thread, PrintStream out) {
+    out.print("\"" + t.getThreadName() + "\""
+        + " Id=" + t.getThreadId() + " " + t.getThreadState());
+    if (t.getLockName() != null) {
+      out.print(" on " + t.getLockName());
+    }
+    if (t.getLockOwnerName() != null) {
+      out.print(" owned by \"" + t.getLockOwnerName() + "\" Id=" + t.getLockOwnerId());
+    }
+    if (t.isSuspended()) {
+      out.print(" (suspended)");
+    }
+    if (t.isInNative()) {
+      out.print(" (in native)");
+    }
+    if (thread.isDaemon()) {
+      out.print(" (daemon)");
+    }
+    out.print('\n');
+    StackTraceElement[] stackTrace = t.getStackTrace();
+    MonitorInfo[] lockedMonitors = t.getLockedMonitors();
+    for (int i = 0; i < stackTrace.length; i++) {
+      StackTraceElement ste = stackTrace[i];
+      out.print("\tat " + ste.toString());
+      out.print('\n');
+      if (i == 0 && t.getLockInfo() != null) {
+        Thread.State ts = t.getThreadState();
+        switch (ts) {
+          case BLOCKED:
+            out.print("\t-  blocked on " + t.getLockInfo());
+            out.print('\n');
+            break;
+          case WAITING:
+            out.print("\t-  waiting on " + t.getLockInfo());
+            out.print('\n');
+            break;
+          case TIMED_WAITING:
+            out.print("\t-  waiting on " + t.getLockInfo());
+            out.print('\n');
+            break;
+          default:
+        }
+      }
+
+      for (MonitorInfo mi : lockedMonitors) {
+        if (mi.getLockedStackDepth() == i) {
+          out.print("\t-  locked " + mi);
+          out.print('\n');
+        }
+      }
+    }
+
+    LockInfo[] locks = t.getLockedSynchronizers();
+    if (locks.length > 0) {
+      out.print("\n\tNumber of locked synchronizers = " + locks.length);
+      out.print('\n');
+      for (LockInfo li : locks) {
+        out.print("\t- " + li);
+        out.print('\n');
+      }
+    }
+    out.print('\n');
+  }
+}

--- a/testing/src/main/java/io/grpc/testing/TestWatchDog.java
+++ b/testing/src/main/java/io/grpc/testing/TestWatchDog.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.testing;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Dumps the full stack traces if a test has exceeded the preset timeout.
+ */
+public final class TestWatchDog implements AutoCloseable {
+  private final Thread thread;
+
+  /**
+   * Creates a watch dog with the given timeout.
+   */
+  public TestWatchDog(final long time, final TimeUnit unit) {
+    final long timeoutMillis = unit.toMillis(time);
+    thread = new Thread("TestWatchDog") {
+        @Override public void run() {
+          try {
+            Thread.sleep(timeoutMillis);
+            System.err.println("TestWatchDog expired after " + time + " " + unit);
+            StackTraces.printAll(System.err);
+          } catch (InterruptedException e) {
+            // no-op
+          }
+        }
+      };
+    thread.start();
+  }
+
+  @Override public void close() {
+    thread.interrupt();
+  }
+}


### PR DESCRIPTION
Because `scheduleConnection()` is run under lock, if we ran
`createTransportRunnable` inline, `savedDelayedTransport.setTransport()`
will be under lock which violates the assumption made in
https://github.com/grpc/grpc-java/issues/1408 that
> there is an implicit rule today that channel layer will not hold any lock while calling into transport, and had caused deadlock.