### PR TITLE
netty: update to 4.1.4.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,8 +155,8 @@ subprojects {
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.7.7',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
 
-                netty: 'io.netty:netty-codec-http2:[4.1.3.Final]',
-                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.3.Final' + epoll_suffix,
+                netty: 'io.netty:netty-codec-http2:[4.1.4.Final]',
+                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.4.Final' + epoll_suffix,
                 netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork19',
 
                 // Test dependencies.


### PR DESCRIPTION
It's been released two days ago and gRPC has not been updated yet 😱. Will back port to 1.0

@ejona86 