### PR TITLE
compiler: deprecate interfaces and add ImplBase in codegen

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -71,7 +71,7 @@ public class BenchmarkServiceGrpc {
 
   /**
    */
-  public static interface BenchmarkService {
+  @java.lang.Deprecated public static interface BenchmarkService {
 
     /**
      * <pre>
@@ -93,7 +93,7 @@ public class BenchmarkServiceGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractBenchmarkService implements BenchmarkService, io.grpc.BindableService {
+  public static abstract class BenchmarkServiceImplBase implements BenchmarkService, io.grpc.BindableService {
 
     @java.lang.Override
     public void unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
@@ -114,7 +114,7 @@ public class BenchmarkServiceGrpc {
 
   /**
    */
-  public static interface BenchmarkServiceBlockingClient {
+  @java.lang.Deprecated public static interface BenchmarkServiceBlockingClient {
 
     /**
      * <pre>
@@ -127,7 +127,7 @@ public class BenchmarkServiceGrpc {
 
   /**
    */
-  public static interface BenchmarkServiceFutureClient {
+  @java.lang.Deprecated public static interface BenchmarkServiceFutureClient {
 
     /**
      * <pre>
@@ -220,6 +220,8 @@ public class BenchmarkServiceGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractBenchmarkService extends BenchmarkServiceImplBase {}
+
   private static final int METHODID_UNARY_CALL = 0;
   private static final int METHODID_STREAMING_CALL = 1;
 
@@ -269,7 +271,7 @@ public class BenchmarkServiceGrpc {
         METHOD_STREAMING_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final BenchmarkService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -89,7 +89,7 @@ public class WorkerServiceGrpc {
 
   /**
    */
-  public static interface WorkerService {
+  @java.lang.Deprecated public static interface WorkerService {
 
     /**
      * <pre>
@@ -135,7 +135,7 @@ public class WorkerServiceGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractWorkerService implements WorkerService, io.grpc.BindableService {
+  public static abstract class WorkerServiceImplBase implements WorkerService, io.grpc.BindableService {
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerArgs> runServer(
@@ -168,7 +168,7 @@ public class WorkerServiceGrpc {
 
   /**
    */
-  public static interface WorkerServiceBlockingClient {
+  @java.lang.Deprecated public static interface WorkerServiceBlockingClient {
 
     /**
      * <pre>
@@ -187,7 +187,7 @@ public class WorkerServiceGrpc {
 
   /**
    */
-  public static interface WorkerServiceFutureClient {
+  @java.lang.Deprecated public static interface WorkerServiceFutureClient {
 
     /**
      * <pre>
@@ -314,6 +314,8 @@ public class WorkerServiceGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractWorkerService extends WorkerServiceImplBase {}
+
   private static final int METHODID_CORE_COUNT = 0;
   private static final int METHODID_QUIT_WORKER = 1;
   private static final int METHODID_RUN_SERVER = 2;
@@ -374,7 +376,7 @@ public class WorkerServiceGrpc {
         METHOD_QUIT_WORKER);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final WorkerService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -163,7 +163,7 @@ public class TransportBenchmark {
     }
 
     server = serverBuilder
-        .addService(BenchmarkServiceGrpc.bindService(new AsyncServer.BenchmarkServiceImpl()))
+        .addService(new AsyncServer.BenchmarkServiceImpl())
         .build();
     server.start();
     channel = channelBuilder.build();

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
@@ -147,7 +147,7 @@ final class LoadServer {
               .addMethod(GENERIC_STREAMING_PING_PONG_METHOD, new GenericServiceCallHandler())
               .build());
     } else {
-      serverBuilder.addService(BenchmarkServiceGrpc.bindService(benchmarkService));
+      serverBuilder.addService(benchmarkService);
     }
     server = serverBuilder.build();
 
@@ -196,7 +196,7 @@ final class LoadServer {
     server.shutdownNow();
   }
 
-  private class BenchmarkServiceImpl implements BenchmarkServiceGrpc.BenchmarkService {
+  private class BenchmarkServiceImpl extends BenchmarkServiceGrpc.BenchmarkServiceImplBase {
 
     @Override
     public void unaryCall(Messages.SimpleRequest request,

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
@@ -69,7 +69,7 @@ public class LoadWorker {
         .directExecutor()
         .workerEventLoopGroup(singleThreadGroup)
         .bossEventLoopGroup(singleThreadGroup)
-        .addService(WorkerServiceGrpc.bindService(new WorkerServiceImpl()))
+        .addService(new WorkerServiceImpl())
         .build();
   }
 
@@ -134,7 +134,7 @@ public class LoadWorker {
   /**
    * Implement the worker service contract which can launch clients and servers.
    */
-  private class WorkerServiceImpl implements WorkerServiceGrpc.WorkerService {
+  private class WorkerServiceImpl extends WorkerServiceGrpc.WorkerServiceImplBase {
 
     private LoadServer workerServer;
     private LoadClient workerClient;

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -167,7 +167,7 @@ public class AsyncServer {
         .bossEventLoopGroup(boss)
         .workerEventLoopGroup(worker)
         .channelType(channelType)
-        .addService(BenchmarkServiceGrpc.bindService(new BenchmarkServiceImpl()))
+        .addService(new BenchmarkServiceImpl())
         .sslContext(sslContext)
         .flowControlWindow(config.flowControlWindow);
     if (config.directExecutor) {
@@ -177,7 +177,7 @@ public class AsyncServer {
     return builder.build();
   }
 
-  public static class BenchmarkServiceImpl implements BenchmarkServiceGrpc.BenchmarkService {
+  public static class BenchmarkServiceImpl extends BenchmarkServiceGrpc.BenchmarkServiceImplBase {
 
     @Override
     public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -433,7 +433,7 @@ static void PrintStub(
     map<string, string>* vars,
     Printer* p, StubType type, bool generate_nano) {
   (*vars)["service_name"] = service->name();
-  (*vars)["abstract_name"] = "Abstract" + service->name();
+  (*vars)["abstract_name"] = service->name() + "ImplBase";
   string interface_name = service->name();
   string impl_name = service->name();
   bool abstract = false;
@@ -510,7 +510,7 @@ static void PrintStub(
     GrpcWriteServiceDocComment(p, service);
     p->Print(
         *vars,
-        "public static interface $interface_name$ {\n");
+        "@$Deprecated$ public static interface $interface_name$ {\n");
   } else {
     p->Print(
         *vars,
@@ -883,7 +883,7 @@ static void PrintBindServiceMethod(const ServiceDescriptor* service,
   (*vars)["service_name"] = service->name();
   p->Print(
       *vars,
-      "public static $ServerServiceDefinition$ bindService(\n"
+      "@$Deprecated$ public static $ServerServiceDefinition$ bindService(\n"
       "    final $service_name$ serviceImpl) {\n");
   p->Indent();
   p->Print(*vars,
@@ -1018,6 +1018,9 @@ static void PrintService(const ServiceDescriptor* service,
   PrintStub(service, vars, p, ASYNC_CLIENT_IMPL, generate_nano);
   PrintStub(service, vars, p, BLOCKING_CLIENT_IMPL, generate_nano);
   PrintStub(service, vars, p, FUTURE_CLIENT_IMPL, generate_nano);
+  p->Print(*vars,
+           "@$Deprecated$ public static abstract class Abstract$service_name$"
+           " extends $service_name$ImplBase {}\n\n");
   PrintMethodHandlerClass(service, vars, p, generate_nano);
   PrintGetServiceDescriptorMethod(service, vars, p, generate_nano);
   PrintBindServiceMethod(service, vars, p, generate_nano);
@@ -1068,6 +1071,7 @@ void GenerateService(const ServiceDescriptor* service,
   map<string, string> vars;
   vars["String"] = "java.lang.String";
   vars["Override"] = "java.lang.Override";
+  vars["Deprecated"] = "java.lang.Deprecated";
   vars["Channel"] = "io.grpc.Channel";
   vars["CallOptions"] = "io.grpc.CallOptions";
   vars["MethodType"] = "io.grpc.MethodDescriptor.MethodType";

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -104,7 +104,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestService {
+  @java.lang.Deprecated public static interface TestService {
 
     /**
      * <pre>
@@ -156,7 +156,7 @@ public class TestServiceGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractTestService implements TestService, io.grpc.BindableService {
+  public static abstract class TestServiceImplBase implements TestService, io.grpc.BindableService {
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
@@ -198,7 +198,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestServiceBlockingClient {
+  @java.lang.Deprecated public static interface TestServiceBlockingClient {
 
     /**
      * <pre>
@@ -223,7 +223,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestServiceFutureClient {
+  @java.lang.Deprecated public static interface TestServiceFutureClient {
 
     /**
      * <pre>
@@ -344,6 +344,8 @@ public class TestServiceGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractTestService extends TestServiceImplBase {}
+
   private static final int METHODID_UNARY_CALL = 0;
   private static final int METHODID_STREAMING_OUTPUT_CALL = 1;
   private static final int METHODID_STREAMING_INPUT_CALL = 2;
@@ -409,7 +411,7 @@ public class TestServiceGrpc {
         METHOD_HALF_BIDI_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -104,7 +104,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestService {
+  @java.lang.Deprecated public static interface TestService {
 
     /**
      * <pre>
@@ -156,7 +156,7 @@ public class TestServiceGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractTestService implements TestService, io.grpc.BindableService {
+  public static abstract class TestServiceImplBase implements TestService, io.grpc.BindableService {
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
@@ -198,7 +198,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestServiceBlockingClient {
+  @java.lang.Deprecated public static interface TestServiceBlockingClient {
 
     /**
      * <pre>
@@ -223,7 +223,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestServiceFutureClient {
+  @java.lang.Deprecated public static interface TestServiceFutureClient {
 
     /**
      * <pre>
@@ -344,6 +344,8 @@ public class TestServiceGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractTestService extends TestServiceImplBase {}
+
   private static final int METHODID_UNARY_CALL = 0;
   private static final int METHODID_STREAMING_OUTPUT_CALL = 1;
   private static final int METHODID_STREAMING_INPUT_CALL = 2;
@@ -409,7 +411,7 @@ public class TestServiceGrpc {
         METHOD_HALF_BIDI_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -182,7 +182,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestService {
+  @java.lang.Deprecated public static interface TestService {
 
     /**
      * <pre>
@@ -234,7 +234,7 @@ public class TestServiceGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractTestService implements TestService, io.grpc.BindableService {
+  public static abstract class TestServiceImplBase implements TestService, io.grpc.BindableService {
 
     @java.lang.Override
     public void unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request,
@@ -276,7 +276,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestServiceBlockingClient {
+  @java.lang.Deprecated public static interface TestServiceBlockingClient {
 
     /**
      * <pre>
@@ -301,7 +301,7 @@ public class TestServiceGrpc {
    * Test service that supports all call types.
    * </pre>
    */
-  public static interface TestServiceFutureClient {
+  @java.lang.Deprecated public static interface TestServiceFutureClient {
 
     /**
      * <pre>
@@ -422,6 +422,8 @@ public class TestServiceGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractTestService extends TestServiceImplBase {}
+
   private static final int METHODID_UNARY_CALL = 0;
   private static final int METHODID_STREAMING_OUTPUT_CALL = 1;
   private static final int METHODID_STREAMING_INPUT_CALL = 2;
@@ -487,7 +489,7 @@ public class TestServiceGrpc {
         METHOD_HALF_BIDI_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/core/src/main/java/io/grpc/ServerInterceptors.java
+++ b/core/src/main/java/io/grpc/ServerInterceptors.java
@@ -61,7 +61,6 @@ public class ServerInterceptors {
     return interceptForward(serviceDef, Arrays.asList(interceptors));
   }
 
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1701")
   public static ServerServiceDefinition interceptForward(BindableService bindableService,
       ServerInterceptor... interceptors) {
     return interceptForward(bindableService.bindService(), Arrays.asList(interceptors));
@@ -84,6 +83,12 @@ public class ServerInterceptors {
     return intercept(serviceDef, copy);
   }
 
+  public static ServerServiceDefinition interceptForward(
+      BindableService bindableService,
+      List<? extends ServerInterceptor> interceptors) {
+    return interceptForward(bindableService.bindService(), interceptors);
+  }
+
   /**
    * Create a new {@code ServerServiceDefinition} whose {@link ServerCallHandler}s will call
    * {@code interceptors} before calling the pre-existing {@code ServerCallHandler}. The last
@@ -100,6 +105,7 @@ public class ServerInterceptors {
 
   public static ServerServiceDefinition intercept(BindableService bindableService,
       ServerInterceptor... interceptors) {
+    Preconditions.checkNotNull(bindableService);
     return intercept(bindableService.bindService(), Arrays.asList(interceptors));
   }
 
@@ -124,6 +130,12 @@ public class ServerInterceptors {
       wrapAndAddMethod(serviceDefBuilder, method, interceptors);
     }
     return serviceDefBuilder.build();
+  }
+
+  public static ServerServiceDefinition intercept(BindableService bindableService,
+      List<? extends ServerInterceptor> interceptors) {
+    Preconditions.checkNotNull(bindableService);
+    return intercept(bindableService.bindService(), interceptors);
   }
 
   /**

--- a/core/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -111,7 +111,8 @@ public class ServerInterceptorsTest {
 
   @Test(expected = NullPointerException.class)
   public void npeForNullServiceDefinition() {
-    ServerInterceptors.intercept(null, Arrays.<ServerInterceptor>asList());
+    ServerServiceDefinition serviceDef = null;
+    ServerInterceptors.intercept(serviceDef, Arrays.<ServerInterceptor>asList());
   }
 
   @Test(expected = NullPointerException.class)

--- a/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/helloworld/GreeterGrpc.java
@@ -68,7 +68,7 @@ public class GreeterGrpc {
    * The greeting service definition.
    * </pre>
    */
-  public static interface Greeter {
+  @java.lang.Deprecated public static interface Greeter {
 
     /**
      * <pre>
@@ -80,7 +80,7 @@ public class GreeterGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractGreeter implements Greeter, io.grpc.BindableService {
+  public static abstract class GreeterImplBase implements Greeter, io.grpc.BindableService {
 
     @java.lang.Override
     public void sayHello(io.grpc.examples.helloworld.HelloRequest request,
@@ -98,7 +98,7 @@ public class GreeterGrpc {
    * The greeting service definition.
    * </pre>
    */
-  public static interface GreeterBlockingClient {
+  @java.lang.Deprecated public static interface GreeterBlockingClient {
 
     /**
      * <pre>
@@ -113,7 +113,7 @@ public class GreeterGrpc {
    * The greeting service definition.
    * </pre>
    */
-  public static interface GreeterFutureClient {
+  @java.lang.Deprecated public static interface GreeterFutureClient {
 
     /**
      * <pre>
@@ -198,6 +198,8 @@ public class GreeterGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractGreeter extends GreeterImplBase {}
+
   private static final int METHODID_SAY_HELLO = 0;
 
   private static class MethodHandlers<Req, Resp> implements
@@ -242,7 +244,7 @@ public class GreeterGrpc {
         METHOD_SAY_HELLO);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final Greeter serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
+++ b/examples/src/generated/main/grpc/io/grpc/examples/routeguide/RouteGuideGrpc.java
@@ -95,7 +95,7 @@ public class RouteGuideGrpc {
    * Interface exported by the server.
    * </pre>
    */
-  public static interface RouteGuide {
+  @java.lang.Deprecated public static interface RouteGuide {
 
     /**
      * <pre>
@@ -142,7 +142,7 @@ public class RouteGuideGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractRouteGuide implements RouteGuide, io.grpc.BindableService {
+  public static abstract class RouteGuideImplBase implements RouteGuide, io.grpc.BindableService {
 
     @java.lang.Override
     public void getFeature(io.grpc.examples.routeguide.Point request,
@@ -178,7 +178,7 @@ public class RouteGuideGrpc {
    * Interface exported by the server.
    * </pre>
    */
-  public static interface RouteGuideBlockingClient {
+  @java.lang.Deprecated public static interface RouteGuideBlockingClient {
 
     /**
      * <pre>
@@ -208,7 +208,7 @@ public class RouteGuideGrpc {
    * Interface exported by the server.
    * </pre>
    */
-  public static interface RouteGuideFutureClient {
+  @java.lang.Deprecated public static interface RouteGuideFutureClient {
 
     /**
      * <pre>
@@ -324,6 +324,8 @@ public class RouteGuideGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractRouteGuide extends RouteGuideImplBase {}
+
   private static final int METHODID_GET_FEATURE = 0;
   private static final int METHODID_LIST_FEATURES = 1;
   private static final int METHODID_RECORD_ROUTE = 2;
@@ -384,7 +386,7 @@ public class RouteGuideGrpc {
         METHOD_ROUTE_CHAT);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final RouteGuide serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonClient.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonClient.java
@@ -63,7 +63,7 @@ public final class HelloJsonClient {
   private static final Logger logger = Logger.getLogger(HelloWorldClient.class.getName());
 
   private final ManagedChannel channel;
-  private final GreeterGrpc.GreeterBlockingClient blockingStub;
+  private final HelloJsonStub blockingStub;
 
   /** Construct client connecting to HelloWorld server at {@code host:port}. */
   public HelloJsonClient(String host, int port) {
@@ -109,8 +109,7 @@ public final class HelloJsonClient {
     }
   }
 
-  static final class HelloJsonStub extends AbstractStub<HelloJsonStub>
-      implements GreeterGrpc.GreeterBlockingClient {
+  static final class HelloJsonStub extends AbstractStub<HelloJsonStub> {
 
     static final MethodDescriptor<HelloRequest, HelloReply> METHOD_SAY_HELLO =
         MethodDescriptor.create(
@@ -132,7 +131,6 @@ public final class HelloJsonClient {
       return new HelloJsonStub(channel, callOptions);
     }
 
-    @Override
     public HelloReply sayHello(HelloRequest request) {
       return blockingUnaryCall(
           getChannel(), METHOD_SAY_HELLO, getCallOptions(), request);

--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
@@ -37,7 +37,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.examples.helloworld.GreeterGrpc;
-import io.grpc.examples.helloworld.GreeterGrpc.Greeter;
+import io.grpc.examples.helloworld.GreeterGrpc.GreeterImplBase;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.HelloWorldServer;
@@ -106,7 +106,7 @@ public class HelloJsonServer {
     server.blockUntilShutdown();
   }
 
-  private class GreeterImpl implements GreeterGrpc.Greeter {
+  private class GreeterImpl extends GreeterImplBase {
 
     @Override
     public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {
@@ -116,7 +116,7 @@ public class HelloJsonServer {
     }
   }
 
-  private ServerServiceDefinition bindService(final Greeter serviceImpl) {
+  private ServerServiceDefinition bindService(final GreeterImplBase serviceImpl) {
     return io.grpc.ServerServiceDefinition
         .builder(GreeterGrpc.getServiceDescriptor())
         .addMethod(HelloJsonClient.HelloJsonStub.METHOD_SAY_HELLO,

--- a/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
+++ b/examples/src/main/java/io/grpc/examples/header/CustomHeaderServer.java
@@ -94,7 +94,7 @@ public class CustomHeaderServer {
     server.blockUntilShutdown();
   }
 
-  private class GreeterImpl extends GreeterGrpc.AbstractGreeter {
+  private class GreeterImpl extends GreeterGrpc.GreeterImplBase {
 
     @Override
     public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
@@ -89,7 +89,7 @@ public class HelloWorldServer {
     server.blockUntilShutdown();
   }
 
-  private class GreeterImpl extends GreeterGrpc.AbstractGreeter {
+  private class GreeterImpl extends GreeterGrpc.GreeterImplBase {
 
     @Override
     public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -125,7 +125,7 @@ public class RouteGuideServer {
    *
    * <p>See route_guide.proto for details of the methods.
    */
-  private static class RouteGuideService extends RouteGuideGrpc.AbstractRouteGuide {
+  private static class RouteGuideService extends RouteGuideGrpc.RouteGuideImplBase {
     private final Collection<Feature> features;
     private final ConcurrentMap<Point, List<RouteNote>> routeNotes =
         new ConcurrentHashMap<Point, List<RouteNote>>();

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -62,7 +62,7 @@ public class LoadBalancerGrpc {
 
   /**
    */
-  public static interface LoadBalancer {
+  @java.lang.Deprecated public static interface LoadBalancer {
 
     /**
      * <pre>
@@ -74,7 +74,7 @@ public class LoadBalancerGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractLoadBalancer implements LoadBalancer, io.grpc.BindableService {
+  public static abstract class LoadBalancerImplBase implements LoadBalancer, io.grpc.BindableService {
 
     @java.lang.Override
     public io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceRequest> balanceLoad(
@@ -89,12 +89,12 @@ public class LoadBalancerGrpc {
 
   /**
    */
-  public static interface LoadBalancerBlockingClient {
+  @java.lang.Deprecated public static interface LoadBalancerBlockingClient {
   }
 
   /**
    */
-  public static interface LoadBalancerFutureClient {
+  @java.lang.Deprecated public static interface LoadBalancerFutureClient {
   }
 
   public static class LoadBalancerStub extends io.grpc.stub.AbstractStub<LoadBalancerStub>
@@ -158,6 +158,8 @@ public class LoadBalancerGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractLoadBalancer extends LoadBalancerImplBase {}
+
   private static final int METHODID_BALANCE_LOAD = 0;
 
   private static class MethodHandlers<Req, Resp> implements
@@ -201,7 +203,7 @@ public class LoadBalancerGrpc {
         METHOD_BALANCE_LOAD);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final LoadBalancer serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -71,7 +71,7 @@ public class MetricsServiceGrpc {
 
   /**
    */
-  public static interface MetricsService {
+  @java.lang.Deprecated public static interface MetricsService {
 
     /**
      * <pre>
@@ -92,7 +92,7 @@ public class MetricsServiceGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractMetricsService implements MetricsService, io.grpc.BindableService {
+  public static abstract class MetricsServiceImplBase implements MetricsService, io.grpc.BindableService {
 
     @java.lang.Override
     public void getAllGauges(io.grpc.testing.integration.Metrics.EmptyMessage request,
@@ -113,7 +113,7 @@ public class MetricsServiceGrpc {
 
   /**
    */
-  public static interface MetricsServiceBlockingClient {
+  @java.lang.Deprecated public static interface MetricsServiceBlockingClient {
 
     /**
      * <pre>
@@ -134,7 +134,7 @@ public class MetricsServiceGrpc {
 
   /**
    */
-  public static interface MetricsServiceFutureClient {
+  @java.lang.Deprecated public static interface MetricsServiceFutureClient {
 
     /**
      * <pre>
@@ -233,6 +233,8 @@ public class MetricsServiceGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractMetricsService extends MetricsServiceImplBase {}
+
   private static final int METHODID_GET_ALL_GAUGES = 0;
   private static final int METHODID_GET_GAUGE = 1;
 
@@ -283,7 +285,7 @@ public class MetricsServiceGrpc {
         METHOD_GET_GAUGE);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final MetricsService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -77,7 +77,7 @@ public class ReconnectServiceGrpc {
    * A service used to control reconnect server.
    * </pre>
    */
-  public static interface ReconnectService {
+  @java.lang.Deprecated public static interface ReconnectService {
 
     /**
      */
@@ -91,7 +91,7 @@ public class ReconnectServiceGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractReconnectService implements ReconnectService, io.grpc.BindableService {
+  public static abstract class ReconnectServiceImplBase implements ReconnectService, io.grpc.BindableService {
 
     @java.lang.Override
     public void start(com.google.protobuf.EmptyProtos.Empty request,
@@ -115,7 +115,7 @@ public class ReconnectServiceGrpc {
    * A service used to control reconnect server.
    * </pre>
    */
-  public static interface ReconnectServiceBlockingClient {
+  @java.lang.Deprecated public static interface ReconnectServiceBlockingClient {
 
     /**
      */
@@ -131,7 +131,7 @@ public class ReconnectServiceGrpc {
    * A service used to control reconnect server.
    * </pre>
    */
-  public static interface ReconnectServiceFutureClient {
+  @java.lang.Deprecated public static interface ReconnectServiceFutureClient {
 
     /**
      */
@@ -238,6 +238,8 @@ public class ReconnectServiceGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractReconnectService extends ReconnectServiceImplBase {}
+
   private static final int METHODID_START = 0;
   private static final int METHODID_STOP = 1;
 
@@ -288,7 +290,7 @@ public class ReconnectServiceGrpc {
         METHOD_STOP);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final ReconnectService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -115,7 +115,7 @@ public class TestServiceGrpc {
    * performance with various types of payload.
    * </pre>
    */
-  public static interface TestService {
+  @java.lang.Deprecated public static interface TestService {
 
     /**
      * <pre>
@@ -174,7 +174,7 @@ public class TestServiceGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractTestService implements TestService, io.grpc.BindableService {
+  public static abstract class TestServiceImplBase implements TestService, io.grpc.BindableService {
 
     @java.lang.Override
     public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
@@ -223,7 +223,7 @@ public class TestServiceGrpc {
    * performance with various types of payload.
    * </pre>
    */
-  public static interface TestServiceBlockingClient {
+  @java.lang.Deprecated public static interface TestServiceBlockingClient {
 
     /**
      * <pre>
@@ -255,7 +255,7 @@ public class TestServiceGrpc {
    * performance with various types of payload.
    * </pre>
    */
-  public static interface TestServiceFutureClient {
+  @java.lang.Deprecated public static interface TestServiceFutureClient {
 
     /**
      * <pre>
@@ -403,6 +403,8 @@ public class TestServiceGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractTestService extends TestServiceImplBase {}
+
   private static final int METHODID_EMPTY_CALL = 0;
   private static final int METHODID_UNARY_CALL = 1;
   private static final int METHODID_STREAMING_OUTPUT_CALL = 2;
@@ -474,7 +476,7 @@ public class TestServiceGrpc {
         METHOD_HALF_DUPLEX_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final TestService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -70,7 +70,7 @@ public class UnimplementedServiceGrpc {
    * that case.
    * </pre>
    */
-  public static interface UnimplementedService {
+  @java.lang.Deprecated public static interface UnimplementedService {
 
     /**
      * <pre>
@@ -82,7 +82,7 @@ public class UnimplementedServiceGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractUnimplementedService implements UnimplementedService, io.grpc.BindableService {
+  public static abstract class UnimplementedServiceImplBase implements UnimplementedService, io.grpc.BindableService {
 
     @java.lang.Override
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
@@ -101,7 +101,7 @@ public class UnimplementedServiceGrpc {
    * that case.
    * </pre>
    */
-  public static interface UnimplementedServiceBlockingClient {
+  @java.lang.Deprecated public static interface UnimplementedServiceBlockingClient {
 
     /**
      * <pre>
@@ -117,7 +117,7 @@ public class UnimplementedServiceGrpc {
    * that case.
    * </pre>
    */
-  public static interface UnimplementedServiceFutureClient {
+  @java.lang.Deprecated public static interface UnimplementedServiceFutureClient {
 
     /**
      * <pre>
@@ -202,6 +202,8 @@ public class UnimplementedServiceGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractUnimplementedService extends UnimplementedServiceImplBase {}
+
   private static final int METHODID_UNIMPLEMENTED_CALL = 0;
 
   private static class MethodHandlers<Req, Resp> implements
@@ -246,7 +248,7 @@ public class UnimplementedServiceGrpc {
         METHOD_UNIMPLEMENTED_CALL);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final UnimplementedService serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -131,7 +131,7 @@ public abstract class AbstractInteropTest {
         .build();
 
     builder.addService(ServerInterceptors.intercept(
-        TestServiceGrpc.bindService(new TestServiceImpl(testServiceExecutor)),
+        new TestServiceImpl(testServiceExecutor),
         allInterceptors));
     try {
       server = builder.build().start();
@@ -152,7 +152,7 @@ public abstract class AbstractInteropTest {
 
   protected ManagedChannel channel;
   protected TestServiceGrpc.TestServiceBlockingStub blockingStub;
-  protected TestServiceGrpc.TestService asyncStub;
+  protected TestServiceGrpc.TestServiceStub asyncStub;
 
   /**
    * Must be called by the subclass setup method if overridden.
@@ -777,7 +777,7 @@ public abstract class AbstractInteropTest {
   /** Start a fullDuplexCall which the server will not respond, and verify the deadline expires. */
   @Test(timeout = 10000)
   public void timeoutOnSleepingServer() {
-    TestServiceGrpc.TestService stub = TestServiceGrpc.newStub(channel)
+    TestServiceGrpc.TestServiceStub stub = TestServiceGrpc.newStub(channel)
         .withDeadlineAfter(1, TimeUnit.MILLISECONDS);
     @SuppressWarnings("unchecked")
     StreamObserver<StreamingOutputCallResponse> responseObserver = mock(StreamObserver.class);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -196,7 +196,7 @@ public class StressTestClient {
     Preconditions.checkState(!shutdown, "client was shutdown.");
 
     metricsServer = ServerBuilder.forPort(metricsPort)
-        .addService(MetricsServiceGrpc.bindService(new MetricsServiceImpl()))
+        .addService(new MetricsServiceImpl())
         .build()
         .start();
   }
@@ -517,7 +517,7 @@ public class StressTestClient {
   /**
    * Service that exports the QPS metrics of the stress test.
    */
-  private class MetricsServiceImpl implements MetricsServiceGrpc.MetricsService {
+  private class MetricsServiceImpl extends MetricsServiceGrpc.MetricsServiceImplBase {
 
     @Override
     public void getAllGauges(Metrics.EmptyMessage request,

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -52,8 +52,8 @@ import java.nio.charset.Charset;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
- * Application that starts a client for the {@link TestServiceGrpc.TestService} and runs through a
- * series of tests.
+ * Application that starts a client for the {@link TestServiceGrpc.TestServiceImplBase} and runs
+ * through a series of tests.
  */
 public class TestServiceClient {
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
  * Implementation of the business logic for the TestService. Uses an executor to schedule chunks
  * sent in response streams.
  */
-public class TestServiceImpl implements TestServiceGrpc.TestService {
+public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
   private static final String UNCOMPRESSABLE_FILE =
       "/io/grpc/testing/integration/testdata/uncompressable.bin";
   private final Random random = new Random();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -144,7 +144,7 @@ public class TestServiceServer {
     server = NettyServerBuilder.forPort(port)
         .sslContext(sslContext)
         .addService(ServerInterceptors.intercept(
-            TestServiceGrpc.bindService(new TestServiceImpl(executor)),
+            new TestServiceImpl(executor),
             TestUtils.echoRequestHeadersInterceptor(Util.METADATA_KEY)))
         .build().start();
   }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
@@ -262,7 +262,7 @@ public class CompressionTest {
     }
   }
 
-  private static final class LocalServer extends TestServiceGrpc.AbstractTestService {
+  private static final class LocalServer extends TestServiceGrpc.TestServiceImplBase {
     @Override
     public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
       responseObserver.onNext(SimpleResponse.newBuilder()

--- a/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ConcurrencyTest.java
@@ -214,7 +214,7 @@ public class ConcurrencyTest {
 
     return NettyServerBuilder.forPort(0)
         .sslContext(sslContext)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(serverExecutor)))
+        .addService(new TestServiceImpl(serverExecutor))
         .build()
         .start();
   }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TlsTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TlsTest.java
@@ -130,7 +130,7 @@ public class TlsTest {
       TestUtils.loadX509Cert("ca.pem")
     };
     server = serverBuilder(0, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
+        .addService(new TestServiceImpl(executor))
         .build()
         .start();
 
@@ -166,7 +166,7 @@ public class TlsTest {
       TestUtils.loadX509Cert("ca.pem")
     };
     server = serverBuilder(0, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
+        .addService(new TestServiceImpl(executor))
         .build()
         .start();
 
@@ -213,7 +213,7 @@ public class TlsTest {
       TestUtils.loadX509Cert("ca.pem")
     };
     server = serverBuilder(0, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
+        .addService(new TestServiceImpl(executor))
         .build()
         .start();
 
@@ -255,7 +255,7 @@ public class TlsTest {
       TestUtils.loadX509Cert("ca.pem")
     };
     server = serverBuilder(0, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
-        .addService(TestServiceGrpc.bindService(new TestServiceImpl(executor)))
+        .addService(new TestServiceImpl(executor))
         .build()
         .start();
 

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -62,7 +62,7 @@ public class HealthGrpc {
 
   /**
    */
-  public static interface Health {
+  @java.lang.Deprecated public static interface Health {
 
     /**
      */
@@ -71,7 +71,7 @@ public class HealthGrpc {
   }
 
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1469")
-  public static abstract class AbstractHealth implements Health, io.grpc.BindableService {
+  public static abstract class HealthImplBase implements Health, io.grpc.BindableService {
 
     @java.lang.Override
     public void check(io.grpc.health.v1.HealthCheckRequest request,
@@ -86,7 +86,7 @@ public class HealthGrpc {
 
   /**
    */
-  public static interface HealthBlockingClient {
+  @java.lang.Deprecated public static interface HealthBlockingClient {
 
     /**
      */
@@ -95,7 +95,7 @@ public class HealthGrpc {
 
   /**
    */
-  public static interface HealthFutureClient {
+  @java.lang.Deprecated public static interface HealthFutureClient {
 
     /**
      */
@@ -177,6 +177,8 @@ public class HealthGrpc {
     }
   }
 
+  @java.lang.Deprecated public static abstract class AbstractHealth extends HealthImplBase {}
+
   private static final int METHODID_CHECK = 0;
 
   private static class MethodHandlers<Req, Resp> implements
@@ -221,7 +223,7 @@ public class HealthGrpc {
         METHOD_CHECK);
   }
 
-  public static io.grpc.ServerServiceDefinition bindService(
+  @java.lang.Deprecated public static io.grpc.ServerServiceDefinition bindService(
       final Health serviceImpl) {
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
         .addMethod(

--- a/services/src/main/java/io/grpc/services/HealthServiceImpl.java
+++ b/services/src/main/java/io/grpc/services/HealthServiceImpl.java
@@ -45,7 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 
-final class HealthServiceImpl extends HealthGrpc.AbstractHealth {
+final class HealthServiceImpl extends HealthGrpc.HealthImplBase {
 
   /* Due to the latency of rpc calls, synchronization of the map does not help with consistency.
    * However, need use ConcurrentHashMap to prevent the possible race condition of currently putting

--- a/services/src/main/java/io/grpc/services/HealthStatusManager.java
+++ b/services/src/main/java/io/grpc/services/HealthStatusManager.java
@@ -57,7 +57,7 @@ public final class HealthStatusManager {
   /**
    * Gets the health check service created in the constructor.
    */
-  public HealthGrpc.AbstractHealth getHealthService() {
+  public HealthGrpc.HealthImplBase getHealthService() {
     return healthService;
   }
 

--- a/services/src/test/java/io/grpc/services/HealthStatusManagerTest.java
+++ b/services/src/test/java/io/grpc/services/HealthStatusManagerTest.java
@@ -43,7 +43,7 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.health.v1.HealthCheckRequest;
 import io.grpc.health.v1.HealthCheckResponse;
-import io.grpc.health.v1.HealthGrpc.Health;
+import io.grpc.health.v1.HealthGrpc;
 import io.grpc.stub.StreamObserver;
 
 import org.junit.Test;
@@ -57,7 +57,7 @@ import org.mockito.InOrder;
 public class HealthStatusManagerTest {
 
   private final HealthStatusManager manager = new HealthStatusManager();
-  private final Health health = manager.getHealthService();
+  private final HealthGrpc.HealthImplBase health = manager.getHealthService();
   private final HealthCheckResponse.ServingStatus status
       = HealthCheckResponse.ServingStatus.UNKNOWN;
 


### PR DESCRIPTION
first step to address issue #1469:

- leave and deprecate interfaces in codegen
- introduce `ServiceImplBase`,
- `AbstractService` is deprecated and extends `ServiceImplBase`
- static `bindService()` is deprecated