### PR TITLE
benchmarks: update to using jmh 1.13

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -23,7 +23,7 @@ startScripts.enabled = false
 run.enabled = false
 
 jmh {
-    jmhVersion = '1.12'
+    jmhVersion = '1.13'
     warmupIterations = 10
     iterations = 10
     fork = 1


### PR DESCRIPTION
Mainly to get rid of the nag about updating when running the benchmarks.