### PR TITLE
Allow cache to be shared between Linux and OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ env:
   global:
     - GRADLE_OPTS=-Xmx512m
     - PROTOBUF_VERSION=3.0.0-beta-2
-    - LDFLAGS=-L/tmp/protobuf-${PROTOBUF_VERSION}/lib
-    - CXXFLAGS=-I/tmp/protobuf-${PROTOBUF_VERSION}/include
-    - LD_LIBRARY_PATH=/tmp/protobuf-${PROTOBUF_VERSION}/lib
+    - LDFLAGS=-L/tmp/protobuf/lib
+    - CXXFLAGS=-I/tmp/protobuf/include
+    - LD_LIBRARY_PATH=/tmp/protobuf/lib
 
 before_install:
     # Work around https://github.com/travis-ci/travis-ci/issues/2317
   - if \[ "$TRAVIS_OS_NAME" = linux \]; then jdk_switcher use oraclejdk8; fi
-  - if \[ "$TRAVIS_OS_NAME" = osx \]; then brew update; fi
   - buildscripts/make_dependencies.sh # build protoc into /tmp/protobuf-${PROTOBUF_VERSION}
+  - ln -s "/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)" /tmp/protobuf
   - mkdir -p $HOME/.gradle
   - echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties
 

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -4,7 +4,7 @@
 set -ev
 
 DOWNLOAD_DIR=/tmp/source
-INSTALL_DIR=/tmp/protobuf-${PROTOBUF_VERSION}
+INSTALL_DIR="/tmp/protobuf-$PROTOBUF_VERSION/$(uname -s)-$(uname -p)"
 mkdir -p $DOWNLOAD_DIR
 
 # Make protoc
@@ -17,7 +17,7 @@ else
   pushd $DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}
   ./autogen.sh
   # install here so we don't need sudo
-  ./configure --prefix=${INSTALL_DIR}
+  ./configure --prefix="$INSTALL_DIR"
   make -j$(nproc)
   make install
   popd


### PR DESCRIPTION
It doesn't appear that OS X is saving its cache yet, so this may not be
needed in the future, but for now we need OS X to avoid attempting to
use the Linux binaries.