### PR TITLE
Stop producing a fat grpc-all jar

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -11,9 +11,6 @@ buildscript {
     }
 }
 
-// Make sure that no transitive dependencies are included.
-configurations.compile.transitive = false
-
 def subprojects = [
   project(':grpc-auth'),
   project(':grpc-core'),
@@ -34,21 +31,6 @@ for (subproject in rootProject.subprojects) {
 
 dependencies {
     compile subprojects
-}
-
-// Create a fat jar containing only the direct dependencies
-jar {
-    from {
-        configurations.compile.collect {
-            it.isDirectory() ? it : zipTree(it)
-        }
-    }
-}
-
-sourcesJar {
-    from {
-        subprojects.sourceSets.main.allSource
-    }
 }
 
 javadoc {


### PR DESCRIPTION
grpc-all contains a copy of all the classes and sources of "important"
artifacts. The copy causes problems when grpc-all is mixed with the
individual artifacts like grpc-netty or grpc-core, since they will
collide on the classpath. Avoiding the copy fixes the problem.

See #1597