### PR TITLE
Fix Attribute key lookup to properly compare Keys by string name

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -91,10 +91,29 @@ public final class Attributes {
       return name;
     }
 
+    @Override
+    public int hashCode() {
+      return name.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null) {
+        return false;
+      }
+      if (getClass() != obj.getClass()) {
+        return false;
+      }
+      return name.equals(((Key<?>)obj).name);
+    }
+
     /**
      * Factory method for creating instances of {@link Key}.
      *
-     * @param name the name of Key. Name collision, won't cause key collision.
+     * @param name the name of Key.
      * @param <T> Key type
      * @return Key object
      */

--- a/core/src/test/java/io/grpc/AttributesTest.java
+++ b/core/src/test/java/io/grpc/AttributesTest.java
@@ -55,14 +55,27 @@ public class AttributesTest {
     Attributes attrs = Attributes.newBuilder()
             .set(YOLO_KEY, "To be?")
             .set(YOLO_KEY, "Or not to be?")
-            .set(Attributes.Key.of("yolo"), "I'm not a duplicate")
+            .set(Attributes.Key.of("yolo"), "I a duplicate")
             .build();
-    assertSame("Or not to be?", attrs.get(YOLO_KEY));
-    assertEquals(2, attrs.keys().size());
+    assertSame("I a duplicate", attrs.get(YOLO_KEY));
+    assertEquals(1, attrs.keys().size());
   }
 
   @Test
   public void empty() {
     assertEquals(0, Attributes.EMPTY.keys().size());
+  }
+  
+  @Test
+  public void dynamicAttributes() {
+    Attributes.Key<String> attr1 = Attributes.Key.of("key" + 0);
+    Attributes.Key<String> attr2 = Attributes.Key.of("key" + 0);
+
+    Attributes attrs = Attributes.newBuilder()
+        .set(attr1, "value")
+        .build();
+    
+    assertEquals("value", attrs.get(attr1));
+    assertEquals("value", attrs.get(attr2));
   }
 }


### PR DESCRIPTION
Attributes.java should look up keys by name and not by Key object reference.  This breaks lookup of dynamically defined keys.  This is a regression from 0.13.2.

I noticed that there is a specific unit test in AttributesTest.java allowing this bad behavior and am curious as to why this added in the first place?  Is there a valid use case for this?