### PR TITLE
Provide default implementation for NameResolver.refresh().

### DIFF
--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -75,8 +75,10 @@ public abstract class NameResolver {
    *
    * <p>This is only a hint. Implementation takes it as a signal but may not start resolution
    * immediately.
+   *
+   * <p>The default implementation is no-op.
    */
-  public abstract void refresh();
+  public void refresh() {}
 
   public abstract static class Factory {
     /**

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -267,9 +267,6 @@ public abstract class AbstractManagedChannelImplBuilder
         }
 
         @Override
-        public void refresh() {}
-
-        @Override
         public void shutdown() {}
       };
     }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -174,8 +174,6 @@ public class ManagedChannelImplGetNameResolverTest {
 
     @Override public void start(final Listener listener) {}
 
-    @Override public void refresh() {}
-
     @Override public void shutdown() {}
   }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -612,8 +612,6 @@ public class ManagedChannelImplTest {
         }
       }
 
-      @Override public void refresh() {}
-
       void resolved() {
         listener.onUpdate(servers, Attributes.EMPTY);
       }
@@ -641,8 +639,6 @@ public class ManagedChannelImplTest {
         @Override public void start(final Listener listener) {
           listener.onError(error);
         }
-
-        @Override public void refresh() {}
 
         @Override public void shutdown() {}
       };


### PR DESCRIPTION
It is an optional operation anyway. In a pushing name system, refresh()
wouldn't be necessary.