### PR TITLE
netty: reduce allocations in write queue.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
@@ -38,7 +38,7 @@ import io.grpc.Status;
 /**
  * Command sent from a Netty client stream to the handler to cancel the stream.
  */
-class CancelClientStreamCommand {
+class CancelClientStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final NettyClientStream stream;
   private final Status reason;
 

--- a/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
@@ -40,7 +40,7 @@ import io.grpc.Status;
 /**
  * Command sent from a Netty server stream to the handler to cancel the stream.
  */
-class CancelServerStreamCommand {
+class CancelServerStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final NettyServerStream.TransportState stream;
   private final Status reason;
 

--- a/netty/src/main/java/io/grpc/netty/CreateStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CreateStreamCommand.java
@@ -39,7 +39,7 @@ import io.netty.handler.codec.http2.Http2Headers;
  * A command to create a new stream. This is created by {@link NettyClientStream} and passed to the
  * {@link NettyClientHandler} for processing in the Channel thread.
  */
-class CreateStreamCommand {
+class CreateStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final Http2Headers headers;
   private final NettyClientStream stream;
 

--- a/netty/src/main/java/io/grpc/netty/ForcefulCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/ForcefulCloseCommand.java
@@ -37,7 +37,7 @@ import io.grpc.Status;
  * A command to trigger close and close all streams. It is buffered differently than normal close
  * and also includes reason for closure.
  */
-class ForcefulCloseCommand {
+class ForcefulCloseCommand extends WriteQueue.AbstractQueuedCommand {
   private final Status status;
 
   public ForcefulCloseCommand(Status status) {

--- a/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
+++ b/netty/src/main/java/io/grpc/netty/GracefulCloseCommand.java
@@ -37,7 +37,7 @@ import io.grpc.Status;
  * A command to trigger close. It is buffered differently than normal close and also includes
  * reason for closure.
  */
-class GracefulCloseCommand {
+class GracefulCloseCommand extends WriteQueue.AbstractQueuedCommand {
   private final Status status;
 
   public GracefulCloseCommand(Status status) {

--- a/netty/src/main/java/io/grpc/netty/RequestMessagesCommand.java
+++ b/netty/src/main/java/io/grpc/netty/RequestMessagesCommand.java
@@ -37,7 +37,7 @@ import io.grpc.internal.Stream;
 /**
  * Command which requests messages from the deframer.
  */
-class RequestMessagesCommand {
+class RequestMessagesCommand extends WriteQueue.AbstractQueuedCommand {
 
   private final int numMessages;
   private final Stream stream;

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -34,13 +34,16 @@ package io.grpc.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.channel.ChannelPromise;
 
 /**
  * Command sent from the transport to the Netty channel to send a GRPC frame to the remote endpoint.
  */
-class SendGrpcFrameCommand extends DefaultByteBufHolder {
+class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.QueuedCommand {
   private final StreamIdHolder stream;
   private final boolean endStream;
+
+  private ChannelPromise promise;
 
   SendGrpcFrameCommand(StreamIdHolder stream, ByteBuf content, boolean endStream) {
     super(content);
@@ -115,5 +118,15 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder {
       hash = -hash;
     }
     return hash;
+  }
+
+  @Override
+  public ChannelPromise promise() {
+    return promise;
+  }
+
+  @Override
+  public void promise(ChannelPromise promise) {
+    this.promise = promise;
   }
 }

--- a/netty/src/main/java/io/grpc/netty/SendPingCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendPingCommand.java
@@ -38,7 +38,7 @@ import java.util.concurrent.Executor;
 /**
  * Command sent from the transport to the Netty channel to send a PING frame.
  */
-class SendPingCommand {
+class SendPingCommand extends WriteQueue.AbstractQueuedCommand {
   private final PingCallback callback;
   private final Executor executor;
 

--- a/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
@@ -38,7 +38,7 @@ import io.netty.handler.codec.http2.Http2Headers;
 /**
  * Command sent from the transport to the Netty channel to send response headers to the client.
  */
-class SendResponseHeadersCommand {
+class SendResponseHeadersCommand extends WriteQueue.AbstractQueuedCommand {
   private final StreamIdHolder stream;
   private final Http2Headers headers;
   private final boolean endOfStream;

--- a/netty/src/main/java/io/grpc/netty/WriteQueue.java
+++ b/netty/src/main/java/io/grpc/netty/WriteQueue.java
@@ -31,6 +31,7 @@
 
 package io.grpc.netty;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import io.netty.channel.Channel;
@@ -47,7 +48,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 class WriteQueue {
 
-  private static final int DEQUE_CHUNK_SIZE = 128;
+  // Dequeue in chunks, so we don't have to acquire the queue's log too often.
+  @VisibleForTesting
+  static final int DEQUE_CHUNK_SIZE = 128;
 
   /**
    * {@link Runnable} used to schedule work onto the tail of the event loop.
@@ -60,18 +63,18 @@ class WriteQueue {
   };
 
   private final Channel channel;
-  private final BlockingQueue<Runnable> queue;
+  private final BlockingQueue<QueuedCommand> queue;
   private final AtomicBoolean scheduled = new AtomicBoolean();
 
   /**
    * ArrayDeque to copy queue into when flushing in event loop.
    */
-  private final ArrayDeque<Runnable> writeChunk =
-      new ArrayDeque<Runnable>(DEQUE_CHUNK_SIZE);
+  private final ArrayDeque<QueuedCommand> writeChunk =
+      new ArrayDeque<QueuedCommand>(DEQUE_CHUNK_SIZE);
 
   public WriteQueue(Channel channel) {
     this.channel = Preconditions.checkNotNull(channel, "channel");
-    queue = new LinkedBlockingQueue<Runnable>();
+    queue = new LinkedBlockingQueue<QueuedCommand>();
   }
 
   /**
@@ -93,7 +96,7 @@ class WriteQueue {
    * @param flush true if a flush of the write should be schedule, false if a later call to
    *              enqueue will schedule the flush.
    */
-  ChannelFuture enqueue(Object command, boolean flush) {
+  ChannelFuture enqueue(QueuedCommand command, boolean flush) {
     return enqueue(command, channel.newPromise(), flush);
   }
 
@@ -105,8 +108,12 @@ class WriteQueue {
    * @param flush true if a flush of the write should be schedule, false if a later call to
    *              enqueue will schedule the flush.
    */
-  ChannelFuture enqueue(Object command, ChannelPromise promise, boolean flush) {
-    queue.add(new QueuedCommand(command, promise));
+  ChannelFuture enqueue(QueuedCommand command, ChannelPromise promise, boolean flush) {
+    // Detect erroneous code that tries to reuse command objects.
+    Preconditions.checkNotNull(command.promise() == null, "promise must not be set on command");
+
+    command.promise(promise);
+    queue.add(command);
     if (flush) {
       scheduleFlush();
     }
@@ -117,12 +124,17 @@ class WriteQueue {
    * Process the queue of commands and dispatch them to the stream. This method is only
    * called in the event loop
    */
+  /**
+   * Process the queue of commands and dispatch them to the stream. This method is only
+   * called in the event loop
+   */
   private void flush() {
     try {
       boolean flushed = false;
       while (queue.drainTo(writeChunk, DEQUE_CHUNK_SIZE) > 0) {
         while (writeChunk.size() > 0) {
-          writeChunk.poll().run();
+          QueuedCommand cmd = writeChunk.poll();
+          channel.write(cmd, cmd.promise());
         }
         // Flush each chunk so we are releasing buffers periodically. In theory this loop
         // might never end as new events are continuously added to the queue, if we never
@@ -143,22 +155,33 @@ class WriteQueue {
     }
   }
 
-  /**
-   * Simple wrapper type around a command and its optional completion listener.
-   */
-  private final class QueuedCommand implements Runnable {
-    private final Object command;
-    private final ChannelPromise promise;
+  abstract static class AbstractQueuedCommand implements QueuedCommand {
 
-    private QueuedCommand(Object command, ChannelPromise promise) {
-      this.command = command;
+    private ChannelPromise promise;
+
+    @Override
+    public final void promise(ChannelPromise promise) {
       this.promise = promise;
     }
 
     @Override
-    public void run() {
-      channel.write(command, promise);
+    public final ChannelPromise promise() {
+      return promise;
     }
   }
-}
 
+  /**
+   * Simple wrapper type around a command and its optional completion listener.
+   */
+  interface QueuedCommand {
+    /**
+     * Returns the promise beeing notified of the success/failure of the write.
+     */
+    ChannelPromise promise();
+
+    /**
+     * Sets the promise.
+     */
+    void promise(ChannelPromise promise);
+  }
+}

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -373,12 +373,11 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
   @Test
   public void createIncrementsIdsForActualAndBufferdStreams() throws Exception {
     receiveMaxConcurrentStreams(2);
-    CreateStreamCommand command = new CreateStreamCommand(grpcHeaders, stream);
-    enqueue(command);
+    enqueue(new CreateStreamCommand(grpcHeaders, stream));
     verify(stream).id(eq(3));
-    enqueue(command);
+    enqueue(new CreateStreamCommand(grpcHeaders, stream));
     verify(stream).id(eq(5));
-    enqueue(command);
+    enqueue(new CreateStreamCommand(grpcHeaders, stream));
     verify(stream).id(eq(7));
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -60,6 +60,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.netty.WriteQueue.QueuedCommand;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -380,7 +381,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     metadata.put(GrpcUtil.USER_AGENT_KEY, "bad agent");
     listener = mock(ClientStreamListener.class);
     Mockito.reset(writeQueue);
-    when(writeQueue.enqueue(any(), any(boolean.class))).thenReturn(future);
+    when(writeQueue.enqueue(any(QueuedCommand.class), any(boolean.class))).thenReturn(future);
 
     stream = new NettyClientStreamImpl(methodDescriptor, new Metadata(), channel, handler,
         DEFAULT_MAX_MESSAGE_SIZE, AsciiString.of("localhost"), AsciiString.of("http"),
@@ -404,8 +405,8 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         }
         return null;
       }
-    }).when(writeQueue).enqueue(any(), any(ChannelPromise.class), anyBoolean());
-    when(writeQueue.enqueue(any(), anyBoolean())).thenReturn(future);
+    }).when(writeQueue).enqueue(any(QueuedCommand.class), any(ChannelPromise.class), anyBoolean());
+    when(writeQueue.enqueue(any(QueuedCommand.class), anyBoolean())).thenReturn(future);
     NettyClientStream stream = new NettyClientStreamImpl(methodDescriptor, new Metadata(), channel,
         handler, DEFAULT_MAX_MESSAGE_SIZE, AsciiString.of("localhost"), AsciiString.of("http"),
         AsciiString.of("agent"));

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -194,7 +194,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
     return handler().connection();
   }
 
-  protected final ChannelFuture enqueue(Object command) {
+  protected final ChannelFuture enqueue(WriteQueue.QueuedCommand command) {
     ChannelFuture future = writeQueue.enqueue(command, newPromise(), true);
     channel.runPendingTasks();
     return future;

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -54,6 +54,7 @@ import com.google.common.collect.ListMultimap;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ServerStreamListener;
+import io.grpc.netty.WriteQueue.QueuedCommand;
 import io.netty.buffer.EmptyByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelPromise;
@@ -287,8 +288,8 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
         }
         return null;
       }
-    }).when(writeQueue).enqueue(any(), any(ChannelPromise.class), anyBoolean());
-    when(writeQueue.enqueue(any(), anyBoolean())).thenReturn(future);
+    }).when(writeQueue).enqueue(any(QueuedCommand.class), any(ChannelPromise.class), anyBoolean());
+    when(writeQueue.enqueue(any(QueuedCommand.class), anyBoolean())).thenReturn(future);
     NettyServerStream.TransportState state =
         new NettyServerStream.TransportState(handler, http2Stream, DEFAULT_MAX_MESSAGE_SIZE);
     NettyServerStream stream = new NettyServerStream(channel, state);

--- a/netty/src/test/java/io/grpc/netty/WriteQueueTest.java
+++ b/netty/src/test/java/io/grpc/netty/WriteQueueTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.netty.WriteQueue.QueuedCommand;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@RunWith(JUnit4.class)
+public class WriteQueueTest {
+
+  @Mock
+  public Channel channel;
+
+  @Mock
+  public ChannelPromise promise;
+
+  private QueuedCommand command = new WriteQueue.AbstractQueuedCommand() {
+  };
+
+  private long flushCalledNanos;
+  private long writeCalledNanos;
+
+  /**
+   * Set up for test.
+   */
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    when(channel.newPromise()).thenReturn(promise);
+
+    EventLoop eventLoop = Mockito.mock(EventLoop.class);
+    doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        Runnable r = (Runnable) invocation.getArguments()[0];
+        r.run();
+        return null;
+      }
+    }).when(eventLoop).execute(any(Runnable.class));
+    when(eventLoop.inEventLoop()).thenReturn(true);
+    when(channel.eventLoop()).thenReturn(eventLoop);
+
+    when(channel.flush()).thenAnswer(new Answer<Channel>() {
+      @Override
+      public Channel answer(InvocationOnMock invocation) throws Throwable {
+        flushCalledNanos = System.nanoTime();
+        if (flushCalledNanos == writeCalledNanos) {
+          flushCalledNanos += 1;
+        }
+        return channel;
+      }
+    });
+
+    when(channel.write(command, promise)).thenAnswer(new Answer<ChannelFuture>() {
+      @Override
+      public ChannelFuture answer(InvocationOnMock invocation) throws Throwable {
+        writeCalledNanos = System.nanoTime();
+        if (writeCalledNanos == flushCalledNanos) {
+          writeCalledNanos += 1;
+        }
+        return promise;
+      }
+    });
+  }
+
+  @Test
+  public void singleWriteShouldWork() {
+    WriteQueue queue = new WriteQueue(channel);
+    queue.enqueue(command, true);
+
+    verify(channel).write(command, promise);
+    verify(channel).flush();
+  }
+
+  @Test
+  public void multipleWritesShouldBeBatched() {
+    WriteQueue queue = new WriteQueue(channel);
+    for (int i = 0; i < 5; i++) {
+      queue.enqueue(command, false);
+    }
+    queue.scheduleFlush();
+
+    verify(channel, times(5)).write(command, promise);
+    verify(channel).flush();
+  }
+
+  @Test
+  public void maxWritesBeforeFlushShouldBeEnforced() {
+    WriteQueue queue = new WriteQueue(channel);
+    int writes = WriteQueue.DEQUE_CHUNK_SIZE + 10;
+    for (int i = 0; i < writes; i++) {
+      queue.enqueue(command, false);
+    }
+    queue.scheduleFlush();
+
+    verify(channel, times(writes)).write(command, promise);
+    verify(channel, times(2)).flush();
+  }
+
+  @Test(timeout = 10000)
+  public void concurrentWriteAndFlush() throws Throwable {
+    final WriteQueue queue = new WriteQueue(channel);
+    final CountDownLatch flusherStarted = new CountDownLatch(1);
+    final AtomicBoolean doneWriting = new AtomicBoolean();
+    Thread flusher = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        flusherStarted.countDown();
+        while (!doneWriting.get()) {
+          queue.scheduleFlush();
+          assertFlushCalledAfterWrites();
+        }
+        // No more writes, so this flush should drain all writes from the queue
+        queue.scheduleFlush();
+        assertFlushCalledAfterWrites();
+      }
+
+      void assertFlushCalledAfterWrites() {
+        if (flushCalledNanos - writeCalledNanos <= 0) {
+          fail("flush must be called after all writes");
+        }
+      }
+    });
+
+    class ExceptionHandler implements Thread.UncaughtExceptionHandler {
+      private Throwable throwable;
+
+      @Override
+      public void uncaughtException(Thread t, Throwable e) {
+        throwable = e;
+      }
+
+      void checkException() throws Throwable {
+        if (throwable != null) {
+          throw throwable;
+        }
+      }
+    }
+
+    ExceptionHandler exHandler = new ExceptionHandler();
+    flusher.setUncaughtExceptionHandler(exHandler);
+
+    flusher.start();
+    flusherStarted.await();
+    int writes = 10 * WriteQueue.DEQUE_CHUNK_SIZE;
+    for (int i = 0; i < writes; i++) {
+      queue.enqueue(command, false);
+    }
+    doneWriting.set(true);
+    flusher.join();
+
+    exHandler.checkException();
+    verify(channel, times(writes)).write(command, promise);
+  }
+}


### PR DESCRIPTION
- Merge all the command objects with QueuedCommand so to save one object allocation per write.
- Add unit tests

----

This PR is the same as #1989, but without changes to flush. My throughput benchmarks don't show noticable gains through this change (but also no degradation), but less object allocations and tests seem like a good idea in general?