### PR TITLE
Simplify commands in Android README

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -11,19 +11,16 @@ PREREQUISITES
 
 INSTALL
 -------
-**1. Clone the gRPC Java git repo**
-```sh
-$ git clone https://github.com/grpc/grpc-java
-$ cd grpc-java
-```
 
-**2. Install gRPC Java (not necessary for released versions)**
+1. (Only for non-released versions) Install gRPC Java
 ```sh
+$ cd ../..
 $ ./gradlew install -PskipCodegen=true
+$ cd examples/android
 ```
 
-**3. Install the app**
+2. Install the app
 ```sh
-$ cd examples/android/helloworld  (or cd examples/android/routeguide)
+$ cd helloworld  # or "cd routeguide"
 $ ./gradlew installDebug
 ```


### PR DESCRIPTION
Comments should really use '#', since it is shell. Also, we avoid
telling users to clone the git repo since 1) this is basically implicit
already and 2) it encourages them to checkout master instead of using
the latest release. This is especially helpful when the document is
referenced from http://grpc.io/docs since they specify checking out the
latest release (which is much easier to maintain when using jekyll which
is not an option here).