### PR TITLE
core: allocate less garbage iterators in Metadata.serialize

### DIFF
--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -305,10 +305,12 @@ public final class Metadata {
     byte[][] serialized = new byte[storeCount * 2][];
     int i = 0;
     for (Map.Entry<String, List<MetadataEntry>> storeEntry : store.entrySet()) {
-      for (MetadataEntry metadataEntry : storeEntry.getValue()) {
-        serialized[i++] = metadataEntry.key != null
-            ? metadataEntry.key.asciiName() : storeEntry.getKey().getBytes(US_ASCII);
-        serialized[i++] = metadataEntry.getSerialized();
+      // Foreach allocates an iterator per.
+      List<MetadataEntry> values = storeEntry.getValue();
+      for (int k = 0; k < values.size(); k++) {
+        serialized[i++] = values.get(k).key != null
+            ? values.get(k).key.asciiName() : storeEntry.getKey().getBytes(US_ASCII);
+        serialized[i++] = values.get(k).getSerialized();
       }
     }
     return serialized;


### PR DESCRIPTION
Before:
```
HeadersBenchmark.convertClientHeaders             10  sample   99004   806.749 ±   4.692  ns/op
HeadersBenchmark.convertClientHeaders             20  sample  105673  1540.814 ±  86.361  ns/op
HeadersBenchmark.convertClientHeaders             50  sample  188978  3347.881 ±  71.778  ns/op
HeadersBenchmark.convertClientHeaders            100  sample  189913  6626.884 ±  94.348  ns/op
HeadersBenchmark.convertServerHeaders             10  sample  107884   766.328 ±  49.338  ns/op
HeadersBenchmark.convertServerHeaders             20  sample  122568  1303.501 ±   8.820  ns/op
HeadersBenchmark.convertServerHeaders             50  sample  109281  2920.586 ±  93.654  ns/op
HeadersBenchmark.convertServerHeaders            100  sample  196784  6429.566 ± 108.588  ns/op
```

After:
```
HeadersBenchmark.convertClientHeaders             10  sample  113274   715.382 ±  5.412  ns/op
HeadersBenchmark.convertClientHeaders             20  sample  128654  1294.677 ± 67.867  ns/op
HeadersBenchmark.convertClientHeaders             50  sample  112598  2814.925 ± 62.291  ns/op
HeadersBenchmark.convertClientHeaders            100  sample  116920  5383.146 ± 90.205  ns/op
HeadersBenchmark.convertServerHeaders             10  sample  130004   626.243 ±  3.528  ns/op
HeadersBenchmark.convertServerHeaders             20  sample  142054  1185.193 ± 80.272  ns/op
HeadersBenchmark.convertServerHeaders             50  sample  115153  2795.715 ± 92.956  ns/op
HeadersBenchmark.convertServerHeaders            100  sample  119520  5249.636 ± 56.089  ns/op
```