### PR TITLE
Make CallOptions and AbstractStub use Deadline.

### DIFF
--- a/core/src/main/java/io/grpc/Deadline.java
+++ b/core/src/main/java/io/grpc/Deadline.java
@@ -114,18 +114,15 @@ public class Deadline {
   /**
    * How much time is remaining in the specified time unit. Internal units are maintained as
    * nanoseconds and conversions are subject to the constraints documented for
-   * {@link TimeUnit#convert}. If there is no time remaining {@code 0} is always returned.
+   * {@link TimeUnit#convert}. If there is no time remaining, the returned duration is how
+   * long ago the deadline expired.
    */
   public long timeRemaining(TimeUnit unit) {
-    if (!expired) {
-      long nowNanos = System.nanoTime();
-      if (deadlineNanos <= nowNanos) {
-        expired = true;
-      } else {
-        return unit.convert(Math.max(0, deadlineNanos - nowNanos), TimeUnit.NANOSECONDS);
-      }
+    final long nowNanos = System.nanoTime();
+    if (!expired && deadlineNanos <= nowNanos) {
+      expired = true;
     }
-    return 0;
+    return unit.convert(deadlineNanos - nowNanos, TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/core/src/main/java/io/grpc/Deadline.java
+++ b/core/src/main/java/io/grpc/Deadline.java
@@ -139,4 +139,9 @@ public class Deadline {
     Preconditions.checkNotNull(scheduler, "scheduler");
     return scheduler.schedule(task, deadlineNanos - System.nanoTime(), TimeUnit.NANOSECONDS);
   }
+
+  @Override
+  public String toString() {
+    return timeRemaining(TimeUnit.NANOSECONDS) + " ns from now";
+  }
 }

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -40,6 +40,7 @@ import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
 import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -50,6 +51,7 @@ import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
+import io.grpc.Deadline;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
@@ -61,7 +63,6 @@ import java.io.InputStream;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
@@ -198,7 +199,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
 
     prepareHeaders(headers, callOptions, userAgent, decompressorRegistry, compressor);
 
-    if (updateTimeoutHeader(callOptions.getDeadlineNanoTime(), headers)) {
+    if (updateTimeoutHeader(callOptions.getDeadline(), headers)) {
       ClientTransport transport = clientTransportProvider.get(callOptions);
       stream = transport.newStream(method, headers);
     } else {
@@ -218,8 +219,8 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
     // they receive cancel before start. Issue #1343 has more details
 
     // Start the deadline timer after stream creation because it will close the stream
-    Long timeoutNanos = getRemainingTimeoutNanos(callOptions.getDeadlineNanoTime());
-    if (timeoutNanos != null) {
+    if (callOptions.getDeadline() != null) {
+      long timeoutNanos = callOptions.getDeadline().timeRemaining(NANOSECONDS);
       deadlineCancellationFuture = startDeadlineTimer(timeoutNanos);
       if (deadlineCancellationFutureShouldBeCancelled) {
         // Race detected! ClientStreamListener.closed may have been called before
@@ -237,15 +238,16 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
    *
    * @return {@code false} if deadline already exceeded
    */
-  static boolean updateTimeoutHeader(@Nullable Long deadlineNanoTime, Metadata headers) {
+  static boolean updateTimeoutHeader(@Nullable Deadline deadline, Metadata headers) {
     // Fill out timeout on the headers
     // TODO(carl-mastrangelo): Find out if this should always remove the timeout,
     // even when returning false.
     headers.removeAll(TIMEOUT_KEY);
-    // Convert the deadline to timeout. Timeout is more favorable than deadline on the wire
-    // because timeout tolerates the clock difference between machines.
-    Long timeoutNanos = getRemainingTimeoutNanos(deadlineNanoTime);
-    if (timeoutNanos != null) {
+
+    if (deadline != null) {
+      // Convert the deadline to timeout. Timeout is more favorable than deadline on the wire
+      // because timeout tolerates the clock difference between machines.
+      long timeoutNanos = deadline.timeRemaining(NANOSECONDS);
       if (timeoutNanos <= 0) {
         return false;
       }
@@ -344,7 +346,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
       public void run() {
         stream.cancel(Status.DEADLINE_EXCEEDED);
       }
-    }, timeoutNanos, TimeUnit.NANOSECONDS);
+    }, timeoutNanos, NANOSECONDS);
   }
 
   private class ClientStreamListenerImpl implements ClientStreamListener {
@@ -411,11 +413,11 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
 
     @Override
     public void closed(Status status, Metadata trailers) {
-      Long timeoutNanos = getRemainingTimeoutNanos(callOptions.getDeadlineNanoTime());
-      if (status.getCode() == Status.Code.CANCELLED && timeoutNanos != null) {
+      if (status.getCode() == Status.Code.CANCELLED && callOptions.getDeadline() != null) {
         // When the server's deadline expires, it can only reset the stream with CANCEL and no
         // description. Since our timer may be delayed in firing, we double-check the deadline and
         // turn the failure into the likely more helpful DEADLINE_EXCEEDED status.
+        long timeoutNanos = callOptions.getDeadline().timeRemaining(NANOSECONDS);
         if (timeoutNanos <= 0) {
           status = Status.DEADLINE_EXCEEDED;
           // Replace trailers to prevent mixing sources of status and trailers.

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -139,7 +139,7 @@ public class CallOptionsTest {
             .withExecutor(new SerializingExecutor(MoreExecutors.directExecutor())).toString());
 
     long remainingNanos = extractRemainingTime(allSet.toString());
-    long delta = TimeUnit.MILLISECONDS.toNanos(10);
+    long delta = TimeUnit.MILLISECONDS.toNanos(20);
     assertNotNull(allSet.getDeadline());
     assertEquals(remainingNanos, allSet.getDeadline().timeRemaining(NANOSECONDS), delta);
   }
@@ -147,11 +147,12 @@ public class CallOptionsTest {
   @Test
   @Deprecated
   public void testWithDeadlineNanoTime() {
-    CallOptions opts = CallOptions.DEFAULT.withDeadlineNanoTime(10L);
+    CallOptions opts = CallOptions.DEFAULT.withDeadlineNanoTime(System.nanoTime());
     assertNotNull(opts.getDeadlineNanoTime());
     assertTrue(opts.getDeadlineNanoTime() <= System.nanoTime());
     assertNotNull(opts.getDeadline());
-    assertEquals(0, opts.getDeadline().timeRemaining(NANOSECONDS));
+    long delta = MILLISECONDS.toNanos(10);
+    assertEquals(0, opts.getDeadline().timeRemaining(NANOSECONDS), delta);
     assertTrue(opts.getDeadline().isExpired());
   }
 

--- a/core/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -31,6 +31,7 @@
 
 package io.grpc;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -244,8 +245,8 @@ public class ClientInterceptorsTest {
 
   @Test
   public void callOptions() {
-    final CallOptions initialCallOptions = CallOptions.DEFAULT.withDeadlineNanoTime(100L);
-    final CallOptions newCallOptions = initialCallOptions.withDeadlineNanoTime(300L);
+    final CallOptions initialCallOptions = CallOptions.DEFAULT.withDeadlineAfter(100, NANOSECONDS);
+    final CallOptions newCallOptions = initialCallOptions.withDeadlineAfter(300, NANOSECONDS);
     assertNotSame(initialCallOptions, newCallOptions);
     ClientInterceptor interceptor = spy(new ClientInterceptor() {
       @Override

--- a/core/src/test/java/io/grpc/DeadlineTest.java
+++ b/core/src/test/java/io/grpc/DeadlineTest.java
@@ -44,6 +44,8 @@ import org.junit.runners.JUnit4;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Tests for {@link Context}.
@@ -136,5 +138,26 @@ public class DeadlineTest {
     if (!latch.await(10, TimeUnit.MILLISECONDS)) {
       fail("Deadline listener did not execute in time");
     }
+  }
+
+  @Test
+  public void testToString() {
+    Deadline d = Deadline.after(0, TimeUnit.MILLISECONDS);
+    assertEquals(0, extractRemainingTime(d.toString()), delta);
+
+    d = Deadline.after(-1, TimeUnit.HOURS);
+    assertEquals(d.timeRemaining(TimeUnit.NANOSECONDS), extractRemainingTime(d.toString()), delta);
+
+    d = Deadline.after(10, TimeUnit.SECONDS);
+    assertEquals(d.timeRemaining(TimeUnit.NANOSECONDS), extractRemainingTime(d.toString()), delta);
+  }
+
+  private static long extractRemainingTime(String deadlineStr) {
+    final Pattern p = Pattern.compile("(\\-?[0-9]+) ns from now");
+    Matcher m = p.matcher(deadlineStr);
+    assertTrue(m.matches());
+    assertEquals(1, m.groupCount());
+
+    return Long.valueOf(m.group(1));
   }
 }

--- a/core/src/test/java/io/grpc/DeadlineTest.java
+++ b/core/src/test/java/io/grpc/DeadlineTest.java
@@ -53,11 +53,14 @@ import java.util.regex.Pattern;
 @RunWith(JUnit4.class)
 public class DeadlineTest {
 
+  // Allowed inaccuracy when comparing the remaining time of a deadline.
+  private final long delta = TimeUnit.MILLISECONDS.toNanos(20);
+
   @Test
   public void immediateDeadlineIsExpired() {
     Deadline deadline = Deadline.after(0, TimeUnit.SECONDS);
     assertTrue(deadline.isExpired());
-    assertEquals(0, deadline.timeRemaining(TimeUnit.NANOSECONDS));
+    assertEquals(0, deadline.timeRemaining(TimeUnit.NANOSECONDS), delta);
   }
 
   @Test
@@ -67,14 +70,14 @@ public class DeadlineTest {
     assertFalse(deadline.isExpired());
     Thread.sleep(101);
     assertTrue(deadline.isExpired());
-    assertEquals(0, deadline.timeRemaining(TimeUnit.NANOSECONDS));
+    assertEquals(0, deadline.timeRemaining(TimeUnit.NANOSECONDS), delta);
   }
 
   @Test
   public void pastDeadlineIsExpired() {
     Deadline deadline = Deadline.after(-1, TimeUnit.SECONDS);
     assertTrue(deadline.isExpired());
-    assertEquals(0, deadline.timeRemaining(TimeUnit.NANOSECONDS));
+    assertEquals(TimeUnit.SECONDS.toNanos(-1), deadline.timeRemaining(TimeUnit.NANOSECONDS), delta);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -423,8 +423,8 @@ public class ClientCallImplTest {
 
   @Test
   public void deadlineExceededBeforeCallStarted() {
-    CallOptions callOptions = CallOptions.DEFAULT.withDeadlineNanoTime(TimeUnit.SECONDS.toNanos(1));
-    fakeClock.forwardTime(1, TimeUnit.SECONDS);
+    CallOptions callOptions = CallOptions.DEFAULT.withDeadlineAfter(0, TimeUnit.SECONDS);
+    fakeClock.forwardTime(System.nanoTime(), TimeUnit.NANOSECONDS);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         DESCRIPTOR,
         new SerializingExecutor(Executors.newSingleThreadExecutor()),

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -96,6 +96,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Unit tests for {@link ManagedChannelImpl}. */
@@ -162,7 +163,7 @@ public class ManagedChannelImplTest {
     ManagedChannel channel = createChannel(
         new FakeNameResolverFactory(true), NO_INTERCEPTOR);
     ClientCall<String, Integer> call =
-        channel.newCall(method, CallOptions.DEFAULT.withDeadlineNanoTime(System.nanoTime()));
+        channel.newCall(method, CallOptions.DEFAULT.withDeadlineAfter(0, TimeUnit.NANOSECONDS));
     call.start(mockCallListener, new Metadata());
     verify(mockCallListener, timeout(1000)).onClose(
         same(Status.DEADLINE_EXCEEDED), any(Metadata.class));

--- a/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
+++ b/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
@@ -110,7 +110,7 @@ public class StubConfigTest {
     TestServiceGrpc.TestServiceBlockingStub reconfiguredStub = stub.withDeadlineNanoTime(deadline);
     // New altered config
     assertNotNull(reconfiguredStub.getCallOptions().getDeadlineNanoTime());
-    long delta = MILLISECONDS.toNanos(10);
+    long delta = MILLISECONDS.toNanos(20);
     assertEquals(deadline, reconfiguredStub.getCallOptions().getDeadlineNanoTime(), delta);
     // Default config unchanged
     assertNull(stub.getCallOptions().getDeadlineNanoTime());

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -37,6 +37,7 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
+import io.grpc.Deadline;
 import io.grpc.ExperimentalApi;
 
 import java.util.concurrent.TimeUnit;
@@ -98,6 +99,19 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   protected abstract S build(Channel channel, CallOptions callOptions);
 
   /**
+   * Returns a new stub with an absolute deadline.
+   *
+   * <p>This is mostly used for propagating an existing deadline. {@link #withDeadlineAfter} is the
+   * recommended way of setting a new deadline,
+   *
+   * @param deadline the deadline or {@code null} for unsetting the deadline.
+   */
+  @ExperimentalApi
+  public final S withDeadline(@Nullable Deadline deadline) {
+    return build(channel, callOptions.withDeadline(deadline));
+  }
+
+  /**
    * Returns a new stub with an absolute deadline in nanoseconds in the clock as per {@link
    * System#nanoTime()}.
    *
@@ -105,7 +119,9 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
    * recommended way of setting a new deadline,
    *
    * @param deadlineNanoTime nanoseconds in the clock as per {@link System#nanoTime()}
+   * @deprecated  Use {@link #withDeadline(Deadline)} instead.
    */
+  @Deprecated
   public final S withDeadlineNanoTime(@Nullable Long deadlineNanoTime) {
     return build(channel, callOptions.withDeadlineNanoTime(deadlineNanoTime));
   }


### PR DESCRIPTION
- Made CallOptions use the Deadline type instead of a
  long to represent a deadline.
- Added new methods CallOptions.withDeadline(Deadline) and
  AbstractStub.withDeadline(Deadline). The methods are
  marked experimental, as the Deadline class is marked
  experimental. These methods are meant to replace
  CallOptions.withDeadlineNanoTime(Long) and
  AbstractStub.withDeadlineNanoTime(Long), which have
  been deprecated.
- Updated CallOptions.toString() to include all fields.