### PR TITLE
Fix flakiness of testConfigureDeadlineNanoTime with warmup

### DIFF
--- a/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
+++ b/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
@@ -107,11 +107,13 @@ public class StubConfigTest {
     // Create a default stub
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
     assertNull(stub.getCallOptions().getDeadlineNanoTime());
+    // Warm up JVM
+    stub.withDeadlineNanoTime(deadline);
     // Reconfigure it
     TestServiceGrpc.TestServiceBlockingStub reconfiguredStub = stub.withDeadlineNanoTime(deadline);
     // New altered config
     assertNotNull(reconfiguredStub.getCallOptions().getDeadlineNanoTime());
-    long maxDelta = MILLISECONDS.toNanos(30);
+    long maxDelta = MILLISECONDS.toNanos(10);
     long actualDelta = Math.abs(reconfiguredStub.getCallOptions().getDeadlineNanoTime() - deadline);
     assertTrue(maxDelta + " < " + actualDelta, maxDelta >= actualDelta);
     // Default config unchanged


### PR DESCRIPTION
Without the warm up I saw large deltas, like 2,262,968ns and
1,712,558ns, on my machine. With the single-line warm up the deltas
decreased dramitically, like 385ns and 536ns. Since our times are so
much better now, decreasing the required delta to 10ms seems reasonable.

This would seem to support the theory that the flakiness was caused by
the class loader, which may even be doing I/O.

Fixes #1646