### PR TITLE
core: Remove usage of LogExceptionRunnable from Deadline

### DIFF
--- a/core/src/main/java/io/grpc/Context.java
+++ b/core/src/main/java/io/grpc/Context.java
@@ -108,7 +108,7 @@ import javax.annotation.Nullable;
  */
 public class Context {
 
-  private static final Logger LOG = Logger.getLogger(Context.class.getName());
+  private static final Logger log = Logger.getLogger(Context.class.getName());
 
   private static final Object[][] EMPTY_ENTRIES = new Object[0][2];
 
@@ -354,7 +354,7 @@ public class Context {
       // Log a severe message instead of throwing an exception as the context to attach is assumed
       // to be the correct one and the unbalanced state represents a coding mistake in a lower
       // layer in the stack that cannot be recovered from here.
-      LOG.log(Level.SEVERE, "Context was not attached when detaching",
+      log.log(Level.SEVERE, "Context was not attached when detaching",
           new Throwable().fillInStackTrace());
     }
   }
@@ -657,7 +657,11 @@ public class Context {
           pendingDeadline = deadline.runOnExpiration(new Runnable() {
             @Override
             public void run() {
-              cancel(cause);
+              try {
+                cancel(cause);
+              } catch (Throwable t) {
+                log.log(Level.SEVERE, "Cancel threw an exception, which should not happen", t);
+              }
             }
           }, scheduler);
         } else {
@@ -817,7 +821,7 @@ public class Context {
       try {
         executor.execute(this);
       } catch (Throwable t) {
-        LOG.log(Level.INFO, "Exception notifying context listener", t);
+        log.log(Level.INFO, "Exception notifying context listener", t);
       }
     }
 

--- a/core/src/main/java/io/grpc/Deadline.java
+++ b/core/src/main/java/io/grpc/Deadline.java
@@ -34,8 +34,6 @@ package io.grpc;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-import io.grpc.internal.LogExceptionRunnable;
-
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -150,8 +148,7 @@ public final class Deadline implements Comparable<Deadline> {
   public ScheduledFuture<?> runOnExpiration(Runnable task, ScheduledExecutorService scheduler) {
     Preconditions.checkNotNull(task, "task");
     Preconditions.checkNotNull(scheduler, "scheduler");
-    return scheduler.schedule(new LogExceptionRunnable(task),
-        deadlineNanos - ticker.read(), TimeUnit.NANOSECONDS);
+    return scheduler.schedule(task, deadlineNanos - ticker.read(), TimeUnit.NANOSECONDS);
   }
 
   @Override


### PR DESCRIPTION
io.grpc should not be depending on anything from internal. Also, the
convenience method of Deadline is part of our public API and shouldn't
use LogExceptionRunnable because it would surprise our users.

Swapped to lower-case 'log' since the logger is not immutable.