### PR TITLE
core: CallCredentials

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -120,6 +120,11 @@ public final class Attributes {
       return this;
     }
 
+    public <T> Builder setAll(Attributes other) {
+      product.data.putAll(other.data);
+      return this;
+    }
+
     /**
      * Build the attributes. Can only be called once.
      */

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import io.grpc.Attributes.Key;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Carries credential data that will be propagated to the server via request metadata for each RPC.
+ */
+@ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
+public interface CallCredentials {
+  /**
+   * The security level of the transport. It is guaranteed to be present in the {@code attrs} passed
+   * to {@link #applyRequestMetadata}. It is by default {@link SecurityLevel#NONE} but can be
+   * overridden by the transport.
+   */
+  public static final Key<SecurityLevel> ATTR_SECURITY_LEVEL =
+      Key.of("io.grpc.CallCredentials.securityLevel");
+
+  /**
+   * The authority string used to authenticate the server. Usually it's the server's host name. It
+   * is guaranteed to be present in the {@code attrs} passed to {@link #applyRequestMetadata}. It is
+   * by default from the channel, but can be overridden by the transport and {@link
+   * io.grpc.CallOptions} with increasing precedence.
+   */
+  public static final Key<String> ATTR_AUTHORITY = Key.of("io.grpc.CallCredentials.authority");
+
+  /**
+   * Pass the credential data to the given {@link MetadataApplier}, which will propagate it to
+   * the request metadata.
+   *
+   * <p>It is called for each individual RPC, before the stream is about to be created on a
+   * transport. Implementations should not block in this method. If metadata is not immediately
+   * available, e.g., needs to be fetched from network, the implementation may give the {@code
+   * applier} to an asynchronous task which will eventually call the {@code applier}. The RPC
+   * proceeds only after the {@code applier} is called.
+   *
+   * @param method The method descriptor of this RPC
+   * @param attrs Additional attributes from the transport, along with the keys defined in this
+   *        interface (i.e. the {@code ATTR_*} fields) which are guaranteed to be present.
+   * @param appExecutor The application thread-pool. It is provided to the implementation in case it
+   *        needs to perform blocking operations.
+   * @param applier The outlet of the produced headers. It can be called either before or after this
+   *        method returns.
+   */
+  void applyRequestMetadata(
+      MethodDescriptor<?, ?> method, Attributes attrs,
+      Executor appExecutor, MetadataApplier applier);
+
+  /**
+   * The outlet of the produced headers. Not thread-safe.
+   *
+   * <p>Exactly one of its methods must be called to make the RPC proceed.
+   */
+  public interface MetadataApplier {
+    /**
+     * Called when headers are successfully generated. They will be merged into the original
+     * headers.
+     */
+    void apply(Metadata headers);
+
+    /**
+     * Called when there has been an error when preparing the headers. This will fail the RPC.
+     */
+    void fail(Status status);
+  }
+}

--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -62,6 +62,9 @@ public final class CallOptions {
   @Nullable
   private String authority;
 
+  @Nullable
+  private CallCredentials credentials;
+
   private Attributes affinity = Attributes.EMPTY;
 
   @Nullable
@@ -82,6 +85,16 @@ public final class CallOptions {
   public CallOptions withAuthority(@Nullable String authority) {
     CallOptions newOptions = new CallOptions(this);
     newOptions.authority = authority;
+    return newOptions;
+  }
+
+  /**
+   * Returns a new {@code CallOptions} with the given call credentials.
+   */
+  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
+  public CallOptions withCredentials(@Nullable CallCredentials credentials) {
+    CallOptions newOptions = new CallOptions(this);
+    newOptions.credentials = credentials;
     return newOptions;
   }
 
@@ -202,6 +215,15 @@ public final class CallOptions {
   }
 
   /**
+   * Returns the call credentials.
+   */
+  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
+  @Nullable
+  public CallCredentials getCredentials() {
+    return credentials;
+  }
+
+  /**
    * Returns a new {@code CallOptions} with {@code executor} to be used instead of the default
    * executor specified with {@link ManagedChannelBuilder#executor}.
    */
@@ -294,6 +316,7 @@ public final class CallOptions {
   private CallOptions(CallOptions other) {
     deadline = other.deadline;
     authority = other.authority;
+    credentials = other.credentials;
     affinity = other.affinity;
     executor = other.executor;
     compressorName = other.compressorName;
@@ -305,6 +328,7 @@ public final class CallOptions {
     MoreObjects.ToStringHelper toStringHelper = MoreObjects.toStringHelper(this);
     toStringHelper.add("deadline", deadline);
     toStringHelper.add("authority", authority);
+    toStringHelper.add("callCredentials", credentials);
     toStringHelper.add("affinity", affinity);
     toStringHelper.add("executor", executor != null ? executor.getClass() : null);
     toStringHelper.add("compressorName", compressorName);

--- a/core/src/main/java/io/grpc/SecurityLevel.java
+++ b/core/src/main/java/io/grpc/SecurityLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,30 +29,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.internal;
+package io.grpc;
 
-import java.io.Closeable;
-import java.net.SocketAddress;
-
-import javax.annotation.Nullable;
-
-/** Pre-configured factory for creating {@link ConnectionClientTransport} instances. */
-public interface ClientTransportFactory extends Closeable {
+/**
+ * The level of security guarantee in communications.
+ */
+@ExperimentalApi
+public enum SecurityLevel {
   /**
-   * Creates an unstarted transport for exclusive use.
-   *
-   * @param serverAddress the address that the transport is connected to
-   * @param authority the HTTP/2 authority of the server
+   * No security guarantee.
    */
-  ConnectionClientTransport newClientTransport(SocketAddress serverAddress, String authority,
-      @Nullable String userAgent);
+  NONE,
 
   /**
-   * Releases any resources.
-   *
-   * <p>After this method has been called, it's no longer valid to call
-   * {@link #newClientTransport}. No guarantees about thread-safety are made.
+   * The other party is authenticated and the data is not tampered with.
    */
-  @Override
-  void close();
+  INTEGRITY,
+
+  /**
+   * In addition to {@code INTEGRITY}, the data is only visible to the intended communication
+   * parties.
+   */
+  PRIVACY_AND_INTEGRITY
 }

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -37,7 +37,7 @@ import io.grpc.ExperimentalApi;
 import io.grpc.Internal;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.ManagedClientTransport;
+import io.grpc.internal.ConnectionClientTransport;
 
 import java.net.SocketAddress;
 
@@ -94,7 +94,7 @@ public class InProcessChannelBuilder extends
     }
 
     @Override
-    public ManagedClientTransport newClientTransport(
+    public ConnectionClientTransport newClientTransport(
         SocketAddress addr, String authority, String userAgent) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -43,6 +43,7 @@ import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
+import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.NoopClientStream;
@@ -65,7 +66,7 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
-class InProcessTransport implements ServerTransport, ManagedClientTransport {
+class InProcessTransport implements ServerTransport, ConnectionClientTransport {
   private static final Logger log = Logger.getLogger(InProcessTransport.class.getName());
 
   private final String name;
@@ -204,6 +205,11 @@ class InProcessTransport implements ServerTransport, ManagedClientTransport {
   @Override
   public String getLogId() {
     return GrpcUtil.getLogId(this);
+  }
+
+  @Override
+  public Attributes getAttrs() {
+    return Attributes.EMPTY;
   }
 
   private synchronized void notifyShutdown(Status s) {

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -248,7 +248,7 @@ public abstract class AbstractManagedChannelImplBuilder
     }
 
     @Override
-    public ManagedClientTransport newClientTransport(SocketAddress serverAddress,
+    public ConnectionClientTransport newClientTransport(SocketAddress serverAddress,
         String authority, @Nullable String userAgent) {
       return factory.newClientTransport(serverAddress, authorityOverride, userAgent);
     }

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.grpc.Attributes;
+import io.grpc.CallCredentials;
+import io.grpc.CallOptions;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.SecurityLevel;
+
+import java.net.SocketAddress;
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
+
+final class CallCredentialsApplyingTransportFactory implements ClientTransportFactory {
+  private final ClientTransportFactory delegate;
+  private final Executor appExecutor;
+
+  CallCredentialsApplyingTransportFactory(
+      ClientTransportFactory delegate, Executor appExecutor) {
+    this.delegate = checkNotNull(delegate, "delegate");
+    this.appExecutor = checkNotNull(appExecutor, "appExecutor");
+  }
+
+  @Override
+  public ConnectionClientTransport newClientTransport(
+      SocketAddress serverAddress, String authority, @Nullable String userAgent) {
+    return new Transport(
+        delegate.newClientTransport(serverAddress, authority, userAgent), authority);
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  private class Transport extends ForwardingConnectionClientTransport {
+    private final ConnectionClientTransport delegate;
+    private final String authority;
+
+    Transport(ConnectionClientTransport delegate, String authority) {
+      this.delegate = checkNotNull(delegate, "delegate");
+      this.authority = checkNotNull(authority, "authority");
+    }
+
+    @Override
+    protected ConnectionClientTransport delegate() {
+      return delegate;
+    }
+
+    @Override
+    public ClientStream newStream(
+        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+      CallCredentials creds = callOptions.getCredentials();
+      if (creds != null) {
+        MetadataApplierImpl applier = new MetadataApplierImpl(
+            delegate, method, headers, callOptions);
+        Attributes.Builder effectiveAttrsBuilder = Attributes.newBuilder()
+            .set(CallCredentials.ATTR_AUTHORITY, authority)
+            .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
+            .setAll(delegate.getAttrs());
+        if (callOptions.getAuthority() != null) {
+          effectiveAttrsBuilder.set(CallCredentials.ATTR_AUTHORITY, callOptions.getAuthority());
+        }
+        creds.applyRequestMetadata(method, effectiveAttrsBuilder.build(),
+            firstNonNull(callOptions.getExecutor(), appExecutor), applier);
+        return applier.returnStream();
+      } else {
+        return delegate.newStream(method, headers, callOptions);
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,28 +31,18 @@
 
 package io.grpc.internal;
 
-import java.io.Closeable;
-import java.net.SocketAddress;
+import io.grpc.Attributes;
 
-import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
-/** Pre-configured factory for creating {@link ConnectionClientTransport} instances. */
-public interface ClientTransportFactory extends Closeable {
+/**
+ * A {@link ManagedClientTransport} that is based on a connection.
+ */
+@ThreadSafe
+public interface ConnectionClientTransport extends ManagedClientTransport {
   /**
-   * Creates an unstarted transport for exclusive use.
-   *
-   * @param serverAddress the address that the transport is connected to
-   * @param authority the HTTP/2 authority of the server
+   * Returns a set of attributes, which may vary depending on the state of the transport. The keys
+   * should define in what states they will be present.
    */
-  ConnectionClientTransport newClientTransport(SocketAddress serverAddress, String authority,
-      @Nullable String userAgent);
-
-  /**
-   * Releases any resources.
-   *
-   * <p>After this method has been called, it's no longer valid to call
-   * {@link #newClientTransport}. No guarantees about thread-safety are made.
-   */
-  @Override
-  void close();
+  Attributes getAttrs();
 }

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -34,6 +34,8 @@ package io.grpc.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import io.grpc.Compressor;
 import io.grpc.Decompressor;
 import io.grpc.Metadata;
@@ -300,5 +302,10 @@ class DelayedStream implements ClientStream {
         }
       });
     }
+  }
+
+  @VisibleForTesting
+  ClientStream getRealStream() {
+    return realStream;
   }
 }

--- a/core/src/main/java/io/grpc/internal/FailingClientStream.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientStream.java
@@ -58,4 +58,8 @@ class FailingClientStream extends NoopClientStream {
     started = true;
     listener.closed(error, new Metadata());
   }
+
+  Status getError() {
+    return error;
+  }
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -166,7 +166,8 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     this.backoffPolicyProvider = backoffPolicyProvider;
     this.nameResolver = getNameResolver(target, nameResolverFactory, nameResolverParams);
     this.loadBalancer = loadBalancerFactory.newLoadBalancer(nameResolver.getServiceAuthority(), tm);
-    this.transportFactory = transportFactory;
+    this.transportFactory =
+        new CallCredentialsApplyingTransportFactory(transportFactory, this.executor);
     this.interceptorChannel = ClientInterceptors.intercept(new RealChannel(), interceptors);
     scheduledExecutor = SharedResourceHolder.get(TIMER_SERVICE);
     this.decompressorRegistry = decompressorRegistry;

--- a/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
+++ b/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import io.grpc.CallCredentials.MetadataApplier;
+import io.grpc.CallOptions;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+final class MetadataApplierImpl implements MetadataApplier {
+  private final ClientTransport transport;
+  private final MethodDescriptor<?, ?> method;
+  private final Metadata origHeaders;
+  private final CallOptions callOptions;
+
+  private final Object lock = new Object();
+
+  // null if neither apply() or returnStream() are called.
+  // Needs this lock because apply() and returnStream() may race
+  @GuardedBy("lock")
+  @Nullable
+  private ClientStream returnedStream;
+
+  boolean finalized;
+
+  // not null if returnStream() was called before apply()
+  DelayedStream delayedStream;
+
+  MetadataApplierImpl(ClientTransport transport, MethodDescriptor<?, ?> method,
+      Metadata origHeaders, CallOptions callOptions) {
+    this.transport = transport;
+    this.method = method;
+    this.origHeaders = origHeaders;
+    this.callOptions = callOptions;
+  }
+
+  @Override
+  public void apply(Metadata headers) {
+    checkState(!finalized, "apply() or fail() already called");
+    origHeaders.merge(headers);
+    finalizeWith(transport.newStream(method, origHeaders, callOptions));
+  }
+
+  @Override
+  public void fail(Status status) {
+    checkArgument(!status.isOk(), "Cannot fail with OK status");
+    checkState(!finalized, "apply() or fail() already called");
+    finalizeWith(new FailingClientStream(status));
+  }
+
+  private void finalizeWith(ClientStream stream) {
+    checkState(!finalized, "already finalized");
+    finalized = true;
+    synchronized (lock) {
+      if (returnedStream == null) {
+        // Fast path: returnStream() hasn't been called, the call will use the
+        // real stream directly.
+        returnedStream = stream;
+        return;
+      }
+    }
+    // returnStream() has been called before me, thus delayedStream must have been
+    // created.
+    checkState(delayedStream != null, "delayedStream is null");
+    delayedStream.setStream(stream);
+  }
+
+  /**
+   * Return a stream on which the RPC will run on.
+   */
+  ClientStream returnStream() {
+    synchronized (lock) {
+      if (returnedStream == null) {
+        // apply() has not been called, needs to buffer the requests.
+        delayedStream = new DelayedStream();
+        return returnedStream = delayedStream;
+      } else {
+        return returnedStream;
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/TransportSet.java
+++ b/core/src/main/java/io/grpc/internal/TransportSet.java
@@ -107,7 +107,7 @@ final class TransportSet implements WithLogId {
    */
   @GuardedBy("lock")
   @Nullable
-  private ManagedClientTransport pendingTransport;
+  private ConnectionClientTransport pendingTransport;
 
   private final LoadBalancer<ClientTransport> loadBalancer;
 
@@ -195,7 +195,7 @@ final class TransportSet implements WithLogId {
       nextAddressIndex = 0;
     }
 
-    ManagedClientTransport transport =
+    ConnectionClientTransport transport =
         transportFactory.newClientTransport(address, authority, userAgent);
     if (log.isLoggable(Level.FINE)) {
       log.log(Level.FINE, "[{0}] Created {1} for {2}",
@@ -265,7 +265,7 @@ final class TransportSet implements WithLogId {
    */
   final void shutdown() {
     ManagedClientTransport savedActiveTransport;
-    ManagedClientTransport savedPendingTransport;
+    ConnectionClientTransport savedPendingTransport;
     boolean runCallback = false;
     synchronized (lock) {
       if (shutdown) {

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.Attributes;
+import io.grpc.CallCredentials.MetadataApplier;
+import io.grpc.CallCredentials;
+import io.grpc.CallOptions;
+import io.grpc.IntegerMarshaller;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.SecurityLevel;
+import io.grpc.Status;
+import io.grpc.StringMarshaller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.SocketAddress;
+import java.util.concurrent.Executor;
+
+/**
+ * Unit test for {@link CallCredentials} applying functionality implemented by {@link
+ * CallCredentialsApplyingTransportFactory} and {@link MetadataApplierImpl}.
+ */
+@RunWith(JUnit4.class)
+public class CallCredentialsApplyingTest {
+  @Mock
+  private ClientTransportFactory mockTransportFactory;
+
+  @Mock
+  private ConnectionClientTransport mockTransport;
+
+  @Mock
+  private ClientStream mockStream;
+
+  @Mock
+  private CallCredentials mockCreds;
+
+  @Mock
+  private Executor mockExecutor;
+
+  @Mock
+  private SocketAddress address;
+
+  private static final String authority = "testauthority";
+  private static final String userAgent = "testuseragent";
+  private static final Attributes.Key<String> ATTR_KEY = Attributes.Key.of("somekey");
+  private static final String ATTR_VALUE = "somevalue";
+  private static final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
+      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
+      new StringMarshaller(), new IntegerMarshaller());
+  private static final Metadata.Key<String> ORIG_HEADER_KEY =
+      Metadata.Key.of("header1", Metadata.ASCII_STRING_MARSHALLER);
+  private static final String ORIG_HEADER_VALUE = "some original header value";
+  private static final Metadata.Key<String> CREDS_KEY =
+      Metadata.Key.of("test-creds", Metadata.ASCII_STRING_MARSHALLER);
+  private static final String CREDS_VALUE = "some credentials";
+
+  private final Metadata origHeaders = new Metadata();
+  private ForwardingConnectionClientTransport transport;
+  private CallOptions callOptions;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    origHeaders.put(ORIG_HEADER_KEY, ORIG_HEADER_VALUE);
+    when(mockTransportFactory.newClientTransport(address, authority, userAgent))
+        .thenReturn(mockTransport);
+    when(mockTransport.newStream(same(method), any(Metadata.class), any(CallOptions.class)))
+        .thenReturn(mockStream);
+    ClientTransportFactory transportFactory = new CallCredentialsApplyingTransportFactory(
+        mockTransportFactory, mockExecutor);
+    transport = (ForwardingConnectionClientTransport) transportFactory.newClientTransport(
+        address, authority, userAgent);
+    callOptions = CallOptions.DEFAULT.withCredentials(mockCreds);
+    verify(mockTransportFactory).newClientTransport(address, authority, userAgent);
+    assertSame(mockTransport, transport.delegate());
+  }
+
+  @Test
+  public void parameterPropagation_base() {
+    Attributes transportAttrs = Attributes.newBuilder().set(ATTR_KEY, ATTR_VALUE).build();
+    when(mockTransport.getAttrs()).thenReturn(transportAttrs);
+
+    transport.newStream(method, origHeaders, callOptions);
+
+    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(same(method), attrsCaptor.capture(), same(mockExecutor),
+        any(MetadataApplier.class));
+    Attributes attrs = attrsCaptor.getValue();
+    assertSame(ATTR_VALUE, attrs.get(ATTR_KEY));
+    assertSame(authority, attrs.get(CallCredentials.ATTR_AUTHORITY));
+    assertSame(SecurityLevel.NONE, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+  }
+
+  @Test
+  public void parameterPropagation_overrideByTransport() {
+    Attributes transportAttrs = Attributes.newBuilder()
+        .set(ATTR_KEY, ATTR_VALUE)
+        .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
+        .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
+        .build();
+    when(mockTransport.getAttrs()).thenReturn(transportAttrs);
+
+    transport.newStream(method, origHeaders, callOptions);
+
+    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(same(method), attrsCaptor.capture(), same(mockExecutor),
+        any(MetadataApplier.class));
+    Attributes attrs = attrsCaptor.getValue();
+    assertSame(ATTR_VALUE, attrs.get(ATTR_KEY));
+    assertEquals("transport-override-authority", attrs.get(CallCredentials.ATTR_AUTHORITY));
+    assertSame(SecurityLevel.INTEGRITY, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+  }
+
+  @Test
+  public void parameterPropagation_overrideByCallOptions() {
+    Attributes transportAttrs = Attributes.newBuilder()
+        .set(ATTR_KEY, ATTR_VALUE)
+        .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
+        .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
+        .build();
+    when(mockTransport.getAttrs()).thenReturn(transportAttrs);
+    Executor anotherExecutor = mock(Executor.class);
+
+    transport.newStream(method, origHeaders,
+        callOptions.withAuthority("calloptions-authority").withExecutor(anotherExecutor));
+
+    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(same(method), attrsCaptor.capture(),
+        same(anotherExecutor), any(MetadataApplier.class));
+    Attributes attrs = attrsCaptor.getValue();
+    assertSame(ATTR_VALUE, attrs.get(ATTR_KEY));
+    assertEquals("calloptions-authority", attrs.get(CallCredentials.ATTR_AUTHORITY));
+    assertSame(SecurityLevel.INTEGRITY, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+  }
+
+  @Test
+  public void applyMetadata_inline() {
+    when(mockTransport.getAttrs()).thenReturn(Attributes.EMPTY);
+    doAnswer(new Answer<Void>() {
+        @Override
+        public Void answer(InvocationOnMock invocation) throws Throwable {
+          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[3];
+          Metadata headers = new Metadata();
+          headers.put(CREDS_KEY, CREDS_VALUE);
+          applier.apply(headers);
+          return null;
+        }
+      }).when(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
+          same(mockExecutor), any(MetadataApplier.class));
+
+    ClientStream stream = transport.newStream(method, origHeaders, callOptions);
+
+    verify(mockTransport).newStream(method, origHeaders, callOptions);
+    assertSame(mockStream, stream);
+    assertEquals(CREDS_VALUE, origHeaders.get(CREDS_KEY));
+    assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
+  }
+
+  @Test
+  public void fail_inline() {
+    final Status error = Status.FAILED_PRECONDITION.withDescription("channel not secure for creds");
+    when(mockTransport.getAttrs()).thenReturn(Attributes.EMPTY);
+    doAnswer(new Answer<Void>() {
+        @Override
+        public Void answer(InvocationOnMock invocation) throws Throwable {
+          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[3];
+          applier.fail(error);
+          return null;
+        }
+      }).when(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
+          same(mockExecutor), any(MetadataApplier.class));
+
+    FailingClientStream stream =
+        (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
+
+    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    assertSame(error, stream.getError());
+  }
+
+  @Test
+  public void applyMetadata_delayed() {
+    when(mockTransport.getAttrs()).thenReturn(Attributes.EMPTY);
+
+    // Will call applyRequestMetadata(), which is no-op.
+    DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
+
+    ArgumentCaptor<MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
+        same(mockExecutor), applierCaptor.capture());
+    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+
+    Metadata headers = new Metadata();
+    headers.put(CREDS_KEY, CREDS_VALUE);
+    applierCaptor.getValue().apply(headers);
+
+    verify(mockTransport).newStream(method, origHeaders, callOptions);
+    assertSame(mockStream, stream.getRealStream());
+    assertEquals(CREDS_VALUE, origHeaders.get(CREDS_KEY));
+    assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
+  }
+
+  @Test
+  public void fail_delayed() {
+    when(mockTransport.getAttrs()).thenReturn(Attributes.EMPTY);
+
+    // Will call applyRequestMetadata(), which is no-op.
+    DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
+
+    ArgumentCaptor<MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
+        same(mockExecutor), applierCaptor.capture());
+
+    Status error = Status.FAILED_PRECONDITION.withDescription("channel not secure for creds");
+    applierCaptor.getValue().fail(error);
+
+    verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
+    FailingClientStream failingStream = (FailingClientStream) stream.getRealStream();
+    assertSame(error, failingStream.getError());
+  }
+
+  @Test
+  public void noCreds() {
+    callOptions = callOptions.withCredentials(null);
+    ClientStream stream = transport.newStream(method, origHeaders, callOptions);
+
+    verify(mockTransport).newStream(method, origHeaders, callOptions);
+    assertSame(mockStream, stream);
+    assertNull(origHeaders.get(CREDS_KEY));
+    assertEquals(ORIG_HEADER_VALUE, origHeaders.get(ORIG_HEADER_KEY));
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -127,7 +127,7 @@ public class ManagedChannelImplTest {
   @Captor
   private ArgumentCaptor<Status> statusCaptor;
   @Mock
-  private ManagedClientTransport mockTransport;
+  private ConnectionClientTransport mockTransport;
   @Mock
   private ClientTransportFactory mockTransportFactory;
   @Mock
@@ -581,8 +581,8 @@ public class ManagedChannelImplTest {
       };
     final ResolvedServerInfo goodServer = new ResolvedServerInfo(goodAddress, Attributes.EMPTY);
     final ResolvedServerInfo badServer = new ResolvedServerInfo(badAddress, Attributes.EMPTY);
-    final ManagedClientTransport goodTransport = mock(ManagedClientTransport.class);
-    final ManagedClientTransport badTransport = mock(ManagedClientTransport.class);
+    final ConnectionClientTransport goodTransport = mock(ConnectionClientTransport.class);
+    final ConnectionClientTransport badTransport = mock(ConnectionClientTransport.class);
     when(goodTransport.newStream(any(MethodDescriptor.class), any(Metadata.class)))
         .thenReturn(mock(ClientStream.class));
     when(mockTransportFactory.newClientTransport(
@@ -639,8 +639,8 @@ public class ManagedChannelImplTest {
       };
     final ResolvedServerInfo server1 = new ResolvedServerInfo(addr1, Attributes.EMPTY);
     final ResolvedServerInfo server2 = new ResolvedServerInfo(addr2, Attributes.EMPTY);
-    final ManagedClientTransport transport1 = mock(ManagedClientTransport.class);
-    final ManagedClientTransport transport2 = mock(ManagedClientTransport.class);
+    final ConnectionClientTransport transport1 = mock(ConnectionClientTransport.class);
+    final ConnectionClientTransport transport2 = mock(ConnectionClientTransport.class);
     when(mockTransportFactory.newClientTransport(same(addr1), any(String.class), any(String.class)))
         .thenReturn(transport1);
     when(mockTransportFactory.newClientTransport(same(addr2), any(String.class), any(String.class)))
@@ -695,8 +695,8 @@ public class ManagedChannelImplTest {
     final ResolvedServerInfo server1 = new ResolvedServerInfo(addr1, Attributes.EMPTY);
     final ResolvedServerInfo server2 = new ResolvedServerInfo(addr2, Attributes.EMPTY);
     // Addr1 will have two transports throughout this test.
-    final ManagedClientTransport transport1 = mock(ManagedClientTransport.class);
-    final ManagedClientTransport transport2 = mock(ManagedClientTransport.class);
+    final ConnectionClientTransport transport1 = mock(ConnectionClientTransport.class);
+    final ConnectionClientTransport transport2 = mock(ConnectionClientTransport.class);
     when(transport1.newStream(any(MethodDescriptor.class), any(Metadata.class)))
         .thenReturn(mock(ClientStream.class));
     when(transport2.newStream(any(MethodDescriptor.class), any(Metadata.class)))

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -160,10 +160,10 @@ public class ManagedChannelImplTransportManagerTest {
     // The real transport
     MockClientTransportInfo transportInfo = transports.poll(1, TimeUnit.SECONDS);
     transportInfo.listener.transportReady();
-    ClientTransport t2 = tm.getTransport(addressGroup);
+    ForwardingConnectionClientTransport t2 =
+        (ForwardingConnectionClientTransport) tm.getTransport(addressGroup);
     assertTrue(t1 instanceof DelayedClientTransport);
-    assertFalse(t2 instanceof DelayedClientTransport);
-    assertSame(transportInfo.transport, t2);
+    assertSame(transportInfo.transport, t2.delegate());
     verify(mockBackoffPolicyProvider, times(0)).get();
     verify(mockBackoffPolicy, times(0)).nextBackoffMillis();
     verifyNoMoreInteractions(mockTransportFactory);

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -56,14 +56,14 @@ final class TestUtils {
     /**
      * A mock transport created by the mock transport factory.
      */
-    final ManagedClientTransport transport;
+    final ConnectionClientTransport transport;
 
     /**
      * The listener passed to the start() of the mock transport.
      */
     final ManagedClientTransport.Listener listener;
 
-    MockClientTransportInfo(ManagedClientTransport transport,
+    MockClientTransportInfo(ConnectionClientTransport transport,
         ManagedClientTransport.Listener listener) {
       this.transport = transport;
       this.listener = listener;
@@ -81,10 +81,10 @@ final class TestUtils {
     final BlockingQueue<MockClientTransportInfo> captor =
         new LinkedBlockingQueue<MockClientTransportInfo>();
 
-    doAnswer(new Answer<ManagedClientTransport>() {
+    doAnswer(new Answer<ConnectionClientTransport>() {
       @Override
-      public ManagedClientTransport answer(InvocationOnMock invocation) throws Throwable {
-        final ManagedClientTransport mockTransport = mock(ManagedClientTransport.class);
+      public ConnectionClientTransport answer(InvocationOnMock invocation) throws Throwable {
+        final ConnectionClientTransport mockTransport = mock(ConnectionClientTransport.class);
         when(mockTransport.newStream(any(MethodDescriptor.class), any(Metadata.class),
             any(CallOptions.class))).thenReturn(mock(ClientStream.class));
         // Save the listener

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -43,8 +43,8 @@ import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.SharedResourceHolder;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
@@ -310,7 +310,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
     }
 
     @Override
-    public ManagedClientTransport newClientTransport(
+    public ConnectionClientTransport newClientTransport(
         SocketAddress serverAddress, String authority, @Nullable String userAgent) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
@@ -321,7 +321,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
     }
 
     @Internal  // This is strictly for internal use.  Depend on this at your own peril.
-    public ManagedClientTransport newClientTransport(SocketAddress serverAddress,
+    public ConnectionClientTransport newClientTransport(SocketAddress serverAddress,
         String authority, String userAgent, ProtocolNegotiator negotiator) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -36,14 +36,15 @@ import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
 
+import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
+import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
-import io.grpc.internal.ManagedClientTransport;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -60,9 +61,9 @@ import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
 /**
- * A Netty-based {@link ManagedClientTransport} implementation.
+ * A Netty-based {@link ConnectionClientTransport} implementation.
  */
-class NettyClientTransport implements ManagedClientTransport {
+class NettyClientTransport implements ConnectionClientTransport {
   private final SocketAddress address;
   private final Class<? extends Channel> channelType;
   private final EventLoopGroup group;
@@ -218,6 +219,12 @@ class NettyClientTransport implements ManagedClientTransport {
   @Override
   public String getLogId() {
     return GrpcUtil.getLogId(this);
+  }
+
+  @Override
+  public Attributes getAttrs() {
+    // TODO(zhangkun83): fill channel security attributes
+    return Attributes.EMPTY;
   }
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -47,8 +47,8 @@ import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.SharedResourceHolder.Resource;
 
@@ -260,7 +260,7 @@ public class OkHttpChannelBuilder extends
     }
 
     @Override
-    public ManagedClientTransport newClientTransport(
+    public ConnectionClientTransport newClientTransport(
         SocketAddress addr, String authority, @Nullable String userAgent) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -39,15 +39,16 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.SettableFuture;
 
+import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import io.grpc.Status.Code;
+import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
-import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.okhttp.internal.ConnectionSpec;
 import io.grpc.okhttp.internal.framed.ErrorCode;
@@ -88,9 +89,9 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
- * A okhttp-based {@link ManagedClientTransport} implementation.
+ * A okhttp-based {@link ConnectionClientTransport} implementation.
  */
-class OkHttpClientTransport implements ManagedClientTransport {
+class OkHttpClientTransport implements ConnectionClientTransport {
   private static final Map<ErrorCode, Status> ERROR_CODE_TO_STATUS = buildErrorCodeToStatusMap();
   private static final Logger log = Logger.getLogger(OkHttpClientTransport.class.getName());
   private static final OkHttpClientStream[] EMPTY_STREAM_ARRAY = new OkHttpClientStream[0];
@@ -478,6 +479,12 @@ class OkHttpClientTransport implements ManagedClientTransport {
 
       stopIfNecessary();
     }
+  }
+
+  @Override
+  public Attributes getAttrs() {
+    // TODO(zhangkun83): fill channel security attributes
+    return Attributes.EMPTY;
   }
 
   /**

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -33,6 +33,7 @@ package io.grpc.stub;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
@@ -171,5 +172,13 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
    */
   public final S withInterceptors(ClientInterceptor... interceptors) {
     return build(ClientInterceptors.intercept(channel, interceptors), callOptions);
+  }
+
+  /**
+   * Returns a new stub that uses the given call credentials.
+   */
+  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
+  public final S withCallCredentials(CallCredentials credentials) {
+    return build(channel, callOptions.withCredentials(credentials));
   }
 }


### PR DESCRIPTION
Introduce CallCredentials as a first-class option to allow applications to set per-call credentials into headers for outgoing RPCs. This will supersede `ClientAuthInterceptor`. It has access to more information (e.g., transport attributes, MethodDescriptor) and allows results to be returned asynchronously, e.g., after a blocking I/O which was a problem with `ClientAuthInterceptor`.