### PR TITLE
core: remove extra allocation in MessageFramer

### DIFF
--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -320,11 +320,14 @@ public class MessageFramer {
 
   /** OutputStream whose write()s are passed to the framer. */
   private class OutputStreamAdapter extends OutputStream {
-    private final byte[] singleByte = new byte[1];
-
+    /**
+     * This is slow, don't call it.  If you care about write overhead, use a BufferedOutputStream.
+     * Better yet, you can use your own single byte buffer and call
+     * {@link #write(byte[], int, int)}.
+     */
     @Override
     public void write(int b) {
-      singleByte[0] = (byte) b;
+      byte[] singleByte = new byte[]{(byte)b};
       write(singleByte, 0, 1);
     }
 
@@ -344,7 +347,7 @@ public class MessageFramer {
 
     /**
      * This is slow, don't call it.  If you care about write overhead, use a BufferedOutputStream.
-     * Better yet, you can use your own single byte buffer and called
+     * Better yet, you can use your own single byte buffer and call
      * {@link #write(byte[], int, int)}.
      */
     @Override


### PR DESCRIPTION
OutputStreamAdapter is a private class, and is only ever called by two
places: ByteStreams.copy, which never calls the single byte method, and
DrainTo, which potentially can.  There are two classes that implement
DrainTo, which is primarily ProtoInputStream.  It calls
MessageLite.writeTo(OutputStream) or back again to ByteStreams.copy.

MessageLite.writeTo in turn wraps the OutputStream in a
CodedOutputStream.OutputStreamEncoder, which then never calls the single
byte version.  Thus, all know implementations never call the single
byte override.

Additionally, it is well known that the single byte write is slow, and
is expected to be wrapped in a BufferedOutputStream if there are many
small writes.
