### PR TITLE
core: Hard-code a list of providers for Android

### DIFF
--- a/core/src/test/java/io/grpc/internal/DnsNameResolverProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverProviderTest.java
@@ -52,7 +52,19 @@ public class DnsNameResolverProviderTest {
 
   @Test
   public void provided() {
-    for (NameResolverProvider current : NameResolverProvider.providers()) {
+    for (NameResolverProvider current
+        : NameResolverProvider.getCandidatesViaServiceLoader(getClass().getClassLoader())) {
+      if (current instanceof DnsNameResolverProvider) {
+        return;
+      }
+    }
+    fail("DnsNameResolverProvider not registered");
+  }
+
+  @Test
+  public void providedHardCoded() {
+    for (NameResolverProvider current
+        : NameResolverProvider.getCandidatesViaHardCoded(getClass().getClassLoader())) {
       if (current instanceof DnsNameResolverProvider) {
         return;
       }

--- a/netty/src/test/java/io/grpc/netty/NettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelProviderTest.java
@@ -34,6 +34,7 @@ package io.grpc.netty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.grpc.ManagedChannelProvider;
 
@@ -48,7 +49,24 @@ public class NettyChannelProviderTest {
 
   @Test
   public void provided() {
-    assertSame(NettyChannelProvider.class, ManagedChannelProvider.provider().getClass());
+    for (ManagedChannelProvider current
+        : ManagedChannelProvider.getCandidatesViaServiceLoader(getClass().getClassLoader())) {
+      if (current instanceof NettyChannelProvider) {
+        return;
+      }
+    }
+    fail("ServiceLoader unable to load NettyChannelProvider");
+  }
+
+  @Test
+  public void providedHardCoded() {
+    for (ManagedChannelProvider current
+        : ManagedChannelProvider.getCandidatesViaHardCoded(getClass().getClassLoader())) {
+      if (current instanceof NettyChannelProvider) {
+        return;
+      }
+    }
+    fail("Hard coded unable to load NettyChannelProvider");
   }
 
   @Test

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelProviderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelProviderTest.java
@@ -41,8 +41,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.ServiceLoader;
-
 /** Unit tests for {@link OkHttpChannelProvider}. */
 @RunWith(JUnit4.class)
 public class OkHttpChannelProviderTest {
@@ -50,12 +48,24 @@ public class OkHttpChannelProviderTest {
 
   @Test
   public void provided() {
-    for (ManagedChannelProvider current : ServiceLoader.load(ManagedChannelProvider.class)) {
+    for (ManagedChannelProvider current
+        : ManagedChannelProvider.getCandidatesViaServiceLoader(getClass().getClassLoader())) {
       if (current instanceof OkHttpChannelProvider) {
         return;
       }
     }
     fail("ServiceLoader unable to load OkHttpChannelProvider");
+  }
+
+  @Test
+  public void providedHardCoded() {
+    for (ManagedChannelProvider current
+        : ManagedChannelProvider.getCandidatesViaHardCoded(getClass().getClassLoader())) {
+      if (current instanceof OkHttpChannelProvider) {
+        return;
+      }
+    }
+    fail("Hard coded unable to load OkHttpChannelProvider");
   }
 
   @Test


### PR DESCRIPTION
Class.getResource() is expensive on Android, which is used by
ServiceLoader. So we hard-code a list for Android instead.

Fixes #2037 