### PR TITLE
Refactor HandlerRegistry

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
@@ -32,9 +32,9 @@
 package io.grpc.benchmarks.netty;
 
 import io.grpc.MethodDescriptor;
-import io.grpc.MutableHandlerRegistryImpl;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
+import io.grpc.util.MutableHandlerRegistry;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -50,7 +50,7 @@ import java.util.List;
 import java.util.Random;
 
 /**
- * Benchmark for {@link MutableHandlerRegistryImpl}.
+ * Benchmark for {@link MutableHandlerRegistry}.
  */
 @State(Scope.Benchmark)
 @Fork(1)
@@ -68,7 +68,7 @@ public class HandlerRegistryBenchmark {
   @Param({"100"})
   public int methodCountPerService;
 
-  private MutableHandlerRegistryImpl registry;
+  private MutableHandlerRegistry registry;
   private List<String> fullMethodNames;
 
   /**
@@ -76,7 +76,7 @@ public class HandlerRegistryBenchmark {
    */
   @Setup(Level.Trial)
   public void setup() throws Exception {
-    registry = new MutableHandlerRegistryImpl();
+    registry = new MutableHandlerRegistry();
     fullMethodNames = new ArrayList<String>(serviceCount * methodCountPerService);
     for (int serviceIndex = 0; serviceIndex < serviceCount; ++serviceIndex) {
       String serviceName = randomString();
@@ -94,7 +94,7 @@ public class HandlerRegistryBenchmark {
   }
 
   /**
-   * Benchmark the {@link MutableHandlerRegistryImpl#lookupMethod(String)} throughput.
+   * Benchmark the {@link MutableHandlerRegistry#lookupMethod(String)} throughput.
    */
   @Benchmark
   public void lookupMethod(Blackhole bh) {

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -75,8 +75,6 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * Adds a service implementation to the handler registry.
    *
    * @param service ServerServiceDefinition object
-   * @throws UnsupportedOperationException if this builder does not support dynamically adding
-   *                                       services.
    */
   public abstract T addService(ServerServiceDefinition service);
 
@@ -84,11 +82,16 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * Adds a service implementation to the handler registry.
    *
    * @param bindableService BindableService object
-   * @throws UnsupportedOperationException if this builder does not support dynamically adding
-   *     services.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1701")
   public abstract T addService(BindableService bindableService);
+
+  /**
+   * Sets a fallback handler registry that will be looked up in if a method is not found in the
+   * primary registry.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/933")
+  public abstract T fallbackHandlerRegistry(@Nullable HandlerRegistry fallbackRegistry);
 
   /**
    * Makes the server use TLS.
@@ -104,7 +107,7 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * decompressors are in {@code DecompressorRegistry.getDefaultInstance}.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
-  public abstract T decompressorRegistry(DecompressorRegistry registry);
+  public abstract T decompressorRegistry(@Nullable DecompressorRegistry registry);
 
   /**
    * Set the compression registry for use in the channel.  This is an advanced API call and
@@ -112,7 +115,7 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * compressors are in {@code CompressorRegistry.getDefaultInstance}.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
-  public abstract T compressorRegistry(CompressorRegistry registry);
+  public abstract T compressorRegistry(@Nullable CompressorRegistry registry);
 
   /**
    * Builds a server using the given parameters.

--- a/core/src/main/java/io/grpc/ServerServiceDefinition.java
+++ b/core/src/main/java/io/grpc/ServerServiceDefinition.java
@@ -75,7 +75,8 @@ public final class ServerServiceDefinition {
    *
    * @param name the fully qualified name without leading slash. E.g., "com.foo.Foo/Bar"
    */
-  ServerMethodDefinition<?, ?> getMethod(String name) {
+  @Internal
+  public ServerMethodDefinition<?, ?> getMethod(String name) {
     return methods.get(name);
   }
 

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -34,7 +34,6 @@ package io.grpc.inprocess;
 import com.google.common.base.Preconditions;
 
 import io.grpc.ExperimentalApi;
-import io.grpc.HandlerRegistry;
 import io.grpc.internal.AbstractServerImplBuilder;
 
 import java.io.File;
@@ -52,17 +51,6 @@ public final class InProcessServerBuilder
    * Create a server builder that will bind with the given name.
    *
    * @param name the identity of the server for clients to connect to
-   * @param registry the registry of handlers used for dispatching incoming calls
-   * @return a new builder
-   */
-  public static InProcessServerBuilder forName(String name, HandlerRegistry registry) {
-    return new InProcessServerBuilder(name, registry);
-  }
-
-  /**
-   * Create a server builder that will bind with the given name.
-   *
-   * @param name the identity of the server for clients to connect to
    * @return a new builder
    */
   public static InProcessServerBuilder forName(String name) {
@@ -70,11 +58,6 @@ public final class InProcessServerBuilder
   }
 
   private final String name;
-
-  private InProcessServerBuilder(String name, HandlerRegistry registry) {
-    super(registry);
-    this.name = Preconditions.checkNotNull(name, "name");
-  }
 
   private InProcessServerBuilder(String name) {
     this.name = Preconditions.checkNotNull(name, "name");

--- a/core/src/main/java/io/grpc/util/MutableHandlerRegistry.java
+++ b/core/src/main/java/io/grpc/util/MutableHandlerRegistry.java
@@ -29,7 +29,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc;
+package io.grpc.util;
+
+import io.grpc.ExperimentalApi;
+import io.grpc.HandlerRegistry;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -45,17 +51,15 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/933")
-public final class MutableHandlerRegistryImpl extends MutableHandlerRegistry {
+public final class MutableHandlerRegistry extends HandlerRegistry {
   private final ConcurrentMap<String, ServerServiceDefinition> services
       = new ConcurrentHashMap<String, ServerServiceDefinition>();
 
-  @Override
   @Nullable
   public ServerServiceDefinition addService(ServerServiceDefinition service) {
     return services.put(service.getName(), service);
   }
 
-  @Override
   public boolean removeService(ServerServiceDefinition service) {
     return services.remove(service.getName(), service);
   }

--- a/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
+++ b/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc;
+package io.grpc.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -42,6 +42,10 @@ import static org.mockito.Mockito.mock;
 
 import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
 
 import org.junit.After;
 import org.junit.Test;
@@ -49,10 +53,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
-/** Unit tests for {@link MutableHandlerRegistryImpl}. */
+/** Unit tests for {@link MutableHandlerRegistry}. */
 @RunWith(JUnit4.class)
-public class MutableHandlerRegistryImplTest {
-  private MutableHandlerRegistry registry = new MutableHandlerRegistryImpl();
+public class MutableHandlerRegistryTest {
+  private MutableHandlerRegistry registry = new MutableHandlerRegistry();
   @SuppressWarnings("unchecked")
   private Marshaller<String> requestMarshaller = mock(Marshaller.class);
   @SuppressWarnings("unchecked")

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -37,7 +37,6 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import com.google.common.base.Preconditions;
 
 import io.grpc.ExperimentalApi;
-import io.grpc.HandlerRegistry;
 import io.grpc.Internal;
 import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.GrpcUtil;
@@ -84,18 +83,6 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
   }
 
   /**
-   * Creates a server builder that will bind to the given port and use the {@link HandlerRegistry}
-   * for call dispatching.
-   *
-   * @param registry the registry of handlers used for dispatching incoming calls.
-   * @param port the port on which to the server is to be bound.
-   * @return the server builder.
-   */
-  public static NettyServerBuilder forRegistryAndPort(HandlerRegistry registry, int port) {
-    return new NettyServerBuilder(registry, port);
-  }
-
-  /**
    * Creates a server builder configured with the given {@link SocketAddress}.
    *
    * @param address the socket address on which the server is to be bound.
@@ -106,11 +93,6 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
   }
 
   private NettyServerBuilder(int port) {
-    this.address = new InetSocketAddress(port);
-  }
-
-  private NettyServerBuilder(HandlerRegistry registry, int port) {
-    super(registry);
     this.address = new InetSocketAddress(port);
   }
 


### PR DESCRIPTION
See #933

- Create `InternalHandlerRegistry`, an immutable look-up table. Handlers
  passed to `ServerBuilder.addService()` go to this registry. This covers
  the most common use cases. By keeping the registry internal we could
  freely change the registry's interface to accommodate optimizations,
  e.g., for hpack.

- The internal registry uses a flat fullMethodName -> handler look-up
  table instead of a hierarchical one used before. It faster because it
  saves one look-up and a substring.

- Introduces the fallback registry, settable by
  `ServerBuilder.fallbackHandlerRegistry()`, for advanced users who want a
  dynamic registry. Move the current `MutableHandlerRegistryImpl` to
  `io.grpc.util.MutableHandlerRegistry` as a stock implementation of the
  fallback registry. The `io.grpc.MutableHandlerRegistry` interface is now removed.

@ejona86 @louiscryan 