### PR TITLE
Json example

### DIFF
--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloJsonClient.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloJsonClient.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.examples.helloworld;
+
+import static io.grpc.stub.ClientCalls.blockingUnaryCall;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.stub.AbstractStub;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class HelloJsonClient {
+  private static final Logger logger = Logger.getLogger(HelloWorldClient.class.getName());
+
+  private final ManagedChannel channel;
+  private final GreeterGrpc.GreeterBlockingClient blockingStub;
+
+  /** Construct client connecting to HelloWorld server at {@code host:port}. */
+  public HelloJsonClient(String host, int port) {
+    channel = ManagedChannelBuilder.forAddress(host, port)
+        .usePlaintext(true)
+        .build();
+    blockingStub = new HelloJsonStub(channel);
+  }
+
+  public void shutdown() throws InterruptedException {
+    channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+  }
+
+  /** Say hello to server. */
+  public void greet(String name) {
+    logger.info("Will try to greet " + name + " ...");
+    HelloRequest request = HelloRequest.newBuilder().setName(name).build();
+    HelloReply response;
+    try {
+      response = blockingStub.sayHello(request);
+    } catch (StatusRuntimeException e) {
+      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      return;
+    }
+    logger.info("Greeting: " + response.getMessage());
+  }
+
+  /**
+   * Greet server. If provided, the first element of {@code args} is the name to use in the
+   * greeting.
+   */
+  public static void main(String[] args) throws Exception {
+    HelloJsonClient client = new HelloJsonClient("localhost", 50051);
+    try {
+      /* Access a service running on the local machine on port 50051 */
+      String user = "world";
+      if (args.length > 0) {
+        user = args[0]; /* Use the arg as the name to greet if provided */
+      }
+      client.greet(user);
+    } finally {
+      client.shutdown();
+    }
+  }
+
+  static final class HelloJsonStub extends AbstractStub<HelloJsonStub>
+      implements GreeterGrpc.GreeterBlockingClient {
+
+    static final MethodDescriptor<HelloRequest, HelloReply> METHOD_SAY_HELLO =
+        MethodDescriptor.create(
+            GreeterGrpc.METHOD_SAY_HELLO.getType(),
+            GreeterGrpc.METHOD_SAY_HELLO.getFullMethodName(),
+            ProtoUtils.jsonMarshaller(HelloRequest.getDefaultInstance()),
+            ProtoUtils.jsonMarshaller(HelloReply.getDefaultInstance()));
+
+    protected HelloJsonStub(Channel channel) {
+      super(channel);
+    }
+
+    protected HelloJsonStub(Channel channel, CallOptions callOptions) {
+      super(channel, callOptions);
+    }
+
+    @Override
+    protected HelloJsonStub build(Channel channel, CallOptions callOptions) {
+      return new HelloJsonStub(channel, callOptions);
+    }
+
+    @Override
+    public HelloReply sayHello(HelloRequest request) {
+      return blockingUnaryCall(
+          getChannel(), METHOD_SAY_HELLO, getCallOptions(), request);
+    }
+  }
+}
+

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloJsonServer.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloJsonServer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.examples.helloworld;
+
+import static io.grpc.stub.ServerCalls.asyncUnaryCall;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.examples.helloworld.GreeterGrpc.Greeter;
+import io.grpc.stub.ServerCalls.UnaryMethod;
+import io.grpc.stub.StreamObserver;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+/**
+ * Server that manages startup/shutdown of a {@code Greeter} server.
+ */
+public class HelloJsonServer {
+  private static final Logger logger = Logger.getLogger(HelloWorldServer.class.getName());
+
+  /* The port on which the server should run */
+  private int port = 50051;
+  private Server server;
+
+  private void start() throws IOException {
+    server = ServerBuilder.forPort(port)
+        .addService(bindService(new GreeterImpl()))
+        .build()
+        .start();
+    logger.info("Server started, listening on " + port);
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+        System.err.println("*** shutting down gRPC server since JVM is shutting down");
+        HelloJsonServer.this.stop();
+        System.err.println("*** server shut down");
+      }
+    });
+  }
+
+  private void stop() {
+    if (server != null) {
+      server.shutdown();
+    }
+  }
+
+  /**
+   * Await termination on the main thread since the grpc library uses daemon threads.
+   */
+  private void blockUntilShutdown() throws InterruptedException {
+    if (server != null) {
+      server.awaitTermination();
+    }
+  }
+
+  /**
+   * Main launches the server from the command line.
+   */
+  public static void main(String[] args) throws IOException, InterruptedException {
+    final HelloJsonServer server = new HelloJsonServer();
+    server.start();
+    server.blockUntilShutdown();
+  }
+
+  private class GreeterImpl implements GreeterGrpc.Greeter {
+
+    @Override
+    public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {
+      HelloReply reply = HelloReply.newBuilder().setMessage("Hello " + req.getName()).build();
+      responseObserver.onNext(reply);
+      responseObserver.onCompleted();
+    }
+  }
+
+  private ServerServiceDefinition bindService(final Greeter serviceImpl) {
+    return io.grpc.ServerServiceDefinition.builder(GreeterGrpc.SERVICE_NAME)
+        .addMethod(
+          HelloJsonClient.HelloJsonStub.METHOD_SAY_HELLO,
+          asyncUnaryCall(
+              new UnaryMethod<HelloRequest, HelloReply>() {
+                @Override
+                public void invoke(
+                    HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+                  serviceImpl.sayHello(request, responseObserver);
+                }
+              }))
+        .build();
+  }
+}

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -7,7 +7,8 @@ description = 'gRPC: Protobuf'
 dependencies {
     compile project(':grpc-core'),
             libraries.protobuf,
-            libraries.guava
+            libraries.guava,
+            libraries.protobuf_util
 }
 
 animalsniffer {


### PR DESCRIPTION
*~*~*~*~*~*~*~*~*~
This is a prototype, a WIP, and may need to be refined in the future.
*~*~*~*~*~*~*~*~*~


This PR shows off how to make a Client and Server that speak Json encoded Proto over the wire.  It tries to reuse most of the stubs when possible to minimize code impact.

This explicitly does not attempt to take on some of the harder problems such as performance optimization that the existing proto marshaller has done.  The JsonFormat util is not amenable to streaming, so may need to be changed in the future.    

Additionally this does not attempt at all to address jsonName encoding or "Any" message types.  This will need to change in the future, but it would be good to have an example showing off how to plugin a different marshaller in.  There have been several requests regarding Json support, so I believe it's time to   get the ball rolling. 