### PR TITLE
core: add transportInUse() to transport listener.

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -247,8 +247,11 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
     private void streamClosed() {
       synchronized (InProcessTransport.this) {
         boolean justRemovedAnElement = streams.remove(this);
-        if (shutdown && streams.isEmpty() && justRemovedAnElement) {
-          notifyTerminated();
+        if (streams.isEmpty() && justRemovedAnElement) {
+          clientTransportListener.transportInUse(false);
+          if (shutdown) {
+            notifyTerminated();
+          }
         }
       }
     }
@@ -548,6 +551,9 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
               serverStream, method.getFullMethodName(), headers);
           clientStream.setListener(serverStreamListener);
           streams.add(InProcessTransport.InProcessStream.this);
+          if (streams.size() == 1) {
+            clientTransportListener.transportInUse(true);
+          }
         }
       }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -521,6 +521,8 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
           }
 
           @Override public void transportReady() {}
+
+          @Override public void transportInUse(boolean inUse) {}
         });
       boolean savedShutdown;
       synchronized (lock) {

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -106,5 +106,11 @@ public interface ManagedClientTransport extends ClientTransport, WithLogId {
      * called at most once.
      */
     void transportReady();
+
+    /**
+     * Called whenever the transport's in-use state has changed. A transport is in-use when it has
+     * at least one stream.
+     */
+    void transportInUse(boolean inUse);
   }
 }

--- a/core/src/main/java/io/grpc/internal/TransportSet.java
+++ b/core/src/main/java/io/grpc/internal/TransportSet.java
@@ -332,6 +332,9 @@ final class TransportSet implements WithLogId {
     public void transportReady() {}
 
     @Override
+    public void transportInUse(boolean inUse) {}
+
+    @Override
     public void transportShutdown(Status status) {}
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/ClientTransportLifecycleManager.java
+++ b/netty/src/main/java/io/grpc/netty/ClientTransportLifecycleManager.java
@@ -39,6 +39,7 @@ final class ClientTransportLifecycleManager {
   private final ManagedClientTransport.Listener listener;
   private boolean transportReady;
   private boolean transportShutdown;
+  private boolean transportInUse;
   /** null iff !transportShutdown. */
   private Status shutdownStatus;
   /** null iff !transportShutdown. */
@@ -65,6 +66,14 @@ final class ClientTransportLifecycleManager {
     shutdownStatus = s;
     shutdownThrowable = s.asException();
     listener.transportShutdown(s);
+  }
+
+  public void notifyInUse(boolean inUse) {
+    if (inUse == transportInUse) {
+      return;
+    }
+    transportInUse = inUse;
+    listener.transportInUse(inUse);
   }
 
   public void notifyTerminated(Status s) {

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -177,6 +177,18 @@ class NettyClientHandler extends AbstractNettyHandler {
       public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
         goingAway(statusFromGoAway(errorCode, ByteBufUtil.getBytes(debugData)));
       }
+
+      @Override
+      public void onStreamAdded(Http2Stream stream) {
+        NettyClientHandler.this.lifecycleManager.notifyInUse(true);
+      }
+
+      @Override
+      public void onStreamRemoved(Http2Stream stream) {
+        if (connection().numActiveStreams() == 0) {
+          NettyClientHandler.this.lifecycleManager.notifyInUse(false);
+        }
+      }
     });
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -116,6 +116,11 @@ abstract class NettyClientStream extends Http2ClientStream implements StreamIdHo
         !method.getType().clientSendsOneMessage()).addListener(failureListener);
   }
 
+  @Override
+  public void transportReportStatus(Status newStatus, boolean stopDelivery, Metadata trailers) {
+    super.transportReportStatus(newStatus, stopDelivery, trailers);
+  }
+
   /**
    * Intended to be overriden by NettyClientTransport, which has more information about failures.
    * May only be called from event loop.


### PR DESCRIPTION
A transport is "in use" iff number of streams > 0. In following changes the channel will use this information when deciding whether it should transit to the IDLE mode (#1276).