### PR TITLE
Don't hold a lock in DelayedStream when calling realStream

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -208,11 +209,11 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
       stream.setAuthority(callOptions.getAuthority());
     }
     stream.setCompressor(compressor);
+
+    stream.start(new ClientStreamListenerImpl(observer));
     if (compressor != Codec.Identity.NONE) {
       stream.setMessageCompression(true);
     }
-
-    stream.start(new ClientStreamListenerImpl(observer));
     // Delay any sources of cancellation after start(), because most of the transports are broken if
     // they receive cancel before start. Issue #1343 has more details
 
@@ -269,6 +270,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
   @Override
   public void request(int numMessages) {
     Preconditions.checkState(stream != null, "Not started");
+    checkArgument(numMessages >= 0, "Number requested must be non-negative");
     stream.request(numMessages);
   }
 

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -219,6 +219,18 @@ public class DelayedClientTransportTest {
     verify(mockRealTransport).ping(same(pingCallback), same(mockExecutor));
   }
 
+  @Test public void shutdownThenPing() {
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    delayedTransport.ping(pingCallback, mockExecutor);
+    verifyNoMoreInteractions(pingCallback);
+    ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(mockExecutor).execute(runnableCaptor.capture());
+    runnableCaptor.getValue().run();
+    verify(pingCallback).onFailure(any(Throwable.class));
+  }
+
   @Test public void shutdownThenNewStream() {
     delayedTransport.shutdown();
     verify(transportListener).transportShutdown(any(Status.class));


### PR DESCRIPTION
Our currently lock ordering rules prohibit holding a lock when calling
the channel and stream. This change avoids the lock for both
DelayedClientTransport and DelayedStream. It is effectively a rewrite of
DelayedStream.

The fixes to ClientCallImpl were to ensure sane state in DelayedStream.