### PR TITLE
benchmarks: avoid 2 copies in favor of one

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -246,9 +246,13 @@ public abstract class AbstractBenchmark {
 
     // Create buffers of the desired size for requests and responses.
     PooledByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
-    request = alloc.buffer(requestSize.bytes());
+    // Use a heap buffer for now, since MessageFramer doesn't know how to directly convert this
+    // into a WritableBuffer
+    // TODO(carl-mastrangelo): convert this into a regular buffer() call.  See
+    // https://github.com/grpc/grpc-java/issues/2062#issuecomment-234646216
+    request = alloc.heapBuffer(requestSize.bytes());
     request.writerIndex(request.capacity() - 1);
-    response = alloc.buffer(responseSize.bytes());
+    response = alloc.heapBuffer(responseSize.bytes());
     response.writerIndex(response.capacity() - 1);
 
     // Simple method that sends and receives NettyByteBuf


### PR DESCRIPTION
MessageFramer calls Drainable.drainTo with a special output stream of
OutputStreamAdapter.  Currently, ByteBufInputStream writes to this output
stream by allocating a heapBuffer in UnsafeByteBufUtil.getBytes, copying
from the direct byte buffer of BBIS, and then copies to the direct byte
buffer from MessageFramer.writeRaw().

This change is an easy way to cut down on wasted memory, even though
ideally there would be some way to have less copies.  The actual data is
only around 10 bytes, but causes O(10)s of megabytes allocation for the
heap pool.

For #2062