### PR TITLE
Add a log message for unknown client streams

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -301,6 +301,8 @@ class NettyClientHandler extends AbstractNettyHandler {
     NettyClientStream stream = clientStream(connection().stream(http2Ex.streamId()));
     if (stream != null) {
       stream.transportReportStatus(Utils.statusFromThrowable(cause), false, new Metadata());
+    } else {
+      logger.log(Level.FINE, "Stream error for unknown stream " + http2Ex.streamId(), cause);
     }
 
     // Delegate to the base class to send a RST_STREAM.


### PR DESCRIPTION
NettyServerHandler works differently for some reason.   The base class will never send a reset stream in the case the stream is null, (in `Http2ConnectionHandler.resetStream`), so I am not sure why NSH only calls it when the stream is null.

In any case, this would have been really helpful in debugging, since the exception is otherwise ignored.