### PR TITLE
Attach an exception to client-initiated CANCELLED.

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -62,6 +62,7 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 
 import java.io.InputStream;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -312,7 +313,8 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
       // Cancel is called in exception handling cases, so it may be the case that the
       // stream was never successfully created.
       if (stream != null) {
-        stream.cancel(Status.CANCELLED);
+        stream.cancel(Status.CANCELLED.withCause(
+            new CancellationException("Client requested cancellation")));
       }
     } finally {
       if (context != null) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -349,7 +349,8 @@ public abstract class AbstractInteropTest {
     requestObserver.onError(new RuntimeException());
     responseObserver.awaitCompletion();
     assertEquals(Arrays.<StreamingInputCallResponse>asList(), responseObserver.getValues());
-    assertEquals(Status.CANCELLED, Status.fromThrowable(responseObserver.getError()));
+    assertEquals(Status.Code.CANCELLED,
+        Status.fromThrowable(responseObserver.getError()).getCode());
   }
 
   @Test(timeout = 10000)
@@ -377,7 +378,7 @@ public abstract class AbstractInteropTest {
     requestObserver.onError(new RuntimeException());
     ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
     verify(responseObserver, timeout(OPERATION_TIMEOUT)).onError(captor.capture());
-    assertEquals(Status.CANCELLED, Status.fromThrowable(captor.getValue()));
+    assertEquals(Status.Code.CANCELLED, Status.fromThrowable(captor.getValue()).getCode());
     verifyNoMoreInteractions(responseObserver);
   }
 


### PR DESCRIPTION
This tells us where is the cancellation initiated, which is important
information for debugging.

Resolves #1589 