### PR TITLE
Update proto packages to reflect directory structure

### DIFF
--- a/android-interop-testing/app/src/main/proto/io/grpc/android/integrationtest/messages.proto
+++ b/android-interop-testing/app/src/main/proto/io/grpc/android/integrationtest/messages.proto
@@ -32,7 +32,7 @@
 
 syntax = "proto3";
 
-package grpc.testing;
+package grpc.testing.androidintegration;
 
 option java_package = "io.grpc.android.integrationtest";
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -24,7 +24,7 @@ public class BenchmarkServiceGrpc {
 
   private BenchmarkServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.BenchmarkService";
+  public static final String SERVICE_NAME = "grpc.benchmarks.BenchmarkService";
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi
@@ -33,7 +33,7 @@ public class BenchmarkServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
-              "grpc.testing.BenchmarkService", "UnaryCall"),
+              "grpc.benchmarks.BenchmarkService", "UnaryCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -42,7 +42,7 @@ public class BenchmarkServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
-              "grpc.testing.BenchmarkService", "StreamingCall"),
+              "grpc.benchmarks.BenchmarkService", "StreamingCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()));
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -24,7 +24,7 @@ public class WorkerServiceGrpc {
 
   private WorkerServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.WorkerService";
+  public static final String SERVICE_NAME = "grpc.benchmarks.WorkerService";
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi
@@ -33,7 +33,7 @@ public class WorkerServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
-              "grpc.testing.WorkerService", "RunServer"),
+              "grpc.benchmarks.WorkerService", "RunServer"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Control.ServerArgs.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Control.ServerStatus.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -42,7 +42,7 @@ public class WorkerServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
-              "grpc.testing.WorkerService", "RunClient"),
+              "grpc.benchmarks.WorkerService", "RunClient"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Control.ClientArgs.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Control.ClientStatus.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -51,7 +51,7 @@ public class WorkerServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
-              "grpc.testing.WorkerService", "CoreCount"),
+              "grpc.benchmarks.WorkerService", "CoreCount"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Control.CoreRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Control.CoreResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -60,7 +60,7 @@ public class WorkerServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
-              "grpc.testing.WorkerService", "QuitWorker"),
+              "grpc.benchmarks.WorkerService", "QuitWorker"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()));
 

--- a/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Control.java
+++ b/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Control.java
@@ -9,7 +9,7 @@ public final class Control {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   /**
-   * Protobuf enum {@code grpc.testing.ClientType}
+   * Protobuf enum {@code grpc.benchmarks.ClientType}
    */
   public enum ClientType
       implements com.google.protobuf.ProtocolMessageEnum {
@@ -97,11 +97,11 @@ public final class Control {
       this.value = value;
     }
 
-    // @@protoc_insertion_point(enum_scope:grpc.testing.ClientType)
+    // @@protoc_insertion_point(enum_scope:grpc.benchmarks.ClientType)
   }
 
   /**
-   * Protobuf enum {@code grpc.testing.ServerType}
+   * Protobuf enum {@code grpc.benchmarks.ServerType}
    */
   public enum ServerType
       implements com.google.protobuf.ProtocolMessageEnum {
@@ -198,11 +198,11 @@ public final class Control {
       this.value = value;
     }
 
-    // @@protoc_insertion_point(enum_scope:grpc.testing.ServerType)
+    // @@protoc_insertion_point(enum_scope:grpc.benchmarks.ServerType)
   }
 
   /**
-   * Protobuf enum {@code grpc.testing.RpcType}
+   * Protobuf enum {@code grpc.benchmarks.RpcType}
    */
   public enum RpcType
       implements com.google.protobuf.ProtocolMessageEnum {
@@ -290,11 +290,11 @@ public final class Control {
       this.value = value;
     }
 
-    // @@protoc_insertion_point(enum_scope:grpc.testing.RpcType)
+    // @@protoc_insertion_point(enum_scope:grpc.benchmarks.RpcType)
   }
 
   public interface PoissonParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.PoissonParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.PoissonParams)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -307,7 +307,7 @@ public final class Control {
     double getOfferedLoad();
   }
   /**
-   * Protobuf type {@code grpc.testing.PoissonParams}
+   * Protobuf type {@code grpc.benchmarks.PoissonParams}
    *
    * <pre>
    * Parameters of poisson process distribution, which is a good representation
@@ -316,7 +316,7 @@ public final class Control {
    */
   public  static final class PoissonParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.PoissonParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.PoissonParams)
       PoissonParamsOrBuilder {
     // Use PoissonParams.newBuilder() to construct.
     private PoissonParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -369,12 +369,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_PoissonParams_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_PoissonParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_PoissonParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_PoissonParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.PoissonParams.class, io.grpc.benchmarks.proto.Control.PoissonParams.Builder.class);
     }
@@ -495,7 +495,7 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.PoissonParams}
+     * Protobuf type {@code grpc.benchmarks.PoissonParams}
      *
      * <pre>
      * Parameters of poisson process distribution, which is a good representation
@@ -504,16 +504,16 @@ public final class Control {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.PoissonParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.PoissonParams)
         io.grpc.benchmarks.proto.Control.PoissonParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_PoissonParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_PoissonParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_PoissonParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_PoissonParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.PoissonParams.class, io.grpc.benchmarks.proto.Control.PoissonParams.Builder.class);
       }
@@ -541,7 +541,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_PoissonParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_PoissonParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.PoissonParams getDefaultInstanceForType() {
@@ -651,10 +651,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.PoissonParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.PoissonParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.PoissonParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.PoissonParams)
     private static final io.grpc.benchmarks.proto.Control.PoissonParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.PoissonParams();
@@ -699,7 +699,7 @@ public final class Control {
   }
 
   public interface UniformParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.UniformParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.UniformParams)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -713,11 +713,11 @@ public final class Control {
     double getInterarrivalHi();
   }
   /**
-   * Protobuf type {@code grpc.testing.UniformParams}
+   * Protobuf type {@code grpc.benchmarks.UniformParams}
    */
   public  static final class UniformParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.UniformParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.UniformParams)
       UniformParamsOrBuilder {
     // Use UniformParams.newBuilder() to construct.
     private UniformParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -776,12 +776,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_UniformParams_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_UniformParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_UniformParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_UniformParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.UniformParams.class, io.grpc.benchmarks.proto.Control.UniformParams.Builder.class);
     }
@@ -914,20 +914,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.UniformParams}
+     * Protobuf type {@code grpc.benchmarks.UniformParams}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.UniformParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.UniformParams)
         io.grpc.benchmarks.proto.Control.UniformParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_UniformParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_UniformParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_UniformParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_UniformParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.UniformParams.class, io.grpc.benchmarks.proto.Control.UniformParams.Builder.class);
       }
@@ -957,7 +957,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_UniformParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_UniformParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.UniformParams getDefaultInstanceForType() {
@@ -1085,10 +1085,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.UniformParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.UniformParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.UniformParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.UniformParams)
     private static final io.grpc.benchmarks.proto.Control.UniformParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.UniformParams();
@@ -1133,7 +1133,7 @@ public final class Control {
   }
 
   public interface DeterministicParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.DeterministicParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.DeterministicParams)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -1142,11 +1142,11 @@ public final class Control {
     double getOfferedLoad();
   }
   /**
-   * Protobuf type {@code grpc.testing.DeterministicParams}
+   * Protobuf type {@code grpc.benchmarks.DeterministicParams}
    */
   public  static final class DeterministicParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.DeterministicParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.DeterministicParams)
       DeterministicParamsOrBuilder {
     // Use DeterministicParams.newBuilder() to construct.
     private DeterministicParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -1199,12 +1199,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_DeterministicParams_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_DeterministicParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_DeterministicParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_DeterministicParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.DeterministicParams.class, io.grpc.benchmarks.proto.Control.DeterministicParams.Builder.class);
     }
@@ -1321,20 +1321,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.DeterministicParams}
+     * Protobuf type {@code grpc.benchmarks.DeterministicParams}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.DeterministicParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.DeterministicParams)
         io.grpc.benchmarks.proto.Control.DeterministicParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_DeterministicParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_DeterministicParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_DeterministicParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_DeterministicParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.DeterministicParams.class, io.grpc.benchmarks.proto.Control.DeterministicParams.Builder.class);
       }
@@ -1362,7 +1362,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_DeterministicParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_DeterministicParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.DeterministicParams getDefaultInstanceForType() {
@@ -1460,10 +1460,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.DeterministicParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.DeterministicParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.DeterministicParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.DeterministicParams)
     private static final io.grpc.benchmarks.proto.Control.DeterministicParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.DeterministicParams();
@@ -1508,7 +1508,7 @@ public final class Control {
   }
 
   public interface ParetoParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ParetoParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ParetoParams)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -1522,11 +1522,11 @@ public final class Control {
     double getAlpha();
   }
   /**
-   * Protobuf type {@code grpc.testing.ParetoParams}
+   * Protobuf type {@code grpc.benchmarks.ParetoParams}
    */
   public  static final class ParetoParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ParetoParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ParetoParams)
       ParetoParamsOrBuilder {
     // Use ParetoParams.newBuilder() to construct.
     private ParetoParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -1585,12 +1585,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ParetoParams_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ParetoParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ParetoParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ParetoParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.ParetoParams.class, io.grpc.benchmarks.proto.Control.ParetoParams.Builder.class);
     }
@@ -1723,20 +1723,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ParetoParams}
+     * Protobuf type {@code grpc.benchmarks.ParetoParams}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ParetoParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ParetoParams)
         io.grpc.benchmarks.proto.Control.ParetoParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ParetoParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ParetoParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ParetoParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ParetoParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.ParetoParams.class, io.grpc.benchmarks.proto.Control.ParetoParams.Builder.class);
       }
@@ -1766,7 +1766,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ParetoParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ParetoParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.ParetoParams getDefaultInstanceForType() {
@@ -1894,10 +1894,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ParetoParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ParetoParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ParetoParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ParetoParams)
     private static final io.grpc.benchmarks.proto.Control.ParetoParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.ParetoParams();
@@ -1942,11 +1942,11 @@ public final class Control {
   }
 
   public interface ClosedLoopParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ClosedLoopParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ClosedLoopParams)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code grpc.testing.ClosedLoopParams}
+   * Protobuf type {@code grpc.benchmarks.ClosedLoopParams}
    *
    * <pre>
    * Once an RPC finishes, immediately start a new one.
@@ -1955,7 +1955,7 @@ public final class Control {
    */
   public  static final class ClosedLoopParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ClosedLoopParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ClosedLoopParams)
       ClosedLoopParamsOrBuilder {
     // Use ClosedLoopParams.newBuilder() to construct.
     private ClosedLoopParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -2001,12 +2001,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClosedLoopParams_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClosedLoopParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClosedLoopParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClosedLoopParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.ClosedLoopParams.class, io.grpc.benchmarks.proto.Control.ClosedLoopParams.Builder.class);
     }
@@ -2107,7 +2107,7 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ClosedLoopParams}
+     * Protobuf type {@code grpc.benchmarks.ClosedLoopParams}
      *
      * <pre>
      * Once an RPC finishes, immediately start a new one.
@@ -2116,16 +2116,16 @@ public final class Control {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ClosedLoopParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ClosedLoopParams)
         io.grpc.benchmarks.proto.Control.ClosedLoopParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClosedLoopParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClosedLoopParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClosedLoopParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClosedLoopParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.ClosedLoopParams.class, io.grpc.benchmarks.proto.Control.ClosedLoopParams.Builder.class);
       }
@@ -2151,7 +2151,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClosedLoopParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClosedLoopParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.ClosedLoopParams getDefaultInstanceForType() {
@@ -2219,10 +2219,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ClosedLoopParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ClosedLoopParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ClosedLoopParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ClosedLoopParams)
     private static final io.grpc.benchmarks.proto.Control.ClosedLoopParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.ClosedLoopParams();
@@ -2267,62 +2267,62 @@ public final class Control {
   }
 
   public interface LoadParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.LoadParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.LoadParams)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+     * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
      */
     io.grpc.benchmarks.proto.Control.ClosedLoopParams getClosedLoop();
     /**
-     * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+     * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
      */
     io.grpc.benchmarks.proto.Control.ClosedLoopParamsOrBuilder getClosedLoopOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+     * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
      */
     io.grpc.benchmarks.proto.Control.PoissonParams getPoisson();
     /**
-     * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+     * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
      */
     io.grpc.benchmarks.proto.Control.PoissonParamsOrBuilder getPoissonOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+     * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
      */
     io.grpc.benchmarks.proto.Control.UniformParams getUniform();
     /**
-     * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+     * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
      */
     io.grpc.benchmarks.proto.Control.UniformParamsOrBuilder getUniformOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+     * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
      */
     io.grpc.benchmarks.proto.Control.DeterministicParams getDeterm();
     /**
-     * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+     * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
      */
     io.grpc.benchmarks.proto.Control.DeterministicParamsOrBuilder getDetermOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+     * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
      */
     io.grpc.benchmarks.proto.Control.ParetoParams getPareto();
     /**
-     * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+     * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
      */
     io.grpc.benchmarks.proto.Control.ParetoParamsOrBuilder getParetoOrBuilder();
 
     public io.grpc.benchmarks.proto.Control.LoadParams.LoadCase getLoadCase();
   }
   /**
-   * Protobuf type {@code grpc.testing.LoadParams}
+   * Protobuf type {@code grpc.benchmarks.LoadParams}
    */
   public  static final class LoadParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.LoadParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.LoadParams)
       LoadParamsOrBuilder {
     // Use LoadParams.newBuilder() to construct.
     private LoadParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -2439,12 +2439,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_LoadParams_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_LoadParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_LoadParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_LoadParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.LoadParams.class, io.grpc.benchmarks.proto.Control.LoadParams.Builder.class);
     }
@@ -2488,7 +2488,7 @@ public final class Control {
 
     public static final int CLOSED_LOOP_FIELD_NUMBER = 1;
     /**
-     * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+     * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
      */
     public io.grpc.benchmarks.proto.Control.ClosedLoopParams getClosedLoop() {
       if (loadCase_ == 1) {
@@ -2497,7 +2497,7 @@ public final class Control {
       return io.grpc.benchmarks.proto.Control.ClosedLoopParams.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+     * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
      */
     public io.grpc.benchmarks.proto.Control.ClosedLoopParamsOrBuilder getClosedLoopOrBuilder() {
       if (loadCase_ == 1) {
@@ -2508,7 +2508,7 @@ public final class Control {
 
     public static final int POISSON_FIELD_NUMBER = 2;
     /**
-     * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+     * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
      */
     public io.grpc.benchmarks.proto.Control.PoissonParams getPoisson() {
       if (loadCase_ == 2) {
@@ -2517,7 +2517,7 @@ public final class Control {
       return io.grpc.benchmarks.proto.Control.PoissonParams.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+     * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
      */
     public io.grpc.benchmarks.proto.Control.PoissonParamsOrBuilder getPoissonOrBuilder() {
       if (loadCase_ == 2) {
@@ -2528,7 +2528,7 @@ public final class Control {
 
     public static final int UNIFORM_FIELD_NUMBER = 3;
     /**
-     * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+     * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
      */
     public io.grpc.benchmarks.proto.Control.UniformParams getUniform() {
       if (loadCase_ == 3) {
@@ -2537,7 +2537,7 @@ public final class Control {
       return io.grpc.benchmarks.proto.Control.UniformParams.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+     * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
      */
     public io.grpc.benchmarks.proto.Control.UniformParamsOrBuilder getUniformOrBuilder() {
       if (loadCase_ == 3) {
@@ -2548,7 +2548,7 @@ public final class Control {
 
     public static final int DETERM_FIELD_NUMBER = 4;
     /**
-     * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+     * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
      */
     public io.grpc.benchmarks.proto.Control.DeterministicParams getDeterm() {
       if (loadCase_ == 4) {
@@ -2557,7 +2557,7 @@ public final class Control {
       return io.grpc.benchmarks.proto.Control.DeterministicParams.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+     * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
      */
     public io.grpc.benchmarks.proto.Control.DeterministicParamsOrBuilder getDetermOrBuilder() {
       if (loadCase_ == 4) {
@@ -2568,7 +2568,7 @@ public final class Control {
 
     public static final int PARETO_FIELD_NUMBER = 5;
     /**
-     * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+     * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
      */
     public io.grpc.benchmarks.proto.Control.ParetoParams getPareto() {
       if (loadCase_ == 5) {
@@ -2577,7 +2577,7 @@ public final class Control {
       return io.grpc.benchmarks.proto.Control.ParetoParams.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+     * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
      */
     public io.grpc.benchmarks.proto.Control.ParetoParamsOrBuilder getParetoOrBuilder() {
       if (loadCase_ == 5) {
@@ -2717,20 +2717,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.LoadParams}
+     * Protobuf type {@code grpc.benchmarks.LoadParams}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.LoadParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.LoadParams)
         io.grpc.benchmarks.proto.Control.LoadParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_LoadParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_LoadParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_LoadParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_LoadParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.LoadParams.class, io.grpc.benchmarks.proto.Control.LoadParams.Builder.class);
       }
@@ -2758,7 +2758,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_LoadParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_LoadParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.LoadParams getDefaultInstanceForType() {
@@ -2895,7 +2895,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.ClosedLoopParams, io.grpc.benchmarks.proto.Control.ClosedLoopParams.Builder, io.grpc.benchmarks.proto.Control.ClosedLoopParamsOrBuilder> closedLoopBuilder_;
       /**
-       * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+       * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ClosedLoopParams getClosedLoop() {
         if (closedLoopBuilder_ == null) {
@@ -2911,7 +2911,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+       * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
        */
       public Builder setClosedLoop(io.grpc.benchmarks.proto.Control.ClosedLoopParams value) {
         if (closedLoopBuilder_ == null) {
@@ -2927,7 +2927,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+       * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
        */
       public Builder setClosedLoop(
           io.grpc.benchmarks.proto.Control.ClosedLoopParams.Builder builderForValue) {
@@ -2941,7 +2941,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+       * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
        */
       public Builder mergeClosedLoop(io.grpc.benchmarks.proto.Control.ClosedLoopParams value) {
         if (closedLoopBuilder_ == null) {
@@ -2963,7 +2963,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+       * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
        */
       public Builder clearClosedLoop() {
         if (closedLoopBuilder_ == null) {
@@ -2982,13 +2982,13 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+       * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ClosedLoopParams.Builder getClosedLoopBuilder() {
         return getClosedLoopFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+       * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ClosedLoopParamsOrBuilder getClosedLoopOrBuilder() {
         if ((loadCase_ == 1) && (closedLoopBuilder_ != null)) {
@@ -3001,7 +3001,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ClosedLoopParams closed_loop = 1;</code>
+       * <code>optional .grpc.benchmarks.ClosedLoopParams closed_loop = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.ClosedLoopParams, io.grpc.benchmarks.proto.Control.ClosedLoopParams.Builder, io.grpc.benchmarks.proto.Control.ClosedLoopParamsOrBuilder> 
@@ -3025,7 +3025,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.PoissonParams, io.grpc.benchmarks.proto.Control.PoissonParams.Builder, io.grpc.benchmarks.proto.Control.PoissonParamsOrBuilder> poissonBuilder_;
       /**
-       * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+       * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.PoissonParams getPoisson() {
         if (poissonBuilder_ == null) {
@@ -3041,7 +3041,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+       * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
        */
       public Builder setPoisson(io.grpc.benchmarks.proto.Control.PoissonParams value) {
         if (poissonBuilder_ == null) {
@@ -3057,7 +3057,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+       * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
        */
       public Builder setPoisson(
           io.grpc.benchmarks.proto.Control.PoissonParams.Builder builderForValue) {
@@ -3071,7 +3071,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+       * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
        */
       public Builder mergePoisson(io.grpc.benchmarks.proto.Control.PoissonParams value) {
         if (poissonBuilder_ == null) {
@@ -3093,7 +3093,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+       * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
        */
       public Builder clearPoisson() {
         if (poissonBuilder_ == null) {
@@ -3112,13 +3112,13 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+       * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.PoissonParams.Builder getPoissonBuilder() {
         return getPoissonFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+       * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.PoissonParamsOrBuilder getPoissonOrBuilder() {
         if ((loadCase_ == 2) && (poissonBuilder_ != null)) {
@@ -3131,7 +3131,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.PoissonParams poisson = 2;</code>
+       * <code>optional .grpc.benchmarks.PoissonParams poisson = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.PoissonParams, io.grpc.benchmarks.proto.Control.PoissonParams.Builder, io.grpc.benchmarks.proto.Control.PoissonParamsOrBuilder> 
@@ -3155,7 +3155,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.UniformParams, io.grpc.benchmarks.proto.Control.UniformParams.Builder, io.grpc.benchmarks.proto.Control.UniformParamsOrBuilder> uniformBuilder_;
       /**
-       * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+       * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
        */
       public io.grpc.benchmarks.proto.Control.UniformParams getUniform() {
         if (uniformBuilder_ == null) {
@@ -3171,7 +3171,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+       * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
        */
       public Builder setUniform(io.grpc.benchmarks.proto.Control.UniformParams value) {
         if (uniformBuilder_ == null) {
@@ -3187,7 +3187,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+       * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
        */
       public Builder setUniform(
           io.grpc.benchmarks.proto.Control.UniformParams.Builder builderForValue) {
@@ -3201,7 +3201,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+       * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
        */
       public Builder mergeUniform(io.grpc.benchmarks.proto.Control.UniformParams value) {
         if (uniformBuilder_ == null) {
@@ -3223,7 +3223,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+       * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
        */
       public Builder clearUniform() {
         if (uniformBuilder_ == null) {
@@ -3242,13 +3242,13 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+       * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
        */
       public io.grpc.benchmarks.proto.Control.UniformParams.Builder getUniformBuilder() {
         return getUniformFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+       * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
        */
       public io.grpc.benchmarks.proto.Control.UniformParamsOrBuilder getUniformOrBuilder() {
         if ((loadCase_ == 3) && (uniformBuilder_ != null)) {
@@ -3261,7 +3261,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.UniformParams uniform = 3;</code>
+       * <code>optional .grpc.benchmarks.UniformParams uniform = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.UniformParams, io.grpc.benchmarks.proto.Control.UniformParams.Builder, io.grpc.benchmarks.proto.Control.UniformParamsOrBuilder> 
@@ -3285,7 +3285,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.DeterministicParams, io.grpc.benchmarks.proto.Control.DeterministicParams.Builder, io.grpc.benchmarks.proto.Control.DeterministicParamsOrBuilder> determBuilder_;
       /**
-       * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+       * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
        */
       public io.grpc.benchmarks.proto.Control.DeterministicParams getDeterm() {
         if (determBuilder_ == null) {
@@ -3301,7 +3301,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+       * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
        */
       public Builder setDeterm(io.grpc.benchmarks.proto.Control.DeterministicParams value) {
         if (determBuilder_ == null) {
@@ -3317,7 +3317,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+       * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
        */
       public Builder setDeterm(
           io.grpc.benchmarks.proto.Control.DeterministicParams.Builder builderForValue) {
@@ -3331,7 +3331,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+       * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
        */
       public Builder mergeDeterm(io.grpc.benchmarks.proto.Control.DeterministicParams value) {
         if (determBuilder_ == null) {
@@ -3353,7 +3353,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+       * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
        */
       public Builder clearDeterm() {
         if (determBuilder_ == null) {
@@ -3372,13 +3372,13 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+       * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
        */
       public io.grpc.benchmarks.proto.Control.DeterministicParams.Builder getDetermBuilder() {
         return getDetermFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+       * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
        */
       public io.grpc.benchmarks.proto.Control.DeterministicParamsOrBuilder getDetermOrBuilder() {
         if ((loadCase_ == 4) && (determBuilder_ != null)) {
@@ -3391,7 +3391,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.DeterministicParams determ = 4;</code>
+       * <code>optional .grpc.benchmarks.DeterministicParams determ = 4;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.DeterministicParams, io.grpc.benchmarks.proto.Control.DeterministicParams.Builder, io.grpc.benchmarks.proto.Control.DeterministicParamsOrBuilder> 
@@ -3415,7 +3415,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.ParetoParams, io.grpc.benchmarks.proto.Control.ParetoParams.Builder, io.grpc.benchmarks.proto.Control.ParetoParamsOrBuilder> paretoBuilder_;
       /**
-       * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+       * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
        */
       public io.grpc.benchmarks.proto.Control.ParetoParams getPareto() {
         if (paretoBuilder_ == null) {
@@ -3431,7 +3431,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+       * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
        */
       public Builder setPareto(io.grpc.benchmarks.proto.Control.ParetoParams value) {
         if (paretoBuilder_ == null) {
@@ -3447,7 +3447,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+       * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
        */
       public Builder setPareto(
           io.grpc.benchmarks.proto.Control.ParetoParams.Builder builderForValue) {
@@ -3461,7 +3461,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+       * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
        */
       public Builder mergePareto(io.grpc.benchmarks.proto.Control.ParetoParams value) {
         if (paretoBuilder_ == null) {
@@ -3483,7 +3483,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+       * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
        */
       public Builder clearPareto() {
         if (paretoBuilder_ == null) {
@@ -3502,13 +3502,13 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+       * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
        */
       public io.grpc.benchmarks.proto.Control.ParetoParams.Builder getParetoBuilder() {
         return getParetoFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+       * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
        */
       public io.grpc.benchmarks.proto.Control.ParetoParamsOrBuilder getParetoOrBuilder() {
         if ((loadCase_ == 5) && (paretoBuilder_ != null)) {
@@ -3521,7 +3521,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ParetoParams pareto = 5;</code>
+       * <code>optional .grpc.benchmarks.ParetoParams pareto = 5;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.ParetoParams, io.grpc.benchmarks.proto.Control.ParetoParams.Builder, io.grpc.benchmarks.proto.Control.ParetoParamsOrBuilder> 
@@ -3552,10 +3552,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.LoadParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.LoadParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.LoadParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.LoadParams)
     private static final io.grpc.benchmarks.proto.Control.LoadParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.LoadParams();
@@ -3600,7 +3600,7 @@ public final class Control {
   }
 
   public interface SecurityParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.SecurityParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.SecurityParams)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -3619,7 +3619,7 @@ public final class Control {
         getServerHostOverrideBytes();
   }
   /**
-   * Protobuf type {@code grpc.testing.SecurityParams}
+   * Protobuf type {@code grpc.benchmarks.SecurityParams}
    *
    * <pre>
    * presence of SecurityParams implies use of TLS
@@ -3627,7 +3627,7 @@ public final class Control {
    */
   public  static final class SecurityParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.SecurityParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.SecurityParams)
       SecurityParamsOrBuilder {
     // Use SecurityParams.newBuilder() to construct.
     private SecurityParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -3687,12 +3687,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_SecurityParams_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_SecurityParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_SecurityParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_SecurityParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.SecurityParams.class, io.grpc.benchmarks.proto.Control.SecurityParams.Builder.class);
     }
@@ -3849,7 +3849,7 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.SecurityParams}
+     * Protobuf type {@code grpc.benchmarks.SecurityParams}
      *
      * <pre>
      * presence of SecurityParams implies use of TLS
@@ -3857,16 +3857,16 @@ public final class Control {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.SecurityParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.SecurityParams)
         io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_SecurityParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_SecurityParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_SecurityParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_SecurityParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.SecurityParams.class, io.grpc.benchmarks.proto.Control.SecurityParams.Builder.class);
       }
@@ -3896,7 +3896,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_SecurityParams_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_SecurityParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.SecurityParams getDefaultInstanceForType() {
@@ -4068,10 +4068,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.SecurityParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.SecurityParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.SecurityParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.SecurityParams)
     private static final io.grpc.benchmarks.proto.Control.SecurityParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.SecurityParams();
@@ -4116,7 +4116,7 @@ public final class Control {
   }
 
   public interface ClientConfigOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ClientConfig)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ClientConfig)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -4155,24 +4155,24 @@ public final class Control {
         getServerTargetsBytes(int index);
 
     /**
-     * <code>optional .grpc.testing.ClientType client_type = 2;</code>
+     * <code>optional .grpc.benchmarks.ClientType client_type = 2;</code>
      */
     int getClientTypeValue();
     /**
-     * <code>optional .grpc.testing.ClientType client_type = 2;</code>
+     * <code>optional .grpc.benchmarks.ClientType client_type = 2;</code>
      */
     io.grpc.benchmarks.proto.Control.ClientType getClientType();
 
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
      */
     boolean hasSecurityParams();
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
      */
     io.grpc.benchmarks.proto.Control.SecurityParams getSecurityParams();
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
      */
     io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder getSecurityParamsOrBuilder();
 
@@ -4206,16 +4206,16 @@ public final class Control {
     int getAsyncClientThreads();
 
     /**
-     * <code>optional .grpc.testing.RpcType rpc_type = 8;</code>
+     * <code>optional .grpc.benchmarks.RpcType rpc_type = 8;</code>
      */
     int getRpcTypeValue();
     /**
-     * <code>optional .grpc.testing.RpcType rpc_type = 8;</code>
+     * <code>optional .grpc.benchmarks.RpcType rpc_type = 8;</code>
      */
     io.grpc.benchmarks.proto.Control.RpcType getRpcType();
 
     /**
-     * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+     * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
      *
      * <pre>
      * The requested load for the entire client (aggregated over all the threads).
@@ -4223,7 +4223,7 @@ public final class Control {
      */
     boolean hasLoadParams();
     /**
-     * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+     * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
      *
      * <pre>
      * The requested load for the entire client (aggregated over all the threads).
@@ -4231,7 +4231,7 @@ public final class Control {
      */
     io.grpc.benchmarks.proto.Control.LoadParams getLoadParams();
     /**
-     * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+     * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
      *
      * <pre>
      * The requested load for the entire client (aggregated over all the threads).
@@ -4240,28 +4240,28 @@ public final class Control {
     io.grpc.benchmarks.proto.Control.LoadParamsOrBuilder getLoadParamsOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
      */
     boolean hasPayloadConfig();
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
      */
     io.grpc.benchmarks.proto.Payloads.PayloadConfig getPayloadConfig();
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
      */
     io.grpc.benchmarks.proto.Payloads.PayloadConfigOrBuilder getPayloadConfigOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+     * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
      */
     boolean hasHistogramParams();
     /**
-     * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+     * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
      */
     io.grpc.benchmarks.proto.Stats.HistogramParams getHistogramParams();
     /**
-     * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+     * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
      */
     io.grpc.benchmarks.proto.Stats.HistogramParamsOrBuilder getHistogramParamsOrBuilder();
 
@@ -4296,11 +4296,11 @@ public final class Control {
     int getCoreLimit();
   }
   /**
-   * Protobuf type {@code grpc.testing.ClientConfig}
+   * Protobuf type {@code grpc.benchmarks.ClientConfig}
    */
   public  static final class ClientConfig extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ClientConfig)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ClientConfig)
       ClientConfigOrBuilder {
     // Use ClientConfig.newBuilder() to construct.
     private ClientConfig(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -4475,12 +4475,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientConfig_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientConfig_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientConfig_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientConfig_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.ClientConfig.class, io.grpc.benchmarks.proto.Control.ClientConfig.Builder.class);
     }
@@ -4534,13 +4534,13 @@ public final class Control {
     public static final int CLIENT_TYPE_FIELD_NUMBER = 2;
     private int clientType_;
     /**
-     * <code>optional .grpc.testing.ClientType client_type = 2;</code>
+     * <code>optional .grpc.benchmarks.ClientType client_type = 2;</code>
      */
     public int getClientTypeValue() {
       return clientType_;
     }
     /**
-     * <code>optional .grpc.testing.ClientType client_type = 2;</code>
+     * <code>optional .grpc.benchmarks.ClientType client_type = 2;</code>
      */
     public io.grpc.benchmarks.proto.Control.ClientType getClientType() {
       io.grpc.benchmarks.proto.Control.ClientType result = io.grpc.benchmarks.proto.Control.ClientType.valueOf(clientType_);
@@ -4550,19 +4550,19 @@ public final class Control {
     public static final int SECURITY_PARAMS_FIELD_NUMBER = 3;
     private io.grpc.benchmarks.proto.Control.SecurityParams securityParams_;
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
      */
     public boolean hasSecurityParams() {
       return securityParams_ != null;
     }
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
      */
     public io.grpc.benchmarks.proto.Control.SecurityParams getSecurityParams() {
       return securityParams_ == null ? io.grpc.benchmarks.proto.Control.SecurityParams.getDefaultInstance() : securityParams_;
     }
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
      */
     public io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder getSecurityParamsOrBuilder() {
       return getSecurityParams();
@@ -4612,13 +4612,13 @@ public final class Control {
     public static final int RPC_TYPE_FIELD_NUMBER = 8;
     private int rpcType_;
     /**
-     * <code>optional .grpc.testing.RpcType rpc_type = 8;</code>
+     * <code>optional .grpc.benchmarks.RpcType rpc_type = 8;</code>
      */
     public int getRpcTypeValue() {
       return rpcType_;
     }
     /**
-     * <code>optional .grpc.testing.RpcType rpc_type = 8;</code>
+     * <code>optional .grpc.benchmarks.RpcType rpc_type = 8;</code>
      */
     public io.grpc.benchmarks.proto.Control.RpcType getRpcType() {
       io.grpc.benchmarks.proto.Control.RpcType result = io.grpc.benchmarks.proto.Control.RpcType.valueOf(rpcType_);
@@ -4628,7 +4628,7 @@ public final class Control {
     public static final int LOAD_PARAMS_FIELD_NUMBER = 10;
     private io.grpc.benchmarks.proto.Control.LoadParams loadParams_;
     /**
-     * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+     * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
      *
      * <pre>
      * The requested load for the entire client (aggregated over all the threads).
@@ -4638,7 +4638,7 @@ public final class Control {
       return loadParams_ != null;
     }
     /**
-     * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+     * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
      *
      * <pre>
      * The requested load for the entire client (aggregated over all the threads).
@@ -4648,7 +4648,7 @@ public final class Control {
       return loadParams_ == null ? io.grpc.benchmarks.proto.Control.LoadParams.getDefaultInstance() : loadParams_;
     }
     /**
-     * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+     * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
      *
      * <pre>
      * The requested load for the entire client (aggregated over all the threads).
@@ -4661,19 +4661,19 @@ public final class Control {
     public static final int PAYLOAD_CONFIG_FIELD_NUMBER = 11;
     private io.grpc.benchmarks.proto.Payloads.PayloadConfig payloadConfig_;
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
      */
     public boolean hasPayloadConfig() {
       return payloadConfig_ != null;
     }
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
      */
     public io.grpc.benchmarks.proto.Payloads.PayloadConfig getPayloadConfig() {
       return payloadConfig_ == null ? io.grpc.benchmarks.proto.Payloads.PayloadConfig.getDefaultInstance() : payloadConfig_;
     }
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
      */
     public io.grpc.benchmarks.proto.Payloads.PayloadConfigOrBuilder getPayloadConfigOrBuilder() {
       return getPayloadConfig();
@@ -4682,19 +4682,19 @@ public final class Control {
     public static final int HISTOGRAM_PARAMS_FIELD_NUMBER = 12;
     private io.grpc.benchmarks.proto.Stats.HistogramParams histogramParams_;
     /**
-     * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+     * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
      */
     public boolean hasHistogramParams() {
       return histogramParams_ != null;
     }
     /**
-     * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+     * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
      */
     public io.grpc.benchmarks.proto.Stats.HistogramParams getHistogramParams() {
       return histogramParams_ == null ? io.grpc.benchmarks.proto.Stats.HistogramParams.getDefaultInstance() : histogramParams_;
     }
     /**
-     * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+     * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
      */
     public io.grpc.benchmarks.proto.Stats.HistogramParamsOrBuilder getHistogramParamsOrBuilder() {
       return getHistogramParams();
@@ -4943,20 +4943,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ClientConfig}
+     * Protobuf type {@code grpc.benchmarks.ClientConfig}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ClientConfig)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ClientConfig)
         io.grpc.benchmarks.proto.Control.ClientConfigOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientConfig_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientConfig_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientConfig_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientConfig_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.ClientConfig.class, io.grpc.benchmarks.proto.Control.ClientConfig.Builder.class);
       }
@@ -5022,7 +5022,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientConfig_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientConfig_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.ClientConfig getDefaultInstanceForType() {
@@ -5302,13 +5302,13 @@ public final class Control {
 
       private int clientType_ = 0;
       /**
-       * <code>optional .grpc.testing.ClientType client_type = 2;</code>
+       * <code>optional .grpc.benchmarks.ClientType client_type = 2;</code>
        */
       public int getClientTypeValue() {
         return clientType_;
       }
       /**
-       * <code>optional .grpc.testing.ClientType client_type = 2;</code>
+       * <code>optional .grpc.benchmarks.ClientType client_type = 2;</code>
        */
       public Builder setClientTypeValue(int value) {
         clientType_ = value;
@@ -5316,14 +5316,14 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientType client_type = 2;</code>
+       * <code>optional .grpc.benchmarks.ClientType client_type = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.ClientType getClientType() {
         io.grpc.benchmarks.proto.Control.ClientType result = io.grpc.benchmarks.proto.Control.ClientType.valueOf(clientType_);
         return result == null ? io.grpc.benchmarks.proto.Control.ClientType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.ClientType client_type = 2;</code>
+       * <code>optional .grpc.benchmarks.ClientType client_type = 2;</code>
        */
       public Builder setClientType(io.grpc.benchmarks.proto.Control.ClientType value) {
         if (value == null) {
@@ -5335,7 +5335,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientType client_type = 2;</code>
+       * <code>optional .grpc.benchmarks.ClientType client_type = 2;</code>
        */
       public Builder clearClientType() {
         
@@ -5348,13 +5348,13 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.SecurityParams, io.grpc.benchmarks.proto.Control.SecurityParams.Builder, io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder> securityParamsBuilder_;
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
        */
       public boolean hasSecurityParams() {
         return securityParamsBuilder_ != null || securityParams_ != null;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
        */
       public io.grpc.benchmarks.proto.Control.SecurityParams getSecurityParams() {
         if (securityParamsBuilder_ == null) {
@@ -5364,7 +5364,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
        */
       public Builder setSecurityParams(io.grpc.benchmarks.proto.Control.SecurityParams value) {
         if (securityParamsBuilder_ == null) {
@@ -5380,7 +5380,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
        */
       public Builder setSecurityParams(
           io.grpc.benchmarks.proto.Control.SecurityParams.Builder builderForValue) {
@@ -5394,7 +5394,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
        */
       public Builder mergeSecurityParams(io.grpc.benchmarks.proto.Control.SecurityParams value) {
         if (securityParamsBuilder_ == null) {
@@ -5412,7 +5412,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
        */
       public Builder clearSecurityParams() {
         if (securityParamsBuilder_ == null) {
@@ -5426,7 +5426,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
        */
       public io.grpc.benchmarks.proto.Control.SecurityParams.Builder getSecurityParamsBuilder() {
         
@@ -5434,7 +5434,7 @@ public final class Control {
         return getSecurityParamsFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
        */
       public io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder getSecurityParamsOrBuilder() {
         if (securityParamsBuilder_ != null) {
@@ -5445,7 +5445,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 3;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.SecurityParams, io.grpc.benchmarks.proto.Control.SecurityParams.Builder, io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder> 
@@ -5583,13 +5583,13 @@ public final class Control {
 
       private int rpcType_ = 0;
       /**
-       * <code>optional .grpc.testing.RpcType rpc_type = 8;</code>
+       * <code>optional .grpc.benchmarks.RpcType rpc_type = 8;</code>
        */
       public int getRpcTypeValue() {
         return rpcType_;
       }
       /**
-       * <code>optional .grpc.testing.RpcType rpc_type = 8;</code>
+       * <code>optional .grpc.benchmarks.RpcType rpc_type = 8;</code>
        */
       public Builder setRpcTypeValue(int value) {
         rpcType_ = value;
@@ -5597,14 +5597,14 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.RpcType rpc_type = 8;</code>
+       * <code>optional .grpc.benchmarks.RpcType rpc_type = 8;</code>
        */
       public io.grpc.benchmarks.proto.Control.RpcType getRpcType() {
         io.grpc.benchmarks.proto.Control.RpcType result = io.grpc.benchmarks.proto.Control.RpcType.valueOf(rpcType_);
         return result == null ? io.grpc.benchmarks.proto.Control.RpcType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.RpcType rpc_type = 8;</code>
+       * <code>optional .grpc.benchmarks.RpcType rpc_type = 8;</code>
        */
       public Builder setRpcType(io.grpc.benchmarks.proto.Control.RpcType value) {
         if (value == null) {
@@ -5616,7 +5616,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.RpcType rpc_type = 8;</code>
+       * <code>optional .grpc.benchmarks.RpcType rpc_type = 8;</code>
        */
       public Builder clearRpcType() {
         
@@ -5629,7 +5629,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.LoadParams, io.grpc.benchmarks.proto.Control.LoadParams.Builder, io.grpc.benchmarks.proto.Control.LoadParamsOrBuilder> loadParamsBuilder_;
       /**
-       * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+       * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
        *
        * <pre>
        * The requested load for the entire client (aggregated over all the threads).
@@ -5639,7 +5639,7 @@ public final class Control {
         return loadParamsBuilder_ != null || loadParams_ != null;
       }
       /**
-       * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+       * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
        *
        * <pre>
        * The requested load for the entire client (aggregated over all the threads).
@@ -5653,7 +5653,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+       * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
        *
        * <pre>
        * The requested load for the entire client (aggregated over all the threads).
@@ -5673,7 +5673,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+       * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
        *
        * <pre>
        * The requested load for the entire client (aggregated over all the threads).
@@ -5691,7 +5691,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+       * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
        *
        * <pre>
        * The requested load for the entire client (aggregated over all the threads).
@@ -5713,7 +5713,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+       * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
        *
        * <pre>
        * The requested load for the entire client (aggregated over all the threads).
@@ -5731,7 +5731,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+       * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
        *
        * <pre>
        * The requested load for the entire client (aggregated over all the threads).
@@ -5743,7 +5743,7 @@ public final class Control {
         return getLoadParamsFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+       * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
        *
        * <pre>
        * The requested load for the entire client (aggregated over all the threads).
@@ -5758,7 +5758,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.LoadParams load_params = 10;</code>
+       * <code>optional .grpc.benchmarks.LoadParams load_params = 10;</code>
        *
        * <pre>
        * The requested load for the entire client (aggregated over all the threads).
@@ -5782,13 +5782,13 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Payloads.PayloadConfig, io.grpc.benchmarks.proto.Payloads.PayloadConfig.Builder, io.grpc.benchmarks.proto.Payloads.PayloadConfigOrBuilder> payloadConfigBuilder_;
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
        */
       public boolean hasPayloadConfig() {
         return payloadConfigBuilder_ != null || payloadConfig_ != null;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.PayloadConfig getPayloadConfig() {
         if (payloadConfigBuilder_ == null) {
@@ -5798,7 +5798,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
        */
       public Builder setPayloadConfig(io.grpc.benchmarks.proto.Payloads.PayloadConfig value) {
         if (payloadConfigBuilder_ == null) {
@@ -5814,7 +5814,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
        */
       public Builder setPayloadConfig(
           io.grpc.benchmarks.proto.Payloads.PayloadConfig.Builder builderForValue) {
@@ -5828,7 +5828,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
        */
       public Builder mergePayloadConfig(io.grpc.benchmarks.proto.Payloads.PayloadConfig value) {
         if (payloadConfigBuilder_ == null) {
@@ -5846,7 +5846,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
        */
       public Builder clearPayloadConfig() {
         if (payloadConfigBuilder_ == null) {
@@ -5860,7 +5860,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.PayloadConfig.Builder getPayloadConfigBuilder() {
         
@@ -5868,7 +5868,7 @@ public final class Control {
         return getPayloadConfigFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.PayloadConfigOrBuilder getPayloadConfigOrBuilder() {
         if (payloadConfigBuilder_ != null) {
@@ -5879,7 +5879,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 11;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 11;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Payloads.PayloadConfig, io.grpc.benchmarks.proto.Payloads.PayloadConfig.Builder, io.grpc.benchmarks.proto.Payloads.PayloadConfigOrBuilder> 
@@ -5899,13 +5899,13 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Stats.HistogramParams, io.grpc.benchmarks.proto.Stats.HistogramParams.Builder, io.grpc.benchmarks.proto.Stats.HistogramParamsOrBuilder> histogramParamsBuilder_;
       /**
-       * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+       * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
        */
       public boolean hasHistogramParams() {
         return histogramParamsBuilder_ != null || histogramParams_ != null;
       }
       /**
-       * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+       * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
        */
       public io.grpc.benchmarks.proto.Stats.HistogramParams getHistogramParams() {
         if (histogramParamsBuilder_ == null) {
@@ -5915,7 +5915,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+       * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
        */
       public Builder setHistogramParams(io.grpc.benchmarks.proto.Stats.HistogramParams value) {
         if (histogramParamsBuilder_ == null) {
@@ -5931,7 +5931,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+       * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
        */
       public Builder setHistogramParams(
           io.grpc.benchmarks.proto.Stats.HistogramParams.Builder builderForValue) {
@@ -5945,7 +5945,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+       * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
        */
       public Builder mergeHistogramParams(io.grpc.benchmarks.proto.Stats.HistogramParams value) {
         if (histogramParamsBuilder_ == null) {
@@ -5963,7 +5963,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+       * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
        */
       public Builder clearHistogramParams() {
         if (histogramParamsBuilder_ == null) {
@@ -5977,7 +5977,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+       * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
        */
       public io.grpc.benchmarks.proto.Stats.HistogramParams.Builder getHistogramParamsBuilder() {
         
@@ -5985,7 +5985,7 @@ public final class Control {
         return getHistogramParamsFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+       * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
        */
       public io.grpc.benchmarks.proto.Stats.HistogramParamsOrBuilder getHistogramParamsOrBuilder() {
         if (histogramParamsBuilder_ != null) {
@@ -5996,7 +5996,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.HistogramParams histogram_params = 12;</code>
+       * <code>optional .grpc.benchmarks.HistogramParams histogram_params = 12;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Stats.HistogramParams, io.grpc.benchmarks.proto.Stats.HistogramParams.Builder, io.grpc.benchmarks.proto.Stats.HistogramParamsOrBuilder> 
@@ -6142,10 +6142,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ClientConfig)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ClientConfig)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ClientConfig)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ClientConfig)
     private static final io.grpc.benchmarks.proto.Control.ClientConfig DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.ClientConfig();
@@ -6190,28 +6190,28 @@ public final class Control {
   }
 
   public interface ClientStatusOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ClientStatus)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ClientStatus)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
      */
     boolean hasStats();
     /**
-     * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
      */
     io.grpc.benchmarks.proto.Stats.ClientStats getStats();
     /**
-     * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
      */
     io.grpc.benchmarks.proto.Stats.ClientStatsOrBuilder getStatsOrBuilder();
   }
   /**
-   * Protobuf type {@code grpc.testing.ClientStatus}
+   * Protobuf type {@code grpc.benchmarks.ClientStatus}
    */
   public  static final class ClientStatus extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ClientStatus)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ClientStatus)
       ClientStatusOrBuilder {
     // Use ClientStatus.newBuilder() to construct.
     private ClientStatus(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -6271,12 +6271,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientStatus_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientStatus_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientStatus_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientStatus_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.ClientStatus.class, io.grpc.benchmarks.proto.Control.ClientStatus.Builder.class);
     }
@@ -6284,19 +6284,19 @@ public final class Control {
     public static final int STATS_FIELD_NUMBER = 1;
     private io.grpc.benchmarks.proto.Stats.ClientStats stats_;
     /**
-     * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
      */
     public boolean hasStats() {
       return stats_ != null;
     }
     /**
-     * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
      */
     public io.grpc.benchmarks.proto.Stats.ClientStats getStats() {
       return stats_ == null ? io.grpc.benchmarks.proto.Stats.ClientStats.getDefaultInstance() : stats_;
     }
     /**
-     * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
      */
     public io.grpc.benchmarks.proto.Stats.ClientStatsOrBuilder getStatsOrBuilder() {
       return getStats();
@@ -6405,20 +6405,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ClientStatus}
+     * Protobuf type {@code grpc.benchmarks.ClientStatus}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ClientStatus)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ClientStatus)
         io.grpc.benchmarks.proto.Control.ClientStatusOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientStatus_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientStatus_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientStatus_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientStatus_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.ClientStatus.class, io.grpc.benchmarks.proto.Control.ClientStatus.Builder.class);
       }
@@ -6450,7 +6450,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientStatus_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientStatus_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.ClientStatus getDefaultInstanceForType() {
@@ -6520,13 +6520,13 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Stats.ClientStats, io.grpc.benchmarks.proto.Stats.ClientStats.Builder, io.grpc.benchmarks.proto.Stats.ClientStatsOrBuilder> statsBuilder_;
       /**
-       * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
        */
       public boolean hasStats() {
         return statsBuilder_ != null || stats_ != null;
       }
       /**
-       * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
        */
       public io.grpc.benchmarks.proto.Stats.ClientStats getStats() {
         if (statsBuilder_ == null) {
@@ -6536,7 +6536,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
        */
       public Builder setStats(io.grpc.benchmarks.proto.Stats.ClientStats value) {
         if (statsBuilder_ == null) {
@@ -6552,7 +6552,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
        */
       public Builder setStats(
           io.grpc.benchmarks.proto.Stats.ClientStats.Builder builderForValue) {
@@ -6566,7 +6566,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
        */
       public Builder mergeStats(io.grpc.benchmarks.proto.Stats.ClientStats value) {
         if (statsBuilder_ == null) {
@@ -6584,7 +6584,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
        */
       public Builder clearStats() {
         if (statsBuilder_ == null) {
@@ -6598,7 +6598,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
        */
       public io.grpc.benchmarks.proto.Stats.ClientStats.Builder getStatsBuilder() {
         
@@ -6606,7 +6606,7 @@ public final class Control {
         return getStatsFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
        */
       public io.grpc.benchmarks.proto.Stats.ClientStatsOrBuilder getStatsOrBuilder() {
         if (statsBuilder_ != null) {
@@ -6617,7 +6617,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ClientStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientStats stats = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Stats.ClientStats, io.grpc.benchmarks.proto.Stats.ClientStats.Builder, io.grpc.benchmarks.proto.Stats.ClientStatsOrBuilder> 
@@ -6643,10 +6643,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ClientStatus)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ClientStatus)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ClientStatus)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ClientStatus)
     private static final io.grpc.benchmarks.proto.Control.ClientStatus DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.ClientStatus();
@@ -6691,7 +6691,7 @@ public final class Control {
   }
 
   public interface MarkOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.Mark)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.Mark)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -6704,7 +6704,7 @@ public final class Control {
     boolean getReset();
   }
   /**
-   * Protobuf type {@code grpc.testing.Mark}
+   * Protobuf type {@code grpc.benchmarks.Mark}
    *
    * <pre>
    * Request current stats
@@ -6712,7 +6712,7 @@ public final class Control {
    */
   public  static final class Mark extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.Mark)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.Mark)
       MarkOrBuilder {
     // Use Mark.newBuilder() to construct.
     private Mark(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -6765,12 +6765,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Mark_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Mark_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Mark_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Mark_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.Mark.class, io.grpc.benchmarks.proto.Control.Mark.Builder.class);
     }
@@ -6891,7 +6891,7 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.Mark}
+     * Protobuf type {@code grpc.benchmarks.Mark}
      *
      * <pre>
      * Request current stats
@@ -6899,16 +6899,16 @@ public final class Control {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.Mark)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.Mark)
         io.grpc.benchmarks.proto.Control.MarkOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Mark_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Mark_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Mark_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Mark_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.Mark.class, io.grpc.benchmarks.proto.Control.Mark.Builder.class);
       }
@@ -6936,7 +6936,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Mark_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Mark_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.Mark getDefaultInstanceForType() {
@@ -7046,10 +7046,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.Mark)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.Mark)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.Mark)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.Mark)
     private static final io.grpc.benchmarks.proto.Control.Mark DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.Mark();
@@ -7094,35 +7094,35 @@ public final class Control {
   }
 
   public interface ClientArgsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ClientArgs)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ClientArgs)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
      */
     io.grpc.benchmarks.proto.Control.ClientConfig getSetup();
     /**
-     * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
      */
     io.grpc.benchmarks.proto.Control.ClientConfigOrBuilder getSetupOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.Mark mark = 2;</code>
+     * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
      */
     io.grpc.benchmarks.proto.Control.Mark getMark();
     /**
-     * <code>optional .grpc.testing.Mark mark = 2;</code>
+     * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
      */
     io.grpc.benchmarks.proto.Control.MarkOrBuilder getMarkOrBuilder();
 
     public io.grpc.benchmarks.proto.Control.ClientArgs.ArgtypeCase getArgtypeCase();
   }
   /**
-   * Protobuf type {@code grpc.testing.ClientArgs}
+   * Protobuf type {@code grpc.benchmarks.ClientArgs}
    */
   public  static final class ClientArgs extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ClientArgs)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ClientArgs)
       ClientArgsOrBuilder {
     // Use ClientArgs.newBuilder() to construct.
     private ClientArgs(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -7197,12 +7197,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientArgs_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientArgs_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientArgs_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientArgs_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.ClientArgs.class, io.grpc.benchmarks.proto.Control.ClientArgs.Builder.class);
     }
@@ -7240,7 +7240,7 @@ public final class Control {
 
     public static final int SETUP_FIELD_NUMBER = 1;
     /**
-     * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
      */
     public io.grpc.benchmarks.proto.Control.ClientConfig getSetup() {
       if (argtypeCase_ == 1) {
@@ -7249,7 +7249,7 @@ public final class Control {
       return io.grpc.benchmarks.proto.Control.ClientConfig.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+     * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
      */
     public io.grpc.benchmarks.proto.Control.ClientConfigOrBuilder getSetupOrBuilder() {
       if (argtypeCase_ == 1) {
@@ -7260,7 +7260,7 @@ public final class Control {
 
     public static final int MARK_FIELD_NUMBER = 2;
     /**
-     * <code>optional .grpc.testing.Mark mark = 2;</code>
+     * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
      */
     public io.grpc.benchmarks.proto.Control.Mark getMark() {
       if (argtypeCase_ == 2) {
@@ -7269,7 +7269,7 @@ public final class Control {
       return io.grpc.benchmarks.proto.Control.Mark.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.Mark mark = 2;</code>
+     * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
      */
     public io.grpc.benchmarks.proto.Control.MarkOrBuilder getMarkOrBuilder() {
       if (argtypeCase_ == 2) {
@@ -7388,20 +7388,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ClientArgs}
+     * Protobuf type {@code grpc.benchmarks.ClientArgs}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ClientArgs)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ClientArgs)
         io.grpc.benchmarks.proto.Control.ClientArgsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientArgs_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientArgs_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientArgs_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientArgs_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.ClientArgs.class, io.grpc.benchmarks.proto.Control.ClientArgs.Builder.class);
       }
@@ -7429,7 +7429,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ClientArgs_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ClientArgs_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.ClientArgs getDefaultInstanceForType() {
@@ -7533,7 +7533,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.ClientConfig, io.grpc.benchmarks.proto.Control.ClientConfig.Builder, io.grpc.benchmarks.proto.Control.ClientConfigOrBuilder> setupBuilder_;
       /**
-       * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ClientConfig getSetup() {
         if (setupBuilder_ == null) {
@@ -7549,7 +7549,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
        */
       public Builder setSetup(io.grpc.benchmarks.proto.Control.ClientConfig value) {
         if (setupBuilder_ == null) {
@@ -7565,7 +7565,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
        */
       public Builder setSetup(
           io.grpc.benchmarks.proto.Control.ClientConfig.Builder builderForValue) {
@@ -7579,7 +7579,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
        */
       public Builder mergeSetup(io.grpc.benchmarks.proto.Control.ClientConfig value) {
         if (setupBuilder_ == null) {
@@ -7601,7 +7601,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
        */
       public Builder clearSetup() {
         if (setupBuilder_ == null) {
@@ -7620,13 +7620,13 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ClientConfig.Builder getSetupBuilder() {
         return getSetupFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ClientConfigOrBuilder getSetupOrBuilder() {
         if ((argtypeCase_ == 1) && (setupBuilder_ != null)) {
@@ -7639,7 +7639,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ClientConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ClientConfig setup = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.ClientConfig, io.grpc.benchmarks.proto.Control.ClientConfig.Builder, io.grpc.benchmarks.proto.Control.ClientConfigOrBuilder> 
@@ -7663,7 +7663,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.Mark, io.grpc.benchmarks.proto.Control.Mark.Builder, io.grpc.benchmarks.proto.Control.MarkOrBuilder> markBuilder_;
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.Mark getMark() {
         if (markBuilder_ == null) {
@@ -7679,7 +7679,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public Builder setMark(io.grpc.benchmarks.proto.Control.Mark value) {
         if (markBuilder_ == null) {
@@ -7695,7 +7695,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public Builder setMark(
           io.grpc.benchmarks.proto.Control.Mark.Builder builderForValue) {
@@ -7709,7 +7709,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public Builder mergeMark(io.grpc.benchmarks.proto.Control.Mark value) {
         if (markBuilder_ == null) {
@@ -7731,7 +7731,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public Builder clearMark() {
         if (markBuilder_ == null) {
@@ -7750,13 +7750,13 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.Mark.Builder getMarkBuilder() {
         return getMarkFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.MarkOrBuilder getMarkOrBuilder() {
         if ((argtypeCase_ == 2) && (markBuilder_ != null)) {
@@ -7769,7 +7769,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.Mark, io.grpc.benchmarks.proto.Control.Mark.Builder, io.grpc.benchmarks.proto.Control.MarkOrBuilder> 
@@ -7800,10 +7800,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ClientArgs)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ClientArgs)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ClientArgs)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ClientArgs)
     private static final io.grpc.benchmarks.proto.Control.ClientArgs DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.ClientArgs();
@@ -7848,28 +7848,28 @@ public final class Control {
   }
 
   public interface ServerConfigOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ServerConfig)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ServerConfig)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.ServerType server_type = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerType server_type = 1;</code>
      */
     int getServerTypeValue();
     /**
-     * <code>optional .grpc.testing.ServerType server_type = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerType server_type = 1;</code>
      */
     io.grpc.benchmarks.proto.Control.ServerType getServerType();
 
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
      */
     boolean hasSecurityParams();
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
      */
     io.grpc.benchmarks.proto.Control.SecurityParams getSecurityParams();
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
      */
     io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder getSecurityParamsOrBuilder();
 
@@ -7901,7 +7901,7 @@ public final class Control {
     int getCoreLimit();
 
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
      *
      * <pre>
      * payload config, used in generic server
@@ -7909,7 +7909,7 @@ public final class Control {
      */
     boolean hasPayloadConfig();
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
      *
      * <pre>
      * payload config, used in generic server
@@ -7917,7 +7917,7 @@ public final class Control {
      */
     io.grpc.benchmarks.proto.Payloads.PayloadConfig getPayloadConfig();
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
      *
      * <pre>
      * payload config, used in generic server
@@ -7951,11 +7951,11 @@ public final class Control {
     int getCoreList(int index);
   }
   /**
-   * Protobuf type {@code grpc.testing.ServerConfig}
+   * Protobuf type {@code grpc.benchmarks.ServerConfig}
    */
   public  static final class ServerConfig extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ServerConfig)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ServerConfig)
       ServerConfigOrBuilder {
     // Use ServerConfig.newBuilder() to construct.
     private ServerConfig(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -8078,12 +8078,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerConfig_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerConfig_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerConfig_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerConfig_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.ServerConfig.class, io.grpc.benchmarks.proto.Control.ServerConfig.Builder.class);
     }
@@ -8092,13 +8092,13 @@ public final class Control {
     public static final int SERVER_TYPE_FIELD_NUMBER = 1;
     private int serverType_;
     /**
-     * <code>optional .grpc.testing.ServerType server_type = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerType server_type = 1;</code>
      */
     public int getServerTypeValue() {
       return serverType_;
     }
     /**
-     * <code>optional .grpc.testing.ServerType server_type = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerType server_type = 1;</code>
      */
     public io.grpc.benchmarks.proto.Control.ServerType getServerType() {
       io.grpc.benchmarks.proto.Control.ServerType result = io.grpc.benchmarks.proto.Control.ServerType.valueOf(serverType_);
@@ -8108,19 +8108,19 @@ public final class Control {
     public static final int SECURITY_PARAMS_FIELD_NUMBER = 2;
     private io.grpc.benchmarks.proto.Control.SecurityParams securityParams_;
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
      */
     public boolean hasSecurityParams() {
       return securityParams_ != null;
     }
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
      */
     public io.grpc.benchmarks.proto.Control.SecurityParams getSecurityParams() {
       return securityParams_ == null ? io.grpc.benchmarks.proto.Control.SecurityParams.getDefaultInstance() : securityParams_;
     }
     /**
-     * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
      */
     public io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder getSecurityParamsOrBuilder() {
       return getSecurityParams();
@@ -8168,7 +8168,7 @@ public final class Control {
     public static final int PAYLOAD_CONFIG_FIELD_NUMBER = 9;
     private io.grpc.benchmarks.proto.Payloads.PayloadConfig payloadConfig_;
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
      *
      * <pre>
      * payload config, used in generic server
@@ -8178,7 +8178,7 @@ public final class Control {
       return payloadConfig_ != null;
     }
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
      *
      * <pre>
      * payload config, used in generic server
@@ -8188,7 +8188,7 @@ public final class Control {
       return payloadConfig_ == null ? io.grpc.benchmarks.proto.Payloads.PayloadConfig.getDefaultInstance() : payloadConfig_;
     }
     /**
-     * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+     * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
      *
      * <pre>
      * payload config, used in generic server
@@ -8393,20 +8393,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ServerConfig}
+     * Protobuf type {@code grpc.benchmarks.ServerConfig}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ServerConfig)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ServerConfig)
         io.grpc.benchmarks.proto.Control.ServerConfigOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerConfig_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerConfig_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerConfig_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerConfig_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.ServerConfig.class, io.grpc.benchmarks.proto.Control.ServerConfig.Builder.class);
       }
@@ -8454,7 +8454,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerConfig_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerConfig_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.ServerConfig getDefaultInstanceForType() {
@@ -8565,13 +8565,13 @@ public final class Control {
 
       private int serverType_ = 0;
       /**
-       * <code>optional .grpc.testing.ServerType server_type = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerType server_type = 1;</code>
        */
       public int getServerTypeValue() {
         return serverType_;
       }
       /**
-       * <code>optional .grpc.testing.ServerType server_type = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerType server_type = 1;</code>
        */
       public Builder setServerTypeValue(int value) {
         serverType_ = value;
@@ -8579,14 +8579,14 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerType server_type = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerType server_type = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ServerType getServerType() {
         io.grpc.benchmarks.proto.Control.ServerType result = io.grpc.benchmarks.proto.Control.ServerType.valueOf(serverType_);
         return result == null ? io.grpc.benchmarks.proto.Control.ServerType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.ServerType server_type = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerType server_type = 1;</code>
        */
       public Builder setServerType(io.grpc.benchmarks.proto.Control.ServerType value) {
         if (value == null) {
@@ -8598,7 +8598,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerType server_type = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerType server_type = 1;</code>
        */
       public Builder clearServerType() {
         
@@ -8611,13 +8611,13 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.SecurityParams, io.grpc.benchmarks.proto.Control.SecurityParams.Builder, io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder> securityParamsBuilder_;
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
        */
       public boolean hasSecurityParams() {
         return securityParamsBuilder_ != null || securityParams_ != null;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.SecurityParams getSecurityParams() {
         if (securityParamsBuilder_ == null) {
@@ -8627,7 +8627,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
        */
       public Builder setSecurityParams(io.grpc.benchmarks.proto.Control.SecurityParams value) {
         if (securityParamsBuilder_ == null) {
@@ -8643,7 +8643,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
        */
       public Builder setSecurityParams(
           io.grpc.benchmarks.proto.Control.SecurityParams.Builder builderForValue) {
@@ -8657,7 +8657,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
        */
       public Builder mergeSecurityParams(io.grpc.benchmarks.proto.Control.SecurityParams value) {
         if (securityParamsBuilder_ == null) {
@@ -8675,7 +8675,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
        */
       public Builder clearSecurityParams() {
         if (securityParamsBuilder_ == null) {
@@ -8689,7 +8689,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.SecurityParams.Builder getSecurityParamsBuilder() {
         
@@ -8697,7 +8697,7 @@ public final class Control {
         return getSecurityParamsFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder getSecurityParamsOrBuilder() {
         if (securityParamsBuilder_ != null) {
@@ -8708,7 +8708,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.SecurityParams security_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SecurityParams security_params = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.SecurityParams, io.grpc.benchmarks.proto.Control.SecurityParams.Builder, io.grpc.benchmarks.proto.Control.SecurityParamsOrBuilder> 
@@ -8842,7 +8842,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Payloads.PayloadConfig, io.grpc.benchmarks.proto.Payloads.PayloadConfig.Builder, io.grpc.benchmarks.proto.Payloads.PayloadConfigOrBuilder> payloadConfigBuilder_;
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
        *
        * <pre>
        * payload config, used in generic server
@@ -8852,7 +8852,7 @@ public final class Control {
         return payloadConfigBuilder_ != null || payloadConfig_ != null;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
        *
        * <pre>
        * payload config, used in generic server
@@ -8866,7 +8866,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
        *
        * <pre>
        * payload config, used in generic server
@@ -8886,7 +8886,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
        *
        * <pre>
        * payload config, used in generic server
@@ -8904,7 +8904,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
        *
        * <pre>
        * payload config, used in generic server
@@ -8926,7 +8926,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
        *
        * <pre>
        * payload config, used in generic server
@@ -8944,7 +8944,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
        *
        * <pre>
        * payload config, used in generic server
@@ -8956,7 +8956,7 @@ public final class Control {
         return getPayloadConfigFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
        *
        * <pre>
        * payload config, used in generic server
@@ -8971,7 +8971,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.PayloadConfig payload_config = 9;</code>
+       * <code>optional .grpc.benchmarks.PayloadConfig payload_config = 9;</code>
        *
        * <pre>
        * payload config, used in generic server
@@ -9095,10 +9095,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ServerConfig)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ServerConfig)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ServerConfig)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ServerConfig)
     private static final io.grpc.benchmarks.proto.Control.ServerConfig DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.ServerConfig();
@@ -9143,35 +9143,35 @@ public final class Control {
   }
 
   public interface ServerArgsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ServerArgs)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ServerArgs)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
      */
     io.grpc.benchmarks.proto.Control.ServerConfig getSetup();
     /**
-     * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
      */
     io.grpc.benchmarks.proto.Control.ServerConfigOrBuilder getSetupOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.Mark mark = 2;</code>
+     * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
      */
     io.grpc.benchmarks.proto.Control.Mark getMark();
     /**
-     * <code>optional .grpc.testing.Mark mark = 2;</code>
+     * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
      */
     io.grpc.benchmarks.proto.Control.MarkOrBuilder getMarkOrBuilder();
 
     public io.grpc.benchmarks.proto.Control.ServerArgs.ArgtypeCase getArgtypeCase();
   }
   /**
-   * Protobuf type {@code grpc.testing.ServerArgs}
+   * Protobuf type {@code grpc.benchmarks.ServerArgs}
    */
   public  static final class ServerArgs extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ServerArgs)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ServerArgs)
       ServerArgsOrBuilder {
     // Use ServerArgs.newBuilder() to construct.
     private ServerArgs(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -9246,12 +9246,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerArgs_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerArgs_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerArgs_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerArgs_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.ServerArgs.class, io.grpc.benchmarks.proto.Control.ServerArgs.Builder.class);
     }
@@ -9289,7 +9289,7 @@ public final class Control {
 
     public static final int SETUP_FIELD_NUMBER = 1;
     /**
-     * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
      */
     public io.grpc.benchmarks.proto.Control.ServerConfig getSetup() {
       if (argtypeCase_ == 1) {
@@ -9298,7 +9298,7 @@ public final class Control {
       return io.grpc.benchmarks.proto.Control.ServerConfig.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
      */
     public io.grpc.benchmarks.proto.Control.ServerConfigOrBuilder getSetupOrBuilder() {
       if (argtypeCase_ == 1) {
@@ -9309,7 +9309,7 @@ public final class Control {
 
     public static final int MARK_FIELD_NUMBER = 2;
     /**
-     * <code>optional .grpc.testing.Mark mark = 2;</code>
+     * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
      */
     public io.grpc.benchmarks.proto.Control.Mark getMark() {
       if (argtypeCase_ == 2) {
@@ -9318,7 +9318,7 @@ public final class Control {
       return io.grpc.benchmarks.proto.Control.Mark.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.Mark mark = 2;</code>
+     * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
      */
     public io.grpc.benchmarks.proto.Control.MarkOrBuilder getMarkOrBuilder() {
       if (argtypeCase_ == 2) {
@@ -9437,20 +9437,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ServerArgs}
+     * Protobuf type {@code grpc.benchmarks.ServerArgs}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ServerArgs)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ServerArgs)
         io.grpc.benchmarks.proto.Control.ServerArgsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerArgs_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerArgs_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerArgs_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerArgs_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.ServerArgs.class, io.grpc.benchmarks.proto.Control.ServerArgs.Builder.class);
       }
@@ -9478,7 +9478,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerArgs_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerArgs_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.ServerArgs getDefaultInstanceForType() {
@@ -9582,7 +9582,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.ServerConfig, io.grpc.benchmarks.proto.Control.ServerConfig.Builder, io.grpc.benchmarks.proto.Control.ServerConfigOrBuilder> setupBuilder_;
       /**
-       * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ServerConfig getSetup() {
         if (setupBuilder_ == null) {
@@ -9598,7 +9598,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
        */
       public Builder setSetup(io.grpc.benchmarks.proto.Control.ServerConfig value) {
         if (setupBuilder_ == null) {
@@ -9614,7 +9614,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
        */
       public Builder setSetup(
           io.grpc.benchmarks.proto.Control.ServerConfig.Builder builderForValue) {
@@ -9628,7 +9628,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
        */
       public Builder mergeSetup(io.grpc.benchmarks.proto.Control.ServerConfig value) {
         if (setupBuilder_ == null) {
@@ -9650,7 +9650,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
        */
       public Builder clearSetup() {
         if (setupBuilder_ == null) {
@@ -9669,13 +9669,13 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ServerConfig.Builder getSetupBuilder() {
         return getSetupFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
        */
       public io.grpc.benchmarks.proto.Control.ServerConfigOrBuilder getSetupOrBuilder() {
         if ((argtypeCase_ == 1) && (setupBuilder_ != null)) {
@@ -9688,7 +9688,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ServerConfig setup = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerConfig setup = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.ServerConfig, io.grpc.benchmarks.proto.Control.ServerConfig.Builder, io.grpc.benchmarks.proto.Control.ServerConfigOrBuilder> 
@@ -9712,7 +9712,7 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.Mark, io.grpc.benchmarks.proto.Control.Mark.Builder, io.grpc.benchmarks.proto.Control.MarkOrBuilder> markBuilder_;
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.Mark getMark() {
         if (markBuilder_ == null) {
@@ -9728,7 +9728,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public Builder setMark(io.grpc.benchmarks.proto.Control.Mark value) {
         if (markBuilder_ == null) {
@@ -9744,7 +9744,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public Builder setMark(
           io.grpc.benchmarks.proto.Control.Mark.Builder builderForValue) {
@@ -9758,7 +9758,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public Builder mergeMark(io.grpc.benchmarks.proto.Control.Mark value) {
         if (markBuilder_ == null) {
@@ -9780,7 +9780,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public Builder clearMark() {
         if (markBuilder_ == null) {
@@ -9799,13 +9799,13 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.Mark.Builder getMarkBuilder() {
         return getMarkFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       public io.grpc.benchmarks.proto.Control.MarkOrBuilder getMarkOrBuilder() {
         if ((argtypeCase_ == 2) && (markBuilder_ != null)) {
@@ -9818,7 +9818,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.Mark mark = 2;</code>
+       * <code>optional .grpc.benchmarks.Mark mark = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Control.Mark, io.grpc.benchmarks.proto.Control.Mark.Builder, io.grpc.benchmarks.proto.Control.MarkOrBuilder> 
@@ -9849,10 +9849,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ServerArgs)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ServerArgs)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ServerArgs)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ServerArgs)
     private static final io.grpc.benchmarks.proto.Control.ServerArgs DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.ServerArgs();
@@ -9897,19 +9897,19 @@ public final class Control {
   }
 
   public interface ServerStatusOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ServerStatus)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ServerStatus)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
      */
     boolean hasStats();
     /**
-     * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
      */
     io.grpc.benchmarks.proto.Stats.ServerStats getStats();
     /**
-     * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
      */
     io.grpc.benchmarks.proto.Stats.ServerStatsOrBuilder getStatsOrBuilder();
 
@@ -9932,11 +9932,11 @@ public final class Control {
     int getCores();
   }
   /**
-   * Protobuf type {@code grpc.testing.ServerStatus}
+   * Protobuf type {@code grpc.benchmarks.ServerStatus}
    */
   public  static final class ServerStatus extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ServerStatus)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ServerStatus)
       ServerStatusOrBuilder {
     // Use ServerStatus.newBuilder() to construct.
     private ServerStatus(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -10008,12 +10008,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerStatus_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerStatus_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerStatus_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerStatus_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.ServerStatus.class, io.grpc.benchmarks.proto.Control.ServerStatus.Builder.class);
     }
@@ -10021,19 +10021,19 @@ public final class Control {
     public static final int STATS_FIELD_NUMBER = 1;
     private io.grpc.benchmarks.proto.Stats.ServerStats stats_;
     /**
-     * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
      */
     public boolean hasStats() {
       return stats_ != null;
     }
     /**
-     * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
      */
     public io.grpc.benchmarks.proto.Stats.ServerStats getStats() {
       return stats_ == null ? io.grpc.benchmarks.proto.Stats.ServerStats.getDefaultInstance() : stats_;
     }
     /**
-     * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+     * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
      */
     public io.grpc.benchmarks.proto.Stats.ServerStatsOrBuilder getStatsOrBuilder() {
       return getStats();
@@ -10182,20 +10182,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ServerStatus}
+     * Protobuf type {@code grpc.benchmarks.ServerStatus}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ServerStatus)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ServerStatus)
         io.grpc.benchmarks.proto.Control.ServerStatusOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerStatus_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerStatus_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerStatus_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerStatus_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.ServerStatus.class, io.grpc.benchmarks.proto.Control.ServerStatus.Builder.class);
       }
@@ -10231,7 +10231,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_ServerStatus_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_ServerStatus_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.ServerStatus getDefaultInstanceForType() {
@@ -10309,13 +10309,13 @@ public final class Control {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Stats.ServerStats, io.grpc.benchmarks.proto.Stats.ServerStats.Builder, io.grpc.benchmarks.proto.Stats.ServerStatsOrBuilder> statsBuilder_;
       /**
-       * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
        */
       public boolean hasStats() {
         return statsBuilder_ != null || stats_ != null;
       }
       /**
-       * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
        */
       public io.grpc.benchmarks.proto.Stats.ServerStats getStats() {
         if (statsBuilder_ == null) {
@@ -10325,7 +10325,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
        */
       public Builder setStats(io.grpc.benchmarks.proto.Stats.ServerStats value) {
         if (statsBuilder_ == null) {
@@ -10341,7 +10341,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
        */
       public Builder setStats(
           io.grpc.benchmarks.proto.Stats.ServerStats.Builder builderForValue) {
@@ -10355,7 +10355,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
        */
       public Builder mergeStats(io.grpc.benchmarks.proto.Stats.ServerStats value) {
         if (statsBuilder_ == null) {
@@ -10373,7 +10373,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
        */
       public Builder clearStats() {
         if (statsBuilder_ == null) {
@@ -10387,7 +10387,7 @@ public final class Control {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
        */
       public io.grpc.benchmarks.proto.Stats.ServerStats.Builder getStatsBuilder() {
         
@@ -10395,7 +10395,7 @@ public final class Control {
         return getStatsFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
        */
       public io.grpc.benchmarks.proto.Stats.ServerStatsOrBuilder getStatsOrBuilder() {
         if (statsBuilder_ != null) {
@@ -10406,7 +10406,7 @@ public final class Control {
         }
       }
       /**
-       * <code>optional .grpc.testing.ServerStats stats = 1;</code>
+       * <code>optional .grpc.benchmarks.ServerStats stats = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Stats.ServerStats, io.grpc.benchmarks.proto.Stats.ServerStats.Builder, io.grpc.benchmarks.proto.Stats.ServerStatsOrBuilder> 
@@ -10508,10 +10508,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ServerStatus)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ServerStatus)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ServerStatus)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ServerStatus)
     private static final io.grpc.benchmarks.proto.Control.ServerStatus DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.ServerStatus();
@@ -10556,15 +10556,15 @@ public final class Control {
   }
 
   public interface CoreRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.CoreRequest)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.CoreRequest)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code grpc.testing.CoreRequest}
+   * Protobuf type {@code grpc.benchmarks.CoreRequest}
    */
   public  static final class CoreRequest extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.CoreRequest)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.CoreRequest)
       CoreRequestOrBuilder {
     // Use CoreRequest.newBuilder() to construct.
     private CoreRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -10610,12 +10610,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreRequest_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreRequest_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.CoreRequest.class, io.grpc.benchmarks.proto.Control.CoreRequest.Builder.class);
     }
@@ -10716,20 +10716,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.CoreRequest}
+     * Protobuf type {@code grpc.benchmarks.CoreRequest}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.CoreRequest)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.CoreRequest)
         io.grpc.benchmarks.proto.Control.CoreRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreRequest_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreRequest_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.CoreRequest.class, io.grpc.benchmarks.proto.Control.CoreRequest.Builder.class);
       }
@@ -10755,7 +10755,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreRequest_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreRequest_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.CoreRequest getDefaultInstanceForType() {
@@ -10823,10 +10823,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.CoreRequest)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.CoreRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.CoreRequest)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.CoreRequest)
     private static final io.grpc.benchmarks.proto.Control.CoreRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.CoreRequest();
@@ -10871,7 +10871,7 @@ public final class Control {
   }
 
   public interface CoreResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.CoreResponse)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.CoreResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -10884,11 +10884,11 @@ public final class Control {
     int getCores();
   }
   /**
-   * Protobuf type {@code grpc.testing.CoreResponse}
+   * Protobuf type {@code grpc.benchmarks.CoreResponse}
    */
   public  static final class CoreResponse extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.CoreResponse)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.CoreResponse)
       CoreResponseOrBuilder {
     // Use CoreResponse.newBuilder() to construct.
     private CoreResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -10941,12 +10941,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreResponse_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreResponse_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.CoreResponse.class, io.grpc.benchmarks.proto.Control.CoreResponse.Builder.class);
     }
@@ -11067,20 +11067,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.CoreResponse}
+     * Protobuf type {@code grpc.benchmarks.CoreResponse}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.CoreResponse)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.CoreResponse)
         io.grpc.benchmarks.proto.Control.CoreResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreResponse_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreResponse_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreResponse_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.CoreResponse.class, io.grpc.benchmarks.proto.Control.CoreResponse.Builder.class);
       }
@@ -11108,7 +11108,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_CoreResponse_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_CoreResponse_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.CoreResponse getDefaultInstanceForType() {
@@ -11218,10 +11218,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.CoreResponse)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.CoreResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.CoreResponse)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.CoreResponse)
     private static final io.grpc.benchmarks.proto.Control.CoreResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.CoreResponse();
@@ -11266,15 +11266,15 @@ public final class Control {
   }
 
   public interface VoidOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.Void)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.Void)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code grpc.testing.Void}
+   * Protobuf type {@code grpc.benchmarks.Void}
    */
   public  static final class Void extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.Void)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.Void)
       VoidOrBuilder {
     // Use Void.newBuilder() to construct.
     private Void(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -11320,12 +11320,12 @@ public final class Control {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Void_descriptor;
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Void_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Void_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Void_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Control.Void.class, io.grpc.benchmarks.proto.Control.Void.Builder.class);
     }
@@ -11426,20 +11426,20 @@ public final class Control {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.Void}
+     * Protobuf type {@code grpc.benchmarks.Void}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.Void)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.Void)
         io.grpc.benchmarks.proto.Control.VoidOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Void_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Void_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Void_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Void_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Control.Void.class, io.grpc.benchmarks.proto.Control.Void.Builder.class);
       }
@@ -11465,7 +11465,7 @@ public final class Control {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Control.internal_static_grpc_testing_Void_descriptor;
+        return io.grpc.benchmarks.proto.Control.internal_static_grpc_benchmarks_Void_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Control.Void getDefaultInstanceForType() {
@@ -11533,10 +11533,10 @@ public final class Control {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.Void)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.Void)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.Void)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.Void)
     private static final io.grpc.benchmarks.proto.Control.Void DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Control.Void();
@@ -11581,90 +11581,90 @@ public final class Control {
   }
 
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_PoissonParams_descriptor;
+    internal_static_grpc_benchmarks_PoissonParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_PoissonParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_PoissonParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_UniformParams_descriptor;
+    internal_static_grpc_benchmarks_UniformParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_UniformParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_UniformParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_DeterministicParams_descriptor;
+    internal_static_grpc_benchmarks_DeterministicParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_DeterministicParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_DeterministicParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ParetoParams_descriptor;
+    internal_static_grpc_benchmarks_ParetoParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ParetoParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ParetoParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ClosedLoopParams_descriptor;
+    internal_static_grpc_benchmarks_ClosedLoopParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ClosedLoopParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ClosedLoopParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_LoadParams_descriptor;
+    internal_static_grpc_benchmarks_LoadParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_LoadParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_LoadParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_SecurityParams_descriptor;
+    internal_static_grpc_benchmarks_SecurityParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_SecurityParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_SecurityParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ClientConfig_descriptor;
+    internal_static_grpc_benchmarks_ClientConfig_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ClientConfig_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ClientConfig_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ClientStatus_descriptor;
+    internal_static_grpc_benchmarks_ClientStatus_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ClientStatus_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ClientStatus_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_Mark_descriptor;
+    internal_static_grpc_benchmarks_Mark_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_Mark_fieldAccessorTable;
+      internal_static_grpc_benchmarks_Mark_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ClientArgs_descriptor;
+    internal_static_grpc_benchmarks_ClientArgs_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ClientArgs_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ClientArgs_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ServerConfig_descriptor;
+    internal_static_grpc_benchmarks_ServerConfig_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ServerConfig_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ServerConfig_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ServerArgs_descriptor;
+    internal_static_grpc_benchmarks_ServerArgs_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ServerArgs_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ServerArgs_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ServerStatus_descriptor;
+    internal_static_grpc_benchmarks_ServerStatus_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ServerStatus_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ServerStatus_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_CoreRequest_descriptor;
+    internal_static_grpc_benchmarks_CoreRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_CoreRequest_fieldAccessorTable;
+      internal_static_grpc_benchmarks_CoreRequest_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_CoreResponse_descriptor;
+    internal_static_grpc_benchmarks_CoreResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_CoreResponse_fieldAccessorTable;
+      internal_static_grpc_benchmarks_CoreResponse_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_Void_descriptor;
+    internal_static_grpc_benchmarks_Void_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_Void_fieldAccessorTable;
+      internal_static_grpc_benchmarks_Void_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -11674,56 +11674,58 @@ public final class Control {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\rcontrol.proto\022\014grpc.testing\032\016payloads." +
-      "proto\032\013stats.proto\"%\n\rPoissonParams\022\024\n\014o" +
-      "ffered_load\030\001 \001(\001\"A\n\rUniformParams\022\027\n\017in" +
-      "terarrival_lo\030\001 \001(\001\022\027\n\017interarrival_hi\030\002" +
-      " \001(\001\"+\n\023DeterministicParams\022\024\n\014offered_l" +
-      "oad\030\001 \001(\001\"8\n\014ParetoParams\022\031\n\021interarriva" +
-      "l_base\030\001 \001(\001\022\r\n\005alpha\030\002 \001(\001\"\022\n\020ClosedLoo" +
-      "pParams\"\216\002\n\nLoadParams\0225\n\013closed_loop\030\001 " +
-      "\001(\0132\036.grpc.testing.ClosedLoopParamsH\000\022.\n" +
-      "\007poisson\030\002 \001(\0132\033.grpc.testing.PoissonPar",
-      "amsH\000\022.\n\007uniform\030\003 \001(\0132\033.grpc.testing.Un" +
-      "iformParamsH\000\0223\n\006determ\030\004 \001(\0132!.grpc.tes" +
-      "ting.DeterministicParamsH\000\022,\n\006pareto\030\005 \001" +
-      "(\0132\032.grpc.testing.ParetoParamsH\000B\006\n\004load" +
-      "\"C\n\016SecurityParams\022\023\n\013use_test_ca\030\001 \001(\010\022" +
-      "\034\n\024server_host_override\030\002 \001(\t\"\326\003\n\014Client" +
-      "Config\022\026\n\016server_targets\030\001 \003(\t\022-\n\013client" +
-      "_type\030\002 \001(\0162\030.grpc.testing.ClientType\0225\n" +
-      "\017security_params\030\003 \001(\0132\034.grpc.testing.Se" +
-      "curityParams\022$\n\034outstanding_rpcs_per_cha",
-      "nnel\030\004 \001(\005\022\027\n\017client_channels\030\005 \001(\005\022\034\n\024a" +
-      "sync_client_threads\030\007 \001(\005\022\'\n\010rpc_type\030\010 " +
-      "\001(\0162\025.grpc.testing.RpcType\022-\n\013load_param" +
-      "s\030\n \001(\0132\030.grpc.testing.LoadParams\0223\n\016pay" +
-      "load_config\030\013 \001(\0132\033.grpc.testing.Payload" +
-      "Config\0227\n\020histogram_params\030\014 \001(\0132\035.grpc." +
-      "testing.HistogramParams\022\021\n\tcore_list\030\r \003" +
-      "(\005\022\022\n\ncore_limit\030\016 \001(\005\"8\n\014ClientStatus\022(" +
-      "\n\005stats\030\001 \001(\0132\031.grpc.testing.ClientStats" +
-      "\"\025\n\004Mark\022\r\n\005reset\030\001 \001(\010\"h\n\nClientArgs\022+\n",
-      "\005setup\030\001 \001(\0132\032.grpc.testing.ClientConfig" +
-      "H\000\022\"\n\004mark\030\002 \001(\0132\022.grpc.testing.MarkH\000B\t" +
-      "\n\007argtype\"\374\001\n\014ServerConfig\022-\n\013server_typ" +
-      "e\030\001 \001(\0162\030.grpc.testing.ServerType\0225\n\017sec" +
-      "urity_params\030\002 \001(\0132\034.grpc.testing.Securi" +
-      "tyParams\022\014\n\004port\030\004 \001(\005\022\034\n\024async_server_t" +
-      "hreads\030\007 \001(\005\022\022\n\ncore_limit\030\010 \001(\005\0223\n\016payl" +
-      "oad_config\030\t \001(\0132\033.grpc.testing.PayloadC" +
-      "onfig\022\021\n\tcore_list\030\n \003(\005\"h\n\nServerArgs\022+" +
-      "\n\005setup\030\001 \001(\0132\032.grpc.testing.ServerConfi",
-      "gH\000\022\"\n\004mark\030\002 \001(\0132\022.grpc.testing.MarkH\000B" +
-      "\t\n\007argtype\"U\n\014ServerStatus\022(\n\005stats\030\001 \001(" +
-      "\0132\031.grpc.testing.ServerStats\022\014\n\004port\030\002 \001" +
-      "(\005\022\r\n\005cores\030\003 \001(\005\"\r\n\013CoreRequest\"\035\n\014Core" +
-      "Response\022\r\n\005cores\030\001 \001(\005\"\006\n\004Void*/\n\nClien" +
-      "tType\022\017\n\013SYNC_CLIENT\020\000\022\020\n\014ASYNC_CLIENT\020\001" +
-      "*I\n\nServerType\022\017\n\013SYNC_SERVER\020\000\022\020\n\014ASYNC" +
-      "_SERVER\020\001\022\030\n\024ASYNC_GENERIC_SERVER\020\002*#\n\007R" +
-      "pcType\022\t\n\005UNARY\020\000\022\r\n\tSTREAMING\020\001B#\n\030io.g" +
-      "rpc.benchmarks.protoB\007Controlb\006proto3"
+      "\n\rcontrol.proto\022\017grpc.benchmarks\032\016payloa" +
+      "ds.proto\032\013stats.proto\"%\n\rPoissonParams\022\024" +
+      "\n\014offered_load\030\001 \001(\001\"A\n\rUniformParams\022\027\n" +
+      "\017interarrival_lo\030\001 \001(\001\022\027\n\017interarrival_h" +
+      "i\030\002 \001(\001\"+\n\023DeterministicParams\022\024\n\014offere" +
+      "d_load\030\001 \001(\001\"8\n\014ParetoParams\022\031\n\021interarr" +
+      "ival_base\030\001 \001(\001\022\r\n\005alpha\030\002 \001(\001\"\022\n\020Closed" +
+      "LoopParams\"\235\002\n\nLoadParams\0228\n\013closed_loop" +
+      "\030\001 \001(\0132!.grpc.benchmarks.ClosedLoopParam" +
+      "sH\000\0221\n\007poisson\030\002 \001(\0132\036.grpc.benchmarks.P",
+      "oissonParamsH\000\0221\n\007uniform\030\003 \001(\0132\036.grpc.b" +
+      "enchmarks.UniformParamsH\000\0226\n\006determ\030\004 \001(" +
+      "\0132$.grpc.benchmarks.DeterministicParamsH" +
+      "\000\022/\n\006pareto\030\005 \001(\0132\035.grpc.benchmarks.Pare" +
+      "toParamsH\000B\006\n\004load\"C\n\016SecurityParams\022\023\n\013" +
+      "use_test_ca\030\001 \001(\010\022\034\n\024server_host_overrid" +
+      "e\030\002 \001(\t\"\350\003\n\014ClientConfig\022\026\n\016server_targe" +
+      "ts\030\001 \003(\t\0220\n\013client_type\030\002 \001(\0162\033.grpc.ben" +
+      "chmarks.ClientType\0228\n\017security_params\030\003 " +
+      "\001(\0132\037.grpc.benchmarks.SecurityParams\022$\n\034",
+      "outstanding_rpcs_per_channel\030\004 \001(\005\022\027\n\017cl" +
+      "ient_channels\030\005 \001(\005\022\034\n\024async_client_thre" +
+      "ads\030\007 \001(\005\022*\n\010rpc_type\030\010 \001(\0162\030.grpc.bench" +
+      "marks.RpcType\0220\n\013load_params\030\n \001(\0132\033.grp" +
+      "c.benchmarks.LoadParams\0226\n\016payload_confi" +
+      "g\030\013 \001(\0132\036.grpc.benchmarks.PayloadConfig\022" +
+      ":\n\020histogram_params\030\014 \001(\0132 .grpc.benchma" +
+      "rks.HistogramParams\022\021\n\tcore_list\030\r \003(\005\022\022" +
+      "\n\ncore_limit\030\016 \001(\005\";\n\014ClientStatus\022+\n\005st" +
+      "ats\030\001 \001(\0132\034.grpc.benchmarks.ClientStats\"",
+      "\025\n\004Mark\022\r\n\005reset\030\001 \001(\010\"n\n\nClientArgs\022.\n\005" +
+      "setup\030\001 \001(\0132\035.grpc.benchmarks.ClientConf" +
+      "igH\000\022%\n\004mark\030\002 \001(\0132\025.grpc.benchmarks.Mar" +
+      "kH\000B\t\n\007argtype\"\205\002\n\014ServerConfig\0220\n\013serve" +
+      "r_type\030\001 \001(\0162\033.grpc.benchmarks.ServerTyp" +
+      "e\0228\n\017security_params\030\002 \001(\0132\037.grpc.benchm" +
+      "arks.SecurityParams\022\014\n\004port\030\004 \001(\005\022\034\n\024asy" +
+      "nc_server_threads\030\007 \001(\005\022\022\n\ncore_limit\030\010 " +
+      "\001(\005\0226\n\016payload_config\030\t \001(\0132\036.grpc.bench" +
+      "marks.PayloadConfig\022\021\n\tcore_list\030\n \003(\005\"n",
+      "\n\nServerArgs\022.\n\005setup\030\001 \001(\0132\035.grpc.bench" +
+      "marks.ServerConfigH\000\022%\n\004mark\030\002 \001(\0132\025.grp" +
+      "c.benchmarks.MarkH\000B\t\n\007argtype\"X\n\014Server" +
+      "Status\022+\n\005stats\030\001 \001(\0132\034.grpc.benchmarks." +
+      "ServerStats\022\014\n\004port\030\002 \001(\005\022\r\n\005cores\030\003 \001(\005" +
+      "\"\r\n\013CoreRequest\"\035\n\014CoreResponse\022\r\n\005cores" +
+      "\030\001 \001(\005\"\006\n\004Void*/\n\nClientType\022\017\n\013SYNC_CLI" +
+      "ENT\020\000\022\020\n\014ASYNC_CLIENT\020\001*I\n\nServerType\022\017\n" +
+      "\013SYNC_SERVER\020\000\022\020\n\014ASYNC_SERVER\020\001\022\030\n\024ASYN" +
+      "C_GENERIC_SERVER\020\002*#\n\007RpcType\022\t\n\005UNARY\020\000",
+      "\022\r\n\tSTREAMING\020\001B#\n\030io.grpc.benchmarks.pr" +
+      "otoB\007Controlb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -11739,107 +11741,107 @@ public final class Control {
           io.grpc.benchmarks.proto.Payloads.getDescriptor(),
           io.grpc.benchmarks.proto.Stats.getDescriptor(),
         }, assigner);
-    internal_static_grpc_testing_PoissonParams_descriptor =
+    internal_static_grpc_benchmarks_PoissonParams_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_grpc_testing_PoissonParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_PoissonParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_PoissonParams_descriptor,
+        internal_static_grpc_benchmarks_PoissonParams_descriptor,
         new java.lang.String[] { "OfferedLoad", });
-    internal_static_grpc_testing_UniformParams_descriptor =
+    internal_static_grpc_benchmarks_UniformParams_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_grpc_testing_UniformParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_UniformParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_UniformParams_descriptor,
+        internal_static_grpc_benchmarks_UniformParams_descriptor,
         new java.lang.String[] { "InterarrivalLo", "InterarrivalHi", });
-    internal_static_grpc_testing_DeterministicParams_descriptor =
+    internal_static_grpc_benchmarks_DeterministicParams_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_grpc_testing_DeterministicParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_DeterministicParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_DeterministicParams_descriptor,
+        internal_static_grpc_benchmarks_DeterministicParams_descriptor,
         new java.lang.String[] { "OfferedLoad", });
-    internal_static_grpc_testing_ParetoParams_descriptor =
+    internal_static_grpc_benchmarks_ParetoParams_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_grpc_testing_ParetoParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ParetoParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ParetoParams_descriptor,
+        internal_static_grpc_benchmarks_ParetoParams_descriptor,
         new java.lang.String[] { "InterarrivalBase", "Alpha", });
-    internal_static_grpc_testing_ClosedLoopParams_descriptor =
+    internal_static_grpc_benchmarks_ClosedLoopParams_descriptor =
       getDescriptor().getMessageTypes().get(4);
-    internal_static_grpc_testing_ClosedLoopParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ClosedLoopParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ClosedLoopParams_descriptor,
+        internal_static_grpc_benchmarks_ClosedLoopParams_descriptor,
         new java.lang.String[] { });
-    internal_static_grpc_testing_LoadParams_descriptor =
+    internal_static_grpc_benchmarks_LoadParams_descriptor =
       getDescriptor().getMessageTypes().get(5);
-    internal_static_grpc_testing_LoadParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_LoadParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_LoadParams_descriptor,
+        internal_static_grpc_benchmarks_LoadParams_descriptor,
         new java.lang.String[] { "ClosedLoop", "Poisson", "Uniform", "Determ", "Pareto", "Load", });
-    internal_static_grpc_testing_SecurityParams_descriptor =
+    internal_static_grpc_benchmarks_SecurityParams_descriptor =
       getDescriptor().getMessageTypes().get(6);
-    internal_static_grpc_testing_SecurityParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_SecurityParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_SecurityParams_descriptor,
+        internal_static_grpc_benchmarks_SecurityParams_descriptor,
         new java.lang.String[] { "UseTestCa", "ServerHostOverride", });
-    internal_static_grpc_testing_ClientConfig_descriptor =
+    internal_static_grpc_benchmarks_ClientConfig_descriptor =
       getDescriptor().getMessageTypes().get(7);
-    internal_static_grpc_testing_ClientConfig_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ClientConfig_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ClientConfig_descriptor,
+        internal_static_grpc_benchmarks_ClientConfig_descriptor,
         new java.lang.String[] { "ServerTargets", "ClientType", "SecurityParams", "OutstandingRpcsPerChannel", "ClientChannels", "AsyncClientThreads", "RpcType", "LoadParams", "PayloadConfig", "HistogramParams", "CoreList", "CoreLimit", });
-    internal_static_grpc_testing_ClientStatus_descriptor =
+    internal_static_grpc_benchmarks_ClientStatus_descriptor =
       getDescriptor().getMessageTypes().get(8);
-    internal_static_grpc_testing_ClientStatus_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ClientStatus_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ClientStatus_descriptor,
+        internal_static_grpc_benchmarks_ClientStatus_descriptor,
         new java.lang.String[] { "Stats", });
-    internal_static_grpc_testing_Mark_descriptor =
+    internal_static_grpc_benchmarks_Mark_descriptor =
       getDescriptor().getMessageTypes().get(9);
-    internal_static_grpc_testing_Mark_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_Mark_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_Mark_descriptor,
+        internal_static_grpc_benchmarks_Mark_descriptor,
         new java.lang.String[] { "Reset", });
-    internal_static_grpc_testing_ClientArgs_descriptor =
+    internal_static_grpc_benchmarks_ClientArgs_descriptor =
       getDescriptor().getMessageTypes().get(10);
-    internal_static_grpc_testing_ClientArgs_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ClientArgs_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ClientArgs_descriptor,
+        internal_static_grpc_benchmarks_ClientArgs_descriptor,
         new java.lang.String[] { "Setup", "Mark", "Argtype", });
-    internal_static_grpc_testing_ServerConfig_descriptor =
+    internal_static_grpc_benchmarks_ServerConfig_descriptor =
       getDescriptor().getMessageTypes().get(11);
-    internal_static_grpc_testing_ServerConfig_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ServerConfig_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ServerConfig_descriptor,
+        internal_static_grpc_benchmarks_ServerConfig_descriptor,
         new java.lang.String[] { "ServerType", "SecurityParams", "Port", "AsyncServerThreads", "CoreLimit", "PayloadConfig", "CoreList", });
-    internal_static_grpc_testing_ServerArgs_descriptor =
+    internal_static_grpc_benchmarks_ServerArgs_descriptor =
       getDescriptor().getMessageTypes().get(12);
-    internal_static_grpc_testing_ServerArgs_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ServerArgs_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ServerArgs_descriptor,
+        internal_static_grpc_benchmarks_ServerArgs_descriptor,
         new java.lang.String[] { "Setup", "Mark", "Argtype", });
-    internal_static_grpc_testing_ServerStatus_descriptor =
+    internal_static_grpc_benchmarks_ServerStatus_descriptor =
       getDescriptor().getMessageTypes().get(13);
-    internal_static_grpc_testing_ServerStatus_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ServerStatus_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ServerStatus_descriptor,
+        internal_static_grpc_benchmarks_ServerStatus_descriptor,
         new java.lang.String[] { "Stats", "Port", "Cores", });
-    internal_static_grpc_testing_CoreRequest_descriptor =
+    internal_static_grpc_benchmarks_CoreRequest_descriptor =
       getDescriptor().getMessageTypes().get(14);
-    internal_static_grpc_testing_CoreRequest_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_CoreRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_CoreRequest_descriptor,
+        internal_static_grpc_benchmarks_CoreRequest_descriptor,
         new java.lang.String[] { });
-    internal_static_grpc_testing_CoreResponse_descriptor =
+    internal_static_grpc_benchmarks_CoreResponse_descriptor =
       getDescriptor().getMessageTypes().get(15);
-    internal_static_grpc_testing_CoreResponse_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_CoreResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_CoreResponse_descriptor,
+        internal_static_grpc_benchmarks_CoreResponse_descriptor,
         new java.lang.String[] { "Cores", });
-    internal_static_grpc_testing_Void_descriptor =
+    internal_static_grpc_benchmarks_Void_descriptor =
       getDescriptor().getMessageTypes().get(16);
-    internal_static_grpc_testing_Void_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_Void_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_Void_descriptor,
+        internal_static_grpc_benchmarks_Void_descriptor,
         new java.lang.String[] { });
     io.grpc.benchmarks.proto.Payloads.getDescriptor();
     io.grpc.benchmarks.proto.Stats.getDescriptor();

--- a/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Messages.java
+++ b/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Messages.java
@@ -9,7 +9,7 @@ public final class Messages {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   /**
-   * Protobuf enum {@code grpc.testing.PayloadType}
+   * Protobuf enum {@code grpc.benchmarks.PayloadType}
    *
    * <pre>
    * The type of payload that should be returned.
@@ -134,11 +134,11 @@ public final class Messages {
       this.value = value;
     }
 
-    // @@protoc_insertion_point(enum_scope:grpc.testing.PayloadType)
+    // @@protoc_insertion_point(enum_scope:grpc.benchmarks.PayloadType)
   }
 
   /**
-   * Protobuf enum {@code grpc.testing.CompressionType}
+   * Protobuf enum {@code grpc.benchmarks.CompressionType}
    *
    * <pre>
    * Compression algorithms
@@ -247,15 +247,15 @@ public final class Messages {
       this.value = value;
     }
 
-    // @@protoc_insertion_point(enum_scope:grpc.testing.CompressionType)
+    // @@protoc_insertion_point(enum_scope:grpc.benchmarks.CompressionType)
   }
 
   public interface PayloadOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.Payload)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.Payload)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.PayloadType type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType type = 1;</code>
      *
      * <pre>
      * The type of data in body.
@@ -263,7 +263,7 @@ public final class Messages {
      */
     int getTypeValue();
     /**
-     * <code>optional .grpc.testing.PayloadType type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType type = 1;</code>
      *
      * <pre>
      * The type of data in body.
@@ -281,7 +281,7 @@ public final class Messages {
     com.google.protobuf.ByteString getBody();
   }
   /**
-   * Protobuf type {@code grpc.testing.Payload}
+   * Protobuf type {@code grpc.benchmarks.Payload}
    *
    * <pre>
    * A block of data, to simply increase gRPC message size.
@@ -289,7 +289,7 @@ public final class Messages {
    */
   public  static final class Payload extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.Payload)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.Payload)
       PayloadOrBuilder {
     // Use Payload.newBuilder() to construct.
     private Payload(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -349,12 +349,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_Payload_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_Payload_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_Payload_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_Payload_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.Payload.class, io.grpc.benchmarks.proto.Messages.Payload.Builder.class);
     }
@@ -362,7 +362,7 @@ public final class Messages {
     public static final int TYPE_FIELD_NUMBER = 1;
     private int type_;
     /**
-     * <code>optional .grpc.testing.PayloadType type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType type = 1;</code>
      *
      * <pre>
      * The type of data in body.
@@ -372,7 +372,7 @@ public final class Messages {
       return type_;
     }
     /**
-     * <code>optional .grpc.testing.PayloadType type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType type = 1;</code>
      *
      * <pre>
      * The type of data in body.
@@ -506,7 +506,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.Payload}
+     * Protobuf type {@code grpc.benchmarks.Payload}
      *
      * <pre>
      * A block of data, to simply increase gRPC message size.
@@ -514,16 +514,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.Payload)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.Payload)
         io.grpc.benchmarks.proto.Messages.PayloadOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_Payload_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_Payload_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_Payload_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_Payload_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.Payload.class, io.grpc.benchmarks.proto.Messages.Payload.Builder.class);
       }
@@ -553,7 +553,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_Payload_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_Payload_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.Payload getDefaultInstanceForType() {
@@ -621,7 +621,7 @@ public final class Messages {
 
       private int type_ = 0;
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -631,7 +631,7 @@ public final class Messages {
         return type_;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -643,7 +643,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -654,7 +654,7 @@ public final class Messages {
         return result == null ? io.grpc.benchmarks.proto.Messages.PayloadType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -670,7 +670,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -734,10 +734,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.Payload)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.Payload)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.Payload)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.Payload)
     private static final io.grpc.benchmarks.proto.Messages.Payload DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.Payload();
@@ -782,7 +782,7 @@ public final class Messages {
   }
 
   public interface EchoStatusOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.EchoStatus)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.EchoStatus)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -801,7 +801,7 @@ public final class Messages {
         getMessageBytes();
   }
   /**
-   * Protobuf type {@code grpc.testing.EchoStatus}
+   * Protobuf type {@code grpc.benchmarks.EchoStatus}
    *
    * <pre>
    * A protobuf representation for grpc status. This is used by test
@@ -810,7 +810,7 @@ public final class Messages {
    */
   public  static final class EchoStatus extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.EchoStatus)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.EchoStatus)
       EchoStatusOrBuilder {
     // Use EchoStatus.newBuilder() to construct.
     private EchoStatus(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -870,12 +870,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_EchoStatus_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_EchoStatus_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_EchoStatus_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_EchoStatus_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.EchoStatus.class, io.grpc.benchmarks.proto.Messages.EchoStatus.Builder.class);
     }
@@ -1032,7 +1032,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.EchoStatus}
+     * Protobuf type {@code grpc.benchmarks.EchoStatus}
      *
      * <pre>
      * A protobuf representation for grpc status. This is used by test
@@ -1041,16 +1041,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.EchoStatus)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.EchoStatus)
         io.grpc.benchmarks.proto.Messages.EchoStatusOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_EchoStatus_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_EchoStatus_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_EchoStatus_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_EchoStatus_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.EchoStatus.class, io.grpc.benchmarks.proto.Messages.EchoStatus.Builder.class);
       }
@@ -1080,7 +1080,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_EchoStatus_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_EchoStatus_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.EchoStatus getDefaultInstanceForType() {
@@ -1252,10 +1252,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.EchoStatus)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.EchoStatus)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.EchoStatus)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.EchoStatus)
     private static final io.grpc.benchmarks.proto.Messages.EchoStatus DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.EchoStatus();
@@ -1300,11 +1300,11 @@ public final class Messages {
   }
 
   public interface SimpleRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.SimpleRequest)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.SimpleRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -1313,7 +1313,7 @@ public final class Messages {
      */
     int getResponseTypeValue();
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -1333,7 +1333,7 @@ public final class Messages {
     int getResponseSize();
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -1341,7 +1341,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -1349,7 +1349,7 @@ public final class Messages {
      */
     io.grpc.benchmarks.proto.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -1376,7 +1376,7 @@ public final class Messages {
     boolean getFillOauthScope();
 
     /**
-     * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+     * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
      *
      * <pre>
      * Compression algorithm to be used by the server for the response (stream)
@@ -1384,7 +1384,7 @@ public final class Messages {
      */
     int getResponseCompressionValue();
     /**
-     * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+     * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
      *
      * <pre>
      * Compression algorithm to be used by the server for the response (stream)
@@ -1393,7 +1393,7 @@ public final class Messages {
     io.grpc.benchmarks.proto.Messages.CompressionType getResponseCompression();
 
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -1401,7 +1401,7 @@ public final class Messages {
      */
     boolean hasResponseStatus();
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -1409,7 +1409,7 @@ public final class Messages {
      */
     io.grpc.benchmarks.proto.Messages.EchoStatus getResponseStatus();
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -1418,7 +1418,7 @@ public final class Messages {
     io.grpc.benchmarks.proto.Messages.EchoStatusOrBuilder getResponseStatusOrBuilder();
   }
   /**
-   * Protobuf type {@code grpc.testing.SimpleRequest}
+   * Protobuf type {@code grpc.benchmarks.SimpleRequest}
    *
    * <pre>
    * Unary request.
@@ -1426,7 +1426,7 @@ public final class Messages {
    */
   public  static final class SimpleRequest extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.SimpleRequest)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.SimpleRequest)
       SimpleRequestOrBuilder {
     // Use SimpleRequest.newBuilder() to construct.
     private SimpleRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -1531,12 +1531,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleRequest_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleRequest_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.SimpleRequest.class, io.grpc.benchmarks.proto.Messages.SimpleRequest.Builder.class);
     }
@@ -1544,7 +1544,7 @@ public final class Messages {
     public static final int RESPONSE_TYPE_FIELD_NUMBER = 1;
     private int responseType_;
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -1555,7 +1555,7 @@ public final class Messages {
       return responseType_;
     }
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -1584,7 +1584,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 3;
     private io.grpc.benchmarks.proto.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -1594,7 +1594,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -1604,7 +1604,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.benchmarks.proto.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -1643,7 +1643,7 @@ public final class Messages {
     public static final int RESPONSE_COMPRESSION_FIELD_NUMBER = 6;
     private int responseCompression_;
     /**
-     * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+     * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
      *
      * <pre>
      * Compression algorithm to be used by the server for the response (stream)
@@ -1653,7 +1653,7 @@ public final class Messages {
       return responseCompression_;
     }
     /**
-     * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+     * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
      *
      * <pre>
      * Compression algorithm to be used by the server for the response (stream)
@@ -1667,7 +1667,7 @@ public final class Messages {
     public static final int RESPONSE_STATUS_FIELD_NUMBER = 7;
     private io.grpc.benchmarks.proto.Messages.EchoStatus responseStatus_;
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -1677,7 +1677,7 @@ public final class Messages {
       return responseStatus_ != null;
     }
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -1687,7 +1687,7 @@ public final class Messages {
       return responseStatus_ == null ? io.grpc.benchmarks.proto.Messages.EchoStatus.getDefaultInstance() : responseStatus_;
     }
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -1842,7 +1842,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.SimpleRequest}
+     * Protobuf type {@code grpc.benchmarks.SimpleRequest}
      *
      * <pre>
      * Unary request.
@@ -1850,16 +1850,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.SimpleRequest)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.SimpleRequest)
         io.grpc.benchmarks.proto.Messages.SimpleRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleRequest_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleRequest_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.SimpleRequest.class, io.grpc.benchmarks.proto.Messages.SimpleRequest.Builder.class);
       }
@@ -1907,7 +1907,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleRequest_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleRequest_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.SimpleRequest getDefaultInstanceForType() {
@@ -2003,7 +2003,7 @@ public final class Messages {
 
       private int responseType_ = 0;
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -2014,7 +2014,7 @@ public final class Messages {
         return responseType_;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -2027,7 +2027,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -2039,7 +2039,7 @@ public final class Messages {
         return result == null ? io.grpc.benchmarks.proto.Messages.PayloadType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -2056,7 +2056,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -2115,7 +2115,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Messages.Payload, io.grpc.benchmarks.proto.Messages.Payload.Builder, io.grpc.benchmarks.proto.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -2125,7 +2125,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -2139,7 +2139,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -2159,7 +2159,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -2177,7 +2177,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -2199,7 +2199,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -2217,7 +2217,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -2229,7 +2229,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -2244,7 +2244,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -2342,7 +2342,7 @@ public final class Messages {
 
       private int responseCompression_ = 0;
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -2352,7 +2352,7 @@ public final class Messages {
         return responseCompression_;
       }
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -2364,7 +2364,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -2375,7 +2375,7 @@ public final class Messages {
         return result == null ? io.grpc.benchmarks.proto.Messages.CompressionType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -2391,7 +2391,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -2408,7 +2408,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Messages.EchoStatus, io.grpc.benchmarks.proto.Messages.EchoStatus.Builder, io.grpc.benchmarks.proto.Messages.EchoStatusOrBuilder> responseStatusBuilder_;
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -2418,7 +2418,7 @@ public final class Messages {
         return responseStatusBuilder_ != null || responseStatus_ != null;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -2432,7 +2432,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -2452,7 +2452,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -2470,7 +2470,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -2492,7 +2492,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -2510,7 +2510,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -2522,7 +2522,7 @@ public final class Messages {
         return getResponseStatusFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -2537,7 +2537,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -2567,10 +2567,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.SimpleRequest)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.SimpleRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.SimpleRequest)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.SimpleRequest)
     private static final io.grpc.benchmarks.proto.Messages.SimpleRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.SimpleRequest();
@@ -2615,11 +2615,11 @@ public final class Messages {
   }
 
   public interface SimpleResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.SimpleResponse)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.SimpleResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -2627,7 +2627,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -2635,7 +2635,7 @@ public final class Messages {
      */
     io.grpc.benchmarks.proto.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -2682,7 +2682,7 @@ public final class Messages {
         getOauthScopeBytes();
   }
   /**
-   * Protobuf type {@code grpc.testing.SimpleResponse}
+   * Protobuf type {@code grpc.benchmarks.SimpleResponse}
    *
    * <pre>
    * Unary response, as configured by the request.
@@ -2690,7 +2690,7 @@ public final class Messages {
    */
   public  static final class SimpleResponse extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.SimpleResponse)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.SimpleResponse)
       SimpleResponseOrBuilder {
     // Use SimpleResponse.newBuilder() to construct.
     private SimpleResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -2764,12 +2764,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleResponse_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleResponse_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.SimpleResponse.class, io.grpc.benchmarks.proto.Messages.SimpleResponse.Builder.class);
     }
@@ -2777,7 +2777,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 1;
     private io.grpc.benchmarks.proto.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -2787,7 +2787,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -2797,7 +2797,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.benchmarks.proto.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -3008,7 +3008,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.SimpleResponse}
+     * Protobuf type {@code grpc.benchmarks.SimpleResponse}
      *
      * <pre>
      * Unary response, as configured by the request.
@@ -3016,16 +3016,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.SimpleResponse)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.SimpleResponse)
         io.grpc.benchmarks.proto.Messages.SimpleResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleResponse_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleResponse_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleResponse_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.SimpleResponse.class, io.grpc.benchmarks.proto.Messages.SimpleResponse.Builder.class);
       }
@@ -3061,7 +3061,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_SimpleResponse_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_SimpleResponse_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.SimpleResponse getDefaultInstanceForType() {
@@ -3141,7 +3141,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Messages.Payload, io.grpc.benchmarks.proto.Messages.Payload.Builder, io.grpc.benchmarks.proto.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -3151,7 +3151,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -3165,7 +3165,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -3185,7 +3185,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -3203,7 +3203,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -3225,7 +3225,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -3243,7 +3243,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -3255,7 +3255,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -3270,7 +3270,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -3483,10 +3483,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.SimpleResponse)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.SimpleResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.SimpleResponse)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.SimpleResponse)
     private static final io.grpc.benchmarks.proto.Messages.SimpleResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.SimpleResponse();
@@ -3531,11 +3531,11 @@ public final class Messages {
   }
 
   public interface StreamingInputCallRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.StreamingInputCallRequest)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.StreamingInputCallRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3543,7 +3543,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3551,7 +3551,7 @@ public final class Messages {
      */
     io.grpc.benchmarks.proto.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3560,7 +3560,7 @@ public final class Messages {
     io.grpc.benchmarks.proto.Messages.PayloadOrBuilder getPayloadOrBuilder();
   }
   /**
-   * Protobuf type {@code grpc.testing.StreamingInputCallRequest}
+   * Protobuf type {@code grpc.benchmarks.StreamingInputCallRequest}
    *
    * <pre>
    * Client-streaming request.
@@ -3568,7 +3568,7 @@ public final class Messages {
    */
   public  static final class StreamingInputCallRequest extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.StreamingInputCallRequest)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.StreamingInputCallRequest)
       StreamingInputCallRequestOrBuilder {
     // Use StreamingInputCallRequest.newBuilder() to construct.
     private StreamingInputCallRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -3628,12 +3628,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallRequest_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallRequest_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.StreamingInputCallRequest.class, io.grpc.benchmarks.proto.Messages.StreamingInputCallRequest.Builder.class);
     }
@@ -3641,7 +3641,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 1;
     private io.grpc.benchmarks.proto.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3651,7 +3651,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3661,7 +3661,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.benchmarks.proto.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3774,7 +3774,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.StreamingInputCallRequest}
+     * Protobuf type {@code grpc.benchmarks.StreamingInputCallRequest}
      *
      * <pre>
      * Client-streaming request.
@@ -3782,16 +3782,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.StreamingInputCallRequest)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.StreamingInputCallRequest)
         io.grpc.benchmarks.proto.Messages.StreamingInputCallRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallRequest_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallRequest_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.StreamingInputCallRequest.class, io.grpc.benchmarks.proto.Messages.StreamingInputCallRequest.Builder.class);
       }
@@ -3823,7 +3823,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallRequest_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallRequest_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.StreamingInputCallRequest getDefaultInstanceForType() {
@@ -3893,7 +3893,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Messages.Payload, io.grpc.benchmarks.proto.Messages.Payload.Builder, io.grpc.benchmarks.proto.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3903,7 +3903,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3917,7 +3917,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3937,7 +3937,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3955,7 +3955,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3977,7 +3977,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3995,7 +3995,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -4007,7 +4007,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -4022,7 +4022,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -4052,10 +4052,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.StreamingInputCallRequest)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.StreamingInputCallRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.StreamingInputCallRequest)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.StreamingInputCallRequest)
     private static final io.grpc.benchmarks.proto.Messages.StreamingInputCallRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.StreamingInputCallRequest();
@@ -4100,7 +4100,7 @@ public final class Messages {
   }
 
   public interface StreamingInputCallResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.StreamingInputCallResponse)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.StreamingInputCallResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -4113,7 +4113,7 @@ public final class Messages {
     int getAggregatedPayloadSize();
   }
   /**
-   * Protobuf type {@code grpc.testing.StreamingInputCallResponse}
+   * Protobuf type {@code grpc.benchmarks.StreamingInputCallResponse}
    *
    * <pre>
    * Client-streaming response.
@@ -4121,7 +4121,7 @@ public final class Messages {
    */
   public  static final class StreamingInputCallResponse extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.StreamingInputCallResponse)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.StreamingInputCallResponse)
       StreamingInputCallResponseOrBuilder {
     // Use StreamingInputCallResponse.newBuilder() to construct.
     private StreamingInputCallResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -4174,12 +4174,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallResponse_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallResponse_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.StreamingInputCallResponse.class, io.grpc.benchmarks.proto.Messages.StreamingInputCallResponse.Builder.class);
     }
@@ -4300,7 +4300,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.StreamingInputCallResponse}
+     * Protobuf type {@code grpc.benchmarks.StreamingInputCallResponse}
      *
      * <pre>
      * Client-streaming response.
@@ -4308,16 +4308,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.StreamingInputCallResponse)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.StreamingInputCallResponse)
         io.grpc.benchmarks.proto.Messages.StreamingInputCallResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallResponse_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallResponse_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallResponse_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.StreamingInputCallResponse.class, io.grpc.benchmarks.proto.Messages.StreamingInputCallResponse.Builder.class);
       }
@@ -4345,7 +4345,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingInputCallResponse_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingInputCallResponse_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.StreamingInputCallResponse getDefaultInstanceForType() {
@@ -4455,10 +4455,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.StreamingInputCallResponse)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.StreamingInputCallResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.StreamingInputCallResponse)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.StreamingInputCallResponse)
     private static final io.grpc.benchmarks.proto.Messages.StreamingInputCallResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.StreamingInputCallResponse();
@@ -4503,7 +4503,7 @@ public final class Messages {
   }
 
   public interface ResponseParametersOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ResponseParameters)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ResponseParameters)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -4527,7 +4527,7 @@ public final class Messages {
     int getIntervalUs();
   }
   /**
-   * Protobuf type {@code grpc.testing.ResponseParameters}
+   * Protobuf type {@code grpc.benchmarks.ResponseParameters}
    *
    * <pre>
    * Configuration for a particular response.
@@ -4535,7 +4535,7 @@ public final class Messages {
    */
   public  static final class ResponseParameters extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ResponseParameters)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ResponseParameters)
       ResponseParametersOrBuilder {
     // Use ResponseParameters.newBuilder() to construct.
     private ResponseParameters(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -4594,12 +4594,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ResponseParameters_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ResponseParameters_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ResponseParameters_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ResponseParameters_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.ResponseParameters.class, io.grpc.benchmarks.proto.Messages.ResponseParameters.Builder.class);
     }
@@ -4742,7 +4742,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ResponseParameters}
+     * Protobuf type {@code grpc.benchmarks.ResponseParameters}
      *
      * <pre>
      * Configuration for a particular response.
@@ -4750,16 +4750,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ResponseParameters)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ResponseParameters)
         io.grpc.benchmarks.proto.Messages.ResponseParametersOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ResponseParameters_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ResponseParameters_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ResponseParameters_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ResponseParameters_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.ResponseParameters.class, io.grpc.benchmarks.proto.Messages.ResponseParameters.Builder.class);
       }
@@ -4789,7 +4789,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ResponseParameters_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ResponseParameters_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.ResponseParameters getDefaultInstanceForType() {
@@ -4947,10 +4947,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ResponseParameters)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ResponseParameters)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ResponseParameters)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ResponseParameters)
     private static final io.grpc.benchmarks.proto.Messages.ResponseParameters DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.ResponseParameters();
@@ -4995,11 +4995,11 @@ public final class Messages {
   }
 
   public interface StreamingOutputCallRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.StreamingOutputCallRequest)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.StreamingOutputCallRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -5010,7 +5010,7 @@ public final class Messages {
      */
     int getResponseTypeValue();
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -5022,7 +5022,7 @@ public final class Messages {
     io.grpc.benchmarks.proto.Messages.PayloadType getResponseType();
 
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5031,7 +5031,7 @@ public final class Messages {
     java.util.List<io.grpc.benchmarks.proto.Messages.ResponseParameters> 
         getResponseParametersList();
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5039,7 +5039,7 @@ public final class Messages {
      */
     io.grpc.benchmarks.proto.Messages.ResponseParameters getResponseParameters(int index);
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5047,7 +5047,7 @@ public final class Messages {
      */
     int getResponseParametersCount();
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5056,7 +5056,7 @@ public final class Messages {
     java.util.List<? extends io.grpc.benchmarks.proto.Messages.ResponseParametersOrBuilder> 
         getResponseParametersOrBuilderList();
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5066,7 +5066,7 @@ public final class Messages {
         int index);
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -5074,7 +5074,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -5082,7 +5082,7 @@ public final class Messages {
      */
     io.grpc.benchmarks.proto.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -5091,7 +5091,7 @@ public final class Messages {
     io.grpc.benchmarks.proto.Messages.PayloadOrBuilder getPayloadOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+     * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
      *
      * <pre>
      * Compression algorithm to be used by the server for the response (stream)
@@ -5099,7 +5099,7 @@ public final class Messages {
      */
     int getResponseCompressionValue();
     /**
-     * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+     * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
      *
      * <pre>
      * Compression algorithm to be used by the server for the response (stream)
@@ -5108,7 +5108,7 @@ public final class Messages {
     io.grpc.benchmarks.proto.Messages.CompressionType getResponseCompression();
 
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -5116,7 +5116,7 @@ public final class Messages {
      */
     boolean hasResponseStatus();
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -5124,7 +5124,7 @@ public final class Messages {
      */
     io.grpc.benchmarks.proto.Messages.EchoStatus getResponseStatus();
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -5133,7 +5133,7 @@ public final class Messages {
     io.grpc.benchmarks.proto.Messages.EchoStatusOrBuilder getResponseStatusOrBuilder();
   }
   /**
-   * Protobuf type {@code grpc.testing.StreamingOutputCallRequest}
+   * Protobuf type {@code grpc.benchmarks.StreamingOutputCallRequest}
    *
    * <pre>
    * Server-streaming request.
@@ -5141,7 +5141,7 @@ public final class Messages {
    */
   public  static final class StreamingOutputCallRequest extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.StreamingOutputCallRequest)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.StreamingOutputCallRequest)
       StreamingOutputCallRequestOrBuilder {
     // Use StreamingOutputCallRequest.newBuilder() to construct.
     private StreamingOutputCallRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -5240,12 +5240,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.StreamingOutputCallRequest.class, io.grpc.benchmarks.proto.Messages.StreamingOutputCallRequest.Builder.class);
     }
@@ -5254,7 +5254,7 @@ public final class Messages {
     public static final int RESPONSE_TYPE_FIELD_NUMBER = 1;
     private int responseType_;
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -5267,7 +5267,7 @@ public final class Messages {
       return responseType_;
     }
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -5284,7 +5284,7 @@ public final class Messages {
     public static final int RESPONSE_PARAMETERS_FIELD_NUMBER = 2;
     private java.util.List<io.grpc.benchmarks.proto.Messages.ResponseParameters> responseParameters_;
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5294,7 +5294,7 @@ public final class Messages {
       return responseParameters_;
     }
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5305,7 +5305,7 @@ public final class Messages {
       return responseParameters_;
     }
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5315,7 +5315,7 @@ public final class Messages {
       return responseParameters_.size();
     }
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5325,7 +5325,7 @@ public final class Messages {
       return responseParameters_.get(index);
     }
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -5339,7 +5339,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 3;
     private io.grpc.benchmarks.proto.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -5349,7 +5349,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -5359,7 +5359,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.benchmarks.proto.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -5372,7 +5372,7 @@ public final class Messages {
     public static final int RESPONSE_COMPRESSION_FIELD_NUMBER = 6;
     private int responseCompression_;
     /**
-     * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+     * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
      *
      * <pre>
      * Compression algorithm to be used by the server for the response (stream)
@@ -5382,7 +5382,7 @@ public final class Messages {
       return responseCompression_;
     }
     /**
-     * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+     * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
      *
      * <pre>
      * Compression algorithm to be used by the server for the response (stream)
@@ -5396,7 +5396,7 @@ public final class Messages {
     public static final int RESPONSE_STATUS_FIELD_NUMBER = 7;
     private io.grpc.benchmarks.proto.Messages.EchoStatus responseStatus_;
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -5406,7 +5406,7 @@ public final class Messages {
       return responseStatus_ != null;
     }
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -5416,7 +5416,7 @@ public final class Messages {
       return responseStatus_ == null ? io.grpc.benchmarks.proto.Messages.EchoStatus.getDefaultInstance() : responseStatus_;
     }
     /**
-     * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+     * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
      *
      * <pre>
      * Whether server should return a given status
@@ -5557,7 +5557,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.StreamingOutputCallRequest}
+     * Protobuf type {@code grpc.benchmarks.StreamingOutputCallRequest}
      *
      * <pre>
      * Server-streaming request.
@@ -5565,16 +5565,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.StreamingOutputCallRequest)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.StreamingOutputCallRequest)
         io.grpc.benchmarks.proto.Messages.StreamingOutputCallRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.StreamingOutputCallRequest.class, io.grpc.benchmarks.proto.Messages.StreamingOutputCallRequest.Builder.class);
       }
@@ -5623,7 +5623,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallRequest_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.StreamingOutputCallRequest getDefaultInstanceForType() {
@@ -5746,7 +5746,7 @@ public final class Messages {
 
       private int responseType_ = 0;
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5759,7 +5759,7 @@ public final class Messages {
         return responseType_;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5774,7 +5774,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5788,7 +5788,7 @@ public final class Messages {
         return result == null ? io.grpc.benchmarks.proto.Messages.PayloadType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5807,7 +5807,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.benchmarks.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5836,7 +5836,7 @@ public final class Messages {
           io.grpc.benchmarks.proto.Messages.ResponseParameters, io.grpc.benchmarks.proto.Messages.ResponseParameters.Builder, io.grpc.benchmarks.proto.Messages.ResponseParametersOrBuilder> responseParametersBuilder_;
 
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5850,7 +5850,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5864,7 +5864,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5878,7 +5878,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5899,7 +5899,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5917,7 +5917,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5937,7 +5937,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5958,7 +5958,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5976,7 +5976,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5994,7 +5994,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -6013,7 +6013,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -6030,7 +6030,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -6047,7 +6047,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -6058,7 +6058,7 @@ public final class Messages {
         return getResponseParametersFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -6072,7 +6072,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -6087,7 +6087,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -6098,7 +6098,7 @@ public final class Messages {
             io.grpc.benchmarks.proto.Messages.ResponseParameters.getDefaultInstance());
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -6110,7 +6110,7 @@ public final class Messages {
             index, io.grpc.benchmarks.proto.Messages.ResponseParameters.getDefaultInstance());
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.benchmarks.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -6139,7 +6139,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Messages.Payload, io.grpc.benchmarks.proto.Messages.Payload.Builder, io.grpc.benchmarks.proto.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -6149,7 +6149,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -6163,7 +6163,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -6183,7 +6183,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -6201,7 +6201,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -6223,7 +6223,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -6241,7 +6241,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -6253,7 +6253,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -6268,7 +6268,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -6290,7 +6290,7 @@ public final class Messages {
 
       private int responseCompression_ = 0;
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -6300,7 +6300,7 @@ public final class Messages {
         return responseCompression_;
       }
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -6312,7 +6312,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -6323,7 +6323,7 @@ public final class Messages {
         return result == null ? io.grpc.benchmarks.proto.Messages.CompressionType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -6339,7 +6339,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.CompressionType response_compression = 6;</code>
+       * <code>optional .grpc.benchmarks.CompressionType response_compression = 6;</code>
        *
        * <pre>
        * Compression algorithm to be used by the server for the response (stream)
@@ -6356,7 +6356,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Messages.EchoStatus, io.grpc.benchmarks.proto.Messages.EchoStatus.Builder, io.grpc.benchmarks.proto.Messages.EchoStatusOrBuilder> responseStatusBuilder_;
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -6366,7 +6366,7 @@ public final class Messages {
         return responseStatusBuilder_ != null || responseStatus_ != null;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -6380,7 +6380,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -6400,7 +6400,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -6418,7 +6418,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -6440,7 +6440,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -6458,7 +6458,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -6470,7 +6470,7 @@ public final class Messages {
         return getResponseStatusFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -6485,7 +6485,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.EchoStatus response_status = 7;</code>
+       * <code>optional .grpc.benchmarks.EchoStatus response_status = 7;</code>
        *
        * <pre>
        * Whether server should return a given status
@@ -6515,10 +6515,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.StreamingOutputCallRequest)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.StreamingOutputCallRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.StreamingOutputCallRequest)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.StreamingOutputCallRequest)
     private static final io.grpc.benchmarks.proto.Messages.StreamingOutputCallRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.StreamingOutputCallRequest();
@@ -6563,11 +6563,11 @@ public final class Messages {
   }
 
   public interface StreamingOutputCallResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.StreamingOutputCallResponse)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.StreamingOutputCallResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -6575,7 +6575,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -6583,7 +6583,7 @@ public final class Messages {
      */
     io.grpc.benchmarks.proto.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -6592,7 +6592,7 @@ public final class Messages {
     io.grpc.benchmarks.proto.Messages.PayloadOrBuilder getPayloadOrBuilder();
   }
   /**
-   * Protobuf type {@code grpc.testing.StreamingOutputCallResponse}
+   * Protobuf type {@code grpc.benchmarks.StreamingOutputCallResponse}
    *
    * <pre>
    * Server-streaming response, as configured by the request and parameters.
@@ -6600,7 +6600,7 @@ public final class Messages {
    */
   public  static final class StreamingOutputCallResponse extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.StreamingOutputCallResponse)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.StreamingOutputCallResponse)
       StreamingOutputCallResponseOrBuilder {
     // Use StreamingOutputCallResponse.newBuilder() to construct.
     private StreamingOutputCallResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -6660,12 +6660,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.StreamingOutputCallResponse.class, io.grpc.benchmarks.proto.Messages.StreamingOutputCallResponse.Builder.class);
     }
@@ -6673,7 +6673,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 1;
     private io.grpc.benchmarks.proto.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -6683,7 +6683,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -6693,7 +6693,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.benchmarks.proto.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -6806,7 +6806,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.StreamingOutputCallResponse}
+     * Protobuf type {@code grpc.benchmarks.StreamingOutputCallResponse}
      *
      * <pre>
      * Server-streaming response, as configured by the request and parameters.
@@ -6814,16 +6814,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.StreamingOutputCallResponse)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.StreamingOutputCallResponse)
         io.grpc.benchmarks.proto.Messages.StreamingOutputCallResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallResponse_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.StreamingOutputCallResponse.class, io.grpc.benchmarks.proto.Messages.StreamingOutputCallResponse.Builder.class);
       }
@@ -6855,7 +6855,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_StreamingOutputCallResponse_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.StreamingOutputCallResponse getDefaultInstanceForType() {
@@ -6925,7 +6925,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Messages.Payload, io.grpc.benchmarks.proto.Messages.Payload.Builder, io.grpc.benchmarks.proto.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6935,7 +6935,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6949,7 +6949,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6969,7 +6969,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6987,7 +6987,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -7009,7 +7009,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -7027,7 +7027,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -7039,7 +7039,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -7054,7 +7054,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.benchmarks.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -7084,10 +7084,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.StreamingOutputCallResponse)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.StreamingOutputCallResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.StreamingOutputCallResponse)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.StreamingOutputCallResponse)
     private static final io.grpc.benchmarks.proto.Messages.StreamingOutputCallResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.StreamingOutputCallResponse();
@@ -7132,7 +7132,7 @@ public final class Messages {
   }
 
   public interface ReconnectInfoOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ReconnectInfo)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ReconnectInfo)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -7154,7 +7154,7 @@ public final class Messages {
     int getBackoffMs(int index);
   }
   /**
-   * Protobuf type {@code grpc.testing.ReconnectInfo}
+   * Protobuf type {@code grpc.benchmarks.ReconnectInfo}
    *
    * <pre>
    * For reconnect interop test only.
@@ -7164,7 +7164,7 @@ public final class Messages {
    */
   public  static final class ReconnectInfo extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ReconnectInfo)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ReconnectInfo)
       ReconnectInfoOrBuilder {
     // Use ReconnectInfo.newBuilder() to construct.
     private ReconnectInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -7242,12 +7242,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ReconnectInfo_descriptor;
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ReconnectInfo_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ReconnectInfo_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ReconnectInfo_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Messages.ReconnectInfo.class, io.grpc.benchmarks.proto.Messages.ReconnectInfo.Builder.class);
     }
@@ -7410,7 +7410,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ReconnectInfo}
+     * Protobuf type {@code grpc.benchmarks.ReconnectInfo}
      *
      * <pre>
      * For reconnect interop test only.
@@ -7420,16 +7420,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ReconnectInfo)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ReconnectInfo)
         io.grpc.benchmarks.proto.Messages.ReconnectInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ReconnectInfo_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ReconnectInfo_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ReconnectInfo_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ReconnectInfo_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Messages.ReconnectInfo.class, io.grpc.benchmarks.proto.Messages.ReconnectInfo.Builder.class);
       }
@@ -7459,7 +7459,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_testing_ReconnectInfo_descriptor;
+        return io.grpc.benchmarks.proto.Messages.internal_static_grpc_benchmarks_ReconnectInfo_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Messages.ReconnectInfo getDefaultInstanceForType() {
@@ -7642,10 +7642,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ReconnectInfo)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ReconnectInfo)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ReconnectInfo)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ReconnectInfo)
     private static final io.grpc.benchmarks.proto.Messages.ReconnectInfo DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Messages.ReconnectInfo();
@@ -7690,55 +7690,55 @@ public final class Messages {
   }
 
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_Payload_descriptor;
+    internal_static_grpc_benchmarks_Payload_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_Payload_fieldAccessorTable;
+      internal_static_grpc_benchmarks_Payload_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_EchoStatus_descriptor;
+    internal_static_grpc_benchmarks_EchoStatus_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_EchoStatus_fieldAccessorTable;
+      internal_static_grpc_benchmarks_EchoStatus_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_SimpleRequest_descriptor;
+    internal_static_grpc_benchmarks_SimpleRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_SimpleRequest_fieldAccessorTable;
+      internal_static_grpc_benchmarks_SimpleRequest_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_SimpleResponse_descriptor;
+    internal_static_grpc_benchmarks_SimpleResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_SimpleResponse_fieldAccessorTable;
+      internal_static_grpc_benchmarks_SimpleResponse_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_StreamingInputCallRequest_descriptor;
+    internal_static_grpc_benchmarks_StreamingInputCallRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_StreamingInputCallRequest_fieldAccessorTable;
+      internal_static_grpc_benchmarks_StreamingInputCallRequest_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_StreamingInputCallResponse_descriptor;
+    internal_static_grpc_benchmarks_StreamingInputCallResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_StreamingInputCallResponse_fieldAccessorTable;
+      internal_static_grpc_benchmarks_StreamingInputCallResponse_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ResponseParameters_descriptor;
+    internal_static_grpc_benchmarks_ResponseParameters_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ResponseParameters_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ResponseParameters_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_StreamingOutputCallRequest_descriptor;
+    internal_static_grpc_benchmarks_StreamingOutputCallRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_StreamingOutputCallRequest_fieldAccessorTable;
+      internal_static_grpc_benchmarks_StreamingOutputCallRequest_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_StreamingOutputCallResponse_descriptor;
+    internal_static_grpc_benchmarks_StreamingOutputCallResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_StreamingOutputCallResponse_fieldAccessorTable;
+      internal_static_grpc_benchmarks_StreamingOutputCallResponse_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ReconnectInfo_descriptor;
+    internal_static_grpc_benchmarks_ReconnectInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ReconnectInfo_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ReconnectInfo_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -7748,39 +7748,40 @@ public final class Messages {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\016messages.proto\022\014grpc.testing\"@\n\007Payloa" +
-      "d\022\'\n\004type\030\001 \001(\0162\031.grpc.testing.PayloadTy" +
-      "pe\022\014\n\004body\030\002 \001(\014\"+\n\nEchoStatus\022\014\n\004code\030\001" +
-      " \001(\005\022\017\n\007message\030\002 \001(\t\"\241\002\n\rSimpleRequest\022" +
-      "0\n\rresponse_type\030\001 \001(\0162\031.grpc.testing.Pa" +
-      "yloadType\022\025\n\rresponse_size\030\002 \001(\005\022&\n\007payl" +
-      "oad\030\003 \001(\0132\025.grpc.testing.Payload\022\025\n\rfill" +
-      "_username\030\004 \001(\010\022\030\n\020fill_oauth_scope\030\005 \001(" +
-      "\010\022;\n\024response_compression\030\006 \001(\0162\035.grpc.t" +
-      "esting.CompressionType\0221\n\017response_statu",
-      "s\030\007 \001(\0132\030.grpc.testing.EchoStatus\"_\n\016Sim" +
-      "pleResponse\022&\n\007payload\030\001 \001(\0132\025.grpc.test" +
-      "ing.Payload\022\020\n\010username\030\002 \001(\t\022\023\n\013oauth_s" +
-      "cope\030\003 \001(\t\"C\n\031StreamingInputCallRequest\022" +
-      "&\n\007payload\030\001 \001(\0132\025.grpc.testing.Payload\"" +
-      "=\n\032StreamingInputCallResponse\022\037\n\027aggrega" +
-      "ted_payload_size\030\001 \001(\005\"7\n\022ResponseParame" +
-      "ters\022\014\n\004size\030\001 \001(\005\022\023\n\013interval_us\030\002 \001(\005\"" +
-      "\245\002\n\032StreamingOutputCallRequest\0220\n\rrespon" +
-      "se_type\030\001 \001(\0162\031.grpc.testing.PayloadType",
-      "\022=\n\023response_parameters\030\002 \003(\0132 .grpc.tes" +
-      "ting.ResponseParameters\022&\n\007payload\030\003 \001(\013" +
-      "2\025.grpc.testing.Payload\022;\n\024response_comp" +
-      "ression\030\006 \001(\0162\035.grpc.testing.Compression" +
-      "Type\0221\n\017response_status\030\007 \001(\0132\030.grpc.tes" +
-      "ting.EchoStatus\"E\n\033StreamingOutputCallRe" +
-      "sponse\022&\n\007payload\030\001 \001(\0132\025.grpc.testing.P" +
-      "ayload\"3\n\rReconnectInfo\022\016\n\006passed\030\001 \001(\010\022" +
-      "\022\n\nbackoff_ms\030\002 \003(\005*?\n\013PayloadType\022\020\n\014CO" +
-      "MPRESSABLE\020\000\022\022\n\016UNCOMPRESSABLE\020\001\022\n\n\006RAND",
-      "OM\020\002*2\n\017CompressionType\022\010\n\004NONE\020\000\022\010\n\004GZI" +
-      "P\020\001\022\013\n\007DEFLATE\020\002B$\n\030io.grpc.benchmarks.p" +
-      "rotoB\010Messagesb\006proto3"
+      "\n\016messages.proto\022\017grpc.benchmarks\"C\n\007Pay" +
+      "load\022*\n\004type\030\001 \001(\0162\034.grpc.benchmarks.Pay" +
+      "loadType\022\014\n\004body\030\002 \001(\014\"+\n\nEchoStatus\022\014\n\004" +
+      "code\030\001 \001(\005\022\017\n\007message\030\002 \001(\t\"\255\002\n\rSimpleRe" +
+      "quest\0223\n\rresponse_type\030\001 \001(\0162\034.grpc.benc" +
+      "hmarks.PayloadType\022\025\n\rresponse_size\030\002 \001(" +
+      "\005\022)\n\007payload\030\003 \001(\0132\030.grpc.benchmarks.Pay" +
+      "load\022\025\n\rfill_username\030\004 \001(\010\022\030\n\020fill_oaut" +
+      "h_scope\030\005 \001(\010\022>\n\024response_compression\030\006 " +
+      "\001(\0162 .grpc.benchmarks.CompressionType\0224\n",
+      "\017response_status\030\007 \001(\0132\033.grpc.benchmarks" +
+      ".EchoStatus\"b\n\016SimpleResponse\022)\n\007payload" +
+      "\030\001 \001(\0132\030.grpc.benchmarks.Payload\022\020\n\010user" +
+      "name\030\002 \001(\t\022\023\n\013oauth_scope\030\003 \001(\t\"F\n\031Strea" +
+      "mingInputCallRequest\022)\n\007payload\030\001 \001(\0132\030." +
+      "grpc.benchmarks.Payload\"=\n\032StreamingInpu" +
+      "tCallResponse\022\037\n\027aggregated_payload_size" +
+      "\030\001 \001(\005\"7\n\022ResponseParameters\022\014\n\004size\030\001 \001" +
+      "(\005\022\023\n\013interval_us\030\002 \001(\005\"\264\002\n\032StreamingOut" +
+      "putCallRequest\0223\n\rresponse_type\030\001 \001(\0162\034.",
+      "grpc.benchmarks.PayloadType\022@\n\023response_" +
+      "parameters\030\002 \003(\0132#.grpc.benchmarks.Respo" +
+      "nseParameters\022)\n\007payload\030\003 \001(\0132\030.grpc.be" +
+      "nchmarks.Payload\022>\n\024response_compression" +
+      "\030\006 \001(\0162 .grpc.benchmarks.CompressionType" +
+      "\0224\n\017response_status\030\007 \001(\0132\033.grpc.benchma" +
+      "rks.EchoStatus\"H\n\033StreamingOutputCallRes" +
+      "ponse\022)\n\007payload\030\001 \001(\0132\030.grpc.benchmarks" +
+      ".Payload\"3\n\rReconnectInfo\022\016\n\006passed\030\001 \001(" +
+      "\010\022\022\n\nbackoff_ms\030\002 \003(\005*?\n\013PayloadType\022\020\n\014",
+      "COMPRESSABLE\020\000\022\022\n\016UNCOMPRESSABLE\020\001\022\n\n\006RA" +
+      "NDOM\020\002*2\n\017CompressionType\022\010\n\004NONE\020\000\022\010\n\004G" +
+      "ZIP\020\001\022\013\n\007DEFLATE\020\002B$\n\030io.grpc.benchmarks" +
+      ".protoB\010Messagesb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -7794,65 +7795,65 @@ public final class Messages {
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
-    internal_static_grpc_testing_Payload_descriptor =
+    internal_static_grpc_benchmarks_Payload_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_grpc_testing_Payload_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_Payload_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_Payload_descriptor,
+        internal_static_grpc_benchmarks_Payload_descriptor,
         new java.lang.String[] { "Type", "Body", });
-    internal_static_grpc_testing_EchoStatus_descriptor =
+    internal_static_grpc_benchmarks_EchoStatus_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_grpc_testing_EchoStatus_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_EchoStatus_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_EchoStatus_descriptor,
+        internal_static_grpc_benchmarks_EchoStatus_descriptor,
         new java.lang.String[] { "Code", "Message", });
-    internal_static_grpc_testing_SimpleRequest_descriptor =
+    internal_static_grpc_benchmarks_SimpleRequest_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_grpc_testing_SimpleRequest_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_SimpleRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_SimpleRequest_descriptor,
+        internal_static_grpc_benchmarks_SimpleRequest_descriptor,
         new java.lang.String[] { "ResponseType", "ResponseSize", "Payload", "FillUsername", "FillOauthScope", "ResponseCompression", "ResponseStatus", });
-    internal_static_grpc_testing_SimpleResponse_descriptor =
+    internal_static_grpc_benchmarks_SimpleResponse_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_grpc_testing_SimpleResponse_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_SimpleResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_SimpleResponse_descriptor,
+        internal_static_grpc_benchmarks_SimpleResponse_descriptor,
         new java.lang.String[] { "Payload", "Username", "OauthScope", });
-    internal_static_grpc_testing_StreamingInputCallRequest_descriptor =
+    internal_static_grpc_benchmarks_StreamingInputCallRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
-    internal_static_grpc_testing_StreamingInputCallRequest_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_StreamingInputCallRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_StreamingInputCallRequest_descriptor,
+        internal_static_grpc_benchmarks_StreamingInputCallRequest_descriptor,
         new java.lang.String[] { "Payload", });
-    internal_static_grpc_testing_StreamingInputCallResponse_descriptor =
+    internal_static_grpc_benchmarks_StreamingInputCallResponse_descriptor =
       getDescriptor().getMessageTypes().get(5);
-    internal_static_grpc_testing_StreamingInputCallResponse_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_StreamingInputCallResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_StreamingInputCallResponse_descriptor,
+        internal_static_grpc_benchmarks_StreamingInputCallResponse_descriptor,
         new java.lang.String[] { "AggregatedPayloadSize", });
-    internal_static_grpc_testing_ResponseParameters_descriptor =
+    internal_static_grpc_benchmarks_ResponseParameters_descriptor =
       getDescriptor().getMessageTypes().get(6);
-    internal_static_grpc_testing_ResponseParameters_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ResponseParameters_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ResponseParameters_descriptor,
+        internal_static_grpc_benchmarks_ResponseParameters_descriptor,
         new java.lang.String[] { "Size", "IntervalUs", });
-    internal_static_grpc_testing_StreamingOutputCallRequest_descriptor =
+    internal_static_grpc_benchmarks_StreamingOutputCallRequest_descriptor =
       getDescriptor().getMessageTypes().get(7);
-    internal_static_grpc_testing_StreamingOutputCallRequest_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_StreamingOutputCallRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_StreamingOutputCallRequest_descriptor,
+        internal_static_grpc_benchmarks_StreamingOutputCallRequest_descriptor,
         new java.lang.String[] { "ResponseType", "ResponseParameters", "Payload", "ResponseCompression", "ResponseStatus", });
-    internal_static_grpc_testing_StreamingOutputCallResponse_descriptor =
+    internal_static_grpc_benchmarks_StreamingOutputCallResponse_descriptor =
       getDescriptor().getMessageTypes().get(8);
-    internal_static_grpc_testing_StreamingOutputCallResponse_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_StreamingOutputCallResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_StreamingOutputCallResponse_descriptor,
+        internal_static_grpc_benchmarks_StreamingOutputCallResponse_descriptor,
         new java.lang.String[] { "Payload", });
-    internal_static_grpc_testing_ReconnectInfo_descriptor =
+    internal_static_grpc_benchmarks_ReconnectInfo_descriptor =
       getDescriptor().getMessageTypes().get(9);
-    internal_static_grpc_testing_ReconnectInfo_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ReconnectInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ReconnectInfo_descriptor,
+        internal_static_grpc_benchmarks_ReconnectInfo_descriptor,
         new java.lang.String[] { "Passed", "BackoffMs", });
   }
 

--- a/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Payloads.java
+++ b/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Payloads.java
@@ -9,7 +9,7 @@ public final class Payloads {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   public interface ByteBufferParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ByteBufferParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ByteBufferParams)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -23,11 +23,11 @@ public final class Payloads {
     int getRespSize();
   }
   /**
-   * Protobuf type {@code grpc.testing.ByteBufferParams}
+   * Protobuf type {@code grpc.benchmarks.ByteBufferParams}
    */
   public  static final class ByteBufferParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ByteBufferParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ByteBufferParams)
       ByteBufferParamsOrBuilder {
     // Use ByteBufferParams.newBuilder() to construct.
     private ByteBufferParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -86,12 +86,12 @@ public final class Payloads {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ByteBufferParams_descriptor;
+      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ByteBufferParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ByteBufferParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ByteBufferParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Payloads.ByteBufferParams.class, io.grpc.benchmarks.proto.Payloads.ByteBufferParams.Builder.class);
     }
@@ -224,20 +224,20 @@ public final class Payloads {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ByteBufferParams}
+     * Protobuf type {@code grpc.benchmarks.ByteBufferParams}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ByteBufferParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ByteBufferParams)
         io.grpc.benchmarks.proto.Payloads.ByteBufferParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ByteBufferParams_descriptor;
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ByteBufferParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ByteBufferParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ByteBufferParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Payloads.ByteBufferParams.class, io.grpc.benchmarks.proto.Payloads.ByteBufferParams.Builder.class);
       }
@@ -267,7 +267,7 @@ public final class Payloads {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ByteBufferParams_descriptor;
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ByteBufferParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Payloads.ByteBufferParams getDefaultInstanceForType() {
@@ -395,10 +395,10 @@ public final class Payloads {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ByteBufferParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ByteBufferParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ByteBufferParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ByteBufferParams)
     private static final io.grpc.benchmarks.proto.Payloads.ByteBufferParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Payloads.ByteBufferParams();
@@ -443,7 +443,7 @@ public final class Payloads {
   }
 
   public interface SimpleProtoParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.SimpleProtoParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.SimpleProtoParams)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -457,11 +457,11 @@ public final class Payloads {
     int getRespSize();
   }
   /**
-   * Protobuf type {@code grpc.testing.SimpleProtoParams}
+   * Protobuf type {@code grpc.benchmarks.SimpleProtoParams}
    */
   public  static final class SimpleProtoParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.SimpleProtoParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.SimpleProtoParams)
       SimpleProtoParamsOrBuilder {
     // Use SimpleProtoParams.newBuilder() to construct.
     private SimpleProtoParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -520,12 +520,12 @@ public final class Payloads {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_SimpleProtoParams_descriptor;
+      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_SimpleProtoParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_SimpleProtoParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_SimpleProtoParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Payloads.SimpleProtoParams.class, io.grpc.benchmarks.proto.Payloads.SimpleProtoParams.Builder.class);
     }
@@ -658,20 +658,20 @@ public final class Payloads {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.SimpleProtoParams}
+     * Protobuf type {@code grpc.benchmarks.SimpleProtoParams}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.SimpleProtoParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.SimpleProtoParams)
         io.grpc.benchmarks.proto.Payloads.SimpleProtoParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_SimpleProtoParams_descriptor;
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_SimpleProtoParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_SimpleProtoParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_SimpleProtoParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Payloads.SimpleProtoParams.class, io.grpc.benchmarks.proto.Payloads.SimpleProtoParams.Builder.class);
       }
@@ -701,7 +701,7 @@ public final class Payloads {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_SimpleProtoParams_descriptor;
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_SimpleProtoParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Payloads.SimpleProtoParams getDefaultInstanceForType() {
@@ -829,10 +829,10 @@ public final class Payloads {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.SimpleProtoParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.SimpleProtoParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.SimpleProtoParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.SimpleProtoParams)
     private static final io.grpc.benchmarks.proto.Payloads.SimpleProtoParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Payloads.SimpleProtoParams();
@@ -877,11 +877,11 @@ public final class Payloads {
   }
 
   public interface ComplexProtoParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ComplexProtoParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ComplexProtoParams)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code grpc.testing.ComplexProtoParams}
+   * Protobuf type {@code grpc.benchmarks.ComplexProtoParams}
    *
    * <pre>
    * TODO (vpai): Fill this in once the details of complex, representative
@@ -890,7 +890,7 @@ public final class Payloads {
    */
   public  static final class ComplexProtoParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ComplexProtoParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ComplexProtoParams)
       ComplexProtoParamsOrBuilder {
     // Use ComplexProtoParams.newBuilder() to construct.
     private ComplexProtoParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -936,12 +936,12 @@ public final class Payloads {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ComplexProtoParams_descriptor;
+      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ComplexProtoParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ComplexProtoParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ComplexProtoParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Payloads.ComplexProtoParams.class, io.grpc.benchmarks.proto.Payloads.ComplexProtoParams.Builder.class);
     }
@@ -1042,7 +1042,7 @@ public final class Payloads {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ComplexProtoParams}
+     * Protobuf type {@code grpc.benchmarks.ComplexProtoParams}
      *
      * <pre>
      * TODO (vpai): Fill this in once the details of complex, representative
@@ -1051,16 +1051,16 @@ public final class Payloads {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ComplexProtoParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ComplexProtoParams)
         io.grpc.benchmarks.proto.Payloads.ComplexProtoParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ComplexProtoParams_descriptor;
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ComplexProtoParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ComplexProtoParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ComplexProtoParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Payloads.ComplexProtoParams.class, io.grpc.benchmarks.proto.Payloads.ComplexProtoParams.Builder.class);
       }
@@ -1086,7 +1086,7 @@ public final class Payloads {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_ComplexProtoParams_descriptor;
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_ComplexProtoParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Payloads.ComplexProtoParams getDefaultInstanceForType() {
@@ -1154,10 +1154,10 @@ public final class Payloads {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ComplexProtoParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ComplexProtoParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ComplexProtoParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ComplexProtoParams)
     private static final io.grpc.benchmarks.proto.Payloads.ComplexProtoParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Payloads.ComplexProtoParams();
@@ -1202,44 +1202,44 @@ public final class Payloads {
   }
 
   public interface PayloadConfigOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.PayloadConfig)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.PayloadConfig)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+     * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
      */
     io.grpc.benchmarks.proto.Payloads.ByteBufferParams getBytebufParams();
     /**
-     * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+     * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
      */
     io.grpc.benchmarks.proto.Payloads.ByteBufferParamsOrBuilder getBytebufParamsOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
      */
     io.grpc.benchmarks.proto.Payloads.SimpleProtoParams getSimpleParams();
     /**
-     * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
      */
     io.grpc.benchmarks.proto.Payloads.SimpleProtoParamsOrBuilder getSimpleParamsOrBuilder();
 
     /**
-     * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+     * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
      */
     io.grpc.benchmarks.proto.Payloads.ComplexProtoParams getComplexParams();
     /**
-     * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+     * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
      */
     io.grpc.benchmarks.proto.Payloads.ComplexProtoParamsOrBuilder getComplexParamsOrBuilder();
 
     public io.grpc.benchmarks.proto.Payloads.PayloadConfig.PayloadCase getPayloadCase();
   }
   /**
-   * Protobuf type {@code grpc.testing.PayloadConfig}
+   * Protobuf type {@code grpc.benchmarks.PayloadConfig}
    */
   public  static final class PayloadConfig extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.PayloadConfig)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.PayloadConfig)
       PayloadConfigOrBuilder {
     // Use PayloadConfig.newBuilder() to construct.
     private PayloadConfig(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -1328,12 +1328,12 @@ public final class Payloads {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_PayloadConfig_descriptor;
+      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_PayloadConfig_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_PayloadConfig_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_PayloadConfig_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Payloads.PayloadConfig.class, io.grpc.benchmarks.proto.Payloads.PayloadConfig.Builder.class);
     }
@@ -1373,7 +1373,7 @@ public final class Payloads {
 
     public static final int BYTEBUF_PARAMS_FIELD_NUMBER = 1;
     /**
-     * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+     * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
      */
     public io.grpc.benchmarks.proto.Payloads.ByteBufferParams getBytebufParams() {
       if (payloadCase_ == 1) {
@@ -1382,7 +1382,7 @@ public final class Payloads {
       return io.grpc.benchmarks.proto.Payloads.ByteBufferParams.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+     * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
      */
     public io.grpc.benchmarks.proto.Payloads.ByteBufferParamsOrBuilder getBytebufParamsOrBuilder() {
       if (payloadCase_ == 1) {
@@ -1393,7 +1393,7 @@ public final class Payloads {
 
     public static final int SIMPLE_PARAMS_FIELD_NUMBER = 2;
     /**
-     * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
      */
     public io.grpc.benchmarks.proto.Payloads.SimpleProtoParams getSimpleParams() {
       if (payloadCase_ == 2) {
@@ -1402,7 +1402,7 @@ public final class Payloads {
       return io.grpc.benchmarks.proto.Payloads.SimpleProtoParams.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+     * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
      */
     public io.grpc.benchmarks.proto.Payloads.SimpleProtoParamsOrBuilder getSimpleParamsOrBuilder() {
       if (payloadCase_ == 2) {
@@ -1413,7 +1413,7 @@ public final class Payloads {
 
     public static final int COMPLEX_PARAMS_FIELD_NUMBER = 3;
     /**
-     * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+     * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
      */
     public io.grpc.benchmarks.proto.Payloads.ComplexProtoParams getComplexParams() {
       if (payloadCase_ == 3) {
@@ -1422,7 +1422,7 @@ public final class Payloads {
       return io.grpc.benchmarks.proto.Payloads.ComplexProtoParams.getDefaultInstance();
     }
     /**
-     * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+     * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
      */
     public io.grpc.benchmarks.proto.Payloads.ComplexProtoParamsOrBuilder getComplexParamsOrBuilder() {
       if (payloadCase_ == 3) {
@@ -1548,20 +1548,20 @@ public final class Payloads {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.PayloadConfig}
+     * Protobuf type {@code grpc.benchmarks.PayloadConfig}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.PayloadConfig)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.PayloadConfig)
         io.grpc.benchmarks.proto.Payloads.PayloadConfigOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_PayloadConfig_descriptor;
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_PayloadConfig_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_PayloadConfig_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_PayloadConfig_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Payloads.PayloadConfig.class, io.grpc.benchmarks.proto.Payloads.PayloadConfig.Builder.class);
       }
@@ -1589,7 +1589,7 @@ public final class Payloads {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_testing_PayloadConfig_descriptor;
+        return io.grpc.benchmarks.proto.Payloads.internal_static_grpc_benchmarks_PayloadConfig_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Payloads.PayloadConfig getDefaultInstanceForType() {
@@ -1704,7 +1704,7 @@ public final class Payloads {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Payloads.ByteBufferParams, io.grpc.benchmarks.proto.Payloads.ByteBufferParams.Builder, io.grpc.benchmarks.proto.Payloads.ByteBufferParamsOrBuilder> bytebufParamsBuilder_;
       /**
-       * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+       * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.ByteBufferParams getBytebufParams() {
         if (bytebufParamsBuilder_ == null) {
@@ -1720,7 +1720,7 @@ public final class Payloads {
         }
       }
       /**
-       * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+       * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
        */
       public Builder setBytebufParams(io.grpc.benchmarks.proto.Payloads.ByteBufferParams value) {
         if (bytebufParamsBuilder_ == null) {
@@ -1736,7 +1736,7 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+       * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
        */
       public Builder setBytebufParams(
           io.grpc.benchmarks.proto.Payloads.ByteBufferParams.Builder builderForValue) {
@@ -1750,7 +1750,7 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+       * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
        */
       public Builder mergeBytebufParams(io.grpc.benchmarks.proto.Payloads.ByteBufferParams value) {
         if (bytebufParamsBuilder_ == null) {
@@ -1772,7 +1772,7 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+       * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
        */
       public Builder clearBytebufParams() {
         if (bytebufParamsBuilder_ == null) {
@@ -1791,13 +1791,13 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+       * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.ByteBufferParams.Builder getBytebufParamsBuilder() {
         return getBytebufParamsFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+       * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.ByteBufferParamsOrBuilder getBytebufParamsOrBuilder() {
         if ((payloadCase_ == 1) && (bytebufParamsBuilder_ != null)) {
@@ -1810,7 +1810,7 @@ public final class Payloads {
         }
       }
       /**
-       * <code>optional .grpc.testing.ByteBufferParams bytebuf_params = 1;</code>
+       * <code>optional .grpc.benchmarks.ByteBufferParams bytebuf_params = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Payloads.ByteBufferParams, io.grpc.benchmarks.proto.Payloads.ByteBufferParams.Builder, io.grpc.benchmarks.proto.Payloads.ByteBufferParamsOrBuilder> 
@@ -1834,7 +1834,7 @@ public final class Payloads {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Payloads.SimpleProtoParams, io.grpc.benchmarks.proto.Payloads.SimpleProtoParams.Builder, io.grpc.benchmarks.proto.Payloads.SimpleProtoParamsOrBuilder> simpleParamsBuilder_;
       /**
-       * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.SimpleProtoParams getSimpleParams() {
         if (simpleParamsBuilder_ == null) {
@@ -1850,7 +1850,7 @@ public final class Payloads {
         }
       }
       /**
-       * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
        */
       public Builder setSimpleParams(io.grpc.benchmarks.proto.Payloads.SimpleProtoParams value) {
         if (simpleParamsBuilder_ == null) {
@@ -1866,7 +1866,7 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
        */
       public Builder setSimpleParams(
           io.grpc.benchmarks.proto.Payloads.SimpleProtoParams.Builder builderForValue) {
@@ -1880,7 +1880,7 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
        */
       public Builder mergeSimpleParams(io.grpc.benchmarks.proto.Payloads.SimpleProtoParams value) {
         if (simpleParamsBuilder_ == null) {
@@ -1902,7 +1902,7 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
        */
       public Builder clearSimpleParams() {
         if (simpleParamsBuilder_ == null) {
@@ -1921,13 +1921,13 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.SimpleProtoParams.Builder getSimpleParamsBuilder() {
         return getSimpleParamsFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.SimpleProtoParamsOrBuilder getSimpleParamsOrBuilder() {
         if ((payloadCase_ == 2) && (simpleParamsBuilder_ != null)) {
@@ -1940,7 +1940,7 @@ public final class Payloads {
         }
       }
       /**
-       * <code>optional .grpc.testing.SimpleProtoParams simple_params = 2;</code>
+       * <code>optional .grpc.benchmarks.SimpleProtoParams simple_params = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Payloads.SimpleProtoParams, io.grpc.benchmarks.proto.Payloads.SimpleProtoParams.Builder, io.grpc.benchmarks.proto.Payloads.SimpleProtoParamsOrBuilder> 
@@ -1964,7 +1964,7 @@ public final class Payloads {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Payloads.ComplexProtoParams, io.grpc.benchmarks.proto.Payloads.ComplexProtoParams.Builder, io.grpc.benchmarks.proto.Payloads.ComplexProtoParamsOrBuilder> complexParamsBuilder_;
       /**
-       * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+       * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.ComplexProtoParams getComplexParams() {
         if (complexParamsBuilder_ == null) {
@@ -1980,7 +1980,7 @@ public final class Payloads {
         }
       }
       /**
-       * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+       * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
        */
       public Builder setComplexParams(io.grpc.benchmarks.proto.Payloads.ComplexProtoParams value) {
         if (complexParamsBuilder_ == null) {
@@ -1996,7 +1996,7 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+       * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
        */
       public Builder setComplexParams(
           io.grpc.benchmarks.proto.Payloads.ComplexProtoParams.Builder builderForValue) {
@@ -2010,7 +2010,7 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+       * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
        */
       public Builder mergeComplexParams(io.grpc.benchmarks.proto.Payloads.ComplexProtoParams value) {
         if (complexParamsBuilder_ == null) {
@@ -2032,7 +2032,7 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+       * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
        */
       public Builder clearComplexParams() {
         if (complexParamsBuilder_ == null) {
@@ -2051,13 +2051,13 @@ public final class Payloads {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+       * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.ComplexProtoParams.Builder getComplexParamsBuilder() {
         return getComplexParamsFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+       * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
        */
       public io.grpc.benchmarks.proto.Payloads.ComplexProtoParamsOrBuilder getComplexParamsOrBuilder() {
         if ((payloadCase_ == 3) && (complexParamsBuilder_ != null)) {
@@ -2070,7 +2070,7 @@ public final class Payloads {
         }
       }
       /**
-       * <code>optional .grpc.testing.ComplexProtoParams complex_params = 3;</code>
+       * <code>optional .grpc.benchmarks.ComplexProtoParams complex_params = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Payloads.ComplexProtoParams, io.grpc.benchmarks.proto.Payloads.ComplexProtoParams.Builder, io.grpc.benchmarks.proto.Payloads.ComplexProtoParamsOrBuilder> 
@@ -2101,10 +2101,10 @@ public final class Payloads {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.PayloadConfig)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.PayloadConfig)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.PayloadConfig)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.PayloadConfig)
     private static final io.grpc.benchmarks.proto.Payloads.PayloadConfig DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Payloads.PayloadConfig();
@@ -2149,25 +2149,25 @@ public final class Payloads {
   }
 
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ByteBufferParams_descriptor;
+    internal_static_grpc_benchmarks_ByteBufferParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ByteBufferParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ByteBufferParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_SimpleProtoParams_descriptor;
+    internal_static_grpc_benchmarks_SimpleProtoParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_SimpleProtoParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_SimpleProtoParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ComplexProtoParams_descriptor;
+    internal_static_grpc_benchmarks_ComplexProtoParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ComplexProtoParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ComplexProtoParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_PayloadConfig_descriptor;
+    internal_static_grpc_benchmarks_PayloadConfig_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_PayloadConfig_fieldAccessorTable;
+      internal_static_grpc_benchmarks_PayloadConfig_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -2177,17 +2177,17 @@ public final class Payloads {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\016payloads.proto\022\014grpc.testing\"7\n\020ByteBu" +
-      "fferParams\022\020\n\010req_size\030\001 \001(\005\022\021\n\tresp_siz" +
-      "e\030\002 \001(\005\"8\n\021SimpleProtoParams\022\020\n\010req_size" +
-      "\030\001 \001(\005\022\021\n\tresp_size\030\002 \001(\005\"\024\n\022ComplexProt" +
-      "oParams\"\312\001\n\rPayloadConfig\0228\n\016bytebuf_par" +
-      "ams\030\001 \001(\0132\036.grpc.testing.ByteBufferParam" +
-      "sH\000\0228\n\rsimple_params\030\002 \001(\0132\037.grpc.testin" +
-      "g.SimpleProtoParamsH\000\022:\n\016complex_params\030" +
-      "\003 \001(\0132 .grpc.testing.ComplexProtoParamsH" +
-      "\000B\t\n\007payloadB$\n\030io.grpc.benchmarks.proto",
-      "B\010Payloadsb\006proto3"
+      "\n\016payloads.proto\022\017grpc.benchmarks\"7\n\020Byt" +
+      "eBufferParams\022\020\n\010req_size\030\001 \001(\005\022\021\n\tresp_" +
+      "size\030\002 \001(\005\"8\n\021SimpleProtoParams\022\020\n\010req_s" +
+      "ize\030\001 \001(\005\022\021\n\tresp_size\030\002 \001(\005\"\024\n\022ComplexP" +
+      "rotoParams\"\323\001\n\rPayloadConfig\022;\n\016bytebuf_" +
+      "params\030\001 \001(\0132!.grpc.benchmarks.ByteBuffe" +
+      "rParamsH\000\022;\n\rsimple_params\030\002 \001(\0132\".grpc." +
+      "benchmarks.SimpleProtoParamsH\000\022=\n\016comple" +
+      "x_params\030\003 \001(\0132#.grpc.benchmarks.Complex" +
+      "ProtoParamsH\000B\t\n\007payloadB$\n\030io.grpc.benc",
+      "hmarks.protoB\010Payloadsb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -2201,29 +2201,29 @@ public final class Payloads {
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
-    internal_static_grpc_testing_ByteBufferParams_descriptor =
+    internal_static_grpc_benchmarks_ByteBufferParams_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_grpc_testing_ByteBufferParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ByteBufferParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ByteBufferParams_descriptor,
+        internal_static_grpc_benchmarks_ByteBufferParams_descriptor,
         new java.lang.String[] { "ReqSize", "RespSize", });
-    internal_static_grpc_testing_SimpleProtoParams_descriptor =
+    internal_static_grpc_benchmarks_SimpleProtoParams_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_grpc_testing_SimpleProtoParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_SimpleProtoParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_SimpleProtoParams_descriptor,
+        internal_static_grpc_benchmarks_SimpleProtoParams_descriptor,
         new java.lang.String[] { "ReqSize", "RespSize", });
-    internal_static_grpc_testing_ComplexProtoParams_descriptor =
+    internal_static_grpc_benchmarks_ComplexProtoParams_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_grpc_testing_ComplexProtoParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ComplexProtoParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ComplexProtoParams_descriptor,
+        internal_static_grpc_benchmarks_ComplexProtoParams_descriptor,
         new java.lang.String[] { });
-    internal_static_grpc_testing_PayloadConfig_descriptor =
+    internal_static_grpc_benchmarks_PayloadConfig_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_grpc_testing_PayloadConfig_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_PayloadConfig_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_PayloadConfig_descriptor,
+        internal_static_grpc_benchmarks_PayloadConfig_descriptor,
         new java.lang.String[] { "BytebufParams", "SimpleParams", "ComplexParams", "Payload", });
   }
 

--- a/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Services.java
+++ b/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Services.java
@@ -17,21 +17,22 @@ public final class Services {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\016services.proto\022\014grpc.testing\032\016messages" +
-      ".proto\032\rcontrol.proto2\252\001\n\020BenchmarkServi" +
-      "ce\022F\n\tUnaryCall\022\033.grpc.testing.SimpleReq" +
-      "uest\032\034.grpc.testing.SimpleResponse\022N\n\rSt" +
-      "reamingCall\022\033.grpc.testing.SimpleRequest" +
-      "\032\034.grpc.testing.SimpleResponse(\0010\0012\227\002\n\rW" +
-      "orkerService\022E\n\tRunServer\022\030.grpc.testing" +
-      ".ServerArgs\032\032.grpc.testing.ServerStatus(" +
-      "\0010\001\022E\n\tRunClient\022\030.grpc.testing.ClientAr" +
-      "gs\032\032.grpc.testing.ClientStatus(\0010\001\022B\n\tCo",
-      "reCount\022\031.grpc.testing.CoreRequest\032\032.grp" +
-      "c.testing.CoreResponse\0224\n\nQuitWorker\022\022.g" +
-      "rpc.testing.Void\032\022.grpc.testing.VoidB$\n\030" +
-      "io.grpc.benchmarks.protoB\010Servicesb\006prot" +
-      "o3"
+      "\n\016services.proto\022\017grpc.benchmarks\032\016messa" +
+      "ges.proto\032\rcontrol.proto2\266\001\n\020BenchmarkSe" +
+      "rvice\022L\n\tUnaryCall\022\036.grpc.benchmarks.Sim" +
+      "pleRequest\032\037.grpc.benchmarks.SimpleRespo" +
+      "nse\022T\n\rStreamingCall\022\036.grpc.benchmarks.S" +
+      "impleRequest\032\037.grpc.benchmarks.SimpleRes" +
+      "ponse(\0010\0012\257\002\n\rWorkerService\022K\n\tRunServer" +
+      "\022\033.grpc.benchmarks.ServerArgs\032\035.grpc.ben" +
+      "chmarks.ServerStatus(\0010\001\022K\n\tRunClient\022\033." +
+      "grpc.benchmarks.ClientArgs\032\035.grpc.benchm",
+      "arks.ClientStatus(\0010\001\022H\n\tCoreCount\022\034.grp" +
+      "c.benchmarks.CoreRequest\032\035.grpc.benchmar" +
+      "ks.CoreResponse\022:\n\nQuitWorker\022\025.grpc.ben" +
+      "chmarks.Void\032\025.grpc.benchmarks.VoidB$\n\030i" +
+      "o.grpc.benchmarks.protoB\010Servicesb\006proto" +
+      "3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Stats.java
+++ b/benchmarks/src/generated/main/java/io/grpc/benchmarks/proto/Stats.java
@@ -9,7 +9,7 @@ public final class Stats {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   public interface ServerStatsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ServerStats)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ServerStats)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -41,11 +41,11 @@ public final class Stats {
     double getTimeSystem();
   }
   /**
-   * Protobuf type {@code grpc.testing.ServerStats}
+   * Protobuf type {@code grpc.benchmarks.ServerStats}
    */
   public  static final class ServerStats extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ServerStats)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ServerStats)
       ServerStatsOrBuilder {
     // Use ServerStats.newBuilder() to construct.
     private ServerStats(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -110,12 +110,12 @@ public final class Stats {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ServerStats_descriptor;
+      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ServerStats_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ServerStats_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ServerStats_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Stats.ServerStats.class, io.grpc.benchmarks.proto.Stats.ServerStats.Builder.class);
     }
@@ -277,20 +277,20 @@ public final class Stats {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ServerStats}
+     * Protobuf type {@code grpc.benchmarks.ServerStats}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ServerStats)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ServerStats)
         io.grpc.benchmarks.proto.Stats.ServerStatsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ServerStats_descriptor;
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ServerStats_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ServerStats_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ServerStats_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Stats.ServerStats.class, io.grpc.benchmarks.proto.Stats.ServerStats.Builder.class);
       }
@@ -322,7 +322,7 @@ public final class Stats {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ServerStats_descriptor;
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ServerStats_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Stats.ServerStats getDefaultInstanceForType() {
@@ -519,10 +519,10 @@ public final class Stats {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ServerStats)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ServerStats)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ServerStats)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ServerStats)
     private static final io.grpc.benchmarks.proto.Stats.ServerStats DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Stats.ServerStats();
@@ -567,7 +567,7 @@ public final class Stats {
   }
 
   public interface HistogramParamsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.HistogramParams)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.HistogramParams)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -589,7 +589,7 @@ public final class Stats {
     double getMaxPossible();
   }
   /**
-   * Protobuf type {@code grpc.testing.HistogramParams}
+   * Protobuf type {@code grpc.benchmarks.HistogramParams}
    *
    * <pre>
    * Histogram params based on grpc/support/histogram.c
@@ -597,7 +597,7 @@ public final class Stats {
    */
   public  static final class HistogramParams extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.HistogramParams)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.HistogramParams)
       HistogramParamsOrBuilder {
     // Use HistogramParams.newBuilder() to construct.
     private HistogramParams(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -656,12 +656,12 @@ public final class Stats {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramParams_descriptor;
+      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramParams_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramParams_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramParams_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Stats.HistogramParams.class, io.grpc.benchmarks.proto.Stats.HistogramParams.Builder.class);
     }
@@ -802,7 +802,7 @@ public final class Stats {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.HistogramParams}
+     * Protobuf type {@code grpc.benchmarks.HistogramParams}
      *
      * <pre>
      * Histogram params based on grpc/support/histogram.c
@@ -810,16 +810,16 @@ public final class Stats {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.HistogramParams)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.HistogramParams)
         io.grpc.benchmarks.proto.Stats.HistogramParamsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramParams_descriptor;
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramParams_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramParams_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramParams_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Stats.HistogramParams.class, io.grpc.benchmarks.proto.Stats.HistogramParams.Builder.class);
       }
@@ -849,7 +849,7 @@ public final class Stats {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramParams_descriptor;
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramParams_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Stats.HistogramParams getDefaultInstanceForType() {
@@ -1001,10 +1001,10 @@ public final class Stats {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.HistogramParams)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.HistogramParams)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.HistogramParams)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.HistogramParams)
     private static final io.grpc.benchmarks.proto.Stats.HistogramParams DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Stats.HistogramParams();
@@ -1049,7 +1049,7 @@ public final class Stats {
   }
 
   public interface HistogramDataOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.HistogramData)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.HistogramData)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -1091,7 +1091,7 @@ public final class Stats {
     double getCount();
   }
   /**
-   * Protobuf type {@code grpc.testing.HistogramData}
+   * Protobuf type {@code grpc.benchmarks.HistogramData}
    *
    * <pre>
    * Histogram data based on grpc/support/histogram.c
@@ -1099,7 +1099,7 @@ public final class Stats {
    */
   public  static final class HistogramData extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.HistogramData)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.HistogramData)
       HistogramDataOrBuilder {
     // Use HistogramData.newBuilder() to construct.
     private HistogramData(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -1201,12 +1201,12 @@ public final class Stats {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramData_descriptor;
+      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramData_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramData_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramData_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Stats.HistogramData.class, io.grpc.benchmarks.proto.Stats.HistogramData.Builder.class);
     }
@@ -1433,7 +1433,7 @@ public final class Stats {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.HistogramData}
+     * Protobuf type {@code grpc.benchmarks.HistogramData}
      *
      * <pre>
      * Histogram data based on grpc/support/histogram.c
@@ -1441,16 +1441,16 @@ public final class Stats {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.HistogramData)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.HistogramData)
         io.grpc.benchmarks.proto.Stats.HistogramDataOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramData_descriptor;
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramData_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramData_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramData_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Stats.HistogramData.class, io.grpc.benchmarks.proto.Stats.HistogramData.Builder.class);
       }
@@ -1488,7 +1488,7 @@ public final class Stats {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_HistogramData_descriptor;
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_HistogramData_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Stats.HistogramData getDefaultInstanceForType() {
@@ -1791,10 +1791,10 @@ public final class Stats {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.HistogramData)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.HistogramData)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.HistogramData)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.HistogramData)
     private static final io.grpc.benchmarks.proto.Stats.HistogramData DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Stats.HistogramData();
@@ -1839,11 +1839,11 @@ public final class Stats {
   }
 
   public interface ClientStatsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ClientStats)
+      // @@protoc_insertion_point(interface_extends:grpc.benchmarks.ClientStats)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+     * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
      *
      * <pre>
      * Latency histogram. Data points are in nanoseconds.
@@ -1851,7 +1851,7 @@ public final class Stats {
      */
     boolean hasLatencies();
     /**
-     * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+     * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
      *
      * <pre>
      * Latency histogram. Data points are in nanoseconds.
@@ -1859,7 +1859,7 @@ public final class Stats {
      */
     io.grpc.benchmarks.proto.Stats.HistogramData getLatencies();
     /**
-     * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+     * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
      *
      * <pre>
      * Latency histogram. Data points are in nanoseconds.
@@ -1887,11 +1887,11 @@ public final class Stats {
     double getTimeSystem();
   }
   /**
-   * Protobuf type {@code grpc.testing.ClientStats}
+   * Protobuf type {@code grpc.benchmarks.ClientStats}
    */
   public  static final class ClientStats extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ClientStats)
+      // @@protoc_insertion_point(message_implements:grpc.benchmarks.ClientStats)
       ClientStatsOrBuilder {
     // Use ClientStats.newBuilder() to construct.
     private ClientStats(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -1969,12 +1969,12 @@ public final class Stats {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ClientStats_descriptor;
+      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ClientStats_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ClientStats_fieldAccessorTable
+      return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ClientStats_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.benchmarks.proto.Stats.ClientStats.class, io.grpc.benchmarks.proto.Stats.ClientStats.Builder.class);
     }
@@ -1982,7 +1982,7 @@ public final class Stats {
     public static final int LATENCIES_FIELD_NUMBER = 1;
     private io.grpc.benchmarks.proto.Stats.HistogramData latencies_;
     /**
-     * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+     * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
      *
      * <pre>
      * Latency histogram. Data points are in nanoseconds.
@@ -1992,7 +1992,7 @@ public final class Stats {
       return latencies_ != null;
     }
     /**
-     * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+     * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
      *
      * <pre>
      * Latency histogram. Data points are in nanoseconds.
@@ -2002,7 +2002,7 @@ public final class Stats {
       return latencies_ == null ? io.grpc.benchmarks.proto.Stats.HistogramData.getDefaultInstance() : latencies_;
     }
     /**
-     * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+     * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
      *
      * <pre>
      * Latency histogram. Data points are in nanoseconds.
@@ -2167,20 +2167,20 @@ public final class Stats {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ClientStats}
+     * Protobuf type {@code grpc.benchmarks.ClientStats}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ClientStats)
+        // @@protoc_insertion_point(builder_implements:grpc.benchmarks.ClientStats)
         io.grpc.benchmarks.proto.Stats.ClientStatsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ClientStats_descriptor;
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ClientStats_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ClientStats_fieldAccessorTable
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ClientStats_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.benchmarks.proto.Stats.ClientStats.class, io.grpc.benchmarks.proto.Stats.ClientStats.Builder.class);
       }
@@ -2218,7 +2218,7 @@ public final class Stats {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_testing_ClientStats_descriptor;
+        return io.grpc.benchmarks.proto.Stats.internal_static_grpc_benchmarks_ClientStats_descriptor;
       }
 
       public io.grpc.benchmarks.proto.Stats.ClientStats getDefaultInstanceForType() {
@@ -2300,7 +2300,7 @@ public final class Stats {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.benchmarks.proto.Stats.HistogramData, io.grpc.benchmarks.proto.Stats.HistogramData.Builder, io.grpc.benchmarks.proto.Stats.HistogramDataOrBuilder> latenciesBuilder_;
       /**
-       * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+       * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
        *
        * <pre>
        * Latency histogram. Data points are in nanoseconds.
@@ -2310,7 +2310,7 @@ public final class Stats {
         return latenciesBuilder_ != null || latencies_ != null;
       }
       /**
-       * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+       * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
        *
        * <pre>
        * Latency histogram. Data points are in nanoseconds.
@@ -2324,7 +2324,7 @@ public final class Stats {
         }
       }
       /**
-       * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+       * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
        *
        * <pre>
        * Latency histogram. Data points are in nanoseconds.
@@ -2344,7 +2344,7 @@ public final class Stats {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+       * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
        *
        * <pre>
        * Latency histogram. Data points are in nanoseconds.
@@ -2362,7 +2362,7 @@ public final class Stats {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+       * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
        *
        * <pre>
        * Latency histogram. Data points are in nanoseconds.
@@ -2384,7 +2384,7 @@ public final class Stats {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+       * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
        *
        * <pre>
        * Latency histogram. Data points are in nanoseconds.
@@ -2402,7 +2402,7 @@ public final class Stats {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+       * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
        *
        * <pre>
        * Latency histogram. Data points are in nanoseconds.
@@ -2414,7 +2414,7 @@ public final class Stats {
         return getLatenciesFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+       * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
        *
        * <pre>
        * Latency histogram. Data points are in nanoseconds.
@@ -2429,7 +2429,7 @@ public final class Stats {
         }
       }
       /**
-       * <code>optional .grpc.testing.HistogramData latencies = 1;</code>
+       * <code>optional .grpc.benchmarks.HistogramData latencies = 1;</code>
        *
        * <pre>
        * Latency histogram. Data points are in nanoseconds.
@@ -2549,10 +2549,10 @@ public final class Stats {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ClientStats)
+      // @@protoc_insertion_point(builder_scope:grpc.benchmarks.ClientStats)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ClientStats)
+    // @@protoc_insertion_point(class_scope:grpc.benchmarks.ClientStats)
     private static final io.grpc.benchmarks.proto.Stats.ClientStats DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.benchmarks.proto.Stats.ClientStats();
@@ -2597,25 +2597,25 @@ public final class Stats {
   }
 
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ServerStats_descriptor;
+    internal_static_grpc_benchmarks_ServerStats_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ServerStats_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ServerStats_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_HistogramParams_descriptor;
+    internal_static_grpc_benchmarks_HistogramParams_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_HistogramParams_fieldAccessorTable;
+      internal_static_grpc_benchmarks_HistogramParams_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_HistogramData_descriptor;
+    internal_static_grpc_benchmarks_HistogramData_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_HistogramData_fieldAccessorTable;
+      internal_static_grpc_benchmarks_HistogramData_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ClientStats_descriptor;
+    internal_static_grpc_benchmarks_ClientStats_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ClientStats_fieldAccessorTable;
+      internal_static_grpc_benchmarks_ClientStats_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -2625,18 +2625,18 @@ public final class Stats {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\013stats.proto\022\014grpc.testing\"K\n\013ServerSta" +
-      "ts\022\024\n\014time_elapsed\030\001 \001(\001\022\021\n\ttime_user\030\002 " +
-      "\001(\001\022\023\n\013time_system\030\003 \001(\001\";\n\017HistogramPar" +
-      "ams\022\022\n\nresolution\030\001 \001(\001\022\024\n\014max_possible\030" +
-      "\002 \001(\001\"w\n\rHistogramData\022\016\n\006bucket\030\001 \003(\r\022\020" +
-      "\n\010min_seen\030\002 \001(\001\022\020\n\010max_seen\030\003 \001(\001\022\013\n\003su" +
-      "m\030\004 \001(\001\022\026\n\016sum_of_squares\030\005 \001(\001\022\r\n\005count" +
-      "\030\006 \001(\001\"{\n\013ClientStats\022.\n\tlatencies\030\001 \001(\013" +
-      "2\033.grpc.testing.HistogramData\022\024\n\014time_el" +
-      "apsed\030\002 \001(\001\022\021\n\ttime_user\030\003 \001(\001\022\023\n\013time_s",
-      "ystem\030\004 \001(\001B!\n\030io.grpc.benchmarks.protoB" +
-      "\005Statsb\006proto3"
+      "\n\013stats.proto\022\017grpc.benchmarks\"K\n\013Server" +
+      "Stats\022\024\n\014time_elapsed\030\001 \001(\001\022\021\n\ttime_user" +
+      "\030\002 \001(\001\022\023\n\013time_system\030\003 \001(\001\";\n\017Histogram" +
+      "Params\022\022\n\nresolution\030\001 \001(\001\022\024\n\014max_possib" +
+      "le\030\002 \001(\001\"w\n\rHistogramData\022\016\n\006bucket\030\001 \003(" +
+      "\r\022\020\n\010min_seen\030\002 \001(\001\022\020\n\010max_seen\030\003 \001(\001\022\013\n" +
+      "\003sum\030\004 \001(\001\022\026\n\016sum_of_squares\030\005 \001(\001\022\r\n\005co" +
+      "unt\030\006 \001(\001\"~\n\013ClientStats\0221\n\tlatencies\030\001 " +
+      "\001(\0132\036.grpc.benchmarks.HistogramData\022\024\n\014t" +
+      "ime_elapsed\030\002 \001(\001\022\021\n\ttime_user\030\003 \001(\001\022\023\n\013",
+      "time_system\030\004 \001(\001B!\n\030io.grpc.benchmarks." +
+      "protoB\005Statsb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -2650,29 +2650,29 @@ public final class Stats {
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
-    internal_static_grpc_testing_ServerStats_descriptor =
+    internal_static_grpc_benchmarks_ServerStats_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_grpc_testing_ServerStats_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ServerStats_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ServerStats_descriptor,
+        internal_static_grpc_benchmarks_ServerStats_descriptor,
         new java.lang.String[] { "TimeElapsed", "TimeUser", "TimeSystem", });
-    internal_static_grpc_testing_HistogramParams_descriptor =
+    internal_static_grpc_benchmarks_HistogramParams_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_grpc_testing_HistogramParams_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_HistogramParams_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_HistogramParams_descriptor,
+        internal_static_grpc_benchmarks_HistogramParams_descriptor,
         new java.lang.String[] { "Resolution", "MaxPossible", });
-    internal_static_grpc_testing_HistogramData_descriptor =
+    internal_static_grpc_benchmarks_HistogramData_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_grpc_testing_HistogramData_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_HistogramData_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_HistogramData_descriptor,
+        internal_static_grpc_benchmarks_HistogramData_descriptor,
         new java.lang.String[] { "Bucket", "MinSeen", "MaxSeen", "Sum", "SumOfSquares", "Count", });
-    internal_static_grpc_testing_ClientStats_descriptor =
+    internal_static_grpc_benchmarks_ClientStats_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_grpc_testing_ClientStats_fieldAccessorTable = new
+    internal_static_grpc_benchmarks_ClientStats_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ClientStats_descriptor,
+        internal_static_grpc_benchmarks_ClientStats_descriptor,
         new java.lang.String[] { "Latencies", "TimeElapsed", "TimeUser", "TimeSystem", });
   }
 

--- a/benchmarks/src/main/proto/control.proto
+++ b/benchmarks/src/main/proto/control.proto
@@ -32,7 +32,7 @@ syntax = "proto3";
 import "payloads.proto";
 import "stats.proto";
 
-package grpc.testing;
+package grpc.benchmarks;
 
 option java_package = "io.grpc.benchmarks.proto";
 option java_outer_classname = "Control";

--- a/benchmarks/src/main/proto/messages.proto
+++ b/benchmarks/src/main/proto/messages.proto
@@ -31,7 +31,7 @@
 
 syntax = "proto3";
 
-package grpc.testing;
+package grpc.benchmarks;
 
 option java_package = "io.grpc.benchmarks.proto";
 option java_outer_classname = "Messages";

--- a/benchmarks/src/main/proto/payloads.proto
+++ b/benchmarks/src/main/proto/payloads.proto
@@ -29,7 +29,7 @@
 
 syntax = "proto3";
 
-package grpc.testing;
+package grpc.benchmarks;
 
 option java_package = "io.grpc.benchmarks.proto";
 option java_outer_classname = "Payloads";

--- a/benchmarks/src/main/proto/services.proto
+++ b/benchmarks/src/main/proto/services.proto
@@ -34,7 +34,7 @@ syntax = "proto3";
 import "messages.proto";
 import "control.proto";
 
-package grpc.testing;
+package grpc.benchmarks;
 
 option java_package = "io.grpc.benchmarks.proto";
 option java_outer_classname = "Services";

--- a/benchmarks/src/main/proto/stats.proto
+++ b/benchmarks/src/main/proto/stats.proto
@@ -29,7 +29,7 @@
 
 syntax = "proto3";
 
-package grpc.testing;
+package grpc.benchmarks;
 
 option java_package = "io.grpc.benchmarks.proto";
 option java_outer_classname = "Stats";

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -24,7 +24,7 @@ public class MetricsServiceGrpc {
 
   private MetricsServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.MetricsService";
+  public static final String SERVICE_NAME = "grpc.testing.integration.MetricsService";
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi
@@ -33,7 +33,7 @@ public class MetricsServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
           generateFullMethodName(
-              "grpc.testing.MetricsService", "GetAllGauges"),
+              "grpc.testing.integration.MetricsService", "GetAllGauges"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Metrics.EmptyMessage.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -42,7 +42,7 @@ public class MetricsServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
-              "grpc.testing.MetricsService", "GetGauge"),
+              "grpc.testing.integration.MetricsService", "GetGauge"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Metrics.GaugeRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()));
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -27,7 +27,7 @@ public class ReconnectServiceGrpc {
 
   private ReconnectServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.ReconnectService";
+  public static final String SERVICE_NAME = "grpc.testing.integration.ReconnectService";
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi
@@ -36,7 +36,7 @@ public class ReconnectServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
-              "grpc.testing.ReconnectService", "Start"),
+              "grpc.testing.integration.ReconnectService", "Start"),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -45,7 +45,7 @@ public class ReconnectServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
-              "grpc.testing.ReconnectService", "Stop"),
+              "grpc.testing.integration.ReconnectService", "Stop"),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.ReconnectInfo.getDefaultInstance()));
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -28,7 +28,7 @@ public class TestServiceGrpc {
 
   private TestServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.TestService";
+  public static final String SERVICE_NAME = "grpc.testing.integration.TestService";
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi
@@ -37,7 +37,7 @@ public class TestServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
-              "grpc.testing.TestService", "EmptyCall"),
+              "grpc.testing.integration.TestService", "EmptyCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -46,7 +46,7 @@ public class TestServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
-              "grpc.testing.TestService", "UnaryCall"),
+              "grpc.testing.integration.TestService", "UnaryCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -55,7 +55,7 @@ public class TestServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
           generateFullMethodName(
-              "grpc.testing.TestService", "StreamingOutputCall"),
+              "grpc.testing.integration.TestService", "StreamingOutputCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -64,7 +64,7 @@ public class TestServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
           generateFullMethodName(
-              "grpc.testing.TestService", "StreamingInputCall"),
+              "grpc.testing.integration.TestService", "StreamingInputCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingInputCallResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -73,7 +73,7 @@ public class TestServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
-              "grpc.testing.TestService", "FullDuplexCall"),
+              "grpc.testing.integration.TestService", "FullDuplexCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()));
   @io.grpc.ExperimentalApi
@@ -82,7 +82,7 @@ public class TestServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
           generateFullMethodName(
-              "grpc.testing.TestService", "HalfDuplexCall"),
+              "grpc.testing.integration.TestService", "HalfDuplexCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()));
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -28,7 +28,7 @@ public class UnimplementedServiceGrpc {
 
   private UnimplementedServiceGrpc() {}
 
-  public static final String SERVICE_NAME = "grpc.testing.UnimplementedService";
+  public static final String SERVICE_NAME = "grpc.testing.integration.UnimplementedService";
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi
@@ -37,7 +37,7 @@ public class UnimplementedServiceGrpc {
       io.grpc.MethodDescriptor.create(
           io.grpc.MethodDescriptor.MethodType.UNARY,
           generateFullMethodName(
-              "grpc.testing.UnimplementedService", "UnimplementedCall"),
+              "grpc.testing.integration.UnimplementedService", "UnimplementedCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()));
 

--- a/interop-testing/src/generated/main/java/com/google/protobuf/EmptyProtos.java
+++ b/interop-testing/src/generated/main/java/com/google/protobuf/EmptyProtos.java
@@ -9,24 +9,24 @@ public final class EmptyProtos {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   public interface EmptyOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.Empty)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.Empty)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code grpc.testing.Empty}
+   * Protobuf type {@code grpc.testing.integration.Empty}
    *
    * <pre>
    * An empty message that you can re-use to avoid defining duplicated empty
    * messages in your project. A typical example is to use it as argument or the
    * return value of a service API. For instance:
    *   service Foo {
-   *     rpc Bar (grpc.testing.Empty) returns (grpc.testing.Empty) { };
+   *     rpc Bar (grpc.testing.integration.Empty) returns (grpc.testing.integration.Empty) { };
    *   };
    * </pre>
    */
   public  static final class Empty extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.Empty)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.Empty)
       EmptyOrBuilder {
     // Use Empty.newBuilder() to construct.
     private Empty(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -76,12 +76,12 @@ public final class EmptyProtos {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_Empty_descriptor;
+      return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_integration_Empty_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_Empty_fieldAccessorTable
+      return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_integration_Empty_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.protobuf.EmptyProtos.Empty.class, com.google.protobuf.EmptyProtos.Empty.Builder.class);
     }
@@ -184,29 +184,29 @@ public final class EmptyProtos {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.Empty}
+     * Protobuf type {@code grpc.testing.integration.Empty}
      *
      * <pre>
      * An empty message that you can re-use to avoid defining duplicated empty
      * messages in your project. A typical example is to use it as argument or the
      * return value of a service API. For instance:
      *   service Foo {
-     *     rpc Bar (grpc.testing.Empty) returns (grpc.testing.Empty) { };
+     *     rpc Bar (grpc.testing.integration.Empty) returns (grpc.testing.integration.Empty) { };
      *   };
      * </pre>
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.Empty)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.Empty)
         com.google.protobuf.EmptyProtos.EmptyOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_Empty_descriptor;
+        return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_integration_Empty_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_Empty_fieldAccessorTable
+        return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_integration_Empty_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.google.protobuf.EmptyProtos.Empty.class, com.google.protobuf.EmptyProtos.Empty.Builder.class);
       }
@@ -232,7 +232,7 @@ public final class EmptyProtos {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_Empty_descriptor;
+        return com.google.protobuf.EmptyProtos.internal_static_grpc_testing_integration_Empty_descriptor;
       }
 
       public com.google.protobuf.EmptyProtos.Empty getDefaultInstanceForType() {
@@ -291,10 +291,10 @@ public final class EmptyProtos {
         return this;
       }
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.Empty)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.Empty)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.Empty)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.Empty)
     private static final com.google.protobuf.EmptyProtos.Empty DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new com.google.protobuf.EmptyProtos.Empty();
@@ -339,10 +339,10 @@ public final class EmptyProtos {
   }
 
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_Empty_descriptor;
+    internal_static_grpc_testing_integration_Empty_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_Empty_fieldAccessorTable;
+      internal_static_grpc_testing_integration_Empty_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -353,8 +353,8 @@ public final class EmptyProtos {
   static {
     java.lang.String[] descriptorData = {
       "\n\'io/grpc/testing/integration/empty.prot" +
-      "o\022\014grpc.testing\"\007\n\005EmptyB\"\n\023com.google.p" +
-      "rotobufB\013EmptyProtos"
+      "o\022\030grpc.testing.integration\"\007\n\005EmptyB\"\n\023" +
+      "com.google.protobufB\013EmptyProtos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -368,11 +368,11 @@ public final class EmptyProtos {
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
-    internal_static_grpc_testing_Empty_descriptor =
+    internal_static_grpc_testing_integration_Empty_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_grpc_testing_Empty_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_Empty_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_Empty_descriptor,
+        internal_static_grpc_testing_integration_Empty_descriptor,
         new java.lang.String[] { });
   }
 

--- a/interop-testing/src/generated/main/java/io/grpc/testing/integration/Messages.java
+++ b/interop-testing/src/generated/main/java/io/grpc/testing/integration/Messages.java
@@ -9,7 +9,7 @@ public final class Messages {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   /**
-   * Protobuf enum {@code grpc.testing.PayloadType}
+   * Protobuf enum {@code grpc.testing.integration.PayloadType}
    *
    * <pre>
    * The type of payload that should be returned.
@@ -134,15 +134,15 @@ public final class Messages {
       this.value = value;
     }
 
-    // @@protoc_insertion_point(enum_scope:grpc.testing.PayloadType)
+    // @@protoc_insertion_point(enum_scope:grpc.testing.integration.PayloadType)
   }
 
   public interface PayloadOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.Payload)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.Payload)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.PayloadType type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType type = 1;</code>
      *
      * <pre>
      * The type of data in body.
@@ -150,7 +150,7 @@ public final class Messages {
      */
     int getTypeValue();
     /**
-     * <code>optional .grpc.testing.PayloadType type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType type = 1;</code>
      *
      * <pre>
      * The type of data in body.
@@ -168,7 +168,7 @@ public final class Messages {
     com.google.protobuf.ByteString getBody();
   }
   /**
-   * Protobuf type {@code grpc.testing.Payload}
+   * Protobuf type {@code grpc.testing.integration.Payload}
    *
    * <pre>
    * A block of data, to simply increase gRPC message size.
@@ -176,7 +176,7 @@ public final class Messages {
    */
   public  static final class Payload extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.Payload)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.Payload)
       PayloadOrBuilder {
     // Use Payload.newBuilder() to construct.
     private Payload(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -236,12 +236,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_Payload_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_Payload_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_Payload_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_Payload_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.Payload.class, io.grpc.testing.integration.Messages.Payload.Builder.class);
     }
@@ -249,7 +249,7 @@ public final class Messages {
     public static final int TYPE_FIELD_NUMBER = 1;
     private int type_;
     /**
-     * <code>optional .grpc.testing.PayloadType type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType type = 1;</code>
      *
      * <pre>
      * The type of data in body.
@@ -259,7 +259,7 @@ public final class Messages {
       return type_;
     }
     /**
-     * <code>optional .grpc.testing.PayloadType type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType type = 1;</code>
      *
      * <pre>
      * The type of data in body.
@@ -393,7 +393,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.Payload}
+     * Protobuf type {@code grpc.testing.integration.Payload}
      *
      * <pre>
      * A block of data, to simply increase gRPC message size.
@@ -401,16 +401,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.Payload)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.Payload)
         io.grpc.testing.integration.Messages.PayloadOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_Payload_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_Payload_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_Payload_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_Payload_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.Payload.class, io.grpc.testing.integration.Messages.Payload.Builder.class);
       }
@@ -440,7 +440,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_Payload_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_Payload_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.Payload getDefaultInstanceForType() {
@@ -508,7 +508,7 @@ public final class Messages {
 
       private int type_ = 0;
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -518,7 +518,7 @@ public final class Messages {
         return type_;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -530,7 +530,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -541,7 +541,7 @@ public final class Messages {
         return result == null ? io.grpc.testing.integration.Messages.PayloadType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -557,7 +557,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType type = 1;</code>
        *
        * <pre>
        * The type of data in body.
@@ -621,10 +621,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.Payload)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.Payload)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.Payload)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.Payload)
     private static final io.grpc.testing.integration.Messages.Payload DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.Payload();
@@ -669,11 +669,11 @@ public final class Messages {
   }
 
   public interface SimpleRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.SimpleRequest)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.SimpleRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -682,7 +682,7 @@ public final class Messages {
      */
     int getResponseTypeValue();
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -702,7 +702,7 @@ public final class Messages {
     int getResponseSize();
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -710,7 +710,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -718,7 +718,7 @@ public final class Messages {
      */
     io.grpc.testing.integration.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -745,7 +745,7 @@ public final class Messages {
     boolean getFillOauthScope();
   }
   /**
-   * Protobuf type {@code grpc.testing.SimpleRequest}
+   * Protobuf type {@code grpc.testing.integration.SimpleRequest}
    *
    * <pre>
    * Unary request.
@@ -753,7 +753,7 @@ public final class Messages {
    */
   public  static final class SimpleRequest extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.SimpleRequest)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.SimpleRequest)
       SimpleRequestOrBuilder {
     // Use SimpleRequest.newBuilder() to construct.
     private SimpleRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -838,12 +838,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleRequest_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleRequest_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.SimpleRequest.class, io.grpc.testing.integration.Messages.SimpleRequest.Builder.class);
     }
@@ -851,7 +851,7 @@ public final class Messages {
     public static final int RESPONSE_TYPE_FIELD_NUMBER = 1;
     private int responseType_;
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -862,7 +862,7 @@ public final class Messages {
       return responseType_;
     }
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -891,7 +891,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 3;
     private io.grpc.testing.integration.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -901,7 +901,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -911,7 +911,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.testing.integration.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -1078,7 +1078,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.SimpleRequest}
+     * Protobuf type {@code grpc.testing.integration.SimpleRequest}
      *
      * <pre>
      * Unary request.
@@ -1086,16 +1086,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.SimpleRequest)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.SimpleRequest)
         io.grpc.testing.integration.Messages.SimpleRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleRequest_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleRequest_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.SimpleRequest.class, io.grpc.testing.integration.Messages.SimpleRequest.Builder.class);
       }
@@ -1135,7 +1135,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleRequest_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleRequest_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.SimpleRequest getDefaultInstanceForType() {
@@ -1219,7 +1219,7 @@ public final class Messages {
 
       private int responseType_ = 0;
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -1230,7 +1230,7 @@ public final class Messages {
         return responseType_;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -1243,7 +1243,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -1255,7 +1255,7 @@ public final class Messages {
         return result == null ? io.grpc.testing.integration.Messages.PayloadType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -1272,7 +1272,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -1331,7 +1331,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.testing.integration.Messages.Payload, io.grpc.testing.integration.Messages.Payload.Builder, io.grpc.testing.integration.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -1341,7 +1341,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -1355,7 +1355,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -1375,7 +1375,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -1393,7 +1393,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -1415,7 +1415,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -1433,7 +1433,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -1445,7 +1445,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -1460,7 +1460,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -1566,10 +1566,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.SimpleRequest)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.SimpleRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.SimpleRequest)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.SimpleRequest)
     private static final io.grpc.testing.integration.Messages.SimpleRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.SimpleRequest();
@@ -1614,11 +1614,11 @@ public final class Messages {
   }
 
   public interface SimpleResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.SimpleResponse)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.SimpleResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -1626,7 +1626,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -1634,7 +1634,7 @@ public final class Messages {
      */
     io.grpc.testing.integration.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -1681,7 +1681,7 @@ public final class Messages {
         getOauthScopeBytes();
   }
   /**
-   * Protobuf type {@code grpc.testing.SimpleResponse}
+   * Protobuf type {@code grpc.testing.integration.SimpleResponse}
    *
    * <pre>
    * Unary response, as configured by the request.
@@ -1689,7 +1689,7 @@ public final class Messages {
    */
   public  static final class SimpleResponse extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.SimpleResponse)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.SimpleResponse)
       SimpleResponseOrBuilder {
     // Use SimpleResponse.newBuilder() to construct.
     private SimpleResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -1763,12 +1763,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleResponse_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleResponse_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.SimpleResponse.class, io.grpc.testing.integration.Messages.SimpleResponse.Builder.class);
     }
@@ -1776,7 +1776,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 1;
     private io.grpc.testing.integration.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -1786,7 +1786,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -1796,7 +1796,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.testing.integration.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase message size.
@@ -2007,7 +2007,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.SimpleResponse}
+     * Protobuf type {@code grpc.testing.integration.SimpleResponse}
      *
      * <pre>
      * Unary response, as configured by the request.
@@ -2015,16 +2015,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.SimpleResponse)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.SimpleResponse)
         io.grpc.testing.integration.Messages.SimpleResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleResponse_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleResponse_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleResponse_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.SimpleResponse.class, io.grpc.testing.integration.Messages.SimpleResponse.Builder.class);
       }
@@ -2060,7 +2060,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleResponse_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleResponse_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.SimpleResponse getDefaultInstanceForType() {
@@ -2140,7 +2140,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.testing.integration.Messages.Payload, io.grpc.testing.integration.Messages.Payload.Builder, io.grpc.testing.integration.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -2150,7 +2150,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -2164,7 +2164,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -2184,7 +2184,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -2202,7 +2202,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -2224,7 +2224,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -2242,7 +2242,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -2254,7 +2254,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -2269,7 +2269,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase message size.
@@ -2482,10 +2482,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.SimpleResponse)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.SimpleResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.SimpleResponse)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.SimpleResponse)
     private static final io.grpc.testing.integration.Messages.SimpleResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.SimpleResponse();
@@ -2530,7 +2530,7 @@ public final class Messages {
   }
 
   public interface SimpleContextOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.SimpleContext)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.SimpleContext)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -2544,11 +2544,11 @@ public final class Messages {
         getValueBytes();
   }
   /**
-   * Protobuf type {@code grpc.testing.SimpleContext}
+   * Protobuf type {@code grpc.testing.integration.SimpleContext}
    */
   public  static final class SimpleContext extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.SimpleContext)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.SimpleContext)
       SimpleContextOrBuilder {
     // Use SimpleContext.newBuilder() to construct.
     private SimpleContext(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -2602,12 +2602,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleContext_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleContext_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleContext_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleContext_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.SimpleContext.class, io.grpc.testing.integration.Messages.SimpleContext.Builder.class);
     }
@@ -2748,20 +2748,20 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.SimpleContext}
+     * Protobuf type {@code grpc.testing.integration.SimpleContext}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.SimpleContext)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.SimpleContext)
         io.grpc.testing.integration.Messages.SimpleContextOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleContext_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleContext_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleContext_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleContext_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.SimpleContext.class, io.grpc.testing.integration.Messages.SimpleContext.Builder.class);
       }
@@ -2789,7 +2789,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_SimpleContext_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_SimpleContext_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.SimpleContext getDefaultInstanceForType() {
@@ -2931,10 +2931,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.SimpleContext)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.SimpleContext)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.SimpleContext)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.SimpleContext)
     private static final io.grpc.testing.integration.Messages.SimpleContext DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.SimpleContext();
@@ -2979,11 +2979,11 @@ public final class Messages {
   }
 
   public interface StreamingInputCallRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.StreamingInputCallRequest)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.StreamingInputCallRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -2991,7 +2991,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -2999,7 +2999,7 @@ public final class Messages {
      */
     io.grpc.testing.integration.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3008,7 +3008,7 @@ public final class Messages {
     io.grpc.testing.integration.Messages.PayloadOrBuilder getPayloadOrBuilder();
   }
   /**
-   * Protobuf type {@code grpc.testing.StreamingInputCallRequest}
+   * Protobuf type {@code grpc.testing.integration.StreamingInputCallRequest}
    *
    * <pre>
    * Client-streaming request.
@@ -3016,7 +3016,7 @@ public final class Messages {
    */
   public  static final class StreamingInputCallRequest extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.StreamingInputCallRequest)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.StreamingInputCallRequest)
       StreamingInputCallRequestOrBuilder {
     // Use StreamingInputCallRequest.newBuilder() to construct.
     private StreamingInputCallRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -3076,12 +3076,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallRequest_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallRequest_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.StreamingInputCallRequest.class, io.grpc.testing.integration.Messages.StreamingInputCallRequest.Builder.class);
     }
@@ -3089,7 +3089,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 1;
     private io.grpc.testing.integration.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3099,7 +3099,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3109,7 +3109,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.testing.integration.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -3222,7 +3222,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.StreamingInputCallRequest}
+     * Protobuf type {@code grpc.testing.integration.StreamingInputCallRequest}
      *
      * <pre>
      * Client-streaming request.
@@ -3230,16 +3230,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.StreamingInputCallRequest)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.StreamingInputCallRequest)
         io.grpc.testing.integration.Messages.StreamingInputCallRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallRequest_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallRequest_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.StreamingInputCallRequest.class, io.grpc.testing.integration.Messages.StreamingInputCallRequest.Builder.class);
       }
@@ -3271,7 +3271,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallRequest_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallRequest_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.StreamingInputCallRequest getDefaultInstanceForType() {
@@ -3341,7 +3341,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.testing.integration.Messages.Payload, io.grpc.testing.integration.Messages.Payload.Builder, io.grpc.testing.integration.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3351,7 +3351,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3365,7 +3365,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3385,7 +3385,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3403,7 +3403,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3425,7 +3425,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3443,7 +3443,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3455,7 +3455,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3470,7 +3470,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -3500,10 +3500,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.StreamingInputCallRequest)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.StreamingInputCallRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.StreamingInputCallRequest)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.StreamingInputCallRequest)
     private static final io.grpc.testing.integration.Messages.StreamingInputCallRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.StreamingInputCallRequest();
@@ -3548,7 +3548,7 @@ public final class Messages {
   }
 
   public interface StreamingInputCallResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.StreamingInputCallResponse)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.StreamingInputCallResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -3561,7 +3561,7 @@ public final class Messages {
     int getAggregatedPayloadSize();
   }
   /**
-   * Protobuf type {@code grpc.testing.StreamingInputCallResponse}
+   * Protobuf type {@code grpc.testing.integration.StreamingInputCallResponse}
    *
    * <pre>
    * Client-streaming response.
@@ -3569,7 +3569,7 @@ public final class Messages {
    */
   public  static final class StreamingInputCallResponse extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.StreamingInputCallResponse)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.StreamingInputCallResponse)
       StreamingInputCallResponseOrBuilder {
     // Use StreamingInputCallResponse.newBuilder() to construct.
     private StreamingInputCallResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -3622,12 +3622,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallResponse_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallResponse_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.StreamingInputCallResponse.class, io.grpc.testing.integration.Messages.StreamingInputCallResponse.Builder.class);
     }
@@ -3748,7 +3748,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.StreamingInputCallResponse}
+     * Protobuf type {@code grpc.testing.integration.StreamingInputCallResponse}
      *
      * <pre>
      * Client-streaming response.
@@ -3756,16 +3756,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.StreamingInputCallResponse)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.StreamingInputCallResponse)
         io.grpc.testing.integration.Messages.StreamingInputCallResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallResponse_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallResponse_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallResponse_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.StreamingInputCallResponse.class, io.grpc.testing.integration.Messages.StreamingInputCallResponse.Builder.class);
       }
@@ -3793,7 +3793,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingInputCallResponse_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingInputCallResponse_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.StreamingInputCallResponse getDefaultInstanceForType() {
@@ -3903,10 +3903,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.StreamingInputCallResponse)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.StreamingInputCallResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.StreamingInputCallResponse)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.StreamingInputCallResponse)
     private static final io.grpc.testing.integration.Messages.StreamingInputCallResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.StreamingInputCallResponse();
@@ -3951,7 +3951,7 @@ public final class Messages {
   }
 
   public interface ResponseParametersOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ResponseParameters)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.ResponseParameters)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -3975,7 +3975,7 @@ public final class Messages {
     int getIntervalUs();
   }
   /**
-   * Protobuf type {@code grpc.testing.ResponseParameters}
+   * Protobuf type {@code grpc.testing.integration.ResponseParameters}
    *
    * <pre>
    * Configuration for a particular response.
@@ -3983,7 +3983,7 @@ public final class Messages {
    */
   public  static final class ResponseParameters extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ResponseParameters)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.ResponseParameters)
       ResponseParametersOrBuilder {
     // Use ResponseParameters.newBuilder() to construct.
     private ResponseParameters(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -4042,12 +4042,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ResponseParameters_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ResponseParameters_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ResponseParameters_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ResponseParameters_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.ResponseParameters.class, io.grpc.testing.integration.Messages.ResponseParameters.Builder.class);
     }
@@ -4190,7 +4190,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ResponseParameters}
+     * Protobuf type {@code grpc.testing.integration.ResponseParameters}
      *
      * <pre>
      * Configuration for a particular response.
@@ -4198,16 +4198,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ResponseParameters)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.ResponseParameters)
         io.grpc.testing.integration.Messages.ResponseParametersOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ResponseParameters_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ResponseParameters_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ResponseParameters_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ResponseParameters_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.ResponseParameters.class, io.grpc.testing.integration.Messages.ResponseParameters.Builder.class);
       }
@@ -4237,7 +4237,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ResponseParameters_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ResponseParameters_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.ResponseParameters getDefaultInstanceForType() {
@@ -4395,10 +4395,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ResponseParameters)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.ResponseParameters)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ResponseParameters)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.ResponseParameters)
     private static final io.grpc.testing.integration.Messages.ResponseParameters DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.ResponseParameters();
@@ -4443,11 +4443,11 @@ public final class Messages {
   }
 
   public interface StreamingOutputCallRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.StreamingOutputCallRequest)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.StreamingOutputCallRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -4458,7 +4458,7 @@ public final class Messages {
      */
     int getResponseTypeValue();
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -4470,7 +4470,7 @@ public final class Messages {
     io.grpc.testing.integration.Messages.PayloadType getResponseType();
 
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4479,7 +4479,7 @@ public final class Messages {
     java.util.List<io.grpc.testing.integration.Messages.ResponseParameters> 
         getResponseParametersList();
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4487,7 +4487,7 @@ public final class Messages {
      */
     io.grpc.testing.integration.Messages.ResponseParameters getResponseParameters(int index);
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4495,7 +4495,7 @@ public final class Messages {
      */
     int getResponseParametersCount();
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4504,7 +4504,7 @@ public final class Messages {
     java.util.List<? extends io.grpc.testing.integration.Messages.ResponseParametersOrBuilder> 
         getResponseParametersOrBuilderList();
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4514,7 +4514,7 @@ public final class Messages {
         int index);
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -4522,7 +4522,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -4530,7 +4530,7 @@ public final class Messages {
      */
     io.grpc.testing.integration.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -4539,7 +4539,7 @@ public final class Messages {
     io.grpc.testing.integration.Messages.PayloadOrBuilder getPayloadOrBuilder();
   }
   /**
-   * Protobuf type {@code grpc.testing.StreamingOutputCallRequest}
+   * Protobuf type {@code grpc.testing.integration.StreamingOutputCallRequest}
    *
    * <pre>
    * Server-streaming request.
@@ -4547,7 +4547,7 @@ public final class Messages {
    */
   public  static final class StreamingOutputCallRequest extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.StreamingOutputCallRequest)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.StreamingOutputCallRequest)
       StreamingOutputCallRequestOrBuilder {
     // Use StreamingOutputCallRequest.newBuilder() to construct.
     private StreamingOutputCallRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -4626,12 +4626,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.StreamingOutputCallRequest.class, io.grpc.testing.integration.Messages.StreamingOutputCallRequest.Builder.class);
     }
@@ -4640,7 +4640,7 @@ public final class Messages {
     public static final int RESPONSE_TYPE_FIELD_NUMBER = 1;
     private int responseType_;
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -4653,7 +4653,7 @@ public final class Messages {
       return responseType_;
     }
     /**
-     * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+     * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
      *
      * <pre>
      * Desired payload type in the response from the server.
@@ -4670,7 +4670,7 @@ public final class Messages {
     public static final int RESPONSE_PARAMETERS_FIELD_NUMBER = 2;
     private java.util.List<io.grpc.testing.integration.Messages.ResponseParameters> responseParameters_;
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4680,7 +4680,7 @@ public final class Messages {
       return responseParameters_;
     }
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4691,7 +4691,7 @@ public final class Messages {
       return responseParameters_;
     }
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4701,7 +4701,7 @@ public final class Messages {
       return responseParameters_.size();
     }
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4711,7 +4711,7 @@ public final class Messages {
       return responseParameters_.get(index);
     }
     /**
-     * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+     * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
      *
      * <pre>
      * Configuration for each expected response message.
@@ -4725,7 +4725,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 3;
     private io.grpc.testing.integration.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -4735,7 +4735,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -4745,7 +4745,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.testing.integration.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 3;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
      *
      * <pre>
      * Optional input payload sent along with the request.
@@ -4872,7 +4872,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.StreamingOutputCallRequest}
+     * Protobuf type {@code grpc.testing.integration.StreamingOutputCallRequest}
      *
      * <pre>
      * Server-streaming request.
@@ -4880,16 +4880,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.StreamingOutputCallRequest)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.StreamingOutputCallRequest)
         io.grpc.testing.integration.Messages.StreamingOutputCallRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.StreamingOutputCallRequest.class, io.grpc.testing.integration.Messages.StreamingOutputCallRequest.Builder.class);
       }
@@ -4930,7 +4930,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallRequest_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallRequest_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.StreamingOutputCallRequest getDefaultInstanceForType() {
@@ -5041,7 +5041,7 @@ public final class Messages {
 
       private int responseType_ = 0;
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5054,7 +5054,7 @@ public final class Messages {
         return responseType_;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5069,7 +5069,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5083,7 +5083,7 @@ public final class Messages {
         return result == null ? io.grpc.testing.integration.Messages.PayloadType.UNRECOGNIZED : result;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5102,7 +5102,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.PayloadType response_type = 1;</code>
+       * <code>optional .grpc.testing.integration.PayloadType response_type = 1;</code>
        *
        * <pre>
        * Desired payload type in the response from the server.
@@ -5131,7 +5131,7 @@ public final class Messages {
           io.grpc.testing.integration.Messages.ResponseParameters, io.grpc.testing.integration.Messages.ResponseParameters.Builder, io.grpc.testing.integration.Messages.ResponseParametersOrBuilder> responseParametersBuilder_;
 
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5145,7 +5145,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5159,7 +5159,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5173,7 +5173,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5194,7 +5194,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5212,7 +5212,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5232,7 +5232,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5253,7 +5253,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5271,7 +5271,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5289,7 +5289,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5308,7 +5308,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5325,7 +5325,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5342,7 +5342,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5353,7 +5353,7 @@ public final class Messages {
         return getResponseParametersFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5367,7 +5367,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5382,7 +5382,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5393,7 +5393,7 @@ public final class Messages {
             io.grpc.testing.integration.Messages.ResponseParameters.getDefaultInstance());
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5405,7 +5405,7 @@ public final class Messages {
             index, io.grpc.testing.integration.Messages.ResponseParameters.getDefaultInstance());
       }
       /**
-       * <code>repeated .grpc.testing.ResponseParameters response_parameters = 2;</code>
+       * <code>repeated .grpc.testing.integration.ResponseParameters response_parameters = 2;</code>
        *
        * <pre>
        * Configuration for each expected response message.
@@ -5434,7 +5434,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.testing.integration.Messages.Payload, io.grpc.testing.integration.Messages.Payload.Builder, io.grpc.testing.integration.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -5444,7 +5444,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -5458,7 +5458,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -5478,7 +5478,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -5496,7 +5496,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -5518,7 +5518,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -5536,7 +5536,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -5548,7 +5548,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -5563,7 +5563,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 3;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 3;</code>
        *
        * <pre>
        * Optional input payload sent along with the request.
@@ -5593,10 +5593,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.StreamingOutputCallRequest)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.StreamingOutputCallRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.StreamingOutputCallRequest)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.StreamingOutputCallRequest)
     private static final io.grpc.testing.integration.Messages.StreamingOutputCallRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.StreamingOutputCallRequest();
@@ -5641,11 +5641,11 @@ public final class Messages {
   }
 
   public interface StreamingOutputCallResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.StreamingOutputCallResponse)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.StreamingOutputCallResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -5653,7 +5653,7 @@ public final class Messages {
      */
     boolean hasPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -5661,7 +5661,7 @@ public final class Messages {
      */
     io.grpc.testing.integration.Messages.Payload getPayload();
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -5670,7 +5670,7 @@ public final class Messages {
     io.grpc.testing.integration.Messages.PayloadOrBuilder getPayloadOrBuilder();
   }
   /**
-   * Protobuf type {@code grpc.testing.StreamingOutputCallResponse}
+   * Protobuf type {@code grpc.testing.integration.StreamingOutputCallResponse}
    *
    * <pre>
    * Server-streaming response, as configured by the request and parameters.
@@ -5678,7 +5678,7 @@ public final class Messages {
    */
   public  static final class StreamingOutputCallResponse extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.StreamingOutputCallResponse)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.StreamingOutputCallResponse)
       StreamingOutputCallResponseOrBuilder {
     // Use StreamingOutputCallResponse.newBuilder() to construct.
     private StreamingOutputCallResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -5738,12 +5738,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.StreamingOutputCallResponse.class, io.grpc.testing.integration.Messages.StreamingOutputCallResponse.Builder.class);
     }
@@ -5751,7 +5751,7 @@ public final class Messages {
     public static final int PAYLOAD_FIELD_NUMBER = 1;
     private io.grpc.testing.integration.Messages.Payload payload_;
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -5761,7 +5761,7 @@ public final class Messages {
       return payload_ != null;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -5771,7 +5771,7 @@ public final class Messages {
       return payload_ == null ? io.grpc.testing.integration.Messages.Payload.getDefaultInstance() : payload_;
     }
     /**
-     * <code>optional .grpc.testing.Payload payload = 1;</code>
+     * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
      *
      * <pre>
      * Payload to increase response size.
@@ -5884,7 +5884,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.StreamingOutputCallResponse}
+     * Protobuf type {@code grpc.testing.integration.StreamingOutputCallResponse}
      *
      * <pre>
      * Server-streaming response, as configured by the request and parameters.
@@ -5892,16 +5892,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.StreamingOutputCallResponse)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.StreamingOutputCallResponse)
         io.grpc.testing.integration.Messages.StreamingOutputCallResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallResponse_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.StreamingOutputCallResponse.class, io.grpc.testing.integration.Messages.StreamingOutputCallResponse.Builder.class);
       }
@@ -5933,7 +5933,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_StreamingOutputCallResponse_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_StreamingOutputCallResponse_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.StreamingOutputCallResponse getDefaultInstanceForType() {
@@ -6003,7 +6003,7 @@ public final class Messages {
       private com.google.protobuf.SingleFieldBuilder<
           io.grpc.testing.integration.Messages.Payload, io.grpc.testing.integration.Messages.Payload.Builder, io.grpc.testing.integration.Messages.PayloadOrBuilder> payloadBuilder_;
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6013,7 +6013,7 @@ public final class Messages {
         return payloadBuilder_ != null || payload_ != null;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6027,7 +6027,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6047,7 +6047,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6065,7 +6065,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6087,7 +6087,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6105,7 +6105,7 @@ public final class Messages {
         return this;
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6117,7 +6117,7 @@ public final class Messages {
         return getPayloadFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6132,7 +6132,7 @@ public final class Messages {
         }
       }
       /**
-       * <code>optional .grpc.testing.Payload payload = 1;</code>
+       * <code>optional .grpc.testing.integration.Payload payload = 1;</code>
        *
        * <pre>
        * Payload to increase response size.
@@ -6162,10 +6162,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.StreamingOutputCallResponse)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.StreamingOutputCallResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.StreamingOutputCallResponse)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.StreamingOutputCallResponse)
     private static final io.grpc.testing.integration.Messages.StreamingOutputCallResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.StreamingOutputCallResponse();
@@ -6210,7 +6210,7 @@ public final class Messages {
   }
 
   public interface ReconnectInfoOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.ReconnectInfo)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.ReconnectInfo)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -6232,7 +6232,7 @@ public final class Messages {
     int getBackoffMs(int index);
   }
   /**
-   * Protobuf type {@code grpc.testing.ReconnectInfo}
+   * Protobuf type {@code grpc.testing.integration.ReconnectInfo}
    *
    * <pre>
    * For reconnect interop test only.
@@ -6242,7 +6242,7 @@ public final class Messages {
    */
   public  static final class ReconnectInfo extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.ReconnectInfo)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.ReconnectInfo)
       ReconnectInfoOrBuilder {
     // Use ReconnectInfo.newBuilder() to construct.
     private ReconnectInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -6320,12 +6320,12 @@ public final class Messages {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ReconnectInfo_descriptor;
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ReconnectInfo_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ReconnectInfo_fieldAccessorTable
+      return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ReconnectInfo_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Messages.ReconnectInfo.class, io.grpc.testing.integration.Messages.ReconnectInfo.Builder.class);
     }
@@ -6488,7 +6488,7 @@ public final class Messages {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.ReconnectInfo}
+     * Protobuf type {@code grpc.testing.integration.ReconnectInfo}
      *
      * <pre>
      * For reconnect interop test only.
@@ -6498,16 +6498,16 @@ public final class Messages {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.ReconnectInfo)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.ReconnectInfo)
         io.grpc.testing.integration.Messages.ReconnectInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ReconnectInfo_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ReconnectInfo_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ReconnectInfo_fieldAccessorTable
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ReconnectInfo_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Messages.ReconnectInfo.class, io.grpc.testing.integration.Messages.ReconnectInfo.Builder.class);
       }
@@ -6537,7 +6537,7 @@ public final class Messages {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_ReconnectInfo_descriptor;
+        return io.grpc.testing.integration.Messages.internal_static_grpc_testing_integration_ReconnectInfo_descriptor;
       }
 
       public io.grpc.testing.integration.Messages.ReconnectInfo getDefaultInstanceForType() {
@@ -6720,10 +6720,10 @@ public final class Messages {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.ReconnectInfo)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.ReconnectInfo)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.ReconnectInfo)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.ReconnectInfo)
     private static final io.grpc.testing.integration.Messages.ReconnectInfo DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Messages.ReconnectInfo();
@@ -6768,55 +6768,55 @@ public final class Messages {
   }
 
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_Payload_descriptor;
+    internal_static_grpc_testing_integration_Payload_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_Payload_fieldAccessorTable;
+      internal_static_grpc_testing_integration_Payload_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_SimpleRequest_descriptor;
+    internal_static_grpc_testing_integration_SimpleRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_SimpleRequest_fieldAccessorTable;
+      internal_static_grpc_testing_integration_SimpleRequest_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_SimpleResponse_descriptor;
+    internal_static_grpc_testing_integration_SimpleResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_SimpleResponse_fieldAccessorTable;
+      internal_static_grpc_testing_integration_SimpleResponse_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_SimpleContext_descriptor;
+    internal_static_grpc_testing_integration_SimpleContext_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_SimpleContext_fieldAccessorTable;
+      internal_static_grpc_testing_integration_SimpleContext_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_StreamingInputCallRequest_descriptor;
+    internal_static_grpc_testing_integration_StreamingInputCallRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_StreamingInputCallRequest_fieldAccessorTable;
+      internal_static_grpc_testing_integration_StreamingInputCallRequest_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_StreamingInputCallResponse_descriptor;
+    internal_static_grpc_testing_integration_StreamingInputCallResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_StreamingInputCallResponse_fieldAccessorTable;
+      internal_static_grpc_testing_integration_StreamingInputCallResponse_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ResponseParameters_descriptor;
+    internal_static_grpc_testing_integration_ResponseParameters_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ResponseParameters_fieldAccessorTable;
+      internal_static_grpc_testing_integration_ResponseParameters_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_StreamingOutputCallRequest_descriptor;
+    internal_static_grpc_testing_integration_StreamingOutputCallRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_StreamingOutputCallRequest_fieldAccessorTable;
+      internal_static_grpc_testing_integration_StreamingOutputCallRequest_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_StreamingOutputCallResponse_descriptor;
+    internal_static_grpc_testing_integration_StreamingOutputCallResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_StreamingOutputCallResponse_fieldAccessorTable;
+      internal_static_grpc_testing_integration_StreamingOutputCallResponse_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_ReconnectInfo_descriptor;
+    internal_static_grpc_testing_integration_ReconnectInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_ReconnectInfo_fieldAccessorTable;
+      internal_static_grpc_testing_integration_ReconnectInfo_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -6827,27 +6827,30 @@ public final class Messages {
   static {
     java.lang.String[] descriptorData = {
       "\n*io/grpc/testing/integration/messages.p" +
-      "roto\022\014grpc.testing\"@\n\007Payload\022\'\n\004type\030\001 " +
-      "\001(\0162\031.grpc.testing.PayloadType\022\014\n\004body\030\002" +
-      " \001(\014\"\261\001\n\rSimpleRequest\0220\n\rresponse_type\030" +
-      "\001 \001(\0162\031.grpc.testing.PayloadType\022\025\n\rresp" +
-      "onse_size\030\002 \001(\005\022&\n\007payload\030\003 \001(\0132\025.grpc." +
-      "testing.Payload\022\025\n\rfill_username\030\004 \001(\010\022\030" +
-      "\n\020fill_oauth_scope\030\005 \001(\010\"_\n\016SimpleRespon" +
-      "se\022&\n\007payload\030\001 \001(\0132\025.grpc.testing.Paylo" +
-      "ad\022\020\n\010username\030\002 \001(\t\022\023\n\013oauth_scope\030\003 \001(",
-      "\t\"\036\n\rSimpleContext\022\r\n\005value\030\001 \001(\t\"C\n\031Str" +
-      "eamingInputCallRequest\022&\n\007payload\030\001 \001(\0132" +
-      "\025.grpc.testing.Payload\"=\n\032StreamingInput" +
-      "CallResponse\022\037\n\027aggregated_payload_size\030" +
-      "\001 \001(\005\"7\n\022ResponseParameters\022\014\n\004size\030\001 \001(" +
-      "\005\022\023\n\013interval_us\030\002 \001(\005\"\265\001\n\032StreamingOutp" +
-      "utCallRequest\0220\n\rresponse_type\030\001 \001(\0162\031.g" +
-      "rpc.testing.PayloadType\022=\n\023response_para" +
-      "meters\030\002 \003(\0132 .grpc.testing.ResponsePara" +
-      "meters\022&\n\007payload\030\003 \001(\0132\025.grpc.testing.P",
-      "ayload\"E\n\033StreamingOutputCallResponse\022&\n" +
-      "\007payload\030\001 \001(\0132\025.grpc.testing.Payload\"3\n" +
+      "roto\022\030grpc.testing.integration\"L\n\007Payloa" +
+      "d\0223\n\004type\030\001 \001(\0162%.grpc.testing.integrati" +
+      "on.PayloadType\022\014\n\004body\030\002 \001(\014\"\311\001\n\rSimpleR" +
+      "equest\022<\n\rresponse_type\030\001 \001(\0162%.grpc.tes" +
+      "ting.integration.PayloadType\022\025\n\rresponse" +
+      "_size\030\002 \001(\005\0222\n\007payload\030\003 \001(\0132!.grpc.test" +
+      "ing.integration.Payload\022\025\n\rfill_username" +
+      "\030\004 \001(\010\022\030\n\020fill_oauth_scope\030\005 \001(\010\"k\n\016Simp" +
+      "leResponse\0222\n\007payload\030\001 \001(\0132!.grpc.testi",
+      "ng.integration.Payload\022\020\n\010username\030\002 \001(\t" +
+      "\022\023\n\013oauth_scope\030\003 \001(\t\"\036\n\rSimpleContext\022\r" +
+      "\n\005value\030\001 \001(\t\"O\n\031StreamingInputCallReque" +
+      "st\0222\n\007payload\030\001 \001(\0132!.grpc.testing.integ" +
+      "ration.Payload\"=\n\032StreamingInputCallResp" +
+      "onse\022\037\n\027aggregated_payload_size\030\001 \001(\005\"7\n" +
+      "\022ResponseParameters\022\014\n\004size\030\001 \001(\005\022\023\n\013int" +
+      "erval_us\030\002 \001(\005\"\331\001\n\032StreamingOutputCallRe" +
+      "quest\022<\n\rresponse_type\030\001 \001(\0162%.grpc.test" +
+      "ing.integration.PayloadType\022I\n\023response_",
+      "parameters\030\002 \003(\0132,.grpc.testing.integrat" +
+      "ion.ResponseParameters\0222\n\007payload\030\003 \001(\0132" +
+      "!.grpc.testing.integration.Payload\"Q\n\033St" +
+      "reamingOutputCallResponse\0222\n\007payload\030\001 \001" +
+      "(\0132!.grpc.testing.integration.Payload\"3\n" +
       "\rReconnectInfo\022\016\n\006passed\030\001 \001(\010\022\022\n\nbackof" +
       "f_ms\030\002 \003(\005*?\n\013PayloadType\022\020\n\014COMPRESSABL" +
       "E\020\000\022\022\n\016UNCOMPRESSABLE\020\001\022\n\n\006RANDOM\020\002B\035\n\033i" +
@@ -6865,65 +6868,65 @@ public final class Messages {
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
-    internal_static_grpc_testing_Payload_descriptor =
+    internal_static_grpc_testing_integration_Payload_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_grpc_testing_Payload_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_Payload_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_Payload_descriptor,
+        internal_static_grpc_testing_integration_Payload_descriptor,
         new java.lang.String[] { "Type", "Body", });
-    internal_static_grpc_testing_SimpleRequest_descriptor =
+    internal_static_grpc_testing_integration_SimpleRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_grpc_testing_SimpleRequest_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_SimpleRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_SimpleRequest_descriptor,
+        internal_static_grpc_testing_integration_SimpleRequest_descriptor,
         new java.lang.String[] { "ResponseType", "ResponseSize", "Payload", "FillUsername", "FillOauthScope", });
-    internal_static_grpc_testing_SimpleResponse_descriptor =
+    internal_static_grpc_testing_integration_SimpleResponse_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_grpc_testing_SimpleResponse_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_SimpleResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_SimpleResponse_descriptor,
+        internal_static_grpc_testing_integration_SimpleResponse_descriptor,
         new java.lang.String[] { "Payload", "Username", "OauthScope", });
-    internal_static_grpc_testing_SimpleContext_descriptor =
+    internal_static_grpc_testing_integration_SimpleContext_descriptor =
       getDescriptor().getMessageTypes().get(3);
-    internal_static_grpc_testing_SimpleContext_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_SimpleContext_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_SimpleContext_descriptor,
+        internal_static_grpc_testing_integration_SimpleContext_descriptor,
         new java.lang.String[] { "Value", });
-    internal_static_grpc_testing_StreamingInputCallRequest_descriptor =
+    internal_static_grpc_testing_integration_StreamingInputCallRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
-    internal_static_grpc_testing_StreamingInputCallRequest_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_StreamingInputCallRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_StreamingInputCallRequest_descriptor,
+        internal_static_grpc_testing_integration_StreamingInputCallRequest_descriptor,
         new java.lang.String[] { "Payload", });
-    internal_static_grpc_testing_StreamingInputCallResponse_descriptor =
+    internal_static_grpc_testing_integration_StreamingInputCallResponse_descriptor =
       getDescriptor().getMessageTypes().get(5);
-    internal_static_grpc_testing_StreamingInputCallResponse_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_StreamingInputCallResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_StreamingInputCallResponse_descriptor,
+        internal_static_grpc_testing_integration_StreamingInputCallResponse_descriptor,
         new java.lang.String[] { "AggregatedPayloadSize", });
-    internal_static_grpc_testing_ResponseParameters_descriptor =
+    internal_static_grpc_testing_integration_ResponseParameters_descriptor =
       getDescriptor().getMessageTypes().get(6);
-    internal_static_grpc_testing_ResponseParameters_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_ResponseParameters_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ResponseParameters_descriptor,
+        internal_static_grpc_testing_integration_ResponseParameters_descriptor,
         new java.lang.String[] { "Size", "IntervalUs", });
-    internal_static_grpc_testing_StreamingOutputCallRequest_descriptor =
+    internal_static_grpc_testing_integration_StreamingOutputCallRequest_descriptor =
       getDescriptor().getMessageTypes().get(7);
-    internal_static_grpc_testing_StreamingOutputCallRequest_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_StreamingOutputCallRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_StreamingOutputCallRequest_descriptor,
+        internal_static_grpc_testing_integration_StreamingOutputCallRequest_descriptor,
         new java.lang.String[] { "ResponseType", "ResponseParameters", "Payload", });
-    internal_static_grpc_testing_StreamingOutputCallResponse_descriptor =
+    internal_static_grpc_testing_integration_StreamingOutputCallResponse_descriptor =
       getDescriptor().getMessageTypes().get(8);
-    internal_static_grpc_testing_StreamingOutputCallResponse_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_StreamingOutputCallResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_StreamingOutputCallResponse_descriptor,
+        internal_static_grpc_testing_integration_StreamingOutputCallResponse_descriptor,
         new java.lang.String[] { "Payload", });
-    internal_static_grpc_testing_ReconnectInfo_descriptor =
+    internal_static_grpc_testing_integration_ReconnectInfo_descriptor =
       getDescriptor().getMessageTypes().get(9);
-    internal_static_grpc_testing_ReconnectInfo_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_ReconnectInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_ReconnectInfo_descriptor,
+        internal_static_grpc_testing_integration_ReconnectInfo_descriptor,
         new java.lang.String[] { "Passed", "BackoffMs", });
   }
 

--- a/interop-testing/src/generated/main/java/io/grpc/testing/integration/Metrics.java
+++ b/interop-testing/src/generated/main/java/io/grpc/testing/integration/Metrics.java
@@ -9,7 +9,7 @@ public final class Metrics {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   public interface GaugeResponseOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.GaugeResponse)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.GaugeResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -45,7 +45,7 @@ public final class Metrics {
     public io.grpc.testing.integration.Metrics.GaugeResponse.ValueCase getValueCase();
   }
   /**
-   * Protobuf type {@code grpc.testing.GaugeResponse}
+   * Protobuf type {@code grpc.testing.integration.GaugeResponse}
    *
    * <pre>
    * Reponse message containing the gauge name and value
@@ -53,7 +53,7 @@ public final class Metrics {
    */
   public  static final class GaugeResponse extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.GaugeResponse)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.GaugeResponse)
       GaugeResponseOrBuilder {
     // Use GaugeResponse.newBuilder() to construct.
     private GaugeResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -123,12 +123,12 @@ public final class Metrics {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeResponse_descriptor;
+      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeResponse_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeResponse_fieldAccessorTable
+      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Metrics.GaugeResponse.class, io.grpc.testing.integration.Metrics.GaugeResponse.Builder.class);
     }
@@ -391,7 +391,7 @@ public final class Metrics {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.GaugeResponse}
+     * Protobuf type {@code grpc.testing.integration.GaugeResponse}
      *
      * <pre>
      * Reponse message containing the gauge name and value
@@ -399,16 +399,16 @@ public final class Metrics {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.GaugeResponse)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.GaugeResponse)
         io.grpc.testing.integration.Metrics.GaugeResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeResponse_descriptor;
+        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeResponse_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeResponse_fieldAccessorTable
+        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Metrics.GaugeResponse.class, io.grpc.testing.integration.Metrics.GaugeResponse.Builder.class);
       }
@@ -438,7 +438,7 @@ public final class Metrics {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeResponse_descriptor;
+        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeResponse_descriptor;
       }
 
       public io.grpc.testing.integration.Metrics.GaugeResponse getDefaultInstanceForType() {
@@ -764,10 +764,10 @@ public final class Metrics {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.GaugeResponse)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.GaugeResponse)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.GaugeResponse)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.GaugeResponse)
     private static final io.grpc.testing.integration.Metrics.GaugeResponse DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Metrics.GaugeResponse();
@@ -812,7 +812,7 @@ public final class Metrics {
   }
 
   public interface GaugeRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.GaugeRequest)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.GaugeRequest)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -826,7 +826,7 @@ public final class Metrics {
         getNameBytes();
   }
   /**
-   * Protobuf type {@code grpc.testing.GaugeRequest}
+   * Protobuf type {@code grpc.testing.integration.GaugeRequest}
    *
    * <pre>
    * Request message containing the gauge name
@@ -834,7 +834,7 @@ public final class Metrics {
    */
   public  static final class GaugeRequest extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.GaugeRequest)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.GaugeRequest)
       GaugeRequestOrBuilder {
     // Use GaugeRequest.newBuilder() to construct.
     private GaugeRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -888,12 +888,12 @@ public final class Metrics {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeRequest_descriptor;
+      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeRequest_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeRequest_fieldAccessorTable
+      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Metrics.GaugeRequest.class, io.grpc.testing.integration.Metrics.GaugeRequest.Builder.class);
     }
@@ -1034,7 +1034,7 @@ public final class Metrics {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.GaugeRequest}
+     * Protobuf type {@code grpc.testing.integration.GaugeRequest}
      *
      * <pre>
      * Request message containing the gauge name
@@ -1042,16 +1042,16 @@ public final class Metrics {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.GaugeRequest)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.GaugeRequest)
         io.grpc.testing.integration.Metrics.GaugeRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeRequest_descriptor;
+        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeRequest_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeRequest_fieldAccessorTable
+        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Metrics.GaugeRequest.class, io.grpc.testing.integration.Metrics.GaugeRequest.Builder.class);
       }
@@ -1079,7 +1079,7 @@ public final class Metrics {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_GaugeRequest_descriptor;
+        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_GaugeRequest_descriptor;
       }
 
       public io.grpc.testing.integration.Metrics.GaugeRequest getDefaultInstanceForType() {
@@ -1221,10 +1221,10 @@ public final class Metrics {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.GaugeRequest)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.GaugeRequest)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.GaugeRequest)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.GaugeRequest)
     private static final io.grpc.testing.integration.Metrics.GaugeRequest DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Metrics.GaugeRequest();
@@ -1269,15 +1269,15 @@ public final class Metrics {
   }
 
   public interface EmptyMessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:grpc.testing.EmptyMessage)
+      // @@protoc_insertion_point(interface_extends:grpc.testing.integration.EmptyMessage)
       com.google.protobuf.MessageOrBuilder {
   }
   /**
-   * Protobuf type {@code grpc.testing.EmptyMessage}
+   * Protobuf type {@code grpc.testing.integration.EmptyMessage}
    */
   public  static final class EmptyMessage extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:grpc.testing.EmptyMessage)
+      // @@protoc_insertion_point(message_implements:grpc.testing.integration.EmptyMessage)
       EmptyMessageOrBuilder {
     // Use EmptyMessage.newBuilder() to construct.
     private EmptyMessage(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -1323,12 +1323,12 @@ public final class Metrics {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_EmptyMessage_descriptor;
+      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_EmptyMessage_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_EmptyMessage_fieldAccessorTable
+      return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_EmptyMessage_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               io.grpc.testing.integration.Metrics.EmptyMessage.class, io.grpc.testing.integration.Metrics.EmptyMessage.Builder.class);
     }
@@ -1429,20 +1429,20 @@ public final class Metrics {
       return builder;
     }
     /**
-     * Protobuf type {@code grpc.testing.EmptyMessage}
+     * Protobuf type {@code grpc.testing.integration.EmptyMessage}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:grpc.testing.EmptyMessage)
+        // @@protoc_insertion_point(builder_implements:grpc.testing.integration.EmptyMessage)
         io.grpc.testing.integration.Metrics.EmptyMessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_EmptyMessage_descriptor;
+        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_EmptyMessage_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_EmptyMessage_fieldAccessorTable
+        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_EmptyMessage_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 io.grpc.testing.integration.Metrics.EmptyMessage.class, io.grpc.testing.integration.Metrics.EmptyMessage.Builder.class);
       }
@@ -1468,7 +1468,7 @@ public final class Metrics {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_EmptyMessage_descriptor;
+        return io.grpc.testing.integration.Metrics.internal_static_grpc_testing_integration_EmptyMessage_descriptor;
       }
 
       public io.grpc.testing.integration.Metrics.EmptyMessage getDefaultInstanceForType() {
@@ -1536,10 +1536,10 @@ public final class Metrics {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:grpc.testing.EmptyMessage)
+      // @@protoc_insertion_point(builder_scope:grpc.testing.integration.EmptyMessage)
     }
 
-    // @@protoc_insertion_point(class_scope:grpc.testing.EmptyMessage)
+    // @@protoc_insertion_point(class_scope:grpc.testing.integration.EmptyMessage)
     private static final io.grpc.testing.integration.Metrics.EmptyMessage DEFAULT_INSTANCE;
     static {
       DEFAULT_INSTANCE = new io.grpc.testing.integration.Metrics.EmptyMessage();
@@ -1584,20 +1584,20 @@ public final class Metrics {
   }
 
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_GaugeResponse_descriptor;
+    internal_static_grpc_testing_integration_GaugeResponse_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_GaugeResponse_fieldAccessorTable;
+      internal_static_grpc_testing_integration_GaugeResponse_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_GaugeRequest_descriptor;
+    internal_static_grpc_testing_integration_GaugeRequest_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_GaugeRequest_fieldAccessorTable;
+      internal_static_grpc_testing_integration_GaugeRequest_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_grpc_testing_EmptyMessage_descriptor;
+    internal_static_grpc_testing_integration_EmptyMessage_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_grpc_testing_EmptyMessage_fieldAccessorTable;
+      internal_static_grpc_testing_integration_EmptyMessage_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -1608,16 +1608,17 @@ public final class Metrics {
   static {
     java.lang.String[] descriptorData = {
       "\n)io/grpc/testing/integration/metrics.pr" +
-      "oto\022\014grpc.testing\"l\n\rGaugeResponse\022\014\n\004na" +
-      "me\030\001 \001(\t\022\024\n\nlong_value\030\002 \001(\003H\000\022\026\n\014double" +
-      "_value\030\003 \001(\001H\000\022\026\n\014string_value\030\004 \001(\tH\000B\007" +
-      "\n\005value\"\034\n\014GaugeRequest\022\014\n\004name\030\001 \001(\t\"\016\n" +
-      "\014EmptyMessage2\240\001\n\016MetricsService\022I\n\014GetA" +
-      "llGauges\022\032.grpc.testing.EmptyMessage\032\033.g" +
-      "rpc.testing.GaugeResponse0\001\022C\n\010GetGauge\022" +
-      "\032.grpc.testing.GaugeRequest\032\033.grpc.testi" +
-      "ng.GaugeResponseB\035\n\033io.grpc.testing.inte",
-      "grationb\006proto3"
+      "oto\022\030grpc.testing.integration\"l\n\rGaugeRe" +
+      "sponse\022\014\n\004name\030\001 \001(\t\022\024\n\nlong_value\030\002 \001(\003" +
+      "H\000\022\026\n\014double_value\030\003 \001(\001H\000\022\026\n\014string_val" +
+      "ue\030\004 \001(\tH\000B\007\n\005value\"\034\n\014GaugeRequest\022\014\n\004n" +
+      "ame\030\001 \001(\t\"\016\n\014EmptyMessage2\320\001\n\016MetricsSer" +
+      "vice\022a\n\014GetAllGauges\022&.grpc.testing.inte" +
+      "gration.EmptyMessage\032\'.grpc.testing.inte" +
+      "gration.GaugeResponse0\001\022[\n\010GetGauge\022&.gr" +
+      "pc.testing.integration.GaugeRequest\032\'.gr",
+      "pc.testing.integration.GaugeResponseB\035\n\033" +
+      "io.grpc.testing.integrationb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -1631,23 +1632,23 @@ public final class Metrics {
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
-    internal_static_grpc_testing_GaugeResponse_descriptor =
+    internal_static_grpc_testing_integration_GaugeResponse_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_grpc_testing_GaugeResponse_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_GaugeResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_GaugeResponse_descriptor,
+        internal_static_grpc_testing_integration_GaugeResponse_descriptor,
         new java.lang.String[] { "Name", "LongValue", "DoubleValue", "StringValue", "Value", });
-    internal_static_grpc_testing_GaugeRequest_descriptor =
+    internal_static_grpc_testing_integration_GaugeRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_grpc_testing_GaugeRequest_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_GaugeRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_GaugeRequest_descriptor,
+        internal_static_grpc_testing_integration_GaugeRequest_descriptor,
         new java.lang.String[] { "Name", });
-    internal_static_grpc_testing_EmptyMessage_descriptor =
+    internal_static_grpc_testing_integration_EmptyMessage_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_grpc_testing_EmptyMessage_fieldAccessorTable = new
+    internal_static_grpc_testing_integration_EmptyMessage_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_grpc_testing_EmptyMessage_descriptor,
+        internal_static_grpc_testing_integration_EmptyMessage_descriptor,
         new java.lang.String[] { });
   }
 

--- a/interop-testing/src/generated/main/java/io/grpc/testing/integration/Test.java
+++ b/interop-testing/src/generated/main/java/io/grpc/testing/integration/Test.java
@@ -18,30 +18,36 @@ public final class Test {
   static {
     java.lang.String[] descriptorData = {
       "\n&io/grpc/testing/integration/test.proto" +
-      "\022\014grpc.testing\032\'io/grpc/testing/integrat" +
-      "ion/empty.proto\032*io/grpc/testing/integra" +
-      "tion/messages.proto2\273\004\n\013TestService\0225\n\tE" +
-      "mptyCall\022\023.grpc.testing.Empty\032\023.grpc.tes" +
-      "ting.Empty\022F\n\tUnaryCall\022\033.grpc.testing.S" +
-      "impleRequest\032\034.grpc.testing.SimpleRespon" +
-      "se\022l\n\023StreamingOutputCall\022(.grpc.testing" +
-      ".StreamingOutputCallRequest\032).grpc.testi" +
-      "ng.StreamingOutputCallResponse0\001\022i\n\022Stre",
-      "amingInputCall\022\'.grpc.testing.StreamingI" +
-      "nputCallRequest\032(.grpc.testing.Streaming" +
-      "InputCallResponse(\001\022i\n\016FullDuplexCall\022(." +
-      "grpc.testing.StreamingOutputCallRequest\032" +
-      ").grpc.testing.StreamingOutputCallRespon" +
-      "se(\0010\001\022i\n\016HalfDuplexCall\022(.grpc.testing." +
-      "StreamingOutputCallRequest\032).grpc.testin" +
-      "g.StreamingOutputCallResponse(\0010\0012U\n\024Uni" +
-      "mplementedService\022=\n\021UnimplementedCall\022\023" +
-      ".grpc.testing.Empty\032\023.grpc.testing.Empty",
-      "2\177\n\020ReconnectService\0221\n\005Start\022\023.grpc.tes" +
-      "ting.Empty\032\023.grpc.testing.Empty\0228\n\004Stop\022" +
-      "\023.grpc.testing.Empty\032\033.grpc.testing.Reco" +
-      "nnectInfoB\035\n\033io.grpc.testing.integration" +
-      "b\006proto3"
+      "\022\030grpc.testing.integration\032\'io/grpc/test" +
+      "ing/integration/empty.proto\032*io/grpc/tes" +
+      "ting/integration/messages.proto2\317\005\n\013Test" +
+      "Service\022M\n\tEmptyCall\022\037.grpc.testing.inte" +
+      "gration.Empty\032\037.grpc.testing.integration" +
+      ".Empty\022^\n\tUnaryCall\022\'.grpc.testing.integ" +
+      "ration.SimpleRequest\032(.grpc.testing.inte" +
+      "gration.SimpleResponse\022\204\001\n\023StreamingOutp" +
+      "utCall\0224.grpc.testing.integration.Stream",
+      "ingOutputCallRequest\0325.grpc.testing.inte" +
+      "gration.StreamingOutputCallResponse0\001\022\201\001" +
+      "\n\022StreamingInputCall\0223.grpc.testing.inte" +
+      "gration.StreamingInputCallRequest\0324.grpc" +
+      ".testing.integration.StreamingInputCallR" +
+      "esponse(\001\022\201\001\n\016FullDuplexCall\0224.grpc.test" +
+      "ing.integration.StreamingOutputCallReque" +
+      "st\0325.grpc.testing.integration.StreamingO" +
+      "utputCallResponse(\0010\001\022\201\001\n\016HalfDuplexCall" +
+      "\0224.grpc.testing.integration.StreamingOut",
+      "putCallRequest\0325.grpc.testing.integratio" +
+      "n.StreamingOutputCallResponse(\0010\0012m\n\024Uni" +
+      "mplementedService\022U\n\021UnimplementedCall\022\037" +
+      ".grpc.testing.integration.Empty\032\037.grpc.t" +
+      "esting.integration.Empty2\257\001\n\020ReconnectSe" +
+      "rvice\022I\n\005Start\022\037.grpc.testing.integratio" +
+      "n.Empty\032\037.grpc.testing.integration.Empty" +
+      "\022P\n\004Stop\022\037.grpc.testing.integration.Empt" +
+      "y\032\'.grpc.testing.integration.ReconnectIn" +
+      "foB\035\n\033io.grpc.testing.integrationb\006proto",
+      "3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/interop-testing/src/main/proto/io/grpc/testing/integration/empty.proto
+++ b/interop-testing/src/main/proto/io/grpc/testing/integration/empty.proto
@@ -30,7 +30,7 @@
 
 syntax = "proto2";
 
-package grpc.testing;
+package grpc.testing.integration;
 
 option java_package = "com.google.protobuf";
 option java_outer_classname = "EmptyProtos";
@@ -40,7 +40,7 @@ option java_outer_classname = "EmptyProtos";
 // return value of a service API. For instance:
 //
 //   service Foo {
-//     rpc Bar (grpc.testing.Empty) returns (grpc.testing.Empty) { };
+//     rpc Bar (grpc.testing.integration.Empty) returns (grpc.testing.integration.Empty) { };
 //   };
 //
 message Empty {}

--- a/interop-testing/src/main/proto/io/grpc/testing/integration/messages.proto
+++ b/interop-testing/src/main/proto/io/grpc/testing/integration/messages.proto
@@ -32,7 +32,7 @@
 
 syntax = "proto3";
 
-package grpc.testing;
+package grpc.testing.integration;
 
 option java_package = "io.grpc.testing.integration";
 

--- a/interop-testing/src/main/proto/io/grpc/testing/integration/metrics.proto
+++ b/interop-testing/src/main/proto/io/grpc/testing/integration/metrics.proto
@@ -35,7 +35,7 @@
 // service.
 syntax = "proto3";
 
-package grpc.testing;
+package grpc.testing.integration;
 
 option java_package = "io.grpc.testing.integration";
 

--- a/interop-testing/src/main/proto/io/grpc/testing/integration/test.proto
+++ b/interop-testing/src/main/proto/io/grpc/testing/integration/test.proto
@@ -35,7 +35,7 @@ syntax = "proto3";
 import "io/grpc/testing/integration/empty.proto";
 import "io/grpc/testing/integration/messages.proto";
 
-package grpc.testing;
+package grpc.testing.integration;
 
 option java_package = "io.grpc.testing.integration";
 
@@ -43,7 +43,7 @@ option java_package = "io.grpc.testing.integration";
 // performance with various types of payload.
 service TestService {
   // One empty request followed by one empty response.
-  rpc EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+  rpc EmptyCall(grpc.testing.integration.Empty) returns (grpc.testing.integration.Empty);
 
   // One request followed by one response.
   rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
@@ -76,11 +76,11 @@ service TestService {
 // that case.
 service UnimplementedService {
   // A call that no server should implement
-  rpc UnimplementedCall(grpc.testing.Empty) returns(grpc.testing.Empty);  
+  rpc UnimplementedCall(grpc.testing.integration.Empty) returns(grpc.testing.integration.Empty);  
 }
 
 // A service used to control reconnect server.
 service ReconnectService {
-  rpc Start(grpc.testing.Empty) returns (grpc.testing.Empty);
-  rpc Stop(grpc.testing.Empty) returns (grpc.testing.ReconnectInfo);
+  rpc Start(grpc.testing.integration.Empty) returns (grpc.testing.integration.Empty);
+  rpc Stop(grpc.testing.integration.Empty) returns (grpc.testing.integration.ReconnectInfo);
 }


### PR DESCRIPTION
When building a database of proto descriptors, a lot of the package name + message names collide.  This groups the protos to be in packages that reflect their directory structure so they don't collide.  

A couple of these are similar, but not quite the same.