### PR TITLE
Support for retrying logic on client side

### DIFF
--- a/core/src/main/java/io/grpc/ClientInterceptors.java
+++ b/core/src/main/java/io/grpc/ClientInterceptors.java
@@ -37,6 +37,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
+import io.grpc.internal.IdempotentRetryPolicy;
+import io.grpc.internal.RetryPolicy;
+import io.grpc.internal.SharedResourceHolder;
 
 /**
  * Utility methods for working with {@link ClientInterceptor}s.
@@ -201,6 +213,198 @@ public class ClientInterceptors {
         // about the error through the listener.
         delegate = (ClientCall<ReqT, RespT>) NOOP_CALL;
         responseListener.onClose(Status.fromThrowable(e), new Metadata());
+      }
+    }
+  }
+
+  public static class RetryingInterceptor implements ClientInterceptor {
+    // TODO(lukaszx0) have default logger for this one to give more visibility into when/what gets
+    // retried?
+    // private final Logger logger = Logger.getLogger(RetryingInterceptor.class.getName());
+    private final RetryPolicy.Provider retryPolicyProvider;
+
+    public RetryingInterceptor(RetryPolicy.Provider retryPolicyProvider) {
+      this.retryPolicyProvider = retryPolicyProvider;
+    }
+
+    public RetryingInterceptor() {
+      this.retryPolicyProvider = new IdempotentRetryPolicy.Provider();
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+
+      // Only UNARY calls can be retried, streaming call errors should be handled by user.
+      if (method.getType() != MethodDescriptor.MethodType.UNARY) {
+        return next.newCall(method, callOptions);
+      }
+
+      return new RetryingCall<ReqT, RespT>(retryPolicyProvider, method, callOptions, next);
+    }
+
+    private class RetryingCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
+      private final RetryPolicy retryPolicy;
+      private final MethodDescriptor<ReqT, RespT> method;
+      private final CallOptions callOptions;
+      private final Channel channel;
+      private final ScheduledExecutorService scheduledExecutor;
+      private Listener<RespT> responseListener;
+      private Metadata requestHeaders;
+      private ReqT requestMessage;
+      private boolean compressionEnabled;
+      private final Queue<AttemptListener> attemptListeners =
+              new ConcurrentLinkedQueue<AttemptListener>();
+      private volatile AttemptListener latestResponse;
+      private volatile ScheduledFuture<?> retryTask;
+
+      RetryingCall(RetryPolicy.Provider retryPolicyProvider, MethodDescriptor<ReqT, RespT> method,
+                   CallOptions callOptions, Channel channel) {
+        this.method = method;
+        this.callOptions = callOptions;
+        this.channel = channel;
+        this.retryPolicy = retryPolicyProvider.get();
+        this.scheduledExecutor = SharedResourceHolder.get(TIMER_SERVICE);
+      }
+
+      @Override
+      public void start(Listener<RespT> listener, Metadata headers) {
+        checkState(attemptListeners.isEmpty());
+        checkState(responseListener == null);
+        checkState(requestHeaders == null);
+        responseListener = listener;
+        requestHeaders = headers;
+        ClientCall<ReqT, RespT> firstCall = channel.newCall(method, callOptions);
+        AttemptListener attemptListener = new AttemptListener(firstCall);
+        attemptListeners.add(attemptListener);
+        firstCall.start(attemptListener, headers);
+      }
+
+      @Override
+      public void request(int numMessages) {
+        lastCall().request(numMessages);
+      }
+
+      @Override
+      public void cancel() {
+        for (AttemptListener attempt : attemptListeners) {
+          attempt.call.cancel();
+        }
+        if (retryTask != null) {
+          retryTask.cancel(true);
+        }
+      }
+
+      @Override
+      public void halfClose() {
+        lastCall().halfClose();
+      }
+
+      @Override
+      public void sendMessage(ReqT message) {
+        checkState(requestMessage == null);
+        requestMessage = message;
+        lastCall().sendMessage(message);
+      }
+
+      @Override
+      public boolean isReady() {
+        return lastCall().isReady();
+      }
+
+      @Override
+      public void setMessageCompression(boolean enabled) {
+        compressionEnabled = enabled;
+        lastCall().setMessageCompression(enabled);
+      }
+
+      private void maybeRetry(AttemptListener attempt) {
+        Status status = attempt.responseStatus;
+        if (status.isOk() || !retryPolicy.isRetryable(status, method, callOptions)) {
+          useResponse(attempt);
+          return;
+        }
+
+        long nextBackoffMillis = retryPolicy.getNextBackoffMillis();
+        long nextBackoffNano = TimeUnit.MILLISECONDS.toNanos(nextBackoffMillis);
+        long deadlineNanoTime =  firstNonNull(callOptions.getDeadlineNanoTime(), -1).longValue();
+
+        Status.Code code = status.getCode();
+        if (code == Status.Code.CANCELLED || code == Status.Code.DEADLINE_EXCEEDED ||
+            (deadlineNanoTime > -1 && deadlineNanoTime < nextBackoffNano)) {
+          AttemptListener latest = latestResponse;
+          if (latest != null) {
+            useResponse(latest);
+          } else {
+            useResponse(attempt);
+          }
+          return;
+        }
+        latestResponse = attempt;
+        retryTask = scheduledExecutor.schedule(new Runnable() {
+          @Override
+          public void run() {
+            ClientCall<ReqT, RespT> nextCall = channel.newCall(method, callOptions);
+            AttemptListener nextAttemptListener = new AttemptListener(nextCall);
+            attemptListeners.add(nextAttemptListener);
+            nextCall.start(nextAttemptListener, requestHeaders);
+            nextCall.setMessageCompression(compressionEnabled);
+            nextCall.sendMessage(requestMessage);
+            // TODO(lukaszx0): In other places, we're preemptively fetching two requests for
+            // unary calls should we do the same here?
+            nextCall.request(1);
+            nextCall.halfClose();
+          }
+        }, nextBackoffMillis, TimeUnit.MILLISECONDS);
+      }
+
+      private void useResponse(AttemptListener attempt) {
+        responseListener.onHeaders(attempt.responseHeaders);
+        if (attempt.responseMessage != null) {
+          responseListener.onMessage(attempt.responseMessage);
+        }
+        responseListener.onClose(attempt.responseStatus, attempt.responseTrailers);
+      }
+
+      private ClientCall<ReqT, RespT> lastCall() {
+        checkState(!attemptListeners.isEmpty());
+        return attemptListeners.peek().call;
+      }
+
+      private class AttemptListener extends ClientCall.Listener<RespT> {
+        final ClientCall<ReqT, RespT> call;
+        Metadata responseHeaders;
+        RespT responseMessage;
+        Status responseStatus;
+        Metadata responseTrailers;
+
+        AttemptListener(ClientCall<ReqT, RespT> call) {
+          this.call = call;
+        }
+
+        @Override
+        public void onHeaders(Metadata headers) {
+          responseHeaders = headers;
+        }
+
+        @Override
+        public void onMessage(RespT message) {
+          responseMessage = message;
+        }
+
+        @Override
+        public void onClose(Status status, Metadata trailers) {
+          responseStatus = status;
+          responseTrailers = trailers;
+          maybeRetry(this);
+        }
+
+        @Override
+        public void onReady() {
+          // Pass-through to original listener.
+          // TODO(lukaszx0): Maybe only on first attempt?
+          responseListener.onReady();
+        }
       }
     }
   }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -193,7 +193,7 @@ public abstract class AbstractManagedChannelImplBuilder
     return new ManagedChannelImpl(
         target,
         // TODO(carl-mastrangelo): Allow clients to pass this in
-        new ExponentialBackoffPolicy.Provider(),
+        new ExponentialBackoffPolicy.ReconnectProvider(),
         firstNonNull(nameResolverFactory, NameResolverRegistry.getDefaultRegistry()),
         getNameResolverParams(),
         firstNonNull(loadBalancerFactory, SimpleLoadBalancerFactory.getInstance()),

--- a/core/src/main/java/io/grpc/internal/ExponentialBackoffPolicy.java
+++ b/core/src/main/java/io/grpc/internal/ExponentialBackoffPolicy.java
@@ -39,7 +39,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Exponential backoff policy for reconnects.
+ * Exponential backoff policy for reconnects and call retries.
  */
 final class ExponentialBackoffPolicy implements BackoffPolicy {
   /**
@@ -52,6 +52,16 @@ final class ExponentialBackoffPolicy implements BackoffPolicy {
     public BackoffPolicy get() {
       return new ExponentialBackoffPolicy(new Random(), TimeUnit.SECONDS.toMillis(1),
               TimeUnit.MINUTES.toMillis(2),  1.6, .2);
+    }
+  }
+
+  /**
+   * Provider tuned for call retries.
+   */
+  static final class CallRetryProvider implements BackoffPolicy.Provider {
+    @Override
+    public BackoffPolicy get() {
+      return new ExponentialBackoffPolicy(new Random(), 50, TimeUnit.SECONDS.toMillis(30), 2, .2);
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/RetryPolicy.java
+++ b/core/src/main/java/io/grpc/internal/RetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,47 +31,28 @@
 
 package io.grpc.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import io.grpc.CallOptions;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
-
-/**
- * Test for {@link ExponentialBackoffPolicy}.
- */
-@RunWith(JUnit4.class)
-public class ExponentialBackoffPolicyTest {
-  private Random notRandom = new Random() {
-    @Override
-    public double nextDouble() {
-      return .5;
-    }
-  };
-
-  @Test
-  public void maxDelayReached() {
-    long maxBackoffMillis = 120 * 1000;
-    ExponentialBackoffPolicy policy = new ExponentialBackoffPolicy(notRandom,
-            TimeUnit.SECONDS.toMillis(1), maxBackoffMillis, 1.6, 0);
-    for (int i = 0; i < 50; i++) {
-      if (maxBackoffMillis == policy.nextBackoffMillis()) {
-        return; // Success
-      }
-    }
-    assertEquals("max delay not reached", maxBackoffMillis, policy.nextBackoffMillis());
+public abstract class RetryPolicy {
+  public interface Provider {
+    RetryPolicy get();
   }
 
-  @Test public void canProvideReconnectBackoff() {
-    assertNotNull(new ExponentialBackoffPolicy.ReconnectProvider().get());
+  private final BackoffPolicy backoffPolicy;
+
+  RetryPolicy(BackoffPolicy.Provider backoffPolicy) {
+    this.backoffPolicy = backoffPolicy.get();
   }
 
-  @Test public void canProvideRetryBackoff() {
-    assertNotNull(new ExponentialBackoffPolicy.CallRetryProvider().get());
+  RetryPolicy() {
+    this(new ExponentialBackoffPolicy.CallRetryProvider());
   }
+
+  public long getNextBackoffMillis() {
+    return backoffPolicy.nextBackoffMillis();
+  }
+
+  public abstract boolean isRetryable(Status status, MethodDescriptor method, CallOptions callOptions);
 }
-

--- a/core/src/test/java/io/grpc/internal/ExponentialBackoffPolicyTest.java
+++ b/core/src/test/java/io/grpc/internal/ExponentialBackoffPolicyTest.java
@@ -39,13 +39,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Test for {@link ExponentialBackoffPolicy}.
  */
 @RunWith(JUnit4.class)
 public class ExponentialBackoffPolicyTest {
-  private ExponentialBackoffPolicy policy = new ExponentialBackoffPolicy();
   private Random notRandom = new Random() {
     @Override
     public double nextDouble() {
@@ -56,9 +56,8 @@ public class ExponentialBackoffPolicyTest {
   @Test
   public void maxDelayReached() {
     long maxBackoffMillis = 120 * 1000;
-    policy.setMaxBackoffMillis(maxBackoffMillis)
-        .setJitter(0)
-        .setRandom(notRandom);
+    ExponentialBackoffPolicy policy = new ExponentialBackoffPolicy(notRandom,
+            TimeUnit.SECONDS.toMillis(1), maxBackoffMillis, 1.6, 0);
     for (int i = 0; i < 50; i++) {
       if (maxBackoffMillis == policy.nextBackoffMillis()) {
         return; // Success
@@ -67,8 +66,8 @@ public class ExponentialBackoffPolicyTest {
     assertEquals("max delay not reached", maxBackoffMillis, policy.nextBackoffMillis());
   }
 
-  @Test public void canProvide() {
-    assertNotNull(new ExponentialBackoffPolicy.Provider().get());
+  @Test public void canProvideReconnectBackoff() {
+    assertNotNull(new ExponentialBackoffPolicy.ReconnectProvider().get());
   }
 }
 


### PR DESCRIPTION
This PR provides support for client side retries using interceptors. This is work which I mentioned in https://github.com/grpc/grpc-java/pull/1566 and in current form it depends on this PR being merged (see `IdempotentRetryPolicy:42`).

I think that grpc should ship with retry support of some kind hence I'm pushing this up for review and vetting. It lacks tests, documentations and polishing but I'm happy to work on it further if we decide to include it in core.

Big thanks for @jhump who worked with me on this.

cc @ericzundel
