### PR TITLE
auth: revert ClientAuthInterceptor to its original implementation.

### DIFF
--- a/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
+++ b/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
@@ -38,8 +38,17 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors.CheckedForwardingClientCall;
+import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StatusException;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 /**
@@ -56,14 +65,104 @@ public final class ClientAuthInterceptor implements ClientInterceptor {
 
   private final Credentials credentials;
 
+  private Metadata cached;
+  private Map<String, List<String>> lastMetadata;
+
   public ClientAuthInterceptor(
       Credentials credentials, @SuppressWarnings("unused") Executor executor) {
     this.credentials = Preconditions.checkNotNull(credentials);
+    // TODO(louiscryan): refresh token asynchronously with this executor.
   }
 
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
       final MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, final Channel next) {
-    return next.newCall(method, callOptions.withCredentials(MoreCallCredentials.from(credentials)));
+    // TODO(ejona86): If the call fails for Auth reasons, this does not properly propagate info that
+    // would be in WWW-Authenticate, because it does not yet have access to the header.
+    return new CheckedForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+      @Override
+      protected void checkedStart(Listener<RespT> responseListener, Metadata headers)
+          throws StatusException {
+        Metadata cachedSaved;
+        URI uri = serviceUri(next, method);
+        synchronized (ClientAuthInterceptor.this) {
+          // TODO(louiscryan): This is icky but the current auth library stores the same
+          // metadata map until the next refresh cycle. This will be fixed once
+          // https://github.com/google/google-auth-library-java/issues/3
+          // is resolved.
+          // getRequestMetadata() may return a different map based on the provided URI, i.e., for
+          // JWT. However, today it does not cache JWT and so we won't bother tring to cache its
+          // return value based on the URI.
+          Map<String, List<String>> latestMetadata = getRequestMetadata(uri);
+          if (lastMetadata == null || lastMetadata != latestMetadata) {
+            lastMetadata = latestMetadata;
+            cached = toHeaders(lastMetadata);
+          }
+          cachedSaved = cached;
+        }
+        headers.merge(cachedSaved);
+        delegate().start(responseListener, headers);
+      }
+    };
+  }
+
+  /**
+   * Generate a JWT-specific service URI. The URI is simply an identifier with enough information
+   * for a service to know that the JWT was intended for it. The URI will commonly be verified with
+   * a simple string equality check.
+   */
+  private URI serviceUri(Channel channel, MethodDescriptor<?, ?> method) throws StatusException {
+    String authority = channel.authority();
+    if (authority == null) {
+      throw Status.UNAUTHENTICATED.withDescription("Channel has no authority").asException();
+    }
+    // Always use HTTPS, by definition.
+    final String scheme = "https";
+    final int defaultPort = 443;
+    String path = "/" + MethodDescriptor.extractFullServiceName(method.getFullMethodName());
+    URI uri;
+    try {
+      uri = new URI(scheme, authority, path, null, null);
+    } catch (URISyntaxException e) {
+      throw Status.UNAUTHENTICATED.withDescription("Unable to construct service URI for auth")
+          .withCause(e).asException();
+    }
+    // The default port must not be present. Alternative ports should be present.
+    if (uri.getPort() == defaultPort) {
+      uri = removePort(uri);
+    }
+    return uri;
+  }
+
+  private URI removePort(URI uri) throws StatusException {
+    try {
+      return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), -1 /* port */,
+          uri.getPath(), uri.getQuery(), uri.getFragment());
+    } catch (URISyntaxException e) {
+      throw Status.UNAUTHENTICATED.withDescription(
+            "Unable to construct service URI after removing port")
+          .withCause(e).asException();
+    }
+  }
+
+  private Map<String, List<String>> getRequestMetadata(URI uri) throws StatusException {
+    try {
+      return credentials.getRequestMetadata(uri);
+    } catch (IOException e) {
+      throw Status.UNAUTHENTICATED.withCause(e).asException();
+    }
+  }
+
+  private static final Metadata toHeaders(Map<String, List<String>> metadata) {
+    Metadata headers = new Metadata();
+    if (metadata != null) {
+      for (String key : metadata.keySet()) {
+        Metadata.Key<String> headerKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+        for (String value : metadata.get(key)) {
+          headers.put(headerKey, value);
+        }
+      }
+    }
+    return headers;
   }
 }

--- a/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
+++ b/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTests.java
@@ -31,27 +31,44 @@
 
 package io.grpc.auth;
 
-import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.OAuth2Credentials;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
+import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.Status;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.Date;
 import java.util.concurrent.Executor;
 
 /**
@@ -60,8 +77,13 @@ import java.util.concurrent.Executor;
 @RunWith(JUnit4.class)
 @Deprecated
 public class ClientAuthInterceptorTests {
-  @Mock
-  Executor executor;
+
+  private static final Metadata.Key<String> AUTHORIZATION = Metadata.Key.of("Authorization",
+      Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> EXTRA_AUTHORIZATION = Metadata.Key.of(
+      "Extra-Authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+  private final Executor executor = MoreExecutors.directExecutor();
 
   @Mock
   Credentials credentials;
@@ -75,10 +97,13 @@ public class ClientAuthInterceptorTests {
   MethodDescriptor<String, Integer> descriptor;
 
   @Mock
+  ClientCall.Listener<Integer> listener;
+
+  @Mock
   Channel channel;
 
-  @Captor
-  ArgumentCaptor<CallOptions> callOptionsCaptor;
+  @Mock
+  ClientCall<String, Integer> call;
 
   ClientAuthInterceptor interceptor;
 
@@ -88,17 +113,82 @@ public class ClientAuthInterceptorTests {
     MockitoAnnotations.initMocks(this);
     descriptor = MethodDescriptor.create(
         MethodDescriptor.MethodType.UNKNOWN, "a.service/method", stringMarshaller, intMarshaller);
+    when(channel.newCall(same(descriptor), any(CallOptions.class))).thenReturn(call);
+    doReturn("localhost:443").when(channel).authority();
     interceptor = new ClientAuthInterceptor(credentials, executor);
   }
 
   @Test
-  public void callCredentialsSet() throws Exception {
+  public void testCopyCredentialToHeaders() throws IOException {
+    ListMultimap<String, String> values = LinkedListMultimap.create();
+    values.put("Authorization", "token1");
+    values.put("Authorization", "token2");
+    values.put("Extra-Authorization", "token3");
+    values.put("Extra-Authorization", "token4");
+    when(credentials.getRequestMetadata(any(URI.class))).thenReturn(Multimaps.asMap(values));
     ClientCall<String, Integer> interceptedCall =
         interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
+    Metadata headers = new Metadata();
+    interceptedCall.start(listener, headers);
+    verify(call).start(listener, headers);
 
-    verify(channel).newCall(same(descriptor), callOptionsCaptor.capture());
-    GoogleAuthLibraryCallCredentials callCredentials =
-        (GoogleAuthLibraryCallCredentials) callOptionsCaptor.getValue().getCredentials();
-    assertSame(credentials, callCredentials.creds);
+    Iterable<String> authorization = headers.getAll(AUTHORIZATION);
+    Assert.assertArrayEquals(new String[]{"token1", "token2"},
+        Iterables.toArray(authorization, String.class));
+    Iterable<String> extraAuthorization = headers.getAll(EXTRA_AUTHORIZATION);
+    Assert.assertArrayEquals(new String[]{"token3", "token4"},
+        Iterables.toArray(extraAuthorization, String.class));
+  }
+
+  @Test
+  public void testCredentialsThrows() throws IOException {
+    when(credentials.getRequestMetadata(any(URI.class))).thenThrow(new IOException("Broken"));
+    ClientCall<String, Integer> interceptedCall =
+        interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
+    Metadata headers = new Metadata();
+    interceptedCall.start(listener, headers);
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+    Mockito.verify(listener).onClose(statusCaptor.capture(), isA(Metadata.class));
+    Assert.assertNull(headers.getAll(AUTHORIZATION));
+    Mockito.verify(call, never()).start(listener, headers);
+    Assert.assertEquals(Status.Code.UNAUTHENTICATED, statusCaptor.getValue().getCode());
+    Assert.assertNotNull(statusCaptor.getValue().getCause());
+  }
+
+  @Test
+  public void testWithOAuth2Credential() {
+    final AccessToken token = new AccessToken("allyourbase", new Date(Long.MAX_VALUE));
+    final OAuth2Credentials oAuth2Credentials = new OAuth2Credentials() {
+      @Override
+      public AccessToken refreshAccessToken() throws IOException {
+        return token;
+      }
+    };
+    interceptor = new ClientAuthInterceptor(oAuth2Credentials, executor);
+    ClientCall<String, Integer> interceptedCall =
+        interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
+    Metadata headers = new Metadata();
+    interceptedCall.start(listener, headers);
+    verify(call).start(listener, headers);
+    Iterable<String> authorization = headers.getAll(AUTHORIZATION);
+    Assert.assertArrayEquals(new String[]{"Bearer allyourbase"},
+        Iterables.toArray(authorization, String.class));
+  }
+
+  @Test
+  public void verifyServiceUri() throws IOException {
+    ClientCall<String, Integer> interceptedCall;
+
+    doReturn("example.com:443").when(channel).authority();
+    interceptedCall = interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
+    interceptedCall.start(listener, new Metadata());
+    verify(credentials).getRequestMetadata(URI.create("https://example.com/a.service"));
+    interceptedCall.cancel("Cancel for test", null);
+
+    doReturn("example.com:123").when(channel).authority();
+    interceptedCall = interceptor.interceptCall(descriptor, CallOptions.DEFAULT, channel);
+    interceptedCall.start(listener, new Metadata());
+    verify(credentials).getRequestMetadata(URI.create("https://example.com:123/a.service"));
+    interceptedCall.cancel("Cancel for test", null);
   }
 }


### PR DESCRIPTION
This partially reverts commit def237d9606cc226f6b523f0818ae2ae664645cf.

This is to avoid breaking internal tests that specifically verify the
behavior of the original implementation.