### PR TITLE
Context deadline propagation should cascade

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -58,7 +58,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Future;
 
 final class ServerCallImpl<ReqT, RespT> extends ServerCall<RespT> {
   private final ServerStream stream;
@@ -198,9 +197,8 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<RespT> {
     return cancelled;
   }
 
-  ServerStreamListener newServerStreamListener(ServerCall.Listener<ReqT> listener,
-      Future<?> timeout) {
-    return new ServerStreamListenerImpl<ReqT>(this, listener, timeout, context);
+  ServerStreamListener newServerStreamListener(ServerCall.Listener<ReqT> listener) {
+    return new ServerStreamListenerImpl<ReqT>(this, listener, context);
   }
 
   @Override
@@ -216,16 +214,14 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<RespT> {
   static final class ServerStreamListenerImpl<ReqT> implements ServerStreamListener {
     private final ServerCallImpl<ReqT, ?> call;
     private final ServerCall.Listener<ReqT> listener;
-    private final Future<?> timeout;
     private final Context.CancellableContext context;
     private boolean messageReceived;
 
     public ServerStreamListenerImpl(
-        ServerCallImpl<ReqT, ?> call, ServerCall.Listener<ReqT> listener, Future<?> timeout,
+        ServerCallImpl<ReqT, ?> call, ServerCall.Listener<ReqT> listener,
         Context.CancellableContext context) {
       this.call = checkNotNull(call, "call");
       this.listener = checkNotNull(listener, "listener must not be null");
-      this.timeout = checkNotNull(timeout, "timeout");
       this.context = checkNotNull(context, "context");
     }
 
@@ -265,7 +261,6 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<RespT> {
 
     @Override
     public void closed(Status status) {
-      timeout.cancel(true);
       try {
         if (status.isOk()) {
           listener.onComplete();

--- a/core/src/test/java/io/grpc/ContextsTest.java
+++ b/core/src/test/java/io/grpc/ContextsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import static io.grpc.Contexts.statusFromCancelled;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.grpc.internal.FakeClock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Tests for {@link Contexts}.
+ */
+@RunWith(JUnit4.class)
+public class ContextsTest {
+
+  @Test
+  public void statusFromCancelled_returnNullIfCtxNotCancelled() {
+    Context context = Context.current();
+    assertFalse(context.isCancelled());
+    assertNull(statusFromCancelled(context));
+  }
+
+  @Test
+  public void statusFromCancelled_returnStatusAsSetOnCtx() {
+    Context.CancellableContext cancellableContext = Context.current().fork();
+    cancellableContext.cancel(Status.DEADLINE_EXCEEDED.withDescription("foo bar").asException());
+    Status status = statusFromCancelled(cancellableContext);
+    assertNotNull(status);
+    assertEquals(Status.Code.DEADLINE_EXCEEDED, status.getCode());
+    assertEquals("foo bar", status.getDescription());
+  }
+
+  @Test
+  public void statusFromCancelled_shouldReturnStatusWithCauseAttached() {
+    Context.CancellableContext cancellableContext = Context.current().fork();
+    Throwable t = new Throwable();
+    cancellableContext.cancel(t);
+    Status status = statusFromCancelled(cancellableContext);
+    assertNotNull(status);
+    assertEquals(Status.Code.CANCELLED, status.getCode());
+    assertSame(t, status.getCause());
+  }
+
+  @Test
+  public void statusFromCancelled_TimeoutExceptionShouldMapToDeadlineExceeded() {
+    FakeClock fakeClock = new FakeClock();
+    Context.CancellableContext cancellableContext = Context.current()
+        .withDeadlineAfter(100, TimeUnit.MILLISECONDS, fakeClock.scheduledExecutorService);
+    fakeClock.forwardTime(System.nanoTime(), TimeUnit.NANOSECONDS);
+    fakeClock.forwardMillis(100);
+
+    assertTrue(cancellableContext.isCancelled());
+    assertThat(cancellableContext.cancellationCause(), instanceOf(TimeoutException.class));
+
+    Status status = statusFromCancelled(cancellableContext);
+    assertNotNull(status);
+    assertEquals(Status.Code.DEADLINE_EXCEEDED, status.getCode());
+    assertEquals("context timed out", status.getDescription());
+  }
+
+  @Test
+  public void statusFromCancelled_returnCancelledIfCauseIsNull() {
+    Context.CancellableContext cancellableContext = Context.current().fork();
+    cancellableContext.cancel(null);
+    assertTrue(cancellableContext.isCancelled());
+    Status status = statusFromCancelled(cancellableContext);
+    assertNotNull(status);
+    assertEquals(Status.Code.CANCELLED, status.getCode());
+  }
+
+  /** This is a whitebox test, to verify a special case of the implementation. */
+  @Test
+  public void statusFromCancelled_StatusUnknownShouldWork() {
+    Context.CancellableContext cancellableContext = Context.current().fork();
+    Exception e = Status.UNKNOWN.asException();
+    cancellableContext.cancel(e);
+    assertTrue(cancellableContext.isCancelled());
+
+    Status status = statusFromCancelled(cancellableContext);
+    assertNotNull(status);
+    assertEquals(Status.Code.UNKNOWN, status.getCode());
+    assertSame(e, status.getCause());
+  }
+
+  @Test
+  public void statusFromCancelled_shouldThrowIfCtxIsNull() {
+    try {
+      statusFromCancelled(null);
+      fail("NPE expected");
+    } catch (NullPointerException npe) {
+      assertEquals("context must not be null", npe.getMessage());
+    }
+  }
+
+}

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -165,8 +165,10 @@ public class ManagedChannelImplTest {
     ClientCall<String, Integer> call =
         channel.newCall(method, CallOptions.DEFAULT.withDeadlineAfter(0, TimeUnit.NANOSECONDS));
     call.start(mockCallListener, new Metadata());
-    verify(mockCallListener, timeout(1000)).onClose(
-        same(Status.DEADLINE_EXCEEDED), any(Metadata.class));
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+    verify(mockCallListener, timeout(1000)).onClose(statusCaptor.capture(), any(Metadata.class));
+    Status status = statusCaptor.getValue();
+    assertSame(Status.DEADLINE_EXCEEDED.getCode(), status.getCode());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -189,7 +189,7 @@ public class ServerCallImplTest {
   @Test
   public void streamListener_halfClosed() {
     ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, timeout, context);
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
 
     streamListener.halfClosed();
 
@@ -199,7 +199,7 @@ public class ServerCallImplTest {
   @Test
   public void streamListener_halfClosed_onlyOnce() {
     ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, timeout, context);
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
     streamListener.halfClosed();
     // canceling the call should short circuit future halfClosed() calls.
     streamListener.closed(Status.CANCELLED);
@@ -212,12 +212,11 @@ public class ServerCallImplTest {
   @Test
   public void streamListener_closedOk() {
     ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, timeout, context);
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
 
     streamListener.closed(Status.OK);
 
     verify(callListener).onComplete();
-    assertTrue(timeout.isCancelled());
     assertTrue(context.isCancelled());
     assertNull(context.cancellationCause());
   }
@@ -225,12 +224,11 @@ public class ServerCallImplTest {
   @Test
   public void streamListener_closedCancelled() {
     ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, timeout, context);
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
 
     streamListener.closed(Status.CANCELLED);
 
     verify(callListener).onCancel();
-    assertTrue(timeout.isCancelled());
     assertTrue(context.isCancelled());
     assertNull(context.cancellationCause());
   }
@@ -238,7 +236,7 @@ public class ServerCallImplTest {
   @Test
   public void streamListener_onReady() {
     ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, timeout, context);
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
 
     streamListener.onReady();
 
@@ -248,7 +246,7 @@ public class ServerCallImplTest {
   @Test
   public void streamListener_onReady_onlyOnce() {
     ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, timeout, context);
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
     streamListener.onReady();
     // canceling the call should short circuit future halfClosed() calls.
     streamListener.closed(Status.CANCELLED);
@@ -261,7 +259,7 @@ public class ServerCallImplTest {
   @Test
   public void streamListener_messageRead() {
     ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, timeout, context);
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
     streamListener.messageRead(method.streamRequest(1234L));
 
     verify(callListener).onMessage(1234L);
@@ -270,7 +268,7 @@ public class ServerCallImplTest {
   @Test
   public void streamListener_messageRead_unaryFailsOnMultiple() {
     ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, timeout, context);
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
     streamListener.messageRead(method.streamRequest(1234L));
     streamListener.messageRead(method.streamRequest(1234L));
 
@@ -284,7 +282,7 @@ public class ServerCallImplTest {
   @Test
   public void streamListener_messageRead_onlyOnce() {
     ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, timeout, context);
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
     streamListener.messageRead(method.streamRequest(1234L));
     // canceling the call should short circuit future halfClosed() calls.
     streamListener.closed(Status.CANCELLED);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -643,7 +643,7 @@ public abstract class AbstractInteropTest {
                .build()).next();
       fail("Expected deadline to be exceeded");
     } catch (Throwable t) {
-      assertEquals(Status.DEADLINE_EXCEEDED, Status.fromThrowable(t));
+      assertEquals(Status.DEADLINE_EXCEEDED.getCode(), Status.fromThrowable(t).getCode());
     }
   }
 
@@ -666,7 +666,8 @@ public abstract class AbstractInteropTest {
         .withDeadlineAfter(30, TimeUnit.MILLISECONDS)
         .streamingOutputCall(request, recorder);
     recorder.awaitCompletion();
-    assertEquals(Status.DEADLINE_EXCEEDED, Status.fromThrowable(recorder.getError()));
+    assertEquals(Status.DEADLINE_EXCEEDED.getCode(),
+        Status.fromThrowable(recorder.getError()).getCode());
   }
 
   @Test(timeout = 10000)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/CascadingTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CascadingTest.java
@@ -121,7 +121,7 @@ public class CascadingTest {
     } catch (StatusRuntimeException sre) {
       // Wait for the workers to finish
       Status status = Status.fromThrowable(sre);
-      assertEquals(Status.Code.CANCELLED, status.getCode());
+      assertEquals(Status.Code.DEADLINE_EXCEEDED, status.getCode());
 
       // Should have 3 calls before timeout propagates
       assertEquals(3, nodeCount.get());
@@ -229,7 +229,8 @@ public class CascadingTest {
                           blockingStub.unaryCall((Messages.SimpleRequest) message);
                         } catch (Exception e) {
                           Status status = Status.fromThrowable(e);
-                          if (status.getCode() == Status.Code.CANCELLED) {
+                          if (status.getCode() == Status.Code.CANCELLED
+                              || status.getCode() == Status.Code.DEADLINE_EXCEEDED) {
                             observedCancellations.countDown();
                           } else if (status.getCode() == Status.Code.ABORTED) {
                             // Propagate aborted back up


### PR DESCRIPTION
A call's timeout as specified in its metadata should be set depending
on the deadline of the call's context. If a call has an explicit deadline
set (through CallOptions), then the smaller deadline (from context and call options)
should be used to compute the timeout.

Minor Fixes:
 - A Context no longer uses a TimeoutException as the cancellation cause
   when its deadline has been exceeded, but a StatusException with the
   status set to Status.DEADLINE_EXCEEDED.
 - Introduced method Context.statusFromCancelledContext(Context)