### PR TITLE
core: cache decompressor registry encodings, and make it copy on write

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/DecompressorRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/DecompressorRegistryBenchmark.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import io.grpc.internal.GrpcUtil;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Decomressor Registry encoding benchmark.
+ */
+@State(Scope.Benchmark)
+public class DecompressorRegistryBenchmark {
+
+  @Param({"0", "1", "2"})
+  public int extraEncodings;
+
+  private DecompressorRegistry reg = DecompressorRegistry.getDefaultInstance();
+
+  @Setup
+  public void setUp() throws Exception {
+    reg = DecompressorRegistry.getDefaultInstance();
+    for (int i = 0; i < extraEncodings; i++) {
+      reg = reg.with(new Decompressor() {
+
+        @Override
+        public String getMessageEncoding() {
+          return UUID.randomUUID().toString();
+
+        }
+
+        @Override
+        public InputStream decompress(InputStream is) throws IOException {
+          return null;
+
+        }
+      }, true);
+    }
+  }
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public String dynamicAcceptEncoding() {
+    if (!reg.getAdvertisedMessageEncodings().isEmpty()) {
+      return GrpcUtil.ACCEPT_ENCODING_JOINER.join(reg.getAdvertisedMessageEncodings());
+    }
+    return "";
+  }
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public String staticAcceptEncoding() {
+    return reg.getRawAdvertisedMessageEncodings();
+  }
+}
+

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -37,7 +37,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.grpc.Contexts.statusFromCancelled;
 import static io.grpc.Status.DEADLINE_EXCEEDED;
-import static io.grpc.internal.GrpcUtil.ACCEPT_ENCODING_JOINER;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
@@ -146,10 +145,9 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
     }
 
     headers.removeAll(MESSAGE_ACCEPT_ENCODING_KEY);
-    if (!decompressorRegistry.getAdvertisedMessageEncodings().isEmpty()) {
-      String acceptEncoding =
-          ACCEPT_ENCODING_JOINER.join(decompressorRegistry.getAdvertisedMessageEncodings());
-      headers.put(MESSAGE_ACCEPT_ENCODING_KEY, acceptEncoding);
+    String advertisedEncodings = decompressorRegistry.getRawAdvertisedMessageEncodings();
+    if (!advertisedEncodings.isEmpty()) {
+      headers.put(MESSAGE_ACCEPT_ENCODING_KEY, advertisedEncodings);
     }
   }
 

--- a/core/src/test/java/io/grpc/DecompressorRegistryTest.java
+++ b/core/src/test/java/io/grpc/DecompressorRegistryTest.java
@@ -52,7 +52,7 @@ import java.util.Set;
 public class DecompressorRegistryTest {
 
   private final Dummy dummyDecompressor = new Dummy();
-  private final DecompressorRegistry registry = DecompressorRegistry.newEmptyInstance();
+  private DecompressorRegistry registry = DecompressorRegistry.emptyInstance();
 
   @Test
   public void lookupDecompressor_checkDefaultMessageEncodingsExist() {
@@ -83,7 +83,7 @@ public class DecompressorRegistryTest {
 
   @Test
   public void registerDecompressor_advertisedDecompressor() {
-    registry.register(dummyDecompressor, true);
+    registry = registry.with(dummyDecompressor, true);
 
     assertTrue(registry.getAdvertisedMessageEncodings()
         .contains(dummyDecompressor.getMessageEncoding()));
@@ -91,7 +91,7 @@ public class DecompressorRegistryTest {
 
   @Test
   public void registerDecompressor_nonadvertisedDecompressor() {
-    registry.register(dummyDecompressor, false);
+    registry = registry.with(dummyDecompressor, false);
 
     assertFalse(registry.getAdvertisedMessageEncodings()
         .contains(dummyDecompressor.getMessageEncoding()));

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -86,7 +86,9 @@ public class TransportCompressionTest extends AbstractInteropTest {
   private static final Fzip FZIPPER = new Fzip("gzip", new Codec.Gzip());
   private volatile boolean expectFzip;
 
-  private static final DecompressorRegistry decompressors = DecompressorRegistry.newEmptyInstance();
+  private static final DecompressorRegistry decompressors = DecompressorRegistry.emptyInstance()
+      .with(Codec.Identity.NONE, false)
+      .with(FZIPPER, true);
   private static final CompressorRegistry compressors = CompressorRegistry.newEmptyInstance();
 
   @Before
@@ -98,8 +100,6 @@ public class TransportCompressionTest extends AbstractInteropTest {
   /** Start server. */
   @BeforeClass
   public static void startServer() {
-    decompressors.register(Codec.Identity.NONE, false);
-    decompressors.register(FZIPPER, true);
     compressors.register(FZIPPER);
     compressors.register(Codec.Identity.NONE);
     startStaticServer(


### PR DESCRIPTION
Changes DecompressorRegistry to be copy on write, and pre builds the encoding string ahead of time.   This is a minor API change, but it is experimental.  Performance isn't vastly different, but it cuts down on generated garbage.  Chances are benefits are greater than those listed below since the encoder is probably not going to be "hot" by the JIT's understanding.

For https://github.com/grpc/grpc-java/issues/1885

```
Benchmark                                            (extraEncodings)    Mode     Cnt    Score    Error  Units
DecompressorRegistryBenchmark.dynamicAcceptEncoding                 0  sample  121380  204.817 ± 66.285  ns/op
DecompressorRegistryBenchmark.dynamicAcceptEncoding                 1  sample  166036  254.933 ±  1.753  ns/op
DecompressorRegistryBenchmark.dynamicAcceptEncoding                 2  sample  111063  386.081 ± 56.939  ns/op
DecompressorRegistryBenchmark.staticAcceptEncoding                  0  sample   98956   46.230 ±  0.910  ns/op
DecompressorRegistryBenchmark.staticAcceptEncoding                  1  sample   98801   43.715 ±  0.727  ns/op
DecompressorRegistryBenchmark.staticAcceptEncoding                  2  sample   94014   44.654 ±  0.499  ns/op


```