### PR TITLE
interop-testing: Enable message compression for large unary tests

### DIFF
--- a/core/src/main/java/io/grpc/CompressorRegistry.java
+++ b/core/src/main/java/io/grpc/CompressorRegistry.java
@@ -49,7 +49,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class CompressorRegistry {
   private static final CompressorRegistry DEFAULT_INSTANCE = new CompressorRegistry(
-      new Codec.Gzip());
+      new Codec.Gzip(),
+      Codec.Identity.NONE);
 
   public static CompressorRegistry getDefaultInstance() {
     return DEFAULT_INSTANCE;

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -132,9 +132,10 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<RespT> {
       }
     }
     inboundHeaders = null;
-    if (compressor != Codec.Identity.NONE) {
-      headers.put(MESSAGE_ENCODING_KEY, compressor.getMessageEncoding());
-    }
+
+    // Always put compressor, even if it's identity.
+    headers.put(MESSAGE_ENCODING_KEY, compressor.getMessageEncoding());
+
     stream.setCompressor(compressor);
 
     headers.removeAll(MESSAGE_ACCEPT_ENCODING_KEY);

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -99,4 +99,11 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    * @param count more messages
    */
   public abstract void request(int count);
+
+  /**
+   * Sets message compression for subsequent calls to {@link #onNext}.
+   *
+   * @param enable whether to enable compression.
+   */
+  public abstract void setMessageCompression(boolean enable);
 }

--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -56,4 +56,12 @@ public abstract class ServerCallStreamObserver<V> extends CallStreamObserver<V> 
    * @param onCancelHandler to call when client has cancelled the call.
    */
   public abstract void setOnCancelHandler(Runnable onCancelHandler);
+
+  /**
+   * Sets the compression algorithm to use for the call.  May only be called before sending any
+   * messages.
+   *
+   * @param compression the compression algorithm to use.
+   */
+  public abstract void setCompression(String compression);
 }

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -249,7 +249,7 @@ public class ServerCalls {
     StreamObserver<ReqT> invoke(StreamObserver<RespT> responseObserver);
   }
 
-  private static class ServerCallStreamObserverImpl<RespT>
+  private static final class ServerCallStreamObserverImpl<RespT>
       extends ServerCallStreamObserver<RespT> {
     final ServerCall<RespT> call;
     volatile boolean cancelled;
@@ -263,8 +263,18 @@ public class ServerCalls {
       this.call = call;
     }
 
-    private final void freeze() {
+    private void freeze() {
       this.frozen = true;
+    }
+
+    @Override
+    public void setMessageCompression(boolean enable) {
+      call.setMessageCompression(enable);
+    }
+
+    @Override
+    public void setCompression(String compression) {
+      call.setCompression(compression);
     }
 
     @Override


### PR DESCRIPTION
cc: @dgquintas  