### PR TITLE
benchmarks: use Concurrent Mark and Sweep GC for benchmark worker

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -50,7 +50,8 @@ configureProtoCompilation()
 def vmArgs = [
         "-server",
         "-Xms2g",
-        "-Xmx2g"
+        "-Xmx2g",
+        "-XX:+UseConcMarkSweepGC"
 ]
 
 task qps_client(type: CreateStartScripts) {


### PR DESCRIPTION
This does not affect JMH, despite having noticeable gains for it.  We can decide in the future if that is appropriate.

cc: @vjpai @buchgr @louiscryan 