### PR TITLE
Run createTransportRunnable outside of lock.

### DIFF
--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -102,6 +102,7 @@ final class FakeClock {
     @Override public ScheduledFuture<?> schedule(Runnable cmd, long delay, TimeUnit unit) {
       ScheduledTask task = new ScheduledTask(currentTimeNanos + unit.toNanos(delay), cmd);
       tasks.add(task);
+      runDueTasks();
       return task;
     }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -37,9 +37,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -196,6 +198,11 @@ public class ManagedChannelImplTest {
     verify(mockTransport, timeout(1000)).newStream(same(method), same(headers));
     verify(mockStream).start(streamListenerCaptor.capture());
     verify(mockStream).setCompressor(isA(Compressor.class));
+    // Depends on how quick the real transport is created, ClientCallImpl may start on mockStream
+    // directly, or on a DelayedStream which later starts mockStream. In the former case,
+    // setMessageCompression() is not called. In the latter case, it is (in
+    // DelayedStream.startStream()).
+    verify(mockStream, atMost(1)).setMessageCompression(anyBoolean());
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
 
     // Second call

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -73,7 +73,7 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -174,7 +174,7 @@ public class ManagedChannelImplTransportManagerTest {
     SocketAddress addr2 = mock(SocketAddress.class);
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(Arrays.asList(addr1, addr2));
 
-    LinkedList<MockClientTransportInfo> transports =
+    BlockingQueue<MockClientTransportInfo> transports =
         TestUtils.captureTransports(mockTransportFactory);
 
     // Invocation counters
@@ -222,7 +222,7 @@ public class ManagedChannelImplTransportManagerTest {
     SocketAddress addr2 = mock(SocketAddress.class);
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(Arrays.asList(addr1, addr2));
 
-    LinkedList<MockClientTransportInfo> transports =
+    BlockingQueue<MockClientTransportInfo> transports =
         TestUtils.captureTransports(mockTransportFactory);
 
     // Invocation counters

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -43,7 +43,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.net.SocketAddress;
-import java.util.LinkedList;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Common utility methods for tests.
@@ -74,9 +75,10 @@ final class TestUtils {
    * returns a list of {@link MockClientTransportInfo}, each of which is a started mock transport
    * and its listener.
    */
-  static LinkedList<MockClientTransportInfo> captureTransports(
+  static BlockingQueue<MockClientTransportInfo> captureTransports(
       ClientTransportFactory mockTransportFactory) {
-    final LinkedList<MockClientTransportInfo> captor = new LinkedList<MockClientTransportInfo>();
+    final BlockingQueue<MockClientTransportInfo> captor =
+        new LinkedBlockingQueue<MockClientTransportInfo>();
 
     doAnswer(new Answer<ManagedClientTransport>() {
       @Override

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -64,7 +64,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.net.SocketAddress;
 import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.concurrent.BlockingQueue;
 
 /**
  * Unit tests for {@link TransportSet}.
@@ -94,7 +94,7 @@ public class TransportSetTest {
 
   private TransportSet transportSet;
   private EquivalentAddressGroup addressGroup;
-  private LinkedList<MockClientTransportInfo> transports;
+  private BlockingQueue<MockClientTransportInfo> transports;
 
   @Before public void setUp() {
     MockitoAnnotations.initMocks(this);


### PR DESCRIPTION
Because `scheduleConnection()` is run under lock, if we ran
`createTransportRunnable` inside `scheduleConnection()`,
`savedDelayedTransport.setTransport()` will be under lock which violates
the assumption made in https://github.com/grpc/grpc-java/issues/1408 that

> there is an implicit rule today that channel layer will not hold any lock while calling into transport

and had caused deadlock with `InProcessTransport`.

This is a partial back-port of 0e14516f5a5cbee5e60e467bfbc48a8a3197ff40
from master. A large portion of changes on tests is not ported because
of conflict caused by API changes in master.