### PR TITLE
Optimize for the normal case when we need to send keepalive pings.

### DIFF
--- a/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
@@ -72,7 +72,7 @@ public final class KeepAliveManagerTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    keepAliveManager = new KeepAliveManager(transport, scheduler, ticker, 1000, 2000);
+    keepAliveManager = new KeepAliveManager(transport, scheduler, ticker, 1000, 2000, 10);
   }
 
   @Test


### PR DESCRIPTION
In the current implementation, when we receive a ping response, we will schedule a new ping.
However, right after that, the ping response will trigger a onDataReceived, which delays the next ping just a little bit. This causes a normal keepalive ping to be scheduled twice.