### PR TITLE
core: Improve error message when lacking NameResolverProviders

### DIFF
--- a/core/src/main/java/io/grpc/NameResolverProvider.java
+++ b/core/src/main/java/io/grpc/NameResolverProvider.java
@@ -32,6 +32,7 @@
 package io.grpc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -141,6 +142,7 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
 
     @Override
     public NameResolver newNameResolver(URI targetUri, Attributes params) {
+      checkForProviders();
       for (NameResolverProvider provider : providers) {
         NameResolver resolver = provider.newNameResolver(targetUri, params);
         if (resolver != null) {
@@ -152,10 +154,14 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
 
     @Override
     public String getDefaultScheme() {
-      if (providers.isEmpty()) {
-        return "noproviders";
-      }
+      checkForProviders();
       return providers.get(0).getDefaultScheme();
+    }
+
+    private void checkForProviders() {
+      Preconditions.checkState(!providers.isEmpty(),
+          "No NameResolverProviders found via ServiceLoader, including for DNS. "
+          + "This is probably due to a broken build. If using ProGuard, check your configuration");
     }
   }
 }

--- a/core/src/test/java/io/grpc/NameResolverProviderTest.java
+++ b/core/src/test/java/io/grpc/NameResolverProviderTest.java
@@ -34,6 +34,8 @@ package io.grpc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import io.grpc.internal.DnsNameResolverProvider;
@@ -60,8 +62,6 @@ public class NameResolverProviderTest {
         "io/grpc/NameResolverProviderTest-doesNotExist.txt");
     List<NameResolverProvider> providers = NameResolverProvider.load(cl);
     assertEquals(Collections.<NameResolverProvider>emptyList(), providers);
-    assertEquals("noproviders", NameResolverProvider.asFactory(providers).getDefaultScheme());
-    assertNull(null, NameResolverProvider.asFactory(providers).newNameResolver(uri, attributes));
   }
 
   @Test
@@ -89,6 +89,18 @@ public class NameResolverProviderTest {
   }
 
   @Test
+  public void getDefaultScheme_noProvider() {
+    List<NameResolverProvider> providers = Collections.<NameResolverProvider>emptyList();
+    NameResolver.Factory factory = NameResolverProvider.asFactory(providers);
+    try {
+      factory.getDefaultScheme();
+      fail("Expected exception");
+    } catch (IllegalStateException ex) {
+      assertTrue(ex.toString(), ex.getMessage().contains("No NameResolverProviders found"));
+    }
+  }
+
+  @Test
   public void newNameResolver_providerReturnsNull() {
     List<NameResolverProvider> providers = Collections.<NameResolverProvider>singletonList(
         new BaseProvider(true, 5) {
@@ -100,6 +112,18 @@ public class NameResolverProviderTest {
           }
         });
     assertNull(NameResolverProvider.asFactory(providers).newNameResolver(uri, attributes));
+  }
+
+  @Test
+  public void newNameResolver_noProvider() {
+    List<NameResolverProvider> providers = Collections.<NameResolverProvider>emptyList();
+    NameResolver.Factory factory = NameResolverProvider.asFactory(providers);
+    try {
+      factory.newNameResolver(uri, attributes);
+      fail("Expected exception");
+    } catch (IllegalStateException ex) {
+      assertTrue(ex.toString(), ex.getMessage().contains("No NameResolverProviders found"));
+    }
   }
 
   @Test


### PR DESCRIPTION
This is to improve debugging as in #1982.