### PR TITLE
Fixed directory in README.md for output scripts.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,19 +13,19 @@ $ ./gradlew installDist
 
 This creates the scripts `hello-world-server`, `hello-world-client`,
 `route-guide-server`, and `route-guide-client` in the
-`build/install/grpc-examples/bin/` directory that run the examples. Each
+`build/install/examples/bin/` directory that run the examples. Each
 example requires the server to be running before starting the client.
 
 For example, to try the hello world example first run:
 
 ```
-$ ./build/install/grpc-examples/bin/hello-world-server
+$ ./build/install/examples/bin/hello-world-server
 ```
 
 And in a different terminal window run:
 
 ```
-$ ./build/install/grpc-examples/bin/hello-world-client
+$ ./build/install/examples/bin/hello-world-client
 ```
 
 That's it!


### PR DESCRIPTION
I've been playing with the examples and noticed that the output directories don't quite match those in the readme. I believe this string is set by the root project name in `settings.gradle` which is "examples", not "grpc-examples".
