### PR TITLE
netty: use custom Http2Headers class for encoding Metadata

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -605,7 +605,7 @@ public abstract class AbstractInteropTest {
     Assert.assertEquals(contextValue, trailersCapture.get().get(METADATA_KEY));
   }
 
-  @Test(timeout = 100000000)
+  @Test(timeout = 10000)
   public void sendsTimeoutHeader() {
     long configuredTimeoutMinutes = 100;
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel)

--- a/netty/src/main/java/io/grpc/netty/AbstractHttp2Headers.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractHttp2Headers.java
@@ -1,0 +1,559 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import io.netty.handler.codec.Headers;
+import io.netty.handler.codec.http2.Http2Headers;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+abstract class AbstractHttp2Headers implements Http2Headers {
+
+  @Override
+  public int size() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Set<CharSequence> names() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CharSequence get(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CharSequence get(CharSequence name, CharSequence defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CharSequence getAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CharSequence getAndRemove(CharSequence name, CharSequence defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<CharSequence> getAll(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<CharSequence> getAllAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Boolean getBoolean(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean getBoolean(CharSequence name, boolean defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Byte getByte(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte getByte(CharSequence name, byte defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Character getChar(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public char getChar(CharSequence name, char defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Short getShort(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public short getShort(CharSequence name, short defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Integer getInt(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getInt(CharSequence name, int defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Long getLong(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLong(CharSequence name, long defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Float getFloat(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float getFloat(CharSequence name, float defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Double getDouble(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDouble(CharSequence name, double defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Long getTimeMillis(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getTimeMillis(CharSequence name, long defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Boolean getBooleanAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean getBooleanAndRemove(CharSequence name, boolean defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Byte getByteAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte getByteAndRemove(CharSequence name, byte defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Character getCharAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public char getCharAndRemove(CharSequence name, char defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Short getShortAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public short getShortAndRemove(CharSequence name, short defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Integer getIntAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getIntAndRemove(CharSequence name, int defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Long getLongAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLongAndRemove(CharSequence name, long defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Float getFloatAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float getFloatAndRemove(CharSequence name, float defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Double getDoubleAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDoubleAndRemove(CharSequence name, double defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Long getTimeMillisAndRemove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getTimeMillisAndRemove(CharSequence name, long defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean contains(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean contains(CharSequence name, CharSequence value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsObject(CharSequence name, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsBoolean(CharSequence name, boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsByte(CharSequence name, byte value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsChar(CharSequence name, char value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsShort(CharSequence name, short value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsInt(CharSequence name, int value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsLong(CharSequence name, long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsFloat(CharSequence name, float value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsDouble(CharSequence name, double value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsTimeMillis(CharSequence name, long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers add(CharSequence name, CharSequence... values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers add(Headers<? extends CharSequence, ? extends CharSequence, ?> headers) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers add(CharSequence name, CharSequence value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers add(CharSequence name, Iterable<? extends CharSequence> values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addObject(CharSequence name, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addObject(CharSequence name, Iterable<?> values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addObject(CharSequence name, Object... values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addBoolean(CharSequence name, boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addByte(CharSequence name, byte value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addChar(CharSequence name, char value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addShort(CharSequence name, short value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addInt(CharSequence name, int value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addLong(CharSequence name, long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addFloat(CharSequence name, float value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addDouble(CharSequence name, double value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers addTimeMillis(CharSequence name, long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers set(Headers<? extends CharSequence, ? extends CharSequence, ?> headers) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers set(CharSequence name, CharSequence value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers set(CharSequence name, Iterable<? extends CharSequence> values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers set(CharSequence name, CharSequence... values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setObject(CharSequence name, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setObject(CharSequence name, Iterable<?> values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setObject(CharSequence name, Object... values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setBoolean(CharSequence name, boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setByte(CharSequence name, byte value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setChar(CharSequence name, char value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setShort(CharSequence name, short value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setInt(CharSequence name, int value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setLong(CharSequence name, long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setFloat(CharSequence name, float value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setDouble(CharSequence name, double value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setTimeMillis(CharSequence name, long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers setAll(Headers<? extends CharSequence, ? extends CharSequence, ?> headers) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Iterator<Entry<CharSequence, CharSequence>> iterator() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers method(CharSequence value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CharSequence method() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers scheme(CharSequence value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CharSequence scheme() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers authority(CharSequence value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CharSequence authority() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers path(CharSequence value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CharSequence path() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Http2Headers status(CharSequence value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CharSequence status() {
+    throw new UnsupportedOperationException();
+  }
+}
+

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2Headers.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2Headers.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.AsciiString;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+
+/**
+ * A custom implementation of Http2Headers that only includes methods used by gRPC.
+ */
+final class GrpcHttp2Headers extends AbstractHttp2Headers {
+
+  private final AsciiString[] normalHeaders;
+  private final AsciiString[] preHeaders;
+  private static final AsciiString[] EMPTY = new AsciiString[]{};
+
+  static GrpcHttp2Headers clientRequestHeaders(byte[][] serializedMetadata, AsciiString authority,
+      AsciiString path, AsciiString method, AsciiString scheme, AsciiString userAgent) {
+    AsciiString[] preHeaders = new AsciiString[] {
+        Http2Headers.PseudoHeaderName.AUTHORITY.value(), authority,
+        Http2Headers.PseudoHeaderName.PATH.value(), path,
+        Http2Headers.PseudoHeaderName.METHOD.value(), method,
+        Http2Headers.PseudoHeaderName.SCHEME.value(), scheme,
+        Utils.CONTENT_TYPE_HEADER, Utils.CONTENT_TYPE_GRPC,
+        Utils.TE_HEADER, Utils.TE_TRAILERS,
+        Utils.USER_AGENT, userAgent,
+    };
+    return new GrpcHttp2Headers(preHeaders, serializedMetadata);
+  }
+
+  static GrpcHttp2Headers serverResponseHeaders(byte[][] serializedMetadata) {
+    AsciiString[] preHeaders = new AsciiString[] {
+        Http2Headers.PseudoHeaderName.STATUS.value(), Utils.STATUS_OK,
+        Utils.CONTENT_TYPE_HEADER, Utils.CONTENT_TYPE_GRPC,
+    };
+    return new GrpcHttp2Headers(preHeaders, serializedMetadata);
+  }
+
+  static GrpcHttp2Headers serverResponseTrailers(byte[][] serializedMetadata) {
+    return new GrpcHttp2Headers(EMPTY, serializedMetadata);
+  }
+
+  private GrpcHttp2Headers(AsciiString[] preHeaders, byte[][] serializedMetadata) {
+    normalHeaders = new AsciiString[serializedMetadata.length];
+    for (int i = 0; i < normalHeaders.length; i++) {
+      normalHeaders[i] = new AsciiString(serializedMetadata[i], false);
+    }
+    this.preHeaders = preHeaders;
+  }
+
+  @Override
+  public Iterator<Entry<CharSequence, CharSequence>> iterator() {
+    return new Itr();
+  }
+
+  @Override
+  public int size() {
+    return (normalHeaders.length + preHeaders.length) / 2;
+  }
+
+  private class Itr implements Entry<CharSequence, CharSequence>,
+      Iterator<Entry<CharSequence, CharSequence>> {
+    private int idx;
+    private AsciiString[] current = preHeaders.length != 0 ? preHeaders : normalHeaders;
+    private AsciiString key;
+    private AsciiString value;
+
+    @Override
+    public boolean hasNext() {
+      return idx < current.length;
+    }
+
+    /**
+     * This function is ordered specifically to get ideal performance on OpenJDK.  If you decide to
+     * change it, even in ways that don't seem possible to affect performance, please benchmark
+     * speeds before and after.
+     */
+    @Override
+    public Entry<CharSequence, CharSequence> next() {
+      if (hasNext()) {
+        key = current[idx];
+        value = current[idx + 1];
+        idx += 2;
+        if (idx >= current.length && current == preHeaders) {
+          current = normalHeaders;
+          idx = 0;
+        }
+        return this;
+      } else {
+        throw new NoSuchElementException();
+      }
+    }
+
+    @Override
+    public CharSequence getKey() {
+      return key;
+    }
+
+    @Override
+    public CharSequence getValue() {
+      return value;
+    }
+
+    @Override
+    public CharSequence setValue(CharSequence value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
Before:
```
Benchmark                              (headerCount)    Mode     Cnt     Score    Error  Units
HeadersBenchmark.convertClientHeaders             10  sample  119785   684.202 ±  4.531  ns/op
HeadersBenchmark.convertClientHeaders             20  sample  137935  1176.324 ± 34.101  ns/op
HeadersBenchmark.convertClientHeaders             50  sample  114824  2793.422 ± 76.779  ns/op
HeadersBenchmark.convertClientHeaders            100  sample  110157  5720.402 ± 65.462  ns/op
HeadersBenchmark.convertServerHeaders             10  sample  127963   640.391 ±  3.215  ns/op
HeadersBenchmark.convertServerHeaders             20  sample  134060  1190.960 ±  4.222  ns/op
HeadersBenchmark.convertServerHeaders             50  sample  116292  2713.037 ±  7.151  ns/op
HeadersBenchmark.convertServerHeaders            100  sample  115921  5427.773 ± 50.070  ns/op
```

After:
```
Benchmark                              (headerCount)    Mode     Cnt     Score    Error  Units
HeadersBenchmark.convertClientHeaders             10  sample  164584   520.479 ± 28.973  ns/op
HeadersBenchmark.convertClientHeaders             20  sample  191581   853.866 ± 25.689  ns/op
HeadersBenchmark.convertClientHeaders             50  sample  166162  1904.264 ± 30.057  ns/op
HeadersBenchmark.convertClientHeaders            100  sample  162615  3836.205 ±  8.345  ns/op
HeadersBenchmark.convertServerHeaders             10  sample   99981   418.113 ±  3.090  ns/op
HeadersBenchmark.convertServerHeaders             20  sample  198148   822.495 ± 23.354  ns/op
HeadersBenchmark.convertServerHeaders             50  sample  165877  1906.003 ±  5.161  ns/op
HeadersBenchmark.convertServerHeaders            100  sample  163624  3843.244 ± 45.640  ns/op
```

+cc: @ejona86 