### PR TITLE
Remove ReferenceCounted and add close() to ClientTransportFactory. Fixes #927

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -237,20 +237,8 @@ public abstract class AbstractManagedChannelImplBuilder
     }
 
     @Override
-    public int referenceCount() {
-      return factory.referenceCount();
-    }
-
-    @Override
-    public ReferenceCounted retain() {
-      factory.retain();
-      return this;
-    }
-
-    @Override
-    public ReferenceCounted release() {
-      factory.release();
-      return this;
+    public void close() {
+      factory.close();
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -31,10 +31,11 @@
 
 package io.grpc.internal;
 
+import java.io.Closeable;
 import java.net.SocketAddress;
 
 /** Pre-configured factory for creating {@link ManagedClientTransport} instances. */
-public interface ClientTransportFactory extends ReferenceCounted {
+public interface ClientTransportFactory extends Closeable {
   /**
    * Creates an unstarted transport for exclusive use.
    *
@@ -42,4 +43,14 @@ public interface ClientTransportFactory extends ReferenceCounted {
    * @param authority the HTTP/2 authority of the server
    */
   ManagedClientTransport newClientTransport(SocketAddress serverAddress, String authority);
+
+  /**
+   * Releases any resources.
+   *
+   *<p>
+   * After this method has been called, it's no longer valid to call
+   * {@link #newClientTransport(SocketAddress, String)}. No guarantees about thread-safety are made.
+   */
+  @Override
+  void close();
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -363,7 +363,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
         SharedResourceHolder.release(GrpcUtil.SHARED_CHANNEL_EXECUTOR, (ExecutorService) executor);
       }
       // Release the transport factory so that it can deallocate any resources.
-      transportFactory.release();
+      transportFactory.close();
     }
   }
 

--- a/core/src/test/java/io/grpc/inprocess/InProcessClientTransportFactoryTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessClientTransportFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,50 +29,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.internal;
+package io.grpc.inprocess;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.testing.AbstractClientTransportFactoryTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-/**
- * Base implementation for all reference counted objects.
- */
-public abstract class AbstractReferenceCounted implements ReferenceCounted {
-  private final AtomicInteger refCount = new AtomicInteger(1);
-
-  @Override
-  public final int referenceCount() {
-    return refCount.get();
-  }
+@RunWith(JUnit4.class)
+public class InProcessClientTransportFactoryTest extends AbstractClientTransportFactoryTest {
 
   @Override
-  public final ReferenceCounted retain() {
-    int newCount = refCount.incrementAndGet();
-    if (newCount <= 1) {
-      throw illegalReferenceCount(newCount);
-    }
-    return this;
-  }
-
-  @Override
-  public final ReferenceCounted release() {
-    int newCount = refCount.decrementAndGet();
-    if (newCount < 0) {
-      throw illegalReferenceCount(newCount);
-    }
-    if (newCount == 0) {
-      deallocate();
-    }
-    return this;
-  }
-
-  /**
-   * Called once {@link #referenceCount()} is equals 0.
-   */
-  protected abstract void deallocate();
-
-  private IllegalStateException illegalReferenceCount(int count) {
-    throw new IllegalStateException(String.format("Illegal reference count for class %s: %d",
-            getClass().getName(),
-            count));
+  protected ClientTransportFactory newClientTransportFactory() {
+    return InProcessChannelBuilder.forName("test-transport").buildTransportFactory();
   }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -249,7 +249,7 @@ public class ManagedChannelImplTest {
     transportListener.transportTerminated();
     assertTrue(channel.isTerminated());
 
-    verify(mockTransportFactory).release();
+    verify(mockTransportFactory).close();
     verifyNoMoreInteractions(mockTransportFactory);
     verify(mockTransport, atLeast(0)).getLogId();
     verifyNoMoreInteractions(mockTransport);

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportFactoryTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportFactoryTest.java
@@ -32,55 +32,16 @@
 package io.grpc.netty;
 
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.Server;
-import io.grpc.internal.testing.AbstractTransportTest;
+import io.grpc.internal.testing.AbstractClientTransportFactoryTest;
 import io.grpc.testing.TestUtils;
-
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.net.InetSocketAddress;
-
-/** Unit tests for Netty transport. */
 @RunWith(JUnit4.class)
-public class NettyTransportTest extends AbstractTransportTest {
-  private static final int SERVER_PORT = TestUtils.pickUnusedPort();
-  // Avoid LocalChannel for testing because LocalChannel can fail with
-  // io.netty.channel.ChannelException instead of java.net.ConnectException which breaks
-  // serverNotListening test.
-  private ClientTransportFactory clientFactory = NettyChannelBuilder
-      // Although specified here, address is ignored because we never call build.
-      .forAddress("localhost", SERVER_PORT)
-      .flowControlWindow(65 * 1024)
-      .negotiationType(NegotiationType.PLAINTEXT)
-      .buildTransportFactory();
-
-  @After
-  public void releaseClientFactory() {
-    clientFactory.close();
+public class NettyClientTransportFactoryTest extends AbstractClientTransportFactoryTest {
+  @Override protected ClientTransportFactory newClientTransportFactory() {
+    return NettyChannelBuilder
+        .forAddress("localhost", TestUtils.pickUnusedPort())
+        .buildTransportFactory();
   }
-
-  @Override
-  protected Server newServer() {
-    return NettyServerBuilder
-        .forPort(SERVER_PORT)
-        .flowControlWindow(65 * 1024)
-        .buildTransportServer();
-  }
-
-  @Override
-  protected ManagedClientTransport newClientTransport() {
-    return clientFactory.newClientTransport(
-        new InetSocketAddress("localhost", SERVER_PORT), "localhost:" + SERVER_PORT);
-  }
-
-  // TODO(ejona): Flaky
-  @Test
-  @Ignore
-  @Override
-  public void flowControlPushBack() {}
 }

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -9,7 +9,8 @@ dependencies {
             libraries.okio
 
     // Tests depend on base class defined by core module.
-    testCompile project(':grpc-core').sourceSets.test.output
+    testCompile project(':grpc-core').sourceSets.test.output,
+                project(":grpc-testing")
 }
 
 project.sourceSets {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportFactoryTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportFactoryTest.java
@@ -29,58 +29,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.netty;
+package io.grpc.okhttp;
 
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.Server;
-import io.grpc.internal.testing.AbstractTransportTest;
+import io.grpc.internal.testing.AbstractClientTransportFactoryTest;
 import io.grpc.testing.TestUtils;
-
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.net.InetSocketAddress;
-
-/** Unit tests for Netty transport. */
 @RunWith(JUnit4.class)
-public class NettyTransportTest extends AbstractTransportTest {
-  private static final int SERVER_PORT = TestUtils.pickUnusedPort();
-  // Avoid LocalChannel for testing because LocalChannel can fail with
-  // io.netty.channel.ChannelException instead of java.net.ConnectException which breaks
-  // serverNotListening test.
-  private ClientTransportFactory clientFactory = NettyChannelBuilder
-      // Although specified here, address is ignored because we never call build.
-      .forAddress("localhost", SERVER_PORT)
-      .flowControlWindow(65 * 1024)
-      .negotiationType(NegotiationType.PLAINTEXT)
-      .buildTransportFactory();
-
-  @After
-  public void releaseClientFactory() {
-    clientFactory.close();
-  }
-
+public class OkHttpClientTransportFactoryTest extends AbstractClientTransportFactoryTest {
   @Override
-  protected Server newServer() {
-    return NettyServerBuilder
-        .forPort(SERVER_PORT)
-        .flowControlWindow(65 * 1024)
-        .buildTransportServer();
+  protected ClientTransportFactory newClientTransportFactory() {
+    return OkHttpChannelBuilder.forAddress("localhost", TestUtils.pickUnusedPort())
+        .buildTransportFactory();
   }
-
-  @Override
-  protected ManagedClientTransport newClientTransport() {
-    return clientFactory.newClientTransport(
-        new InetSocketAddress("localhost", SERVER_PORT), "localhost:" + SERVER_PORT);
-  }
-
-  // TODO(ejona): Flaky
-  @Test
-  @Ignore
-  @Override
-  public void flowControlPushBack() {}
 }


### PR DESCRIPTION
Maybe I overengineered, considering that `ClientTransportFactory` is internal. Unsure. You tell me :-).