### PR TITLE
okhttp: Remove wrong status description

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -548,10 +548,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
    * Finish all active streams due to an IOException, then close the transport.
    */
   void onException(Throwable failureCause) {
+    Preconditions.checkNotNull(failureCause, "failureCause");
     Status status = Status.UNAVAILABLE.withCause(failureCause);
-    if (failureCause != null) {
-      status = status.augmentDescription("No provided cause");
-    }
     startGoAway(0, ErrorCode.INTERNAL_ERROR, status);
   }
 


### PR DESCRIPTION
The != should have been ==. However, it is provable that the exception
won't be null, but we want to make that fact obvious when auditing. So
we just fail if the exception is ever null.

I will backport this to v3.0.x