### PR TITLE
core: call newStream() and applyRequestMetadata() under context.

### DIFF
--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -60,11 +60,11 @@ public interface CallCredentials {
    * Pass the credential data to the given {@link MetadataApplier}, which will propagate it to
    * the request metadata.
    *
-   * <p>It is called for each individual RPC, before the stream is about to be created on a
-   * transport. Implementations should not block in this method. If metadata is not immediately
-   * available, e.g., needs to be fetched from network, the implementation may give the {@code
-   * applier} to an asynchronous task which will eventually call the {@code applier}. The RPC
-   * proceeds only after the {@code applier} is called.
+   * <p>It is called for each individual RPC, within the {@link Context} of the call, before the
+   * stream is about to be created on a transport. Implementations should not block in this
+   * method. If metadata is not immediately available, e.g., needs to be fetched from network, the
+   * implementation may give the {@code applier} to an asynchronous task which will eventually call
+   * the {@code applier}. The RPC proceeds only after the {@code applier} is called.
    *
    * @param method The method descriptor of this RPC
    * @param attrs Additional attributes from the transport, along with the keys defined in this

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -211,7 +211,12 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
       updateTimeoutHeaders(effectiveDeadline, callOptions.getDeadline(),
           context.getDeadline(), headers);
       ClientTransport transport = clientTransportProvider.get(callOptions);
-      stream = transport.newStream(method, headers, callOptions);
+      Context origContext = context.attach();
+      try {
+        stream = transport.newStream(method, headers, callOptions);
+      } finally {
+        context.detach(origContext);
+      }
     } else {
       stream = new FailingClientStream(DEADLINE_EXCEEDED);
     }

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -55,6 +55,8 @@ public interface ClientTransport {
    * the error information. Any sent messages for this stream will be buffered until creation has
    * completed (either successfully or unsuccessfully).
    *
+   * <p>This method is called under the {@link io.grpc.Context} of the {@link io.grpc.ClientCall}.
+   *
    * @param method the descriptor of the remote method to be called for this stream.
    * @param headers to send at the beginning of the call
    * @param callOptions runtime options of the call

--- a/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
+++ b/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
@@ -37,6 +37,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallOptions;
+import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -49,6 +50,7 @@ final class MetadataApplierImpl implements MetadataApplier {
   private final MethodDescriptor<?, ?> method;
   private final Metadata origHeaders;
   private final CallOptions callOptions;
+  private final Context ctx;
 
   private final Object lock = new Object();
 
@@ -69,6 +71,7 @@ final class MetadataApplierImpl implements MetadataApplier {
     this.method = method;
     this.origHeaders = origHeaders;
     this.callOptions = callOptions;
+    this.ctx = Context.current();
   }
 
   @Override
@@ -76,7 +79,14 @@ final class MetadataApplierImpl implements MetadataApplier {
     checkState(!finalized, "apply() or fail() already called");
     checkNotNull(headers, "headers");
     origHeaders.merge(headers);
-    finalizeWith(transport.newStream(method, origHeaders, callOptions));
+    ClientStream realStream;
+    Context origCtx = ctx.attach();
+    try {
+      realStream = transport.newStream(method, origHeaders, callOptions);
+    } finally {
+      ctx.detach(origCtx);
+    }
+    finalizeWith(realStream);
   }
 
   @Override


### PR DESCRIPTION
`ClientTransport.newStream()` and
`CallCredentials.applyRequestMetadata()` is now called under the context
of the call.  This can be used to pass any call-specific information to
`CallCredentials`.