### PR TITLE
netty: detect when ALPN was not used. Fixes #522

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -170,8 +170,11 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
    * GrpcSslContexts}, but options could have been overridden.
    */
   public final NettyChannelBuilder sslContext(SslContext sslContext) {
-    checkArgument(sslContext == null || sslContext.isClient(),
-        "Server SSL context can not be used for client channel");
+    if (sslContext != null) {
+      checkArgument(sslContext.isClient(),
+          "Server SSL context can not be used for client channel");
+      GrpcSslContexts.ensureAlpnAndH2Enabled(sslContext.applicationProtocolNegotiator());
+    }
     this.sslContext = sslContext;
     return this;
   }

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -159,8 +159,11 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    * have been configured with {@link GrpcSslContexts}, but options could have been overridden.
    */
   public NettyServerBuilder sslContext(SslContext sslContext) {
-    checkArgument(sslContext == null || sslContext.isServer(),
-        "Client SSL context can not be used for server");
+    if (sslContext != null) {
+      checkArgument(sslContext.isServer(),
+          "Client SSL context can not be used for server");
+      GrpcSslContexts.ensureAlpnAndH2Enabled(sslContext.applicationProtocolNegotiator());
+    }
     this.sslContext = sslContext;
     return this;
   }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -32,7 +32,7 @@
 package io.grpc.netty;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.netty.GrpcSslContexts.HTTP2_VERSIONS;
+import static io.grpc.netty.GrpcSslContexts.HTTP2_VERSION;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -152,7 +152,7 @@ public final class ProtocolNegotiators {
       if (evt instanceof SslHandshakeCompletionEvent) {
         SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
         if (handshakeEvent.isSuccess()) {
-          if (HTTP2_VERSIONS.contains(sslHandler(ctx.pipeline()).applicationProtocol())) {
+          if (HTTP2_VERSION.equals(sslHandler(ctx.pipeline()).applicationProtocol())) {
             // Successfully negotiated the protocol. Replace this handler with
             // the GRPC handler.
             ctx.pipeline().replace(this, null, grpcHandler);
@@ -500,7 +500,7 @@ public final class ProtocolNegotiators {
         SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
         if (handshakeEvent.isSuccess()) {
           SslHandler handler = ctx.pipeline().get(SslHandler.class);
-          if (HTTP2_VERSIONS.contains(handler.applicationProtocol())) {
+          if (HTTP2_VERSION.equals(handler.applicationProtocol())) {
             // Successfully negotiated the protocol.
             logSslEngineDetails(Level.FINER, ctx, "TLS negotiation succeeded.", null);
             writeBufferedAndRemove(ctx);


### PR DESCRIPTION
For client + server.

However, when connecting to a server that does not support ALPN, the TLS Handshake fails (on the client) and the client dies with a `SSLException: engine closed`. I believe this is a bug in Netty + OpenSSL, as it does not appear to happen when using JDK + Jetty. I am looking into it right now.