### PR TITLE
core/internal: add 3-arg newStream method to ClientTransport interface

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -34,6 +34,7 @@ package io.grpc.inprocess;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.grpc.Attributes;
+import io.grpc.CallOptions;
 import io.grpc.Compressor;
 import io.grpc.Decompressor;
 import io.grpc.Metadata;
@@ -126,7 +127,7 @@ class InProcessTransport implements ServerTransport, ManagedClientTransport {
 
   @Override
   public synchronized ClientStream newStream(
-      final MethodDescriptor<?, ?> method, final Metadata headers) {
+      final MethodDescriptor<?, ?> method, final Metadata headers, final CallOptions callOptions) {
     if (shutdownStatus != null) {
       final Status capturedStatus = shutdownStatus;
       return new NoopClientStream() {
@@ -138,6 +139,12 @@ class InProcessTransport implements ServerTransport, ManagedClientTransport {
     }
 
     return new InProcessStream(method, headers).clientStream;
+  }
+
+  @Override
+  public synchronized ClientStream newStream(
+      final MethodDescriptor<?, ?> method, final Metadata headers) {
+    return newStream(method, headers, CallOptions.DEFAULT);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -205,7 +205,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
       updateTimeoutHeaders(effectiveDeadline, callOptions.getDeadline(),
           parentContext.getDeadline(), headers);
       ClientTransport transport = clientTransportProvider.get(callOptions);
-      stream = transport.newStream(method, headers);
+      stream = transport.newStream(method, headers, callOptions);
     } else {
       stream = new FailingClientStream(DEADLINE_EXCEEDED);
     }

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 
@@ -56,9 +57,13 @@ public interface ClientTransport {
    *
    * @param method the descriptor of the remote method to be called for this stream.
    * @param headers to send at the beginning of the call
+   * @param callOptions runtime options of the call
    * @return the newly created stream.
    */
   // TODO(nmittler): Consider also throwing for stopping.
+  ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions);
+
+  // TODO(zdapeng): Remove tow-argument version in favor of three-argument overload.
   ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers);
 
   /**

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -34,6 +34,7 @@ package io.grpc.internal;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -54,8 +55,14 @@ class FailingClientTransport implements ClientTransport {
   }
 
   @Override
-  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
+  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers, CallOptions
+      callOptions) {
     return new FailingClientStream(error);
+  }
+
+  @Override
+  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
+    return newStream(method, headers, CallOptions.DEFAULT);
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 
@@ -84,8 +85,8 @@ final class TestUtils {
       @Override
       public ManagedClientTransport answer(InvocationOnMock invocation) throws Throwable {
         final ManagedClientTransport mockTransport = mock(ManagedClientTransport.class);
-        when(mockTransport.newStream(any(MethodDescriptor.class), any(Metadata.class)))
-            .thenReturn(mock(ClientStream.class));
+        when(mockTransport.newStream(any(MethodDescriptor.class), any(Metadata.class),
+            any(CallOptions.class))).thenReturn(mock(ClientStream.class));
         // Save the listener
         doAnswer(new Answer<Void>() {
           @Override

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Stopwatch;
 
+import io.grpc.CallOptions;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.IntegerMarshaller;
 import io.grpc.LoadBalancer;
@@ -450,7 +451,8 @@ public class TransportSetTest {
     verify(transportInfo.transport, times(0)).newStream(
         any(MethodDescriptor.class), any(Metadata.class));
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(transportInfo.transport).newStream(same(method), same(headers));
+    verify(transportInfo.transport).newStream(same(method), same(headers),
+        same(CallOptions.DEFAULT));
     verify(transportInfo.transport).shutdown();
     transportInfo.listener.transportShutdown(Status.UNAVAILABLE);
     verify(mockTransportSetCallback, never()).onTerminated();

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -36,6 +36,7 @@ import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
 
+import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -112,7 +113,8 @@ class NettyClientTransport implements ManagedClientTransport {
   }
 
   @Override
-  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
+  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers, CallOptions
+      callOptions) {
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
     return new NettyClientStream(method, headers, channel, handler, maxMessageSize, authority,
@@ -122,6 +124,11 @@ class NettyClientTransport implements ManagedClientTransport {
         return NettyClientTransport.this.statusFromFailedFuture(f);
       }
     };
+  }
+
+  @Override
+  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
+    return newStream(method, headers, CallOptions.DEFAULT);
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -39,6 +39,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.SettableFuture;
 
+import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
@@ -246,11 +247,18 @@ class OkHttpClientTransport implements ManagedClientTransport {
   }
 
   @Override
-  public OkHttpClientStream newStream(final MethodDescriptor<?, ?> method, final Metadata headers) {
+  public OkHttpClientStream newStream(final MethodDescriptor<?, ?> method, final Metadata
+      headers, CallOptions callOptions) {
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
     return new OkHttpClientStream(method, headers, frameWriter, OkHttpClientTransport.this,
         outboundFlow, lock, maxMessageSize, defaultAuthority, userAgent);
+  }
+
+  @Override
+  public OkHttpClientStream newStream(final MethodDescriptor<?, ?> method, final Metadata
+      headers) {
+    return newStream(method, headers, CallOptions.DEFAULT);
   }
 
   @GuardedBy("lock")


### PR DESCRIPTION
adding 
`ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions);`
to `ClientTransport` interface

Created this PR first because both fail fast implementation and another change will be using this interface change