### PR TITLE
Overload useTransportSecurity to accept factories

### DIFF
--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -35,6 +35,8 @@ import java.io.File;
 import java.util.concurrent.Executor;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
 
 /**
  * A builder for {@link Server} instances.
@@ -86,6 +88,15 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * @param privateKey file containing the private key
    */
   public abstract T useTransportSecurity(File certChain, File privateKey);
+
+  /**
+   * Makes the server use TLS.
+   *
+   * @param trustManagerFactory {@link TrustManagerFactory}
+   * @param keyManagerFactory {@link KeyManagerFactory}
+   */
+  public abstract T useTransportSecurity(TrustManagerFactory trustManagerFactory,
+                                         KeyManagerFactory keyManagerFactory);
 
   /**
    * Set the decompression registry for use in the channel.  This is an advanced API call and

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -39,6 +39,9 @@ import io.grpc.internal.AbstractServerImplBuilder;
 
 import java.io.File;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
 /**
  * Builder for a server that services in-process requests. Clients identify the in-process server by
  * its name.
@@ -83,6 +86,12 @@ public final class InProcessServerBuilder
   @Override
   protected InProcessServer buildTransportServer() {
     return new InProcessServer(name);
+  }
+
+  @Override
+  public InProcessServerBuilder useTransportSecurity(TrustManagerFactory trustManagerFactory,
+                                                     KeyManagerFactory keyManagerFactory) {
+    throw new UnsupportedOperationException("TLS not supported in InProcessServer");
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -47,6 +47,9 @@ import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import java.io.File;
 import java.util.Set;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
 /**
  * Utility for configuring SslContext for gRPC.
  */
@@ -107,6 +110,18 @@ public class GrpcSslContexts {
   public static SslContextBuilder forServer(
       File keyCertChainFile, File keyFile, String keyPassword) {
     return configure(SslContextBuilder.forServer(keyCertChainFile, keyFile, keyPassword));
+  }
+
+  /**
+   * Creates a SslContextBuilder with custom factories for trust manager and key manager.
+   *
+   * @see NettyServerBuilder#useTransportSecurity(TrustManagerFactory, KeyManagerFactory)
+   * @see #configure(SslContextBuilder)
+   */
+  public static SslContextBuilder forServer(TrustManagerFactory trustManagerFactory,
+                                            KeyManagerFactory keyManagerFactory) {
+    return configure(SslContextBuilder.forServer(keyManagerFactory)
+            .trustManager(trustManagerFactory));
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -51,7 +51,9 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
 
 /**
  * A builder to help simplify the construction of a Netty-based GRPC server.
@@ -244,6 +246,18 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
     return new NettyServer(address, channelType, bossEventLoopGroup, workerEventLoopGroup,
         negotiator, maxConcurrentCallsPerConnection, flowControlWindow, maxMessageSize,
         maxHeaderListSize);
+  }
+
+  @Override
+  public NettyServerBuilder useTransportSecurity(TrustManagerFactory trustManagerFactory,
+                                                 KeyManagerFactory keyManagerFactory) {
+    try {
+      sslContext = GrpcSslContexts.forServer(trustManagerFactory, keyManagerFactory).build();
+    } catch (SSLException e) {
+      // This should likely be some other, easier to catch exception.
+      throw new RuntimeException(e);
+    }
+    return this;
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -254,8 +254,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
     try {
       sslContext = GrpcSslContexts.forServer(trustManagerFactory, keyManagerFactory).build();
     } catch (SSLException e) {
-      // This should likely be some other, easier to catch exception.
-      throw new RuntimeException(e);
+      throw new IllegalArgumentException(e);
     }
     return this;
   }
@@ -265,8 +264,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
     try {
       sslContext = GrpcSslContexts.forServer(certChain, privateKey).build();
     } catch (SSLException e) {
-      // This should likely be some other, easier to catch exception.
-      throw new RuntimeException(e);
+      throw new IllegalArgumentException(e);
     }
     return this;
   }


### PR DESCRIPTION
This enables providing custom Trust and Key manager implementations for gRPC server.

We have some custom setup around SSL in our apps where we provide `ReloadingKeyManager` to our RPC servers which allows us to roll keys without restarting servers.

In order to support it with grpc, we need to be able to pass custom `TrustManagerFactory` and `KeyManagerFactory`, this PR would enable it.

cc @jhump @ericzundel