### PR TITLE
Handle empty address list from NameResolver.

### DIFF
--- a/core/src/main/java/io/grpc/EquivalentAddressGroup.java
+++ b/core/src/main/java/io/grpc/EquivalentAddressGroup.java
@@ -31,6 +31,8 @@
 
 package io.grpc;
 
+import com.google.common.base.Preconditions;
+
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,6 +51,7 @@ public final class EquivalentAddressGroup {
   private final List<SocketAddress> addrs;
 
   public EquivalentAddressGroup(List<SocketAddress> addrs) {
+    Preconditions.checkArgument(!addrs.isEmpty(), "addrs is empty");
     this.addrs = Collections.unmodifiableList(new ArrayList<SocketAddress>(addrs));
   }
 

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -68,6 +68,9 @@ public abstract class LoadBalancer<T> {
    * Handles newly resolved addresses and service config from name resolution system.
    *
    * <p>Implementations should not modify the given {@code servers}.
+   *
+   * @param servers the resolved server addresses. Never empty.
+   * @param config extra configuration data from naming system.
    */
   public void handleResolvedAddresses(List<ResolvedServerInfo> servers, Attributes config) { }
 

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -119,6 +119,9 @@ public abstract class NameResolver {
      * Handles updates on resolved addresses and config.
      *
      * <p>Implementations will not modify the given {@code servers}.
+     *
+     * @param servers the resolved server addresses. An empty list will trigger {@link #onError}
+     * @param config extra configuration data from naming system
      */
     void onUpdate(List<ResolvedServerInfo> servers, Attributes config);
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -168,7 +168,11 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     this.nameResolver.start(new NameResolver.Listener() {
       @Override
       public void onUpdate(List<ResolvedServerInfo> servers, Attributes config) {
-        loadBalancer.handleResolvedAddresses(servers, config);
+        if (servers.isEmpty()) {
+          onError(Status.UNAVAILABLE.withDescription("NameResolver returned an empty list"));
+        } else {
+          loadBalancer.handleResolvedAddresses(servers, config);
+        }
       }
 
       @Override


### PR DESCRIPTION
Passing an empty list to NameResolver.Listener.onUpdate() will trigger
onError(). It is documented in the javadoc and enforced by
ManagedChannelImpl.

Forbid empty address list in EquivalentAddressGroup.

Resolves #1657