### PR TITLE
Flow control (disabled by default) in netty and unit tests

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -103,6 +103,7 @@ class NettyClientHandler extends AbstractNettyHandler {
    */
   private static final Status EXHAUSTED_STREAMS_STATUS =
           Status.UNAVAILABLE.withDescription("Stream IDs have been exhausted");
+  private static final long USER_PING_PAYLOAD = 1111;
 
   private final Http2Connection.PropertyKey streamKey;
   private final ClientTransportLifecycleManager lifecycleManager;
@@ -120,6 +121,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     Http2FrameReader frameReader = new DefaultHttp2FrameReader(headersDecoder);
     Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
     Http2Connection connection = new DefaultHttp2Connection(false);
+
     return newHandler(
         connection, frameReader, frameWriter, lifecycleManager, flowControlWindow, ticker);
   }
@@ -145,8 +147,8 @@ class NettyClientHandler extends AbstractNettyHandler {
         new DefaultHttp2ConnectionEncoder(connection, frameWriter));
 
     // Create the local flow controller configured to auto-refill the connection window.
-    connection.local().flowController(new DefaultHttp2LocalFlowController(connection,
-            DEFAULT_WINDOW_UPDATE_RATIO, true));
+    connection.local().flowController(
+        new DefaultHttp2LocalFlowController(connection, DEFAULT_WINDOW_UPDATE_RATIO, true));
 
     Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder,
         frameReader);
@@ -172,6 +174,7 @@ class NettyClientHandler extends AbstractNettyHandler {
 
     Http2Connection connection = encoder.connection();
     streamKey = connection.newKey();
+
     connection.addListener(new Http2ConnectionAdapter() {
       @Override
       public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
@@ -219,6 +222,11 @@ class NettyClientHandler extends AbstractNettyHandler {
     }
   }
 
+  // @VisibleForTesting
+  // FlowControlPinger flowControlPinger() {
+  // return flowControlPing;
+  // }
+
   void startWriteQueue(Channel channel) {
     clientWriteQueue = new WriteQueue(channel);
   }
@@ -246,10 +254,13 @@ class NettyClientHandler extends AbstractNettyHandler {
   /**
    * Handler for an inbound HTTP/2 DATA frame.
    */
-  private void onDataRead(int streamId, ByteBuf data, boolean endOfStream) {
+
+  private void onDataRead(int streamId, ByteBuf data, int padding, boolean endOfStream) {
+    flowControlPing().onDataRead(data.readableBytes(), padding);
     NettyClientStream stream = clientStream(requireHttp2Stream(streamId));
     stream.transportDataReceived(data, endOfStream);
   }
+
 
   /**
    * Handler for an inbound HTTP/2 RST_STREAM frame, terminating a stream.
@@ -449,7 +460,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     promise.setSuccess();
     promise = ctx().newPromise();
     // set outstanding operation
-    long data = random.nextLong();
+    long data = USER_PING_PAYLOAD;
     ByteBuf buffer = ctx.alloc().buffer(8);
     buffer.writeLong(data);
     Stopwatch stopwatch = Stopwatch.createStarted(ticker);
@@ -585,7 +596,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     @Override
     public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
         boolean endOfStream) throws Http2Exception {
-      NettyClientHandler.this.onDataRead(streamId, data, endOfStream);
+      NettyClientHandler.this.onDataRead(streamId, data, padding, endOfStream);
       return padding;
     }
 
@@ -607,17 +618,23 @@ class NettyClientHandler extends AbstractNettyHandler {
       NettyClientHandler.this.onRstStreamRead(streamId, errorCode);
     }
 
-    @Override public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data)
-        throws Http2Exception {
+    @Override
+    public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
       Http2Ping p = ping;
-      if (p != null) {
+      if (data.getLong(data.readerIndex()) == flowControlPing().payload()) {
+        flowControlPing().updateWindow();
+        if (logger.isLoggable(Level.FINE)) {
+          logger.log(Level.FINE, String.format("Window: %d",
+              decoder().flowController().initialWindowSize(connection().connectionStream())));
+        }
+      } else if (p != null) {
         long ackPayload = data.readLong();
         if (p.payload() == ackPayload) {
           p.complete();
           ping = null;
         } else {
-          logger.log(Level.WARNING, String.format("Received unexpected ping ack. "
-              + "Expecting %d, got %d", p.payload(), ackPayload));
+          logger.log(Level.WARNING, String.format(
+              "Received unexpected ping ack. Expecting %d, got %d", p.payload(), ackPayload));
         }
       } else {
         logger.warning("Received unexpected ping ack. No ping outstanding");

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -353,4 +353,9 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   protected WriteQueue initWriteQueue() {
     return handler().getWriteQueue();
   }
+
+  @Override
+  protected void makeStream() throws Exception {
+    createStream();
+  }
 }


### PR DESCRIPTION
switch added to turn off window updates by default, but otherwise basically the same as the last flow control PR 