### PR TITLE
stub: Avoid double-wrapping status

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -224,10 +224,10 @@ public class ClientCalls {
       // If we have an embedded status, use it and replace the cause
       if (cause instanceof StatusException) {
         StatusException se = (StatusException) cause;
-        return new StatusRuntimeException(se.getStatus().withCause(t), se.getTrailers());
+        return new StatusRuntimeException(se.getStatus(), se.getTrailers());
       } else if (cause instanceof StatusRuntimeException) {
         StatusRuntimeException se = (StatusRuntimeException) cause;
-        return new StatusRuntimeException(se.getStatus().withCause(t), se.getTrailers());
+        return new StatusRuntimeException(se.getStatus(), se.getTrailers());
       }
       cause = cause.getCause();
     }

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -139,7 +139,7 @@ public class ClientCallsTest {
   @Test
   public void unaryBlockingCallFailed() throws Exception {
     Integer req = 2;
-    final Status status = Status.INTERNAL;
+    final Status status = Status.INTERNAL.withDescription("Unique status");
     final Metadata trailers = new Metadata();
 
     doAnswer(new Answer<Void>() {
@@ -156,7 +156,7 @@ public class ClientCallsTest {
       ClientCalls.blockingUnaryCall(call, req);
       fail("Should fail");
     } catch (StatusRuntimeException e) {
-      assertSame(status.getCode(), e.getStatus().getCode());
+      assertSame(status, e.getStatus());
       assertSame(trailers, e.getTrailers());
     }
   }


### PR DESCRIPTION
780b2696 caused all failures for blocked unary stubs to have a
StatusRuntimeException as the cause of the StatusRuntimeException, with
the two exceptions having almost the same status.

I will backport this to v3.0.x