### PR TITLE
interop: Add constant for necessary max message size

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -108,7 +108,8 @@ import javax.net.ssl.SSLSession;
  * Abstract base class for all GRPC transport tests.
  */
 public abstract class AbstractInteropTest {
-
+  /** Must be at least {@link #unaryPayloadLength()}, plus some to account for encoding overhead. */
+  public static final int MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
   public static final Metadata.Key<Messages.SimpleContext> METADATA_KEY =
       ProtoUtils.keyForProto(Messages.SimpleContext.getDefaultInstance());
   private static final AtomicReference<ServerCall<?, ?>> serverCallCapture =

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -143,7 +143,7 @@ public class TestServiceServer {
     }
     server = NettyServerBuilder.forPort(port)
         .sslContext(sslContext)
-        .maxMessageSize(16 * 1024 * 1024)
+        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .addService(ServerInterceptors.intercept(
             new TestServiceImpl(executor),
             TestUtils.echoRequestHeadersInterceptor(Util.METADATA_KEY)))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -57,7 +57,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
         NettyServerBuilder
             .forAddress(new LocalAddress("in-process-1"))
             .flowControlWindow(65 * 1024)
-            .maxMessageSize(16 * 1024 * 1024)
+            .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
             .channelType(LocalServerChannel.class));
   }
 
@@ -74,7 +74,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
         .negotiationType(NegotiationType.PLAINTEXT)
         .channelType(LocalChannel.class)
         .flowControlWindow(65 * 1024)
-        .maxMessageSize(16 * 1024 * 1024)
+        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .build();
   }
 }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -60,7 +60,7 @@ public class Http2NettyTest extends AbstractInteropTest {
     try {
       startStaticServer(NettyServerBuilder.forPort(0)
           .flowControlWindow(65 * 1024)
-          .maxMessageSize(16 * 1024 * 1024)
+          .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(GrpcSslContexts
               .forServer(TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"))
               .clientAuth(ClientAuth.REQUIRE)
@@ -84,7 +84,7 @@ public class Http2NettyTest extends AbstractInteropTest {
       return NettyChannelBuilder
           .forAddress(TestUtils.testServerAddress(getPort()))
           .flowControlWindow(65 * 1024)
-          .maxMessageSize(16 * 1024 * 1024)
+          .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(GrpcSslContexts
               .forClient()
               .keyManager(TestUtils.loadCert("client.pem"), TestUtils.loadCert("client.key"))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -88,7 +88,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
       contextBuilder.ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE);
       startStaticServer(NettyServerBuilder.forPort(0)
           .flowControlWindow(65 * 1024)
-          .maxMessageSize(16 * 1024 * 1024)
+          .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(contextBuilder.build()));
     } catch (IOException ex) {
       throw new RuntimeException(ex);
@@ -103,7 +103,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
   @Override
   protected ManagedChannel createChannel() {
     OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("127.0.0.1", getPort())
-        .maxMessageSize(16 * 1024 * 1024)
+        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .connectionSpec(new ConnectionSpec.Builder(OkHttpChannelBuilder.DEFAULT_CONNECTION_SPEC)
             .cipherSuites(TestUtils.preferredTestCiphers().toArray(new String[0]))
             .tlsVersions(ConnectionSpec.MODERN_TLS.tlsVersions().toArray(new TlsVersion[0]))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -102,7 +102,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
     compressors.register(Codec.Identity.NONE);
     startStaticServer(
         NettyServerBuilder.forPort(0)
-            .maxMessageSize(16 * 1024 * 1024)
+            .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
             .compressorRegistry(compressors)
             .decompressorRegistry(decompressors),
         new ServerInterceptor() {
@@ -149,7 +149,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
   @Override
   protected ManagedChannel createChannel() {
     return NettyChannelBuilder.forAddress("localhost", getPort())
-        .maxMessageSize(16 * 1024 * 1024)
+        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .decompressorRegistry(decompressors)
         .compressorRegistry(compressors)
         .intercept(new ClientInterceptor() {


### PR DESCRIPTION
The max message size isn't necessary for the standard cross-language
interop tests, but only our own veryLarge tests.