### PR TITLE
android: Add ProGuard rules for NameResolverProvider

### DIFF
--- a/android-interop-testing/app/proguard-rules.pro
+++ b/android-interop-testing/app/proguard-rules.pro
@@ -15,6 +15,12 @@
 -dontwarn sun.reflect.**
 -dontwarn android.test.**
 
-# Need to create channel through service provider.
+# Providers use their name to load files from META-INF
+-keepnames class io.grpc.ServerProvider
 -keepnames class io.grpc.ManagedChannelProvider
+-keepnames class io.grpc.NameResolverProvider
+
+# The Provider implementations must be kept and retain their names, since the
+# names are referenced from META-INF
+-keep class io.grpc.internal.DnsNameResolverProvider
 -keep class io.grpc.okhttp.OkHttpChannelProvider

--- a/examples/android/app/proguard-rules.pro
+++ b/examples/android/app/proguard-rules.pro
@@ -11,3 +11,13 @@
 
 -dontwarn com.google.common.**
 -dontwarn okio.**
+
+# Providers use their name to load files from META-INF
+-keepnames class io.grpc.ServerProvider
+-keepnames class io.grpc.ManagedChannelProvider
+-keepnames class io.grpc.NameResolverProvider
+
+# The Provider implementations must be kept and retain their names, since the
+# names are referenced from META-INF
+-keep class io.grpc.internal.DnsNameResolverProvider
+-keep class io.grpc.okhttp.OkHttpChannelProvider


### PR DESCRIPTION
Without the rules, all RPCs fail since no providers are found. We like
the idea of RPCs working.

@zsurocking, FYI