### PR TITLE
interop tests: fix race in Compression tests where MetadataEntry.getP…

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/CompressionTest.java
@@ -281,7 +281,9 @@ public class CompressionTest {
         call.setCompression("fzip");
       }
       call.setMessageCompression(enableServerMessageCompression);
-      serverResponseHeaders = headers;
+      Metadata headersCopy = new Metadata();
+      headersCopy.merge(headers);
+      serverResponseHeaders = headersCopy;
       return next.startCall(call, headers);
     }
   }
@@ -319,7 +321,9 @@ public class CompressionTest {
     @Override
     public void onHeaders(Metadata headers) {
       super.onHeaders(headers);
-      clientResponseHeaders = headers;
+      Metadata headersCopy = new Metadata();
+      headersCopy.merge(headers);
+      clientResponseHeaders = headersCopy;
     }
   }
 }


### PR DESCRIPTION
…arsed was being concurrently called.

Metadata is internally not thread safe, so putting it in a volatile is not enough.