### PR TITLE
benchmarks: revert use of CMS GC

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -50,8 +50,7 @@ configureProtoCompilation()
 def vmArgs = [
         "-server",
         "-Xms2g",
-        "-Xmx2g",
-        "-XX:+UseConcMarkSweepGC"
+        "-Xmx2g"
 ]
 
 task qps_client(type: CreateStartScripts) {


### PR DESCRIPTION
Latency was not improved, and throughput dropped on the dashboard.  Revert until we have a dedicated java dashboard for various java VMs.