### PR TITLE
testware: fix flakes caused by pickUnusedPort

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -31,7 +31,7 @@
 
 package io.grpc.benchmarks;
 
-import static io.grpc.testing.TestUtils.pickUnusedPort;
+import static io.grpc.benchmarks.Utils.pickUnusedPort;
 
 import com.google.protobuf.ByteString;
 

--- a/benchmarks/src/main/java/io/grpc/benchmarks/Utils.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/Utils.java
@@ -65,6 +65,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import java.net.SocketAddress;
 import java.util.concurrent.ThreadFactory;
 
@@ -278,5 +279,22 @@ public final class Utils {
         .setResponseSize(respLength)
         .setPayload(payload)
         .build();
+  }
+
+  /**
+   * Picks a port that is not used right at this moment.
+   * Warning: Not thread safe. May see "BindException: Address already in use: bind" if using the
+   * returned port to create a new server socket when other threads/processes are concurrently
+   * creating new sockets without a specific port.
+   */
+  public static int pickUnusedPort() {
+    try {
+      ServerSocket serverSocket = new ServerSocket(0);
+      int port = serverSocket.getLocalPort();
+      serverSocket.close();
+      return port;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
@@ -98,7 +98,7 @@ final class LoadServer {
 
   LoadServer(Control.ServerConfig config) throws Exception {
     LOG.log(Level.INFO, "Server Config \n" + config.toString());
-    port = config.getPort() ==  0 ? TestUtils.pickUnusedPort() : config.getPort();
+    port = config.getPort() ==  0 ? Utils.pickUnusedPort() : config.getPort();
     ServerBuilder<?> serverBuilder = ServerBuilder.forPort(port);
     int asyncThreads = config.getAsyncServerThreads() == 0
         ? Runtime.getRuntime().availableProcessors()

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ServerConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ServerConfiguration.java
@@ -37,7 +37,6 @@ import static java.lang.Integer.parseInt;
 import io.grpc.benchmarks.SocketAddressValidator;
 import io.grpc.benchmarks.Utils;
 import io.grpc.netty.NettyChannelBuilder;
-import io.grpc.testing.TestUtils;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -163,7 +162,7 @@ class ServerConfiguration implements Configuration {
         SocketAddress address = Utils.parseSocketAddress(value);
         if (address instanceof InetSocketAddress) {
           InetSocketAddress addr = (InetSocketAddress) address;
-          int port = addr.getPort() == 0 ? TestUtils.pickUnusedPort() : addr.getPort();
+          int port = addr.getPort() == 0 ? Utils.pickUnusedPort() : addr.getPort();
           // Re-create the address so that the server is available on all local addresses.
           address = new InetSocketAddress(port);
         }

--- a/benchmarks/src/test/java/io/grpc/benchmarks/driver/LoadWorkerTest.java
+++ b/benchmarks/src/test/java/io/grpc/benchmarks/driver/LoadWorkerTest.java
@@ -34,13 +34,13 @@ package io.grpc.benchmarks.driver;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import io.grpc.benchmarks.Utils;
 import io.grpc.benchmarks.proto.Control;
 import io.grpc.benchmarks.proto.Stats;
 import io.grpc.benchmarks.proto.WorkerServiceGrpc;
 import io.grpc.internal.ManagedChannelImpl;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
-import io.grpc.testing.TestUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -71,7 +71,7 @@ public class LoadWorkerTest {
 
   @Before
   public void setup() throws Exception {
-    int port = TestUtils.pickUnusedPort();
+    int port = Utils.pickUnusedPort();
     worker = new LoadWorker(port, 0);
     worker.start();
     channel = NettyChannelBuilder.forAddress("localhost", port).usePlaintext(true).build();

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -49,7 +49,12 @@ public class InProcessTransportTest extends AbstractTransportTest {
   }
 
   @Override
-  protected ManagedClientTransport newClientTransport() {
+  protected InternalServer newServer(InternalServer server) {
+    return newServer();
+  }
+
+  @Override
+  protected ManagedClientTransport newClientTransport(InternalServer server) {
     return new InProcessTransport(transportName);
   }
 }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -49,6 +49,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.ServiceAccountJwtAccessCredentials;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
@@ -142,6 +143,11 @@ public abstract class AbstractInteropTest {
   protected static void stopStaticServer() {
     server.shutdownNow();
     testServiceExecutor.shutdown();
+  }
+
+  @VisibleForTesting
+  static int getPort() {
+    return server.getPort();
   }
 
   protected ManagedChannel channel;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -273,6 +273,11 @@ public class StressTestClient {
     }
   }
 
+  @VisibleForTesting
+  int getMetricServerPort() {
+    return metricsServer.getPort();
+  }
+
   private static List<InetSocketAddress> parseServerAddresses(String addressesStr) {
     List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>();
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -158,6 +158,11 @@ public class TestServiceServer {
     MoreExecutors.shutdownAndAwaitTermination(executor, 5, TimeUnit.SECONDS);
   }
 
+  @VisibleForTesting
+  int getPort() {
+    return server.getPort();
+  }
+
   /**
    * Await termination on the main thread since the grpc library uses daemon threads.
    */

--- a/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
@@ -62,7 +62,6 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.stub.StreamObserver;
-import io.grpc.testing.TestUtils;
 import io.grpc.testing.integration.Messages.Payload;
 import io.grpc.testing.integration.Messages.SimpleRequest;
 import io.grpc.testing.integration.Messages.SimpleResponse;
@@ -199,8 +198,7 @@ public class CompressionTest {
       serverCompressors.register(serverCodec);
     }
 
-    int serverPort = TestUtils.pickUnusedPort();
-    server = ServerBuilder.forPort(serverPort)
+    server = ServerBuilder.forPort(0)
         .addService(
             ServerInterceptors.intercept(new LocalServer(), new ServerCompressorInterceptor()))
         .compressorRegistry(serverCompressors)
@@ -208,7 +206,7 @@ public class CompressionTest {
         .build()
         .start();
 
-    channel = ManagedChannelBuilder.forAddress("localhost", serverPort)
+    channel = ManagedChannelBuilder.forAddress("localhost", server.getPort())
         .decompressorRegistry(clientDecompressors)
         .compressorRegistry(clientCompressors)
         .intercept(new ClientCompressorInterceptor())

--- a/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
@@ -149,7 +149,6 @@ public class ConcurrencyTest {
   private static final int NUM_CONCURRENT_REQUESTS = 100;
   private static final int NUM_RESPONSES_PER_REQUEST = 100;
 
-  private int port = TestUtils.pickUnusedPort();
   private Server server;
   private ManagedChannel clientChannel;
   private TestServiceGrpc.TestServiceStub clientStub;
@@ -213,7 +212,7 @@ public class ConcurrencyTest {
                        .clientAuth(ClientAuth.REQUIRE)
                        .build();
 
-    return NettyServerBuilder.forPort(port)
+    return NettyServerBuilder.forPort(0)
         .sslContext(sslContext)
         .addService(TestServiceGrpc.bindService(new TestServiceImpl(serverExecutor)))
         .build()
@@ -233,7 +232,7 @@ public class ConcurrencyTest {
                        .trustManager(clientTrustedCaCerts)
                        .build();
 
-    return NettyChannelBuilder.forAddress("localhost", port)
+    return NettyChannelBuilder.forAddress("localhost", server.getPort())
         .overrideAuthority(TestUtils.TEST_SERVER_HOST)
         .negotiationType(NegotiationType.TLS)
         .sslContext(sslContext)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -53,13 +53,12 @@ import java.io.IOException;
  */
 @RunWith(JUnit4.class)
 public class Http2NettyTest extends AbstractInteropTest {
-  private static int serverPort = TestUtils.pickUnusedPort();
 
   /** Starts the server with HTTPS. */
   @BeforeClass
   public static void startServer() {
     try {
-      startStaticServer(NettyServerBuilder.forPort(serverPort)
+      startStaticServer(NettyServerBuilder.forPort(0)
           .flowControlWindow(65 * 1024)
           .sslContext(GrpcSslContexts
               .forServer(TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"))
@@ -82,7 +81,7 @@ public class Http2NettyTest extends AbstractInteropTest {
   protected ManagedChannel createChannel() {
     try {
       return NettyChannelBuilder
-          .forAddress(TestUtils.testServerAddress(serverPort))
+          .forAddress(TestUtils.testServerAddress(getPort()))
           .sslContext(GrpcSslContexts
               .forClient()
               .keyManager(TestUtils.loadCert("client.pem"), TestUtils.loadCert("client.key"))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -40,7 +40,6 @@ import com.google.common.collect.ImmutableList;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.testing.TestUtils;
 import io.grpc.testing.integration.Metrics.EmptyMessage;
 import io.grpc.testing.integration.Metrics.GaugeResponse;
 import io.grpc.testing.integration.StressTestClient.TestCaseWeightPair;
@@ -112,22 +111,20 @@ public class StressTestClientTest {
 
   @Test(timeout = 5000)
   public void gaugesShouldBeExported() throws Exception {
-    int serverPort = TestUtils.pickUnusedPort();
-    int metricsPort = TestUtils.pickUnusedPort();
 
     TestServiceServer server = new TestServiceServer();
-    server.parseArgs(new String[]{"--port=" + serverPort, "--use_tls=false"});
+    server.parseArgs(new String[]{"--port=" + 0, "--use_tls=false"});
     server.start();
 
     StressTestClient client = new StressTestClient();
     client.parseArgs(new String[] {"--test_cases=empty_unary:1",
-        "--server_addresses=localhost:" + serverPort, "--metrics_port=" + metricsPort,
+        "--server_addresses=localhost:" + server.getPort(), "--metrics_port=" + 0,
         "--num_stubs_per_channel=2"});
     client.startMetricsService();
     client.runStressTest();
 
     // Connect to the metrics service
-    ManagedChannel ch = ManagedChannelBuilder.forAddress("localhost", metricsPort)
+    ManagedChannel ch = ManagedChannelBuilder.forAddress("localhost", client.getMetricServerPort())
         .usePlaintext(true)
         .build();
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TlsTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TlsTest.java
@@ -91,7 +91,6 @@ public class TlsTest {
   @Parameter(value = 0)
   public SslProvider sslProvider;
 
-  private int port = TestUtils.pickUnusedPort();
   private ScheduledExecutorService executor;
   private Server server;
   private ManagedChannel channel;
@@ -130,7 +129,7 @@ public class TlsTest {
     X509Certificate[] serverTrustedCaCerts = {
       TestUtils.loadX509Cert("ca.pem")
     };
-    server = serverBuilder(port, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
+    server = serverBuilder(0, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
         .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
         .build()
         .start();
@@ -141,7 +140,7 @@ public class TlsTest {
     X509Certificate[] clientTrustedCaCerts = {
       TestUtils.loadX509Cert("ca.pem")
     };
-    channel = clientChannel(port, clientContextBuilder
+    channel = clientChannel(server.getPort(), clientContextBuilder
         .keyManager(clientCertChainFile, clientPrivateKeyFile)
         .trustManager(clientTrustedCaCerts)
         .build());
@@ -166,7 +165,7 @@ public class TlsTest {
     X509Certificate[] serverTrustedCaCerts = {
       TestUtils.loadX509Cert("ca.pem")
     };
-    server = serverBuilder(port, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
+    server = serverBuilder(0, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
         .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
         .build()
         .start();
@@ -179,7 +178,7 @@ public class TlsTest {
     X509Certificate[] clientTrustedCaCerts = {
       TestUtils.loadX509Cert("ca.pem")
     };
-    channel = clientChannel(port, clientContextBuilder
+    channel = clientChannel(server.getPort(), clientContextBuilder
         .keyManager(clientCertChainFile, clientPrivateKeyFile)
         .trustManager(clientTrustedCaCerts)
         .build());
@@ -213,7 +212,7 @@ public class TlsTest {
     X509Certificate[] serverTrustedCaCerts = {
       TestUtils.loadX509Cert("ca.pem")
     };
-    server = serverBuilder(port, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
+    server = serverBuilder(0, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
         .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
         .build()
         .start();
@@ -222,7 +221,7 @@ public class TlsTest {
     X509Certificate[] clientTrustedCaCerts = {
       TestUtils.loadX509Cert("ca.pem")
     };
-    channel = clientChannel(port, clientContextBuilder
+    channel = clientChannel(server.getPort(), clientContextBuilder
         .trustManager(clientTrustedCaCerts)
         .build());
     TestServiceGrpc.TestServiceBlockingStub client = TestServiceGrpc.newBlockingStub(channel);
@@ -255,7 +254,7 @@ public class TlsTest {
     X509Certificate[] serverTrustedCaCerts = {
       TestUtils.loadX509Cert("ca.pem")
     };
-    server = serverBuilder(port, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
+    server = serverBuilder(0, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
         .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
         .build()
         .start();
@@ -266,7 +265,7 @@ public class TlsTest {
     X509Certificate[] clientTrustedCaCerts = {
       TestUtils.loadX509Cert("ca.pem")
     };
-    channel = clientChannel(port, clientContextBuilder
+    channel = clientChannel(server.getPort(), clientContextBuilder
         .keyManager(clientCertChainFile, clientPrivateKeyFile)
         .trustManager(clientTrustedCaCerts)
         .build());

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -55,7 +55,6 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.testing.TestUtils;
 import io.grpc.testing.integration.Messages.CompressionType;
 import io.grpc.testing.integration.Messages.Payload;
 import io.grpc.testing.integration.Messages.PayloadType;
@@ -81,7 +80,6 @@ import java.io.OutputStream;
 @RunWith(JUnit4.class)
 public class TransportCompressionTest extends AbstractInteropTest {
 
-  private static int serverPort = TestUtils.pickUnusedPort();
   // Masquerade as identity.
   private static final Fzip FZIPPER = new Fzip("gzip", new Codec.Gzip());
   private volatile boolean expectFzip;
@@ -103,7 +101,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
     compressors.register(FZIPPER);
     compressors.register(Codec.Identity.NONE);
     startStaticServer(
-        ServerBuilder.forPort(serverPort)
+        ServerBuilder.forPort(0)
             .compressorRegistry(compressors)
             .decompressorRegistry(decompressors),
         new ServerInterceptor() {
@@ -149,7 +147,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
 
   @Override
   protected ManagedChannel createChannel() {
-    return ManagedChannelBuilder.forAddress("localhost", serverPort)
+    return ManagedChannelBuilder.forAddress("localhost", getPort())
         .decompressorRegistry(decompressors)
         .compressorRegistry(compressors)
         .intercept(new ClientInterceptor() {

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportFactoryTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportFactoryTest.java
@@ -33,7 +33,6 @@ package io.grpc.netty;
 
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.testing.AbstractClientTransportFactoryTest;
-import io.grpc.testing.TestUtils;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -41,7 +40,7 @@ import org.junit.runners.JUnit4;
 public class NettyClientTransportFactoryTest extends AbstractClientTransportFactoryTest {
   @Override protected ClientTransportFactory newClientTransportFactory() {
     return NettyChannelBuilder
-        .forAddress("localhost", TestUtils.pickUnusedPort())
+        .forAddress("localhost", 0)
         .buildTransportFactory();
   }
 }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportFactoryTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportFactoryTest.java
@@ -33,7 +33,6 @@ package io.grpc.okhttp;
 
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.testing.AbstractClientTransportFactoryTest;
-import io.grpc.testing.TestUtils;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -41,7 +40,7 @@ import org.junit.runners.JUnit4;
 public class OkHttpClientTransportFactoryTest extends AbstractClientTransportFactoryTest {
   @Override
   protected ClientTransportFactory newClientTransportFactory() {
-    return OkHttpChannelBuilder.forAddress("localhost", TestUtils.pickUnusedPort())
+    return OkHttpChannelBuilder.forAddress("localhost", 0)
         .buildTransportFactory();
   }
 }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
@@ -32,7 +32,6 @@
 package io.grpc.internal.testing;
 
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.testing.TestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -54,10 +53,9 @@ public abstract class AbstractClientTransportFactoryTest {
 
   @Test(expected = IllegalStateException.class)
   public void newClientTransportAfterCloseShouldThrow() {
-    int port = TestUtils.pickUnusedPort();
     ClientTransportFactory transportFactory = newClientTransportFactory();
     transportFactory.close();
     transportFactory.newClientTransport(
-        new InetSocketAddress("localhost", port), "localhost:" + port, "agent");
+        new InetSocketAddress("localhost", 12345), "localhost:" + 12345, "agent");
   }
 }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -58,7 +58,6 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
@@ -106,8 +105,7 @@ public abstract class AbstractTransportTest {
   protected abstract InternalServer newServer();
 
   /**
-   * Builds a new server using a {@link ServerBuilder} with the same attributes
-   * as the given server instance has.
+   * Builds a new server that is listening on the same location as the given server instance does.
    */
   protected abstract InternalServer newServer(InternalServer server);
 
@@ -147,7 +145,6 @@ public abstract class AbstractTransportTest {
   @Before
   public void setUp() {
     server = newServer();
-    //client = newClientTransport();
   }
 
   @After

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -49,7 +49,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
 import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
@@ -144,20 +143,6 @@ public class TestUtils {
         return next.startCall(method, call, requestHeaders);
       }
     };
-  }
-
-  /**
-   * Picks an unused port.
-   */
-  public static int pickUnusedPort() {
-    try {
-      ServerSocket serverSocket = new ServerSocket(0);
-      int port = serverSocket.getLocalPort();
-      serverSocket.close();
-      return port;
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   /**


### PR DESCRIPTION
The thread-unsafe method `io.grpc.testing.TestUtils.pickUnusedPort` causes flakes (#1756) in windows. Need to avoid use of this method in test as in windows the tests are running in different jvms and concurrent calls of this method in multiple processes tend to return the same port number.

There are some usages of this method in benchmarks, so moved the method to `io.grpc.benchmarks.Utils` and the method will only be used in benchmarks and not in test.