### PR TITLE
core: don't create a new context for each client call. Fixes #1926

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
@@ -54,7 +54,6 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 
 import io.grpc.Channel;
-import io.grpc.Context;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.benchmarks.proto.BenchmarkServiceGrpc;
@@ -199,15 +198,10 @@ public class AsyncClient {
         histogram.recordValue((now - lastCall) / 1000);
         lastCall = now;
 
-        Context prevCtx = Context.ROOT.attach();
-        try {
-          if (endTime > now) {
-            stub.unaryCall(request, this);
-          } else {
-            future.done();
-          }
-        } finally {
-          Context.current().detach(prevCtx);
+        if (endTime > now) {
+          stub.unaryCall(request, this);
+        } else {
+          future.done();
         }
       }
     });


### PR DESCRIPTION
Also, undo the hack that makes sure AsyncClient's stack doesn't overflow as it's no longer needed.