### PR TITLE
Trigger name resolution when a live connection closed.

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -397,6 +397,11 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
                 public void onAllAddressesFailed() {
                   nameResolver.refresh();
                 }
+
+                @Override
+                public void onConnectionClosedByServer(Status status) {
+                  nameResolver.refresh();
+                }
               });
           if (log.isLoggable(Level.FINE)) {
             log.log(Level.FINE, "[{0}] {1} created for {2}",


### PR DESCRIPTION
In addition to when all addresses have failed to connect. This is to
cover the case where some addresses have changed in the name system
while some are still there and usable. Without this change, the client
would try to connect old addresses each time it reconnects.

Resolves #1601 