### PR TITLE
core: Move ACCEPT_ENCODING_JOINER to DecompressorRegistry

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/DecompressorRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/DecompressorRegistryBenchmark.java
@@ -31,7 +31,7 @@
 
 package io.grpc;
 
-import io.grpc.internal.GrpcUtil;
+import static io.grpc.DecompressorRegistry.ACCEPT_ENCODING_JOINER;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -87,7 +87,7 @@ public class DecompressorRegistryBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public String dynamicAcceptEncoding() {
     if (!reg.getAdvertisedMessageEncodings().isEmpty()) {
-      return GrpcUtil.ACCEPT_ENCODING_JOINER.join(reg.getAdvertisedMessageEncodings());
+      return ACCEPT_ENCODING_JOINER.join(reg.getAdvertisedMessageEncodings());
     }
     return "";
   }

--- a/core/src/main/java/io/grpc/DecompressorRegistry.java
+++ b/core/src/main/java/io/grpc/DecompressorRegistry.java
@@ -33,7 +33,8 @@ package io.grpc;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.internal.GrpcUtil.ACCEPT_ENCODING_JOINER;
+
+import com.google.common.base.Joiner;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -51,6 +52,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
 @ThreadSafe
 public final class DecompressorRegistry {
+  static final Joiner ACCEPT_ENCODING_JOINER = Joiner.on(',');
+
   public static DecompressorRegistry emptyInstance() {
     return new DecompressorRegistry();
   }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -34,7 +34,6 @@ package io.grpc.internal;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
@@ -142,8 +141,6 @@ public final class GrpcUtil {
   public static final int DEFAULT_MAX_HEADER_LIST_SIZE = 8192;
 
   public static final Splitter ACCEPT_ENCODING_SPLITER = Splitter.on(',').trimResults();
-
-  public static final Joiner ACCEPT_ENCODING_JOINER = Joiner.on(',');
 
   private static final String IMPLEMENTATION_VERION = getImplementationVersion();
 

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -34,7 +34,6 @@ package io.grpc.internal;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static io.grpc.internal.GrpcUtil.ACCEPT_ENCODING_JOINER;
 import static io.grpc.internal.GrpcUtil.ACCEPT_ENCODING_SPLITER;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
@@ -58,7 +57,6 @@ import io.grpc.Status;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Set;
 
 final class ServerCallImpl<ReqT, RespT> extends ServerCall<RespT> {
   private final ServerStream stream;
@@ -139,9 +137,9 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<RespT> {
     stream.setCompressor(compressor);
 
     headers.removeAll(MESSAGE_ACCEPT_ENCODING_KEY);
-    Set<String> acceptEncodings = decompressorRegistry.getAdvertisedMessageEncodings();
-    if (!acceptEncodings.isEmpty()) {
-      headers.put(MESSAGE_ACCEPT_ENCODING_KEY, ACCEPT_ENCODING_JOINER.join(acceptEncodings));
+    String advertisedEncodings = decompressorRegistry.getRawAdvertisedMessageEncodings();
+    if (!advertisedEncodings.isEmpty()) {
+      headers.put(MESSAGE_ACCEPT_ENCODING_KEY, advertisedEncodings);
     }
 
     // Don't check if sendMessage has been called, since it requires that sendHeaders was already


### PR DESCRIPTION
This removes a reference of io.grpc.internal from io.grpc. It also
optimizes server call handling for outbound grpc-accept-encoding header,
as had already been done for client call.