### PR TITLE
netty: don't revalidate when converting between Metadata and Http2Headers

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/netty/HeadersBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/netty/HeadersBenchmark.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.AsciiMarshaller;
+import io.grpc.netty.Utils;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.AsciiString;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Header encoding benchmark.
+ */
+@State(Scope.Benchmark)
+public class HeadersBenchmark {
+  @Param({"10", "20", "50", "100"})
+  public int headerCount;
+
+  @Param({"false", "true"})
+  public boolean validate;
+
+  private final AsciiMarshaller<String> keyMarshaller = new AsciiMarshaller<String>() {
+    @Override
+    public String toAsciiString(String value) {
+      return value;
+    }
+
+    @Override
+    public String parseAsciiString(String serialized) {
+      return serialized;
+    }
+  };
+
+  private Metadata metadata = new Metadata();
+  private AsciiString scheme = new AsciiString("https");
+  private AsciiString defaultPath = new AsciiString("/Service.MethodMethodMethod");
+  private AsciiString authority = new AsciiString("authority.googleapis.bogus");
+
+  @Setup
+  public void setUp() throws Exception {
+    for (int i = 0; i < headerCount; i++) {
+      metadata.put(Metadata.Key.of("key-" + i, keyMarshaller), UUID.randomUUID().toString());
+    }
+    Utils.validateHeaders = validate;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Http2Headers convertHeaders() {
+    return Utils.convertClientHeaders(metadata, scheme, defaultPath, authority);
+  }
+}
+

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -35,6 +35,7 @@ import static io.grpc.internal.GrpcUtil.CONTENT_TYPE_KEY;
 import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
 import static io.netty.util.CharsetUtil.UTF_8;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import io.grpc.Metadata;
@@ -63,6 +64,7 @@ import javax.net.ssl.SSLSession;
 /**
  * Common utility methods.
  */
+@VisibleForTesting
 class Utils {
 
   public static final AsciiString STATUS_OK = AsciiString.of("200");
@@ -83,6 +85,9 @@ class Utils {
 
   public static final AttributeKey<SSLSession> SSL_SESSION_ATTR_KEY =
       AttributeKey.valueOf(SSLSession.class, "ssl-session");
+
+  @VisibleForTesting
+  static boolean validateHeaders = false;
 
   public static Metadata convertHeaders(Http2Headers http2Headers) {
     return new Metadata(convertHeadersToArray(http2Headers));
@@ -155,8 +160,7 @@ class Utils {
 
   private static Http2Headers convertMetadata(Metadata headers) {
     Preconditions.checkNotNull(headers, "headers");
-    boolean validate = true;
-    Http2Headers http2Headers = new DefaultHttp2Headers(validate, headers.headerCount());
+    Http2Headers http2Headers = new DefaultHttp2Headers(validateHeaders, headers.headerCount());
     byte[][] serializedHeaders = TransportFrameUtil.toHttp2Headers(headers);
     for (int i = 0; i < serializedHeaders.length; i += 2) {
       AsciiString name = new AsciiString(serializedHeaders[i], false);


### PR DESCRIPTION
This change doesn't cause, but rather unearths a potential performance gain.  Consider the following:

```
Benchmark                         (direct)  (transport)  (validate)    Mode     Cnt       Score     Error  Units
TransportBenchmark.unaryCall1024      true        NETTY        true  sample  557618  178882.761 ▒ 429.097  ns/op
TransportBenchmark.unaryCall1024      true        NETTY       false  sample  613258  162598.208 ▒ 377.362  ns/op
TransportBenchmark.unaryCall1024     false        NETTY        true  sample  366755  272032.442 ▒ 629.053  ns/op
TransportBenchmark.unaryCall1024     false        NETTY       false  sample  397020  251252.659 ▒ 726.254  ns/op

Also 

Benchmark                         (direct)  (transport)  (validate)    Mode     Cnt       Score     Error  Units
TransportBenchmark.unaryCall1024      true        NETTY        true  sample  558486  178687.649 ▒ 353.134  ns/op
TransportBenchmark.unaryCall1024      true        NETTY       false  sample  624353  159732.303 ▒ 384.432  ns/op
TransportBenchmark.unaryCall1024     false        NETTY        true  sample  371358  268634.961 ▒ 711.681  ns/op
TransportBenchmark.unaryCall1024     false        NETTY       false  sample  391621  254763.291 ▒ 668.236  ns/op
```

Running with the plain Netty Transport to make sure headers go all the way through.  Trying to repeat this experiment several times seems to vary between no perf difference and 15-25us.  I still haven't nailed what exactly the 16% speed up is from.  Running with ASM dumping shows identical x86 assembly codes.  

In any case, the validation Netty does is redundant with that of Metadata 