### PR TITLE
jenkins: Fix Windows build to specify Studio version

### DIFF
--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -28,7 +28,7 @@ del protobuf.zip
 pushd protobuf-3.0.0\cmake
 mkdir build
 cd build
-cmake -Dprotobuf_BUILD_TESTS=OFF ..
+cmake -Dprotobuf_BUILD_TESTS=OFF -G "Visual Studio %VisualStudioVersion:~0,2%" ..
 msbuild /maxcpucount /p:Configuration=Release libprotoc.vcxproj
 call extract_includes.bat
 popd


### PR DESCRIPTION
If there are multiple versions available, cmake won't choose the Visual
Studio version selected by vsvars. So we have to explicitly specify the
generator to use.

This allows grpc-java to run on the shared Windows workers instead of
its own specialized instance.