### PR TITLE
Remove an obsolete comment on ServerServiceDefinition.

### DIFF
--- a/core/src/main/java/io/grpc/ServerServiceDefinition.java
+++ b/core/src/main/java/io/grpc/ServerServiceDefinition.java
@@ -42,9 +42,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** Definition of a service to be exposed via a Server. */
-// TODO(zhangkun83): since the handler map uses fully qualified names as keys, we should
-// consider removing ServerServiceDefinition to and let the registry to have a big map of
-// handlers.
 public final class ServerServiceDefinition {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
   public static Builder builder(String serviceName) {


### PR DESCRIPTION
Commit 9597382 introduced InternalHandlerRegistry as the main registry,
which uses a flat map from fullMethodNames to handlers, thus addressed
the original intention of this comment.

Resolves #1713