### PR TITLE
create AuthorityOverridingTransportFactory instance only in need

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -48,7 +48,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * Creates a channel with a target string, which can be either a valid {@link
    * NameResolver}-compliant URI, or an authority string.
    *
-   * <p>A {@code NameResolver}-compliant URI is an aboslute hierarchical URI as defined by {@link
+   * <p>A {@code NameResolver}-compliant URI is an absolute hierarchical URI as defined by {@link
    * java.net.URI}. Example URIs:
    * <ul>
    *   <li>{@code "dns:///foo.googleapis.com:8080"}</li>

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -190,8 +190,8 @@ public abstract class AbstractManagedChannelImplBuilder
   public ManagedChannelImpl build() {
     ClientTransportFactory transportFactory = buildTransportFactory();
     if (authorityOverride != null) {
-      transportFactory = new AuthorityOverridingTransportFactory(transportFactory,
-        authorityOverride);
+      transportFactory = new AuthorityOverridingTransportFactory(
+        transportFactory, authorityOverride);
     }
     return new ManagedChannelImpl(
         target,
@@ -228,8 +228,9 @@ public abstract class AbstractManagedChannelImplBuilder
 
     AuthorityOverridingTransportFactory(
         ClientTransportFactory factory, String authorityOverride) {
-      this.factory = factory;
-      this.authorityOverride = Preconditions.checkNotNull(authorityOverride);
+      this.factory = Preconditions.checkNotNull(factory, "factory should not be null");
+      this.authorityOverride = Preconditions.checkNotNull(
+        authorityOverride, "authorityOverride should not be null";
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -230,7 +230,7 @@ public abstract class AbstractManagedChannelImplBuilder
         ClientTransportFactory factory, String authorityOverride) {
       this.factory = Preconditions.checkNotNull(factory, "factory should not be null");
       this.authorityOverride = Preconditions.checkNotNull(
-        authorityOverride, "authorityOverride should not be null";
+        authorityOverride, "authorityOverride should not be null");
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -31,8 +31,11 @@
 
 package io.grpc.internal;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
+
 import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
@@ -45,7 +48,6 @@ import io.grpc.NameResolverRegistry;
 import io.grpc.ResolvedServerInfo;
 import io.grpc.SimpleLoadBalancerFactory;
 
-import javax.annotation.Nullable;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -54,7 +56,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
+import javax.annotation.Nullable;
 
 /**
  * The base class for channel builders.
@@ -188,7 +190,8 @@ public abstract class AbstractManagedChannelImplBuilder
   public ManagedChannelImpl build() {
     ClientTransportFactory transportFactory = buildTransportFactory();
     if (authorityOverride != null) {
-      transportFactory = new AuthorityOverridingTransportFactory(transportFactory, authorityOverride);
+      transportFactory = new AuthorityOverridingTransportFactory(transportFactory,
+        authorityOverride);
     }
     return new ManagedChannelImpl(
         target,

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -31,11 +31,8 @@
 
 package io.grpc.internal;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
-
 import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
@@ -48,6 +45,7 @@ import io.grpc.NameResolverRegistry;
 import io.grpc.ResolvedServerInfo;
 import io.grpc.SimpleLoadBalancerFactory;
 
+import javax.annotation.Nullable;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -56,7 +54,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 
-import javax.annotation.Nullable;
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 /**
  * The base class for channel builders.
@@ -189,9 +187,8 @@ public abstract class AbstractManagedChannelImplBuilder
   @Override
   public ManagedChannelImpl build() {
     ClientTransportFactory transportFactory = buildTransportFactory();
-    if (authorityOverride != null ) {
-        transportFactory = new AuthorityOverridingTransportFactory(
-            transportFactory, authorityOverride);
+    if (authorityOverride != null) {
+      transportFactory = new AuthorityOverridingTransportFactory(transportFactory, authorityOverride);
     }
     return new ManagedChannelImpl(
         target,
@@ -224,19 +221,18 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private static class AuthorityOverridingTransportFactory implements ClientTransportFactory {
     final ClientTransportFactory factory;
-    @Nullable final String authorityOverride;
+    final String authorityOverride;
 
     AuthorityOverridingTransportFactory(
-        ClientTransportFactory factory, @Nullable String authorityOverride) {
+        ClientTransportFactory factory, String authorityOverride) {
       this.factory = factory;
-      this.authorityOverride = authorityOverride;
+      this.authorityOverride = Preconditions.checkNotNull(authorityOverride);
     }
 
     @Override
     public ManagedClientTransport newClientTransport(SocketAddress serverAddress,
         String authority) {
-      return factory.newClientTransport(
-          serverAddress, authorityOverride != null ? authorityOverride : authority);
+      return factory.newClientTransport(serverAddress, authorityOverride);
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -188,8 +188,11 @@ public abstract class AbstractManagedChannelImplBuilder
 
   @Override
   public ManagedChannelImpl build() {
-    ClientTransportFactory transportFactory = new AuthorityOverridingTransportFactory(
-        buildTransportFactory(), authorityOverride);
+    ClientTransportFactory transportFactory = buildTransportFactory();
+    if (authorityOverride != null ) {
+        transportFactory = new AuthorityOverridingTransportFactory(
+            transportFactory, authorityOverride);
+    }
     return new ManagedChannelImpl(
         target,
         // TODO(carl-mastrangelo): Allow clients to pass this in


### PR DESCRIPTION
in class AuthorityOverridingTransportFactory, we do nothing just to override the authority, and if authorityOverride is null, in fact we really do nothing in AuthorityOverridingTransportFactory.

So I suggest that we should add a null check before we new AuthorityOverridingTransportFactory instance. If authorityOverride is null, we don't need to create it, we can just use the original one returned by buildTransportFactory().

