### PR TITLE
Print compiler version number in generated files

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: services.proto")
 public class BenchmarkServiceGrpc {
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: services.proto")
 public class WorkerServiceGrpc {
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -75,6 +75,7 @@ model {
   binaries {
     all {
       if (toolChain in Gcc || toolChain in Clang) {
+        cppCompiler.define("GRPC_VERSION", version)
         cppCompiler.args "--std=c++0x"
         addEnvArgs("CXXFLAGS", cppCompiler.args)
         addEnvArgs("CPPFLAGS", cppCompiler.args)
@@ -95,6 +96,7 @@ model {
         }
         addEnvArgs("LDFLAGS", linker.args)
       } else if (toolChain in VisualCpp) {
+        cppCompiler.define("GRPC_VERSION", version)
         cppCompiler.args "/EHsc", "/MT"
         if (rootProject.hasProperty('vcProtobufInclude')) {
           cppCompiler.args "/I${rootProject.vcProtobufInclude}"

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -9,6 +9,15 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/zero_copy_stream.h>
 
+// Stringify helpers used solely to cast GRPC_VERSION
+#ifndef STR
+#define STR(s) #s
+#endif
+
+#ifndef XSTR
+#define XSTR(s) STR(s)
+#endif
+
 namespace java_grpc_generator {
 
 using google::protobuf::FileDescriptor;
@@ -670,10 +679,15 @@ static void PrintService(const ServiceDescriptor* service,
   (*vars)["service_name"] = service->name();
   (*vars)["file_name"] = service->file()->name();
   (*vars)["service_class_name"] = ServiceClassName(service);
+  #ifdef GRPC_VERSION
+    (*vars)["grpc_version"] = " (version " XSTR(GRPC_VERSION) ")";
+  #else
+    (*vars)["grpc_version"] = "";
+  #endif
   p->Print(
       *vars,
       "@$Generated$(\n"
-      "    value = \"by gRPC proto compiler\",\n"
+      "    value = \"by gRPC proto compiler$grpc_version$\",\n"
       "    comments = \"Source: $file_name$\")\n"
       "public class $service_class_name$ {\n\n");
   p->Indent();

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: test.proto")
 public class TestServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: test.proto")
 public class TestServiceGrpc {
 

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -16,7 +16,7 @@ import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 import java.io.IOException;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: test.proto")
 public class TestServiceGrpc {
 

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: helloworld.proto")
 public class GreeterGrpc {
 

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: route_guide.proto")
 public class RouteGuideGrpc {
 

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: load_balancer.proto")
 public class LoadBalancerGrpc {
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: io/grpc/testing/integration/test.proto")
 public class ReconnectServiceGrpc {
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: io/grpc/testing/integration/test.proto")
 public class TestServiceGrpc {
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -14,7 +14,7 @@ import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler",
+    value = "by gRPC proto compiler (version 0.14.0-SNAPSHOT)",
     comments = "Source: io/grpc/testing/integration/test.proto")
 public class UnimplementedServiceGrpc {
 


### PR DESCRIPTION
Simple addition which stamps codegen'ed stubs with version.

I find it very valuable to have such information in files. The only disadvantage is that it'll always regenerate files with new version after upgrades ¯\_(ツ)_/¯