### PR TITLE
benchmarks: use nextUp for nextDelay calculation in OpenLoopClient

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
@@ -227,11 +227,10 @@ public class OpenLoopClient {
       }
     }
 
+    private static final double DELAY_EPSILON = Math.nextUp(0d);
+
     private long nextDelay(int targetQps) {
-      // Smallest value so that (1 - epsilon) != 1
-      // See http://en.wikipedia.org/wiki/Machine_epsilon
-      final double epsilon = 1.11E-16;
-      double seconds = -Math.log(Math.max(rnd.nextDouble(), epsilon)) / targetQps;
+      double seconds = -Math.log(Math.max(rnd.nextDouble(), DELAY_EPSILON)) / targetQps;
       double nanos = seconds * 1000 * 1000 * 1000;
       return Math.round(nanos);
     }


### PR DESCRIPTION
+cc: @buchgr 

I can kind of see the original intent from the comment, but it doesn't seem to actually be used.  epsilon's use would make more sense if the next line was
```
double seconds = -Math.log(Math.max(1 - rnd.nextDouble(), epsilon)) / targetQps;
```

...but it isn't.  This change switches to using the java builtin for getting the next double (as well as making the exponential distribution closer to accurate near the tail.  Previously the max that seconds could be was `36.73700147258049`, but is now `744.4400719213812`.