### PR TITLE
Revert "core: add @GaurdedBy annotations for mutable state of ServerI…

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -60,8 +60,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.concurrent.GuardedBy;
-
 /**
  * Default implementation of {@link io.grpc.Server}, for creation by transports.
  *
@@ -81,23 +79,22 @@ public final class ServerImpl extends io.grpc.Server {
 
   /** Executor for application processing. */
   private Executor executor;
-  @GuardedBy("lock") private boolean usingSharedExecutor;
+  private boolean usingSharedExecutor;
   private final InternalHandlerRegistry registry;
   private final HandlerRegistry fallbackRegistry;
-  @GuardedBy("lock") private boolean started;
-  @GuardedBy("lock") private boolean shutdown;
+  private boolean started;
+  private boolean shutdown;
   /** non-{@code null} if immediate shutdown has been requested. */
-  @GuardedBy("lock") private Status shutdownNowStatus;
+  private Status shutdownNowStatus;
   /** {@code true} if ServerListenerImpl.serverShutdown() was called. */
-  @GuardedBy("lock") private boolean serverShutdownCallbackInvoked;
-  @GuardedBy("lock") private boolean terminated;
+  private boolean serverShutdownCallbackInvoked;
+  private boolean terminated;
   /** Service encapsulating something similar to an accept() socket. */
   private final InternalServer transportServer;
   private final Object lock = new Object();
-  @GuardedBy("lock") private boolean transportServerTerminated;
+  private boolean transportServerTerminated;
   /** {@code transportServer} and services encapsulating something similar to a TCP connection. */
-  @GuardedBy("lock") private final Collection<ServerTransport> transports =
-      new HashSet<ServerTransport>();
+  private final Collection<ServerTransport> transports = new HashSet<ServerTransport>();
 
   private final ScheduledExecutorService timeoutService = SharedResourceHolder.get(TIMER_SERVICE);
   private final Context rootContext;


### PR DESCRIPTION
…mpl"

This reverts commit 8d9283116c23f0ad0e05fa8d3b04563e00165eb5.

The GuardedBy for usingSharedExecutor fails an ErrorProne check that
breaks the build internally. Simply removing the GuardedBy wasn't
acceptable since it can cause confusion as to what its synchronization
needs are, which is also shared with executor; reverting the commit
prevents the confusion because it no longer appears forgotten.