### PR TITLE
Add equals/hashCode to Attributes and ResolvedServerInfo

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -31,6 +31,7 @@
 
 package io.grpc;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import java.util.Collections;
@@ -106,6 +107,42 @@ public final class Attributes {
   @Override
   public String toString() {
     return data.toString();
+  }
+
+  /**
+   * Returns true if the given object is also a {@link Attributes} with an equal attribute values.
+   *
+   * <p>Note that if a stored values are mutable, it is possible for two objects to be considered
+   * equal at one point in time and not equal at another (due to concurrent mutation of attribute
+   * values).
+   *
+   * @param o an object.
+   * @return true if the given object is a {@link Attributes} equal attributes.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Attributes that = (Attributes) o;
+    return Objects.equal(data, that.data);
+  }
+
+  /**
+   * Returns a hash code for the attributes.
+   *
+   * <p>Note that if a stored values are mutable, it is possible for two objects to be considered
+   * equal at one point in time and not equal at another (due to concurrent mutation of attribute
+   * values).
+   *
+   * @return a hash code for the attributes map.
+   */
+  @Override
+  public int hashCode() {
+    return data.hashCode();
   }
 
   public static final class Builder {

--- a/core/src/main/java/io/grpc/ResolvedServerInfo.java
+++ b/core/src/main/java/io/grpc/ResolvedServerInfo.java
@@ -31,6 +31,10 @@
 
 package io.grpc;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Objects;
+
 import java.net.SocketAddress;
 
 import javax.annotation.concurrent.Immutable;
@@ -45,14 +49,23 @@ public final class ResolvedServerInfo {
   private final Attributes attributes;
 
   /**
-   * Constructor.
+   * Constructs a new resolved server without attributes.
    *
-   * @param address the address object
+   * @param address the address of the server
+   */
+  public ResolvedServerInfo(SocketAddress address) {
+    this(address, Attributes.EMPTY);
+  }
+
+  /**
+   * Constructs a new resolved server with attributes.
+   *
+   * @param address the address of the server
    * @param attributes attributes associated with this address.
    */
   public ResolvedServerInfo(SocketAddress address, Attributes attributes) {
-    this.address = address;
-    this.attributes = attributes;
+    this.address = checkNotNull(address);
+    this.attributes = checkNotNull(attributes);
   }
 
   /**
@@ -72,5 +85,43 @@ public final class ResolvedServerInfo {
   @Override
   public String toString() {
     return "[address=" + address + ", attrs=" + attributes + "]";
+  }
+
+  /**
+   * Returns true if the given object is also a {@link ResolvedServerInfo} with an equal address
+   * and equal attribute values.
+   *
+   * <p>Note that if a resolver includes mutable values in the attributes, it is possible for two
+   * objects to be considered equal at one point in time and not equal at another (due to concurrent
+   * mutation of attribute values).
+   *
+   * @param o an object.
+   * @return true if the given object is a {@link ResolvedServerInfo} with an equal address and
+   *     equal attributes.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ResolvedServerInfo that = (ResolvedServerInfo) o;
+    return Objects.equal(address, that.address) && Objects.equal(attributes, that.attributes);
+  }
+
+  /**
+   * Returns a hash code for the server info.
+   *
+   * <p>Note that if a resolver includes mutable values in the attributes, this object's hash code
+   * could change over time. So care must be used when putting these objects into a set or using
+   * them as keys for a map.
+   *
+   * @return a hash code for the server info, computed as described above.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(address, attributes);
   }
 }


### PR DESCRIPTION
Both `Attributes` are `ResolvedServerInfo` immutable value objects, it'd be reasonable to provide custom impls of `equals/hashCode`.

I've just used a standard guava template to generate those.