### PR TITLE
Release 1.0.0-pre2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,37 +27,37 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-netty</artifactId>
-  <version>0.14.0</version>
+  <version>1.0.0-pre2</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-protobuf</artifactId>
-  <version>0.14.0</version>
+  <version>1.0.0-pre2</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-stub</artifactId>
-  <version>0.14.0</version>
+  <version>1.0.0-pre2</version>
 </dependency>
 ```
 
 Or for Gradle with non-Android, add to your dependencies:
 ```gradle
-compile 'io.grpc:grpc-netty:0.14.0'
-compile 'io.grpc:grpc-protobuf:0.14.0'
-compile 'io.grpc:grpc-stub:0.14.0'
+compile 'io.grpc:grpc-netty:1.0.0-pre2'
+compile 'io.grpc:grpc-protobuf:1.0.0-pre2'
+compile 'io.grpc:grpc-stub:1.0.0-pre2'
 ```
 
 For Android client, use `grpc-okhttp` instead of `grpc-netty` and
 `grpc-protobuf-lite` or `grpc-protobuf-nano` instead of `grpc-protobuf`:
 ```gradle
-compile 'io.grpc:grpc-okhttp:0.14.0'
-compile 'io.grpc:grpc-protobuf-lite:0.14.0'
-compile 'io.grpc:grpc-stub:0.14.0'
+compile 'io.grpc:grpc-okhttp:1.0.0-pre2'
+compile 'io.grpc:grpc-protobuf-lite:1.0.0-pre2'
+compile 'io.grpc:grpc-stub:1.0.0-pre2'
 ```
 
 [the JARs]:
-http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.grpc%22%20AND%20v%3A%220.14.0%22
+http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.grpc%22%20AND%20v%3A%221.0.0-pre2%22
 
 Development snapshots are available in [Sonatypes's snapshot
 repository](https://oss.sonatype.org/content/repositories/snapshots/).
@@ -87,9 +87,9 @@ For protobuf-based codegen integrated with the Maven build system, you can use
           protobuf-java directly, you will be transitively depending on the
           protobuf-java version that grpc depends on.
         -->
-        <protocArtifact>com.google.protobuf:protoc:3.0.0-beta-2:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.0.0:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
-        <pluginArtifact>io.grpc:protoc-gen-grpc-java:0.14.0:exe:${os.detected.classifier}</pluginArtifact>
+        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.0-pre2:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
       <executions>
         <execution>
@@ -128,11 +128,11 @@ protobuf {
     // The version of protoc must match protobuf-java. If you don't depend on
     // protobuf-java directly, you will be transitively depending on the
     // protobuf-java version that grpc depends on.
-    artifact = "com.google.protobuf:protoc:3.0.0-beta-2"
+    artifact = "com.google.protobuf:protoc:3.0.0"
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:0.14.0'
+      artifact = 'io.grpc:protoc-gen-grpc-java:1.0.0-pre2'
     }
   }
   generateProtoTasks {

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -32,7 +32,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.0.0-pre2' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -61,10 +61,10 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     // You need to build grpc-java to obtain these libraries below.
-    compile 'io.grpc:grpc-protobuf-nano:1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    compile 'io.grpc:grpc-okhttp:1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    compile 'io.grpc:grpc-stub:1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    compile 'io.grpc:grpc-testing:1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    compile 'io.grpc:grpc-protobuf-nano:1.0.0-pre2' // CURRENT_GRPC_VERSION
+    compile 'io.grpc:grpc-okhttp:1.0.0-pre2' // CURRENT_GRPC_VERSION
+    compile 'io.grpc:grpc-stub:1.0.0-pre2' // CURRENT_GRPC_VERSION
+    compile 'io.grpc:grpc-testing:1.0.0-pre2' // CURRENT_GRPC_VERSION
     compile 'javax.annotation:javax.annotation-api:1.2'
 }
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -18,7 +18,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: services.proto")
 public class BenchmarkServiceGrpc {
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -18,7 +18,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: services.proto")
 public class WorkerServiceGrpc {
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ subprojects {
     apply plugin: "com.google.osdetector"
 
     group = "io.grpc"
-    version = "1.0.0-SNAPSHOT" // CURRENT_GRPC_VERSION
+    version = "1.0.0-pre2" // CURRENT_GRPC_VERSION
 
     sourceCompatibility = 1.6
     targetCompatibility = 1.6

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: test.proto")
 public class TestServiceGrpc {
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: test.proto")
 public class TestServiceGrpc {
 

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -23,7 +23,7 @@ import java.io.IOException;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: test.proto")
 public class TestServiceGrpc {
 

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -34,7 +34,7 @@ protobuf {
             artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0"
         }
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.0.0-pre2' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -62,8 +62,8 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.2.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    compile 'io.grpc:grpc-okhttp:1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    compile 'io.grpc:grpc-protobuf-lite:1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    compile 'io.grpc:grpc-stub:1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+    compile 'io.grpc:grpc-okhttp:1.0.0-pre2' // CURRENT_GRPC_VERSION
+    compile 'io.grpc:grpc-protobuf-lite:1.0.0-pre2' // CURRENT_GRPC_VERSION
+    compile 'io.grpc:grpc-stub:1.0.0-pre2' // CURRENT_GRPC_VERSION
     compile 'javax.annotation:javax.annotation-api:1.2'
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.0.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.0.0-pre2' // CURRENT_GRPC_VERSION
 
 dependencies {
   compile "io.grpc:grpc-netty:${grpcVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,11 +6,11 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.0.0-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.0.0-pre2</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>http://maven.apache.org</url>
   <properties>
-    <grpc.version>1.0.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.0.0-pre2</grpc.version><!-- CURRENT_GRPC_VERSION -->
   </properties>
   <dependencies>
     <dependency>

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -18,7 +18,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: load_balancer.proto")
 public class LoadBalancerGrpc {
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -18,7 +18,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: io/grpc/testing/integration/metrics.proto")
 public class MetricsServiceGrpc {
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -21,7 +21,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: io/grpc/testing/integration/test.proto")
 public class ReconnectServiceGrpc {
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -22,7 +22,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: io/grpc/testing/integration/test.proto")
 public class TestServiceGrpc {
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -22,7 +22,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: io/grpc/testing/integration/test.proto")
 public class UnimplementedServiceGrpc {
 

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -18,7 +18,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.0.0-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.0.0-pre2)",
     comments = "Source: health.proto")
 public class HealthGrpc {
 


### PR DESCRIPTION
I don't plan to merge this into v1.0.x; I'll just have the tag. I bumped the README as a separate commit to 1) have the tag have documentation that matches the version and 2) so that it could (theoretically) be cherry-picked into master after the release. In this case I don't plan to cherry-pick it to master because it is a pre-release, but I wanted to try it out before 1.0.0 in hopes that we may change our RELEASE process slightly.