### PR TITLE
netty: Bump netty dep to 4.1.0.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,8 +142,8 @@ subprojects {
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.7.7',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
 
-                netty: 'io.netty:netty-codec-http2:[4.1.0.CR7]',
-                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.0.CR7' + epoll_suffix,
+                netty: 'io.netty:netty-codec-http2:[4.1.0.Final]',
+                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.0.Final' + epoll_suffix,
                 netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork15:' + osdetector.classifier,
 
                 // Test dependencies.


### PR DESCRIPTION
Is such a thing even possible? Yes it is.

Note that HTTP/2 in Netty still is not stable, so we remain
version-pinned.

CC @nmittler, @Scottmitch, @normanmaurer. Woooo!!!1