### PR TITLE
Ability to create unregistered in-process channels for a server

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -61,6 +61,10 @@ class InProcessServer implements InternalServer {
   @Override
   public void start(ServerListener serverListener) throws IOException {
     this.listener = serverListener;
+    if (name == null) {
+      // anonymous
+      return;
+    }
     // Must be last, as channels can start connecting after this point.
     if (registry.putIfAbsent(name, this) != null) {
       throw new IOException("name already registered: " + name);
@@ -74,8 +78,10 @@ class InProcessServer implements InternalServer {
 
   @Override
   public void shutdown() {
-    if (!registry.remove(name, this)) {
-      throw new AssertionError();
+    if (name != null) {
+      if (!registry.remove(name, this)) {
+        throw new AssertionError();
+      }
     }
     synchronized (this) {
       shutdown = true;

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -138,7 +138,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
 
   @Override
   public ServerImpl build() {
-    io.grpc.internal.InternalServer transportServer = buildTransportServer();
+    InternalServer transportServer = buildTransportServer();
     return new ServerImpl(executor, registry, transportServer, Context.ROOT,
         firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
         firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()));
@@ -150,7 +150,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
    * used by normal users.
    */
   @Internal
-  protected abstract io.grpc.internal.InternalServer buildTransportServer();
+  protected abstract InternalServer buildTransportServer();
 
   private T thisT() {
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -67,7 +67,9 @@ import java.util.concurrent.TimeUnit;
  * <pre><code>public class TcpTransportServerFactory {
  *   public static Server newServer(Executor executor, HandlerRegistry registry,
  *       String configuration) {
- *     return new ServerImpl(executor, registry, new TcpTransportServer(configuration));
+ *     return new ServerImpl(executor, registry, new TcpTransportServer(configuration),
+ *         Context.ROOT, DecompressorRegistry.getDefaultInstance(),
+ *         CompressorRegistry.getDefaultInstance());
  *   }
  * }</code></pre>
  *
@@ -146,6 +148,26 @@ public final class ServerImpl extends io.grpc.Server {
       checkState(!terminated, "Already terminated");
       return transportServer.getPort();
     }
+  }
+
+  public InternalServer internalServer() {
+    return transportServer;
+  }
+
+  public Executor executor() {
+    return executor;
+  }
+
+  public CompressorRegistry compressorRegistry() {
+    return compressorRegistry;
+  }
+
+  public DecompressorRegistry decompressorRegistry() {
+    return decompressorRegistry;
+  }
+
+  public HandlerRegistry handlerRegistry() {
+    return registry;
   }
 
   /**

--- a/core/src/test/java/io/grpc/inprocess/InProcessChannelTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessChannelTest.java
@@ -1,0 +1,88 @@
+package io.grpc.inprocess;
+
+import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StringMarshaller;
+import io.grpc.internal.ManagedChannelImpl;
+import io.grpc.internal.ServerImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JUnit4.class)
+public class InProcessChannelTest {
+  @Test public void anonymousChannel() throws Exception {
+    // Create simple server with one endpoint
+    MethodDescriptor<String, String> unaryMethod =
+        MethodDescriptor.create(MethodType.UNARY, "FooService/Unary",
+            new StringMarshaller(), new StringMarshaller());
+    ServerImpl server = InProcessServerBuilder.forName("doesn't matter")
+        .addService(
+            ServerServiceDefinition.builder("FooService").addMethod(unaryMethod,
+                new ServerCallHandler<String, String>() {
+                  // Call handler simply reverses the request string
+                  @Override
+                  public Listener<String> startCall(MethodDescriptor<String, String> method,
+                      final ServerCall<String> call, Metadata headers) {
+                    call.request(2);
+                    return new Listener<String>() {
+                      @Override public void onMessage(String message) {
+                        call.sendHeaders(new Metadata());
+                        StringBuilder sb = new StringBuilder(message);
+                        sb.reverse();
+                        call.sendMessage(sb.toString());
+                        call.close(Status.OK, new Metadata());
+                      }
+                    };
+                  }
+                })
+            .build())
+        .build();
+
+    // Anonymous in-process channel to the server
+    ManagedChannelImpl channel = InProcessChannelBuilder.anonymousChannelTo(server).build();
+
+    // Try out a call
+    try {
+      ClientCall<String, String> call = channel.newCall(unaryMethod, CallOptions.DEFAULT);
+      final SettableFuture<String> result = SettableFuture.create();
+      call.start(new ClientCall.Listener<String>() {
+        private String response;
+
+        @Override public void onMessage(String message) {
+          this.response = message;
+        }
+
+        @Override public void onClose(Status status, Metadata trailers) {
+          if (status.getCode() == Code.OK) {
+            result.set(response);
+          } else {
+            result.setException(status.asException());
+          }
+        }
+      }, new Metadata());
+      call.sendMessage("abcdefg");
+      call.halfClose();
+      call.request(2);
+
+      String response = result.get();
+      assertEquals("gfedcba", response);
+
+    } finally {
+      channel.shutdown();
+      server.shutdown();
+    }
+  }
+}


### PR DESCRIPTION
@ejona86 

Curious for your thoughts on this. The only new public API is the `InProcessChannelBuilder#anonymousChannelTo(ServerImpl)`.

But I had to also add some public accessors to `ServerImpl`.

The idea is that I already have a server (e.g. one that is listening on a socket) and I just want to create an alternate (in-process) channel to it. I think this addresses #658 as you can just create an in-process server and then a channel connecting to it. Though for... reasons... it ends up creating a second server object and starting it. This doesn't look like it has any material/controversial side effects (at least not right now), but it is admittedly ugly.

I played around with a few different APIs and alternate implementations for this and couldn't find any that I was really happy with.

Another idea I had -- maybe better than what's in this branch right now -- was to require that the `ServerImpl` passed to the new method on `InProcessChannelBuilder` actually be an in-process server (e.g. `assert server.internalServer() instanceof InProcessServer;`). I could get away with exposing fewer accessors on `ServerImpl` that way I think and not need to start the server implicitly. But part of me really likes how boiler-plate-free this current version can be for sharing the same server definition between both a socket transport and in-process transport.

Aside: given the nature of how the messages are exchanged in-memory, I thought about changing both the `InProcessChannelBuilder` and the `InProcessServerBuilder` so that they never actually use compressors/decompressors. Is there something I'm missing there? It seems that otherwise, we can incur unnecessary serialization+compression/deserialization+decompression work.

cc: @lukaszx0 