### PR TITLE
Return Context from fork instead of CancellableContext

### DIFF
--- a/core/src/main/java/io/grpc/Context.java
+++ b/core/src/main/java/io/grpc/Context.java
@@ -317,10 +317,10 @@ public class Context {
 
   /**
    * Create a new context which propagates the values of this context but does not cascade its
-   * cancellation and is its own independent root for cancellation.
+   * cancellation.
    */
-  public CancellableContext fork() {
-    return new Context(this).withCancellation();
+  public Context fork() {
+    return new Context(this);
   }
 
   boolean canBeCancelled() {

--- a/core/src/test/java/io/grpc/ContextTest.java
+++ b/core/src/test/java/io/grpc/ContextTest.java
@@ -128,7 +128,7 @@ public class ContextTest {
 
   @Test
   public void rootCanBeAttached() {
-    Context.CancellableContext fork = Context.ROOT.fork();
+    Context fork = Context.ROOT.fork();
     fork.attach();
     Context.ROOT.attach();
     assertTrue(Context.ROOT.isCurrent());
@@ -426,11 +426,12 @@ public class ContextTest {
     Context.CancellableContext base = Context.current().withCancellation();
     Context fork = base.fork();
     fork.addListener(cancellationListener, MoreExecutors.directExecutor());
+    assertEquals(0, base.listenerCount());
+    assertEquals(0, fork.listenerCount());
     assertTrue(base.cancel(new Throwable()));
     assertNull(listenerNotifedContext);
     assertFalse(fork.isCancelled());
     assertNull(fork.cancellationCause());
-    assertEquals(1, fork.listenerCount());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/ContextsTest.java
+++ b/core/src/test/java/io/grpc/ContextsTest.java
@@ -65,7 +65,7 @@ public class ContextsTest {
 
   @Test
   public void statusFromCancelled_returnStatusAsSetOnCtx() {
-    Context.CancellableContext cancellableContext = Context.current().fork();
+    Context.CancellableContext cancellableContext = Context.current().withCancellation();
     cancellableContext.cancel(Status.DEADLINE_EXCEEDED.withDescription("foo bar").asException());
     Status status = statusFromCancelled(cancellableContext);
     assertNotNull(status);
@@ -75,7 +75,7 @@ public class ContextsTest {
 
   @Test
   public void statusFromCancelled_shouldReturnStatusWithCauseAttached() {
-    Context.CancellableContext cancellableContext = Context.current().fork();
+    Context.CancellableContext cancellableContext = Context.current().withCancellation();
     Throwable t = new Throwable();
     cancellableContext.cancel(t);
     Status status = statusFromCancelled(cancellableContext);
@@ -103,7 +103,7 @@ public class ContextsTest {
 
   @Test
   public void statusFromCancelled_returnCancelledIfCauseIsNull() {
-    Context.CancellableContext cancellableContext = Context.current().fork();
+    Context.CancellableContext cancellableContext = Context.current().withCancellation();
     cancellableContext.cancel(null);
     assertTrue(cancellableContext.isCancelled());
     Status status = statusFromCancelled(cancellableContext);
@@ -114,7 +114,7 @@ public class ContextsTest {
   /** This is a whitebox test, to verify a special case of the implementation. */
   @Test
   public void statusFromCancelled_StatusUnknownShouldWork() {
-    Context.CancellableContext cancellableContext = Context.current().fork();
+    Context.CancellableContext cancellableContext = Context.current().withCancellation();
     Exception e = Status.UNKNOWN.asException();
     cancellableContext.cancel(e);
     assertTrue(cancellableContext.isCancelled());


### PR DESCRIPTION
It is trivial to call withCancellation() after the fork().
CancellableContexts are required to be cancelled eventually, so
returning Context instead is easier when cancellation is not necessary.

Fixes #1626