### PR TITLE
Simplify nano flag to codegen to just 'nano' from 'nano=true'

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -47,7 +47,7 @@ protobuf {
             task.plugins {
                 grpc {
                     // Options added to --grpc_out
-                    option 'nano=true'
+                    option 'nano'
                 }
             }
         }

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -40,7 +40,7 @@ $ protoc --plugin=protoc-gen-grpc-java=build/binaries/java_pluginExecutable/prot
 To generate Java interfaces with protobuf nano:
 ```
 $ protoc --plugin=protoc-gen-grpc-java=build/binaries/java_pluginExecutable/protoc-gen-grpc-java \
-  --grpc-java_out=nano=true:"$OUTPUT_FILE" --proto_path="$DIR_OF_PROTO_FILE" "$PROTO_FILE"
+  --grpc-java_out=nano:"$OUTPUT_FILE" --proto_path="$DIR_OF_PROTO_FILE" "$PROTO_FILE"
 ```
 
 ## Installing the codegen to Maven local repository

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -168,7 +168,7 @@ protobuf {
       }
       task.plugins {
         grpc {
-          option 'nano=true'
+          option 'nano'
         }
       }
     }

--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -38,7 +38,7 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
     java_grpc_generator::ProtoFlavor flavor =
         java_grpc_generator::ProtoFlavor::NORMAL;
     for (int i = 0; i < options.size(); i++) {
-      if (options[i].first == "nano" && options[i].second == "true") {
+      if (options[i].first == "nano") {
         flavor = java_grpc_generator::ProtoFlavor::NANO;
       } else if (options[i].first == "lite") {
         flavor = java_grpc_generator::ProtoFlavor::LITE;

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -46,7 +46,7 @@ protobuf {
             task.plugins {
                 grpc {
                     // Options added to --grpc_out
-                    option 'nano=true'
+                    option 'nano'
                 }
             }
         }


### PR DESCRIPTION
'nano=true' still works, but any value is now ignored. This is to align
with our lite flag, but also just because It's Cleaner.

Note that this is counter to what javanano does. Javanano requires all
flags have a value and uses true/false for many values.