### PR TITLE
context: Remove tests for Key Equality.

### DIFF
--- a/core/src/test/java/io/grpc/ContextTest.java
+++ b/core/src/test/java/io/grpc/ContextTest.java
@@ -693,17 +693,6 @@ public class ContextTest {
     }
   }
 
-  @Test
-  public void testKeyEqualsHashCode() {
-    assertTrue(PET.equals(PET));
-    assertFalse(PET.equals(Context.key("pet")));
-    assertFalse(PET.equals(FOOD));
-    assertFalse(PET.equals("pet"));
-    assertFalse(PET.equals(null));
-
-    assertEquals(PET.hashCode(), PET.hashCode());
-  }
-
   private static class QueuedExecutor implements Executor {
     private final Queue<Runnable> runnables = new ArrayDeque<Runnable>();
 


### PR DESCRIPTION
Since #1350 Key doesn't use special equals check.  These tests raise an error prone warning, and are useless, so remove them.