### PR TITLE
Remove static initializer blocks

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -128,7 +128,7 @@ public abstract class AbstractBenchmark {
 
   private static final CallOptions CALL_OPTIONS = CallOptions.DEFAULT;
 
-  private static final InetAddress BENCHMARK_ADDR;
+  private static final InetAddress BENCHMARK_ADDR = buildBenchmarkAddr();
 
   /**
    * Resolve the address bound to the benchmark interface. Currently we assume it's a
@@ -148,7 +148,7 @@ public abstract class AbstractBenchmark {
    * sudo ip addr add dev lo 127.127.127.127/32 label lo:benchmark
    * </pre>
    */
-  static {
+  private static InetAddress buildBenchmarkAddr() {
     InetAddress tmp = null;
     try {
       Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
@@ -180,9 +180,8 @@ public abstract class AbstractBenchmark {
         throw new RuntimeException(uhe);
       }
     }
-    BENCHMARK_ADDR = tmp;
+    return tmp;
   }
-
 
   protected Server server;
   protected ByteBuf request;

--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -37,6 +37,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.TreeMap;
 
@@ -233,9 +234,9 @@ public final class Status {
   }
 
   // Create the canonical list of Status instances indexed by their code values.
-  private static final List<Status> STATUS_LIST;
+  private static final List<Status> STATUS_LIST = buildStatusList();
 
-  static {
+  private static List<Status> buildStatusList() {
     TreeMap<Integer, Status> canonicalizer = new TreeMap<Integer, Status>();
     for (Code code : Code.values()) {
       Status replaced = canonicalizer.put(code.value(), new Status(code));
@@ -244,7 +245,7 @@ public final class Status {
             + replaced.getCode().name() + " & " + code.name());
       }
     }
-    STATUS_LIST = new ArrayList<Status>(canonicalizer.values());
+    return Collections.unmodifiableList(new ArrayList<Status>(canonicalizer.values()));
   }
 
   // A pseudo-enum of Status instances mapped 1:1 with values in Code. This simplifies construction

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -200,15 +200,17 @@ public final class GrpcUtil {
     HTTP_1_1_REQUIRED(0xD, Status.UNKNOWN);
 
     // Populate a mapping of code to enum value for quick look-up.
-    private static final Http2Error[] codeMap;
-    static {
+    private static final Http2Error[] codeMap = buildHttp2CodeMap();
+
+    private static Http2Error[] buildHttp2CodeMap() {
       Http2Error[] errors = Http2Error.values();
       int size = (int) errors[errors.length - 1].code() + 1;
-      codeMap = new Http2Error[size];
+      Http2Error[] http2CodeMap = new Http2Error[size];
       for (Http2Error error : errors) {
         int index = (int) error.code();
-        codeMap[index] = error;
+        http2CodeMap[index] = error;
       }
+      return http2CodeMap;
     }
 
     private final int code;

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -67,6 +67,7 @@ import io.grpc.StringMarshaller;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -98,7 +99,8 @@ public class ServerImplTest {
   private final DecompressorRegistry decompressorRegistry =
       DecompressorRegistry.getDefaultInstance();
 
-  static {
+  @BeforeClass
+  public static void beforeStartUp() {
     // Cancel the root context. Server will fork it so the per-call context should not
     // be cancelled.
     SERVER_CONTEXT.cancel(null);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -88,11 +88,11 @@ import javax.net.ssl.SSLSocketFactory;
  * A okhttp-based {@link ManagedClientTransport} implementation.
  */
 class OkHttpClientTransport implements ManagedClientTransport {
-  private static final Map<ErrorCode, Status> ERROR_CODE_TO_STATUS;
+  private static final Map<ErrorCode, Status> ERROR_CODE_TO_STATUS = buildErrorCodeToStatusMap();
   private static final Logger log = Logger.getLogger(OkHttpClientTransport.class.getName());
   private static final OkHttpClientStream[] EMPTY_STREAM_ARRAY = new OkHttpClientStream[0];
 
-  static {
+  private static Map<ErrorCode, Status> buildErrorCodeToStatusMap() {
     Map<ErrorCode, Status> errorToStatus = new EnumMap<ErrorCode, Status>(ErrorCode.class);
     errorToStatus.put(ErrorCode.NO_ERROR,
         Status.INTERNAL.withDescription("No error: A GRPC status of OK should have been sent"));
@@ -118,7 +118,7 @@ class OkHttpClientTransport implements ManagedClientTransport {
         Status.RESOURCE_EXHAUSTED.withDescription("Enhance your calm"));
     errorToStatus.put(ErrorCode.INADEQUATE_SECURITY,
         Status.PERMISSION_DENIED.withDescription("Inadequate security"));
-    ERROR_CODE_TO_STATUS = Collections.unmodifiableMap(errorToStatus);
+    return Collections.unmodifiableMap(errorToStatus);
   }
 
   private final InetSocketAddress address;


### PR DESCRIPTION
I believe this gives better stack traces when there is a failure in static initialization.