### PR TITLE
benchmarks: improve benchmarks recording and shutdown

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/FlowControlledMessagesPerSecondBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/FlowControlledMessagesPerSecondBenchmark.java
@@ -41,8 +41,11 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
 
 /**
  * Benchmark measuring messages per second received from a streaming server. The server
@@ -51,6 +54,9 @@ import java.util.concurrent.atomic.AtomicLong;
 @State(Scope.Benchmark)
 @Fork(1)
 public class FlowControlledMessagesPerSecondBenchmark extends AbstractBenchmark {
+
+  private static final Logger logger =
+      Logger.getLogger(FlowControlledMessagesPerSecondBenchmark.class.getName());
 
   @Param({"1", "2", "4"})
   public int channelCount = 1;
@@ -66,6 +72,8 @@ public class FlowControlledMessagesPerSecondBenchmark extends AbstractBenchmark 
 
   private static AtomicLong callCounter;
   private AtomicBoolean completed;
+  private AtomicBoolean record;
+  private CountDownLatch latch;
 
   /**
    * Use an AuxCounter so we can measure that calls as they occur without consuming CPU
@@ -100,7 +108,9 @@ public class FlowControlledMessagesPerSecondBenchmark extends AbstractBenchmark 
         channelCount);
     callCounter = new AtomicLong();
     completed = new AtomicBoolean();
-    startFlowControlledStreamingCalls(maxConcurrentStreams, callCounter, completed, 1);
+    record = new AtomicBoolean();
+    latch =
+        startFlowControlledStreamingCalls(maxConcurrentStreams, callCounter, record, completed, 1);
   }
 
   /**
@@ -110,7 +120,10 @@ public class FlowControlledMessagesPerSecondBenchmark extends AbstractBenchmark 
   @TearDown(Level.Trial)
   public void teardown() throws Exception {
     completed.set(true);
-    Thread.sleep(5000);
+    if (!latch.await(5, TimeUnit.SECONDS)) {
+      logger.warning("Failed to shutdown all calls.");
+    }
+
     super.teardown();
   }
 
@@ -120,8 +133,10 @@ public class FlowControlledMessagesPerSecondBenchmark extends AbstractBenchmark 
    */
   @Benchmark
   public void stream(AdditionalCounters counters) throws Exception {
+    record.set(true);
     // No need to do anything, just sleep here.
     Thread.sleep(1001);
+    record.set(false);
   }
 
   /**


### PR DESCRIPTION
The benchmarks today do not have a good way to record metrics with precision
or shutdown safely when the benchmark is over.  This change alters the
AbstractBenchmark class to return a latch that can be waited upon when ending
the benchmark.

Benchmarks also would accidentally request way too many messages from the
server by calling request(1) explicitly in addition to the implicit one
in the StreamObserver to Call adapter.  This change adds a few outstanding
requests, but otherwise keeps the request count bounded.

Additionally, benchmark calls would ignore errors, and just shutdown in such
cases.  This changes them to log the error and just wait for the benchmark to
complete.  In the successful case, the benchmark client notifies server by
halfClosing (via onCompleted) where it previously did not.  It is also
careful to only do this once.

Lastly, Benchmarks have been changes to enable and disable recording at exact
points in the benchmark method, rather than waiting for teardown to occur.
Also, recording begins inside the recording method, not in Setup.  JMH may
do other processing before, between, and after iterations.

cc: @louiscryan 
