### PR TITLE
core: Rename withCredentials to withCallCredentials on CallOptions

### DIFF
--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -97,7 +97,7 @@ public final class CallOptions {
    * Returns a new {@code CallOptions} with the given call credentials.
    */
   @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
-  public CallOptions withCredentials(@Nullable CallCredentials credentials) {
+  public CallOptions withCallCredentials(@Nullable CallCredentials credentials) {
     CallOptions newOptions = new CallOptions(this);
     newOptions.credentials = credentials;
     return newOptions;

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -68,7 +68,7 @@ public class CallOptionsTest {
       .withAuthority(sampleAuthority)
       .withDeadline(sampleDeadline)
       .withAffinity(sampleAffinity)
-      .withCredentials(sampleCreds)
+      .withCallCredentials(sampleCreds)
       .withCompression(sampleCompressor)
       .withWaitForReady()
       .withExecutor(directExecutor())
@@ -120,7 +120,8 @@ public class CallOptionsTest {
         .isTrue();
     assertThat(
         equal(allSet,
-            allSet.withCredentials(mock(CallCredentials.class)).withCredentials(sampleCreds)))
+            allSet.withCallCredentials(mock(CallCredentials.class))
+            .withCallCredentials(sampleCreds)))
         .isTrue();
   }
 
@@ -165,7 +166,7 @@ public class CallOptionsTest {
     String actual = allSet
         .withDeadline(null)
         .withExecutor(new SerializingExecutor(directExecutor()))
-        .withCredentials(null)
+        .withCallCredentials(null)
         .toString();
 
     assertThat(actual).isEqualTo(expected);

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -120,7 +120,7 @@ public class CallCredentialsApplyingTest {
         mockTransportFactory, mockExecutor);
     transport = (ForwardingConnectionClientTransport) transportFactory.newClientTransport(
         address, authority, userAgent);
-    callOptions = CallOptions.DEFAULT.withCredentials(mockCreds);
+    callOptions = CallOptions.DEFAULT.withCallCredentials(mockCreds);
     verify(mockTransportFactory).newClientTransport(address, authority, userAgent);
     assertSame(mockTransport, transport.delegate());
   }
@@ -270,7 +270,7 @@ public class CallCredentialsApplyingTest {
 
   @Test
   public void noCreds() {
-    callOptions = callOptions.withCredentials(null);
+    callOptions = callOptions.withCallCredentials(null);
     ClientStream stream = transport.newStream(method, origHeaders, callOptions);
 
     verify(mockTransport).newStream(method, origHeaders, callOptions);

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -179,6 +179,6 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
    */
   @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
   public final S withCallCredentials(CallCredentials credentials) {
-    return build(channel, callOptions.withCredentials(credentials));
+    return build(channel, callOptions.withCallCredentials(credentials));
   }
 }


### PR DESCRIPTION
It was withCallCredentials on the stub to avoid confusion with channel
credentials (which don't exist in Java at this time, but do in other
languages), and having the method names be different doesn't add value.