### PR TITLE
Remove support for Nano's deprecated package names

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -65,7 +65,7 @@ static inline string MethodIdFieldName(const MethodDescriptor* method) {
 
 static inline string MessageFullJavaName(bool nano, const Descriptor* desc) {
   string name = google::protobuf::compiler::java::ClassName(desc);
-  if (nano && !desc->file()->options().javanano_use_deprecated_package()) {
+  if (nano) {
     // XXX: Add "nano" to the original package
     // (https://github.com/grpc/grpc-java/issues/900)
     if (isupper(name[0])) {
@@ -790,7 +790,7 @@ string ServiceJavaPackage(const FileDescriptor* file, bool nano) {
   } else {
     result = "";
   }
-  if (nano && !file->options().javanano_use_deprecated_package()) {
+  if (nano) {
     if (!result.empty()) {
       result += ".";
     }


### PR DESCRIPTION
This requires that all nano protos have .nano in their package name. The
support is expected to be removed from protobuf soon, since using the
deprecated package name causes problems.

@danielweis, FYI