### PR TITLE
all: Add issues for many of the experimental API annotations

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -43,7 +43,7 @@ import javax.annotation.concurrent.Immutable;
 /**
  * An immutable type-safe container of attributes.
  */
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1764")
 @Immutable
 public final class Attributes {
 

--- a/core/src/main/java/io/grpc/BindableService.java
+++ b/core/src/main/java/io/grpc/BindableService.java
@@ -46,7 +46,7 @@ package io.grpc;
  * Server server = ServerBuilder.forPort(1234).addService(new RouteGuideService()).build();
  * </code></pre></p>
  */
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1701")
 public interface BindableService {
   /**
    * Creates {@link ServerServiceDefinition} object for current instance of service implementation.

--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -75,7 +75,7 @@ public final class CallOptions {
    * verification of the overridden value, such as making sure the authority matches the server's
    * TLS certificate.</em>
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/67")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1767")
   public CallOptions withAuthority(@Nullable String authority) {
     CallOptions newOptions = new CallOptions(this);
     newOptions.authority = authority;
@@ -86,7 +86,7 @@ public final class CallOptions {
    * Sets the compression to use for the call.  The compressor must be a valid name known in the
    * {@link CompressorRegistry}.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public CallOptions withCompression(@Nullable String compressorName) {
     CallOptions newOptions = new CallOptions(this);
     newOptions.compressorName = compressorName;
@@ -101,7 +101,7 @@ public final class CallOptions {
    *
    * @param deadline the deadline or {@code null} for unsetting the deadline.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1706")
   public CallOptions withDeadline(@Nullable Deadline deadline) {
     CallOptions newOptions = new CallOptions(this);
     newOptions.deadline = deadline;
@@ -152,7 +152,7 @@ public final class CallOptions {
   /**
    * Returns the deadline or {@code null} if the deadline is not set.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1706")
   @Nullable
   public Deadline getDeadline() {
     return deadline;
@@ -161,7 +161,7 @@ public final class CallOptions {
   /**
    * Returns a new {@code CallOptions} with attributes for affinity-based routing.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1766")
   public CallOptions withAffinity(Attributes affinity) {
     CallOptions newOptions = new CallOptions(this);
     newOptions.affinity = Preconditions.checkNotNull(affinity);
@@ -171,16 +171,15 @@ public final class CallOptions {
   /**
    * Returns the attributes for affinity-based routing.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1766")
   public Attributes getAffinity() {
     return affinity;
   }
 
-
   /**
    * Returns the compressor's name.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   @Nullable
   public String getCompressor() {
     return compressorName;
@@ -196,7 +195,7 @@ public final class CallOptions {
    * TLS certificate.</em>
    */
   @Nullable
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/67")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1767")
   public String getAuthority() {
     return authority;
   }

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -221,7 +221,7 @@ public abstract class ClientCall<ReqT, RespT> {
    * Enables per-message compression, if an encoding type has been negotiated.  If no message
    * encoding has been negotiated, this is a no-op.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1703")
   public void setMessageCompression(boolean enabled) {
     // noop
   }

--- a/core/src/main/java/io/grpc/Codec.java
+++ b/core/src/main/java/io/grpc/Codec.java
@@ -41,7 +41,7 @@ import java.util.zip.GZIPOutputStream;
  * Encloses classes related to the compression and decompression of messages.
  *
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/492")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
 public interface Codec extends Compressor, Decompressor {
   /**
    * A gzip compressor and decompressor.  In the future this will likely support other

--- a/core/src/main/java/io/grpc/Compressor.java
+++ b/core/src/main/java/io/grpc/Compressor.java
@@ -37,7 +37,7 @@ import java.io.OutputStream;
 /**
  * Represents a message compressor.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/492")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
 public interface Compressor {
   /**
    * Returns the message encoding that this compressor uses.

--- a/core/src/main/java/io/grpc/CompressorRegistry.java
+++ b/core/src/main/java/io/grpc/CompressorRegistry.java
@@ -45,7 +45,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * Encloses classes related to the compression and decompression of messages.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/492")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
 @ThreadSafe
 public final class CompressorRegistry {
   private static final CompressorRegistry DEFAULT_INSTANCE = new CompressorRegistry(

--- a/core/src/main/java/io/grpc/Context.java
+++ b/core/src/main/java/io/grpc/Context.java
@@ -106,7 +106,7 @@ import javax.annotation.Nullable;
  * responsibility of the application to ensure that all contexts are properly cancelled.</li>
  * </ul>
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/262")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1705")
 public class Context {
 
   private static final Logger LOG = Logger.getLogger(Context.class.getName());

--- a/core/src/main/java/io/grpc/Contexts.java
+++ b/core/src/main/java/io/grpc/Contexts.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * Utility methods for working with {@link Context}s in GRPC.
  */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1705")
 public class Contexts {
 
   private Contexts() {
@@ -142,7 +143,7 @@ public class Contexts {
    * Returns the {@link Status} of a cancelled context or {@code null} if the context
    * is not cancelled.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1737")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1705")
   public static Status statusFromCancelled(Context context) {
     Preconditions.checkNotNull(context, "context must not be null");
     if (!context.isCancelled()) {

--- a/core/src/main/java/io/grpc/Deadline.java
+++ b/core/src/main/java/io/grpc/Deadline.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * An absolute deadline in system time.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/262")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1706")
 public final class Deadline implements Comparable<Deadline> {
   private static final SystemTicker SYSTEM_TICKER = new SystemTicker();
   // nanoTime has a range of just under 300 years. Only allow up to 100 years in the past or future

--- a/core/src/main/java/io/grpc/Decompressor.java
+++ b/core/src/main/java/io/grpc/Decompressor.java
@@ -37,7 +37,7 @@ import java.io.InputStream;
 /**
  * Represents a message decompressor.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/492")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
 public interface Decompressor {
   /**
    * Returns the message encoding that this compressor uses.

--- a/core/src/main/java/io/grpc/DecompressorRegistry.java
+++ b/core/src/main/java/io/grpc/DecompressorRegistry.java
@@ -49,7 +49,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * Encloses classes related to the compression and decompression of messages.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/492")
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
 @ThreadSafe
 public final class DecompressorRegistry {
 
@@ -93,7 +93,7 @@ public final class DecompressorRegistry {
    * <p>The specification doesn't say anything about ordering, or preference, so the returned codes
    * can be arbitrary.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/492")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public Set<String> getAdvertisedMessageEncodings() {
     Set<String> advertisedDecompressors = new HashSet<String>(decompressors.size());
     for (Entry<String, DecompressorInfo> entry : decompressors.entrySet()) {

--- a/core/src/main/java/io/grpc/DnsNameResolverFactory.java
+++ b/core/src/main/java/io/grpc/DnsNameResolverFactory.java
@@ -52,7 +52,7 @@ import java.net.URI;
  *   <li>{@code "dns:///foo.googleapis.com"} (without port)</li>
  * </ul>
  */
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1769")
 public final class DnsNameResolverFactory extends NameResolver.Factory {
 
   private static final String SCHEME = "dns";

--- a/core/src/main/java/io/grpc/EquivalentAddressGroup.java
+++ b/core/src/main/java/io/grpc/EquivalentAddressGroup.java
@@ -45,7 +45,7 @@ import java.util.List;
  * them is equally sufficient. They do have order. An address appears earlier on the list is likely
  * to be tried earlier.
  */
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
 public final class EquivalentAddressGroup {
 
   private final List<SocketAddress> addrs;

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 // TODO(zhangkun83): since it's also used for non-loadbalancing cases like pick-first,
 // "RequestRouter" might be a better name.
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 @ThreadSafe
 public abstract class LoadBalancer<T> {
   /**
@@ -57,6 +57,7 @@ public abstract class LoadBalancer<T> {
    *
    * @param affinity for affinity-based routing
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1766")
   public abstract T pickTransport(Attributes affinity);
 
   /**

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -72,7 +72,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    *   <li>{@code "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"}</li>
    * </ul>
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1773")
   public static ManagedChannelBuilder<?> forTarget(String target) {
     return ManagedChannelProvider.provider().builderForTarget(target);
   }
@@ -129,7 +129,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    *
    * <p>Should only used by tests.
    */
-  @ExperimentalApi("primarily for testing")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1767")
   public abstract T overrideAuthority(String authority);
 
   /*
@@ -142,7 +142,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @param skipNegotiation @{code true} if there is a priori knowledge that the endpoint supports
    *                        plaintext, {@code false} if plaintext use must be negotiated.
    */
-  @ExperimentalApi("primarily for testing")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1772")
   public abstract T usePlaintext(boolean skipNegotiation);
 
   /*
@@ -151,7 +151,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * <p>If this method is not called, the builder will look up in the global resolver registry for
    * a factory for the provided target.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
   public abstract T nameResolverFactory(NameResolver.Factory resolverFactory);
 
   /**
@@ -160,7 +160,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * <p>If this method is not called, the builder will use {@link SimpleLoadBalancerFactory} for the
    * channel.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
   public abstract T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory);
 
   /**
@@ -168,7 +168,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * shouldn't be used unless you are using custom message encoding.   The default supported
    * decompressors are in {@code DecompressorRegistry.getDefaultInstance}.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public abstract T decompressorRegistry(DecompressorRegistry registry);
 
   /**
@@ -176,7 +176,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * shouldn't be used unless you are using custom message encoding.   The default supported
    * compressors are in {@code CompressorRegistry.getDefaultInstance}.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public abstract T compressorRegistry(CompressorRegistry registry);
 
   /**

--- a/core/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/core/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -130,7 +130,6 @@ public abstract class ManagedChannelProvider {
   /**
    * Creates a new builder with the given target URI.
    */
-  @ExperimentalApi
   protected abstract ManagedChannelBuilder<?> builderForTarget(String target);
 
   public static final class ProviderNotFoundException extends RuntimeException {

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -143,7 +143,7 @@ public class MethodDescriptor<ReqT, RespT> {
    * @param requestMarshaller the marshaller used to encode and decode requests
    * @param responseMarshaller the marshaller used to encode and decode responses
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
   public static <RequestT, ResponseT> MethodDescriptor<RequestT, ResponseT> create(
       MethodType type, String fullMethodName,
       Marshaller<RequestT> requestMarshaller,
@@ -220,7 +220,7 @@ public class MethodDescriptor<ReqT, RespT> {
   /**
    * Returns whether this method is idempotent.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1775")
   public boolean isIdempotent() {
     return idempotent;
   }
@@ -231,7 +231,7 @@ public class MethodDescriptor<ReqT, RespT> {
    * @param idempotent the idempotency of this method.
    * @return a new copy of MethodDescriptor.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1775")
   public MethodDescriptor<ReqT, RespT> withIdempotent(boolean idempotent) {
     return new MethodDescriptor<ReqT, RespT>(type, fullMethodName, requestMarshaller,
         responseMarshaller, idempotent);
@@ -243,7 +243,7 @@ public class MethodDescriptor<ReqT, RespT> {
    * @param fullServiceName the fully qualified service name that is prefixed with the package name
    * @param methodName the short method name
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
   public static String generateFullMethodName(String fullServiceName, String methodName) {
     return fullServiceName + "/" + methodName;
   }
@@ -253,7 +253,7 @@ public class MethodDescriptor<ReqT, RespT> {
    * {@code null} if the input is malformed, but you cannot rely on it for the validity of the
    * input.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
   @Nullable
   public static String extractFullServiceName(String fullMethodName) {
     int index = fullMethodName.lastIndexOf('/');

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>The addresses and attributes of a target may be changed over time, thus the caller registers a
  * {@link Listener} to receive continuous updates.
  */
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
 @ThreadSafe
 public abstract class NameResolver {
   /**

--- a/core/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/core/src/main/java/io/grpc/NameResolverRegistry.java
@@ -42,7 +42,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * A registry that holds various {@link NameResolver.Factory}s and dispatches target URI to the
  * first one that can handle it.
  */
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
 @ThreadSafe
 public final class NameResolverRegistry extends NameResolver.Factory {
   private static final NameResolverRegistry defaultRegistry =

--- a/core/src/main/java/io/grpc/PartialForwardingServerCall.java
+++ b/core/src/main/java/io/grpc/PartialForwardingServerCall.java
@@ -67,13 +67,13 @@ abstract class PartialForwardingServerCall<RespT> extends ServerCall<RespT> {
   }
 
   @Override
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1703")
   public void setMessageCompression(boolean enabled) {
     delegate().setMessageCompression(enabled);
   }
 
   @Override
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public void setCompression(String compressor) {
     delegate().setCompression(compressor);
   }

--- a/core/src/main/java/io/grpc/ResolvedServerInfo.java
+++ b/core/src/main/java/io/grpc/ResolvedServerInfo.java
@@ -38,7 +38,7 @@ import javax.annotation.concurrent.Immutable;
 /**
  * The information about a server from a {@link NameResolver}.
  */
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
 @Immutable
 public final class ResolvedServerInfo {
   private final SocketAddress address;

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -103,7 +103,7 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * shouldn't be used unless you are using custom message encoding.   The default supported
    * decompressors are in {@code DecompressorRegistry.getDefaultInstance}.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public abstract T decompressorRegistry(DecompressorRegistry registry);
 
   /**
@@ -111,7 +111,7 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * shouldn't be used unless you are using custom message encoding.   The default supported
    * compressors are in {@code CompressorRegistry.getDefaultInstance}.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public abstract T compressorRegistry(CompressorRegistry registry);
 
   /**

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -196,7 +196,7 @@ public abstract class ServerCall<RespT> {
    * Enables per-message compression, if an encoding type has been negotiated.  If no message
    * encoding has been negotiated, this is a no-op.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public void setMessageCompression(boolean enabled) {
     // noop
   }
@@ -210,7 +210,7 @@ public abstract class ServerCall<RespT> {
    * @param compressor the name of the compressor to use.
    * @throws IllegalArgumentException if the compressor name can not be found.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public void setCompression(String compressor) {
     // noop
   }

--- a/core/src/main/java/io/grpc/ServerCallHandler.java
+++ b/core/src/main/java/io/grpc/ServerCallHandler.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Interface to initiate processing of incoming remote calls. Advanced applications and generated
  * code will implement this interface to allows {@link Server}s to invoke service methods.
  */
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/933")
 @ThreadSafe
 public interface ServerCallHandler<RequestT, ResponseT> {
   /**

--- a/core/src/main/java/io/grpc/ServerMethodDefinition.java
+++ b/core/src/main/java/io/grpc/ServerMethodDefinition.java
@@ -36,7 +36,7 @@ package io.grpc;
  *
  * @see ServerServiceDefinition
  */
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
 public final class ServerMethodDefinition<ReqT, RespT> {
   private final MethodDescriptor<ReqT, RespT> method;
   private final ServerCallHandler<ReqT, RespT> handler;

--- a/core/src/main/java/io/grpc/ServerServiceDefinition.java
+++ b/core/src/main/java/io/grpc/ServerServiceDefinition.java
@@ -46,7 +46,7 @@ import java.util.Map;
 // consider removing ServerServiceDefinition to and let the registry to have a big map of
 // handlers.
 public final class ServerServiceDefinition {
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
   public static Builder builder(String serviceName) {
     return new Builder(serviceName);
   }
@@ -65,7 +65,7 @@ public final class ServerServiceDefinition {
     return name;
   }
 
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
   public Collection<ServerMethodDefinition<?, ?>> getMethods() {
     return methods.values();
   }
@@ -82,7 +82,7 @@ public final class ServerServiceDefinition {
   /** Builder for constructing Service instances. */
   public static final class Builder {
     private final String serviceName;
-    private final Map<String, ServerMethodDefinition<?, ?>> methods = 
+    private final Map<String, ServerMethodDefinition<?, ?>> methods =
         new HashMap<String, ServerMethodDefinition<?, ?>>();
 
     private Builder(String serviceName) {
@@ -95,7 +95,7 @@ public final class ServerServiceDefinition {
      * @param method the {@link MethodDescriptor} of this method.
      * @param handler handler for incoming calls
      */
-    @ExperimentalApi
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
     public <ReqT, RespT> Builder addMethod(
         MethodDescriptor<ReqT, RespT> method, ServerCallHandler<ReqT, RespT> handler) {
       return addMethod(ServerMethodDefinition.create(
@@ -104,7 +104,7 @@ public final class ServerServiceDefinition {
     }
 
     /** Add a method to be supported by the service. */
-    @ExperimentalApi
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
     public <ReqT, RespT> Builder addMethod(ServerMethodDefinition<ReqT, RespT> def) {
       MethodDescriptor<ReqT, RespT> method = def.getMethodDescriptor();
       checkArgument(

--- a/core/src/main/java/io/grpc/SimpleLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/SimpleLoadBalancerFactory.java
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.GuardedBy;
  * addresses from the {@link NameResolver}.
  */
 // TODO(zhangkun83): Only pick-first is implemented. We need to implement round-robin.
-@ExperimentalApi
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 public final class SimpleLoadBalancerFactory extends LoadBalancer.Factory {
 
   private static final SimpleLoadBalancerFactory instance = new SimpleLoadBalancerFactory();

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -40,7 +40,6 @@ import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
-import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.NameResolver;
@@ -146,14 +145,12 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   @Override
-  @ExperimentalApi
   public final T decompressorRegistry(DecompressorRegistry registry) {
     this.decompressorRegistry = registry;
     return thisT();
   }
 
   @Override
-  @ExperimentalApi
   public final T compressorRegistry(CompressorRegistry registry) {
     this.compressorRegistry = registry;
     return thisT();

--- a/core/src/main/java/io/grpc/internal/ContextRunnable.java
+++ b/core/src/main/java/io/grpc/internal/ContextRunnable.java
@@ -32,13 +32,11 @@
 package io.grpc.internal;
 
 import io.grpc.Context;
-import io.grpc.ExperimentalApi;
 
 /**
  * Utility base implementation of {@link Runnable} that performs the same function as
  * {@link Context#wrap(Runnable)} without requiring the construction of an additional object.
  */
-@ExperimentalApi
 abstract class ContextRunnable implements Runnable {
 
   private final Context context;

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -106,7 +106,7 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
    *
    * @param deadline the deadline or {@code null} for unsetting the deadline.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1706")
   public final S withDeadline(@Nullable Deadline deadline) {
     return build(channel, callOptions.withDeadline(deadline));
   }
@@ -144,7 +144,7 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
    *
    * @param compressorName the name (e.g. "gzip") of the compressor to use.
    */
-  @ExperimentalApi
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public final S withCompression(String compressorName) {
     return build(channel, callOptions.withCompression(compressorName));
   }


### PR DESCRIPTION
Removed some annotations if they were on internal classes.

These annotations describe why the annotation should be present, not if the feature is complete, which is why some of the issues changed.