### PR TITLE
Warn users shutdownNow doesn't behave as documented

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -64,6 +64,8 @@ public abstract class ManagedChannel extends Channel {
    * Initiates a forceful shutdown in which preexisting and new calls are cancelled. Although
    * forceful, the shutdown process is still not instantaneous; {@link #isTerminated()} will likely
    * return {@code false} immediately after this method returns.
+   *
+   * <p>NOT YET IMPLEMENTED. This method currently behaves identically to shutdown().
    */
   public abstract ManagedChannel shutdownNow();
 


### PR DESCRIPTION
This just places back a warning that was mistakenly removed in b687bdc.

Fixes #1500