### PR TITLE
core: Overwrite values for existing custom call option keys, instead of keeping old values around.

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/CallOptionsBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/CallOptionsBenchmark.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.benchmarks;
+
+import io.grpc.CallOptions;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Call options benchmark.
+ */
+@State(Scope.Benchmark)
+public class CallOptionsBenchmark {
+
+  @Param({"1", "2", "4", "8"})
+  public int customOptionsCount;
+
+  private List<CallOptions.Key<String>> customOptions;
+
+  private CallOptions allOpts;
+  private List<CallOptions.Key<String>> shuffledCustomOptions;
+
+  /**
+   * Setup.
+   */
+  @Setup
+  public void setUp() throws Exception {
+    customOptions = new ArrayList<CallOptions.Key<String>>(customOptionsCount);
+    for (int i = 0; i < customOptionsCount; i++) {
+      customOptions.add(CallOptions.Key.of("name " + i, "defaultvalue"));
+    }
+
+    allOpts = CallOptions.DEFAULT;
+    for (int i = 0; i < customOptionsCount; i++) {
+      allOpts = allOpts.withOption(customOptions.get(i), "value");
+    }
+
+    shuffledCustomOptions = new ArrayList<CallOptions.Key<String>>(customOptions);
+    // Make the shuffling deterministic
+    Collections.shuffle(shuffledCustomOptions, new Random(1));
+  }
+
+  /**
+   * Adding custom call options without duplicate keys.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public CallOptions withOption() {
+    CallOptions opts = CallOptions.DEFAULT;
+    for (int i = 0; i < customOptions.size(); i++) {
+      opts = opts.withOption(customOptions.get(i), "value");
+    }
+    return opts;
+  }
+
+  /**
+   * Adding custom call options, overwritting existing keys.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public CallOptions withOptionDuplicates() {
+    CallOptions opts = allOpts;
+    for (int i = 1; i < shuffledCustomOptions.size(); i++) {
+      opts = opts.withOption(shuffledCustomOptions.get(i), "value2");
+    }
+    return opts;
+  }
+}

--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -69,7 +69,7 @@ public final class CallOptions {
 
   @Nullable
   private String compressorName;
-  
+
   private Object[][] customOptions = new Object[0][2];
 
   /**
@@ -260,7 +260,7 @@ public final class CallOptions {
     newOptions.executor = executor;
     return newOptions;
   }
-  
+
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
   public static final class Key<T> {
     private final String name;
@@ -295,8 +295,8 @@ public final class CallOptions {
   }
 
   /**
-   * Set a custom option.  Any existing value for the key overridden.
-   * 
+   * Sets a custom option. Any existing value for the key is overwritten.
+   *
    * @param key The option key
    * @param value The option value.
    */
@@ -304,13 +304,27 @@ public final class CallOptions {
   public <T> CallOptions withOption(Key<T> key, T value) {
     Preconditions.checkNotNull(key);
     Preconditions.checkNotNull(value);
-      
+
     CallOptions newOptions = new CallOptions(this);
-    newOptions.customOptions = new Object[customOptions.length + 1][2];
-    newOptions.customOptions[0] = new Object[] { key, value};
-    if (customOptions.length > 0) {
-      System.arraycopy(customOptions, 0, newOptions.customOptions, 1, customOptions.length);
+    int existingIdx = -1;
+    for (int i = 0; i < customOptions.length; i++) {
+      if (key.equals(customOptions[i][0])) {
+        existingIdx = i;
+        break;
+      }
     }
+
+    newOptions.customOptions = new Object[customOptions.length + (existingIdx == -1 ? 1 : 0)][2];
+    System.arraycopy(customOptions, 0, newOptions.customOptions, 0, customOptions.length);
+
+    if (existingIdx == -1) {
+      // Add a new option
+      newOptions.customOptions[customOptions.length] = new Object[] {key, value};
+    } else {
+      // Replace an existing option
+      newOptions.customOptions[existingIdx][1] = value;
+    }
+
     return newOptions;
   }
 

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -161,7 +161,7 @@ public class CallOptionsTest {
     String expected = "CallOptions{deadline=null, authority=authority, callCredentials=null, "
         + "affinity={sample=blah}, "
         + "executor=class io.grpc.internal.SerializingExecutor, compressorName=compressor, "
-        + "customOptions=[[option2, value2], [option1, value1]], waitForReady=true}";
+        + "customOptions=[[option1, value1], [option2, value2]], waitForReady=true}";
     String actual = allSet
         .withDeadline(null)
         .withExecutor(new SerializingExecutor(directExecutor()))


### PR DESCRIPTION
cc: @dapengzhang0 

This PR resulted from this discussion https://github.com/grpc/grpc-java/pull/1918#discussion_r66713223

The performance of this PR seems identical with the current master and it fixes `toString` when having overwritten existing keys. Another upside of this change is that there is no unexpected performance degradation in case someone frequently changes the value of the same key.

**This PR:**
```
CallOptionsBenchmark.withOption                               1  sample  184633    253.033 ±  3.066  ns/op
CallOptionsBenchmark.withOption                               2  sample  163158    528.771 ± 14.739  ns/op
CallOptionsBenchmark.withOption                               4  sample  129367   1277.749 ± 60.131  ns/op
CallOptionsBenchmark.withOption                               8  sample  185144   3421.190 ± 23.552  ns/op
CallOptionsBenchmark.withOption                              16  sample  121435  10338.319 ± 50.105  ns/op
CallOptionsBenchmark.withOptionDuplicates                     1  sample  161893     59.429 ±  1.184  ns/op
CallOptionsBenchmark.withOptionDuplicates                     2  sample  142616    316.315 ±  1.904  ns/op
CallOptionsBenchmark.withOptionDuplicates                     4  sample  136853   1197.563 ± 26.170  ns/op
CallOptionsBenchmark.withOptionDuplicates                     8  sample  145914   4336.151 ± 21.998  ns/op
CallOptionsBenchmark.withOptionDuplicates                    16  sample  164104  15307.636 ± 68.240  ns/op
```

**Current master:**
```
Benchmark                                  (customOptionsCount)    Mode     Cnt      Score     Error  Units
CallOptionsBenchmark.withOption                               1  sample  185854    248.739 ±   1.742  ns/op
CallOptionsBenchmark.withOption                               2  sample  160535    525.485 ±   2.570  ns/op
CallOptionsBenchmark.withOption                               4  sample  130372   1243.345 ±  12.546  ns/op
CallOptionsBenchmark.withOption                               8  sample  188768   3371.729 ±  33.134  ns/op
CallOptionsBenchmark.withOption                              16  sample  122475  10260.304 ±  54.070  ns/op
CallOptionsBenchmark.withOptionDuplicates                     1  sample  161350     68.328 ±  13.531  ns/op
CallOptionsBenchmark.withOptionDuplicates                     2  sample  123365    359.238 ±  11.963  ns/op
CallOptionsBenchmark.withOptionDuplicates                     4  sample  106779   1518.031 ±  26.066  ns/op
CallOptionsBenchmark.withOptionDuplicates                     8  sample  110973   5675.588 ±  37.980  ns/op
CallOptionsBenchmark.withOptionDuplicates                    16  sample  112241  22359.046 ± 116.701  ns/op
```