### PR TITLE
core: Enable per-message compression bit by default

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -220,7 +220,8 @@ public abstract class ClientCall<ReqT, RespT> {
 
   /**
    * Enables per-message compression, if an encoding type has been negotiated.  If no message
-   * encoding has been negotiated, this is a no-op.
+   * encoding has been negotiated, this is a no-op. By default per-message compression is enabled,
+   * but may not have any effect if compression is not enabled on the call.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1703")
   public void setMessageCompression(boolean enabled) {

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -195,7 +195,8 @@ public abstract class ServerCall<ReqT, RespT> {
 
   /**
    * Enables per-message compression, if an encoding type has been negotiated.  If no message
-   * encoding has been negotiated, this is a no-op.
+   * encoding has been negotiated, this is a no-op. By default per-message compression is enabled,
+   * but may not have any effect if compression is not enabled on the call.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public void setMessageCompression(boolean enabled) {

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -216,9 +216,6 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
     stream.setCompressor(compressor);
 
     stream.start(new ClientStreamListenerImpl(observer));
-    if (compressor != Codec.Identity.NONE) {
-      stream.setMessageCompression(true);
-    }
 
     // Delay any sources of cancellation after start(), because most of the transports are broken if
     // they receive cancel before start. Issue #1343 has more details

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -81,7 +81,7 @@ public class MessageFramer {
   private final Sink sink;
   private WritableBuffer buffer;
   private Compressor compressor = Codec.Identity.NONE;
-  private boolean messageCompression;
+  private boolean messageCompression = true;
   private final OutputStreamAdapter outputStreamAdapter = new OutputStreamAdapter();
   private final byte[] headerScratch = new byte[HEADER_LENGTH];
   private final WritableBufferAllocator bufferAllocator;

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -107,16 +107,6 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
     headers.removeAll(MESSAGE_ENCODING_KEY);
     if (compressor == null) {
       compressor = Codec.Identity.NONE;
-      if (inboundHeaders.containsKey(MESSAGE_ACCEPT_ENCODING_KEY)) {
-        String acceptEncodings = inboundHeaders.get(MESSAGE_ACCEPT_ENCODING_KEY);
-        for (String acceptEncoding : ACCEPT_ENCODING_SPLITER.split(acceptEncodings)) {
-          Compressor c = compressorRegistry.lookupCompressor(acceptEncoding);
-          if (c != null) {
-            compressor = c;
-            break;
-          }
-        }
-      }
     } else {
       if (inboundHeaders.containsKey(MESSAGE_ACCEPT_ENCODING_KEY)) {
         String acceptEncodings = inboundHeaders.get(MESSAGE_ACCEPT_ENCODING_KEY);

--- a/core/src/main/java/io/grpc/internal/Stream.java
+++ b/core/src/main/java/io/grpc/internal/Stream.java
@@ -97,7 +97,8 @@ public interface Stream {
 
   /**
    * Enables per-message compression, if an encoding type has been negotiated.  If no message
-   * encoding has been negotiated, this is a no-op.
+   * encoding has been negotiated, this is a no-op. By default per-message compression is enabled,
+   * but may not have any effect if compression is not enabled on the call.
    */
   void setMessageCompression(boolean enable);
 }

--- a/core/src/test/java/io/grpc/internal/MessageFramerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageFramerTest.java
@@ -238,9 +238,8 @@ public class MessageFramerTest {
   @Test
   public void compressed() throws Exception {
     allocator = new BytesWritableBufferAllocator(100, Integer.MAX_VALUE);
-    framer = new MessageFramer(sink, allocator)
-        .setCompressor(new Codec.Gzip())
-        .setMessageCompression(true);
+    // setMessageCompression should default to true
+    framer = new MessageFramer(sink, allocator).setCompressor(new Codec.Gzip());
     writeKnownLength(framer, new byte[1000]);
     framer.flush();
     // The GRPC header is written first as a separate frame.

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -99,11 +99,9 @@ public class TestServiceImpl implements TestServiceGrpc.TestService {
           // fallthrough, just use gzip
         case GZIP:
           obs.setCompression("gzip");
-          obs.setMessageCompression(true);
           break;
         case NONE:
           obs.setCompression("identity");
-          obs.setMessageCompression(false);
           break;
         case UNRECOGNIZED:
           // fallthrough

--- a/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
@@ -279,6 +279,9 @@ public class CompressionTest {
     @Override
     public <ReqT, RespT> io.grpc.ServerCall.Listener<ReqT> interceptCall(
         ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+      if (serverEncoding) {
+        call.setCompression("fzip");
+      }
       call.setMessageCompression(enableServerMessageCompression);
       serverResponseHeaders = headers;
       return next.startCall(call, headers);


### PR DESCRIPTION
This does not enable compression by default, but if the application
chooses to enable compression for a Call, messages will be compressed
without also needing to enable per-message compression.

Disabling per-message compression is intended as a security feature and
should be relatively rarely used, but it was the default. Thus we
required clients to use more advanced interfaces unnecessarily.

To keep client and server behavior consistent, the server also has
per-message compression enabled by default. However, to prevent
compressing on the wire by default, servers no longer enable compression
for the response by default.