### PR TITLE
Begin consuming protobuf-lite artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,6 +151,8 @@ subprojects {
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
                 okio: 'com.squareup.okio:okio:1.6.0',
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
+                // swap to ${protobufVersion} after versions align again
+                protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
                 protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.7.7',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -160,7 +160,11 @@ protobuf {
   }
   plugins {
     javalite {
-      artifact = "com.google.protobuf:protoc-gen-javalite:${protobufVersion}"
+      if (project.hasProperty('protoc-gen-javalite')) {
+        path = project['protoc-gen-javalite']
+      } else {
+        artifact = "com.google.protobuf:protoc-gen-javalite:${protobufVersion}"
+      }
     }
     grpc {
       path = javaPluginPath

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -1,13 +1,61 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+    }
+    dependencies {
+        classpath libraries.protobuf_plugin
+    }
+}
+
 plugins {
     id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
 }
+
+apply plugin: 'com.google.protobuf'
 
 description = 'gRPC: Protobuf Lite'
 
 dependencies {
     compile project(':grpc-core'),
-            libraries.protobuf,
+            libraries.protobuf_lite,
             libraries.guava
+
+    testProtobuf libraries.protobuf
+}
+
+compileTestJava {
+  // Protobuf-generated Lite produces quite a few warnings.
+  options.compilerArgs += ["-Xlint:-rawtypes", "-Xlint:-unchecked", "-Xlint:-fallthrough"]
+}
+
+protobuf {
+  protoc {
+    if (project.hasProperty('protoc')) {
+      path = project.protoc
+    } else {
+      artifact = "com.google.protobuf:protoc:${protobufVersion}"
+    }
+  }
+  plugins {
+    javalite {
+      if (project.hasProperty('protoc-gen-javalite')) {
+        path = project['protoc-gen-javalite']
+      } else {
+        artifact = "com.google.protobuf:protoc-gen-javalite:${protobufVersion}"
+      }
+    }
+  }
+  generateProtoTasks {
+    ofSourceSet('test')*.each { task ->
+      task.builtins {
+        remove java
+      }
+      task.plugins {
+        javalite {}
+      }
+    }
+  }
 }
 
 animalsniffer {

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -6,10 +6,13 @@ description = 'gRPC: Protobuf'
 
 dependencies {
     compile project(':grpc-core'),
-            project(':grpc-protobuf-lite'),
             libraries.protobuf,
             libraries.guava,
             libraries.protobuf_util
+
+    compile (project(':grpc-protobuf-lite')) {
+        exclude group: 'com.google.protobuf', module: 'protobuf-lite'
+    }
 }
 
 animalsniffer {


### PR DESCRIPTION
I will back-port this to v1.0.x.

Protobuf-lite since beta-4 is now more of a fork than a subset of
protobuf-java, which may cause us problems later since lite API is not
stable. Also, lite-generated code may now depend on APIs only in
protobuf-lite, so our users must depend on the protobuf-lite runtime.
Having all our users explicitly override the dependency is bothersome to
them and can easily only expose problems only after we do a release.

So now we are doing the dependency overriding; most users should "just
work" and pick up the correct protobuf artifact. I've confirmed the
exclusion is listed in the grpc-protobuf pom and "gradle dependencies"
and "mvn dependency:tree" do not include protobuf-lite for the examples.
Vanilla protobuf users are most likely to experience any breakage, which
should detect problems more quickly since we use protobuf-java more
frequently than protobuf-lite during development.

protobuf-lite does not include pre-generated code for the well-known
protos, so users will need to generate them themselves for the moment
(google/protobuf#1889).

Note that today changing deps does not noticeably reduce the method code
for our users, since ProGuard already is stripping most classes. The
difference in output is only a reduction of 3 classes and 6 methods for
the android example.