### PR TITLE
netty: Bump Netty dependency to 4.1.1.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,9 +138,9 @@ subprojects {
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.7.4',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
 
-                netty: 'io.netty:netty-codec-http2:[4.1.0.Final]',
-                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.0.Final' + epoll_suffix,
-                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork15:' + osdetector.classifier,
+                netty: 'io.netty:netty-codec-http2:[4.1.1.Final]',
+                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.1.Final' + epoll_suffix,
+                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork17:' + osdetector.classifier,
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',


### PR DESCRIPTION
Bumping tcnative was not required to be done at the same time as Netty.
But the new tcnative should now work correctly on Windows and be smaller
on Linux.

This is a cherry-pick from master for the v0.14.x branch.