### PR TITLE
all: add parameter name to checkNotNull

### DIFF
--- a/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
+++ b/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
@@ -70,7 +70,7 @@ public final class ClientAuthInterceptor implements ClientInterceptor {
 
   public ClientAuthInterceptor(
       Credentials credentials, @SuppressWarnings("unused") Executor executor) {
-    this.credentials = Preconditions.checkNotNull(credentials);
+    this.credentials = Preconditions.checkNotNull(credentials, "credentials");
     // TODO(louiscryan): refresh token asynchronously with this executor.
   }
 

--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -183,7 +183,7 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1766")
   public CallOptions withAffinity(Attributes affinity) {
     CallOptions newOptions = new CallOptions(this);
-    newOptions.affinity = Preconditions.checkNotNull(affinity);
+    newOptions.affinity = Preconditions.checkNotNull(affinity, "affinity");
     return newOptions;
   }
 
@@ -289,7 +289,7 @@ public final class CallOptions {
      * @return Key object
      */
     public static <T> Key<T> of(String name, T defaultValue) {
-      Preconditions.checkNotNull(name);
+      Preconditions.checkNotNull(name, "name");
       return new Key<T>(name, defaultValue);
     }
   }
@@ -302,8 +302,8 @@ public final class CallOptions {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
   public <T> CallOptions withOption(Key<T> key, T value) {
-    Preconditions.checkNotNull(key);
-    Preconditions.checkNotNull(value);
+    Preconditions.checkNotNull(key, "key");
+    Preconditions.checkNotNull(value, "value");
 
     CallOptions newOptions = new CallOptions(this);
     int existingIdx = -1;
@@ -335,7 +335,7 @@ public final class CallOptions {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
   @SuppressWarnings("unchecked")
   public <T> T getOption(Key<T> key) {
-    Preconditions.checkNotNull(key);
+    Preconditions.checkNotNull(key, "key");
     for (int i = 0; i < customOptions.length; i++) {
       if (key.equals(customOptions[i][0])) {
         return (T) customOptions[i][1];

--- a/core/src/main/java/io/grpc/ClientInterceptors.java
+++ b/core/src/main/java/io/grpc/ClientInterceptors.java
@@ -98,7 +98,7 @@ public class ClientInterceptors {
    * @return a new channel instance with the interceptors applied.
    */
   public static Channel intercept(Channel channel, List<? extends ClientInterceptor> interceptors) {
-    Preconditions.checkNotNull(channel);
+    Preconditions.checkNotNull(channel, "channel");
     for (ClientInterceptor interceptor : interceptors) {
       channel = new InterceptorChannel(channel, interceptor);
     }

--- a/core/src/main/java/io/grpc/Context.java
+++ b/core/src/main/java/io/grpc/Context.java
@@ -349,7 +349,7 @@ public class Context {
    * will still be bound.
    */
   public void detach(Context toAttach) {
-    Preconditions.checkNotNull(toAttach);
+    Preconditions.checkNotNull(toAttach, "toAttach");
     if (toAttach.attach() != this) {
       // Log a severe message instead of throwing an exception as the context to attach is assumed
       // to be the correct one and the unbalanced state represents a coding mistake in a lower
@@ -406,8 +406,8 @@ public class Context {
    */
   public void addListener(final CancellationListener cancellationListener,
                           final Executor executor) {
-    Preconditions.checkNotNull(cancellationListener);
-    Preconditions.checkNotNull(executor);
+    Preconditions.checkNotNull(cancellationListener, "cancellationListener");
+    Preconditions.checkNotNull(executor, "executor");
     if (canBeCancelled) {
       ExecutableListener executableListener =
           new ExecutableListener(executor, cancellationListener);
@@ -778,7 +778,7 @@ public class Context {
     }
 
     Key(String name, T defaultValue) {
-      this.name = Preconditions.checkNotNull(name);
+      this.name = Preconditions.checkNotNull(name, "name");
       this.defaultValue = defaultValue;
     }
 

--- a/core/src/main/java/io/grpc/Deadline.java
+++ b/core/src/main/java/io/grpc/Deadline.java
@@ -60,7 +60,7 @@ public final class Deadline implements Comparable<Deadline> {
 
   @VisibleForTesting
   static Deadline after(long duration, TimeUnit units, Ticker ticker) {
-    Preconditions.checkNotNull(units);
+    Preconditions.checkNotNull(units, "units");
     return new Deadline(ticker, units.toNanos(duration), true);
   }
 

--- a/core/src/main/java/io/grpc/DecompressorRegistry.java
+++ b/core/src/main/java/io/grpc/DecompressorRegistry.java
@@ -160,7 +160,7 @@ public final class DecompressorRegistry {
     final boolean advertised;
 
     DecompressorInfo(Decompressor decompressor, boolean advertised) {
-      this.decompressor = checkNotNull(decompressor);
+      this.decompressor = checkNotNull(decompressor, "decompressor");
       this.advertised = advertised;
     }
   }

--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -320,7 +320,7 @@ public final class Metadata {
    * Perform a simple merge of two sets of metadata.
    */
   public void merge(Metadata other) {
-    Preconditions.checkNotNull(other);
+    Preconditions.checkNotNull(other, "other");
     for (Map.Entry<String, List<MetadataEntry>> keyEntry : other.store.entrySet()) {
       for (int i = 0; i < keyEntry.getValue().size(); i++) {
         // Must copy the MetadataEntries since they are mutated. If the two Metadata objects are
@@ -334,7 +334,7 @@ public final class Metadata {
    * Merge values for the given set of keys into this set of metadata.
    */
   public void merge(Metadata other, Set<Key<?>> keys) {
-    Preconditions.checkNotNull(other);
+    Preconditions.checkNotNull(other, "other");
     for (Key<?> key : keys) {
       List<MetadataEntry> values = other.store.get(key.name());
       if (values == null) {
@@ -480,7 +480,7 @@ public final class Metadata {
     }
 
     private static String validateName(String n) {
-      checkNotNull(n);
+      checkNotNull(n, "name");
       checkArgument(n.length() != 0, "token must have at least 1 tchar");
       for (int i = 0; i < n.length(); i++) {
         char tChar = n.charAt(i);
@@ -496,7 +496,7 @@ public final class Metadata {
     }
 
     private Key(String name) {
-      this.originalName = checkNotNull(name);
+      this.originalName = checkNotNull(name, "name");
       // Intern the result for faster string identity checking.
       this.name = validateName(this.originalName.toLowerCase(Locale.ROOT)).intern();
       this.nameBytes = this.name.getBytes(US_ASCII);
@@ -604,7 +604,7 @@ public final class Metadata {
           !name.endsWith(BINARY_HEADER_SUFFIX),
           "ASCII header is named %s. It must not end with %s",
           name, BINARY_HEADER_SUFFIX);
-      this.marshaller = Preconditions.checkNotNull(marshaller);
+      this.marshaller = Preconditions.checkNotNull(marshaller, "marshaller");
     }
 
     @Override
@@ -630,8 +630,8 @@ public final class Metadata {
      * Constructor used when application layer adds a parsed value.
      */
     private MetadataEntry(Key<?> key, Object parsed) {
-      this.parsed = Preconditions.checkNotNull(parsed);
-      this.key = Preconditions.checkNotNull(key);
+      this.parsed = Preconditions.checkNotNull(parsed, "parsed");
+      this.key = Preconditions.checkNotNull(key, "key");
       this.isBinary = key instanceof BinaryKey;
     }
 
@@ -639,7 +639,7 @@ public final class Metadata {
      * Constructor used when reading a value from the transport.
      */
     private MetadataEntry(boolean isBinary, byte[] serialized) {
-      Preconditions.checkNotNull(serialized);
+      Preconditions.checkNotNull(serialized, "serialized");
       this.serializedBinary = serialized;
       this.isBinary = isBinary;
     }

--- a/core/src/main/java/io/grpc/ServerInterceptors.java
+++ b/core/src/main/java/io/grpc/ServerInterceptors.java
@@ -105,7 +105,7 @@ public class ServerInterceptors {
 
   public static ServerServiceDefinition intercept(BindableService bindableService,
       ServerInterceptor... interceptors) {
-    Preconditions.checkNotNull(bindableService);
+    Preconditions.checkNotNull(bindableService, "bindableService");
     return intercept(bindableService.bindService(), Arrays.asList(interceptors));
   }
 
@@ -120,7 +120,7 @@ public class ServerInterceptors {
    */
   public static ServerServiceDefinition intercept(ServerServiceDefinition serviceDef,
                                                   List<? extends ServerInterceptor> interceptors) {
-    Preconditions.checkNotNull(serviceDef);
+    Preconditions.checkNotNull(serviceDef, "serviceDef");
     if (interceptors.isEmpty()) {
       return serviceDef;
     }
@@ -134,7 +134,7 @@ public class ServerInterceptors {
 
   public static ServerServiceDefinition intercept(BindableService bindableService,
       List<? extends ServerInterceptor> interceptors) {
-    Preconditions.checkNotNull(bindableService);
+    Preconditions.checkNotNull(bindableService, "bindableService");
     return intercept(bindableService.bindService(), interceptors);
   }
 

--- a/core/src/main/java/io/grpc/ServerServiceDefinition.java
+++ b/core/src/main/java/io/grpc/ServerServiceDefinition.java
@@ -59,7 +59,7 @@ public final class ServerServiceDefinition {
 
   private ServerServiceDefinition(
       ServiceDescriptor serviceDescriptor, Map<String, ServerMethodDefinition<?, ?>> methods) {
-    this.serviceDescriptor = checkNotNull(serviceDescriptor);
+    this.serviceDescriptor = checkNotNull(serviceDescriptor, "serviceDescriptor");
     this.methods = ImmutableMap.copyOf(methods);
   }
 

--- a/core/src/main/java/io/grpc/ServiceDescriptor.java
+++ b/core/src/main/java/io/grpc/ServiceDescriptor.java
@@ -51,7 +51,7 @@ public final class ServiceDescriptor {
   }
 
   public ServiceDescriptor(String name, Collection<MethodDescriptor<?, ?>> methods) {
-    this.name = Preconditions.checkNotNull(name);
+    this.name = Preconditions.checkNotNull(name, "name");
     this.methods = Collections.unmodifiableList(new ArrayList<MethodDescriptor<?, ?>>(methods));
   }
 

--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -406,7 +406,7 @@ public final class Status {
    * @return non-{@code null} status
    */
   public static Status fromThrowable(Throwable t) {
-    Throwable cause = checkNotNull(t);
+    Throwable cause = checkNotNull(t, "t");
     while (cause != null) {
       if (cause instanceof StatusException) {
         return ((StatusException) cause).getStatus();
@@ -426,7 +426,7 @@ public final class Status {
    */
   @ExperimentalApi
   public static Metadata trailersFromThrowable(Throwable t) {
-    Throwable cause = checkNotNull(t);
+    Throwable cause = checkNotNull(t, "t");
     while (cause != null) {
       if (cause instanceof StatusException) {
         return ((StatusException) cause).getTrailers();
@@ -455,7 +455,7 @@ public final class Status {
   }
 
   private Status(Code code, @Nullable String description, @Nullable Throwable cause) {
-    this.code = checkNotNull(code);
+    this.code = checkNotNull(code, "code");
     this.description = description;
     this.cause = cause;
   }

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -64,7 +64,7 @@ public class InProcessChannelBuilder extends
 
   private InProcessChannelBuilder(String name) {
     super(new InProcessSocketAddress(name), "localhost");
-    this.name = Preconditions.checkNotNull(name);
+    this.name = Preconditions.checkNotNull(name, "name");
   }
 
   /**

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -233,8 +233,8 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
     private MethodDescriptor<?, ?> method;
 
     private InProcessStream(MethodDescriptor<?, ?> method, Metadata headers) {
-      this.method = checkNotNull(method);
-      this.headers = checkNotNull(headers);
+      this.method = checkNotNull(method, "method");
+      this.headers = checkNotNull(headers, "headers");
 
     }
 

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -112,7 +112,7 @@ public abstract class AbstractManagedChannelImplBuilder
   private long idleTimeoutMillis = ManagedChannelImpl.IDLE_TIMEOUT_MILLIS_DISABLE;
 
   protected AbstractManagedChannelImplBuilder(String target) {
-    this.target = Preconditions.checkNotNull(target);
+    this.target = Preconditions.checkNotNull(target, "target");
     this.directServerAddress = null;
   }
 

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -177,7 +177,7 @@ public abstract class AbstractServerStream extends AbstractStream2
      * thread.
      */
     public final void setListener(ServerStreamListener listener) {
-      this.listener = Preconditions.checkNotNull(listener);
+      this.listener = Preconditions.checkNotNull(listener, "listener");
 
       // Now that the stream has actually been initialized, call the listener's onReady callback if
       // appropriate.

--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -166,7 +166,7 @@ public abstract class AbstractStream<IdT> implements Stream {
 
   @Override
   public void writeMessage(InputStream message) {
-    checkNotNull(message);
+    checkNotNull(message, "message");
     outboundPhase(Phase.MESSAGE);
     if (!framer.isClosed()) {
       framer.writePayload(message);

--- a/core/src/main/java/io/grpc/internal/AbstractStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream2.java
@@ -65,7 +65,7 @@ public abstract class AbstractStream2 implements Stream {
 
   @Override
   public final void writeMessage(InputStream message) {
-    checkNotNull(message);
+    checkNotNull(message, "message");
     if (!framer().isClosed()) {
       framer().writePayload(message);
     }

--- a/core/src/main/java/io/grpc/internal/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStream.java
@@ -82,7 +82,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
    * @param headers the received headers
    */
   protected void transportHeadersReceived(Metadata headers) {
-    Preconditions.checkNotNull(headers);
+    Preconditions.checkNotNull(headers, "headers");
     if (transportError != null) {
       // Already received a transport error so just augment it.
       transportError = transportError.augmentDescription(headers.toString());
@@ -150,7 +150,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
    * @param trailers the received terminal trailer metadata
    */
   protected void transportTrailersReceived(Metadata trailers) {
-    Preconditions.checkNotNull(trailers);
+    Preconditions.checkNotNull(trailers, "trailers");
     if (transportError != null) {
       // Already received a transport error so just augment it.
       transportError = transportError.augmentDescription(trailers.toString());

--- a/core/src/main/java/io/grpc/internal/LogExceptionRunnable.java
+++ b/core/src/main/java/io/grpc/internal/LogExceptionRunnable.java
@@ -49,7 +49,7 @@ public final class LogExceptionRunnable implements Runnable {
   private final Runnable task;
 
   public LogExceptionRunnable(Runnable task) {
-    this.task = checkNotNull(task);
+    this.task = checkNotNull(task, "task");
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -123,7 +123,7 @@ public final class ServerImpl extends io.grpc.Server {
     this.transportServer = Preconditions.checkNotNull(transportServer, "transportServer");
     // Fork from the passed in context so that it does not propagate cancellation, it only
     // inherits values.
-    this.rootContext = Preconditions.checkNotNull(rootContext).fork();
+    this.rootContext = Preconditions.checkNotNull(rootContext, "rootContext").fork();
     this.decompressorRegistry = decompressorRegistry;
     this.compressorRegistry = compressorRegistry;
   }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -364,10 +364,11 @@ public class StressTestClient {
     Worker(ManagedChannel channel, List<TestCaseWeightPair> testCaseWeightPairs,
         int durationSec, String gaugeName) {
       Preconditions.checkArgument(durationSec >= -1, "durationSec must be gte -1.");
-      this.channel = Preconditions.checkNotNull(channel);
-      this.testCaseWeightPairs = Preconditions.checkNotNull(testCaseWeightPairs);
+      this.channel = Preconditions.checkNotNull(channel, "channel");
+      this.testCaseWeightPairs =
+          Preconditions.checkNotNull(testCaseWeightPairs, "testCaseWeightPairs");
       this.durationSec = durationSec == -1 ? null : durationSec;
-      this.gaugeName = Preconditions.checkNotNull(gaugeName);
+      this.gaugeName = Preconditions.checkNotNull(gaugeName, "gaugeName");
     }
 
     @Override
@@ -493,7 +494,7 @@ public class StressTestClient {
       final Iterator<TestCases> testCases;
 
       WeightedTestCaseSelector(List<TestCaseWeightPair> testCaseWeightPairs) {
-        Preconditions.checkNotNull(testCaseWeightPairs);
+        Preconditions.checkNotNull(testCaseWeightPairs, "testCaseWeightPairs");
         Preconditions.checkArgument(testCaseWeightPairs.size() > 0);
 
         List<TestCases> testCases = new ArrayList<TestCases>();
@@ -549,7 +550,7 @@ public class StressTestClient {
 
     TestCaseWeightPair(TestCases testCase, int weight) {
       Preconditions.checkArgument(weight >= 0, "weight must be positive.");
-      this.testCase = Preconditions.checkNotNull(testCase);
+      this.testCase = Preconditions.checkNotNull(testCase, "testCase");
       this.weight = weight;
     }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -71,7 +71,7 @@ public enum TestCases {
    * matching is done case insensitive.
    */
   public static TestCases fromString(String s) {
-    Preconditions.checkNotNull(s);
+    Preconditions.checkNotNull(s, "s");
     return TestCases.valueOf(s.toUpperCase());
   }
 }

--- a/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
@@ -44,7 +44,7 @@ class CancelClientStreamCommand extends WriteQueue.AbstractQueuedCommand {
 
   CancelClientStreamCommand(NettyClientStream stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream, "stream");
-    Preconditions.checkNotNull(reason);
+    Preconditions.checkNotNull(reason, "reason");
     Preconditions.checkArgument(!reason.isOk(), "Should not cancel with OK status");
     this.reason = reason;
   }

--- a/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
@@ -45,8 +45,8 @@ class CancelServerStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final Status reason;
 
   CancelServerStreamCommand(NettyServerStream.TransportState stream, Status reason) {
-    this.stream = Preconditions.checkNotNull(stream);
-    this.reason = Preconditions.checkNotNull(reason);
+    this.stream = Preconditions.checkNotNull(stream, "stream");
+    this.reason = Preconditions.checkNotNull(reason, "reason");
   }
 
   NettyServerStream.TransportState stream() {

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -124,7 +124,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
    * Specify the channel type to use, by default we use {@link NioSocketChannel}.
    */
   public final NettyChannelBuilder channelType(Class<? extends Channel> channelType) {
-    this.channelType = Preconditions.checkNotNull(channelType);
+    this.channelType = Preconditions.checkNotNull(channelType, "channelType");
     return this;
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -104,7 +104,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    * Specify the channel type to use, by default we use {@link NioServerSocketChannel}.
    */
   public NettyServerBuilder channelType(Class<? extends ServerChannel> channelType) {
-    this.channelType = Preconditions.checkNotNull(channelType);
+    this.channelType = Preconditions.checkNotNull(channelType, "channelType");
     return this;
   }
 

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -223,8 +223,8 @@ public final class ProtocolNegotiators {
     private final int port;
 
     TlsNegotiator(SslContext sslContext, String host, int port) {
-      this.sslContext = checkNotNull(sslContext);
-      this.host = checkNotNull(host);
+      this.sslContext = checkNotNull(sslContext, "sslContext");
+      this.host = checkNotNull(host, "host");
       this.port = port;
     }
 

--- a/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
@@ -44,8 +44,8 @@ class SendResponseHeadersCommand extends WriteQueue.AbstractQueuedCommand {
   private final boolean endOfStream;
 
   SendResponseHeadersCommand(StreamIdHolder stream, Http2Headers headers, boolean endOfStream) {
-    this.stream = Preconditions.checkNotNull(stream);
-    this.headers = Preconditions.checkNotNull(headers);
+    this.stream = Preconditions.checkNotNull(stream, "stream");
+    this.headers = Preconditions.checkNotNull(headers, "headers");
     this.endOfStream = endOfStream;
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
@@ -70,8 +70,8 @@ class AsyncFrameWriter implements FrameWriter {
   void becomeConnected(FrameWriter frameWriter, Socket socket) {
     Preconditions.checkState(this.frameWriter == null,
         "AsyncFrameWriter's setFrameWriter() should only be called once.");
-    this.frameWriter = Preconditions.checkNotNull(frameWriter);
-    this.socket = Preconditions.checkNotNull(socket);
+    this.frameWriter = Preconditions.checkNotNull(frameWriter, "frameWriter");
+    this.socket = Preconditions.checkNotNull(socket, "socket");
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -154,7 +154,7 @@ public class OkHttpChannelBuilder extends
    * <p>Default: <code>TLS</code>
    */
   public final OkHttpChannelBuilder negotiationType(NegotiationType type) {
-    negotiationType = Preconditions.checkNotNull(type);
+    negotiationType = Preconditions.checkNotNull(type, "type");
     return this;
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -211,16 +211,16 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     this.maxMessageSize = maxMessageSize;
     defaultAuthority = "notarealauthority:80";
     this.userAgent = GrpcUtil.getGrpcUserAgent("okhttp", userAgent);
-    this.executor = Preconditions.checkNotNull(executor);
+    this.executor = Preconditions.checkNotNull(executor, "executor");
     serializingExecutor = new SerializingExecutor(executor);
-    this.testFrameReader = Preconditions.checkNotNull(frameReader);
-    this.testFrameWriter = Preconditions.checkNotNull(testFrameWriter);
-    this.socket = Preconditions.checkNotNull(socket);
+    this.testFrameReader = Preconditions.checkNotNull(frameReader, "frameReader");
+    this.testFrameWriter = Preconditions.checkNotNull(testFrameWriter, "testFrameWriter");
+    this.socket = Preconditions.checkNotNull(socket, "socket");
     this.nextStreamId = nextStreamId;
     this.ticker = ticker;
     this.connectionSpec = null;
     this.connectingCallback = connectingCallback;
-    this.connectedFuture = Preconditions.checkNotNull(connectedFuture);
+    this.connectedFuture = Preconditions.checkNotNull(connectedFuture, "connectedFuture");
   }
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -61,7 +61,7 @@ class OkHttpProtocolNegotiator {
 
   @VisibleForTesting
   OkHttpProtocolNegotiator(Platform platform) {
-    this.platform = checkNotNull(platform);
+    this.platform = checkNotNull(platform, "platform");
   }
 
   public static OkHttpProtocolNegotiator get() {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
@@ -65,9 +65,9 @@ final class OkHttpTlsUpgrader {
    */
   public static SSLSocket upgrade(SSLSocketFactory sslSocketFactory,
       Socket socket, String host, int port, ConnectionSpec spec) throws IOException {
-    Preconditions.checkNotNull(sslSocketFactory);
-    Preconditions.checkNotNull(socket);
-    Preconditions.checkNotNull(spec);
+    Preconditions.checkNotNull(sslSocketFactory, "sslSocketFactory");
+    Preconditions.checkNotNull(socket, "socket");
+    Preconditions.checkNotNull(spec, "spec");
     SSLSocket sslSocket = (SSLSocket) sslSocketFactory.createSocket(
         socket, host, port, true /* auto close */);
     spec.apply(sslSocket, false);

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -73,8 +73,8 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
    * @param callOptions the runtime call options to be applied to every call on this stub
    */
   protected AbstractStub(Channel channel, CallOptions callOptions) {
-    this.channel = checkNotNull(channel);
-    this.callOptions = checkNotNull(callOptions);
+    this.channel = checkNotNull(channel, "channel");
+    this.callOptions = checkNotNull(callOptions, "callOptions");
   }
 
   /**
@@ -155,7 +155,7 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   public final S withChannel(Channel newChannel) {
     return build(newChannel, callOptions);
   }
-  
+
   /**
    * Sets a custom option to be passed to client interceptors on the channel
    * {@link io.grpc.ClientInterceptor} via the CallOptions parameter.

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -219,7 +219,7 @@ public class ClientCalls {
    * exception will be generated from an {@link Status#UNKNOWN} status.
    */
   private static StatusRuntimeException toStatusRuntimeException(Throwable t) {
-    Throwable cause = checkNotNull(t);
+    Throwable cause = checkNotNull(t, "t");
     while (cause != null) {
       // If we have an embedded status, use it and replace the cause
       if (cause instanceof StatusException) {

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -372,8 +372,8 @@ public class ServerCalls {
    */
   public static void asyncUnimplementedUnaryCall(MethodDescriptor<?, ?> methodDescriptor,
       StreamObserver<?> responseObserver) {
-    checkNotNull(methodDescriptor);
-    checkNotNull(responseObserver);
+    checkNotNull(methodDescriptor, "methodDescriptor");
+    checkNotNull(responseObserver, "responseObserver");
     responseObserver.onError(Status.UNIMPLEMENTED
         .withDescription(String.format("Method %s is unimplemented",
             methodDescriptor.getFullMethodName()))

--- a/stub/src/main/java/io/grpc/stub/StreamObservers.java
+++ b/stub/src/main/java/io/grpc/stub/StreamObservers.java
@@ -56,8 +56,8 @@ public class StreamObservers {
    */
   public static <V> void copyWithFlowControl(final Iterator<V> source,
       final CallStreamObserver<V> target) {
-    Preconditions.checkNotNull(source);
-    Preconditions.checkNotNull(target);
+    Preconditions.checkNotNull(source, "source");
+    Preconditions.checkNotNull(target, "target");
     target.setOnReadyHandler(new Runnable() {
       @Override
       public void run() {
@@ -84,7 +84,7 @@ public class StreamObservers {
    */
   public static <V> void copyWithFlowControl(final Iterable<V> source,
       CallStreamObserver<V> target) {
-    Preconditions.checkNotNull(source);
+    Preconditions.checkNotNull(source, "source");
     copyWithFlowControl(source.iterator(), target);
   }
 }


### PR DESCRIPTION
After debugging #2153, it would have been nice to know what the exact
parameter was that was null.  This change adds a name for each
checkNotNull (and tries to normalized on static imports in order to
shorten lines)