### PR TITLE
interop-testing: Print JVM Flags by default for Stress tests

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -74,7 +74,7 @@ task stresstest_client(type: CreateStartScripts) {
     applicationName = "stresstest-client"
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + configurations.runtime + configurations.tcnative
-    defaultJvmOpts = ["-verbose:gc"]
+    defaultJvmOpts = ["-verbose:gc", "-XX:+PrintFlagsFinal"]
 }
 
 applicationDistribution.into("bin") {


### PR DESCRIPTION
This is generally useful to know since the client is going to be under memory and CPU pressure.  

For: #1812 

CC: @sreecha 