### PR TITLE
Move server call keys

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -94,8 +94,7 @@ public final class Attributes {
     /**
      * Factory method for creating instances of {@link Key}.
      *
-     * @param name the name of Key, which should be namespaced like com.foo.BarAttribute to avoid
-     *             collision. Name collision, won't cause key collision.
+     * @param name the name of Key. Name collision, won't cause key collision.
      * @param <T> Key type
      * @return Key object
      */

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -74,7 +74,7 @@ public abstract class NameResolver {
      * port number.
      */
     public static final Attributes.Key<Integer> PARAMS_DEFAULT_PORT =
-        Attributes.Key.of("io.grpc.NameResolverDefaultPort");
+        Attributes.Key.of("params-default-port");
 
     /**
      * Creates a {@link NameResolver} for the given target URI, or {@code null} if the given URI

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -58,14 +58,14 @@ public abstract class ServerCall<RespT> {
    */
   @ExperimentalApi
   public static final Attributes.Key<SocketAddress> REMOTE_ADDR_KEY =
-          Attributes.Key.of("io.grpc.RemoteAddr");
+          Attributes.Key.of("remote-addr");
   /**
    * {@link Attributes.Key} for the SSL session of server call attributes
    * {@link ServerCall#attributes()}
    */
   @ExperimentalApi
   public static final Attributes.Key<SSLSession> SSL_SESSION_KEY =
-          Attributes.Key.of("io.grpc.SslSession");
+          Attributes.Key.of("ssl-session");
 
   /**
    * Callbacks for consuming incoming RPC messages.

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -31,6 +31,9 @@
 
 package io.grpc;
 
+import java.net.SocketAddress;
+
+import javax.net.ssl.SSLSession;
 
 /**
  * Encapsulates a single call received from a remote client. Calls may not simply be unary
@@ -49,6 +52,21 @@ package io.grpc;
  * @param <RespT> parsed type of response message.
  */
 public abstract class ServerCall<RespT> {
+  /**
+   * {@link Attributes.Key} for the remote address of server call attributes
+   * {@link ServerCall#attributes()}
+   */
+  @ExperimentalApi
+  public static final Attributes.Key<SocketAddress> REMOTE_ADDR_KEY =
+          Attributes.Key.of("io.grpc.RemoteAddr");
+  /**
+   * {@link Attributes.Key} for the SSL session of server call attributes
+   * {@link ServerCall#attributes()}
+   */
+  @ExperimentalApi
+  public static final Attributes.Key<SSLSession> SSL_SESSION_KEY =
+          Attributes.Key.of("io.grpc.SslSession");
+
   /**
    * Callbacks for consuming incoming RPC messages.
    *

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -41,14 +41,12 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.SharedResourceHolder.Resource;
 
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
-import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map.Entry;
@@ -58,7 +56,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLSession;
 
 /**
  * Common utilities for GRPC.
@@ -94,18 +91,6 @@ public final class GrpcUtil {
    */
   public static final Metadata.Key<String> USER_AGENT_KEY =
           Metadata.Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER);
-
-  /**
-   * {@link io.grpc.Attributes.Key} for the remote address of stream call.
-   */
-  public static final Attributes.Key<SocketAddress> REMOTE_ADDR_STREAM_ATTR_KEY =
-          Attributes.Key.of("io.grpc.RemoteAddr");
-
-  /**
-   * {@link io.grpc.Attributes.Key} for the SSL session of stream call.
-   */
-  public static final Attributes.Key<SSLSession> SSL_SESSION_STREAM_ATTR_KEY =
-          Attributes.Key.of("io.grpc.SslSession");
 
   /**
    * The default port for plain-text connections.

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -940,7 +940,7 @@ public abstract class AbstractInteropTest {
     stub.unaryCall(SimpleRequest.getDefaultInstance());
 
     HostAndPort remoteAddress = HostAndPort.fromString(serverCallCapture.get().attributes()
-            .get(GrpcUtil.REMOTE_ADDR_STREAM_ATTR_KEY).toString());
+            .get(ServerCall.REMOTE_ADDR_KEY).toString());
     assertEquals(expectedRemoteAddress, remoteAddress.getHostText());
   }
 
@@ -953,7 +953,7 @@ public abstract class AbstractInteropTest {
 
     List<Certificate> certificates = Lists.newArrayList();
     SSLSession sslSession =
-        serverCallCapture.get().attributes().get(GrpcUtil.SSL_SESSION_STREAM_ATTR_KEY);
+        serverCallCapture.get().attributes().get(ServerCall.SSL_SESSION_KEY);
     try {
       certificates = Arrays.asList(sslSession.getPeerCertificates());
     } catch (SSLPeerUnverifiedException e) {

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -35,9 +35,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.grpc.Attributes;
 import io.grpc.Metadata;
+import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.internal.AbstractServerStream;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.WritableBuffer;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -159,8 +159,8 @@ class NettyServerStream extends AbstractServerStream<Integer> {
     }
 
     return Attributes.newBuilder()
-        .set(GrpcUtil.REMOTE_ADDR_STREAM_ATTR_KEY, channel.remoteAddress())
-        .set(GrpcUtil.SSL_SESSION_STREAM_ATTR_KEY, sslSession)
+        .set(ServerCall.REMOTE_ADDR_KEY, channel.remoteAddress())
+        .set(ServerCall.SSL_SESSION_KEY, sslSession)
         .build();
   }
 }


### PR DESCRIPTION
This cleans up server call keys added in #1506 by moving them out of internal package.

Additionally, I've attached one more commit which fixes warnings in tests.