### PR TITLE
Differentiate transport to LB services and to servers.

### DIFF
--- a/core/src/main/java/io/grpc/internal/TransportSet.java
+++ b/core/src/main/java/io/grpc/internal/TransportSet.java
@@ -444,21 +444,21 @@ final class TransportSet implements WithLogId {
     }
   }
 
-  interface Callback {
+  abstract static class Callback {
     /**
      * Called when the TransportSet is terminated, which means it's shut down and all transports
      * have been terminated.
      */
-    void onTerminated();
+    public void onTerminated() { }
 
     /**
      * Called when all addresses have failed to connect.
      */
-    void onAllAddressesFailed();
+    public void onAllAddressesFailed() { }
 
     /**
      * Called when a once-live connection is shut down by server-side.
      */
-    void onConnectionClosedByServer(Status status);
+    public void onConnectionClosedByServer(Status status) { }
   }
 }


### PR DESCRIPTION
TransportManager has a new method, createOobTransportProvider(), which
accepts an EquivalentAddressGroup and the authority string. This
addresses three requirements:

1. Per GRPCLB protocol, connections to the remote load-balancer may use a
different authority than the channel's (#1137).

2. Errors from the transports for remote load-balancers should not trigger
name resolution refresh (#1599)

3. For idle state determination, Channel needs to exclude the transport to
the LB service when looking at live RPCs and (#1276).

@ejona86 If the API change looks good to you, I will go ahead and add the test. Follow-up changes in GrpclbLoadBalancer will be in a separate PR.