### PR TITLE
netty: GOAWAY should trigger transportShutdown

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -112,6 +112,7 @@ abstract class NettyClientStream extends Http2ClientStream {
 
   /**
    * Intended to be overriden by NettyClientTransport, which has more information about failures.
+   * May only be called from event loop.
    */
   protected abstract Status statusFromFailedFuture(ChannelFuture f);
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -496,7 +496,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     };
 
     return NettyClientHandler.newHandler(connection, frameReader(), frameWriter(),
-        listener, flowControlWindow,ticker);
+        new ClientTransportLifecycleManager(listener), flowControlWindow, ticker);
   }
 
   @Override


### PR DESCRIPTION
Long-lived streams or lengthy RPCs can keep the transport open for
minutes after a GOAWAY is received. Previously, during this time any new
RPCs would fail with a message like:

> Cannot create stream 5 since this endpoint has received a GOAWAY frame
> with last stream id 3

All usages of goAwayStatus were replaced with lifecycleManager. Although
note that previously goAwayStatus() would never return null because it
would generate a Status if the current field was null.
getShutdownStatus() does not have this feature, so some code was
rearranged to guarantee the Status is non-null before retrieving it.

The listener handling was simplified by 1) avoiding the need for
thread-safety and 2) moving state keeping into a small class for easy
comprehensibility and simplified usage in tests.

NettyClientTransport.shutdown() no longer calls transportShutdown()
because it lies (because the message can be delayed for quite some time)
and because it was the only usage of lifecycleManager not on the event
loop.

Fixes #1359