### PR TITLE
core: Fix onReady race by adding DelayedStreamListener

### DIFF
--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -56,8 +56,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.io.InputStream;
-
 /**
  * Test for {@link AbstractClientStream}.  This class tries to test functionality in
  * AbstractClientStream, but not in any super classes.
@@ -85,7 +83,7 @@ public class AbstractClientStreamTest {
   @Test
   public void cancel_doNotAcceptOk() {
     for (Code code : Code.values()) {
-      ClientStreamListener listener = new BaseClientStreamListener();
+      ClientStreamListener listener = new NoopClientStreamListener();
       AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
       stream.start(listener);
       if (code != Code.OK) {
@@ -103,7 +101,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void cancel_failsOnNull() {
-    ClientStreamListener listener = new BaseClientStreamListener();
+    ClientStreamListener listener = new NoopClientStreamListener();
     AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
     stream.start(listener);
     thrown.expect(NullPointerException.class);
@@ -162,7 +160,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void inboundDataReceived_failsOnNullFrame() {
-    ClientStreamListener listener = new BaseClientStreamListener();
+    ClientStreamListener listener = new NoopClientStreamListener();
     AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
     stream.start(listener);
     thrown.expect(NullPointerException.class);
@@ -281,22 +279,5 @@ public class AbstractClientStreamTest {
 
     @Override
     protected void returnProcessedBytes(int processedBytes) {}
-  }
-
-  /**
-   * No-op base class for testing.
-   */
-  static class BaseClientStreamListener implements ClientStreamListener {
-    @Override
-    public void messageRead(InputStream message) {}
-
-    @Override
-    public void onReady() {}
-
-    @Override
-    public void headersRead(Metadata headers) {}
-
-    @Override
-    public void closed(Status status, Metadata trailers) {}
   }
 }

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -79,6 +79,7 @@ public class DelayedClientTransportTest {
   @Mock private ClientTransport.PingCallback pingCallback;
   @Mock private Executor mockExecutor;
   @Captor private ArgumentCaptor<Status> statusCaptor;
+  @Captor private ArgumentCaptor<ClientStreamListener> listenerCaptor;
 
   private final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
       MethodDescriptor.MethodType.UNKNOWN, "/service/method",
@@ -141,7 +142,11 @@ public class DelayedClientTransportTest {
     assertFalse(delayedTransport.hasPendingStreams());
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions));
-    verify(mockRealStream).start(same(streamListener));
+    verify(mockRealStream).start(listenerCaptor.capture());
+    verifyNoMoreInteractions(streamListener);
+    listenerCaptor.getValue().onReady();
+    verify(streamListener).onReady();
+    verifyNoMoreInteractions(streamListener);
   }
 
   @Test public void newStreamThenSetTransportThenShutdown() {

--- a/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
+++ b/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+import java.io.InputStream;
+
+/**
+ * No-op base class for testing.
+ */
+class NoopClientStreamListener implements ClientStreamListener {
+  @Override
+  public void messageRead(InputStream message) {}
+
+  @Override
+  public void onReady() {}
+
+  @Override
+  public void headersRead(Metadata headers) {}
+
+  @Override
+  public void closed(Status status, Metadata trailers) {}
+}


### PR DESCRIPTION
onReady/isReady previously could disagree causing a sort of deadlock
where the application isn't sending because grpc said not to, but won't
be informed to send via onReady later.