### PR TITLE
TransportSet shutdown() also shuts down the pending transport.

### DIFF
--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -499,6 +499,22 @@ public class TransportSetTest {
   }
 
   @Test
+  public void shutdownBeforeTransportReady() throws Exception {
+    SocketAddress addr = mock(SocketAddress.class);
+    createTransportSet(addr);
+
+    ClientTransport pick = transportSet.obtainActiveTransport();
+    MockClientTransportInfo transportInfo = transports.poll();
+    assertNotSame(transportInfo.transport, pick);
+
+    // Shutdown the TransportSet before the pending transport is ready
+    transportSet.shutdown();
+
+    // The transport should've been shut down even though it's not the active transport yet.
+    verify(transportInfo.transport).shutdown();
+  }
+
+  @Test
   public void obtainTransportAfterShutdown() throws Exception {
     SocketAddress addr = mock(SocketAddress.class);
     createTransportSet(addr);


### PR DESCRIPTION
Previously TransportSet.shutdown() only shuts down the active transport,
which means a transport will not be shutdown if it's not ready yet. This
issue was introduced by #1494 that postponed the assignment of the
active transport till transport ready.