### PR TITLE
Don't allocate extra byte for each MessageFramer

### DIFF
--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -331,14 +331,21 @@ public class MessageFramer {
    * {@link OutputStream}.
    */
   private final class BufferChainOutputStream extends OutputStream {
-
-    private final byte[] singleByte = new byte[1];
     private final List<WritableBuffer> bufferList = new ArrayList<WritableBuffer>();
     private WritableBuffer current;
 
+    /**
+     * This is slow, don't call it.  If you care about write overhead, use a BufferedOutputStream.
+     * Better yet, you can use your own single byte buffer and called
+     * {@link #write(byte[], int, int)}.
+     */
     @Override
-    public void write(int b) {
-      singleByte[0] = (byte) b;
+    public void write(int b) throws IOException {
+      if (current != null && current.writableBytes() > 0) {
+        current.write((byte)b);
+        return;
+      }
+      byte[] singleByte = new byte[]{(byte)b};
       write(singleByte, 0, 1);
     }
 

--- a/core/src/main/java/io/grpc/internal/WritableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/WritableBuffer.java
@@ -51,6 +51,11 @@ public interface WritableBuffer {
   void write(byte[] src, int srcIndex, int length);
 
   /**
+   * Appends a single byte to the buffer.  This is slow so don't call it.
+   */
+  void write(byte b);
+
+  /**
    * Returns the number of bytes one can write to the buffer.
    */
   int writableBytes();

--- a/core/src/test/java/io/grpc/internal/MessageFramerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageFramerTest.java
@@ -371,6 +371,11 @@ public class MessageFramerTest {
     }
 
     @Override
+    public void write(byte b) {
+      data[writeIdx++] = b;
+    }
+
+    @Override
     public int writableBytes() {
       return data.length - writeIdx;
     }

--- a/netty/src/main/java/io/grpc/netty/NettyWritableBuffer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyWritableBuffer.java
@@ -51,6 +51,11 @@ class NettyWritableBuffer implements WritableBuffer {
   }
 
   @Override
+  public void write(byte b) {
+    bytebuf.writeByte(b);
+  }
+
+  @Override
   public int writableBytes() {
     return bytebuf.writableBytes();
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpWritableBuffer.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpWritableBuffer.java
@@ -32,6 +32,7 @@
 package io.grpc.okhttp;
 
 import io.grpc.internal.WritableBuffer;
+
 import okio.Buffer;
 
 class OkHttpWritableBuffer implements WritableBuffer {
@@ -50,6 +51,13 @@ class OkHttpWritableBuffer implements WritableBuffer {
     buffer.write(src, srcIndex, length);
     writableBytes -= length;
     readableBytes += length;
+  }
+
+  @Override
+  public void write(byte b) {
+    buffer.writeByte(b);
+    writableBytes -= 1;
+    readableBytes += 1;
   }
 
   @Override


### PR DESCRIPTION
Addresses #1675 

This is overall slower if the single byte write method is invoked, but we don't expect that to be common case.  