### PR TITLE
docs: Avoid using bindService()

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -245,7 +245,7 @@ avoid needing extra permissions from the OS.
 Server server = ServerBuilder.forPort(8443)
     // Enable TLS
     .useTransportSecurity(certChainFile, privateKeyFile)
-    .addService(TestServiceGrpc.bindService(serviceImplementation))
+    .addService(serviceImplementation)
     .build();
 server.start();
 ```


### PR DESCRIPTION
bindService() is generally not necessary and the static version is
deprecated.