### PR TITLE
Allow passing a message to ClientCall.cancel().

### DIFF
--- a/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
+++ b/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
@@ -182,12 +182,12 @@ public class ClientAuthInterceptorTests {
     interceptedCall = interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
     interceptedCall.start(listener, new Metadata());
     verify(credentials).getRequestMetadata(URI.create("https://example.com/a.service"));
-    interceptedCall.cancel();
+    interceptedCall.cancel("Cancel for test");
 
     doReturn("example.com:123").when(channel).authority();
     interceptedCall = interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
     interceptedCall.start(listener, new Metadata());
     verify(credentials).getRequestMetadata(URI.create("https://example.com:123/a.service"));
-    interceptedCall.cancel();
+    interceptedCall.cancel("Cancel for test");
   }
 }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
@@ -513,7 +513,7 @@ class LoadClient {
             call.sendMessage(genericRequest.slice());
             now = System.nanoTime();
             if (shutdown) {
-              call.cancel();
+              call.cancel("Shutting down");
             }
           }
 

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -157,15 +157,29 @@ public abstract class ClientCall<ReqT, RespT> {
   public abstract void request(int numMessages);
 
   /**
+   * Equivalent as {@code cancel(String)} without passing any useful information.
+   *
+   * @deprecated Use or override {@link #cancel(String)} instead. See
+   *             https://github.com/grpc/grpc-java/issues/1221
+   */
+  @Deprecated
+  public void cancel() {
+    cancel("Cancelled by ClientCall.cancel()");
+  }
+
+  /**
    * Prevent any further processing for this {@code ClientCall}. No further messages may be sent or
    * will be received. The server is informed of cancellations, but may not stop processing the
    * call. Cancellation is permitted if previously {@link #halfClose}d. Cancelling an already {@code
    * cancel()}ed {@code ClientCall} has no effect.
    *
-   *
    * <p>No other methods on this class can be called after this method has been called.
+   *
+   * @param message will appear in the description of the CANCELLED status
    */
-  public abstract void cancel();
+  public void cancel(String message) {
+    throw new UnsupportedOperationException(getClass() + " should implement this method");
+  }
 
   /**
    * Close the call for request message sending. Incoming response messages are unaffected.  This

--- a/core/src/main/java/io/grpc/ClientInterceptors.java
+++ b/core/src/main/java/io/grpc/ClientInterceptors.java
@@ -134,7 +134,7 @@ public class ClientInterceptors {
     public void request(int numMessages) {}
 
     @Override
-    public void cancel() {}
+    public void cancel(String message) {}
 
     @Override
     public void halfClose() {}

--- a/core/src/main/java/io/grpc/ForwardingClientCall.java
+++ b/core/src/main/java/io/grpc/ForwardingClientCall.java
@@ -51,8 +51,8 @@ public abstract class ForwardingClientCall<ReqT, RespT> extends ClientCall<ReqT,
   }
 
   @Override
-  public void cancel() {
-    delegate().cancel();
+  public void cancel(String message) {
+    delegate().cancel(message);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -62,7 +62,6 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 
 import java.io.InputStream;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -304,7 +303,8 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
   }
 
   @Override
-  public void cancel() {
+  public void cancel(String message) {
+    Preconditions.checkArgument(message != null, "cancellation message is null");
     if (cancelCalled) {
       return;
     }
@@ -313,8 +313,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
       // Cancel is called in exception handling cases, so it may be the case that the
       // stream was never successfully created.
       if (stream != null) {
-        stream.cancel(Status.CANCELLED.withCause(
-            new CancellationException("Client requested cancellation")));
+        stream.cancel(Status.CANCELLED.withDescription("Client initiated cancel: " + message));
       }
     } finally {
       if (context != null) {

--- a/core/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -399,7 +399,7 @@ public class ClientInterceptorsTest {
     // Make sure nothing bad happens after the exception.
     ClientCall<?, ?> noop = ((CheckedForwardingClientCall<?, ?>)interceptedCall).delegate();
     // Should not throw, even on bad input
-    noop.cancel();
+    noop.cancel("Cancel in test");
     noop.start(null, null);
     noop.request(-1);
     noop.halfClose();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -289,7 +289,7 @@ public class ManagedChannelImplTest {
     ClientStream mockStream = mock(ClientStream.class);
     when(mockTransport.newStream(same(method), same(headers))).thenReturn(mockStream);
     call.start(mockCallListener, headers);
-    call.cancel();
+    call.cancel("Cancel in test");
 
     verify(mockTransport, timeout(1000)).start(transportListenerCaptor.capture());
     final ManagedClientTransport.Listener transportListener = transportListenerCaptor.getValue();

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -113,7 +113,7 @@ public class ClientCalls {
     try {
       return getUnchecked(futureUnaryCall(call, param));
     } catch (Throwable t) {
-      call.cancel();
+      call.cancel(t.toString());
       throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
     }
   }
@@ -139,7 +139,7 @@ public class ClientCalls {
       }
       return getUnchecked(responseFuture);
     } catch (Throwable t) {
-      call.cancel();
+      call.cancel(t.toString());
       throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
     }
   }
@@ -226,7 +226,7 @@ public class ClientCalls {
       call.sendMessage(param);
       call.halfClose();
     } catch (Throwable t) {
-      call.cancel();
+      call.cancel(t.toString());
       throw t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t);
     }
   }
@@ -265,8 +265,7 @@ public class ClientCalls {
 
     @Override
     public void onError(Throwable t) {
-      // TODO(ejona86): log?
-      call.cancel();
+      call.cancel("Cancelled by client with StreamObserver.onError():" + t);
     }
 
     @Override
@@ -368,7 +367,7 @@ public class ClientCalls {
 
     @Override
     protected void interruptTask() {
-      call.cancel();
+      call.cancel("GrpcFuture was cancelled");
     }
 
     @Override

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -34,6 +34,7 @@ package io.grpc.stub;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -101,7 +102,7 @@ public class ClientCallsTest {
     verify(call).start(listenerCaptor.capture(), any(Metadata.class));
     ClientCall.Listener<String> listener = listenerCaptor.getValue();
     future.cancel(true);
-    verify(call).cancel();
+    verify(call).cancel(eq("GrpcFuture was cancelled"));
     listener.onMessage("bar");
     listener.onClose(Status.OK, new Metadata());
     try {


### PR DESCRIPTION
Alternative to #1714
Resolves #1221, based on its latest comment.