### PR TITLE
Remove references to Throwables.propagate

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -37,7 +37,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -407,8 +406,10 @@ public final class GrpcUtil {
             method.invoke(service, true);
           } catch (NoSuchMethodException e) {
             // no op
+          } catch (RuntimeException e) {
+            throw e;
           } catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
           }
 
           return service;

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -40,7 +40,6 @@ import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 
 import io.grpc.Attributes;
 import io.grpc.Codec;
@@ -158,9 +157,12 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<RespT> {
       InputStream resp = method.streamResponse(message);
       stream.writeMessage(resp);
       stream.flush();
+    } catch (RuntimeException e) {
+      close(Status.fromThrowable(e), new Metadata());
+      throw e;
     } catch (Throwable t) {
       close(Status.fromThrowable(t), new Metadata());
-      throw Throwables.propagate(t);
+      throw new RuntimeException(t);
     }
   }
 

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -35,7 +35,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
 
 import io.grpc.Attributes;
 import io.grpc.Channel;
@@ -43,8 +42,8 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.ResolvedServerInfo;
 import io.grpc.Status;
-import io.grpc.TransportManager.InterimTransport;
 import io.grpc.TransportManager;
+import io.grpc.TransportManager.InterimTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.stub.StreamObserver;
@@ -296,7 +295,7 @@ class GrpclbLoadBalancer<T> extends LoadBalancer<T> {
               newServerMap.put(address, new ResolvedServerInfo(address, Attributes.EMPTY));
             }
           } catch (UnknownHostException e) {
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
           }
         }
       }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
@@ -32,7 +32,6 @@
 package io.grpc.testing.integration;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.ManagedChannel;
@@ -88,7 +87,7 @@ public class ConcurrencyTest {
       this.responsesDoneSignal = responsesDoneSignal;
     }
 
-    @Override 
+    @Override
     public void onCompleted() {
       Preconditions.checkState(numResponsesReceived == NUM_RESPONSES_PER_REQUEST);
       responsesDoneSignal.countDown();
@@ -138,7 +137,7 @@ public class ConcurrencyTest {
         startBarrier.await();
         clientStub.streamingOutputCall(request, new SignalingResponseObserver(responsesDoneSignal));
       } catch (Exception e) {
-        Throwables.propagate(e);
+        throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
       }
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyReadableBuffer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyReadableBuffer.java
@@ -32,7 +32,6 @@
 package io.grpc.netty;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 
 import io.grpc.internal.AbstractReadableBuffer;
 import io.netty.buffer.ByteBuf;
@@ -42,9 +41,9 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 /**
- * A {@link Buffer} implementation that is backed by a Netty {@link ByteBuf}. This class does not
- * call {@link ByteBuf#retain}, so if that is needed it should be called prior to creating this
- * buffer.
+ * A {@link java.nio.Buffer} implementation that is backed by a Netty {@link ByteBuf}. This class
+ * does not call {@link ByteBuf#retain}, so if that is needed it should be called prior to creating
+ * this buffer.
  */
 class NettyReadableBuffer extends AbstractReadableBuffer {
   private final ByteBuf buffer;
@@ -88,7 +87,7 @@ class NettyReadableBuffer extends AbstractReadableBuffer {
     try {
       buffer.readBytes(dest, length);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -32,7 +32,6 @@
 package io.grpc.stub;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -115,7 +114,7 @@ public class ClientCalls {
       return getUnchecked(futureUnaryCall(call, param));
     } catch (Throwable t) {
       call.cancel();
-      throw Throwables.propagate(t);
+      throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
     }
   }
 
@@ -141,7 +140,7 @@ public class ClientCalls {
       return getUnchecked(responseFuture);
     } catch (Throwable t) {
       call.cancel();
-      throw Throwables.propagate(t);
+      throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
     }
   }
 
@@ -228,7 +227,7 @@ public class ClientCalls {
       call.halfClose();
     } catch (Throwable t) {
       call.cancel();
-      throw Throwables.propagate(t);
+      throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
     }
   }
 


### PR DESCRIPTION
Throwables.propagate is going away, so remove our references to it.  I have included two different possible replacements, one with casting, and one with multiple catch statements.  If you like one more than the other I will swap them out. 