### PR TITLE
netty: add toString() to GrpcHttp2Headers

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2Headers.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2Headers.java
@@ -144,4 +144,19 @@ final class GrpcHttp2Headers extends AbstractHttp2Headers {
       throw new UnsupportedOperationException();
     }
   }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder(getClass().getSimpleName()).append('[');
+    String separator = "";
+    for (Entry<CharSequence, CharSequence> e : this) {
+      CharSequence name = e.getKey();
+      CharSequence value = e.getValue();
+      builder.append(separator);
+      builder.append(name).append(": ").append(value);
+      separator = ", ";
+    }
+    builder.append(']');
+    return builder.toString();
+  }
 }


### PR DESCRIPTION
toString() is useful when looking at the log output of a HTTP/2 stream.

Headers with multiple values are simply listed several times i.e. `ascii-key: trailers, ascii-key: dupvalue, ...`