### PR TITLE
Remove unused variables

### DIFF
--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -70,7 +70,6 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
   @Override
   public void applyRequestMetadata(MethodDescriptor<?, ?> method, Attributes attrs,
       Executor appExecutor, final MetadataApplier applier) {
-    Metadata cachedSaved;
     String authority = checkNotNull(attrs.get(ATTR_AUTHORITY), "authority");
     final URI uri;
     try {

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -201,7 +201,7 @@ public final class ServerImpl extends io.grpc.Server {
     }
     // Short-circuiting not strictly necessary, but prevents transports from needing to handle
     // multiple shutdownNow invocations, between here and the serverShutdown callback.
-    if (serverShutdownCallbackInvoked) {
+    if (savedServerShutdownCallbackInvoked) {
       // Have to call shutdownNow, because serverShutdown callback only called shutdown, not
       // shutdownNow
       for (ServerTransport transport : transportsCopy) {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -38,7 +38,6 @@ import static org.junit.Assert.assertNull;
 import com.squareup.okhttp.ConnectionSpec;
 
 import io.grpc.NameResolver;
-import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.GrpcUtil;
 
 import org.junit.Rule;
@@ -66,7 +65,7 @@ public class OkHttpChannelBuilderTest {
       }
     };
 
-    ClientTransportFactory factory = builder.overrideAuthority("[invalidauthority")
+    builder.overrideAuthority("[invalidauthority")
         .negotiationType(NegotiationType.PLAINTEXT)
         .buildTransportFactory();
   }
@@ -77,7 +76,7 @@ public class OkHttpChannelBuilderTest {
     thrown.expectMessage("Invalid authority:");
     OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234);
 
-    ClientTransportFactory factory = builder.overrideAuthority("[invalidauthority")
+    builder.overrideAuthority("[invalidauthority")
         .negotiationType(NegotiationType.PLAINTEXT)
         .buildTransportFactory();
   }

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -166,29 +166,27 @@ public class ClientCallsTest {
   public void disablingInboundAutoFlowControlSuppressesRequestsForMoreMessages()
       throws Exception {
     ArgumentCaptor<ClientCall.Listener<String>> listenerCaptor = ArgumentCaptor.forClass(null);
-    CallStreamObserver<Integer> requestObserver =
-        (CallStreamObserver<Integer>)
-            ClientCalls.asyncBidiStreamingCall(call, new ClientResponseObserver<Integer, String>() {
-              @Override
-              public void beforeStart(ClientCallStreamObserver<Integer> requestStream) {
-                requestStream.disableAutoInboundFlowControl();
-              }
+    ClientCalls.asyncBidiStreamingCall(call, new ClientResponseObserver<Integer, String>() {
+      @Override
+      public void beforeStart(ClientCallStreamObserver<Integer> requestStream) {
+        requestStream.disableAutoInboundFlowControl();
+      }
 
-              @Override
-              public void onNext(String value) {
+      @Override
+      public void onNext(String value) {
 
-              }
+      }
 
-              @Override
-              public void onError(Throwable t) {
+      @Override
+      public void onError(Throwable t) {
 
-              }
+      }
 
-              @Override
-              public void onCompleted() {
+      @Override
+      public void onCompleted() {
 
-              }
-            });
+      }
+    });
     verify(call).start(listenerCaptor.capture(), any(Metadata.class));
     listenerCaptor.getValue().onMessage("message");
     verify(call, times(1)).request(1);

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -335,7 +335,6 @@ public abstract class AbstractTransportTest {
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    ServerStream serverStream = serverStreamCreation.stream;
     ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
 
     Status status = Status.UNKNOWN.withDescription("test shutdownNow");
@@ -366,7 +365,6 @@ public abstract class AbstractTransportTest {
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    ServerStream serverStream = serverStreamCreation.stream;
     ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
 
     serverTransport.shutdownNow(Status.UNKNOWN.withDescription("test shutdownNow"));


### PR DESCRIPTION
This fixed a threading issue in ServerImpl because the unused variable
should have been used.