### PR TITLE
Run createTransportRunnable outside of lock.

### DIFF
--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -102,6 +102,7 @@ final class FakeClock {
     @Override public ScheduledFuture<?> schedule(Runnable cmd, long delay, TimeUnit unit) {
       ScheduledTask task = new ScheduledTask(currentTimeNanos + unit.toNanos(delay), cmd);
       tasks.add(task);
+      runDueTasks();
       return task;
     }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -37,9 +37,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -196,6 +198,11 @@ public class ManagedChannelImplTest {
     verify(mockTransport, timeout(1000)).newStream(same(method), same(headers));
     verify(mockStream).start(streamListenerCaptor.capture());
     verify(mockStream).setCompressor(isA(Compressor.class));
+    // Depends on how quick the real transport is created, ClientCallImpl may start on mockStream
+    // directly, or on a DelayedStream which later starts mockStream. In the former case,
+    // setMessageCompression() is not called. In the latter case, it is (in
+    // DelayedStream.startStream()).
+    verify(mockStream, atMost(1)).setMessageCompression(anyBoolean());
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
 
     // Second call

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -31,17 +31,15 @@
 
 package io.grpc.internal;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.same;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -71,16 +69,15 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Unit tests for {@link ManagedChannelImpl}'s {@link TransportManager} implementation as well as
@@ -113,6 +110,12 @@ public class ManagedChannelImplTransportManagerTest {
   };
 
   private final ExecutorService executor = Executors.newSingleThreadExecutor();
+  private final MethodDescriptor<String, String> method = MethodDescriptor.create(
+      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
+      new StringMarshaller(), new StringMarshaller());
+  private final MethodDescriptor<String, String> method2 = MethodDescriptor.create(
+      MethodDescriptor.MethodType.UNKNOWN, "/service/method2",
+      new StringMarshaller(), new StringMarshaller());
 
   private ManagedChannelImpl channel;
 
@@ -120,6 +123,8 @@ public class ManagedChannelImplTransportManagerTest {
   @Mock private LoadBalancer.Factory mockLoadBalancerFactory;
   @Mock private BackoffPolicy.Provider mockBackoffPolicyProvider;
   @Mock private BackoffPolicy mockBackoffPolicy;
+
+  private BlockingQueue<MockClientTransportInfo> transports;
 
   private TransportManager<ClientTransport> tm;
 
@@ -144,6 +149,7 @@ public class ManagedChannelImplTransportManagerTest {
         = ArgumentCaptor.forClass(null);
     verify(mockLoadBalancerFactory).newLoadBalancer(anyString(), tmCaptor.capture());
     tm = tmCaptor.getValue();
+    transports = TestUtils.captureTransports(mockTransportFactory);
   }
 
   @After
@@ -154,19 +160,18 @@ public class ManagedChannelImplTransportManagerTest {
 
   @Test
   public void createAndReuseTransport() throws Exception {
-    doAnswer(new Answer<ManagedClientTransport>() {
-      @Override
-      public ManagedClientTransport answer(InvocationOnMock invocation) throws Throwable {
-        return mock(ManagedClientTransport.class);
-      }
-    }).when(mockTransportFactory).newClientTransport(any(SocketAddress.class), any(String.class));
-
     SocketAddress addr = mock(SocketAddress.class);
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(addr);
     ClientTransport t1 = tm.getTransport(addressGroup);
-    verify(mockTransportFactory).newClientTransport(addr, authority);
+    verify(mockTransportFactory, timeout(1000)).newClientTransport(addr, authority);
+    // The real transport
+    ClientTransport rt = transports.poll(1, TimeUnit.SECONDS).transport;
     ClientTransport t2 = tm.getTransport(addressGroup);
-    assertSame(t1, t2);
+    // Make sure the first transport is always a real transport. This promise is especially made for
+    // InProcessTransport, because it may run into deadlock if it works under a delayed transport
+    // (https://github.com/grpc/grpc-java/issues/1510).
+    assertSame(rt, t1);
+    assertSame(rt, t2);
     verify(mockBackoffPolicyProvider).get();
     verify(mockBackoffPolicy, times(0)).nextBackoffMillis();
     verifyNoMoreInteractions(mockTransportFactory);
@@ -178,46 +183,49 @@ public class ManagedChannelImplTransportManagerTest {
     SocketAddress addr2 = mock(SocketAddress.class);
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(Arrays.asList(addr1, addr2));
 
-    LinkedList<MockClientTransportInfo> transports =
-        TestUtils.captureTransports(mockTransportFactory);
-
     // Invocation counters
     int backoffReset = 0;
 
     // Pick the first transport
     ClientTransport t1 = tm.getTransport(addressGroup);
     assertNotNull(t1);
-    verify(mockTransportFactory).newClientTransport(addr1, authority);
+    verify(mockTransportFactory, timeout(1000)).newClientTransport(addr1, authority);
     verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
     // Fail the first transport, without setting it to ready
-    transports.poll().listener.transportShutdown(Status.UNAVAILABLE);
+    MockClientTransportInfo transportInfo = transports.poll(1, TimeUnit.SECONDS);
+    ClientTransport rt1 = transportInfo.transport;
+    transportInfo.listener.transportShutdown(Status.UNAVAILABLE);
 
     // Subsequent getTransport() will use the next address
-    ClientTransport t2a = tm.getTransport(addressGroup);
-    assertNotNull(t2a);
+    ClientTransport t2 = tm.getTransport(addressGroup);
+    assertNotNull(t2);
+    t2.newStream(method, new Metadata());
     // Will keep the previous back-off policy, and not consult back-off policy
+    verify(mockTransportFactory, timeout(1000)).newClientTransport(addr2, authority);
     verify(mockBackoffPolicyProvider, times(backoffReset)).get();
-    verify(mockTransportFactory).newClientTransport(addr2, authority);
-    ClientTransport t2b = tm.getTransport(addressGroup);
-    assertSame(t2a, t2b);
-    assertNotSame(t1, t2a);
+    transportInfo = transports.poll(1, TimeUnit.SECONDS);
+    ClientTransport rt2 = transportInfo.transport;
     // Make the second transport ready
-    transports.peek().listener.transportReady();
+    transportInfo.listener.transportReady();
+    verify(rt2, timeout(1000)).newStream(same(method), any(Metadata.class));
     // Disconnect the second transport
-    transports.poll().listener.transportShutdown(Status.UNAVAILABLE);
+    transportInfo.listener.transportShutdown(Status.UNAVAILABLE);
 
     // Subsequent getTransport() will use the next address, which is the first one since we have run
     // out of addresses.
     ClientTransport t3 = tm.getTransport(addressGroup);
-    assertNotSame(t1, t3);
-    assertNotSame(t2a, t3);
+    t3.newStream(method2, new Metadata());
+    verify(mockTransportFactory, timeout(1000).times(2)).newClientTransport(addr1, authority);
     // This time back-off policy was reset, because previous transport was succesfully connected.
     verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
+    transportInfo = transports.poll(1, TimeUnit.SECONDS);
+    ClientTransport rt3 = transportInfo.transport;
+    transportInfo.listener.transportReady();
+    verify(rt3, timeout(1000)).newStream(same(method2), any(Metadata.class));
+
     // Back-off policy was never consulted.
     verify(mockBackoffPolicy, times(0)).nextBackoffMillis();
-    verify(mockTransportFactory, times(2)).newClientTransport(addr1, authority);
     verifyNoMoreInteractions(mockTransportFactory);
-    assertEquals(1, transports.size());
   }
 
   @Test
@@ -225,9 +233,6 @@ public class ManagedChannelImplTransportManagerTest {
     SocketAddress addr1 = mock(SocketAddress.class);
     SocketAddress addr2 = mock(SocketAddress.class);
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(Arrays.asList(addr1, addr2));
-
-    LinkedList<MockClientTransportInfo> transports =
-        TestUtils.captureTransports(mockTransportFactory);
 
     // Invocation counters
     int transportsAddr1 = 0;
@@ -238,33 +243,38 @@ public class ManagedChannelImplTransportManagerTest {
     // First pick succeeds
     ClientTransport t1 = tm.getTransport(addressGroup);
     assertNotNull(t1);
-    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+    verify(mockTransportFactory, timeout(1000).times(++transportsAddr1))
+        .newClientTransport(addr1, authority);
     // Back-off policy was set initially.
     verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
-    transports.peek().listener.transportReady();
+    MockClientTransportInfo transportInfo = transports.poll(1, TimeUnit.SECONDS);
+    transportInfo.listener.transportReady();
     // Then close it
-    transports.poll().listener.transportShutdown(Status.UNAVAILABLE);
+    transportInfo.listener.transportShutdown(Status.UNAVAILABLE);
 
     // Second pick fails. This is the beginning of a series of failures.
     ClientTransport t2 = tm.getTransport(addressGroup);
     assertNotNull(t2);
-    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+    verify(mockTransportFactory, timeout(1000).times(++transportsAddr1))
+        .newClientTransport(addr1, authority);
     // Back-off policy was reset.
     verify(mockBackoffPolicyProvider, times(++backoffReset)).get();
-    transports.poll().listener.transportShutdown(Status.UNAVAILABLE);
+    transports.poll(1, TimeUnit.SECONDS).listener.transportShutdown(Status.UNAVAILABLE);
 
     // Third pick fails too
     ClientTransport t3 = tm.getTransport(addressGroup);
     assertNotNull(t3);
-    verify(mockTransportFactory, times(++transportsAddr2)).newClientTransport(addr2, authority);
+    verify(mockTransportFactory, timeout(1000).times(++transportsAddr2))
+        .newClientTransport(addr2, authority);
     // Back-off policy was not reset.
     verify(mockBackoffPolicyProvider, times(backoffReset)).get();
-    transports.poll().listener.transportShutdown(Status.UNAVAILABLE);
+    transports.poll(1, TimeUnit.SECONDS).listener.transportShutdown(Status.UNAVAILABLE);
 
     // Forth pick is on the first address, back-off policy kicks in.
     ClientTransport t4 = tm.getTransport(addressGroup);
     assertNotNull(t4);
-    verify(mockTransportFactory, times(++transportsAddr1)).newClientTransport(addr1, authority);
+    verify(mockTransportFactory, timeout(1000).times(++transportsAddr1))
+        .newClientTransport(addr1, authority);
     // Back-off policy was not reset, but was consulted.
     verify(mockBackoffPolicyProvider, times(backoffReset)).get();
     verify(mockBackoffPolicy, times(++backoffConsulted)).nextBackoffMillis();
@@ -282,9 +292,6 @@ public class ManagedChannelImplTransportManagerTest {
     InterimTransport<ClientTransport> interimTransport = tm.createInterimTransport();
     ClientTransport transport = interimTransport.transport();
     assertTrue(transport instanceof DelayedClientTransport);
-    MethodDescriptor<String, String> method = MethodDescriptor.create(
-        MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-        new StringMarshaller(), new StringMarshaller());
     ClientStream s1 = transport.newStream(method, new Metadata());
     ClientStreamListener sl1 = mock(ClientStreamListener.class);
     s1.start(sl1);

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -43,7 +43,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.net.SocketAddress;
-import java.util.LinkedList;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Common utility methods for tests.
@@ -74,9 +75,10 @@ final class TestUtils {
    * returns a list of {@link MockClientTransportInfo}, each of which is a started mock transport
    * and its listener.
    */
-  static LinkedList<MockClientTransportInfo> captureTransports(
+  static BlockingQueue<MockClientTransportInfo> captureTransports(
       ClientTransportFactory mockTransportFactory) {
-    final LinkedList<MockClientTransportInfo> captor = new LinkedList<MockClientTransportInfo>();
+    final BlockingQueue<MockClientTransportInfo> captor =
+        new LinkedBlockingQueue<MockClientTransportInfo>();
 
     doAnswer(new Answer<ManagedClientTransport>() {
       @Override

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -62,7 +62,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.net.SocketAddress;
 import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.concurrent.BlockingQueue;
 
 /**
  * Unit tests for {@link TransportSet}.
@@ -92,7 +92,7 @@ public class TransportSetTest {
 
   private TransportSet transportSet;
   private EquivalentAddressGroup addressGroup;
-  private LinkedList<MockClientTransportInfo> transports;
+  private BlockingQueue<MockClientTransportInfo> transports;
 
   @Before public void setUp() {
     MockitoAnnotations.initMocks(this);


### PR DESCRIPTION
Because `scheduleConnection()` is run under lock, if we ran `createTransportRunnable` inside `scheduleConnection()`, `savedDelayedTransport.setTransport()` will be under lock which violates
the assumption made in https://github.com/grpc/grpc-java/issues/1408 that

> there is an implicit rule today that channel layer will not hold any lock while calling into transport

and had caused deadlock with `InProcessTransport`.

Also updated tests to
 1. Make it clear that we want the first obtained transport to be the real transport instead of the delayed transport, because `InProcessTransport` has deadlock issues with delayed transport (grpc/grpc-java/pull/1510)
 2. Not rely on identity equity to check whether `TransportSet` has switched to a different address. Instead, call `newStream()` and check which real transport is actually called, which is more reliable.
 3. Add timeout when checking for real transport creation and starting. Tests in general should not check for implementation detail, e.g., whether certain work is done synchronously.