### PR TITLE
okhttp: fix NPE when using CLEARTEXT connectionSpec

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -34,6 +34,7 @@ package io.grpc.okhttp;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -87,9 +88,9 @@ public class OkHttpChannelBuilder extends
         @Override
         public ExecutorService create() {
           return Executors.newCachedThreadPool(new ThreadFactoryBuilder()
-                  .setDaemon(true)
-                  .setNameFormat("grpc-okhttp-%d")
-                  .build());
+              .setDaemon(true)
+              .setNameFormat("grpc-okhttp-%d")
+              .build());
         }
 
         @Override
@@ -165,8 +166,15 @@ public class OkHttpChannelBuilder extends
    * TLS versions.
    *
    * <p>By default {@link #DEFAULT_CONNECTION_SPEC} will be used.
+   *
+   * <p>This method is only used when building a secure connection. For plaintext
+   * connection, use {@link #usePlaintext} instead.
+   *
+   * @throws IllegalArgumentException
+   *         If {@code connectionSpec} is not with TLS
    */
   public final OkHttpChannelBuilder connectionSpec(ConnectionSpec connectionSpec) {
+    Preconditions.checkArgument(connectionSpec.isTls(), "plaintext connection is not accepted");
     this.connectionSpec = connectionSpec;
     return this;
   }
@@ -197,7 +205,7 @@ public class OkHttpChannelBuilder extends
   @Override
   protected final ClientTransportFactory buildTransportFactory() {
     return new OkHttpTransportFactory(transportExecutor,
-            createSocketFactory(), connectionSpec, maxMessageSize);
+        createSocketFactory(), connectionSpec, maxMessageSize);
   }
 
   @Override
@@ -217,11 +225,13 @@ public class OkHttpChannelBuilder extends
         .set(NameResolver.Factory.PARAMS_DEFAULT_PORT, defaultPort).build();
   }
 
-  private SSLSocketFactory createSocketFactory() {
+  @VisibleForTesting
+  @Nullable
+  SSLSocketFactory createSocketFactory() {
     switch (negotiationType) {
       case TLS:
         return sslSocketFactory == null
-                ? (SSLSocketFactory) SSLSocketFactory.getDefault() : sslSocketFactory;
+            ? (SSLSocketFactory) SSLSocketFactory.getDefault() : sslSocketFactory;
       case PLAINTEXT:
         return null;
       default:
@@ -236,6 +246,7 @@ public class OkHttpChannelBuilder extends
   static final class OkHttpTransportFactory implements ClientTransportFactory {
     private final Executor executor;
     private final boolean usingSharedExecutor;
+    @Nullable
     private final SSLSocketFactory socketFactory;
     private final ConnectionSpec connectionSpec;
     private final int maxMessageSize;
@@ -243,9 +254,9 @@ public class OkHttpChannelBuilder extends
     private boolean closed;
 
     private OkHttpTransportFactory(Executor executor,
-                                   SSLSocketFactory socketFactory,
-                                   ConnectionSpec connectionSpec,
-                                   int maxMessageSize) {
+        @Nullable SSLSocketFactory socketFactory,
+        ConnectionSpec connectionSpec,
+        int maxMessageSize) {
       this.socketFactory = socketFactory;
       this.connectionSpec = connectionSpec;
       this.maxMessageSize = maxMessageSize;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -174,7 +174,7 @@ public class OkHttpChannelBuilder extends
    *         If {@code connectionSpec} is not with TLS
    */
   public final OkHttpChannelBuilder connectionSpec(ConnectionSpec connectionSpec) {
-    Preconditions.checkArgument(connectionSpec.isTls(), "plaintext connection is not accepted");
+    Preconditions.checkArgument(connectionSpec.isTls(), "plaintext ConnectionSpec is not accepted");
     this.connectionSpec = connectionSpec;
     return this;
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/Utils.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Utils.java
@@ -74,7 +74,7 @@ class Utils {
    *         If {@code spec} is not with TLS
    */
   static ConnectionSpec convertSpec(com.squareup.okhttp.ConnectionSpec spec) {
-    Preconditions.checkArgument(spec.isTls(), "plaintext connection is not accepted");
+    Preconditions.checkArgument(spec.isTls(), "plaintext ConnectionSpec is not accepted");
 
     List<com.squareup.okhttp.TlsVersion> tlsVersionList = spec.tlsVersions();
     String[] tlsVersions = new String[tlsVersionList.size()];

--- a/okhttp/src/main/java/io/grpc/okhttp/Utils.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Utils.java
@@ -31,6 +31,8 @@
 
 package io.grpc.okhttp;
 
+import com.google.common.base.Preconditions;
+
 import io.grpc.Metadata;
 import io.grpc.internal.TransportFrameUtil;
 import io.grpc.okhttp.internal.CipherSuite;
@@ -64,7 +66,16 @@ class Utils {
     return TransportFrameUtil.toRawSerializedHeaders(headerValues);
   }
 
+  /**
+   * Converts an instance of {@link com.squareup.okhttp.ConnectionSpec} for a secure connection into
+   * that of {@link ConnectionSpec} in the current package.
+   *
+   * @throws IllegalArgumentException
+   *         If {@code spec} is not with TLS
+   */
   static ConnectionSpec convertSpec(com.squareup.okhttp.ConnectionSpec spec) {
+    Preconditions.checkArgument(spec.isTls(), "plaintext connection is not accepted");
+
     List<com.squareup.okhttp.TlsVersion> tlsVersionList = spec.tlsVersions();
     String[] tlsVersions = new String[tlsVersionList.size()];
     for (int i = 0; i < tlsVersions.length; i++) {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -31,7 +31,15 @@
 
 package io.grpc.okhttp;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.squareup.okhttp.ConnectionSpec;
+
+import io.grpc.NameResolver;
 import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.GrpcUtil;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,6 +47,11 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.net.InetSocketAddress;
+
+/**
+ * Tests for {@link OkHttpChannelBuilder}.
+ */
 @RunWith(JUnit4.class)
 public class OkHttpChannelBuilderTest {
 
@@ -75,6 +88,42 @@ public class OkHttpChannelBuilderTest {
     thrown.expectMessage("Invalid host or port");
 
     OkHttpChannelBuilder.forAddress("invalid_authority", 1234);
+  }
+
+  @Test
+  public void failForUsingClearTextSpecDirectly() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("plaintext connection is not accepted");
+
+    OkHttpChannelBuilder.forAddress("host", 1234).connectionSpec(ConnectionSpec.CLEARTEXT);
+  }
+
+  @Test
+  public void allowUsingTlsConnectionSpec() {
+    OkHttpChannelBuilder.forAddress("host", 1234).connectionSpec(ConnectionSpec.MODERN_TLS);
+  }
+
+  @Test
+  public void usePlaintext_newClientTransportAllowed() {
+    OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("host", 1234).usePlaintext(true);
+    builder.buildTransportFactory().newClientTransport(new InetSocketAddress(5678),
+        "dummy_authority", "dummy_userAgent");
+  }
+
+  @Test
+  public void usePlaintextDefaultPort() {
+    OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("host", 1234).usePlaintext(true);
+    assertEquals(GrpcUtil.DEFAULT_PORT_PLAINTEXT,
+        builder.getNameResolverParams().get(NameResolver.Factory.PARAMS_DEFAULT_PORT).intValue());
+  }
+
+  @Test
+  public void usePlaintextCreatesNullSocketFactory() {
+    OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("host", 1234);
+    assertNotNull(builder.createSocketFactory());
+
+    builder.usePlaintext(true);
+    assertNull(builder.createSocketFactory());
   }
 }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -93,7 +93,7 @@ public class OkHttpChannelBuilderTest {
   @Test
   public void failForUsingClearTextSpecDirectly() {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("plaintext connection is not accepted");
+    thrown.expectMessage("plaintext ConnectionSpec is not accepted");
 
     OkHttpChannelBuilder.forAddress("host", 1234).connectionSpec(ConnectionSpec.CLEARTEXT);
   }

--- a/okhttp/src/test/java/io/grpc/okhttp/UtilsTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/UtilsTest.java
@@ -59,7 +59,7 @@ public class UtilsTest {
   public void convertSpecRejectsPlaintext() {
     com.squareup.okhttp.ConnectionSpec plaintext = com.squareup.okhttp.ConnectionSpec.CLEARTEXT;
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("plaintext connection is not accepted");
+    thrown.expectMessage("plaintext ConnectionSpec is not accepted");
     Utils.convertSpec(plaintext);
   }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/UtilsTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/UtilsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.okhttp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.grpc.okhttp.internal.CipherSuite;
+import io.grpc.okhttp.internal.ConnectionSpec;
+import io.grpc.okhttp.internal.TlsVersion;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.List;
+
+/**
+ * Tests for {@link Utils}.
+ */
+@RunWith(JUnit4.class)
+public class UtilsTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void convertSpecRejectsPlaintext() {
+    com.squareup.okhttp.ConnectionSpec plaintext = com.squareup.okhttp.ConnectionSpec.CLEARTEXT;
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("plaintext connection is not accepted");
+    Utils.convertSpec(plaintext);
+  }
+
+  @Test
+  public void convertSpecKeepsAllData() {
+    com.squareup.okhttp.ConnectionSpec squareSpec = com.squareup.okhttp.ConnectionSpec.MODERN_TLS;
+    ConnectionSpec spec = Utils.convertSpec(squareSpec);
+
+    List<com.squareup.okhttp.TlsVersion> squareTlsVersions = squareSpec.tlsVersions();
+    List<TlsVersion> tlsVersions = spec.tlsVersions();
+    int versionsSize = squareTlsVersions.size();
+    List<com.squareup.okhttp.CipherSuite> squareCipherSuites = squareSpec.cipherSuites();
+    List<CipherSuite> cipherSuites = spec.cipherSuites();
+    int cipherSuitesSize = squareCipherSuites.size();
+
+    assertTrue(spec.isTls());
+    assertTrue(spec.supportsTlsExtensions());
+    assertEquals(versionsSize, tlsVersions.size());
+    for (int i = 0; i < versionsSize; i++) {
+      assertEquals(TlsVersion.forJavaName(squareTlsVersions.get(i).javaName()), tlsVersions.get(i));
+    }
+    assertEquals(cipherSuitesSize, cipherSuites.size());
+    for (int i = 0; i < cipherSuitesSize; i++) {
+      assertEquals(CipherSuite.forJavaName(squareCipherSuites.get(i).name()), cipherSuites.get(i));
+    }
+  }
+}


### PR DESCRIPTION
The only legitimate way to create plaintext connection with okhttp is by calling
`OkHttpChannelBuilder#usePlaintex`

Throw IllegalArgumentException when calling
 `OkHttpChannelBuilder#connectionSpec` or `Utils.convertSpec` directly with CLEARTEXT a `connectionSped` argument.