### PR TITLE
More logging in channel implementations.

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -40,6 +40,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.NoopClientStream;
 import io.grpc.internal.ServerStream;
@@ -166,7 +167,12 @@ class InProcessTransport implements ServerTransport, ManagedClientTransport {
 
   @Override
   public String toString() {
-    return super.toString() + "(" + name + ")";
+    return getLogId() + "(" + name + ")";
+  }
+
+  @Override
+  public String getLogId() {
+    return GrpcUtil.getLogId(this);
   }
 
   private synchronized void notifyShutdown(Status s) {

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -230,6 +230,11 @@ class DelayedClientTransport implements ManagedClientTransport {
     }
   }
 
+  @Override
+  public String getLogId() {
+    return GrpcUtil.getLogId(this);
+  }
+
   private class PendingStream extends DelayedStream {
     private final MethodDescriptor<?, ?> method;
     private final Metadata headers;

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -479,5 +479,12 @@ public final class GrpcUtil {
     }
   }
 
+  /**
+   * The canonical implementation of {@link WithLogId#getLogId}.
+   */
+  public static String getLogId(WithLogId subject) {
+    return subject.getClass().getSimpleName() + "@" + Integer.toHexString(subject.hashCode());
+  }
+
   private GrpcUtil() {}
 }

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -47,7 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * {@link Listener#transportTerminated}.
  */
 @ThreadSafe
-public interface ManagedClientTransport extends ClientTransport {
+public interface ManagedClientTransport extends ClientTransport, WithLogId {
 
   /**
    * Starts transport. This method may only be called once.

--- a/core/src/main/java/io/grpc/internal/WithLogId.java
+++ b/core/src/main/java/io/grpc/internal/WithLogId.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+/**
+ * An object that has an ID that is unique within the JVM, primarily for debug logging.
+ */
+public interface WithLogId {
+  /**
+   * Returns an ID that is primarily used in debug logs. It usually contains the class name and a
+   * numeric ID that is unique among the instances. {@link GprcUtil#getLogId} is a canonical
+   * implementation.
+   *
+   * <p>The subclasses of this interface usually want to include the log ID in their {@link
+   * #toString} results.
+   */
+  String getLogId();
+}

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -248,6 +249,7 @@ public class ManagedChannelImplTest {
 
     verify(mockTransportFactory).release();
     verifyNoMoreInteractions(mockTransportFactory);
+    verify(mockTransport, atLeast(0)).getLogId();
     verifyNoMoreInteractions(mockTransport);
     verifyNoMoreInteractions(mockStream);
   }

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -108,7 +108,7 @@ public class TransportSetTest {
 
   @Test public void singleAddressBackoff() {
     SocketAddress addr = mock(SocketAddress.class);
-    createTransortSet(addr);
+    createTransportSet(addr);
 
     // Invocation counters
     int transportsCreated = 0;
@@ -162,7 +162,7 @@ public class TransportSetTest {
   @Test public void twoAddressesBackoff() {
     SocketAddress addr1 = mock(SocketAddress.class);
     SocketAddress addr2 = mock(SocketAddress.class);
-    createTransortSet(addr1, addr2);
+    createTransportSet(addr1, addr2);
 
     // Invocation counters
     int transportsAddr1 = 0;
@@ -232,7 +232,7 @@ public class TransportSetTest {
   @Test
   public void connectIsLazy() {
     SocketAddress addr = mock(SocketAddress.class);
-    createTransortSet(addr);
+    createTransportSet(addr);
 
     // Invocation counters
     int transportsCreated = 0;
@@ -268,7 +268,7 @@ public class TransportSetTest {
   @Test
   public void shutdownBeforeTransportCreatedWithPendingStream() throws Exception {
     SocketAddress addr = mock(SocketAddress.class);
-    createTransortSet(addr);
+    createTransportSet(addr);
 
     // First transport is created immediately
     ClientTransport pick = transportSet.obtainActiveTransport();
@@ -316,7 +316,7 @@ public class TransportSetTest {
   @Test
   public void shutdownBeforeTransportCreatedWithoutPendingStream() throws Exception {
     SocketAddress addr = mock(SocketAddress.class);
-    createTransortSet(addr);
+    createTransportSet(addr);
 
     // First transport is created immediately
     ClientTransport pick = transportSet.obtainActiveTransport();
@@ -350,7 +350,7 @@ public class TransportSetTest {
   @Test
   public void obtainTransportAfterShutdown() throws Exception {
     SocketAddress addr = mock(SocketAddress.class);
-    createTransortSet(addr);
+    createTransportSet(addr);
 
     transportSet.shutdown();
     ClientTransport pick = transportSet.obtainActiveTransport();
@@ -358,7 +358,14 @@ public class TransportSetTest {
     verify(mockTransportFactory, times(0)).newClientTransport(addr, authority);
   }
 
-  private void createTransortSet(SocketAddress ... addrs) {
+  @Test
+  public void logId() {
+    createTransportSet(mock(SocketAddress.class));
+    assertEquals("TransportSet@" + Integer.toHexString(transportSet.hashCode()),
+        transportSet.getLogId());
+  }
+
+  private void createTransportSet(SocketAddress ... addrs) {
     addressGroup = new EquivalentAddressGroup(Arrays.asList(addrs));
     transportSet = new TransportSet(addressGroup, authority, mockLoadBalancer,
         mockBackoffPolicyProvider, mockTransportFactory, fakeClock.scheduledExecutorService,

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -40,6 +40,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
 import io.grpc.internal.ManagedClientTransport;
 import io.netty.bootstrap.Bootstrap;
@@ -191,7 +192,12 @@ class NettyClientTransport implements ManagedClientTransport {
 
   @Override
   public String toString() {
-    return super.toString() + "(" + address + ")";
+    return getLogId() + "(" + address + ")";
+  }
+
+  @Override
+  public String getLogId() {
+    return GrpcUtil.getLogId(this);
   }
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -400,7 +400,12 @@ class OkHttpClientTransport implements ManagedClientTransport {
 
   @Override
   public String toString() {
-    return super.toString() + "(" + address + ")";
+    return getLogId() + "(" + address + ")";
+  }
+
+  @Override
+  public String getLogId() {
+    return GrpcUtil.getLogId(this);
   }
 
   /**


### PR DESCRIPTION
Add log ID to `ManagedChannelImpl`, `TransportSet` and all client transport implementations, so they can be correlated in the logs. Also added more life-cycle logging in general.

@carl-mastrangelo  @ejona86 