### PR TITLE
Custom CallOptions options

### DIFF
--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -34,6 +34,7 @@ package io.grpc;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
+import java.util.Arrays;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -65,6 +66,8 @@ public final class CallOptions {
 
   @Nullable
   private String compressorName;
+  
+  private Object[][] customOptions = new Object[0][2];
 
   /**
    * Override the HTTP/2 authority the channel claims to be connecting to. <em>This is not
@@ -209,6 +212,75 @@ public final class CallOptions {
     newOptions.executor = executor;
     return newOptions;
   }
+  
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
+  public static final class Key<T> {
+    private final String name;
+    private final T defaultValue;
+
+    private Key(String name, T defaultValue) {
+      this.name = name;
+      this.defaultValue = defaultValue;
+    }
+
+    public T getDefault() {
+      return defaultValue;
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+
+    /**
+     * Factory method for creating instances of {@link Key}.
+     *
+     * @param name the name of Key.
+     * @param defaultValue default value to return when value for key not set
+     * @param <T> Key type
+     * @return Key object
+     */
+    public static <T> Key<T> of(String name, T defaultValue) {
+      Preconditions.checkNotNull(name);
+      return new Key<T>(name, defaultValue);
+    }
+  }
+
+  /**
+   * Set a custom option.  Any existing value for the key overridden.
+   * 
+   * @param key The option key
+   * @param value The option value.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
+  public <T> CallOptions withOption(Key<T> key, T value) {
+    Preconditions.checkNotNull(key);
+    Preconditions.checkNotNull(value);
+      
+    CallOptions newOptions = new CallOptions(this);
+    newOptions.customOptions = new Object[customOptions.length + 1][2];
+    newOptions.customOptions[0] = new Object[] { key, value};
+    if (customOptions.length > 0) {
+      System.arraycopy(customOptions, 0, newOptions.customOptions, 1, customOptions.length);
+    }
+    return newOptions;
+  }
+
+  /**
+   * Get the value for a custom option or its inherent default.
+   * @param key Key identifying option
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
+  @SuppressWarnings("unchecked")
+  public <T> T getOption(Key<T> key) {
+    Preconditions.checkNotNull(key);
+    for (int i = 0; i < customOptions.length; i++) {
+      if (key.equals(customOptions[i][0])) {
+        return (T) customOptions[i][1];
+      }
+    }
+    return key.defaultValue;
+  }
 
   @Nullable
   public Executor getExecutor() {
@@ -227,6 +299,7 @@ public final class CallOptions {
     affinity = other.affinity;
     executor = other.executor;
     compressorName = other.compressorName;
+    customOptions = other.customOptions;
   }
 
   @Override
@@ -237,6 +310,7 @@ public final class CallOptions {
     toStringHelper.add("affinity", affinity);
     toStringHelper.add("executor", executor != null ? executor.getClass() : null);
     toStringHelper.add("compressorName", compressorName);
+    toStringHelper.add("customOptions", Arrays.toString(customOptions));
 
     return toStringHelper.toString();
   }

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -63,6 +63,8 @@ public class CallOptionsTest {
       .withAuthority(sampleAuthority)
       .withDeadline(sampleDeadline)
       .withAffinity(sampleAffinity);
+  private CallOptions.Key<String> option1 = CallOptions.Key.of("option1", "default");
+  private CallOptions.Key<String> option2 = CallOptions.Key.of("option2", "default");
 
   @Test
   public void defaultsAreAllNull() {
@@ -128,7 +130,8 @@ public class CallOptionsTest {
   @Test
   public void toStringMatches_noDeadline_default() {
     String expected = "CallOptions{deadline=null, authority=authority, affinity={sample=blah}, "
-        + "executor=class io.grpc.internal.SerializingExecutor, compressorName=null}";
+        + "executor=class io.grpc.internal.SerializingExecutor, compressorName=null, "
+        + "customOptions=[]}";
     String actual = allSet
         .withDeadline(null)
         .withExecutor(new SerializingExecutor(directExecutor()))
@@ -140,7 +143,7 @@ public class CallOptionsTest {
   @Test
   public void toStringMatches_noDeadline() {
     assertThat("CallOptions{deadline=null, authority=null, "
-        + "affinity={}, executor=null, compressorName=null}")
+        + "affinity={}, executor=null, compressorName=null, customOptions=[]}")
             .isEqualTo(CallOptions.DEFAULT.toString());
   }
 
@@ -165,6 +168,31 @@ public class CallOptionsTest {
     assertAbout(deadline()).that(opts.getDeadline()).isWithin(50, MILLISECONDS).of(reference);
   }
 
+  @Test
+  public void withCustomOptionDefault() {
+    CallOptions opts = CallOptions.DEFAULT;
+    assertThat(opts.getOption(option1)).isEqualTo("default");
+  }
+  
+  @Test
+  public void withCustomOption() {
+    CallOptions opts = CallOptions.DEFAULT.withOption(option1, "v1");
+    assertThat(opts.getOption(option1)).isEqualTo("v1");
+  }
+  
+  @Test
+  public void withCustomOptionLastOneWins() {
+    CallOptions opts = CallOptions.DEFAULT.withOption(option1, "v1").withOption(option1, "v2");
+    assertThat(opts.getOption(option1)).isEqualTo("v2");
+  }
+  
+  @Test
+  public void withMultipleCustomOption() {
+    CallOptions opts = CallOptions.DEFAULT.withOption(option1, "v1").withOption(option2, "v2");
+    assertThat(opts.getOption(option1)).isEqualTo("v1");
+    assertThat(opts.getOption(option2)).isEqualTo("v2");
+  }
+  
   // TODO(carl-mastrangelo): consider making a CallOptionsSubject for Truth.
   private static boolean equal(CallOptions o1, CallOptions o2) {
     return Objects.equal(o1.getDeadline(), o2.getDeadline())

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -155,6 +155,17 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   public final S withChannel(Channel newChannel) {
     return build(newChannel, callOptions);
   }
+  
+  /**
+   * Sets a custom option to be passed to client interceptors on the channel
+   * {@link io.grpc.ClientInterceptor} via the CallOptions parameter.
+   * @param key the option being set
+   * @param value the value for the key
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
+  public final <T> S withOption(CallOptions.Key<T> key, T value) {
+    return build(channel, callOptions.withOption(key, value));
+  }
 
   /**
    * Returns a new stub that has the given interceptors attached to the underlying channel.


### PR DESCRIPTION
Allow for custom options to be set on CallOptions so that per call parameters can be passed in to an already configured interceptor.

Addresses Issue #1800