### PR TITLE
compiler: remove interfaces in codegen

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -71,7 +71,7 @@ public class BenchmarkServiceGrpc {
 
   /**
    */
-  public static interface BenchmarkService {
+  public static abstract class BenchmarkServiceImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
@@ -79,68 +79,45 @@ public class BenchmarkServiceGrpc {
      * The server returns the client payload as-is.
      * </pre>
      */
-    public void unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver);
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * The server returns the client payload as-is.
-     * </pre>
-     */
-    public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingCall(
-        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractBenchmarkService implements BenchmarkService, io.grpc.BindableService {
-
-    @java.lang.Override
     public void unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingCall(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       return asyncUnimplementedStreamingCall(METHOD_STREAMING_CALL, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return BenchmarkServiceGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_UNARY_CALL,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.benchmarks.proto.Messages.SimpleRequest,
+                io.grpc.benchmarks.proto.Messages.SimpleResponse>(
+                  this, METHODID_UNARY_CALL)))
+          .addMethod(
+            METHOD_STREAMING_CALL,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.benchmarks.proto.Messages.SimpleRequest,
+                io.grpc.benchmarks.proto.Messages.SimpleResponse>(
+                  this, METHODID_STREAMING_CALL)))
+          .build();
     }
   }
 
   /**
    */
-  public static interface BenchmarkServiceBlockingClient {
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * The server returns the client payload as-is.
-     * </pre>
-     */
-    public io.grpc.benchmarks.proto.Messages.SimpleResponse unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request);
-  }
-
-  /**
-   */
-  public static interface BenchmarkServiceFutureClient {
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * The server returns the client payload as-is.
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Messages.SimpleResponse> unaryCall(
-        io.grpc.benchmarks.proto.Messages.SimpleRequest request);
-  }
-
-  public static class BenchmarkServiceStub extends io.grpc.stub.AbstractStub<BenchmarkServiceStub>
-      implements BenchmarkService {
+  public static final class BenchmarkServiceStub extends io.grpc.stub.AbstractStub<BenchmarkServiceStub> {
     private BenchmarkServiceStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -156,14 +133,24 @@ public class BenchmarkServiceGrpc {
       return new BenchmarkServiceStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public void unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingCall(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       return asyncBidiStreamingCall(
@@ -171,8 +158,9 @@ public class BenchmarkServiceGrpc {
     }
   }
 
-  public static class BenchmarkServiceBlockingStub extends io.grpc.stub.AbstractStub<BenchmarkServiceBlockingStub>
-      implements BenchmarkServiceBlockingClient {
+  /**
+   */
+  public static final class BenchmarkServiceBlockingStub extends io.grpc.stub.AbstractStub<BenchmarkServiceBlockingStub> {
     private BenchmarkServiceBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -188,15 +176,21 @@ public class BenchmarkServiceGrpc {
       return new BenchmarkServiceBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public io.grpc.benchmarks.proto.Messages.SimpleResponse unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
     }
   }
 
-  public static class BenchmarkServiceFutureStub extends io.grpc.stub.AbstractStub<BenchmarkServiceFutureStub>
-      implements BenchmarkServiceFutureClient {
+  /**
+   */
+  public static final class BenchmarkServiceFutureStub extends io.grpc.stub.AbstractStub<BenchmarkServiceFutureStub> {
     private BenchmarkServiceFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -212,7 +206,12 @@ public class BenchmarkServiceGrpc {
       return new BenchmarkServiceFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Messages.SimpleResponse> unaryCall(
         io.grpc.benchmarks.proto.Messages.SimpleRequest request) {
       return futureUnaryCall(
@@ -228,10 +227,10 @@ public class BenchmarkServiceGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final BenchmarkService serviceImpl;
+    private final BenchmarkServiceImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(BenchmarkService serviceImpl, int methodId) {
+    public MethodHandlers(BenchmarkServiceImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -269,23 +268,76 @@ public class BenchmarkServiceGrpc {
         METHOD_STREAMING_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final BenchmarkService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_UNARY_CALL,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.benchmarks.proto.Messages.SimpleRequest,
-              io.grpc.benchmarks.proto.Messages.SimpleResponse>(
-                serviceImpl, METHODID_UNARY_CALL)))
-        .addMethod(
-          METHOD_STREAMING_CALL,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.benchmarks.proto.Messages.SimpleRequest,
-              io.grpc.benchmarks.proto.Messages.SimpleResponse>(
-                serviceImpl, METHODID_STREAMING_CALL)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements BenchmarkService} with {@code extends BenchmarkServiceImplBase};</li>
+   *   <li> replace usage of {@code BenchmarkService} with {@code BenchmarkServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractBenchmarkService} with {@link BenchmarkServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(BenchmarkServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code BenchmarkServiceBlockingClient} with {@link BenchmarkServiceBlockingStub};</li>
+   *   <li> replace {@code BenchmarkServiceFutureClient} with {@link BenchmarkServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class BenchmarkService {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements BenchmarkService} with {@code extends BenchmarkServiceImplBase};</li>
+   *   <li> replace usage of {@code BenchmarkService} with {@code BenchmarkServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractBenchmarkService} with {@link BenchmarkServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(BenchmarkServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code BenchmarkServiceBlockingClient} with {@link BenchmarkServiceBlockingStub};</li>
+   *   <li> replace {@code BenchmarkServiceFutureClient} with {@link BenchmarkServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class BenchmarkServiceBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements BenchmarkService} with {@code extends BenchmarkServiceImplBase};</li>
+   *   <li> replace usage of {@code BenchmarkService} with {@code BenchmarkServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractBenchmarkService} with {@link BenchmarkServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(BenchmarkServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code BenchmarkServiceBlockingClient} with {@link BenchmarkServiceBlockingStub};</li>
+   *   <li> replace {@code BenchmarkServiceFutureClient} with {@link BenchmarkServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class BenchmarkServiceFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements BenchmarkService} with {@code extends BenchmarkServiceImplBase};</li>
+   *   <li> replace usage of {@code BenchmarkService} with {@code BenchmarkServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractBenchmarkService} with {@link BenchmarkServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(BenchmarkServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code BenchmarkServiceBlockingClient} with {@link BenchmarkServiceBlockingStub};</li>
+   *   <li> replace {@code BenchmarkServiceFutureClient} with {@link BenchmarkServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -89,7 +89,7 @@ public class WorkerServiceGrpc {
 
   /**
    */
-  public static interface WorkerService {
+  public static abstract class WorkerServiceImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
@@ -102,7 +102,9 @@ public class WorkerServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerArgs> runServer(
-        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerStatus> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerStatus> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_RUN_SERVER, responseObserver);
+    }
 
     /**
      * <pre>
@@ -115,99 +117,67 @@ public class WorkerServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientArgs> runClient(
-        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientStatus> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientStatus> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_RUN_CLIENT, responseObserver);
+    }
 
     /**
      * <pre>
      * Just return the core count - unary call
      * </pre>
      */
-    public void coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.CoreResponse> responseObserver);
-
-    /**
-     * <pre>
-     * Quit this worker
-     * </pre>
-     */
-    public void quitWorker(io.grpc.benchmarks.proto.Control.Void request,
-        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractWorkerService implements WorkerService, io.grpc.BindableService {
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerArgs> runServer(
-        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerStatus> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_RUN_SERVER, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientArgs> runClient(
-        io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientStatus> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_RUN_CLIENT, responseObserver);
-    }
-
-    @java.lang.Override
     public void coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.CoreResponse> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_CORE_COUNT, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Quit this worker
+     * </pre>
+     */
     public void quitWorker(io.grpc.benchmarks.proto.Control.Void request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_QUIT_WORKER, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return WorkerServiceGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_RUN_SERVER,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.benchmarks.proto.Control.ServerArgs,
+                io.grpc.benchmarks.proto.Control.ServerStatus>(
+                  this, METHODID_RUN_SERVER)))
+          .addMethod(
+            METHOD_RUN_CLIENT,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.benchmarks.proto.Control.ClientArgs,
+                io.grpc.benchmarks.proto.Control.ClientStatus>(
+                  this, METHODID_RUN_CLIENT)))
+          .addMethod(
+            METHOD_CORE_COUNT,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.benchmarks.proto.Control.CoreRequest,
+                io.grpc.benchmarks.proto.Control.CoreResponse>(
+                  this, METHODID_CORE_COUNT)))
+          .addMethod(
+            METHOD_QUIT_WORKER,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.benchmarks.proto.Control.Void,
+                io.grpc.benchmarks.proto.Control.Void>(
+                  this, METHODID_QUIT_WORKER)))
+          .build();
     }
   }
 
   /**
    */
-  public static interface WorkerServiceBlockingClient {
-
-    /**
-     * <pre>
-     * Just return the core count - unary call
-     * </pre>
-     */
-    public io.grpc.benchmarks.proto.Control.CoreResponse coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request);
-
-    /**
-     * <pre>
-     * Quit this worker
-     * </pre>
-     */
-    public io.grpc.benchmarks.proto.Control.Void quitWorker(io.grpc.benchmarks.proto.Control.Void request);
-  }
-
-  /**
-   */
-  public static interface WorkerServiceFutureClient {
-
-    /**
-     * <pre>
-     * Just return the core count - unary call
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.CoreResponse> coreCount(
-        io.grpc.benchmarks.proto.Control.CoreRequest request);
-
-    /**
-     * <pre>
-     * Quit this worker
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.Void> quitWorker(
-        io.grpc.benchmarks.proto.Control.Void request);
-  }
-
-  public static class WorkerServiceStub extends io.grpc.stub.AbstractStub<WorkerServiceStub>
-      implements WorkerService {
+  public static final class WorkerServiceStub extends io.grpc.stub.AbstractStub<WorkerServiceStub> {
     private WorkerServiceStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -223,28 +193,54 @@ public class WorkerServiceGrpc {
       return new WorkerServiceStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Start server with specified workload.
+     * First request sent specifies the ServerConfig followed by ServerStatus
+     * response. After that, a "Mark" can be sent anytime to request the latest
+     * stats. Closing the stream will initiate shutdown of the test server
+     * and once the shutdown has finished, the OK status is sent to terminate
+     * this RPC.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerArgs> runServer(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerStatus> responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(METHOD_RUN_SERVER, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Start client with specified workload.
+     * First request sent specifies the ClientConfig followed by ClientStatus
+     * response. After that, a "Mark" can be sent anytime to request the latest
+     * stats. Closing the stream will initiate shutdown of the test client
+     * and once the shutdown has finished, the OK status is sent to terminate
+     * this RPC.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientArgs> runClient(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientStatus> responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(METHOD_RUN_CLIENT, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Just return the core count - unary call
+     * </pre>
+     */
     public void coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.CoreResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_CORE_COUNT, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Quit this worker
+     * </pre>
+     */
     public void quitWorker(io.grpc.benchmarks.proto.Control.Void request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
       asyncUnaryCall(
@@ -252,8 +248,9 @@ public class WorkerServiceGrpc {
     }
   }
 
-  public static class WorkerServiceBlockingStub extends io.grpc.stub.AbstractStub<WorkerServiceBlockingStub>
-      implements WorkerServiceBlockingClient {
+  /**
+   */
+  public static final class WorkerServiceBlockingStub extends io.grpc.stub.AbstractStub<WorkerServiceBlockingStub> {
     private WorkerServiceBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -269,21 +266,30 @@ public class WorkerServiceGrpc {
       return new WorkerServiceBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Just return the core count - unary call
+     * </pre>
+     */
     public io.grpc.benchmarks.proto.Control.CoreResponse coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_CORE_COUNT, getCallOptions(), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Quit this worker
+     * </pre>
+     */
     public io.grpc.benchmarks.proto.Control.Void quitWorker(io.grpc.benchmarks.proto.Control.Void request) {
       return blockingUnaryCall(
           getChannel(), METHOD_QUIT_WORKER, getCallOptions(), request);
     }
   }
 
-  public static class WorkerServiceFutureStub extends io.grpc.stub.AbstractStub<WorkerServiceFutureStub>
-      implements WorkerServiceFutureClient {
+  /**
+   */
+  public static final class WorkerServiceFutureStub extends io.grpc.stub.AbstractStub<WorkerServiceFutureStub> {
     private WorkerServiceFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -299,14 +305,22 @@ public class WorkerServiceGrpc {
       return new WorkerServiceFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Just return the core count - unary call
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.CoreResponse> coreCount(
         io.grpc.benchmarks.proto.Control.CoreRequest request) {
       return futureUnaryCall(
           getChannel().newCall(METHOD_CORE_COUNT, getCallOptions()), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Quit this worker
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.Void> quitWorker(
         io.grpc.benchmarks.proto.Control.Void request) {
       return futureUnaryCall(
@@ -324,10 +338,10 @@ public class WorkerServiceGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final WorkerService serviceImpl;
+    private final WorkerServiceImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(WorkerService serviceImpl, int methodId) {
+    public MethodHandlers(WorkerServiceImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -374,37 +388,76 @@ public class WorkerServiceGrpc {
         METHOD_QUIT_WORKER);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final WorkerService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_RUN_SERVER,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.benchmarks.proto.Control.ServerArgs,
-              io.grpc.benchmarks.proto.Control.ServerStatus>(
-                serviceImpl, METHODID_RUN_SERVER)))
-        .addMethod(
-          METHOD_RUN_CLIENT,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.benchmarks.proto.Control.ClientArgs,
-              io.grpc.benchmarks.proto.Control.ClientStatus>(
-                serviceImpl, METHODID_RUN_CLIENT)))
-        .addMethod(
-          METHOD_CORE_COUNT,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.benchmarks.proto.Control.CoreRequest,
-              io.grpc.benchmarks.proto.Control.CoreResponse>(
-                serviceImpl, METHODID_CORE_COUNT)))
-        .addMethod(
-          METHOD_QUIT_WORKER,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.benchmarks.proto.Control.Void,
-              io.grpc.benchmarks.proto.Control.Void>(
-                serviceImpl, METHODID_QUIT_WORKER)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements WorkerService} with {@code extends WorkerServiceImplBase};</li>
+   *   <li> replace usage of {@code WorkerService} with {@code WorkerServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractWorkerService} with {@link WorkerServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(WorkerServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code WorkerServiceBlockingClient} with {@link WorkerServiceBlockingStub};</li>
+   *   <li> replace {@code WorkerServiceFutureClient} with {@link WorkerServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class WorkerService {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements WorkerService} with {@code extends WorkerServiceImplBase};</li>
+   *   <li> replace usage of {@code WorkerService} with {@code WorkerServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractWorkerService} with {@link WorkerServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(WorkerServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code WorkerServiceBlockingClient} with {@link WorkerServiceBlockingStub};</li>
+   *   <li> replace {@code WorkerServiceFutureClient} with {@link WorkerServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class WorkerServiceBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements WorkerService} with {@code extends WorkerServiceImplBase};</li>
+   *   <li> replace usage of {@code WorkerService} with {@code WorkerServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractWorkerService} with {@link WorkerServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(WorkerServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code WorkerServiceBlockingClient} with {@link WorkerServiceBlockingStub};</li>
+   *   <li> replace {@code WorkerServiceFutureClient} with {@link WorkerServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class WorkerServiceFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements WorkerService} with {@code extends WorkerServiceImplBase};</li>
+   *   <li> replace usage of {@code WorkerService} with {@code WorkerServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractWorkerService} with {@link WorkerServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(WorkerServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code WorkerServiceBlockingClient} with {@link WorkerServiceBlockingStub};</li>
+   *   <li> replace {@code WorkerServiceFutureClient} with {@link WorkerServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -163,7 +163,7 @@ public class TransportBenchmark {
     }
 
     server = serverBuilder
-        .addService(BenchmarkServiceGrpc.bindService(new AsyncServer.BenchmarkServiceImpl()))
+        .addService(new AsyncServer.BenchmarkServiceImpl())
         .build();
     server.start();
     channel = channelBuilder.build();

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
@@ -147,7 +147,7 @@ final class LoadServer {
               .addMethod(GENERIC_STREAMING_PING_PONG_METHOD, new GenericServiceCallHandler())
               .build());
     } else {
-      serverBuilder.addService(BenchmarkServiceGrpc.bindService(benchmarkService));
+      serverBuilder.addService(benchmarkService);
     }
     server = serverBuilder.build();
 
@@ -196,7 +196,7 @@ final class LoadServer {
     server.shutdownNow();
   }
 
-  private class BenchmarkServiceImpl implements BenchmarkServiceGrpc.BenchmarkService {
+  private class BenchmarkServiceImpl extends BenchmarkServiceGrpc.BenchmarkServiceImplBase {
 
     @Override
     public void unaryCall(Messages.SimpleRequest request,

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
@@ -69,7 +69,7 @@ public class LoadWorker {
         .directExecutor()
         .workerEventLoopGroup(singleThreadGroup)
         .bossEventLoopGroup(singleThreadGroup)
-        .addService(WorkerServiceGrpc.bindService(new WorkerServiceImpl()))
+        .addService(new WorkerServiceImpl())
         .build();
   }
 
@@ -134,7 +134,7 @@ public class LoadWorker {
   /**
    * Implement the worker service contract which can launch clients and servers.
    */
-  private class WorkerServiceImpl implements WorkerServiceGrpc.WorkerService {
+  private class WorkerServiceImpl extends WorkerServiceGrpc.WorkerServiceImplBase {
 
     private LoadServer workerServer;
     private LoadClient workerClient;

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -167,7 +167,7 @@ public class AsyncServer {
         .bossEventLoopGroup(boss)
         .workerEventLoopGroup(worker)
         .channelType(channelType)
-        .addService(BenchmarkServiceGrpc.bindService(new BenchmarkServiceImpl()))
+        .addService(new BenchmarkServiceImpl())
         .sslContext(sslContext)
         .flowControlWindow(config.flowControlWindow);
     if (config.directExecutor) {
@@ -177,7 +177,7 @@ public class AsyncServer {
     return builder.build();
   }
 
-  public static class BenchmarkServiceImpl implements BenchmarkServiceGrpc.BenchmarkService {
+  public static class BenchmarkServiceImpl extends BenchmarkServiceGrpc.BenchmarkServiceImplBase {
 
     @Override
     public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -104,7 +104,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestService {
+  public static abstract class TestServiceImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
@@ -113,7 +113,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -122,7 +124,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -131,7 +135,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -141,7 +147,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_FULL_BIDI_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -152,44 +160,48 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractTestService implements TestService, io.grpc.BindableService {
-
-    @java.lang.Override
-    public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_FULL_BIDI_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncUnimplementedStreamingCall(METHOD_HALF_BIDI_CALL, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return TestServiceGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_UNARY_CALL,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.SimpleRequest,
+                io.grpc.testing.integration.Test.SimpleResponse>(
+                  this, METHODID_UNARY_CALL)))
+          .addMethod(
+            METHOD_STREAMING_OUTPUT_CALL,
+            asyncServerStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
+                  this, METHODID_STREAMING_OUTPUT_CALL)))
+          .addMethod(
+            METHOD_STREAMING_INPUT_CALL,
+            asyncClientStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingInputCallRequest,
+                io.grpc.testing.integration.Test.StreamingInputCallResponse>(
+                  this, METHODID_STREAMING_INPUT_CALL)))
+          .addMethod(
+            METHOD_FULL_BIDI_CALL,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
+                  this, METHODID_FULL_BIDI_CALL)))
+          .addMethod(
+            METHOD_HALF_BIDI_CALL,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
+                  this, METHODID_HALF_BIDI_CALL)))
+          .build();
     }
   }
 
@@ -198,45 +210,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestServiceBlockingClient {
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * The server returns the client payload as-is.
-     * </pre>
-     */
-    public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request);
-
-    /**
-     * <pre>
-     * One request followed by a sequence of responses (streamed download).
-     * The server returns the payload with client desired type and sizes.
-     * </pre>
-     */
-    public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
-        io.grpc.testing.integration.Test.StreamingOutputCallRequest request);
-  }
-
-  /**
-   * <pre>
-   * Test service that supports all call types.
-   * </pre>
-   */
-  public static interface TestServiceFutureClient {
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * The server returns the client payload as-is.
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
-        io.grpc.testing.integration.Test.SimpleRequest request);
-  }
-
-  public static class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub>
-      implements TestService {
+  public static final class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub> {
     private TestServiceStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -252,35 +226,63 @@ public class TestServiceGrpc {
       return new TestServiceStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by a sequence of responses (streamed download).
+     * The server returns the payload with client desired type and sizes.
+     * </pre>
+     */
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
           getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests followed by one response (streamed upload).
+     * The server returns the aggregated size of client payload as the result.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
           getChannel().newCall(METHOD_STREAMING_INPUT_CALL, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests with each request served by the server immediately.
+     * As one request could lead to multiple responses, this interface
+     * demonstrates the idea of full bidirectionality.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(METHOD_FULL_BIDI_CALL, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests followed by a sequence of responses.
+     * The server buffers all the client requests and then serves them in order. A
+     * stream of responses are returned to the client when the server starts with
+     * first request.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
@@ -288,8 +290,12 @@ public class TestServiceGrpc {
     }
   }
 
-  public static class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub>
-      implements TestServiceBlockingClient {
+  /**
+   * <pre>
+   * Test service that supports all call types.
+   * </pre>
+   */
+  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub> {
     private TestServiceBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -305,13 +311,23 @@ public class TestServiceGrpc {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by a sequence of responses (streamed download).
+     * The server returns the payload with client desired type and sizes.
+     * </pre>
+     */
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
@@ -319,8 +335,12 @@ public class TestServiceGrpc {
     }
   }
 
-  public static class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub>
-      implements TestServiceFutureClient {
+  /**
+   * <pre>
+   * Test service that supports all call types.
+   * </pre>
+   */
+  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub> {
     private TestServiceFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -336,7 +356,12 @@ public class TestServiceGrpc {
       return new TestServiceFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return futureUnaryCall(
@@ -355,10 +380,10 @@ public class TestServiceGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final TestService serviceImpl;
+    private final TestServiceImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(TestService serviceImpl, int methodId) {
+    public MethodHandlers(TestServiceImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -409,44 +434,76 @@ public class TestServiceGrpc {
         METHOD_HALF_BIDI_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final TestService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_UNARY_CALL,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.SimpleRequest,
-              io.grpc.testing.integration.Test.SimpleResponse>(
-                serviceImpl, METHODID_UNARY_CALL)))
-        .addMethod(
-          METHOD_STREAMING_OUTPUT_CALL,
-          asyncServerStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_STREAMING_OUTPUT_CALL)))
-        .addMethod(
-          METHOD_STREAMING_INPUT_CALL,
-          asyncClientStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.StreamingInputCallRequest,
-              io.grpc.testing.integration.Test.StreamingInputCallResponse>(
-                serviceImpl, METHODID_STREAMING_INPUT_CALL)))
-        .addMethod(
-          METHOD_FULL_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_FULL_BIDI_CALL)))
-        .addMethod(
-          METHOD_HALF_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_HALF_BIDI_CALL)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestService {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestServiceBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestServiceFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -104,7 +104,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestService {
+  public static abstract class TestServiceImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
@@ -113,7 +113,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -122,7 +124,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -131,7 +135,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -141,7 +147,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_FULL_BIDI_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -152,44 +160,48 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractTestService implements TestService, io.grpc.BindableService {
-
-    @java.lang.Override
-    public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_FULL_BIDI_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncUnimplementedStreamingCall(METHOD_HALF_BIDI_CALL, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return TestServiceGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_UNARY_CALL,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.SimpleRequest,
+                io.grpc.testing.integration.Test.SimpleResponse>(
+                  this, METHODID_UNARY_CALL)))
+          .addMethod(
+            METHOD_STREAMING_OUTPUT_CALL,
+            asyncServerStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
+                  this, METHODID_STREAMING_OUTPUT_CALL)))
+          .addMethod(
+            METHOD_STREAMING_INPUT_CALL,
+            asyncClientStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingInputCallRequest,
+                io.grpc.testing.integration.Test.StreamingInputCallResponse>(
+                  this, METHODID_STREAMING_INPUT_CALL)))
+          .addMethod(
+            METHOD_FULL_BIDI_CALL,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
+                  this, METHODID_FULL_BIDI_CALL)))
+          .addMethod(
+            METHOD_HALF_BIDI_CALL,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
+                  this, METHODID_HALF_BIDI_CALL)))
+          .build();
     }
   }
 
@@ -198,45 +210,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestServiceBlockingClient {
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * The server returns the client payload as-is.
-     * </pre>
-     */
-    public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request);
-
-    /**
-     * <pre>
-     * One request followed by a sequence of responses (streamed download).
-     * The server returns the payload with client desired type and sizes.
-     * </pre>
-     */
-    public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
-        io.grpc.testing.integration.Test.StreamingOutputCallRequest request);
-  }
-
-  /**
-   * <pre>
-   * Test service that supports all call types.
-   * </pre>
-   */
-  public static interface TestServiceFutureClient {
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * The server returns the client payload as-is.
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
-        io.grpc.testing.integration.Test.SimpleRequest request);
-  }
-
-  public static class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub>
-      implements TestService {
+  public static final class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub> {
     private TestServiceStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -252,35 +226,63 @@ public class TestServiceGrpc {
       return new TestServiceStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by a sequence of responses (streamed download).
+     * The server returns the payload with client desired type and sizes.
+     * </pre>
+     */
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
           getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests followed by one response (streamed upload).
+     * The server returns the aggregated size of client payload as the result.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
           getChannel().newCall(METHOD_STREAMING_INPUT_CALL, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests with each request served by the server immediately.
+     * As one request could lead to multiple responses, this interface
+     * demonstrates the idea of full bidirectionality.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(METHOD_FULL_BIDI_CALL, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests followed by a sequence of responses.
+     * The server buffers all the client requests and then serves them in order. A
+     * stream of responses are returned to the client when the server starts with
+     * first request.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
@@ -288,8 +290,12 @@ public class TestServiceGrpc {
     }
   }
 
-  public static class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub>
-      implements TestServiceBlockingClient {
+  /**
+   * <pre>
+   * Test service that supports all call types.
+   * </pre>
+   */
+  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub> {
     private TestServiceBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -305,13 +311,23 @@ public class TestServiceGrpc {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by a sequence of responses (streamed download).
+     * The server returns the payload with client desired type and sizes.
+     * </pre>
+     */
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
@@ -319,8 +335,12 @@ public class TestServiceGrpc {
     }
   }
 
-  public static class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub>
-      implements TestServiceFutureClient {
+  /**
+   * <pre>
+   * Test service that supports all call types.
+   * </pre>
+   */
+  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub> {
     private TestServiceFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -336,7 +356,12 @@ public class TestServiceGrpc {
       return new TestServiceFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return futureUnaryCall(
@@ -355,10 +380,10 @@ public class TestServiceGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final TestService serviceImpl;
+    private final TestServiceImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(TestService serviceImpl, int methodId) {
+    public MethodHandlers(TestServiceImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -409,44 +434,76 @@ public class TestServiceGrpc {
         METHOD_HALF_BIDI_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final TestService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_UNARY_CALL,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.SimpleRequest,
-              io.grpc.testing.integration.Test.SimpleResponse>(
-                serviceImpl, METHODID_UNARY_CALL)))
-        .addMethod(
-          METHOD_STREAMING_OUTPUT_CALL,
-          asyncServerStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_STREAMING_OUTPUT_CALL)))
-        .addMethod(
-          METHOD_STREAMING_INPUT_CALL,
-          asyncClientStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.StreamingInputCallRequest,
-              io.grpc.testing.integration.Test.StreamingInputCallResponse>(
-                serviceImpl, METHODID_STREAMING_INPUT_CALL)))
-        .addMethod(
-          METHOD_FULL_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_FULL_BIDI_CALL)))
-        .addMethod(
-          METHOD_HALF_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_HALF_BIDI_CALL)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestService {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestServiceBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestServiceFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -182,7 +182,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestService {
+  public static abstract class TestServiceImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
@@ -191,7 +191,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public void unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -200,7 +202,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public void streamingOutputCall(io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -209,7 +213,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> streamingInputCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -219,7 +225,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> fullBidiCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_FULL_BIDI_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -230,44 +238,48 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> halfBidiCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractTestService implements TestService, io.grpc.BindableService {
-
-    @java.lang.Override
-    public void unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public void streamingOutputCall(io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> streamingInputCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> fullBidiCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_FULL_BIDI_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncUnimplementedStreamingCall(METHOD_HALF_BIDI_CALL, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return TestServiceGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_UNARY_CALL,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.nano.Test.SimpleRequest,
+                io.grpc.testing.integration.nano.Test.SimpleResponse>(
+                  this, METHODID_UNARY_CALL)))
+          .addMethod(
+            METHOD_STREAMING_OUTPUT_CALL,
+            asyncServerStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+                io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(
+                  this, METHODID_STREAMING_OUTPUT_CALL)))
+          .addMethod(
+            METHOD_STREAMING_INPUT_CALL,
+            asyncClientStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+                io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>(
+                  this, METHODID_STREAMING_INPUT_CALL)))
+          .addMethod(
+            METHOD_FULL_BIDI_CALL,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+                io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(
+                  this, METHODID_FULL_BIDI_CALL)))
+          .addMethod(
+            METHOD_HALF_BIDI_CALL,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+                io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(
+                  this, METHODID_HALF_BIDI_CALL)))
+          .build();
     }
   }
 
@@ -276,45 +288,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestServiceBlockingClient {
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * The server returns the client payload as-is.
-     * </pre>
-     */
-    public io.grpc.testing.integration.nano.Test.SimpleResponse unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request);
-
-    /**
-     * <pre>
-     * One request followed by a sequence of responses (streamed download).
-     * The server returns the payload with client desired type and sizes.
-     * </pre>
-     */
-    public java.util.Iterator<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> streamingOutputCall(
-        io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request);
-  }
-
-  /**
-   * <pre>
-   * Test service that supports all call types.
-   * </pre>
-   */
-  public static interface TestServiceFutureClient {
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * The server returns the client payload as-is.
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.nano.Test.SimpleResponse> unaryCall(
-        io.grpc.testing.integration.nano.Test.SimpleRequest request);
-  }
-
-  public static class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub>
-      implements TestService {
+  public static final class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub> {
     private TestServiceStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -330,35 +304,63 @@ public class TestServiceGrpc {
       return new TestServiceStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public void unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by a sequence of responses (streamed download).
+     * The server returns the payload with client desired type and sizes.
+     * </pre>
+     */
     public void streamingOutputCall(io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
           getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests followed by one response (streamed upload).
+     * The server returns the aggregated size of client payload as the result.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
           getChannel().newCall(METHOD_STREAMING_INPUT_CALL, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests with each request served by the server immediately.
+     * As one request could lead to multiple responses, this interface
+     * demonstrates the idea of full bidirectionality.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(METHOD_FULL_BIDI_CALL, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests followed by a sequence of responses.
+     * The server buffers all the client requests and then serves them in order. A
+     * stream of responses are returned to the client when the server starts with
+     * first request.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
@@ -366,8 +368,12 @@ public class TestServiceGrpc {
     }
   }
 
-  public static class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub>
-      implements TestServiceBlockingClient {
+  /**
+   * <pre>
+   * Test service that supports all call types.
+   * </pre>
+   */
+  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub> {
     private TestServiceBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -383,13 +389,23 @@ public class TestServiceGrpc {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public io.grpc.testing.integration.nano.Test.SimpleResponse unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by a sequence of responses (streamed download).
+     * The server returns the payload with client desired type and sizes.
+     * </pre>
+     */
     public java.util.Iterator<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
@@ -397,8 +413,12 @@ public class TestServiceGrpc {
     }
   }
 
-  public static class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub>
-      implements TestServiceFutureClient {
+  /**
+   * <pre>
+   * Test service that supports all call types.
+   * </pre>
+   */
+  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub> {
     private TestServiceFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -414,7 +434,12 @@ public class TestServiceGrpc {
       return new TestServiceFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * The server returns the client payload as-is.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.nano.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.nano.Test.SimpleRequest request) {
       return futureUnaryCall(
@@ -433,10 +458,10 @@ public class TestServiceGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final TestService serviceImpl;
+    private final TestServiceImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(TestService serviceImpl, int methodId) {
+    public MethodHandlers(TestServiceImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -487,44 +512,76 @@ public class TestServiceGrpc {
         METHOD_HALF_BIDI_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final TestService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_UNARY_CALL,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.nano.Test.SimpleRequest,
-              io.grpc.testing.integration.nano.Test.SimpleResponse>(
-                serviceImpl, METHODID_UNARY_CALL)))
-        .addMethod(
-          METHOD_STREAMING_OUTPUT_CALL,
-          asyncServerStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-              io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_STREAMING_OUTPUT_CALL)))
-        .addMethod(
-          METHOD_STREAMING_INPUT_CALL,
-          asyncClientStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
-              io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>(
-                serviceImpl, METHODID_STREAMING_INPUT_CALL)))
-        .addMethod(
-          METHOD_FULL_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-              io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_FULL_BIDI_CALL)))
-        .addMethod(
-          METHOD_HALF_BIDI_CALL,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-              io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_HALF_BIDI_CALL)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestService {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestServiceBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestServiceFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -68,28 +68,28 @@ public class GreeterGrpc {
    * The greeting service definition.
    * </pre>
    */
-  public static interface Greeter {
+  public static abstract class GreeterImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
      * Sends a greeting
      * </pre>
      */
-    public void sayHello(io.grpc.examples.helloworld.HelloRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.examples.helloworld.HelloReply> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractGreeter implements Greeter, io.grpc.BindableService {
-
-    @java.lang.Override
     public void sayHello(io.grpc.examples.helloworld.HelloRequest request,
         io.grpc.stub.StreamObserver<io.grpc.examples.helloworld.HelloReply> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_SAY_HELLO, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return GreeterGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_SAY_HELLO,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.examples.helloworld.HelloRequest,
+                io.grpc.examples.helloworld.HelloReply>(
+                  this, METHODID_SAY_HELLO)))
+          .build();
     }
   }
 
@@ -98,34 +98,7 @@ public class GreeterGrpc {
    * The greeting service definition.
    * </pre>
    */
-  public static interface GreeterBlockingClient {
-
-    /**
-     * <pre>
-     * Sends a greeting
-     * </pre>
-     */
-    public io.grpc.examples.helloworld.HelloReply sayHello(io.grpc.examples.helloworld.HelloRequest request);
-  }
-
-  /**
-   * <pre>
-   * The greeting service definition.
-   * </pre>
-   */
-  public static interface GreeterFutureClient {
-
-    /**
-     * <pre>
-     * Sends a greeting
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.helloworld.HelloReply> sayHello(
-        io.grpc.examples.helloworld.HelloRequest request);
-  }
-
-  public static class GreeterStub extends io.grpc.stub.AbstractStub<GreeterStub>
-      implements Greeter {
+  public static final class GreeterStub extends io.grpc.stub.AbstractStub<GreeterStub> {
     private GreeterStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -141,7 +114,11 @@ public class GreeterGrpc {
       return new GreeterStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Sends a greeting
+     * </pre>
+     */
     public void sayHello(io.grpc.examples.helloworld.HelloRequest request,
         io.grpc.stub.StreamObserver<io.grpc.examples.helloworld.HelloReply> responseObserver) {
       asyncUnaryCall(
@@ -149,8 +126,12 @@ public class GreeterGrpc {
     }
   }
 
-  public static class GreeterBlockingStub extends io.grpc.stub.AbstractStub<GreeterBlockingStub>
-      implements GreeterBlockingClient {
+  /**
+   * <pre>
+   * The greeting service definition.
+   * </pre>
+   */
+  public static final class GreeterBlockingStub extends io.grpc.stub.AbstractStub<GreeterBlockingStub> {
     private GreeterBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -166,15 +147,23 @@ public class GreeterGrpc {
       return new GreeterBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Sends a greeting
+     * </pre>
+     */
     public io.grpc.examples.helloworld.HelloReply sayHello(io.grpc.examples.helloworld.HelloRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_SAY_HELLO, getCallOptions(), request);
     }
   }
 
-  public static class GreeterFutureStub extends io.grpc.stub.AbstractStub<GreeterFutureStub>
-      implements GreeterFutureClient {
+  /**
+   * <pre>
+   * The greeting service definition.
+   * </pre>
+   */
+  public static final class GreeterFutureStub extends io.grpc.stub.AbstractStub<GreeterFutureStub> {
     private GreeterFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -190,7 +179,11 @@ public class GreeterGrpc {
       return new GreeterFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Sends a greeting
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.helloworld.HelloReply> sayHello(
         io.grpc.examples.helloworld.HelloRequest request) {
       return futureUnaryCall(
@@ -205,10 +198,10 @@ public class GreeterGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final Greeter serviceImpl;
+    private final GreeterImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(Greeter serviceImpl, int methodId) {
+    public MethodHandlers(GreeterImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -242,16 +235,76 @@ public class GreeterGrpc {
         METHOD_SAY_HELLO);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final Greeter serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_SAY_HELLO,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.examples.helloworld.HelloRequest,
-              io.grpc.examples.helloworld.HelloReply>(
-                serviceImpl, METHODID_SAY_HELLO)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements Greeter} with {@code extends GreeterImplBase};</li>
+   *   <li> replace usage of {@code Greeter} with {@code GreeterImplBase};</li>
+   *   <li> replace usage of {@code AbstractGreeter} with {@link GreeterImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(GreeterGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code GreeterBlockingClient} with {@link GreeterBlockingStub};</li>
+   *   <li> replace {@code GreeterFutureClient} with {@link GreeterFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class Greeter {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements Greeter} with {@code extends GreeterImplBase};</li>
+   *   <li> replace usage of {@code Greeter} with {@code GreeterImplBase};</li>
+   *   <li> replace usage of {@code AbstractGreeter} with {@link GreeterImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(GreeterGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code GreeterBlockingClient} with {@link GreeterBlockingStub};</li>
+   *   <li> replace {@code GreeterFutureClient} with {@link GreeterFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class GreeterBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements Greeter} with {@code extends GreeterImplBase};</li>
+   *   <li> replace usage of {@code Greeter} with {@code GreeterImplBase};</li>
+   *   <li> replace usage of {@code AbstractGreeter} with {@link GreeterImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(GreeterGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code GreeterBlockingClient} with {@link GreeterBlockingStub};</li>
+   *   <li> replace {@code GreeterFutureClient} with {@link GreeterFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class GreeterFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements Greeter} with {@code extends GreeterImplBase};</li>
+   *   <li> replace usage of {@code Greeter} with {@code GreeterImplBase};</li>
+   *   <li> replace usage of {@code AbstractGreeter} with {@link GreeterImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(GreeterGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code GreeterBlockingClient} with {@link GreeterBlockingStub};</li>
+   *   <li> replace {@code GreeterFutureClient} with {@link GreeterFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -95,7 +95,7 @@ public class RouteGuideGrpc {
    * Interface exported by the server.
    * </pre>
    */
-  public static interface RouteGuide {
+  public static abstract class RouteGuideImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
@@ -106,7 +106,9 @@ public class RouteGuideGrpc {
      * </pre>
      */
     public void getFeature(io.grpc.examples.routeguide.Point request,
-        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_GET_FEATURE, responseObserver);
+    }
 
     /**
      * <pre>
@@ -118,7 +120,9 @@ public class RouteGuideGrpc {
      * </pre>
      */
     public void listFeatures(io.grpc.examples.routeguide.Rectangle request,
-        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_LIST_FEATURES, responseObserver);
+    }
 
     /**
      * <pre>
@@ -128,7 +132,9 @@ public class RouteGuideGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Point> recordRoute(
-        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteSummary> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteSummary> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_RECORD_ROUTE, responseObserver);
+    }
 
     /**
      * <pre>
@@ -138,38 +144,41 @@ public class RouteGuideGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> routeChat(
-        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractRouteGuide implements RouteGuide, io.grpc.BindableService {
-
-    @java.lang.Override
-    public void getFeature(io.grpc.examples.routeguide.Point request,
-        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_GET_FEATURE, responseObserver);
-    }
-
-    @java.lang.Override
-    public void listFeatures(io.grpc.examples.routeguide.Rectangle request,
-        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_LIST_FEATURES, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Point> recordRoute(
-        io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteSummary> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_RECORD_ROUTE, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> routeChat(
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> responseObserver) {
       return asyncUnimplementedStreamingCall(METHOD_ROUTE_CHAT, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return RouteGuideGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_GET_FEATURE,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.examples.routeguide.Point,
+                io.grpc.examples.routeguide.Feature>(
+                  this, METHODID_GET_FEATURE)))
+          .addMethod(
+            METHOD_LIST_FEATURES,
+            asyncServerStreamingCall(
+              new MethodHandlers<
+                io.grpc.examples.routeguide.Rectangle,
+                io.grpc.examples.routeguide.Feature>(
+                  this, METHODID_LIST_FEATURES)))
+          .addMethod(
+            METHOD_RECORD_ROUTE,
+            asyncClientStreamingCall(
+              new MethodHandlers<
+                io.grpc.examples.routeguide.Point,
+                io.grpc.examples.routeguide.RouteSummary>(
+                  this, METHODID_RECORD_ROUTE)))
+          .addMethod(
+            METHOD_ROUTE_CHAT,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.examples.routeguide.RouteNote,
+                io.grpc.examples.routeguide.RouteNote>(
+                  this, METHODID_ROUTE_CHAT)))
+          .build();
     }
   }
 
@@ -178,52 +187,7 @@ public class RouteGuideGrpc {
    * Interface exported by the server.
    * </pre>
    */
-  public static interface RouteGuideBlockingClient {
-
-    /**
-     * <pre>
-     * A simple RPC.
-     * Obtains the feature at a given position.
-     * A feature with an empty name is returned if there's no feature at the given
-     * position.
-     * </pre>
-     */
-    public io.grpc.examples.routeguide.Feature getFeature(io.grpc.examples.routeguide.Point request);
-
-    /**
-     * <pre>
-     * A server-to-client streaming RPC.
-     * Obtains the Features available within the given Rectangle.  Results are
-     * streamed rather than returned at once (e.g. in a response message with a
-     * repeated field), as the rectangle may cover a large area and contain a
-     * huge number of features.
-     * </pre>
-     */
-    public java.util.Iterator<io.grpc.examples.routeguide.Feature> listFeatures(
-        io.grpc.examples.routeguide.Rectangle request);
-  }
-
-  /**
-   * <pre>
-   * Interface exported by the server.
-   * </pre>
-   */
-  public static interface RouteGuideFutureClient {
-
-    /**
-     * <pre>
-     * A simple RPC.
-     * Obtains the feature at a given position.
-     * A feature with an empty name is returned if there's no feature at the given
-     * position.
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.routeguide.Feature> getFeature(
-        io.grpc.examples.routeguide.Point request);
-  }
-
-  public static class RouteGuideStub extends io.grpc.stub.AbstractStub<RouteGuideStub>
-      implements RouteGuide {
+  public static final class RouteGuideStub extends io.grpc.stub.AbstractStub<RouteGuideStub> {
     private RouteGuideStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -239,28 +203,55 @@ public class RouteGuideGrpc {
       return new RouteGuideStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A simple RPC.
+     * Obtains the feature at a given position.
+     * A feature with an empty name is returned if there's no feature at the given
+     * position.
+     * </pre>
+     */
     public void getFeature(io.grpc.examples.routeguide.Point request,
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_GET_FEATURE, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A server-to-client streaming RPC.
+     * Obtains the Features available within the given Rectangle.  Results are
+     * streamed rather than returned at once (e.g. in a response message with a
+     * repeated field), as the rectangle may cover a large area and contain a
+     * huge number of features.
+     * </pre>
+     */
     public void listFeatures(io.grpc.examples.routeguide.Rectangle request,
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Feature> responseObserver) {
       asyncServerStreamingCall(
           getChannel().newCall(METHOD_LIST_FEATURES, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A client-to-server streaming RPC.
+     * Accepts a stream of Points on a route being traversed, returning a
+     * RouteSummary when traversal is completed.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.Point> recordRoute(
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteSummary> responseObserver) {
       return asyncClientStreamingCall(
           getChannel().newCall(METHOD_RECORD_ROUTE, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A Bidirectional streaming RPC.
+     * Accepts a stream of RouteNotes sent while a route is being traversed,
+     * while receiving other RouteNotes (e.g. from other users).
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> routeChat(
         io.grpc.stub.StreamObserver<io.grpc.examples.routeguide.RouteNote> responseObserver) {
       return asyncBidiStreamingCall(
@@ -268,8 +259,12 @@ public class RouteGuideGrpc {
     }
   }
 
-  public static class RouteGuideBlockingStub extends io.grpc.stub.AbstractStub<RouteGuideBlockingStub>
-      implements RouteGuideBlockingClient {
+  /**
+   * <pre>
+   * Interface exported by the server.
+   * </pre>
+   */
+  public static final class RouteGuideBlockingStub extends io.grpc.stub.AbstractStub<RouteGuideBlockingStub> {
     private RouteGuideBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -285,13 +280,28 @@ public class RouteGuideGrpc {
       return new RouteGuideBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A simple RPC.
+     * Obtains the feature at a given position.
+     * A feature with an empty name is returned if there's no feature at the given
+     * position.
+     * </pre>
+     */
     public io.grpc.examples.routeguide.Feature getFeature(io.grpc.examples.routeguide.Point request) {
       return blockingUnaryCall(
           getChannel(), METHOD_GET_FEATURE, getCallOptions(), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A server-to-client streaming RPC.
+     * Obtains the Features available within the given Rectangle.  Results are
+     * streamed rather than returned at once (e.g. in a response message with a
+     * repeated field), as the rectangle may cover a large area and contain a
+     * huge number of features.
+     * </pre>
+     */
     public java.util.Iterator<io.grpc.examples.routeguide.Feature> listFeatures(
         io.grpc.examples.routeguide.Rectangle request) {
       return blockingServerStreamingCall(
@@ -299,8 +309,12 @@ public class RouteGuideGrpc {
     }
   }
 
-  public static class RouteGuideFutureStub extends io.grpc.stub.AbstractStub<RouteGuideFutureStub>
-      implements RouteGuideFutureClient {
+  /**
+   * <pre>
+   * Interface exported by the server.
+   * </pre>
+   */
+  public static final class RouteGuideFutureStub extends io.grpc.stub.AbstractStub<RouteGuideFutureStub> {
     private RouteGuideFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -316,7 +330,14 @@ public class RouteGuideGrpc {
       return new RouteGuideFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A simple RPC.
+     * Obtains the feature at a given position.
+     * A feature with an empty name is returned if there's no feature at the given
+     * position.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.examples.routeguide.Feature> getFeature(
         io.grpc.examples.routeguide.Point request) {
       return futureUnaryCall(
@@ -334,10 +355,10 @@ public class RouteGuideGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final RouteGuide serviceImpl;
+    private final RouteGuideImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(RouteGuide serviceImpl, int methodId) {
+    public MethodHandlers(RouteGuideImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -384,37 +405,76 @@ public class RouteGuideGrpc {
         METHOD_ROUTE_CHAT);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final RouteGuide serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_GET_FEATURE,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.examples.routeguide.Point,
-              io.grpc.examples.routeguide.Feature>(
-                serviceImpl, METHODID_GET_FEATURE)))
-        .addMethod(
-          METHOD_LIST_FEATURES,
-          asyncServerStreamingCall(
-            new MethodHandlers<
-              io.grpc.examples.routeguide.Rectangle,
-              io.grpc.examples.routeguide.Feature>(
-                serviceImpl, METHODID_LIST_FEATURES)))
-        .addMethod(
-          METHOD_RECORD_ROUTE,
-          asyncClientStreamingCall(
-            new MethodHandlers<
-              io.grpc.examples.routeguide.Point,
-              io.grpc.examples.routeguide.RouteSummary>(
-                serviceImpl, METHODID_RECORD_ROUTE)))
-        .addMethod(
-          METHOD_ROUTE_CHAT,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.examples.routeguide.RouteNote,
-              io.grpc.examples.routeguide.RouteNote>(
-                serviceImpl, METHODID_ROUTE_CHAT)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements RouteGuide} with {@code extends RouteGuideImplBase};</li>
+   *   <li> replace usage of {@code RouteGuide} with {@code RouteGuideImplBase};</li>
+   *   <li> replace usage of {@code AbstractRouteGuide} with {@link RouteGuideImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(RouteGuideGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code RouteGuideBlockingClient} with {@link RouteGuideBlockingStub};</li>
+   *   <li> replace {@code RouteGuideFutureClient} with {@link RouteGuideFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class RouteGuide {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements RouteGuide} with {@code extends RouteGuideImplBase};</li>
+   *   <li> replace usage of {@code RouteGuide} with {@code RouteGuideImplBase};</li>
+   *   <li> replace usage of {@code AbstractRouteGuide} with {@link RouteGuideImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(RouteGuideGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code RouteGuideBlockingClient} with {@link RouteGuideBlockingStub};</li>
+   *   <li> replace {@code RouteGuideFutureClient} with {@link RouteGuideFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class RouteGuideBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements RouteGuide} with {@code extends RouteGuideImplBase};</li>
+   *   <li> replace usage of {@code RouteGuide} with {@code RouteGuideImplBase};</li>
+   *   <li> replace usage of {@code AbstractRouteGuide} with {@link RouteGuideImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(RouteGuideGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code RouteGuideBlockingClient} with {@link RouteGuideBlockingStub};</li>
+   *   <li> replace {@code RouteGuideFutureClient} with {@link RouteGuideFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class RouteGuideFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements RouteGuide} with {@code extends RouteGuideImplBase};</li>
+   *   <li> replace usage of {@code RouteGuide} with {@code RouteGuideImplBase};</li>
+   *   <li> replace usage of {@code AbstractRouteGuide} with {@link RouteGuideImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(RouteGuideGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code RouteGuideBlockingClient} with {@link RouteGuideBlockingStub};</li>
+   *   <li> replace {@code RouteGuideFutureClient} with {@link RouteGuideFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
@@ -94,7 +94,7 @@ public class CustomHeaderServer {
     server.blockUntilShutdown();
   }
 
-  private class GreeterImpl extends GreeterGrpc.AbstractGreeter {
+  private class GreeterImpl extends GreeterGrpc.GreeterImplBase {
 
     @Override
     public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloJsonClient.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloJsonClient.java
@@ -59,7 +59,7 @@ public final class HelloJsonClient {
   private static final Logger logger = Logger.getLogger(HelloWorldClient.class.getName());
 
   private final ManagedChannel channel;
-  private final GreeterGrpc.GreeterBlockingClient blockingStub;
+  private final HelloJsonStub blockingStub;
 
   /** Construct client connecting to HelloWorld server at {@code host:port}. */
   public HelloJsonClient(String host, int port) {
@@ -105,8 +105,7 @@ public final class HelloJsonClient {
     }
   }
 
-  static final class HelloJsonStub extends AbstractStub<HelloJsonStub>
-      implements GreeterGrpc.GreeterBlockingClient {
+  static final class HelloJsonStub extends AbstractStub<HelloJsonStub> {
 
     static final MethodDescriptor<HelloRequest, HelloReply> METHOD_SAY_HELLO =
         MethodDescriptor.create(
@@ -128,7 +127,6 @@ public final class HelloJsonClient {
       return new HelloJsonStub(channel, callOptions);
     }
 
-    @Override
     public HelloReply sayHello(HelloRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_SAY_HELLO, getCallOptions(), request);

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloJsonServer.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloJsonServer.java
@@ -36,7 +36,7 @@ import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerServiceDefinition;
-import io.grpc.examples.helloworld.GreeterGrpc.Greeter;
+import io.grpc.examples.helloworld.GreeterGrpc.GreeterImplBase;
 import io.grpc.stub.ServerCalls.UnaryMethod;
 import io.grpc.stub.StreamObserver;
 
@@ -102,7 +102,7 @@ public class HelloJsonServer {
     server.blockUntilShutdown();
   }
 
-  private class GreeterImpl implements GreeterGrpc.Greeter {
+  private class GreeterImpl extends GreeterImplBase {
 
     @Override
     public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {
@@ -112,7 +112,7 @@ public class HelloJsonServer {
     }
   }
 
-  private ServerServiceDefinition bindService(final Greeter serviceImpl) {
+  private ServerServiceDefinition bindService(final GreeterImplBase serviceImpl) {
     return io.grpc.ServerServiceDefinition
         .builder(GreeterGrpc.getServiceDescriptor())
         .addMethod(HelloJsonClient.HelloJsonStub.METHOD_SAY_HELLO,

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
@@ -89,7 +89,7 @@ public class HelloWorldServer {
     server.blockUntilShutdown();
   }
 
-  private class GreeterImpl extends GreeterGrpc.AbstractGreeter {
+  private class GreeterImpl extends GreeterGrpc.GreeterImplBase {
 
     @Override
     public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -125,7 +125,7 @@ public class RouteGuideServer {
    *
    * <p>See route_guide.proto for details of the methods.
    */
-  private static class RouteGuideService extends RouteGuideGrpc.AbstractRouteGuide {
+  private static class RouteGuideService extends RouteGuideGrpc.RouteGuideImplBase {
     private final Collection<Feature> features;
     private final ConcurrentMap<Point, List<RouteNote>> routeNotes =
         new ConcurrentHashMap<Point, List<RouteNote>>();

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -62,7 +62,7 @@ public class LoadBalancerGrpc {
 
   /**
    */
-  public static interface LoadBalancer {
+  public static abstract class LoadBalancerImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
@@ -70,35 +70,26 @@ public class LoadBalancerGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceRequest> balanceLoad(
-        io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceResponse> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractLoadBalancer implements LoadBalancer, io.grpc.BindableService {
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceRequest> balanceLoad(
         io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceResponse> responseObserver) {
       return asyncUnimplementedStreamingCall(METHOD_BALANCE_LOAD, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return LoadBalancerGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_BALANCE_LOAD,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.grpclb.LoadBalanceRequest,
+                io.grpc.grpclb.LoadBalanceResponse>(
+                  this, METHODID_BALANCE_LOAD)))
+          .build();
     }
   }
 
   /**
    */
-  public static interface LoadBalancerBlockingClient {
-  }
-
-  /**
-   */
-  public static interface LoadBalancerFutureClient {
-  }
-
-  public static class LoadBalancerStub extends io.grpc.stub.AbstractStub<LoadBalancerStub>
-      implements LoadBalancer {
+  public static final class LoadBalancerStub extends io.grpc.stub.AbstractStub<LoadBalancerStub> {
     private LoadBalancerStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -114,7 +105,11 @@ public class LoadBalancerGrpc {
       return new LoadBalancerStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Bidirectional rpc to get a list of servers.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceRequest> balanceLoad(
         io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceResponse> responseObserver) {
       return asyncBidiStreamingCall(
@@ -122,8 +117,9 @@ public class LoadBalancerGrpc {
     }
   }
 
-  public static class LoadBalancerBlockingStub extends io.grpc.stub.AbstractStub<LoadBalancerBlockingStub>
-      implements LoadBalancerBlockingClient {
+  /**
+   */
+  public static final class LoadBalancerBlockingStub extends io.grpc.stub.AbstractStub<LoadBalancerBlockingStub> {
     private LoadBalancerBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -140,8 +136,9 @@ public class LoadBalancerGrpc {
     }
   }
 
-  public static class LoadBalancerFutureStub extends io.grpc.stub.AbstractStub<LoadBalancerFutureStub>
-      implements LoadBalancerFutureClient {
+  /**
+   */
+  public static final class LoadBalancerFutureStub extends io.grpc.stub.AbstractStub<LoadBalancerFutureStub> {
     private LoadBalancerFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -165,10 +162,10 @@ public class LoadBalancerGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final LoadBalancer serviceImpl;
+    private final LoadBalancerImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(LoadBalancer serviceImpl, int methodId) {
+    public MethodHandlers(LoadBalancerImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -201,16 +198,76 @@ public class LoadBalancerGrpc {
         METHOD_BALANCE_LOAD);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final LoadBalancer serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_BALANCE_LOAD,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.grpclb.LoadBalanceRequest,
-              io.grpc.grpclb.LoadBalanceResponse>(
-                serviceImpl, METHODID_BALANCE_LOAD)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements LoadBalancer} with {@code extends LoadBalancerImplBase};</li>
+   *   <li> replace usage of {@code LoadBalancer} with {@code LoadBalancerImplBase};</li>
+   *   <li> replace usage of {@code AbstractLoadBalancer} with {@link LoadBalancerImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(LoadBalancerGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code LoadBalancerBlockingClient} with {@link LoadBalancerBlockingStub};</li>
+   *   <li> replace {@code LoadBalancerFutureClient} with {@link LoadBalancerFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class LoadBalancer {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements LoadBalancer} with {@code extends LoadBalancerImplBase};</li>
+   *   <li> replace usage of {@code LoadBalancer} with {@code LoadBalancerImplBase};</li>
+   *   <li> replace usage of {@code AbstractLoadBalancer} with {@link LoadBalancerImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(LoadBalancerGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code LoadBalancerBlockingClient} with {@link LoadBalancerBlockingStub};</li>
+   *   <li> replace {@code LoadBalancerFutureClient} with {@link LoadBalancerFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class LoadBalancerBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements LoadBalancer} with {@code extends LoadBalancerImplBase};</li>
+   *   <li> replace usage of {@code LoadBalancer} with {@code LoadBalancerImplBase};</li>
+   *   <li> replace usage of {@code AbstractLoadBalancer} with {@link LoadBalancerImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(LoadBalancerGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code LoadBalancerBlockingClient} with {@link LoadBalancerBlockingStub};</li>
+   *   <li> replace {@code LoadBalancerFutureClient} with {@link LoadBalancerFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class LoadBalancerFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements LoadBalancer} with {@code extends LoadBalancerImplBase};</li>
+   *   <li> replace usage of {@code LoadBalancer} with {@code LoadBalancerImplBase};</li>
+   *   <li> replace usage of {@code AbstractLoadBalancer} with {@link LoadBalancerImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(LoadBalancerGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code LoadBalancerBlockingClient} with {@link LoadBalancerBlockingStub};</li>
+   *   <li> replace {@code LoadBalancerFutureClient} with {@link LoadBalancerFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -71,7 +71,7 @@ public class MetricsServiceGrpc {
 
   /**
    */
-  public static interface MetricsService {
+  public static abstract class MetricsServiceImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
@@ -79,74 +79,44 @@ public class MetricsServiceGrpc {
      * the service
      * </pre>
      */
-    public void getAllGauges(io.grpc.testing.integration.Metrics.EmptyMessage request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver);
-
-    /**
-     * <pre>
-     * Returns the value of one gauge
-     * </pre>
-     */
-    public void getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractMetricsService implements MetricsService, io.grpc.BindableService {
-
-    @java.lang.Override
     public void getAllGauges(io.grpc.testing.integration.Metrics.EmptyMessage request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_GET_ALL_GAUGES, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Returns the value of one gauge
+     * </pre>
+     */
     public void getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_GET_GAUGE, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return MetricsServiceGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_GET_ALL_GAUGES,
+            asyncServerStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Metrics.EmptyMessage,
+                io.grpc.testing.integration.Metrics.GaugeResponse>(
+                  this, METHODID_GET_ALL_GAUGES)))
+          .addMethod(
+            METHOD_GET_GAUGE,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Metrics.GaugeRequest,
+                io.grpc.testing.integration.Metrics.GaugeResponse>(
+                  this, METHODID_GET_GAUGE)))
+          .build();
     }
   }
 
   /**
    */
-  public static interface MetricsServiceBlockingClient {
-
-    /**
-     * <pre>
-     * Returns the values of all the gauges that are currently being maintained by
-     * the service
-     * </pre>
-     */
-    public java.util.Iterator<io.grpc.testing.integration.Metrics.GaugeResponse> getAllGauges(
-        io.grpc.testing.integration.Metrics.EmptyMessage request);
-
-    /**
-     * <pre>
-     * Returns the value of one gauge
-     * </pre>
-     */
-    public io.grpc.testing.integration.Metrics.GaugeResponse getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request);
-  }
-
-  /**
-   */
-  public static interface MetricsServiceFutureClient {
-
-    /**
-     * <pre>
-     * Returns the value of one gauge
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Metrics.GaugeResponse> getGauge(
-        io.grpc.testing.integration.Metrics.GaugeRequest request);
-  }
-
-  public static class MetricsServiceStub extends io.grpc.stub.AbstractStub<MetricsServiceStub>
-      implements MetricsService {
+  public static final class MetricsServiceStub extends io.grpc.stub.AbstractStub<MetricsServiceStub> {
     private MetricsServiceStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -162,14 +132,23 @@ public class MetricsServiceGrpc {
       return new MetricsServiceStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Returns the values of all the gauges that are currently being maintained by
+     * the service
+     * </pre>
+     */
     public void getAllGauges(io.grpc.testing.integration.Metrics.EmptyMessage request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
       asyncServerStreamingCall(
           getChannel().newCall(METHOD_GET_ALL_GAUGES, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Returns the value of one gauge
+     * </pre>
+     */
     public void getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
       asyncUnaryCall(
@@ -177,8 +156,9 @@ public class MetricsServiceGrpc {
     }
   }
 
-  public static class MetricsServiceBlockingStub extends io.grpc.stub.AbstractStub<MetricsServiceBlockingStub>
-      implements MetricsServiceBlockingClient {
+  /**
+   */
+  public static final class MetricsServiceBlockingStub extends io.grpc.stub.AbstractStub<MetricsServiceBlockingStub> {
     private MetricsServiceBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -194,22 +174,32 @@ public class MetricsServiceGrpc {
       return new MetricsServiceBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Returns the values of all the gauges that are currently being maintained by
+     * the service
+     * </pre>
+     */
     public java.util.Iterator<io.grpc.testing.integration.Metrics.GaugeResponse> getAllGauges(
         io.grpc.testing.integration.Metrics.EmptyMessage request) {
       return blockingServerStreamingCall(
           getChannel(), METHOD_GET_ALL_GAUGES, getCallOptions(), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Returns the value of one gauge
+     * </pre>
+     */
     public io.grpc.testing.integration.Metrics.GaugeResponse getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_GET_GAUGE, getCallOptions(), request);
     }
   }
 
-  public static class MetricsServiceFutureStub extends io.grpc.stub.AbstractStub<MetricsServiceFutureStub>
-      implements MetricsServiceFutureClient {
+  /**
+   */
+  public static final class MetricsServiceFutureStub extends io.grpc.stub.AbstractStub<MetricsServiceFutureStub> {
     private MetricsServiceFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -225,7 +215,11 @@ public class MetricsServiceGrpc {
       return new MetricsServiceFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * Returns the value of one gauge
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Metrics.GaugeResponse> getGauge(
         io.grpc.testing.integration.Metrics.GaugeRequest request) {
       return futureUnaryCall(
@@ -241,10 +235,10 @@ public class MetricsServiceGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final MetricsService serviceImpl;
+    private final MetricsServiceImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(MetricsService serviceImpl, int methodId) {
+    public MethodHandlers(MetricsServiceImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -283,23 +277,76 @@ public class MetricsServiceGrpc {
         METHOD_GET_GAUGE);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final MetricsService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_GET_ALL_GAUGES,
-          asyncServerStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Metrics.EmptyMessage,
-              io.grpc.testing.integration.Metrics.GaugeResponse>(
-                serviceImpl, METHODID_GET_ALL_GAUGES)))
-        .addMethod(
-          METHOD_GET_GAUGE,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Metrics.GaugeRequest,
-              io.grpc.testing.integration.Metrics.GaugeResponse>(
-                serviceImpl, METHODID_GET_GAUGE)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements MetricsService} with {@code extends MetricsServiceImplBase};</li>
+   *   <li> replace usage of {@code MetricsService} with {@code MetricsServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractMetricsService} with {@link MetricsServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(MetricsServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code MetricsServiceBlockingClient} with {@link MetricsServiceBlockingStub};</li>
+   *   <li> replace {@code MetricsServiceFutureClient} with {@link MetricsServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class MetricsService {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements MetricsService} with {@code extends MetricsServiceImplBase};</li>
+   *   <li> replace usage of {@code MetricsService} with {@code MetricsServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractMetricsService} with {@link MetricsServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(MetricsServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code MetricsServiceBlockingClient} with {@link MetricsServiceBlockingStub};</li>
+   *   <li> replace {@code MetricsServiceFutureClient} with {@link MetricsServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class MetricsServiceBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements MetricsService} with {@code extends MetricsServiceImplBase};</li>
+   *   <li> replace usage of {@code MetricsService} with {@code MetricsServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractMetricsService} with {@link MetricsServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(MetricsServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code MetricsServiceBlockingClient} with {@link MetricsServiceBlockingStub};</li>
+   *   <li> replace {@code MetricsServiceFutureClient} with {@link MetricsServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class MetricsServiceFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements MetricsService} with {@code extends MetricsServiceImplBase};</li>
+   *   <li> replace usage of {@code MetricsService} with {@code MetricsServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractMetricsService} with {@link MetricsServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(MetricsServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code MetricsServiceBlockingClient} with {@link MetricsServiceBlockingStub};</li>
+   *   <li> replace {@code MetricsServiceFutureClient} with {@link MetricsServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -77,36 +77,39 @@ public class ReconnectServiceGrpc {
    * A service used to control reconnect server.
    * </pre>
    */
-  public static interface ReconnectService {
+  public static abstract class ReconnectServiceImplBase implements io.grpc.BindableService {
 
     /**
      */
-    public void start(com.google.protobuf.EmptyProtos.Empty request,
-        io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver);
-
-    /**
-     */
-    public void stop(com.google.protobuf.EmptyProtos.Empty request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.ReconnectInfo> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractReconnectService implements ReconnectService, io.grpc.BindableService {
-
-    @java.lang.Override
     public void start(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_START, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     */
     public void stop(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.ReconnectInfo> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_STOP, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return ReconnectServiceGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_START,
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.google.protobuf.EmptyProtos.Empty,
+                com.google.protobuf.EmptyProtos.Empty>(
+                  this, METHODID_START)))
+          .addMethod(
+            METHOD_STOP,
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.google.protobuf.EmptyProtos.Empty,
+                io.grpc.testing.integration.Messages.ReconnectInfo>(
+                  this, METHODID_STOP)))
+          .build();
     }
   }
 
@@ -115,37 +118,7 @@ public class ReconnectServiceGrpc {
    * A service used to control reconnect server.
    * </pre>
    */
-  public static interface ReconnectServiceBlockingClient {
-
-    /**
-     */
-    public com.google.protobuf.EmptyProtos.Empty start(com.google.protobuf.EmptyProtos.Empty request);
-
-    /**
-     */
-    public io.grpc.testing.integration.Messages.ReconnectInfo stop(com.google.protobuf.EmptyProtos.Empty request);
-  }
-
-  /**
-   * <pre>
-   * A service used to control reconnect server.
-   * </pre>
-   */
-  public static interface ReconnectServiceFutureClient {
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> start(
-        com.google.protobuf.EmptyProtos.Empty request);
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.ReconnectInfo> stop(
-        com.google.protobuf.EmptyProtos.Empty request);
-  }
-
-  public static class ReconnectServiceStub extends io.grpc.stub.AbstractStub<ReconnectServiceStub>
-      implements ReconnectService {
+  public static final class ReconnectServiceStub extends io.grpc.stub.AbstractStub<ReconnectServiceStub> {
     private ReconnectServiceStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -161,14 +134,16 @@ public class ReconnectServiceGrpc {
       return new ReconnectServiceStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     */
     public void start(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_START, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     */
     public void stop(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.ReconnectInfo> responseObserver) {
       asyncUnaryCall(
@@ -176,8 +151,12 @@ public class ReconnectServiceGrpc {
     }
   }
 
-  public static class ReconnectServiceBlockingStub extends io.grpc.stub.AbstractStub<ReconnectServiceBlockingStub>
-      implements ReconnectServiceBlockingClient {
+  /**
+   * <pre>
+   * A service used to control reconnect server.
+   * </pre>
+   */
+  public static final class ReconnectServiceBlockingStub extends io.grpc.stub.AbstractStub<ReconnectServiceBlockingStub> {
     private ReconnectServiceBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -193,21 +172,27 @@ public class ReconnectServiceGrpc {
       return new ReconnectServiceBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     */
     public com.google.protobuf.EmptyProtos.Empty start(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
           getChannel(), METHOD_START, getCallOptions(), request);
     }
 
-    @java.lang.Override
+    /**
+     */
     public io.grpc.testing.integration.Messages.ReconnectInfo stop(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
           getChannel(), METHOD_STOP, getCallOptions(), request);
     }
   }
 
-  public static class ReconnectServiceFutureStub extends io.grpc.stub.AbstractStub<ReconnectServiceFutureStub>
-      implements ReconnectServiceFutureClient {
+  /**
+   * <pre>
+   * A service used to control reconnect server.
+   * </pre>
+   */
+  public static final class ReconnectServiceFutureStub extends io.grpc.stub.AbstractStub<ReconnectServiceFutureStub> {
     private ReconnectServiceFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -223,14 +208,16 @@ public class ReconnectServiceGrpc {
       return new ReconnectServiceFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> start(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
           getChannel().newCall(METHOD_START, getCallOptions()), request);
     }
 
-    @java.lang.Override
+    /**
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.ReconnectInfo> stop(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
@@ -246,10 +233,10 @@ public class ReconnectServiceGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final ReconnectService serviceImpl;
+    private final ReconnectServiceImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(ReconnectService serviceImpl, int methodId) {
+    public MethodHandlers(ReconnectServiceImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -288,23 +275,76 @@ public class ReconnectServiceGrpc {
         METHOD_STOP);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final ReconnectService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_START,
-          asyncUnaryCall(
-            new MethodHandlers<
-              com.google.protobuf.EmptyProtos.Empty,
-              com.google.protobuf.EmptyProtos.Empty>(
-                serviceImpl, METHODID_START)))
-        .addMethod(
-          METHOD_STOP,
-          asyncUnaryCall(
-            new MethodHandlers<
-              com.google.protobuf.EmptyProtos.Empty,
-              io.grpc.testing.integration.Messages.ReconnectInfo>(
-                serviceImpl, METHODID_STOP)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements ReconnectService} with {@code extends ReconnectServiceImplBase};</li>
+   *   <li> replace usage of {@code ReconnectService} with {@code ReconnectServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractReconnectService} with {@link ReconnectServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(ReconnectServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code ReconnectServiceBlockingClient} with {@link ReconnectServiceBlockingStub};</li>
+   *   <li> replace {@code ReconnectServiceFutureClient} with {@link ReconnectServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class ReconnectService {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements ReconnectService} with {@code extends ReconnectServiceImplBase};</li>
+   *   <li> replace usage of {@code ReconnectService} with {@code ReconnectServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractReconnectService} with {@link ReconnectServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(ReconnectServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code ReconnectServiceBlockingClient} with {@link ReconnectServiceBlockingStub};</li>
+   *   <li> replace {@code ReconnectServiceFutureClient} with {@link ReconnectServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class ReconnectServiceBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements ReconnectService} with {@code extends ReconnectServiceImplBase};</li>
+   *   <li> replace usage of {@code ReconnectService} with {@code ReconnectServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractReconnectService} with {@link ReconnectServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(ReconnectServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code ReconnectServiceBlockingClient} with {@link ReconnectServiceBlockingStub};</li>
+   *   <li> replace {@code ReconnectServiceFutureClient} with {@link ReconnectServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class ReconnectServiceFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements ReconnectService} with {@code extends ReconnectServiceImplBase};</li>
+   *   <li> replace usage of {@code ReconnectService} with {@code ReconnectServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractReconnectService} with {@link ReconnectServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(ReconnectServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code ReconnectServiceBlockingClient} with {@link ReconnectServiceBlockingStub};</li>
+   *   <li> replace {@code ReconnectServiceFutureClient} with {@link ReconnectServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -85,6 +85,15 @@ public class TestServiceGrpc {
               "grpc.testing.TestService", "HalfDuplexCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()));
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_EXTENSION =
+      io.grpc.MethodDescriptor.create(
+          io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
+          generateFullMethodName(
+              "grpc.testing.TestService", "Extension"),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()));
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -115,7 +124,7 @@ public class TestServiceGrpc {
    * performance with various types of payload.
    * </pre>
    */
-  public static interface TestService {
+  public static abstract class TestServiceImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
@@ -123,7 +132,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
-        io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver);
+        io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_EMPTY_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -131,7 +142,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public void unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -140,7 +153,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public void streamingOutputCall(io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -149,7 +164,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> streamingInputCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -159,7 +176,9 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver);
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_FULL_DUPLEX_CALL, responseObserver);
+    }
 
     /**
      * <pre>
@@ -170,50 +189,74 @@ public class TestServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractTestService implements TestService, io.grpc.BindableService {
-
-    @java.lang.Override
-    public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
-        io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_EMPTY_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public void unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public void streamingOutputCall(io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> streamingInputCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
-        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_FULL_DUPLEX_CALL, responseObserver);
-    }
-
-    @java.lang.Override
-    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return asyncUnimplementedStreamingCall(METHOD_HALF_DUPLEX_CALL, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return TestServiceGrpc.bindService(this);
+    /**
+     * <pre>
+     * A new RPC method added to the proto used for testing extensibility.
+     * This should not break the existing test code that was based old version
+     * generated code.
+     * </pre>
+     */
+    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> extension(
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(METHOD_EXTENSION, responseObserver);
+    }
+
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_EMPTY_CALL,
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.google.protobuf.EmptyProtos.Empty,
+                com.google.protobuf.EmptyProtos.Empty>(
+                  this, METHODID_EMPTY_CALL)))
+          .addMethod(
+            METHOD_UNARY_CALL,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Messages.SimpleRequest,
+                io.grpc.testing.integration.Messages.SimpleResponse>(
+                  this, METHODID_UNARY_CALL)))
+          .addMethod(
+            METHOD_STREAMING_OUTPUT_CALL,
+            asyncServerStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
+                  this, METHODID_STREAMING_OUTPUT_CALL)))
+          .addMethod(
+            METHOD_STREAMING_INPUT_CALL,
+            asyncClientStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Messages.StreamingInputCallRequest,
+                io.grpc.testing.integration.Messages.StreamingInputCallResponse>(
+                  this, METHODID_STREAMING_INPUT_CALL)))
+          .addMethod(
+            METHOD_FULL_DUPLEX_CALL,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
+                  this, METHODID_FULL_DUPLEX_CALL)))
+          .addMethod(
+            METHOD_HALF_DUPLEX_CALL,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
+                  this, METHODID_HALF_DUPLEX_CALL)))
+          .addMethod(
+            METHOD_EXTENSION,
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+                io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
+                  this, METHODID_EXTENSION)))
+          .build();
     }
   }
 
@@ -223,59 +266,7 @@ public class TestServiceGrpc {
    * performance with various types of payload.
    * </pre>
    */
-  public static interface TestServiceBlockingClient {
-
-    /**
-     * <pre>
-     * One empty request followed by one empty response.
-     * </pre>
-     */
-    public com.google.protobuf.EmptyProtos.Empty emptyCall(com.google.protobuf.EmptyProtos.Empty request);
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * </pre>
-     */
-    public io.grpc.testing.integration.Messages.SimpleResponse unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request);
-
-    /**
-     * <pre>
-     * One request followed by a sequence of responses (streamed download).
-     * The server returns the payload with client desired type and sizes.
-     * </pre>
-     */
-    public java.util.Iterator<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> streamingOutputCall(
-        io.grpc.testing.integration.Messages.StreamingOutputCallRequest request);
-  }
-
-  /**
-   * <pre>
-   * A simple service to test the various types of RPCs and experiment with
-   * performance with various types of payload.
-   * </pre>
-   */
-  public static interface TestServiceFutureClient {
-
-    /**
-     * <pre>
-     * One empty request followed by one empty response.
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> emptyCall(
-        com.google.protobuf.EmptyProtos.Empty request);
-
-    /**
-     * <pre>
-     * One request followed by one response.
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> unaryCall(
-        io.grpc.testing.integration.Messages.SimpleRequest request);
-  }
-
-  public static class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub>
-      implements TestService {
+  public static final class TestServiceStub extends io.grpc.stub.AbstractStub<TestServiceStub> {
     private TestServiceStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -291,51 +282,100 @@ public class TestServiceGrpc {
       return new TestServiceStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One empty request followed by one empty response.
+     * </pre>
+     */
     public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_EMPTY_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * </pre>
+     */
     public void unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by a sequence of responses (streamed download).
+     * The server returns the payload with client desired type and sizes.
+     * </pre>
+     */
     public void streamingOutputCall(io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
           getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request, responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests followed by one response (streamed upload).
+     * The server returns the aggregated size of client payload as the result.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
           getChannel().newCall(METHOD_STREAMING_INPUT_CALL, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests with each request served by the server immediately.
+     * As one request could lead to multiple responses, this interface
+     * demonstrates the idea of full duplexing.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(METHOD_FULL_DUPLEX_CALL, getCallOptions()), responseObserver);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A sequence of requests followed by a sequence of responses.
+     * The server buffers all the client requests and then serves them in order. A
+     * stream of responses are returned to the client when the server starts with
+     * first request.
+     * </pre>
+     */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(METHOD_HALF_DUPLEX_CALL, getCallOptions()), responseObserver);
     }
+
+    /**
+     * <pre>
+     * A new RPC method added to the proto used for testing extensibility.
+     * This should not break the existing test code that was based old version
+     * generated code.
+     * </pre>
+     */
+    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> extension(
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
+      return asyncBidiStreamingCall(
+          getChannel().newCall(METHOD_EXTENSION, getCallOptions()), responseObserver);
+    }
   }
 
-  public static class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub>
-      implements TestServiceBlockingClient {
+  /**
+   * <pre>
+   * A simple service to test the various types of RPCs and experiment with
+   * performance with various types of payload.
+   * </pre>
+   */
+  public static final class TestServiceBlockingStub extends io.grpc.stub.AbstractStub<TestServiceBlockingStub> {
     private TestServiceBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -351,19 +391,32 @@ public class TestServiceGrpc {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One empty request followed by one empty response.
+     * </pre>
+     */
     public com.google.protobuf.EmptyProtos.Empty emptyCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
           getChannel(), METHOD_EMPTY_CALL, getCallOptions(), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * </pre>
+     */
     public io.grpc.testing.integration.Messages.SimpleResponse unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by a sequence of responses (streamed download).
+     * The server returns the payload with client desired type and sizes.
+     * </pre>
+     */
     public java.util.Iterator<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Messages.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
@@ -371,8 +424,13 @@ public class TestServiceGrpc {
     }
   }
 
-  public static class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub>
-      implements TestServiceFutureClient {
+  /**
+   * <pre>
+   * A simple service to test the various types of RPCs and experiment with
+   * performance with various types of payload.
+   * </pre>
+   */
+  public static final class TestServiceFutureStub extends io.grpc.stub.AbstractStub<TestServiceFutureStub> {
     private TestServiceFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -388,14 +446,22 @@ public class TestServiceGrpc {
       return new TestServiceFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One empty request followed by one empty response.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> emptyCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
           getChannel().newCall(METHOD_EMPTY_CALL, getCallOptions()), request);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * One request followed by one response.
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Messages.SimpleRequest request) {
       return futureUnaryCall(
@@ -409,16 +475,17 @@ public class TestServiceGrpc {
   private static final int METHODID_STREAMING_INPUT_CALL = 3;
   private static final int METHODID_FULL_DUPLEX_CALL = 4;
   private static final int METHODID_HALF_DUPLEX_CALL = 5;
+  private static final int METHODID_EXTENSION = 6;
 
   private static class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final TestService serviceImpl;
+    private final TestServiceImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(TestService serviceImpl, int methodId) {
+    public MethodHandlers(TestServiceImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -458,6 +525,9 @@ public class TestServiceGrpc {
         case METHODID_HALF_DUPLEX_CALL:
           return (io.grpc.stub.StreamObserver<Req>) serviceImpl.halfDuplexCall(
               (io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse>) responseObserver);
+        case METHODID_EXTENSION:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.extension(
+              (io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse>) responseObserver);
         default:
           throw new AssertionError();
       }
@@ -471,54 +541,80 @@ public class TestServiceGrpc {
         METHOD_STREAMING_OUTPUT_CALL,
         METHOD_STREAMING_INPUT_CALL,
         METHOD_FULL_DUPLEX_CALL,
-        METHOD_HALF_DUPLEX_CALL);
+        METHOD_HALF_DUPLEX_CALL,
+        METHOD_EXTENSION);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final TestService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_EMPTY_CALL,
-          asyncUnaryCall(
-            new MethodHandlers<
-              com.google.protobuf.EmptyProtos.Empty,
-              com.google.protobuf.EmptyProtos.Empty>(
-                serviceImpl, METHODID_EMPTY_CALL)))
-        .addMethod(
-          METHOD_UNARY_CALL,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Messages.SimpleRequest,
-              io.grpc.testing.integration.Messages.SimpleResponse>(
-                serviceImpl, METHODID_UNARY_CALL)))
-        .addMethod(
-          METHOD_STREAMING_OUTPUT_CALL,
-          asyncServerStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-              io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_STREAMING_OUTPUT_CALL)))
-        .addMethod(
-          METHOD_STREAMING_INPUT_CALL,
-          asyncClientStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Messages.StreamingInputCallRequest,
-              io.grpc.testing.integration.Messages.StreamingInputCallResponse>(
-                serviceImpl, METHODID_STREAMING_INPUT_CALL)))
-        .addMethod(
-          METHOD_FULL_DUPLEX_CALL,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-              io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_FULL_DUPLEX_CALL)))
-        .addMethod(
-          METHOD_HALF_DUPLEX_CALL,
-          asyncBidiStreamingCall(
-            new MethodHandlers<
-              io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-              io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
-                serviceImpl, METHODID_HALF_DUPLEX_CALL)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestService {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestServiceBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class TestServiceFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements TestService} with {@code extends TestServiceImplBase};</li>
+   *   <li> replace usage of {@code TestService} with {@code TestServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractTestService} with {@link TestServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(TestServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code TestServiceBlockingClient} with {@link TestServiceBlockingStub};</li>
+   *   <li> replace {@code TestServiceFutureClient} with {@link TestServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -70,28 +70,28 @@ public class UnimplementedServiceGrpc {
    * that case.
    * </pre>
    */
-  public static interface UnimplementedService {
+  public static abstract class UnimplementedServiceImplBase implements io.grpc.BindableService {
 
     /**
      * <pre>
      * A call that no server should implement
      * </pre>
      */
-    public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
-        io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractUnimplementedService implements UnimplementedService, io.grpc.BindableService {
-
-    @java.lang.Override
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_UNIMPLEMENTED_CALL, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return UnimplementedServiceGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_UNIMPLEMENTED_CALL,
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.google.protobuf.EmptyProtos.Empty,
+                com.google.protobuf.EmptyProtos.Empty>(
+                  this, METHODID_UNIMPLEMENTED_CALL)))
+          .build();
     }
   }
 
@@ -101,35 +101,7 @@ public class UnimplementedServiceGrpc {
    * that case.
    * </pre>
    */
-  public static interface UnimplementedServiceBlockingClient {
-
-    /**
-     * <pre>
-     * A call that no server should implement
-     * </pre>
-     */
-    public com.google.protobuf.EmptyProtos.Empty unimplementedCall(com.google.protobuf.EmptyProtos.Empty request);
-  }
-
-  /**
-   * <pre>
-   * A simple service NOT implemented at servers so clients can test for
-   * that case.
-   * </pre>
-   */
-  public static interface UnimplementedServiceFutureClient {
-
-    /**
-     * <pre>
-     * A call that no server should implement
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> unimplementedCall(
-        com.google.protobuf.EmptyProtos.Empty request);
-  }
-
-  public static class UnimplementedServiceStub extends io.grpc.stub.AbstractStub<UnimplementedServiceStub>
-      implements UnimplementedService {
+  public static final class UnimplementedServiceStub extends io.grpc.stub.AbstractStub<UnimplementedServiceStub> {
     private UnimplementedServiceStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -145,7 +117,11 @@ public class UnimplementedServiceGrpc {
       return new UnimplementedServiceStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A call that no server should implement
+     * </pre>
+     */
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
@@ -153,8 +129,13 @@ public class UnimplementedServiceGrpc {
     }
   }
 
-  public static class UnimplementedServiceBlockingStub extends io.grpc.stub.AbstractStub<UnimplementedServiceBlockingStub>
-      implements UnimplementedServiceBlockingClient {
+  /**
+   * <pre>
+   * A simple service NOT implemented at servers so clients can test for
+   * that case.
+   * </pre>
+   */
+  public static final class UnimplementedServiceBlockingStub extends io.grpc.stub.AbstractStub<UnimplementedServiceBlockingStub> {
     private UnimplementedServiceBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -170,15 +151,24 @@ public class UnimplementedServiceGrpc {
       return new UnimplementedServiceBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A call that no server should implement
+     * </pre>
+     */
     public com.google.protobuf.EmptyProtos.Empty unimplementedCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
           getChannel(), METHOD_UNIMPLEMENTED_CALL, getCallOptions(), request);
     }
   }
 
-  public static class UnimplementedServiceFutureStub extends io.grpc.stub.AbstractStub<UnimplementedServiceFutureStub>
-      implements UnimplementedServiceFutureClient {
+  /**
+   * <pre>
+   * A simple service NOT implemented at servers so clients can test for
+   * that case.
+   * </pre>
+   */
+  public static final class UnimplementedServiceFutureStub extends io.grpc.stub.AbstractStub<UnimplementedServiceFutureStub> {
     private UnimplementedServiceFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -194,7 +184,11 @@ public class UnimplementedServiceGrpc {
       return new UnimplementedServiceFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     * <pre>
+     * A call that no server should implement
+     * </pre>
+     */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> unimplementedCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
@@ -209,10 +203,10 @@ public class UnimplementedServiceGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final UnimplementedService serviceImpl;
+    private final UnimplementedServiceImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(UnimplementedService serviceImpl, int methodId) {
+    public MethodHandlers(UnimplementedServiceImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -246,16 +240,76 @@ public class UnimplementedServiceGrpc {
         METHOD_UNIMPLEMENTED_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final UnimplementedService serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_UNIMPLEMENTED_CALL,
-          asyncUnaryCall(
-            new MethodHandlers<
-              com.google.protobuf.EmptyProtos.Empty,
-              com.google.protobuf.EmptyProtos.Empty>(
-                serviceImpl, METHODID_UNIMPLEMENTED_CALL)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements UnimplementedService} with {@code extends UnimplementedServiceImplBase};</li>
+   *   <li> replace usage of {@code UnimplementedService} with {@code UnimplementedServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractUnimplementedService} with {@link UnimplementedServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(UnimplementedServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code UnimplementedServiceBlockingClient} with {@link UnimplementedServiceBlockingStub};</li>
+   *   <li> replace {@code UnimplementedServiceFutureClient} with {@link UnimplementedServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class UnimplementedService {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements UnimplementedService} with {@code extends UnimplementedServiceImplBase};</li>
+   *   <li> replace usage of {@code UnimplementedService} with {@code UnimplementedServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractUnimplementedService} with {@link UnimplementedServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(UnimplementedServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code UnimplementedServiceBlockingClient} with {@link UnimplementedServiceBlockingStub};</li>
+   *   <li> replace {@code UnimplementedServiceFutureClient} with {@link UnimplementedServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class UnimplementedServiceBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements UnimplementedService} with {@code extends UnimplementedServiceImplBase};</li>
+   *   <li> replace usage of {@code UnimplementedService} with {@code UnimplementedServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractUnimplementedService} with {@link UnimplementedServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(UnimplementedServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code UnimplementedServiceBlockingClient} with {@link UnimplementedServiceBlockingStub};</li>
+   *   <li> replace {@code UnimplementedServiceFutureClient} with {@link UnimplementedServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class UnimplementedServiceFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements UnimplementedService} with {@code extends UnimplementedServiceImplBase};</li>
+   *   <li> replace usage of {@code UnimplementedService} with {@code UnimplementedServiceImplBase};</li>
+   *   <li> replace usage of {@code AbstractUnimplementedService} with {@link UnimplementedServiceImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(UnimplementedServiceGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code UnimplementedServiceBlockingClient} with {@link UnimplementedServiceBlockingStub};</li>
+   *   <li> replace {@code UnimplementedServiceFutureClient} with {@link UnimplementedServiceFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/interop-testing/src/generated/main/java/io/grpc/testing/integration/Test.java
+++ b/interop-testing/src/generated/main/java/io/grpc/testing/integration/Test.java
@@ -20,7 +20,7 @@ public final class Test {
       "\n&io/grpc/testing/integration/test.proto" +
       "\022\014grpc.testing\032\'io/grpc/testing/integrat" +
       "ion/empty.proto\032*io/grpc/testing/integra" +
-      "tion/messages.proto2\273\004\n\013TestService\0225\n\tE" +
+      "tion/messages.proto2\241\005\n\013TestService\0225\n\tE" +
       "mptyCall\022\023.grpc.testing.Empty\032\023.grpc.tes" +
       "ting.Empty\022F\n\tUnaryCall\022\033.grpc.testing.S" +
       "impleRequest\032\034.grpc.testing.SimpleRespon" +
@@ -34,14 +34,16 @@ public final class Test {
       ").grpc.testing.StreamingOutputCallRespon" +
       "se(\0010\001\022i\n\016HalfDuplexCall\022(.grpc.testing." +
       "StreamingOutputCallRequest\032).grpc.testin" +
-      "g.StreamingOutputCallResponse(\0010\0012U\n\024Uni" +
-      "mplementedService\022=\n\021UnimplementedCall\022\023" +
-      ".grpc.testing.Empty\032\023.grpc.testing.Empty",
-      "2\177\n\020ReconnectService\0221\n\005Start\022\023.grpc.tes" +
-      "ting.Empty\032\023.grpc.testing.Empty\0228\n\004Stop\022" +
-      "\023.grpc.testing.Empty\032\033.grpc.testing.Reco" +
-      "nnectInfoB\035\n\033io.grpc.testing.integration" +
-      "b\006proto3"
+      "g.StreamingOutputCallResponse(\0010\001\022d\n\tExt" +
+      "ension\022(.grpc.testing.StreamingOutputCal" +
+      "lRequest\032).grpc.testing.StreamingOutputC",
+      "allResponse(\0010\0012U\n\024UnimplementedService\022" +
+      "=\n\021UnimplementedCall\022\023.grpc.testing.Empt" +
+      "y\032\023.grpc.testing.Empty2\177\n\020ReconnectServi" +
+      "ce\0221\n\005Start\022\023.grpc.testing.Empty\032\023.grpc." +
+      "testing.Empty\0228\n\004Stop\022\023.grpc.testing.Emp" +
+      "ty\032\033.grpc.testing.ReconnectInfoB\035\n\033io.gr" +
+      "pc.testing.integrationb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -130,7 +130,7 @@ public abstract class AbstractInteropTest {
         .build();
 
     builder.addService(ServerInterceptors.intercept(
-        TestServiceGrpc.bindService(new TestServiceImpl(testServiceExecutor)),
+        new TestServiceImpl(testServiceExecutor).bindService(),
         allInterceptors));
     try {
       server = builder.build().start();
@@ -146,7 +146,7 @@ public abstract class AbstractInteropTest {
 
   protected ManagedChannel channel;
   protected TestServiceGrpc.TestServiceBlockingStub blockingStub;
-  protected TestServiceGrpc.TestService asyncStub;
+  protected TestServiceGrpc.TestServiceStub asyncStub;
 
   /**
    * Must be called by the subclass setup method if overridden.
@@ -771,7 +771,7 @@ public abstract class AbstractInteropTest {
   /** Start a fullDuplexCall which the server will not respond, and verify the deadline expires. */
   @Test(timeout = 10000)
   public void timeoutOnSleepingServer() {
-    TestServiceGrpc.TestService stub = TestServiceGrpc.newStub(channel)
+    TestServiceGrpc.TestServiceStub stub = TestServiceGrpc.newStub(channel)
         .withDeadlineAfter(1, TimeUnit.MILLISECONDS);
     @SuppressWarnings("unchecked")
     StreamObserver<StreamingOutputCallResponse> responseObserver = mock(StreamObserver.class);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -196,7 +196,7 @@ public class StressTestClient {
     Preconditions.checkState(!shutdown, "client was shutdown.");
 
     metricsServer = ServerBuilder.forPort(metricsPort)
-        .addService(MetricsServiceGrpc.bindService(new MetricsServiceImpl()))
+        .addService(new MetricsServiceImpl())
         .build()
         .start();
   }
@@ -512,7 +512,7 @@ public class StressTestClient {
   /**
    * Service that exports the QPS metrics of the stress test.
    */
-  private class MetricsServiceImpl implements MetricsServiceGrpc.MetricsService {
+  private class MetricsServiceImpl extends MetricsServiceGrpc.MetricsServiceImplBase {
 
     @Override
     public void getAllGauges(Metrics.EmptyMessage request,

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -52,7 +52,8 @@ import java.nio.charset.Charset;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
- * Application that starts a client for the {@link TestServiceGrpc.TestService} and runs through a
+ * Application that starts a client for the {@link TestServiceGrpc.TestServiceImplBase} and runs
+ * through a
  * series of tests.
  */
 public class TestServiceClient {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
  * Implementation of the business logic for the TestService. Uses an executor to schedule chunks
  * sent in response streams.
  */
-public class TestServiceImpl implements TestServiceGrpc.TestService {
+public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
   private static final String UNCOMPRESSABLE_FILE =
       "/io/grpc/testing/integration/testdata/uncompressable.bin";
   private final Random random = new Random();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -144,7 +144,7 @@ public class TestServiceServer {
     server = NettyServerBuilder.forPort(port)
         .sslContext(sslContext)
         .addService(ServerInterceptors.intercept(
-            TestServiceGrpc.bindService(new TestServiceImpl(executor)),
+            new TestServiceImpl(executor),
             TestUtils.echoRequestHeadersInterceptor(Util.METADATA_KEY)))
         .build().start();
   }

--- a/interop-testing/src/main/proto/io/grpc/testing/integration/test.proto
+++ b/interop-testing/src/main/proto/io/grpc/testing/integration/test.proto
@@ -70,6 +70,12 @@ service TestService {
   // first request.
   rpc HalfDuplexCall(stream StreamingOutputCallRequest)
       returns (stream StreamingOutputCallResponse);
+
+  // A new RPC method added to the proto used for testing extensibility.
+  // This should not break the existing test code that was based old version
+  // generated code.
+  rpc Extension(stream StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
 }
 
 // A simple service NOT implemented at servers so clients can test for

--- a/interop-testing/src/test/java/io/grpc/testing/integration/CascadingTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CascadingTest.java
@@ -71,7 +71,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class CascadingTest {
 
   @Mock
-  TestServiceGrpc.TestService service;
+  TestServiceGrpc.TestServiceImplBase service;
   private ManagedChannelImpl channel;
   private ServerImpl server;
   private AtomicInteger nodeCount;
@@ -202,7 +202,7 @@ public class CascadingTest {
   private void startChainingServer(final int depthThreshold)
       throws IOException {
     server = InProcessServerBuilder.forName("channel").executor(otherWork).addService(
-        ServerInterceptors.intercept(TestServiceGrpc.bindService(service),
+        ServerInterceptors.intercept(service,
             new ServerInterceptor() {
               @Override
               public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
@@ -258,7 +258,7 @@ public class CascadingTest {
   private void startCallTreeServer(int depthThreshold) throws IOException {
     final AtomicInteger nodeCount = new AtomicInteger((2 << depthThreshold) - 1);
     server = InProcessServerBuilder.forName("channel").executor(otherWork).addService(
-        ServerInterceptors.intercept(TestServiceGrpc.bindService(service),
+        ServerInterceptors.intercept(service,
             new ServerInterceptor() {
               @Override
               public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(

--- a/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
@@ -264,7 +264,7 @@ public class CompressionTest {
     }
   }
 
-  private static final class LocalServer extends TestServiceGrpc.AbstractTestService {
+  private static final class LocalServer extends TestServiceGrpc.TestServiceImplBase {
     @Override
     public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
       responseObserver.onNext(SimpleResponse.newBuilder()

--- a/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
@@ -215,7 +215,7 @@ public class ConcurrencyTest {
 
     return NettyServerBuilder.forPort(port)
         .sslContext(sslContext)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(serverExecutor)))
+        .addService(new TestServiceImpl(serverExecutor))
         .build()
         .start();
   }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TlsTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TlsTest.java
@@ -131,7 +131,7 @@ public class TlsTest {
       TestUtils.loadX509Cert("ca.pem")
     };
     server = serverBuilder(port, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
+        .addService(new TestServiceImpl(executor))
         .build()
         .start();
 
@@ -167,7 +167,7 @@ public class TlsTest {
       TestUtils.loadX509Cert("ca.pem")
     };
     server = serverBuilder(port, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
+        .addService(new TestServiceImpl(executor))
         .build()
         .start();
 
@@ -214,7 +214,7 @@ public class TlsTest {
       TestUtils.loadX509Cert("ca.pem")
     };
     server = serverBuilder(port, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
+        .addService(new TestServiceImpl(executor))
         .build()
         .start();
 
@@ -256,7 +256,7 @@ public class TlsTest {
       TestUtils.loadX509Cert("ca.pem")
     };
     server = serverBuilder(port, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
+        .addService(new TestServiceImpl(executor))
         .build()
         .start();
 

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -62,49 +62,31 @@ public class HealthGrpc {
 
   /**
    */
-  public static interface Health {
+  public static abstract class HealthImplBase implements io.grpc.BindableService {
 
     /**
      */
-    public void check(io.grpc.health.v1.HealthCheckRequest request,
-        io.grpc.stub.StreamObserver<io.grpc.health.v1.HealthCheckResponse> responseObserver);
-  }
-
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractHealth implements Health, io.grpc.BindableService {
-
-    @java.lang.Override
     public void check(io.grpc.health.v1.HealthCheckRequest request,
         io.grpc.stub.StreamObserver<io.grpc.health.v1.HealthCheckResponse> responseObserver) {
       asyncUnimplementedUnaryCall(METHOD_CHECK, responseObserver);
     }
 
-    @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
-      return HealthGrpc.bindService(this);
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            METHOD_CHECK,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.health.v1.HealthCheckRequest,
+                io.grpc.health.v1.HealthCheckResponse>(
+                  this, METHODID_CHECK)))
+          .build();
     }
   }
 
   /**
    */
-  public static interface HealthBlockingClient {
-
-    /**
-     */
-    public io.grpc.health.v1.HealthCheckResponse check(io.grpc.health.v1.HealthCheckRequest request);
-  }
-
-  /**
-   */
-  public static interface HealthFutureClient {
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<io.grpc.health.v1.HealthCheckResponse> check(
-        io.grpc.health.v1.HealthCheckRequest request);
-  }
-
-  public static class HealthStub extends io.grpc.stub.AbstractStub<HealthStub>
-      implements Health {
+  public static final class HealthStub extends io.grpc.stub.AbstractStub<HealthStub> {
     private HealthStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -120,7 +102,8 @@ public class HealthGrpc {
       return new HealthStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     */
     public void check(io.grpc.health.v1.HealthCheckRequest request,
         io.grpc.stub.StreamObserver<io.grpc.health.v1.HealthCheckResponse> responseObserver) {
       asyncUnaryCall(
@@ -128,8 +111,9 @@ public class HealthGrpc {
     }
   }
 
-  public static class HealthBlockingStub extends io.grpc.stub.AbstractStub<HealthBlockingStub>
-      implements HealthBlockingClient {
+  /**
+   */
+  public static final class HealthBlockingStub extends io.grpc.stub.AbstractStub<HealthBlockingStub> {
     private HealthBlockingStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -145,15 +129,17 @@ public class HealthGrpc {
       return new HealthBlockingStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     */
     public io.grpc.health.v1.HealthCheckResponse check(io.grpc.health.v1.HealthCheckRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_CHECK, getCallOptions(), request);
     }
   }
 
-  public static class HealthFutureStub extends io.grpc.stub.AbstractStub<HealthFutureStub>
-      implements HealthFutureClient {
+  /**
+   */
+  public static final class HealthFutureStub extends io.grpc.stub.AbstractStub<HealthFutureStub> {
     private HealthFutureStub(io.grpc.Channel channel) {
       super(channel);
     }
@@ -169,7 +155,8 @@ public class HealthGrpc {
       return new HealthFutureStub(channel, callOptions);
     }
 
-    @java.lang.Override
+    /**
+     */
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.health.v1.HealthCheckResponse> check(
         io.grpc.health.v1.HealthCheckRequest request) {
       return futureUnaryCall(
@@ -184,10 +171,10 @@ public class HealthGrpc {
       io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
       io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
-    private final Health serviceImpl;
+    private final HealthImplBase serviceImpl;
     private final int methodId;
 
-    public MethodHandlers(Health serviceImpl, int methodId) {
+    public MethodHandlers(HealthImplBase serviceImpl, int methodId) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
     }
@@ -221,16 +208,76 @@ public class HealthGrpc {
         METHOD_CHECK);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
-      final Health serviceImpl) {
-    return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
-        .addMethod(
-          METHOD_CHECK,
-          asyncUnaryCall(
-            new MethodHandlers<
-              io.grpc.health.v1.HealthCheckRequest,
-              io.grpc.health.v1.HealthCheckResponse>(
-                serviceImpl, METHODID_CHECK)))
-        .build();
-  }
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements Health} with {@code extends HealthImplBase};</li>
+   *   <li> replace usage of {@code Health} with {@code HealthImplBase};</li>
+   *   <li> replace usage of {@code AbstractHealth} with {@link HealthImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(HealthGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code HealthBlockingClient} with {@link HealthBlockingStub};</li>
+   *   <li> replace {@code HealthFutureClient} with {@link HealthFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class Health {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements Health} with {@code extends HealthImplBase};</li>
+   *   <li> replace usage of {@code Health} with {@code HealthImplBase};</li>
+   *   <li> replace usage of {@code AbstractHealth} with {@link HealthImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(HealthGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code HealthBlockingClient} with {@link HealthBlockingStub};</li>
+   *   <li> replace {@code HealthFutureClient} with {@link HealthFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class HealthBlockingClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements Health} with {@code extends HealthImplBase};</li>
+   *   <li> replace usage of {@code Health} with {@code HealthImplBase};</li>
+   *   <li> replace usage of {@code AbstractHealth} with {@link HealthImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(HealthGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code HealthBlockingClient} with {@link HealthBlockingStub};</li>
+   *   <li> replace {@code HealthFutureClient} with {@link HealthFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final class HealthFutureClient {}
+
+  /**
+   * This can not be used any more since v0.15.
+   * If your code using earlier version of gRPC-java is breaking when upgrading to v0.15,
+   * the following are suggested:
+   * <ul>
+   *   <li> replace {@code extends/implements Health} with {@code extends HealthImplBase};</li>
+   *   <li> replace usage of {@code Health} with {@code HealthImplBase};</li>
+   *   <li> replace usage of {@code AbstractHealth} with {@link HealthImplBase};</li>
+   *   <li> replace {@code serverBuilder.addService(HealthGrpc.bindService(serviceImpl))}
+   *        with {@code serverBuilder.addService(serviceImpl)};</li>
+   *   <li> if you are mocking stubs using mockito, please do not mock them. See the documentation
+   *        on testing with gRPC-java;</li>
+   *   <li> replace {@code HealthBlockingClient} with {@link HealthBlockingStub};</li>
+   *   <li> replace {@code HealthFutureClient} with {@link HealthFutureStub}.</li>
+   * </ul>
+   */
+  @Deprecated public static final void bindService(Object o) {}
+
 }

--- a/services/src/main/java/io/grpc/services/HealthServiceImpl.java
+++ b/services/src/main/java/io/grpc/services/HealthServiceImpl.java
@@ -45,7 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 
-final class HealthServiceImpl extends HealthGrpc.AbstractHealth {
+final class HealthServiceImpl extends HealthGrpc.HealthImplBase {
 
   /* Due to the latency of rpc calls, synchronization of the map does not help with consistency.
    * However, need use ConcurrentHashMap to prevent the possible race condition of currently putting

--- a/services/src/main/java/io/grpc/services/HealthStatusManager.java
+++ b/services/src/main/java/io/grpc/services/HealthStatusManager.java
@@ -57,7 +57,7 @@ public final class HealthStatusManager {
   /**
    * Gets the health check service created in the constructor.
    */
-  public HealthGrpc.AbstractHealth getHealthService() {
+  public HealthGrpc.HealthImplBase getHealthService() {
     return healthService;
   }
 

--- a/services/src/test/java/io/grpc/services/HealthStatusManagerTest.java
+++ b/services/src/test/java/io/grpc/services/HealthStatusManagerTest.java
@@ -43,7 +43,7 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.health.v1.HealthCheckRequest;
 import io.grpc.health.v1.HealthCheckResponse;
-import io.grpc.health.v1.HealthGrpc.Health;
+import io.grpc.health.v1.HealthGrpc;
 import io.grpc.stub.StreamObserver;
 
 import org.junit.Test;
@@ -57,7 +57,7 @@ import org.mockito.InOrder;
 public class HealthStatusManagerTest {
 
   private final HealthStatusManager manager = new HealthStatusManager();
-  private final Health health = manager.getHealthService();
+  private final HealthGrpc.HealthImplBase health = manager.getHealthService();
   private final HealthCheckResponse.ServingStatus status
       = HealthCheckResponse.ServingStatus.UNKNOWN;
 


### PR DESCRIPTION
implemented comments in #1469

> Delete TestService, TestServiceBlockingClient, TestServiceFutureClient. If they were abstract classes, using them on the client-side stub would require multiple inheritance along with with AbstractStub. They offer no real value on server-side.
>  
> Rename AbstractTestService to TestServiceImplBase. Since there is now a stronger split between client/server, we think it still makes sense to rename the class.
>  
> We will not support mocking client-side. Reconfiguration (with with*) is pretty broken when mocking, and makes is very difficult to get accurate CallOptions when mocking. To get CallOptions you are much better off using a ClientInterceptor. To implement a method you are much better off implementing the server service, because it prevents emulating grpc incorrectly (and gRPC does lots of validation checks). Today Mockito is able to mock the stub, even though it lacks a public constructor. So we will mark the stubs final to prevent mocking.
>  
> To improve mocking server-side, TestServiceImplBase.bindService will be made final, which means the method is still functional when mocked. That removes any real use for the static ServiceGrpc.bindService, so it will be deprecated (for later removal) or removed now.
