### PR TITLE
netty: fix incorrect usage of AsciString.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -106,8 +106,9 @@ class Utils {
 
   private static byte[] bytes(CharSequence seq) {
     if (seq instanceof AsciiString) {
-      // Fast path - no copy.
-      return ((AsciiString) seq).array();
+      // Fast path - sometimes copy.
+      AsciiString str = (AsciiString) seq;
+      return str.isEntireArrayUsed() ? str.array() : str.toByteArray();
     }
     // Slow path - copy.
     return seq.toString().getBytes(UTF_8);


### PR DESCRIPTION
An AsciiString object may only use a subsection of its backing byte array. We need to test for this and return a copy of the subsection if necessary.
Big thanks to @normanmaurer for uncovering this issue: https://github.com/netty/netty/issues/5472