### PR TITLE
Rename older AbstractTransportTest to AbstractInteropTest

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -99,7 +99,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Abstract base class for all GRPC transport tests.
  */
-public abstract class AbstractTransportTest {
+public abstract class AbstractInteropTest {
 
   public static final Metadata.Key<Messages.SimpleContext> METADATA_KEY =
       ProtoUtils.keyForProto(Messages.SimpleContext.getDefaultInstance());

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -258,7 +258,7 @@ public class TestServiceClient {
     }
   }
 
-  private class Tester extends AbstractTransportTest {
+  private class Tester extends AbstractInteropTest {
     @Override
     protected ManagedChannel createChannel() {
       if (!useOkHttp) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -48,7 +48,7 @@ import org.junit.runners.JUnit4;
  * Run transport tests over the Netty in-process channel.
  */
 @RunWith(JUnit4.class)
-public class Http2NettyLocalChannelTest extends AbstractTransportTest {
+public class Http2NettyLocalChannelTest extends AbstractInteropTest {
 
   /** Start server. */
   @BeforeClass

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -50,7 +50,7 @@ import java.io.IOException;
  * Integration tests for GRPC over HTTP2 using the Netty framework.
  */
 @RunWith(JUnit4.class)
-public class Http2NettyTest extends AbstractTransportTest {
+public class Http2NettyTest extends AbstractInteropTest {
   private static int serverPort = TestUtils.pickUnusedPort();
 
   /** Starts the server with HTTPS. */

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -68,7 +68,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
  * Integration tests for GRPC over Http2 using the OkHttp framework.
  */
 @RunWith(JUnit4.class)
-public class Http2OkHttpTest extends AbstractTransportTest {
+public class Http2OkHttpTest extends AbstractInteropTest {
   private static int serverPort = TestUtils.pickUnusedPort();
 
   /** Starts the server with HTTPS. */

--- a/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
@@ -42,7 +42,7 @@ import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link InProcess}. */
 @RunWith(JUnit4.class)
-public class InProcessTest extends AbstractTransportTest {
+public class InProcessTest extends AbstractInteropTest {
   private static String serverName = "test";
 
   /** Starts the in-process server. */

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -78,7 +78,7 @@ import java.io.OutputStream;
  * Tests that compression is turned on.
  */
 @RunWith(JUnit4.class)
-public class TransportCompressionTest extends AbstractTransportTest {
+public class TransportCompressionTest extends AbstractInteropTest {
 
   private static int serverPort = TestUtils.pickUnusedPort();
 


### PR DESCRIPTION
There are two AbstractTransportTests. The newest one is the more aptly
named, so rename the older one to AbstractInteropTest to remove name
collision when speaking.

Fixes #1484