### PR TITLE
core: Refactor TransportSet in prep for fail fast

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -229,6 +229,12 @@ class DelayedClientTransport implements ManagedClientTransport {
     }
   }
 
+  public boolean hasPendingStreams() {
+    synchronized (lock) {
+      return pendingStreams != null && !pendingStreams.isEmpty();
+    }
+  }
+
   @VisibleForTesting
   int getPendingStreamsCount() {
     synchronized (lock) {

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -123,13 +123,16 @@ public class DelayedClientTransportTest {
   }
 
   @Test public void streamStartThenSetTransport() {
+    assertFalse(delayedTransport.hasPendingStreams());
     ClientStream stream = delayedTransport.newStream(method, headers);
     stream.start(streamListener);
     assertEquals(1, delayedTransport.getPendingStreamsCount());
+    assertTrue(delayedTransport.hasPendingStreams());
     assertTrue(stream instanceof DelayedStream);
     assertEquals(0, fakeExecutor.numPendingTasks());
     delayedTransport.setTransport(mockRealTransport);
     assertEquals(0, delayedTransport.getPendingStreamsCount());
+    assertFalse(delayedTransport.hasPendingStreams());
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockRealTransport).newStream(same(method), same(headers));
     verify(mockRealStream).start(same(streamListener));


### PR DESCRIPTION
This is functionally equivalent. Some tests needed changes because they
were verifying internal behavior.

CC @dapengzhang0 