### PR TITLE
Disable codecov comment and changes status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: '80'
+    project:
+      default:
+        target: auto
+        threshold: 1
+    changes:
+      default:
+        branches:
+          - nonExistantBranchToDisableTheFeature
+comment: off


### PR DESCRIPTION
They are mostly noise at the moment. The 'changes' status could be
useful, but is a bit too noisy given flakiness in our coverage.