### PR TITLE
Remove some more header copies.

### DIFF
--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -170,6 +170,14 @@ public final class Metadata {
   }
 
   /**
+   * Returns the total number of key-value headers in this metadata, including duplicates.
+   */
+  @Internal
+  public int headerCount() {
+    return storeCount;
+  }
+
+  /**
    * Returns true if a value is defined for the given key.
    */
   public boolean containsKey(Key<?> key) {
@@ -286,7 +294,8 @@ public final class Metadata {
    * of {@link Key}. If the name ends with {@code "-bin"}, the value can be raw binary.  Otherwise,
    * the value must contain only characters listed in the class comments of {@link AsciiMarshaller}
    *
-   * <p>The returned byte arrays <em>must not</em> be modified.
+   * <p>The returned individual byte arrays <em>must not</em> be modified.  However, the top level
+   * array may be modified.
    *
    * <p>This method is intended for transport use only.
    */

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -155,7 +155,8 @@ class Utils {
 
   private static Http2Headers convertMetadata(Metadata headers) {
     Preconditions.checkNotNull(headers, "headers");
-    Http2Headers http2Headers = new DefaultHttp2Headers();
+    boolean validate = true;
+    Http2Headers http2Headers = new DefaultHttp2Headers(validate, headers.headerCount());
     byte[][] serializedHeaders = TransportFrameUtil.toHttp2Headers(headers);
     for (int i = 0; i < serializedHeaders.length; i += 2) {
       AsciiString name = new AsciiString(serializedHeaders[i], false);

--- a/okhttp/src/main/java/io/grpc/okhttp/Headers.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Headers.java
@@ -68,7 +68,8 @@ public class Headers {
     Preconditions.checkNotNull(defaultPath, "defaultPath");
     Preconditions.checkNotNull(authority, "authority");
 
-    List<Header> okhttpHeaders = new ArrayList<Header>(6);
+    // 7 is the number of explicit add calls below.
+    List<Header> okhttpHeaders = new ArrayList<Header>(7 + headers.headerCount());
 
     // Set GRPC-specific headers.
     okhttpHeaders.add(SCHEME_HEADER);


### PR DESCRIPTION
The basic idea here is that for byte[][], the top level array is mutable, but the individual keys and value byte[]'s are not.  

Most of these functions create a new array, copy the old one and then return the new array.  They don't ever keep a reference to it, so I believe it is safe to do this.  I don't care so much about the speed of copying, but more about not creating as much garbage.  Not all garbage collectors are good at picking up short lived memory.

There are still a lot of copies elsewhere.