### PR TITLE
core,netty,okhttp: move user agent out of client call and into the transport

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -94,7 +94,8 @@ public class InProcessChannelBuilder extends
     }
 
     @Override
-    public ManagedClientTransport newClientTransport(SocketAddress addr, String authority) {
+    public ManagedClientTransport newClientTransport(
+        SocketAddress addr, String authority, String userAgent) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -163,7 +163,7 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   @Override
-  public final T userAgent(String userAgent) {
+  public final T userAgent(@Nullable String userAgent) {
     this.userAgent = userAgent;
     return thisT();
   }
@@ -232,8 +232,8 @@ public abstract class AbstractManagedChannelImplBuilder
 
     @Override
     public ManagedClientTransport newClientTransport(SocketAddress serverAddress,
-        String authority) {
-      return factory.newClientTransport(serverAddress, authorityOverride);
+        String authority, @Nullable String userAgent) {
+      return factory.newClientTransport(serverAddress, authorityOverride, userAgent);
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -34,6 +34,8 @@ package io.grpc.internal;
 import java.io.Closeable;
 import java.net.SocketAddress;
 
+import javax.annotation.Nullable;
+
 /** Pre-configured factory for creating {@link ManagedClientTransport} instances. */
 public interface ClientTransportFactory extends Closeable {
   /**
@@ -42,13 +44,14 @@ public interface ClientTransportFactory extends Closeable {
    * @param serverAddress the address that the transport is connected to
    * @param authority the HTTP/2 authority of the server
    */
-  ManagedClientTransport newClientTransport(SocketAddress serverAddress, String authority);
+  ManagedClientTransport newClientTransport(SocketAddress serverAddress, String authority,
+      @Nullable String userAgent);
 
   /**
    * Releases any resources.
    *
    * <p>After this method has been called, it's no longer valid to call
-   * {@link #newClientTransport(SocketAddress, String)}. No guarantees about thread-safety are made.
+   * {@link #newClientTransport}. No guarantees about thread-safety are made.
    */
   @Override
   void close();

--- a/core/src/main/java/io/grpc/internal/TransportSet.java
+++ b/core/src/main/java/io/grpc/internal/TransportSet.java
@@ -67,6 +67,7 @@ final class TransportSet implements WithLogId {
   private final Object lock = new Object();
   private final EquivalentAddressGroup addressGroup;
   private final String authority;
+  private final String userAgent;
   private final BackoffPolicy.Provider backoffPolicyProvider;
   private final Callback callback;
   private final ClientTransportFactory transportFactory;
@@ -122,21 +123,22 @@ final class TransportSet implements WithLogId {
   @Nullable
   private volatile ManagedClientTransport activeTransport;
 
-  TransportSet(EquivalentAddressGroup addressGroup, String authority,
+  TransportSet(EquivalentAddressGroup addressGroup, String authority, String userAgent,
       LoadBalancer<ClientTransport> loadBalancer, BackoffPolicy.Provider backoffPolicyProvider,
       ClientTransportFactory transportFactory, ScheduledExecutorService scheduledExecutor,
       Executor appExecutor, Callback callback) {
-    this(addressGroup, authority, loadBalancer, backoffPolicyProvider, transportFactory,
+    this(addressGroup, authority, userAgent, loadBalancer, backoffPolicyProvider, transportFactory,
         scheduledExecutor, appExecutor, callback, Stopwatch.createUnstarted());
   }
 
   @VisibleForTesting
-  TransportSet(EquivalentAddressGroup addressGroup, String authority,
+  TransportSet(EquivalentAddressGroup addressGroup, String authority, String userAgent,
       LoadBalancer<ClientTransport> loadBalancer, BackoffPolicy.Provider backoffPolicyProvider,
       ClientTransportFactory transportFactory, ScheduledExecutorService scheduledExecutor,
       Executor appExecutor, Callback callback, Stopwatch connectingTimer) {
     this.addressGroup = Preconditions.checkNotNull(addressGroup, "addressGroup");
     this.authority = authority;
+    this.userAgent = userAgent;
     this.loadBalancer = loadBalancer;
     this.backoffPolicyProvider = backoffPolicyProvider;
     this.transportFactory = transportFactory;
@@ -186,7 +188,8 @@ final class TransportSet implements WithLogId {
       nextAddressIndex = 0;
     }
 
-    ManagedClientTransport transport = transportFactory.newClientTransport(address, authority);
+    ManagedClientTransport transport =
+        transportFactory.newClientTransport(address, authority, userAgent);
     if (log.isLoggable(Level.FINE)) {
       log.log(Level.FINE, "[{0}] Created {1} for {2}",
           new Object[] {getLogId(), transport.getLogId(), address});

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.internal.GrpcUtil.ACCEPT_ENCODING_SPLITER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -195,19 +196,18 @@ public class ClientCallImplTest {
   }
 
   @Test
-  public void prepareHeaders_userAgentAdded() {
+  public void prepareHeaders_userAgentRemove() {
     Metadata m = new Metadata();
-    ClientCallImpl.prepareHeaders(m, CallOptions.DEFAULT, "user agent", decompressorRegistry,
-        Codec.Identity.NONE);
+    m.put(GrpcUtil.USER_AGENT_KEY, "batmobile");
+    ClientCallImpl.prepareHeaders(m, decompressorRegistry, Codec.Identity.NONE);
 
-    assertEquals(m.get(GrpcUtil.USER_AGENT_KEY), "user agent");
+    assertThat(m.get(GrpcUtil.USER_AGENT_KEY)).isNull();
   }
 
   @Test
   public void prepareHeaders_ignoreIdentityEncoding() {
     Metadata m = new Metadata();
-    ClientCallImpl.prepareHeaders(m, CallOptions.DEFAULT, "user agent", decompressorRegistry,
-        Codec.Identity.NONE);
+    ClientCallImpl.prepareHeaders(m, decompressorRegistry, Codec.Identity.NONE);
 
     assertNull(m.get(GrpcUtil.MESSAGE_ENCODING_KEY));
   }
@@ -250,8 +250,7 @@ public class ClientCallImplTest {
       }
     }, false); // not advertised
 
-    ClientCallImpl.prepareHeaders(m, CallOptions.DEFAULT, "user agent", customRegistry,
-        Codec.Identity.NONE);
+    ClientCallImpl.prepareHeaders(m, customRegistry, Codec.Identity.NONE);
 
     Iterable<String> acceptedEncodings =
         ACCEPT_ENCODING_SPLITER.split(m.get(GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY));
@@ -267,8 +266,7 @@ public class ClientCallImplTest {
     m.put(GrpcUtil.MESSAGE_ENCODING_KEY, "gzip");
     m.put(GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY, "gzip");
 
-    ClientCallImpl.prepareHeaders(m, CallOptions.DEFAULT, null,
-        DecompressorRegistry.newEmptyInstance(), Codec.Identity.NONE);
+    ClientCallImpl.prepareHeaders(m, DecompressorRegistry.newEmptyInstance(), Codec.Identity.NONE);
 
     assertNull(m.get(GrpcUtil.USER_AGENT_KEY));
     assertNull(m.get(GrpcUtil.MESSAGE_ENCODING_KEY));

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -97,7 +97,8 @@ final class TestUtils {
         }).when(mockTransport).start(any(ManagedClientTransport.Listener.class));
         return mockTransport;
       }
-    }).when(mockTransportFactory).newClientTransport(any(SocketAddress.class), any(String.class));
+    }).when(mockTransportFactory)
+        .newClientTransport(any(SocketAddress.class), any(String.class), any(String.class));
 
     return captor;
   }

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -311,23 +311,23 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
 
     @Override
     public ManagedClientTransport newClientTransport(
-        SocketAddress serverAddress, String authority) {
+        SocketAddress serverAddress, String authority, @Nullable String userAgent) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
       ProtocolNegotiator negotiator = protocolNegotiator != null ? protocolNegotiator :
           createProtocolNegotiator(authority, negotiationType, sslContext);
-      return newClientTransport(serverAddress, authority, negotiator);
+      return newClientTransport(serverAddress, authority, userAgent, negotiator);
     }
 
     @Internal  // This is strictly for internal use.  Depend on this at your own peril.
     public ManagedClientTransport newClientTransport(SocketAddress serverAddress,
-        String authority, ProtocolNegotiator negotiator) {
+        String authority, String userAgent, ProtocolNegotiator negotiator) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
       return new NettyClientTransport(serverAddress, channelType, group, negotiator,
-          flowControlWindow, maxMessageSize, maxHeaderListSize, authority);
+          flowControlWindow, maxMessageSize, maxHeaderListSize, authority, userAgent);
     }
 
     @Override

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -75,12 +75,13 @@ public class NettyTransportTest extends AbstractTransportTest {
   @Override
   protected ManagedClientTransport newClientTransport() {
     return clientFactory.newClientTransport(
-        new InetSocketAddress("localhost", SERVER_PORT), "localhost:" + SERVER_PORT);
+        new InetSocketAddress("localhost", SERVER_PORT),
+        "localhost:" + SERVER_PORT,
+        null /* agent */);
   }
 
-  // TODO(ejona): Flaky
   @Test
-  @Ignore
+  @Ignore("flaky")
   @Override
   public void flowControlPushBack() {}
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/Headers.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Headers.java
@@ -46,6 +46,8 @@ import okio.ByteString;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 /**
  * Constants for request/response headers.
  */
@@ -63,7 +65,7 @@ public class Headers {
    * application thread context.
    */
   public static List<Header> createRequestHeaders(Metadata headers, String defaultPath,
-      String authority) {
+      String authority, @Nullable String applicationUserAgent) {
     Preconditions.checkNotNull(headers, "headers");
     Preconditions.checkNotNull(defaultPath, "defaultPath");
     Preconditions.checkNotNull(authority, "authority");
@@ -79,7 +81,7 @@ public class Headers {
     String path = defaultPath;
     okhttpHeaders.add(new Header(Header.TARGET_PATH, path));
 
-    String userAgent = GrpcUtil.getGrpcUserAgent("okhttp", headers.get(USER_AGENT_KEY));
+    String userAgent = GrpcUtil.getGrpcUserAgent("okhttp", applicationUserAgent);
     okhttpHeaders.add(new Header(GrpcUtil.USER_AGENT_KEY.name(), userAgent));
 
     // All non-pseudo headers must come after pseudo headers.

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -260,13 +260,14 @@ public class OkHttpChannelBuilder extends
     }
 
     @Override
-    public ManagedClientTransport newClientTransport(SocketAddress addr, String authority) {
+    public ManagedClientTransport newClientTransport(
+        SocketAddress addr, String authority, @Nullable String userAgent) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
       InetSocketAddress inetSocketAddr = (InetSocketAddress) addr;
-      return new OkHttpClientTransport(inetSocketAddr, authority, executor, socketFactory,
-          Utils.convertSpec(connectionSpec), maxMessageSize);
+      return new OkHttpClientTransport(inetSocketAddr, authority, userAgent, executor,
+          socketFactory, Utils.convertSpec(connectionSpec), maxMessageSize);
     }
 
     @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -35,7 +35,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import io.grpc.Metadata;
-import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener;
@@ -73,6 +72,7 @@ class OkHttpClientStream extends Http2ClientStream {
   private final OutboundFlowController outboundFlow;
   private final OkHttpClientTransport transport;
   private final Object lock;
+  private final String userAgent;
   private String authority;
   private Object outboundFlowState;
   private volatile Integer id;
@@ -95,7 +95,8 @@ class OkHttpClientStream extends Http2ClientStream {
       OutboundFlowController outboundFlow,
       Object lock,
       int maxMessageSize,
-      String authority) {
+      String authority,
+      @Nullable String userAgent) {
     super(new OkHttpWritableBufferAllocator(), maxMessageSize);
     this.method = method;
     this.headers = headers;
@@ -104,6 +105,7 @@ class OkHttpClientStream extends Http2ClientStream {
     this.outboundFlow = outboundFlow;
     this.lock = lock;
     this.authority = authority;
+    this.userAgent = userAgent;
   }
 
   /**
@@ -136,7 +138,8 @@ class OkHttpClientStream extends Http2ClientStream {
   public void start(ClientStreamListener listener) {
     super.start(listener);
     String defaultPath = "/" + method.getFullMethodName();
-    List<Header> requestHeaders = Headers.createRequestHeaders(headers, defaultPath, authority);
+    List<Header> requestHeaders =
+        Headers.createRequestHeaders(headers, defaultPath, authority, userAgent);
     headers = null;
     synchronized (lock) {
       this.requestHeaders = requestHeaders;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -125,6 +125,7 @@ class OkHttpClientTransport implements ManagedClientTransport {
 
   private final InetSocketAddress address;
   private final String defaultAuthority;
+  private final String userAgent;
   private final Random random = new Random();
   private final Ticker ticker;
   private Listener listener;
@@ -168,8 +169,8 @@ class OkHttpClientTransport implements ManagedClientTransport {
   Runnable connectingCallback;
   SettableFuture<Void> connectedFuture;
 
-  OkHttpClientTransport(InetSocketAddress address, String authority, Executor executor,
-      @Nullable SSLSocketFactory sslSocketFactory, ConnectionSpec connectionSpec,
+  OkHttpClientTransport(InetSocketAddress address, String authority, @Nullable String userAgent,
+      Executor executor, @Nullable SSLSocketFactory sslSocketFactory, ConnectionSpec connectionSpec,
       int maxMessageSize) {
     this.address = Preconditions.checkNotNull(address, "address");
     this.defaultAuthority = authority;
@@ -182,19 +183,21 @@ class OkHttpClientTransport implements ManagedClientTransport {
     this.sslSocketFactory = sslSocketFactory;
     this.connectionSpec = Preconditions.checkNotNull(connectionSpec, "connectionSpec");
     this.ticker = Ticker.systemTicker();
+    this.userAgent = userAgent;
   }
 
   /**
    * Create a transport connected to a fake peer for test.
    */
   @VisibleForTesting
-  OkHttpClientTransport(Executor executor, FrameReader frameReader, FrameWriter testFrameWriter,
-      int nextStreamId, Socket socket, Ticker ticker,
+  OkHttpClientTransport(String userAgent, Executor executor, FrameReader frameReader,
+      FrameWriter testFrameWriter, int nextStreamId, Socket socket, Ticker ticker,
       @Nullable Runnable connectingCallback, SettableFuture<Void> connectedFuture,
       int maxMessageSize) {
     address = null;
     this.maxMessageSize = maxMessageSize;
     defaultAuthority = "notarealauthority:80";
+    this.userAgent = userAgent;
     this.executor = Preconditions.checkNotNull(executor);
     serializingExecutor = new SerializingExecutor(executor);
     this.testFrameReader = Preconditions.checkNotNull(frameReader);
@@ -247,7 +250,7 @@ class OkHttpClientTransport implements ManagedClientTransport {
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
     return new OkHttpClientStream(method, headers, frameWriter, OkHttpClientTransport.this,
-        outboundFlow, lock, maxMessageSize, defaultAuthority);
+        outboundFlow, lock, maxMessageSize, defaultAuthority, userAgent);
   }
 
   @GuardedBy("lock")

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -75,7 +75,7 @@ public class OkHttpClientStreamTest {
     methodDescriptor = MethodDescriptor.create(
         MethodType.UNARY, "/testService/test", marshaller, marshaller);
     stream = new OkHttpClientStream(methodDescriptor, new Metadata(), frameWriter, transport,
-        flowController, lock, MAX_MESSAGE_SIZE, "localhost");
+        flowController, lock, MAX_MESSAGE_SIZE, "localhost", "userAgent");
   }
 
   @Test

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -73,7 +73,9 @@ public class OkHttpTransportTest extends AbstractTransportTest {
   @Override
   protected ManagedClientTransport newClientTransport() {
     return clientFactory.newClientTransport(
-        new InetSocketAddress("127.0.0.1", SERVER_PORT), "127.0.0.1:" + SERVER_PORT);
+        new InetSocketAddress("127.0.0.1", SERVER_PORT),
+        "127.0.0.1:" + SERVER_PORT,
+        null /* agent */);
   }
 
   // TODO(ejona): Flaky/Broken

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
@@ -58,6 +58,6 @@ public abstract class AbstractClientTransportFactoryTest {
     ClientTransportFactory transportFactory = newClientTransportFactory();
     transportFactory.close();
     transportFactory.newClientTransport(
-        new InetSocketAddress("localhost", port), "localhost:" + port);
+        new InetSocketAddress("localhost", port), "localhost:" + port, "agent");
   }
 }


### PR DESCRIPTION
This is a continuation of 5e30b2f7ba57e306ef7818f485c854435fa9802b which cached the user agent string.  The change here makes it also cached when using a custom user agent.