### PR TITLE
Rename internal.Server to internal.TransportServer

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/ByteBufOutputMarshaller.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/ByteBufOutputMarshaller.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Simple {@link MethodDescriptor.Marshaller} for Netty's {@link ByteBuf}.
+ * Simple {@link MethodDescriptor#Marshaller} for Netty's {@link ByteBuf}.
  */
 public class ByteBufOutputMarshaller implements MethodDescriptor.Marshaller<ByteBuf> {
 

--- a/core/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -31,9 +31,9 @@
 
 package io.grpc.inprocess;
 
+import io.grpc.internal.InternalServer;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerTransportListener;
-import io.grpc.internal.TransportServer;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,7 +42,7 @@ import java.util.concurrent.ConcurrentMap;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
-class InProcessServer implements TransportServer {
+class InProcessServer implements InternalServer {
   private static final ConcurrentMap<String, InProcessServer> registry
       = new ConcurrentHashMap<String, InProcessServer>();
 

--- a/core/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -31,9 +31,9 @@
 
 package io.grpc.inprocess;
 
-import io.grpc.internal.Server;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerTransportListener;
+import io.grpc.internal.TransportServer;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,7 +42,7 @@ import java.util.concurrent.ConcurrentMap;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
-class InProcessServer implements Server {
+class InProcessServer implements TransportServer {
   private static final ConcurrentMap<String, InProcessServer> registry
       = new ConcurrentHashMap<String, InProcessServer>();
 

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -138,7 +138,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
 
   @Override
   public ServerImpl build() {
-    io.grpc.internal.TransportServer transportServer = buildTransportServer();
+    io.grpc.internal.InternalServer transportServer = buildTransportServer();
     return new ServerImpl(executor, registry, transportServer, Context.ROOT,
         firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
         firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()));
@@ -150,7 +150,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
    * used by normal users.
    */
   @Internal
-  protected abstract io.grpc.internal.TransportServer buildTransportServer();
+  protected abstract io.grpc.internal.InternalServer buildTransportServer();
 
   private T thisT() {
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -138,7 +138,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
 
   @Override
   public ServerImpl build() {
-    io.grpc.internal.Server transportServer = buildTransportServer();
+    io.grpc.internal.TransportServer transportServer = buildTransportServer();
     return new ServerImpl(executor, registry, transportServer, Context.ROOT,
         firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
         firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()));
@@ -150,7 +150,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
    * used by normal users.
    */
   @Internal
-  protected abstract io.grpc.internal.Server buildTransportServer();
+  protected abstract io.grpc.internal.TransportServer buildTransportServer();
 
   private T thisT() {
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/grpc/internal/InternalServer.java
+++ b/core/src/main/java/io/grpc/internal/InternalServer.java
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * that {@code accept()}s new connections.
  */
 @ThreadSafe
-public interface TransportServer {
+public interface InternalServer {
   /**
    * Starts transport. Implementations must not call {@code listener} until after {@code start()}
    * returns. The method only returns after it has done the equivalent of bind()ing, so it will be

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -85,7 +85,7 @@ public final class ServerImpl extends io.grpc.Server {
   private boolean shutdown;
   private boolean terminated;
   /** Service encapsulating something similar to an accept() socket. */
-  private final TransportServer transportServer;
+  private final InternalServer transportServer;
   private final Object lock = new Object();
   private boolean transportServerTerminated;
   /** {@code transportServer} and services encapsulating something similar to a TCP connection. */
@@ -103,7 +103,7 @@ public final class ServerImpl extends io.grpc.Server {
    * @param executor to call methods on behalf of remote clients
    * @param registry of methods to expose to remote clients.
    */
-  ServerImpl(Executor executor, HandlerRegistry registry, TransportServer transportServer,
+  ServerImpl(Executor executor, HandlerRegistry registry, InternalServer transportServer,
       Context rootContext, DecompressorRegistry decompressorRegistry,
       CompressorRegistry compressorRegistry) {
     this.executor = executor;

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -85,7 +85,7 @@ public final class ServerImpl extends io.grpc.Server {
   private boolean shutdown;
   private boolean terminated;
   /** Service encapsulating something similar to an accept() socket. */
-  private final io.grpc.internal.Server transportServer;
+  private final TransportServer transportServer;
   private final Object lock = new Object();
   private boolean transportServerTerminated;
   /** {@code transportServer} and services encapsulating something similar to a TCP connection. */
@@ -103,7 +103,7 @@ public final class ServerImpl extends io.grpc.Server {
    * @param executor to call methods on behalf of remote clients
    * @param registry of methods to expose to remote clients.
    */
-  ServerImpl(Executor executor, HandlerRegistry registry, io.grpc.internal.Server transportServer,
+  ServerImpl(Executor executor, HandlerRegistry registry, TransportServer transportServer,
       Context rootContext, DecompressorRegistry decompressorRegistry,
       CompressorRegistry compressorRegistry) {
     this.executor = executor;

--- a/core/src/main/java/io/grpc/internal/ServerListener.java
+++ b/core/src/main/java/io/grpc/internal/ServerListener.java
@@ -47,7 +47,7 @@ public interface ServerListener {
 
   /**
    * The server is shutting down. No new transports will be processed, but existing transports may
-   * continue. Shutdown is only caused by a call to {@link TransportServer#shutdown()}. All
+   * continue. Shutdown is only caused by a call to {@link InternalServer#shutdown()}. All
    * resources have been released.
    */
   void serverShutdown();

--- a/core/src/main/java/io/grpc/internal/ServerListener.java
+++ b/core/src/main/java/io/grpc/internal/ServerListener.java
@@ -47,8 +47,8 @@ public interface ServerListener {
 
   /**
    * The server is shutting down. No new transports will be processed, but existing transports may
-   * continue. Shutdown is only caused by a call to {@link Server#shutdown()}. All resources have
-   * been released.
+   * continue. Shutdown is only caused by a call to {@link TransportServer#shutdown()}. All
+   * resources have been released.
    */
   void serverShutdown();
 }

--- a/core/src/main/java/io/grpc/internal/TransportServer.java
+++ b/core/src/main/java/io/grpc/internal/TransportServer.java
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * that {@code accept()}s new connections.
  */
 @ThreadSafe
-public interface Server {
+public interface TransportServer {
   /**
    * Starts transport. Implementations must not call {@code listener} until after {@code start()}
    * returns. The method only returns after it has done the equivalent of bind()ing, so it will be

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -32,7 +32,7 @@
 package io.grpc.inprocess;
 
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.Server;
+import io.grpc.internal.TransportServer;
 import io.grpc.internal.testing.AbstractTransportTest;
 
 import org.junit.runner.RunWith;
@@ -44,7 +44,7 @@ public class InProcessTransportTest extends AbstractTransportTest {
   private static final String transportName = "perfect-for-testing";
 
   @Override
-  protected Server newServer() {
+  protected TransportServer newServer() {
     return new InProcessServer(transportName);
   }
 

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -31,8 +31,8 @@
 
 package io.grpc.inprocess;
 
+import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.TransportServer;
 import io.grpc.internal.testing.AbstractTransportTest;
 
 import org.junit.runner.RunWith;
@@ -44,7 +44,7 @@ public class InProcessTransportTest extends AbstractTransportTest {
   private static final String transportName = "perfect-for-testing";
 
   @Override
-  protected TransportServer newServer() {
+  protected InternalServer newServer() {
     return new InProcessServer(transportName);
   }
 

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -576,7 +576,7 @@ public class ServerImplTest {
     return barrier;
   }
 
-  private static class SimpleServer implements io.grpc.internal.TransportServer {
+  private static class SimpleServer implements io.grpc.internal.InternalServer {
     ServerListener listener;
 
     @Override

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -576,7 +576,7 @@ public class ServerImplTest {
     return barrier;
   }
 
-  private static class SimpleServer implements io.grpc.internal.Server {
+  private static class SimpleServer implements io.grpc.internal.TransportServer {
     ServerListener listener;
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -35,9 +35,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.netty.channel.ChannelOption.SO_BACKLOG;
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 
-import io.grpc.internal.Server;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.SharedResourceHolder;
+import io.grpc.internal.TransportServer;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -60,8 +60,8 @@ import javax.annotation.Nullable;
 /**
  * Netty-based server implementation.
  */
-class NettyServer implements Server {
-  private static final Logger log = Logger.getLogger(Server.class.getName());
+class NettyServer implements TransportServer {
+  private static final Logger log = Logger.getLogger(TransportServer.class.getName());
 
   private final SocketAddress address;
   private final Class<? extends ServerChannel> channelType;

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -35,9 +35,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.netty.channel.ChannelOption.SO_BACKLOG;
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 
+import io.grpc.internal.InternalServer;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.SharedResourceHolder;
-import io.grpc.internal.TransportServer;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -60,8 +60,8 @@ import javax.annotation.Nullable;
 /**
  * Netty-based server implementation.
  */
-class NettyServer implements TransportServer {
-  private static final Logger log = Logger.getLogger(TransportServer.class.getName());
+class NettyServer implements InternalServer {
+  private static final Logger log = Logger.getLogger(InternalServer.class.getName());
 
   private final SocketAddress address;
   private final Class<? extends ServerChannel> channelType;

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -33,7 +33,7 @@ package io.grpc.netty;
 
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.Server;
+import io.grpc.internal.TransportServer;
 import io.grpc.internal.testing.AbstractTransportTest;
 import io.grpc.testing.TestUtils;
 
@@ -65,7 +65,7 @@ public class NettyTransportTest extends AbstractTransportTest {
   }
 
   @Override
-  protected Server newServer() {
+  protected TransportServer newServer() {
     return NettyServerBuilder
         .forPort(SERVER_PORT)
         .flowControlWindow(65 * 1024)

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -32,8 +32,8 @@
 package io.grpc.netty;
 
 import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.TransportServer;
 import io.grpc.internal.testing.AbstractTransportTest;
 import io.grpc.testing.TestUtils;
 
@@ -65,7 +65,7 @@ public class NettyTransportTest extends AbstractTransportTest {
   }
 
   @Override
-  protected TransportServer newServer() {
+  protected InternalServer newServer() {
     return NettyServerBuilder
         .forPort(SERVER_PORT)
         .flowControlWindow(65 * 1024)

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -58,13 +58,13 @@ import io.grpc.Status;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
+import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.ServerTransport;
 import io.grpc.internal.ServerTransportListener;
-import io.grpc.internal.TransportServer;
 
 import org.junit.After;
 import org.junit.Before;
@@ -99,7 +99,7 @@ public abstract class AbstractTransportTest {
    * returned instance should be new and yet be accessible by new client transports. This
    * effectively means that each instance should listen on the same port, or similar.
    */
-  protected abstract TransportServer newServer();
+  protected abstract InternalServer newServer();
 
   /**
    * Returns a new transport that when started will be able to connect to the server.
@@ -111,7 +111,7 @@ public abstract class AbstractTransportTest {
    * {@code serverListener}, otherwise tearDown() can't wait for shutdown which can put following
    * tests in an indeterminate state.
    */
-  private TransportServer server;
+  private InternalServer server;
   private ServerTransport serverTransport;
   private ManagedClientTransport client;
   private MethodDescriptor<String, String> methodDescriptor = MethodDescriptor.create(
@@ -215,7 +215,7 @@ public abstract class AbstractTransportTest {
   public void serverAlreadyListening() throws Exception {
     client = null;
     server.start(serverListener);
-    TransportServer server2 = newServer();
+    InternalServer server2 = newServer();
     thrown.expect(IOException.class);
     server2.start(new MockServerListener());
   }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -59,12 +59,12 @@ import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.Server;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.ServerTransport;
 import io.grpc.internal.ServerTransportListener;
+import io.grpc.internal.TransportServer;
 
 import org.junit.After;
 import org.junit.Before;
@@ -99,7 +99,7 @@ public abstract class AbstractTransportTest {
    * returned instance should be new and yet be accessible by new client transports. This
    * effectively means that each instance should listen on the same port, or similar.
    */
-  protected abstract Server newServer();
+  protected abstract TransportServer newServer();
 
   /**
    * Returns a new transport that when started will be able to connect to the server.
@@ -111,7 +111,7 @@ public abstract class AbstractTransportTest {
    * {@code serverListener}, otherwise tearDown() can't wait for shutdown which can put following
    * tests in an indeterminate state.
    */
-  private Server server;
+  private TransportServer server;
   private ServerTransport serverTransport;
   private ManagedClientTransport client;
   private MethodDescriptor<String, String> methodDescriptor = MethodDescriptor.create(
@@ -215,7 +215,7 @@ public abstract class AbstractTransportTest {
   public void serverAlreadyListening() throws Exception {
     client = null;
     server.start(serverListener);
-    Server server2 = newServer();
+    TransportServer server2 = newServer();
     thrown.expect(IOException.class);
     server2.start(new MockServerListener());
   }


### PR DESCRIPTION
Searching for Server often brings up two (the internal, and external version).  Rename the internal to not conflict.