### PR TITLE
Tweak -Xlint warnings

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -45,6 +45,10 @@ dependencies {
             libraries.math
 }
 
+compileJmhJava {
+  options.compilerArgs = compileJava.options.compilerArgs
+}
+
 configureProtoCompilation()
 
 def vmArgs = [

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,13 @@ subprojects {
     }
 
     [compileJava, compileTestJava].each() {
-        it.options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation", "-Xlint:-options",
-            "-Xlint:rawtypes"]
+        it.options.compilerArgs += ["-Xlint:all", "-Xlint:-options"]
         it.options.encoding = "UTF-8"
+    }
+
+    compileTestJava {
+      // serialVersionUID is basically guaranteed to be useless in our tests
+      options.compilerArgs += ["-Xlint:-serial"]
     }
 
     jar.manifest {

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -135,7 +135,12 @@ sourceSets {
 
 compileTestLiteJava {
   // Protobuf-generated Lite produces quite a few warnings.
-  it.options.compilerArgs.removeAll(["-Xlint:unchecked", "-Xlint:rawtypes"])
+  options.compilerArgs = compileTestJava.options.compilerArgs +
+      ["-Xlint:-unchecked", "-Xlint:-rawtypes"]
+}
+
+compileTestNanoJava {
+  options.compilerArgs = compileTestJava.options.compilerArgs
 }
 
 protobuf {

--- a/core/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/core/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -133,6 +133,8 @@ public abstract class ManagedChannelProvider {
   protected abstract ManagedChannelBuilder<?> builderForTarget(String target);
 
   public static final class ProviderNotFoundException extends RuntimeException {
+    private static final long serialVersionUID = 1;
+
     public ProviderNotFoundException(String msg) {
       super(msg);
     }

--- a/core/src/main/java/io/grpc/inprocess/InProcessSocketAddress.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessSocketAddress.java
@@ -37,6 +37,8 @@ import java.net.SocketAddress;
  * Custom SocketAddress class for {@link InProcessTransport}.
  */
 public class InProcessSocketAddress extends SocketAddress {
+  private static final long serialVersionUID = -2803441206326023474L;
+
   private final String name;
 
   public InProcessSocketAddress(String name) {


### PR DESCRIPTION
This now catches a few more places we needed -Xlint:-options.
InProcessSocketAddress is technically already in our stable API, so I
maintained its current serialVersionUID.