### PR TITLE
propagate unchecked exceptions

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -44,6 +44,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
@@ -386,7 +387,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
             }
           } catch (Throwable t) {
             stream.cancel(Status.CANCELLED.withCause(t).withDescription("Failed to read message."));
-            return;
+            Throwables.propagateIfPossible(t);
           }
         }
       });


### PR DESCRIPTION
As stands, exceptions in `onNext` callbacks seem to get silently swallowed on the callback side.

There's code in `SerializingExecutor` that will log the exceptions but it's never exercised.

This change simply lets the exception percolate up the stack where it's caught and logged by `SerializingExecutor` if it's a `RuntimeException` and (by default) trapped by the uncaught exception handler otherwise.

Not sure this is the best approach ...