### PR TITLE
netty: improve flushing and object allocations in write queue.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
@@ -34,7 +34,6 @@ package io.grpc.netty;
 import com.google.common.base.Preconditions;
 
 import io.grpc.Status;
-import io.netty.channel.ChannelPromise;
 
 /**
  * Command sent from a Netty client stream to the handler to cancel the stream.
@@ -42,8 +41,6 @@ import io.netty.channel.ChannelPromise;
 class CancelClientStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final NettyClientStream stream;
   private final Status reason;
-
-  private ChannelPromise promise;
 
   CancelClientStreamCommand(NettyClientStream stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream, "stream");

--- a/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
@@ -34,13 +34,16 @@ package io.grpc.netty;
 import com.google.common.base.Preconditions;
 
 import io.grpc.Status;
+import io.netty.channel.ChannelPromise;
 
 /**
  * Command sent from a Netty client stream to the handler to cancel the stream.
  */
-class CancelClientStreamCommand {
+class CancelClientStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final NettyClientStream stream;
   private final Status reason;
+
+  private ChannelPromise promise;
 
   CancelClientStreamCommand(NettyClientStream stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream, "stream");

--- a/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
@@ -36,7 +36,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import io.grpc.Status;
-import io.netty.channel.ChannelPromise;
 
 /**
  * Command sent from a Netty server stream to the handler to cancel the stream.
@@ -44,8 +43,6 @@ import io.netty.channel.ChannelPromise;
 class CancelServerStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final NettyServerStream.TransportState stream;
   private final Status reason;
-
-  private ChannelPromise promise;
 
   CancelServerStreamCommand(NettyServerStream.TransportState stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream);

--- a/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
@@ -36,13 +36,16 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import io.grpc.Status;
+import io.netty.channel.ChannelPromise;
 
 /**
  * Command sent from a Netty server stream to the handler to cancel the stream.
  */
-class CancelServerStreamCommand {
+class CancelServerStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final NettyServerStream.TransportState stream;
   private final Status reason;
+
+  private ChannelPromise promise;
 
   CancelServerStreamCommand(NettyServerStream.TransportState stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream);

--- a/netty/src/main/java/io/grpc/netty/CreateStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CreateStreamCommand.java
@@ -33,15 +33,18 @@ package io.grpc.netty;
 
 import com.google.common.base.Preconditions;
 
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2Headers;
 
 /**
  * A command to create a new stream. This is created by {@link NettyClientStream} and passed to the
  * {@link NettyClientHandler} for processing in the Channel thread.
  */
-class CreateStreamCommand {
+class CreateStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final Http2Headers headers;
   private final NettyClientStream stream;
+
+  private ChannelPromise promise;
 
   CreateStreamCommand(Http2Headers headers,
                       NettyClientStream stream) {

--- a/netty/src/main/java/io/grpc/netty/CreateStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CreateStreamCommand.java
@@ -33,7 +33,6 @@ package io.grpc.netty;
 
 import com.google.common.base.Preconditions;
 
-import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2Headers;
 
 /**
@@ -43,8 +42,6 @@ import io.netty.handler.codec.http2.Http2Headers;
 class CreateStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final Http2Headers headers;
   private final NettyClientStream stream;
-
-  private ChannelPromise promise;
 
   CreateStreamCommand(Http2Headers headers,
                       NettyClientStream stream) {

--- a/netty/src/main/java/io/grpc/netty/ForcefulCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/ForcefulCloseCommand.java
@@ -32,13 +32,16 @@
 package io.grpc.netty;
 
 import io.grpc.Status;
+import io.netty.channel.ChannelPromise;
 
 /**
  * A command to trigger close and close all streams. It is buffered differently than normal close
  * and also includes reason for closure.
  */
-class ForcefulCloseCommand {
+class ForcefulCloseCommand extends WriteQueue.AbstractQueuedCommand {
   private final Status status;
+
+  private ChannelPromise promise;
 
   public ForcefulCloseCommand(Status status) {
     this.status = status;

--- a/netty/src/main/java/io/grpc/netty/ForcefulCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/ForcefulCloseCommand.java
@@ -32,7 +32,6 @@
 package io.grpc.netty;
 
 import io.grpc.Status;
-import io.netty.channel.ChannelPromise;
 
 /**
  * A command to trigger close and close all streams. It is buffered differently than normal close
@@ -40,8 +39,6 @@ import io.netty.channel.ChannelPromise;
  */
 class ForcefulCloseCommand extends WriteQueue.AbstractQueuedCommand {
   private final Status status;
-
-  private ChannelPromise promise;
 
   public ForcefulCloseCommand(Status status) {
     this.status = status;

--- a/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
@@ -32,7 +32,6 @@
 package io.grpc.netty;
 
 import io.grpc.Status;
-import io.netty.channel.ChannelPromise;
 
 /**
  * A command to trigger close. It is buffered differently than normal close and also includes
@@ -40,8 +39,6 @@ import io.netty.channel.ChannelPromise;
  */
 class GracefulCloseCommand extends WriteQueue.AbstractQueuedCommand {
   private final Status status;
-
-  private ChannelPromise promise;
 
   public GracefulCloseCommand(Status status) {
     this.status = status;

--- a/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
@@ -32,13 +32,16 @@
 package io.grpc.netty;
 
 import io.grpc.Status;
+import io.netty.channel.ChannelPromise;
 
 /**
  * A command to trigger close. It is buffered differently than normal close and also includes
  * reason for closure.
  */
-class GracefulCloseCommand {
+class GracefulCloseCommand extends WriteQueue.AbstractQueuedCommand {
   private final Status status;
+
+  private ChannelPromise promise;
 
   public GracefulCloseCommand(Status status) {
     this.status = status;

--- a/netty/src/main/java/io/grpc/netty/RequestMessagesCommand.java
+++ b/netty/src/main/java/io/grpc/netty/RequestMessagesCommand.java
@@ -33,15 +33,18 @@ package io.grpc.netty;
 
 import io.grpc.internal.AbstractStream2;
 import io.grpc.internal.Stream;
+import io.netty.channel.ChannelPromise;
 
 /**
  * Command which requests messages from the deframer.
  */
-class RequestMessagesCommand {
+class RequestMessagesCommand extends WriteQueue.AbstractQueuedCommand {
 
   private final int numMessages;
   private final Stream stream;
   private final AbstractStream2.TransportState state;
+
+  private ChannelPromise promise;
 
   public RequestMessagesCommand(Stream stream, int numMessages) {
     this.state = null;

--- a/netty/src/main/java/io/grpc/netty/RequestMessagesCommand.java
+++ b/netty/src/main/java/io/grpc/netty/RequestMessagesCommand.java
@@ -33,7 +33,6 @@ package io.grpc.netty;
 
 import io.grpc.internal.AbstractStream2;
 import io.grpc.internal.Stream;
-import io.netty.channel.ChannelPromise;
 
 /**
  * Command which requests messages from the deframer.
@@ -43,8 +42,6 @@ class RequestMessagesCommand extends WriteQueue.AbstractQueuedCommand {
   private final int numMessages;
   private final Stream stream;
   private final AbstractStream2.TransportState state;
-
-  private ChannelPromise promise;
 
   public RequestMessagesCommand(Stream stream, int numMessages) {
     this.state = null;

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -121,11 +121,6 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.Qu
   }
 
   @Override
-  public Object command() {
-    return this;
-  }
-
-  @Override
   public ChannelPromise promise() {
     return promise;
   }

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -34,13 +34,16 @@ package io.grpc.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.channel.ChannelPromise;
 
 /**
  * Command sent from the transport to the Netty channel to send a GRPC frame to the remote endpoint.
  */
-class SendGrpcFrameCommand extends DefaultByteBufHolder {
+class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.QueuedCommand {
   private final StreamIdHolder stream;
   private final boolean endStream;
+
+  private ChannelPromise promise;
 
   SendGrpcFrameCommand(StreamIdHolder stream, ByteBuf content, boolean endStream) {
     super(content);
@@ -115,5 +118,20 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder {
       hash = -hash;
     }
     return hash;
+  }
+
+  @Override
+  public Object command() {
+    return this;
+  }
+
+  @Override
+  public ChannelPromise promise() {
+    return promise;
+  }
+
+  @Override
+  public void promise(ChannelPromise promise) {
+    this.promise = promise;
   }
 }

--- a/netty/src/main/java/io/grpc/netty/SendPingCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendPingCommand.java
@@ -32,15 +32,18 @@
 package io.grpc.netty;
 
 import io.grpc.internal.ClientTransport.PingCallback;
+import io.netty.channel.ChannelPromise;
 
 import java.util.concurrent.Executor;
 
 /**
  * Command sent from the transport to the Netty channel to send a PING frame.
  */
-class SendPingCommand {
+class SendPingCommand extends WriteQueue.AbstractQueuedCommand {
   private final PingCallback callback;
   private final Executor executor;
+
+  private ChannelPromise promise;
 
   SendPingCommand(PingCallback callback, Executor executor) {
     this.callback = callback;

--- a/netty/src/main/java/io/grpc/netty/SendPingCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendPingCommand.java
@@ -32,7 +32,6 @@
 package io.grpc.netty;
 
 import io.grpc.internal.ClientTransport.PingCallback;
-import io.netty.channel.ChannelPromise;
 
 import java.util.concurrent.Executor;
 
@@ -42,8 +41,6 @@ import java.util.concurrent.Executor;
 class SendPingCommand extends WriteQueue.AbstractQueuedCommand {
   private final PingCallback callback;
   private final Executor executor;
-
-  private ChannelPromise promise;
 
   SendPingCommand(PingCallback callback, Executor executor) {
     this.callback = callback;

--- a/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
@@ -33,7 +33,6 @@ package io.grpc.netty;
 
 import com.google.common.base.Preconditions;
 
-import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2Headers;
 
 /**
@@ -43,8 +42,6 @@ class SendResponseHeadersCommand extends WriteQueue.AbstractQueuedCommand {
   private final StreamIdHolder stream;
   private final Http2Headers headers;
   private final boolean endOfStream;
-
-  private ChannelPromise promise;
 
   SendResponseHeadersCommand(StreamIdHolder stream, Http2Headers headers, boolean endOfStream) {
     this.stream = Preconditions.checkNotNull(stream);

--- a/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
@@ -33,15 +33,18 @@ package io.grpc.netty;
 
 import com.google.common.base.Preconditions;
 
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2Headers;
 
 /**
  * Command sent from the transport to the Netty channel to send response headers to the client.
  */
-class SendResponseHeadersCommand {
+class SendResponseHeadersCommand extends WriteQueue.AbstractQueuedCommand {
   private final StreamIdHolder stream;
   private final Http2Headers headers;
   private final boolean endOfStream;
+
+  private ChannelPromise promise;
 
   SendResponseHeadersCommand(StreamIdHolder stream, Http2Headers headers, boolean endOfStream) {
     this.stream = Preconditions.checkNotNull(stream);

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -373,12 +373,11 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
   @Test
   public void createIncrementsIdsForActualAndBufferdStreams() throws Exception {
     receiveMaxConcurrentStreams(2);
-    CreateStreamCommand command = new CreateStreamCommand(grpcHeaders, stream);
-    enqueue(command);
+    enqueue(new CreateStreamCommand(grpcHeaders, stream));
     verify(stream).id(eq(3));
-    enqueue(command);
+    enqueue(new CreateStreamCommand(grpcHeaders, stream));
     verify(stream).id(eq(5));
-    enqueue(command);
+    enqueue(new CreateStreamCommand(grpcHeaders, stream));
     verify(stream).id(eq(7));
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -60,6 +60,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.netty.WriteQueue.QueuedCommand;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -380,7 +381,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     metadata.put(GrpcUtil.USER_AGENT_KEY, "bad agent");
     listener = mock(ClientStreamListener.class);
     Mockito.reset(writeQueue);
-    when(writeQueue.enqueue(any(), any(boolean.class))).thenReturn(future);
+    when(writeQueue.enqueue(any(QueuedCommand.class), any(boolean.class))).thenReturn(future);
 
     stream = new NettyClientStreamImpl(methodDescriptor, new Metadata(), channel, handler,
         DEFAULT_MAX_MESSAGE_SIZE, AsciiString.of("localhost"), AsciiString.of("http"),
@@ -404,8 +405,8 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         }
         return null;
       }
-    }).when(writeQueue).enqueue(any(), any(ChannelPromise.class), anyBoolean());
-    when(writeQueue.enqueue(any(), anyBoolean())).thenReturn(future);
+    }).when(writeQueue).enqueue(any(QueuedCommand.class), any(ChannelPromise.class), anyBoolean());
+    when(writeQueue.enqueue(any(QueuedCommand.class), anyBoolean())).thenReturn(future);
     NettyClientStream stream = new NettyClientStreamImpl(methodDescriptor, new Metadata(), channel,
         handler, DEFAULT_MAX_MESSAGE_SIZE, AsciiString.of("localhost"), AsciiString.of("http"),
         AsciiString.of("agent"));

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -194,7 +194,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
     return handler().connection();
   }
 
-  protected final ChannelFuture enqueue(Object command) {
+  protected final ChannelFuture enqueue(WriteQueue.QueuedCommand command) {
     ChannelFuture future = writeQueue.enqueue(command, newPromise(), true);
     channel.runPendingTasks();
     return future;

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -54,6 +54,7 @@ import com.google.common.collect.ListMultimap;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ServerStreamListener;
+import io.grpc.netty.WriteQueue.QueuedCommand;
 import io.netty.buffer.EmptyByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelPromise;
@@ -287,8 +288,8 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
         }
         return null;
       }
-    }).when(writeQueue).enqueue(any(), any(ChannelPromise.class), anyBoolean());
-    when(writeQueue.enqueue(any(), anyBoolean())).thenReturn(future);
+    }).when(writeQueue).enqueue(any(QueuedCommand.class), any(ChannelPromise.class), anyBoolean());
+    when(writeQueue.enqueue(any(QueuedCommand.class), anyBoolean())).thenReturn(future);
     NettyServerStream.TransportState state =
         new NettyServerStream.TransportState(handler, http2Stream, DEFAULT_MAX_MESSAGE_SIZE);
     NettyServerStream stream = new NettyServerStream(channel, state);

--- a/netty/src/test/java/io/grpc/netty/WriteQueueTest.java
+++ b/netty/src/test/java/io/grpc/netty/WriteQueueTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public class WriteQueueTest {
+
+  @Mock
+  public Channel channel;
+
+  @Mock
+  public ChannelPromise promise;
+
+  /**
+   * Set up for test.
+   */
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    when(channel.newPromise()).thenReturn(promise);
+
+    EventLoop eventLoop = Mockito.mock(EventLoop.class);
+    doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        Runnable r = (Runnable) invocation.getArguments()[0];
+        r.run();
+        return null;
+      }
+    }).when(eventLoop).execute(any(Runnable.class));
+
+    when(channel.eventLoop()).thenReturn(eventLoop);
+  }
+
+  @Test
+  public void singleWriteShouldWork() {
+    WriteQueue queue = new WriteQueue(channel);
+    Object command = new Object();
+    queue.enqueue(command, true);
+
+    verify(channel).write(eq(command), eq(promise));
+    verify(channel).flush();
+  }
+
+  @Test
+  public void multipleWritesShouldBeBatched() {
+    WriteQueue queue = new WriteQueue(channel);
+    for (int i = 0; i < 5; i++) {
+      queue.enqueue(new Object(), false);
+    }
+    queue.scheduleFlush();
+
+    verify(channel, times(5)).write(any(Object.class), eq(promise));
+    verify(channel).flush();
+  }
+
+  @Test
+  public void maxWritesShouldBeCapped() {
+    WriteQueue queue = new WriteQueue(channel);
+    int writes = WriteQueue.MAX_WRITES_BEFORE_FLUSH + 10;
+    Object command = new Object();
+    for (int i = 0; i < writes; i++) {
+      queue.enqueue(command, false);
+    }
+    queue.scheduleFlush();
+
+    verify(channel, times(writes)).write(eq(command), eq(promise));
+    verify(channel, times(2)).flush();
+  }
+  
+}


### PR DESCRIPTION
This PR contains two separate changes:
1. Instead of flushing every 128 writes, we now (effectively) only flush after having written every element in the write queue. This will allow us to better utilize gathering write system calls (e.g. on Linux `writev` can write 1024 buffers per default). This change only affects [WriteQueue.flush()](https://github.com/grpc/grpc-java/compare/master...buchgr:writequeue?expand=1#diff-0ff32fc8755ff668c8abe5f0da6fe59aR131).
2. Merge all the command objects with `QueuedCommand` so to save one object allocation per write.

I ll add some more tests tomorrow.