### PR TITLE
Remove m2 from Travis cache; it's unused

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ notifications:
 cache:
   directories:
     - /tmp/protobuf-${PROTOBUF_VERSION}
-    - $HOME/.m2/repository/io/netty
     - $HOME/.gradle/caches/modules-2
     - $HOME/.gradle/wrapper
 


### PR DESCRIPTION
This is a remanent from when we were building Netty from master. Gradle
uses ~/.gradle/caches/modules-2/files-2.1/ for its Maven Central cache.