### PR TITLE
Fix flakes in Deadline testing

### DIFF
--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -34,7 +34,6 @@ package io.grpc;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static io.grpc.DeadlineTest.extractRemainingTime;
 import static io.grpc.testing.DeadlineSubject.deadline;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -56,7 +55,8 @@ import java.util.concurrent.Executor;
 @RunWith(JUnit4.class)
 public class CallOptionsTest {
   private String sampleAuthority = "authority";
-  private Deadline sampleDeadline = Deadline.after(1, NANOSECONDS);
+  private Deadline.Ticker ticker = new DeadlineTest.FakeTicker();
+  private Deadline sampleDeadline = Deadline.after(1, NANOSECONDS, ticker);
   private Key<String> sampleKey = Attributes.Key.of("sample");
   private Attributes sampleAffinity = Attributes.newBuilder().set(sampleKey, "blah").build();
   private CallOptions allSet = CallOptions.DEFAULT
@@ -146,8 +146,7 @@ public class CallOptionsTest {
 
   @Test
   public void toStringMatches_withDeadline() {
-    assertAbout(deadline()).that(extractRemainingTime(allSet.toString()))
-        .isWithin(20, MILLISECONDS).of(allSet.getDeadline());
+    allSet.toString().contains("1 ns from now");
   }
 
   @Test


### PR DESCRIPTION
Two commits to fix things up 1) introduce a Ticker to control time reliably when testing Deadline and 2) fix all nanoTime instant calculations to permit time to "wrap around" (a.k.a., overflow, but in nanoTime it i normal operation).

Only the test for SystemTicker uses real time.

Note that providing ticker is internal-only; there is no attempt to support comparison between different tickers (that is, when different tickers are involved it is easy for our methods to return strange results).

@louiscryan, @carl-mastrangelo, FYI