### PR TITLE
auth: Tests should end in Test, not Tests

### DIFF
--- a/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTest.java
+++ b/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTest.java
@@ -76,7 +76,7 @@ import java.util.concurrent.Executor;
  */
 @RunWith(JUnit4.class)
 @Deprecated
-public class ClientAuthInterceptorTests {
+public class ClientAuthInterceptorTest {
 
   private static final Metadata.Key<String> AUTHORIZATION = Metadata.Key.of("Authorization",
       Metadata.ASCII_STRING_MARSHALLER);

--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -85,7 +85,7 @@ import java.util.concurrent.Executor;
  * Tests for {@link GoogleAuthLibraryCallCredentials}.
  */
 @RunWith(JUnit4.class)
-public class GoogleAuthLibraryCallCredentialsTests {
+public class GoogleAuthLibraryCallCredentialsTest {
 
   private static final Metadata.Key<String> AUTHORIZATION = Metadata.Key.of("Authorization",
       Metadata.ASCII_STRING_MARSHALLER);


### PR DESCRIPTION
We use globs internally to find tests, and weren't finding these two
tests. git ls-files confirmed these were the only two files ending in
Tests.