### PR TITLE
Delete the old ClientCall.cancel().

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -160,17 +160,6 @@ public abstract class ClientCall<ReqT, RespT> {
   public abstract void request(int numMessages);
 
   /**
-   * Equivalent as {@link #cancel(String, Throwable)} without passing any useful information.
-   *
-   * @deprecated Use or override {@link #cancel(String, Throwable)} instead. See
-   *             https://github.com/grpc/grpc-java/issues/1221
-   */
-  @Deprecated
-  public void cancel() {
-    cancel("Cancelled by ClientCall.cancel()", null);
-  }
-
-  /**
    * Prevent any further processing for this {@code ClientCall}. No further messages may be sent or
    * will be received. The server is informed of cancellations, but may not stop processing the
    * call. Cancellation is permitted if previously {@link #halfClose}d. Cancelling an already {@code

--- a/core/src/main/java/io/grpc/ForwardingClientCall.java
+++ b/core/src/main/java/io/grpc/ForwardingClientCall.java
@@ -52,12 +52,6 @@ public abstract class ForwardingClientCall<ReqT, RespT> extends ClientCall<ReqT,
     delegate().request(numMessages);
   }
 
-  @Deprecated
-  @Override
-  public void cancel() {
-    delegate().cancel();
-  }
-
   @Override
   public void cancel(@Nullable String message, @Nullable Throwable cause) {
     delegate().cancel(message, cause);


### PR DESCRIPTION
It's deprecated since 0.14.0.

Resolves #1589