### PR TITLE
core,netty: retain buffer in MessageFramer to reuse for subsequent messages

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -250,9 +250,9 @@ public abstract class AbstractBenchmark {
     // into a WritableBuffer
     // TODO(carl-mastrangelo): convert this into a regular buffer() call.  See
     // https://github.com/grpc/grpc-java/issues/2062#issuecomment-234646216
-    request = alloc.buffer(requestSize.bytes());
+    request = alloc.heapBuffer(requestSize.bytes());
     request.writerIndex(request.capacity() - 1);
-    response = alloc.buffer(responseSize.bytes());
+    response = alloc.heapBuffer(responseSize.bytes());
     response.writerIndex(response.capacity() - 1);
 
     // Simple method that sends and receives NettyByteBuf

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -250,9 +250,9 @@ public abstract class AbstractBenchmark {
     // into a WritableBuffer
     // TODO(carl-mastrangelo): convert this into a regular buffer() call.  See
     // https://github.com/grpc/grpc-java/issues/2062#issuecomment-234646216
-    request = alloc.heapBuffer(requestSize.bytes());
+    request = alloc.buffer(requestSize.bytes());
     request.writerIndex(request.capacity() - 1);
-    response = alloc.heapBuffer(responseSize.bytes());
+    response = alloc.buffer(responseSize.bytes());
     response.writerIndex(response.capacity() - 1);
 
     // Simple method that sends and receives NettyByteBuf

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -304,6 +304,8 @@ public class MessageFramer {
 
   private void commitToSink(boolean endOfStream, boolean flush) {
     WritableBuffer buf = buffer;
+    // If we have a buffer still and we are not trying to do the last flush on a close() call,
+    // try and reuse the remainder of the buffer.
     if (buf != null && !isClosed()) {
       buffer = buf.snip();
     }

--- a/core/src/main/java/io/grpc/internal/WritableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/WritableBuffer.java
@@ -31,6 +31,8 @@
 
 package io.grpc.internal;
 
+import javax.annotation.Nullable;
+
 /**
  * An interface for a byte buffer that can only be written to.
  * {@link WritableBuffer}s are a generic way to transfer bytes to
@@ -70,4 +72,13 @@ public interface WritableBuffer {
    * this buffer is no longer used and its resources can be reused.
    */
   void release();
+
+  /**
+   * Creates a new Writable buffer derived from this buffer.  The new buffer represents the
+   * remaining space available for reuse.  After calling snip(), the current buffer may not be
+   * written to.
+   *
+   * @returns a new WritableBuffer or {@code null} if there is not enough remaining space.
+   */
+  @Nullable WritableBuffer snip();
 }

--- a/core/src/test/java/io/grpc/internal/MessageFramerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageFramerTest.java
@@ -394,6 +394,11 @@ public class MessageFramerTest {
     }
 
     @Override
+    public WritableBuffer snip() {
+      return null;
+    }
+
+    @Override
     public boolean equals(Object buffer) {
       if (!(buffer instanceof ByteWritableBuffer)) {
         return false;

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -1,7 +1,8 @@
 description = "gRPC: Netty"
 dependencies {
     compile project(':grpc-core'),
-            libraries.netty
+            libraries.netty,
+            libraries.hdrhistogram
 
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,

--- a/netty/src/main/java/io/grpc/netty/NettyWritableBuffer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyWritableBuffer.java
@@ -73,4 +73,15 @@ class NettyWritableBuffer implements WritableBuffer {
   ByteBuf bytebuf() {
     return bytebuf;
   }
+
+  @Override
+  public WritableBuffer snip() {
+    // If there isn't much room left, don't bother.
+    if (bytebuf.writableBytes() < 16) {
+      return null;
+    }
+    ByteBuf remaining = bytebuf.slice(bytebuf.writerIndex(), bytebuf.writableBytes()).retain();
+    remaining.writerIndex(0);
+    return new NettyWritableBuffer(remaining);
+  }
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpWritableBuffer.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpWritableBuffer.java
@@ -77,4 +77,10 @@ class OkHttpWritableBuffer implements WritableBuffer {
   Buffer buffer() {
     return buffer;
   }
+
+  @Override
+  public WritableBuffer snip() {
+    // not yet implemented.
+    return null;
+  }
 }


### PR DESCRIPTION
When a buffer is allocated in the MessageFramer, the capacity is at least 4K
in size, which leaves a lot of space wasted on small messages.  This change
alters the WritableBuffers to attempt to split themselves into a "remaining"
buffer that reuses space.

This should only have a serious impact on streaming, and only when messages
are small.

Benchmarks for FlowControlled messages per second are promising showing at
least 10%

Results:

```
Benchmark                                                                        (channelCount) (clientExecutor) (maxConcurrentStreams) (responseSize) Mode Cnt Score Error Units Score Error Units Speedup
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  1   DEFAULT 1   SMALL   thrpt   10  755282.751  ±29529.715 ops/s   905364.204  ±29097.292 ops/s   1.198708964
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  1   DEFAULT 2   SMALL   thrpt   10  791301.174  ±20232.22  ops/s   994319.597  ±40626.872 ops/s   1.256562772
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  1   DEFAULT 10  SMALL   thrpt   10  658210.954  ±21180.062 ops/s   857288.67   ±34114.984 ops/s   1.302452754
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  1   DEFAULT 100 SMALL   thrpt   10  657083.367  ±19745.56  ops/s   944762.512  ±19204.798 ops/s   1.437812246
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  1   DIRECT  1   SMALL   thrpt   10  887901.239  ±19285.937 ops/s   1343311.784 ±31011.844 ops/s   1.512906757
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  1   DIRECT  2   SMALL   thrpt   10  970308.851  ±27653.139 ops/s   1307188.816 ±35358.558 ops/s   1.347188387
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  1   DIRECT  10  SMALL   thrpt   10  735228.889  ±24770.534 ops/s   1199052.762 ±33300.275 ops/s   1.630856431
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  1   DIRECT  100 SMALL   thrpt   10  716183.74   ±12900.773 ops/s   1127230.832 ±33133.574 ops/s   1.573940833
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  2   DEFAULT 1   SMALL   thrpt   10  1291716.222 ±31902.31  ops/s   1573493.799 ±39530.656 ops/s   1.218142013
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  2   DEFAULT 2   SMALL   thrpt   10  1268950.933 ±42048.729 ops/s   1536156.083 ±34455.726 ops/s   1.210571696
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  2   DEFAULT 10  SMALL   thrpt   10  1128048.116 ±26606.668 ops/s   1356561.752 ±23734.552 ops/s   1.20257437
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  2   DEFAULT 100 SMALL   thrpt   10  988027.512  ±23084.526 ops/s   1347382.882 ±30614.784 ops/s   1.363709882
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  2   DIRECT  1   SMALL   thrpt   10  1478108.147 ±65561.972 ops/s   2163858.787 ±79516.791 ops/s   1.463938069
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  2   DIRECT  2   SMALL   thrpt   10  1524911.028 ±61438.415 ops/s   2176216.821 ±73718.403 ops/s   1.427110685
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  2   DIRECT  10  SMALL   thrpt   10  1313905.422 ±36649.59  ops/s   2055314.846 ±73080.768 ops/s   1.564279142
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  2   DIRECT  100 SMALL   thrpt   10  1117786.572 ±35215.016 ops/s   1865375.865 ±49877.609 ops/s   1.668812197
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  4   DEFAULT 1   SMALL   thrpt   10  1878378.751 ±26112.523 ops/s   1928202.574 ±43622.205 ops/s   1.026524908
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  4   DEFAULT 2   SMALL   thrpt   10  1982666.038 ±24621.442 ops/s   1941969.538 ±40390.353 ops/s   0.9794738503
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  4   DEFAULT 10  SMALL   thrpt   10  1707623.426 ±20835.524 ops/s   1725687.175 ±18794.404 ops/s   1.010578298
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  4   DEFAULT 100 SMALL   thrpt   10  ≈0    ops/s       1490847.182 ±  43668.394   ops/s
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  4   DIRECT  1   SMALL   thrpt   10  2375070.989 ±53326.398 ops/s   3600611.491 ±68078.043 ops/s   1.51600163
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  4   DIRECT  2   SMALL   thrpt   10  2462611.986 ±49230.177 ops/s   3370385.331 ±73550.54  ops/s   1.368622158
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  4   DIRECT  10  SMALL   thrpt   10  2108888.769 ±37617.889 ops/s   3179585.616 ±75017.316 ops/s   1.507706648
i.g.benchmarks.netty.FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond  4   DIRECT  100 SMALL   thrpt   10  ≈0    ops/s       2292144.755 ±  69949.443   ops/s
```

cc: @louiscryan 
