### PR TITLE
core,netty: split stream state on client-side; AbstractStream2

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2014, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nullable;
+
+/**
+ * The abstract base class for {@link ClientStream} implementations. Extending classes only need to
+ * implement {@link #transportState()} and {@link #abstractClientStreamSink()}. Must only be called
+ * from the sending application thread.
+ */
+public abstract class AbstractClientStream2 extends AbstractStream2
+    implements ClientStream, MessageFramer.Sink {
+
+  private static final Logger log = Logger.getLogger(AbstractClientStream2.class.getName());
+
+  /**
+   * A sink for outbound operations, separated from the stream simply to avoid name
+   * collisions/confusion. Only called from application thread.
+   */
+  protected interface Sink {
+    /**
+     * Sends an outbound frame to the remote end point.
+     *
+     * @param frame a buffer containing the chunk of data to be sent, or {@code null} if {@code
+     *     endOfStream} with no data to send
+     * @param endOfStream {@code true} if this is the last frame; {@code flush} is guaranteed to be
+     *     {@code true} if this is {@code true}
+     * @param flush {@code true} if more data may not be arriving soon
+     */
+    void writeFrame(@Nullable WritableBuffer frame, boolean endOfStream, boolean flush);
+
+    /**
+     * Requests up to the given number of messages from the call to be delivered to the client. This
+     * should end up triggering {@link TransportState#requestMessagesFromDeframer(int)} on the
+     * transport thread.
+     */
+    void request(int numMessages);
+
+    /**
+     * Tears down the stream, typically in the event of a timeout. This method may be called
+     * multiple times and from any thread.
+     *
+     * <p>This is a clone of {@link ClientStream#cancel()}; {@link AbstractClientStream2#cancel}
+     * delegates to this method.
+     */
+    void cancel(Status status);
+  }
+
+  private final MessageFramer framer;
+  private boolean outboundClosed;
+  /**
+   * Whether cancel() has been called. This is not strictly necessary, but removes the delay between
+   * cancel() being called and isReady() beginning to return false, since cancel is commonly
+   * processed asynchronously.
+   */
+  private volatile boolean cancelled;
+
+  protected AbstractClientStream2(WritableBufferAllocator bufferAllocator) {
+    framer = new MessageFramer(this, bufferAllocator);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected abstract TransportState transportState();
+
+  @Override
+  public void start(ClientStreamListener listener) {
+    transportState().setListener(listener);
+  }
+
+  /**
+   * Sink for transport to be called to perform outbound operations. Each stream must have its own
+   * unique sink.
+   */
+  protected abstract Sink abstractClientStreamSink();
+
+  @Override
+  protected final MessageFramer framer() {
+    return framer;
+  }
+
+  @Override
+  public final void request(int numMessages) {
+    abstractClientStreamSink().request(numMessages);
+  }
+
+  @Override
+  public final void deliverFrame(WritableBuffer frame, boolean endOfStream, boolean flush) {
+    Preconditions.checkArgument(frame != null || endOfStream, "null frame before EOS");
+    abstractClientStreamSink().writeFrame(frame, endOfStream, flush);
+  }
+
+  @Override
+  public final void halfClose() {
+    if (!outboundClosed) {
+      outboundClosed = true;
+      endOfMessages();
+    }
+  }
+
+  @Override
+  public final void cancel(Status reason) {
+    Preconditions.checkArgument(!reason.isOk(), "Should not cancel with OK status");
+    cancelled = true;
+    abstractClientStreamSink().cancel(reason);
+  }
+
+  @Override
+  public final boolean isReady() {
+    return super.isReady() && !cancelled;
+  }
+
+  /** This should only called from the transport thread. */
+  protected abstract static class TransportState extends AbstractStream2.TransportState {
+    /** Whether listener.closed() has been called. */
+    private boolean listenerClosed;
+    private ClientStreamListener listener;
+
+    private Runnable deliveryStalledTask;
+
+    private boolean headersReceived;
+    /**
+     * Whether the stream is closed from the transport's perspective. This can differ from {@link
+     * #listenerClosed} because there may still be messages buffered to deliver to the application.
+     */
+    private boolean statusReported;
+
+    protected TransportState(int maxMessageSize) {
+      super(maxMessageSize);
+    }
+
+    @VisibleForTesting
+    public final void setListener(ClientStreamListener listener) {
+      Preconditions.checkState(this.listener == null, "Already called setListener");
+      this.listener = Preconditions.checkNotNull(listener, "listener");
+    }
+
+    @Override
+    public final void deliveryStalled() {
+      if (deliveryStalledTask != null) {
+        deliveryStalledTask.run();
+        deliveryStalledTask = null;
+      }
+    }
+
+    @Override
+    public final void endOfStream() {
+      deliveryStalled();
+    }
+
+    @Override
+    protected final ClientStreamListener listener() {
+      return listener;
+    }
+
+    /**
+     * Called by transport implementations when they receive headers.
+     *
+     * @param headers the parsed headers
+     */
+    protected void inboundHeadersReceived(Metadata headers) {
+      Preconditions.checkState(!statusReported, "Received headers on closed stream");
+      headersReceived = true;
+      listener().headersRead(headers);
+    }
+
+    /**
+     * Processes the contents of a received data frame from the server.
+     *
+     * @param frame the received data frame. Its ownership is transferred to this method.
+     */
+    protected void inboundDataReceived(ReadableBuffer frame) {
+      Preconditions.checkNotNull(frame, "frame");
+      boolean needToCloseFrame = true;
+      try {
+        if (statusReported) {
+          log.log(Level.INFO, "Received data on closed stream");
+          return;
+        }
+        if (!headersReceived) {
+          transportReportStatus(
+              Status.INTERNAL.withDescription("headers not received before payload"),
+              false, new Metadata());
+          return;
+        }
+
+        needToCloseFrame = false;
+        deframe(frame, false);
+      } finally {
+        if (needToCloseFrame) {
+          frame.close();
+        }
+      }
+    }
+
+    /**
+     * Processes the trailers and status from the server.
+     *
+     * @param trailers the received trailers
+     * @param status the status extracted from the trailers
+     */
+    protected void inboundTrailersReceived(Metadata trailers, Status status) {
+      Preconditions.checkNotNull(status, "status");
+      Preconditions.checkNotNull(trailers, "trailers");
+      if (statusReported) {
+        log.log(Level.INFO, "Received trailers on closed stream:\n {1}\n {2}",
+            new Object[]{status, trailers});
+        return;
+      }
+      transportReportStatus(status, false, trailers);
+    }
+
+    /**
+     * Report stream closure with status to the application layer if not already reported. This
+     * method must be called from the transport thread.
+     *
+     * @param status the new status to set
+     * @param stopDelivery if {@code true}, interrupts any further delivery of inbound messages that
+     *        may already be queued up in the deframer. If {@code false}, the listener will be
+     *        notified immediately after all currently completed messages in the deframer have been
+     *        delivered to the application.
+     * @param trailers new instance of {@code Trailers}, either empty or those returned by the
+     *        server
+     */
+    public final void transportReportStatus(final Status status, boolean stopDelivery,
+        final Metadata trailers) {
+      Preconditions.checkNotNull(status, "status");
+      Preconditions.checkNotNull(trailers, "trailers");
+      // If stopDelivery, we continue in case previous invocation is waiting for stall
+      if (statusReported && !stopDelivery) {
+        return;
+      }
+      statusReported = true;
+      onStreamDeallocated();
+
+      // If not stopping delivery, then we must wait until the deframer is stalled (i.e., it has no
+      // complete messages to deliver).
+      if (stopDelivery || isDeframerStalled()) {
+        deliveryStalledTask = null;
+        closeListener(status, trailers);
+      } else {
+        deliveryStalledTask = new Runnable() {
+          @Override
+          public void run() {
+            closeListener(status, trailers);
+          }
+        };
+      }
+    }
+
+    /**
+     * Closes the listener if not previously closed.
+     *
+     * @throws IllegalStateException if the call has not yet been started.
+     */
+    private void closeListener(Status status, Metadata trailers) {
+      if (!listenerClosed) {
+        listenerClosed = true;
+        closeDeframer();
+        listener().closed(status, trailers);
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -43,7 +43,6 @@ import javax.annotation.Nullable;
  * Abstract base class for {@link ServerStream} implementations. Extending classes only need to
  * implement {@link #transportState()} and {@link #abstractServerStreamSink()}. Must only be called
  * from the sending application thread.
-
  */
 public abstract class AbstractServerStream extends AbstractStream2
     implements ServerStream, MessageFramer.Sink {
@@ -158,6 +157,11 @@ public abstract class AbstractServerStream extends AbstractStream2
     abstractServerStreamSink().cancel(status);
   }
 
+  @Override
+  public final boolean isReady() {
+    return super.isReady();
+  }
+
   @Override public Attributes attributes() {
     return Attributes.EMPTY;
   }
@@ -241,6 +245,7 @@ public abstract class AbstractServerStream extends AbstractStream2
     private void closeListener(Status newStatus) {
       if (!listenerClosed) {
         listenerClosed = true;
+        onStreamDeallocated();
         closeDeframer();
         listener().closed(newStatus);
       }

--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2014, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+
+import io.grpc.InternalMetadata;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+import java.nio.charset.Charset;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base implementation for client streams using HTTP2 as the transport.
+ */
+public abstract class Http2ClientStreamTransportState extends AbstractClientStream2.TransportState {
+
+  /**
+   * Metadata marshaller for HTTP status lines.
+   */
+  private static final InternalMetadata.TrustedAsciiMarshaller<Integer> HTTP_STATUS_MARSHALLER =
+      new InternalMetadata.TrustedAsciiMarshaller<Integer>() {
+        @Override
+        public byte[] toAsciiString(Integer value) {
+          throw new UnsupportedOperationException();
+        }
+
+        /**
+         * RFC 7231 says status codes are 3 digits long.
+         *
+         * @see: <a href="https://tools.ietf.org/html/rfc7231#section-6">RFC 7231</a>
+         */
+        @Override
+        public Integer parseAsciiString(byte[] serialized) {
+          if (serialized.length >= 3) {
+            return (serialized[0] - '0') * 100 + (serialized[1] - '0') * 10 + (serialized[2] - '0');
+          }
+          throw new NumberFormatException(
+              "Malformed status code " + new String(serialized, InternalMetadata.US_ASCII));
+        }
+      };
+
+  private static final Metadata.Key<Integer> HTTP2_STATUS = InternalMetadata.keyOf(":status",
+      HTTP_STATUS_MARSHALLER);
+
+  /** When non-{@code null}, {@link #transportErrorMetadata} must also be non-{@code null}. */
+  private Status transportError;
+  private Metadata transportErrorMetadata;
+  private Charset errorCharset = Charsets.UTF_8;
+  private boolean contentTypeChecked;
+
+  protected Http2ClientStreamTransportState(int maxMessageSize) {
+    super(maxMessageSize);
+  }
+
+  /**
+   * Called to process a failure in HTTP/2 processing. It should notify the transport to cancel the
+   * stream and call {@code transportReportStatus()}.
+   */
+  protected abstract void http2ProcessingFailed(Status status, Metadata trailers);
+
+  /**
+   * Called by subclasses whenever {@code Headers} are received from the transport.
+   *
+   * @param headers the received headers
+   */
+  protected void transportHeadersReceived(Metadata headers) {
+    Preconditions.checkNotNull(headers, "headers");
+    if (transportError != null) {
+      // Already received a transport error so just augment it.
+      transportError = transportError.augmentDescription(headers.toString());
+      return;
+    }
+    Status httpStatus = statusFromHttpStatus(headers);
+    if (httpStatus == null) {
+      transportError = Status.INTERNAL.withDescription(
+          "received non-terminal headers with no :status");
+    } else if (!httpStatus.isOk()) {
+      transportError = httpStatus;
+    } else {
+      transportError = checkContentType(headers);
+    }
+    if (transportError != null) {
+      // Note we don't immediately report the transport error, instead we wait for more data on the
+      // stream so we can accumulate more detail into the error before reporting it.
+      transportError = transportError.augmentDescription("\n" + headers);
+      transportErrorMetadata = headers;
+      errorCharset = extractCharset(headers);
+    } else {
+      stripTransportDetails(headers);
+      inboundHeadersReceived(headers);
+    }
+  }
+
+  /**
+   * Called by subclasses whenever a data frame is received from the transport.
+   *
+   * @param frame the received data frame
+   * @param endOfStream {@code true} if there will be no more data received for this stream
+   */
+  protected void transportDataReceived(ReadableBuffer frame, boolean endOfStream) {
+    if (transportError != null) {
+      // We've already detected a transport error and now we're just accumulating more detail
+      // for it.
+      transportError = transportError.augmentDescription("DATA-----------------------------\n"
+          + ReadableBuffers.readAsString(frame, errorCharset));
+      frame.close();
+      if (transportError.getDescription().length() > 1000 || endOfStream) {
+        http2ProcessingFailed(transportError, transportErrorMetadata);
+      }
+    } else {
+      inboundDataReceived(frame);
+      if (endOfStream) {
+        // This is a protocol violation as we expect to receive trailers.
+        transportError =
+            Status.INTERNAL.withDescription("Received unexpected EOS on DATA frame from server.");
+        transportErrorMetadata = new Metadata();
+        transportReportStatus(transportError, false, transportErrorMetadata);
+      }
+    }
+  }
+
+  /**
+   * Called by subclasses for the terminal trailer metadata on a stream.
+   *
+   * @param trailers the received terminal trailer metadata
+   */
+  protected void transportTrailersReceived(Metadata trailers) {
+    Preconditions.checkNotNull(trailers, "trailers");
+    if (transportError != null) {
+      // Already received a transport error so just augment it.
+      transportError = transportError.augmentDescription(trailers.toString());
+    } else {
+      transportError = checkContentType(trailers);
+      transportErrorMetadata = trailers;
+    }
+    if (transportError != null) {
+      http2ProcessingFailed(transportError, transportErrorMetadata);
+    } else {
+      Status status = statusFromTrailers(trailers);
+      stripTransportDetails(trailers);
+      inboundTrailersReceived(trailers, status);
+    }
+  }
+
+  private static Status statusFromHttpStatus(Metadata metadata) {
+    Integer httpStatus = metadata.get(HTTP2_STATUS);
+    if (httpStatus != null) {
+      Status status = GrpcUtil.httpStatusToGrpcStatus(httpStatus);
+      return status.isOk() ? status
+          : status.augmentDescription("extracted status from HTTP :status " + httpStatus);
+    }
+    return null;
+  }
+
+  /**
+   * Extract the response status from trailers.
+   */
+  private static Status statusFromTrailers(Metadata trailers) {
+    Status status = trailers.get(Status.CODE_KEY);
+    if (status == null) {
+      status = statusFromHttpStatus(trailers);
+      if (status == null || status.isOk()) {
+        status = Status.UNKNOWN.withDescription("missing GRPC status in response");
+      } else {
+        status = status.withDescription(
+            "missing GRPC status, inferred error from HTTP status code");
+      }
+    }
+    String message = trailers.get(Status.MESSAGE_KEY);
+    if (message != null) {
+      status = status.augmentDescription(message);
+    }
+    return status;
+  }
+
+  /**
+   * Inspect the content type field from received headers or trailers and return an error Status if
+   * content type is invalid or not present. Returns null if no error was found.
+   */
+  @Nullable
+  private Status checkContentType(Metadata headers) {
+    if (contentTypeChecked) {
+      return null;
+    }
+    contentTypeChecked = true;
+    String contentType = headers.get(GrpcUtil.CONTENT_TYPE_KEY);
+    if (!GrpcUtil.isGrpcContentType(contentType)) {
+      return Status.INTERNAL.withDescription("Invalid content-type: " + contentType);
+    }
+    return null;
+  }
+
+  /**
+   * Inspect the raw metadata and figure out what charset is being used.
+   */
+  private static Charset extractCharset(Metadata headers) {
+    String contentType = headers.get(GrpcUtil.CONTENT_TYPE_KEY);
+    if (contentType != null) {
+      String[] split = contentType.split("charset=");
+      try {
+        return Charset.forName(split[split.length - 1].trim());
+      } catch (Exception t) {
+        // Ignore and assume UTF-8
+      }
+    }
+    return Charsets.UTF_8;
+  }
+
+  /**
+   * Strip HTTP transport implementation details so they don't leak via metadata into
+   * the application layer.
+   */
+  private static void stripTransportDetails(Metadata metadata) {
+    metadata.discardAll(HTTP2_STATUS);
+    metadata.discardAll(Status.CODE_KEY);
+    metadata.discardAll(Status.MESSAGE_KEY);
+  }
+}

--- a/core/src/test/java/io/grpc/internal/AbstractClientStream2Test.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStream2Test.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.Codec;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.internal.MessageFramerTest.ByteWritableBuffer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Test for {@link AbstractClientStream2}.  This class tries to test functionality in
+ * AbstractClientStream2, but not in any super classes.
+ */
+@RunWith(JUnit4.class)
+public class AbstractClientStream2Test {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Mock private ClientStreamListener mockListener;
+  @Captor private ArgumentCaptor<Status> statusCaptor;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  private final WritableBufferAllocator allocator = new WritableBufferAllocator() {
+    @Override
+    public WritableBuffer allocate(int capacityHint) {
+      return new ByteWritableBuffer(capacityHint);
+    }
+  };
+
+  @Test
+  public void cancel_doNotAcceptOk() {
+    for (Code code : Code.values()) {
+      ClientStreamListener listener = new NoopClientStreamListener();
+      AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+      stream.start(listener);
+      if (code != Code.OK) {
+        stream.cancel(Status.fromCodeValue(code.value()));
+      } else {
+        try {
+          stream.cancel(Status.fromCodeValue(code.value()));
+          fail();
+        } catch (IllegalArgumentException e) {
+          // ignore
+        }
+      }
+    }
+  }
+
+  @Test
+  public void cancel_failsOnNull() {
+    ClientStreamListener listener = new NoopClientStreamListener();
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+    stream.start(listener);
+    thrown.expect(NullPointerException.class);
+
+    stream.cancel(null);
+  }
+
+  @Test
+  public void cancel_notifiesOnlyOnce() {
+    final BaseTransportState state = new BaseTransportState();
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, state, new BaseSink() {
+      @Override
+      public void cancel(Status errorStatus) {
+        // Cancel should eventually result in a transportReportStatus on the transport thread
+        state.transportReportStatus(errorStatus, true/*stop delivery*/, new Metadata());
+      }
+    });
+    stream.start(mockListener);
+
+    stream.cancel(Status.DEADLINE_EXCEEDED);
+    stream.cancel(Status.DEADLINE_EXCEEDED);
+
+    verify(mockListener).closed(any(Status.class), any(Metadata.class));
+  }
+
+  @Test
+  public void startFailsOnNullListener() {
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+
+    thrown.expect(NullPointerException.class);
+
+    stream.start(null);
+  }
+
+  @Test
+  public void cantCallStartTwice() {
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+    stream.start(mockListener);
+    thrown.expect(IllegalStateException.class);
+
+    stream.start(mockListener);
+  }
+
+  @Test
+  public void inboundDataReceived_failsOnNullFrame() {
+    ClientStreamListener listener = new NoopClientStreamListener();
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+    stream.start(listener);
+    thrown.expect(NullPointerException.class);
+
+    stream.transportState().inboundDataReceived(null);
+  }
+
+  @Test
+  public void inboundDataReceived_failsOnNoHeaders() {
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+    stream.start(mockListener);
+
+    stream.transportState().inboundDataReceived(ReadableBuffers.empty());
+
+    verify(mockListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
+  }
+
+  @Test
+  public void inboundHeadersReceived_notifiesListener() {
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+    stream.start(mockListener);
+    Metadata headers = new Metadata();
+
+    stream.transportState().inboundHeadersReceived(headers);
+    verify(mockListener).headersRead(headers);
+  }
+
+  @Test
+  public void inboundHeadersReceived_failsIfStatusReported() {
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+    stream.start(mockListener);
+    stream.transportState().transportReportStatus(Status.CANCELLED, false, new Metadata());
+
+    thrown.expect(IllegalStateException.class);
+    stream.transportState().inboundHeadersReceived(new Metadata());
+  }
+
+  @Test
+  public void inboundHeadersReceived_acceptsGzipEncoding() {
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+    stream.start(mockListener);
+    Metadata headers = new Metadata();
+    headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, new Codec.Gzip().getMessageEncoding());
+
+    stream.transportState().inboundHeadersReceived(headers);
+    verify(mockListener).headersRead(headers);
+  }
+
+  @Test
+  public void inboundHeadersReceived_acceptsIdentityEncoding() {
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+    stream.start(mockListener);
+    Metadata headers = new Metadata();
+    headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, Codec.Identity.NONE.getMessageEncoding());
+
+    stream.transportState().inboundHeadersReceived(headers);
+    verify(mockListener).headersRead(headers);
+  }
+
+  @Test
+  public void rstStreamClosesStream() {
+    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator);
+    stream.start(mockListener);
+    // The application will call request when waiting for a message, which will in turn call this
+    // on the transport thread.
+    stream.transportState().requestMessagesFromDeframer(1);
+    // Send first byte of 2 byte message
+    stream.transportState().deframe(ReadableBuffers.wrap(new byte[] {0, 0, 0, 0, 2, 1}), false);
+    Status status = Status.INTERNAL;
+    // Simulate getting a reset
+    stream.transportState().transportReportStatus(status, false /*stop delivery*/, new Metadata());
+
+    verify(mockListener).closed(any(Status.class), any(Metadata.class));
+  }
+
+  /**
+   * No-op base class for testing.
+   */
+  private static class BaseAbstractClientStream extends AbstractClientStream2 {
+    private final TransportState state;
+    private final Sink sink;
+
+    public BaseAbstractClientStream(WritableBufferAllocator allocator) {
+      this(allocator, new BaseTransportState(), new BaseSink());
+    }
+
+    public BaseAbstractClientStream(WritableBufferAllocator allocator, TransportState state,
+        Sink sink) {
+      super(allocator);
+      this.state = state;
+      this.sink = sink;
+    }
+
+    @Override
+    protected Sink abstractClientStreamSink() {
+      return sink;
+    }
+
+    @Override
+    public TransportState transportState() {
+      return state;
+    }
+
+    @Override
+    public void setAuthority(String authority) {}
+  }
+
+  private static class BaseSink implements AbstractClientStream2.Sink {
+    @Override
+    public void request(int numMessages) {}
+
+    @Override
+    public void writeFrame(WritableBuffer frame, boolean endOfStream, boolean flush) {}
+
+    @Override
+    public void cancel(Status reason) {}
+  }
+
+  private static class BaseTransportState extends AbstractClientStream2.TransportState {
+    public BaseTransportState() {
+      super(DEFAULT_MAX_MESSAGE_SIZE);
+    }
+
+    @Override
+    protected void deframeFailed(Throwable cause) {}
+
+    @Override
+    public void bytesRead(int processedBytes) {}
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
@@ -39,17 +39,17 @@ import io.grpc.Status;
  * Command sent from a Netty client stream to the handler to cancel the stream.
  */
 class CancelClientStreamCommand extends WriteQueue.AbstractQueuedCommand {
-  private final NettyClientStream stream;
+  private final NettyClientStream.TransportState stream;
   private final Status reason;
 
-  CancelClientStreamCommand(NettyClientStream stream, Status reason) {
+  CancelClientStreamCommand(NettyClientStream.TransportState stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream, "stream");
     Preconditions.checkNotNull(reason, "reason");
     Preconditions.checkArgument(!reason.isOk(), "Should not cancel with OK status");
     this.reason = reason;
   }
 
-  NettyClientStream stream() {
+  NettyClientStream.TransportState stream() {
     return stream;
   }
 

--- a/netty/src/main/java/io/grpc/netty/CreateStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CreateStreamCommand.java
@@ -41,15 +41,15 @@ import io.netty.handler.codec.http2.Http2Headers;
  */
 class CreateStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final Http2Headers headers;
-  private final NettyClientStream stream;
+  private final NettyClientStream.TransportState stream;
 
   CreateStreamCommand(Http2Headers headers,
-                      NettyClientStream stream) {
+                      NettyClientStream.TransportState stream) {
     this.stream = Preconditions.checkNotNull(stream, "stream");
     this.headers = Preconditions.checkNotNull(headers, "headers");
   }
 
-  NettyClientStream stream() {
+  NettyClientStream.TransportState stream() {
     return stream;
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -120,13 +120,14 @@ class NettyClientTransport implements ConnectionClientTransport {
       callOptions) {
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
-    return new NettyClientStream(method, headers, channel, handler, maxMessageSize, authority,
-        negotiationHandler.scheme(), userAgent) {
-      @Override
-      protected Status statusFromFailedFuture(ChannelFuture f) {
-        return NettyClientTransport.this.statusFromFailedFuture(f);
-      }
-    };
+    return new NettyClientStream(
+        new NettyClientStream.TransportState(handler, maxMessageSize) {
+          @Override
+          protected Status statusFromFailedFuture(ChannelFuture f) {
+            return NettyClientTransport.this.statusFromFailedFuture(f);
+          }
+        },
+        method, headers, channel, authority, negotiationHandler.scheme(), userAgent);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/RequestMessagesCommand.java
+++ b/netty/src/main/java/io/grpc/netty/RequestMessagesCommand.java
@@ -32,7 +32,6 @@
 package io.grpc.netty;
 
 import io.grpc.internal.AbstractStream2;
-import io.grpc.internal.Stream;
 
 /**
  * Command which requests messages from the deframer.
@@ -40,26 +39,14 @@ import io.grpc.internal.Stream;
 class RequestMessagesCommand extends WriteQueue.AbstractQueuedCommand {
 
   private final int numMessages;
-  private final Stream stream;
   private final AbstractStream2.TransportState state;
-
-  public RequestMessagesCommand(Stream stream, int numMessages) {
-    this.state = null;
-    this.numMessages = numMessages;
-    this.stream = stream;
-  }
 
   public RequestMessagesCommand(AbstractStream2.TransportState state, int numMessages) {
     this.state = state;
     this.numMessages = numMessages;
-    this.stream = null;
   }
 
   void requestMessages() {
-    if (stream != null) {
-      stream.request(numMessages);
-    } else {
-      state.requestMessagesFromDeframer(numMessages);
-    }
+    state.requestMessagesFromDeframer(numMessages);
   }
 }

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -177,8 +177,8 @@ public class NettyClientTransportTest {
     } catch (ExecutionException e) {
       Status status = Status.fromThrowable(e);
       assertEquals(INTERNAL, status.getCode());
-      System.err.println(status.getDescription());
-      assertTrue(status.getDescription().contains("deframing"));
+      assertTrue("Missing exceeds maximum from: " + status.getDescription(),
+          status.getDescription().contains("exceeds maximum"));
     }
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyStreamTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyStreamTestBase.java
@@ -138,7 +138,8 @@ public abstract class NettyStreamTestBase<T extends Stream> {
       ((NettyServerStream) stream).transportState()
           .inboundDataReceived(messageFrame(MESSAGE), false);
     } else {
-      ((NettyClientStream) stream).transportDataReceived(messageFrame(MESSAGE), false);
+      ((NettyClientStream) stream).transportState()
+          .transportDataReceived(messageFrame(MESSAGE), false);
     }
     ArgumentCaptor<InputStream> captor = ArgumentCaptor.forClass(InputStream.class);
     verify(listener()).messageRead(captor.capture());


### PR DESCRIPTION
OkHttp will need to be migrated in a future commit.

This is a continuation of what already was done for server-side (#1656). Although
AbstractClientStream2 looks like new code, it is a reorganization of existing code
(although heavily reworked).