### PR TITLE
Use Netty's DefaultThreadFactory instead of Guava's ThreadFactoryBuil…

### DIFF
--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -36,7 +36,6 @@ import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 import static io.netty.util.CharsetUtil.UTF_8;
 
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -50,14 +49,11 @@ import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -203,23 +199,12 @@ class Utils {
 
     @Override
     public EventLoopGroup create() {
-      // Use the executor based constructor so we can work with both Netty4 & Netty5.
-      ThreadFactory threadFactory = new ThreadFactoryBuilder()
-          .setDaemon(true)
-          .setNameFormat(name + "-%d")
-          .build();
+      // Use Netty's DefaultThreadFactory in order to get the benefit of FastThreadLocal.
+      boolean useDaemonThreads = true;
+      ThreadFactory threadFactory = new DefaultThreadFactory(name, useDaemonThreads);
       int parallelism = numEventLoops == 0
           ? Runtime.getRuntime().availableProcessors() * 2 : numEventLoops;
-      final ExecutorService executor = Executors.newFixedThreadPool(parallelism, threadFactory);
-      NioEventLoopGroup nioEventLoopGroup = new NioEventLoopGroup(parallelism, executor);
-      nioEventLoopGroup.terminationFuture().addListener(
-          new GenericFutureListener<Future<Object>>() {
-            @Override
-            public void operationComplete(Future<Object> future) throws Exception {
-              executor.shutdown();
-            }
-          });
-      return nioEventLoopGroup;
+      return new NioEventLoopGroup(parallelism, threadFactory);
     }
 
     @Override


### PR DESCRIPTION
…der.

So far, we have passed a custom Executor to the NioEventLoopGroup constructor,
in order to get custom thread names and be compatible with both Netty 4 and
Netty 5. However, Netty 5 is no more (RIP) and Netty's DefaultThreadFactory
includes some optimizations around thread local storage, that Guava's executor
does not have.

The thread names will be a bit different, as DefaultThreadExecutor additionally
puts in the "thread pool id" after the name prefix.

For example:
```
Before:
grpc-default-boss-ELG-0
grpc-default-worker-ELG-0
grpc-default-worker-ELG-1

After:
grpc-default-boss-ELG-0-0
grpc-default-worker-ELG-1-0
grpc-default-worker-ELG-1-1
```