### PR TITLE
Split-state AbstractStream; sending and receiving

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream2.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2014, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.grpc.Codec;
+import io.grpc.Compressor;
+import io.grpc.Decompressor;
+
+import java.io.InputStream;
+
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * The stream and stream state as used by the application. Must only be called from the sending
+ * application thread.
+ */
+public abstract class AbstractStream2 implements Stream {
+  /** The framer to use for sending messages. */
+  protected abstract MessageFramer framer();
+
+  /**
+   * Obtain the transport state corresponding to this stream. Each stream must have its own unique
+   * transport state.
+   */
+  protected abstract TransportState transportState();
+
+  @Override
+  public final void setMessageCompression(boolean enable) {
+    framer().setMessageCompression(enable);
+  }
+
+  @Override
+  public final void writeMessage(InputStream message) {
+    checkNotNull(message);
+    if (!framer().isClosed()) {
+      framer().writePayload(message);
+    }
+  }
+
+  @Override
+  public final void flush() {
+    if (!framer().isClosed()) {
+      framer().flush();
+    }
+  }
+
+  /**
+   * Closes the underlying framer. Should be called when the outgoing stream is gracefully closed
+   * (half closure on client; closure on server).
+   */
+  protected final void endOfMessages() {
+    framer().close();
+  }
+
+  @Override
+  public final void setCompressor(Compressor compressor) {
+    framer().setCompressor(checkNotNull(compressor, "compressor"));
+  }
+
+  @Override
+  public final void setDecompressor(Decompressor decompressor) {
+    transportState().setDecompressor(checkNotNull(decompressor, "decompressor"));
+  }
+
+  @Override
+  public final boolean isReady() {
+    if (framer().isClosed()) {
+      return false;
+    }
+    return transportState().isReady();
+  }
+
+  /**
+   * Event handler to be called by the subclass when a number of bytes are being queued for sending
+   * to the remote endpoint.
+   *
+   * @param numBytes the number of bytes being sent.
+   */
+  protected final void onSendingBytes(int numBytes) {
+    transportState().onSendingBytes(numBytes);
+  }
+
+  /**
+   * Stream state as used by the transport. This should only called from the transport thread
+   * (except for private interactions with {@code AbstractStream2}).
+   */
+  public abstract static class TransportState implements MessageDeframer.Listener {
+    /**
+     * The default number of queued bytes for a given stream, below which
+     * {@link StreamListener#onReady()} will be called.
+     */
+    private static final int DEFAULT_ONREADY_THRESHOLD = 32 * 1024;
+
+    private final MessageDeframer deframer;
+    private final Object onReadyLock = new Object();
+    /**
+     * The number of bytes currently queued, waiting to be sent. When this falls below
+     * DEFAULT_ONREADY_THRESHOLD, {@link StreamListener#onReady()} will be called.
+     */
+    @GuardedBy("onReadyLock")
+    private int numSentBytesQueued;
+    /**
+     * Indicates the stream has been created on the connection. This implies that the stream is no
+     * longer limited by MAX_CONCURRENT_STREAMS.
+     */
+    @GuardedBy("onReadyLock")
+    private boolean allocated;
+
+    protected TransportState(int maxMessageSize) {
+      deframer = new MessageDeframer(this, Codec.Identity.NONE, maxMessageSize);
+    }
+
+    @VisibleForTesting
+    TransportState(MessageDeframer deframer) {
+      this.deframer = deframer;
+    }
+
+    /**
+     * Override this method to provide a stream listener.
+     */
+    protected abstract StreamListener listener();
+
+    @Override
+    public void messageRead(InputStream is) {
+      listener().messageRead(is);
+    }
+
+    /**
+     * Called when a {@link #deframe(ReadableBuffer, boolean)} operation failed.
+     *
+     * @param cause the actual failure
+     */
+    protected abstract void deframeFailed(Throwable cause);
+
+    /**
+     * Closes this deframer and frees any resources. After this method is called, additional calls
+     * will have no effect.
+     */
+    protected final void closeDeframer() {
+      deframer.close();
+    }
+
+    /**
+     * Called to parse a received frame and attempt delivery of any completed
+     * messages. Must be called from the transport thread.
+     */
+    protected final void deframe(ReadableBuffer frame, boolean endOfStream) {
+      if (deframer.isClosed()) {
+        frame.close();
+        return;
+      }
+      try {
+        deframer.deframe(frame, endOfStream);
+      } catch (Throwable t) {
+        deframeFailed(t);
+      }
+    }
+
+    /**
+     * Called to request the given number of messages from the deframer. Must be called
+     * from the transport thread.
+     */
+    public final void requestMessagesFromDeframer(int numMessages) {
+      if (deframer.isClosed()) {
+        return;
+      }
+      try {
+        deframer.request(numMessages);
+      } catch (Throwable t) {
+        deframeFailed(t);
+      }
+    }
+
+    private void setDecompressor(Decompressor decompressor) {
+      if (deframer.isClosed()) {
+        return;
+      }
+      deframer.setDecompressor(decompressor);
+    }
+
+    private boolean isReady() {
+      synchronized (onReadyLock) {
+        return allocated && numSentBytesQueued < DEFAULT_ONREADY_THRESHOLD;
+      }
+    }
+
+    /**
+     * Event handler to be called by the subclass when the stream's headers have passed any
+     * connection flow control (i.e., MAX_CONCURRENT_STREAMS). It may call the listener's {@link
+     * StreamListener#onReady()} handler if appropriate. This must be called from the transport
+     * thread, since the listener may be called back directly.
+     */
+    protected final void onStreamAllocated() {
+      checkState(listener() != null);
+      synchronized (onReadyLock) {
+        checkState(!allocated, "Already allocated");
+        allocated = true;
+      }
+      notifyIfReady();
+    }
+
+    /**
+     * Event handler to be called by the subclass when a number of bytes are being queued for
+     * sending to the remote endpoint.
+     *
+     * @param numBytes the number of bytes being sent.
+     */
+    private void onSendingBytes(int numBytes) {
+      synchronized (onReadyLock) {
+        numSentBytesQueued += numBytes;
+      }
+    }
+
+    /**
+     * Event handler to be called by the subclass when a number of bytes has been sent to the remote
+     * endpoint. May call back the listener's {@link StreamListener#onReady()} handler if
+     * appropriate.  This must be called from the transport thread, since the listener may be called
+     * back directly.
+     *
+     * @param numBytes the number of bytes that were sent.
+     */
+    public final void onSentBytes(int numBytes) {
+      boolean doNotify;
+      synchronized (onReadyLock) {
+        boolean belowThresholdBefore = numSentBytesQueued < DEFAULT_ONREADY_THRESHOLD;
+        numSentBytesQueued -= numBytes;
+        boolean belowThresholdAfter = numSentBytesQueued < DEFAULT_ONREADY_THRESHOLD;
+        doNotify = !belowThresholdBefore && belowThresholdAfter;
+      }
+      if (doNotify) {
+        notifyIfReady();
+      }
+    }
+
+    private void notifyIfReady() {
+      boolean doNotify;
+      synchronized (onReadyLock) {
+        doNotify = isReady();
+      }
+      if (doNotify) {
+        listener().onReady();
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -51,6 +51,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 /**
  * Encodes gRPC messages to be delivered via the transport layer which implements {@link
  * MessageFramer.Sink}.
@@ -69,7 +71,7 @@ public class MessageFramer {
      * @param endOfStream whether the frame is the last one for the GRPC stream
      * @param flush {@code true} if more data may not be arriving soon
      */
-    void deliverFrame(WritableBuffer frame, boolean endOfStream, boolean flush);
+    void deliverFrame(@Nullable WritableBuffer frame, boolean endOfStream, boolean flush);
   }
 
   private static final int HEADER_LENGTH = 5;

--- a/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
@@ -41,15 +41,15 @@ import io.grpc.Status;
  * Command sent from a Netty server stream to the handler to cancel the stream.
  */
 class CancelServerStreamCommand {
-  private final NettyServerStream stream;
+  private final NettyServerStream.TransportState stream;
   private final Status reason;
 
-  CancelServerStreamCommand(NettyServerStream stream, Status reason) {
+  CancelServerStreamCommand(NettyServerStream.TransportState stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream);
     this.reason = Preconditions.checkNotNull(reason);
   }
 
-  NettyServerStream stream() {
+  NettyServerStream.TransportState stream() {
     return stream;
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -54,7 +54,7 @@ import javax.annotation.Nullable;
 /**
  * Client stream for a Netty transport.
  */
-abstract class NettyClientStream extends Http2ClientStream {
+abstract class NettyClientStream extends Http2ClientStream implements StreamIdHolder {
   private final MethodDescriptor<?, ?> method;
   /** {@code null} after start. */
   private Metadata headers;

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -46,105 +46,40 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Stream;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javax.net.ssl.SSLSession;
 
 /**
- * Server stream for a Netty HTTP2 transport.
+ * Server stream for a Netty HTTP2 transport. Must only be called from the sending application
+ * thread.
  */
-class NettyServerStream extends AbstractServerStream<Integer> {
+class NettyServerStream extends AbstractServerStream {
+  private static final Logger log = Logger.getLogger(NettyServerStream.class.getName());
 
+  private final Sink sink = new Sink();
+  private final TransportState state;
   private final Channel channel;
-  private final NettyServerHandler handler;
-  private final Http2Stream http2Stream;
   private final WriteQueue writeQueue;
   private final Attributes attributes;
 
-  NettyServerStream(Channel channel, Http2Stream http2Stream, NettyServerHandler handler,
-                    int maxMessageSize) {
-    super(new NettyWritableBufferAllocator(channel.alloc()), maxMessageSize);
-    this.writeQueue = handler.getWriteQueue();
+  public NettyServerStream(Channel channel, TransportState state) {
+    super(new NettyWritableBufferAllocator(channel.alloc()));
+    this.state = checkNotNull(state, "transportState");
     this.channel = checkNotNull(channel, "channel");
-    this.http2Stream = checkNotNull(http2Stream, "http2Stream");
-    this.handler = checkNotNull(handler, "handler");
+    this.writeQueue = state.handler.getWriteQueue();
     this.attributes = buildAttributes(channel);
   }
 
   @Override
-  public Integer id() {
-    return http2Stream.id();
+  protected TransportState transportState() {
+    return state;
   }
 
   @Override
-  protected void inboundHeadersReceived(Metadata headers) {
-    super.inboundHeadersReceived(headers);
-  }
-
-  void inboundDataReceived(ByteBuf frame, boolean endOfStream) {
-    super.inboundDataReceived(new NettyReadableBuffer(frame.retain()), endOfStream);
-  }
-
-  @Override
-  public void request(final int numMessages) {
-    if (channel.eventLoop().inEventLoop()) {
-      // Processing data read in the event loop so can call into the deframer immediately
-      requestMessagesFromDeframer(numMessages);
-    } else {
-      writeQueue.enqueue(new RequestMessagesCommand(this, numMessages), true);
-    }
-  }
-
-  @Override
-  protected void inboundDeliveryPaused() {
-    // Do nothing.
-  }
-
-  @Override
-  protected void internalSendHeaders(Metadata headers) {
-    writeQueue.enqueue(new SendResponseHeadersCommand(id(),
-        Utils.convertServerHeaders(headers), false),
-        true);
-  }
-
-  @Override
-  protected void sendFrame(WritableBuffer frame, boolean endOfStream, boolean flush) {
-    ByteBuf bytebuf = ((NettyWritableBuffer) frame).bytebuf();
-    final int numBytes = bytebuf.readableBytes();
-    // Add the bytes to outbound flow control.
-    onSendingBytes(numBytes);
-    writeQueue.enqueue(
-        new SendGrpcFrameCommand(this, bytebuf, endOfStream),
-        channel.newPromise().addListener(new ChannelFutureListener() {
-          @Override
-          public void operationComplete(ChannelFuture future) throws Exception {
-            // Remove the bytes from outbound flow control, optionally notifying
-            // the client that they can send more bytes.
-            onSentBytes(numBytes);
-          }
-        }), flush);
-  }
-
-  @Override
-  protected void sendTrailers(Metadata trailers, boolean headersSent) {
-    Http2Headers http2Trailers = Utils.convertTrailers(trailers, headersSent);
-    writeQueue.enqueue(new SendResponseHeadersCommand(id(), http2Trailers, true), true);
-  }
-
-  @Override
-  protected void returnProcessedBytes(int processedBytes) {
-    handler.returnProcessedBytes(http2Stream, processedBytes);
-    writeQueue.scheduleFlush();
-  }
-
-  @Override
-  protected void sendStreamAbortToClient(Status status, Metadata trailers) {
-    // Cancel the stream.
-    // TODO(nmittler): Consider sending trailers.
-    cancel(status);
-  }
-
-  @Override
-  public void cancel(Status status) {
-    writeQueue.enqueue(new CancelServerStreamCommand(this, status), true);
+  protected Sink abstractServerStreamSink() {
+    return sink;
   }
 
   @Override public Attributes attributes() {
@@ -162,5 +97,93 @@ class NettyServerStream extends AbstractServerStream<Integer> {
         .set(ServerCall.REMOTE_ADDR_KEY, channel.remoteAddress())
         .set(ServerCall.SSL_SESSION_KEY, sslSession)
         .build();
+  }
+
+  private class Sink implements AbstractServerStream.Sink {
+    @Override
+    public void request(final int numMessages) {
+      if (channel.eventLoop().inEventLoop()) {
+        // Processing data read in the event loop so can call into the deframer immediately
+        transportState().requestMessagesFromDeframer(numMessages);
+      } else {
+        writeQueue.enqueue(new RequestMessagesCommand(transportState(), numMessages), true);
+      }
+    }
+
+    @Override
+    public void writeHeaders(Metadata headers) {
+      writeQueue.enqueue(new SendResponseHeadersCommand(transportState(),
+          Utils.convertServerHeaders(headers), false),
+          true);
+    }
+
+    @Override
+    public void writeFrame(WritableBuffer frame, boolean flush) {
+      if (frame == null) {
+        writeQueue.scheduleFlush();
+        return;
+      }
+      ByteBuf bytebuf = ((NettyWritableBuffer) frame).bytebuf();
+      final int numBytes = bytebuf.readableBytes();
+      // Add the bytes to outbound flow control.
+      onSendingBytes(numBytes);
+      writeQueue.enqueue(
+          new SendGrpcFrameCommand(transportState(), bytebuf, false),
+          channel.newPromise().addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+              // Remove the bytes from outbound flow control, optionally notifying
+              // the client that they can send more bytes.
+              transportState().onSentBytes(numBytes);
+            }
+          }), flush);
+    }
+
+    @Override
+    public void writeTrailers(Metadata trailers, boolean headersSent) {
+      Http2Headers http2Trailers = Utils.convertTrailers(trailers, headersSent);
+      writeQueue.enqueue(
+          new SendResponseHeadersCommand(transportState(), http2Trailers, true), true);
+    }
+
+    @Override
+    public void cancel(Status status) {
+      writeQueue.enqueue(new CancelServerStreamCommand(transportState(), status), true);
+    }
+  }
+
+  /** This should only called from the transport thread. */
+  public static class TransportState extends AbstractServerStream.TransportState
+      implements StreamIdHolder {
+    private final Http2Stream http2Stream;
+    private final NettyServerHandler handler;
+
+    public TransportState(NettyServerHandler handler, Http2Stream http2Stream, int maxMessageSize) {
+      super(maxMessageSize);
+      this.http2Stream = checkNotNull(http2Stream, "http2Stream");
+      this.handler = checkNotNull(handler, "handler");
+    }
+
+    @Override
+    public void bytesRead(int processedBytes) {
+      handler.returnProcessedBytes(http2Stream, processedBytes);
+      handler.getWriteQueue().scheduleFlush();
+    }
+
+    @Override
+    protected void deframeFailed(Throwable cause) {
+      log.log(Level.WARNING, "Exception processing message", cause);
+      Status status = Status.fromThrowable(cause);
+      transportReportStatus(status);
+      handler.getWriteQueue().enqueue(new CancelServerStreamCommand(this, status), true);
+    }
+
+    void inboundDataReceived(ByteBuf frame, boolean endOfStream) {
+      super.inboundDataReceived(new NettyReadableBuffer(frame.retain()), endOfStream);
+    }
+
+    public Integer id() {
+      return http2Stream.id();
+    }
   }
 }

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -31,7 +31,6 @@
 
 package io.grpc.netty;
 
-import io.grpc.internal.AbstractStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;
@@ -40,11 +39,10 @@ import io.netty.buffer.DefaultByteBufHolder;
  * Command sent from the transport to the Netty channel to send a GRPC frame to the remote endpoint.
  */
 class SendGrpcFrameCommand extends DefaultByteBufHolder {
-  private final AbstractStream<Integer> stream;
+  private final StreamIdHolder stream;
   private final boolean endStream;
 
-  SendGrpcFrameCommand(AbstractStream<Integer> stream, ByteBuf content,
-      boolean endStream) {
+  SendGrpcFrameCommand(StreamIdHolder stream, ByteBuf content, boolean endStream) {
     super(content);
     this.stream = stream;
     this.endStream = endStream;

--- a/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
@@ -39,18 +39,18 @@ import io.netty.handler.codec.http2.Http2Headers;
  * Command sent from the transport to the Netty channel to send response headers to the client.
  */
 class SendResponseHeadersCommand {
-  private final int streamId;
+  private final StreamIdHolder stream;
   private final Http2Headers headers;
   private final boolean endOfStream;
 
-  SendResponseHeadersCommand(int streamId, Http2Headers headers, boolean endOfStream) {
-    this.streamId = streamId;
+  SendResponseHeadersCommand(StreamIdHolder stream, Http2Headers headers, boolean endOfStream) {
+    this.stream = Preconditions.checkNotNull(stream);
     this.headers = Preconditions.checkNotNull(headers);
     this.endOfStream = endOfStream;
   }
 
-  int streamId() {
-    return streamId;
+  StreamIdHolder stream() {
+    return stream;
   }
 
   Http2Headers headers() {
@@ -67,19 +67,19 @@ class SendResponseHeadersCommand {
       return false;
     }
     SendResponseHeadersCommand thatCmd = (SendResponseHeadersCommand) that;
-    return thatCmd.streamId == streamId
+    return thatCmd.stream.equals(stream)
         && thatCmd.headers.equals(headers)
         && thatCmd.endOfStream == endOfStream;
   }
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(streamId=" + streamId + ", headers=" + headers
+    return getClass().getSimpleName() + "(stream=" + stream.id() + ", headers=" + headers
         + ", endOfStream=" + endOfStream + ")";
   }
 
   @Override
   public int hashCode() {
-    return streamId;
+    return stream.hashCode();
   }
 }

--- a/netty/src/main/java/io/grpc/netty/StreamIdHolder.java
+++ b/netty/src/main/java/io/grpc/netty/StreamIdHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,35 +31,7 @@
 
 package io.grpc.netty;
 
-import io.grpc.internal.AbstractStream2;
-import io.grpc.internal.Stream;
-
-/**
- * Command which requests messages from the deframer.
- */
-class RequestMessagesCommand {
-
-  private final int numMessages;
-  private final Stream stream;
-  private final AbstractStream2.TransportState state;
-
-  public RequestMessagesCommand(Stream stream, int numMessages) {
-    this.state = null;
-    this.numMessages = numMessages;
-    this.stream = stream;
-  }
-
-  public RequestMessagesCommand(AbstractStream2.TransportState state, int numMessages) {
-    this.state = state;
-    this.numMessages = numMessages;
-    this.stream = null;
-  }
-
-  void requestMessages() {
-    if (stream != null) {
-      stream.request(numMessages);
-    } else {
-      state.requestMessagesFromDeframer(numMessages);
-    }
-  }
+/** Container for stream ids. */
+interface StreamIdHolder {
+  public Integer id();
 }

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -133,7 +133,8 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
     createStream();
 
     // Send a frame and verify that it was written.
-    ChannelFuture future = enqueue(new SendGrpcFrameCommand(stream, content(), false));
+    ChannelFuture future = enqueue(
+        new SendGrpcFrameCommand(stream.transportState(), content(), false));
     assertTrue(future.isSuccess());
     verifyWrite().writeData(eq(ctx()), eq(STREAM_ID), eq(content()), eq(0), eq(false),
         any(ChannelPromise.class));
@@ -275,9 +276,9 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   @Test
   public void cancelShouldSendRstStream() throws Exception {
     createStream();
-    enqueue(new CancelServerStreamCommand(stream, Status.DEADLINE_EXCEEDED));
-    verifyWrite().writeRstStream(eq(ctx()), eq(stream.id()), eq(Http2Error.CANCEL.code()),
-        any(ChannelPromise.class));
+    enqueue(new CancelServerStreamCommand(stream.transportState(), Status.DEADLINE_EXCEEDED));
+    verifyWrite().writeRstStream(eq(ctx()), eq(stream.transportState().id()),
+        eq(Http2Error.CANCEL.code()), any(ChannelPromise.class));
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/NettyStreamTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyStreamTestBase.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.grpc.internal.AbstractStream;
+import io.grpc.internal.Stream;
 import io.grpc.internal.StreamListener;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
@@ -71,7 +71,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Base class for Netty stream unit tests.
  */
-public abstract class NettyStreamTestBase<T extends AbstractStream<Integer>> {
+public abstract class NettyStreamTestBase<T extends Stream> {
   protected static final String MESSAGE = "hello world";
   protected static final int STREAM_ID = 1;
 
@@ -135,7 +135,8 @@ public abstract class NettyStreamTestBase<T extends AbstractStream<Integer>> {
     stream.request(1);
 
     if (stream instanceof NettyServerStream) {
-      ((NettyServerStream) stream).inboundDataReceived(messageFrame(MESSAGE), false);
+      ((NettyServerStream) stream).transportState()
+          .inboundDataReceived(messageFrame(MESSAGE), false);
     } else {
       ((NettyClientStream) stream).transportDataReceived(messageFrame(MESSAGE), false);
     }


### PR DESCRIPTION
Note to reviewers: You may want to start with NettyServerStream to help
give a grounding to understand the other changes.

Note also that I don't consider this to be an alternative to #1135. I feel
this PR is a stepping stone in order to do things like #1135. My main
concern during review is to avoid rabbit holing. I know there's many things
I _could_ have done and that will become more obvious due to this PR.
But I really don't want to get too side-tracked on those things and instead
focus more on whether this PR allows us to discuss and implement those
other things easier.

I know there's places that could use more docs, but I didn't feel they
were likely very necessary during initial review. I'm happy to add more
docs if it seems like the changes are well accepted. Included in that is
porting AbstractStream's tests to AbstractStream2.

--------------

This introduces an AbstractStream2 that is intended to replace the
current AbstractStream. Only server-side is implemented in this commit
which is why AbstractStream remains. This is mostly a reorganization of
AbstractStream and children, but minor internal behavioral changes were
required which makes it appear more like a reimplementation.

A strong focus was on splitting state that is maintained on the
application's thread (with Stream) and state that is maintained by the
transport (and used for StreamListener). By splitting the state it makes
it much easier to verify thread-safety and to reason about interactions.

I consider this a stepping stone for making even more changes to
simplify the Stream implementations and do not think some of the changes
are yet at their logical conclusion. Some of the changes may also
immediately be replaced with something better. The focus was to improve
readability and comprehesibility to more easily make more interesting
changes.

The only thing really removed is some state checking during sending
which is already occurring in ServerCallImpl.