### PR TITLE
Change NameResolver#onUpdate API

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -66,17 +66,17 @@ public abstract class LoadBalancer<T> {
   public void shutdown() { }
 
   /**
-   * Handles newly resolved addresses and service config from name resolution system.  Sublists
-   * should be considered equivalent with an {@link EquivalentAddressGroup}, but may be flattened
-   * into a single list if needed.
+   * Handles newly resolved server groups and metadata attributes from name resolution system.
+   * {@code servers} contained in {@link ResolvedServerInfoGroup} should be considered equivalent
+   * but may be flattened into a single list if needed.
    *
    * <p>Implementations should not modify the given {@code servers}.
    *
    * @param servers the resolved server addresses, never empty.
-   * @param config extra configuration data from naming system.
+   * @param attributes extra metadata from naming system.
    */
-  public void handleResolvedAddresses(List<? extends List<ResolvedServerInfo>> servers,
-                                      Attributes config) { }
+  public void handleResolvedAddresses(List<ResolvedServerInfoGroup> servers,
+      Attributes attributes) { }
 
   /**
    * Handles an error from the name resolution system.

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -122,12 +122,11 @@ public abstract class NameResolver {
      *
      * <p>Implementations will not modify the given {@code servers}.
      *
-     * @param servers the resolved server addresses.  Sublists should be considered to be
-     *                an {@link EquivalentAddressGroup}. An empty list or all sublists being empty
-     *                will trigger {@link #onError}
-     * @param config extra configuration data from naming system
+     * @param servers the resolved server groups, containing {@link ResolvedServerInfo} objects. An
+     *                empty list will trigger {@link #onError}
+     * @param attributes extra metadata from naming system
      */
-    void onUpdate(List<? extends List<ResolvedServerInfo>> servers, Attributes config);
+    void onUpdate(List<ResolvedServerInfoGroup> servers, Attributes attributes);
 
     /**
      * Handles an error from the resolver.

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -118,7 +118,7 @@ public abstract class NameResolver {
   @ThreadSafe
   public interface Listener {
     /**
-     * Handles updates on resolved addresses and config.
+     * Handles updates on resolved addresses and attributes.
      *
      * <p>Implementations will not modify the given {@code servers}.
      *

--- a/core/src/main/java/io/grpc/ResolvedServerInfoGroup.java
+++ b/core/src/main/java/io/grpc/ResolvedServerInfoGroup.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A group of {@link ResolvedServerInfo}s that is returned from a {@link NameResolver}.
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
+@Immutable
+public final class ResolvedServerInfoGroup {
+  private final List<ResolvedServerInfo> resolvedServerInfoList;
+  private final Attributes attributes;
+
+  /**
+   * Constructs a new resolved server info group from {@link ResolvedServerInfo} list,
+   * with custom {@link Attributes} attached to it.
+   *
+   * @param resolvedServerInfoList list of resolved server info objects.
+   * @param attributes custom attributes for a given group.
+   */
+  private ResolvedServerInfoGroup(List<ResolvedServerInfo> resolvedServerInfoList,
+      Attributes attributes) {
+    checkArgument(!resolvedServerInfoList.isEmpty(), "empty server list");
+    this.resolvedServerInfoList = Collections.unmodifiableList(resolvedServerInfoList);
+    this.attributes = checkNotNull(attributes, "attributes");
+  }
+
+  /**
+   * Returns immutable list of {@link ResolvedServerInfo} objects for this group.
+   */
+  public List<ResolvedServerInfo> getResolvedServerInfoList() {
+    return resolvedServerInfoList;
+  }
+
+  /**
+   * Returns {@link Attributes} for this group.
+   */
+  public Attributes getAttributes() {
+    return attributes;
+  }
+
+  /**
+   * Converts this group to {@link EquivalentAddressGroup} object.
+   */
+  public EquivalentAddressGroup toEquivalentAddressGroup() {
+    List<SocketAddress> addrs = new ArrayList<SocketAddress>(resolvedServerInfoList.size());
+    for (ResolvedServerInfo resolvedServerInfo : resolvedServerInfoList) {
+      addrs.add(resolvedServerInfo.getAddress());
+    }
+    return new EquivalentAddressGroup(addrs);
+  }
+
+  /**
+   * Creates a new builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Creates a new builder for a group with extra attributes.
+   */
+  public static Builder builder(Attributes attributes) {
+    return new Builder(attributes);
+  }
+
+  /**
+   * Returns true if the given object is also a {@link ResolvedServerInfoGroup} with an equal
+   * attributes and list of {@link ResolvedServerInfo} objects.
+   *
+   * @param o an object.
+   * @return true if the given object is a {@link ResolvedServerInfoGroup} with an equal attributes
+   *     and server info list.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ResolvedServerInfoGroup that = (ResolvedServerInfoGroup) o;
+    return Objects.equal(resolvedServerInfoList, that.resolvedServerInfoList)
+        && Objects.equal(attributes, that.attributes);
+  }
+
+  /**
+   * Returns a hash code for the resolved server info group.
+   *
+   * <p>Note that if a resolver includes mutable values in the attributes, this object's hash code
+   * could change over time. So care must be used when putting these objects into a set or using
+   * them as keys for a map.
+   *
+   * @return a hash code for the server info group.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(resolvedServerInfoList, attributes);
+  }
+
+  @Override
+  public String toString() {
+    return "[servers=" + resolvedServerInfoList + ", attrs=" + attributes + "]";
+  }
+
+  public static class Builder {
+    private final ImmutableList.Builder<ResolvedServerInfo> groupBuilder;
+    private final Attributes attributes;
+
+    public Builder(Attributes attributes) {
+      this.groupBuilder = ImmutableList.builder();
+      this.attributes = attributes;
+    }
+
+    public Builder() {
+      this(Attributes.EMPTY);
+    }
+
+    public Builder add(ResolvedServerInfo resolvedServerInfo) {
+      groupBuilder.add(resolvedServerInfo);
+      return this;
+    }
+
+    public Builder addAll(Collection<ResolvedServerInfo> resolvedServerInfo) {
+      groupBuilder.addAll(resolvedServerInfo);
+      return this;
+    }
+
+    public ResolvedServerInfoGroup build() {
+      return new ResolvedServerInfoGroup(groupBuilder.build(), attributes);
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -48,6 +48,7 @@ import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
 import io.grpc.PickFirstBalancerFactory;
 import io.grpc.ResolvedServerInfo;
+import io.grpc.ResolvedServerInfoGroup;
 
 import java.net.SocketAddress;
 import java.net.URI;
@@ -320,9 +321,8 @@ public abstract class AbstractManagedChannelImplBuilder
 
         @Override
         public void start(final Listener listener) {
-          listener.onUpdate(
-              Collections.singletonList(
-                  Collections.singletonList(new ResolvedServerInfo(address, Attributes.EMPTY))),
+          listener.onUpdate(Collections.singletonList(
+              ResolvedServerInfoGroup.builder().add(new ResolvedServerInfo(address)).build()),
               Attributes.EMPTY);
         }
 

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -37,6 +37,7 @@ import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
 import io.grpc.NameResolver;
 import io.grpc.ResolvedServerInfo;
+import io.grpc.ResolvedServerInfoGroup;
 import io.grpc.Status;
 import io.grpc.internal.SharedResourceHolder.Resource;
 
@@ -44,9 +45,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -160,15 +159,13 @@ class DnsNameResolver extends NameResolver {
             savedListener.onError(Status.UNAVAILABLE.withCause(e));
             return;
           }
-          List<ResolvedServerInfo> servers =
-              new ArrayList<ResolvedServerInfo>(inetAddrs.length);
+          ResolvedServerInfoGroup.Builder servers = ResolvedServerInfoGroup.builder();
           for (int i = 0; i < inetAddrs.length; i++) {
             InetAddress inetAddr = inetAddrs[i];
             servers.add(
                 new ResolvedServerInfo(new InetSocketAddress(inetAddr, port), Attributes.EMPTY));
           }
-          savedListener.onUpdate(
-              Collections.singletonList(servers), Attributes.EMPTY);
+          savedListener.onUpdate(Collections.singletonList(servers.build()), Attributes.EMPTY);
         } finally {
           synchronized (DnsNameResolver.this) {
             resolving = false;

--- a/core/src/main/java/io/grpc/internal/RoundRobinServerList.java
+++ b/core/src/main/java/io/grpc/internal/RoundRobinServerList.java
@@ -40,6 +40,7 @@ import io.grpc.Status;
 import io.grpc.TransportManager;
 
 import java.net.SocketAddress;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -105,17 +106,29 @@ public class RoundRobinServerList<T> {
     /**
      * Adds a server to the list, or {@code null} for a drop entry.
      */
-    public void add(@Nullable SocketAddress address) {
+    public Builder<T> addSocketAddress(@Nullable SocketAddress address) {
       listBuilder.add(new EquivalentAddressGroup(address));
+      return this;
     }
 
     /**
-     * Adds a list of servers to the list grouped into a single {@link EquivalentAddressGroup}.
+     * Adds a address group to the list.
      *
      * @param addresses the addresses to add
      */
-    public void addList(List<SocketAddress> addresses) {
-      listBuilder.add(new EquivalentAddressGroup(addresses));
+    public Builder<T> add(EquivalentAddressGroup addresses) {
+      listBuilder.add(addresses);
+      return this;
+    }
+
+    /**
+     * Adds a list of address groups.
+     *
+     * @param addresses the list of addresses group.
+     */
+    public Builder<T> addAll(Collection<EquivalentAddressGroup> addresses) {
+      listBuilder.addAll(addresses);
+      return this;
     }
 
     public RoundRobinServerList<T> build() {

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -44,7 +44,7 @@ import com.google.common.collect.Iterables;
 
 import io.grpc.Attributes;
 import io.grpc.NameResolver;
-import io.grpc.ResolvedServerInfo;
+import io.grpc.ResolvedServerInfoGroup;
 import io.grpc.Status;
 import io.grpc.internal.SharedResourceHolder.Resource;
 
@@ -107,7 +107,7 @@ public class DnsNameResolverTest {
   @Mock
   private NameResolver.Listener mockListener;
   @Captor
-  private ArgumentCaptor<List<List<ResolvedServerInfo>>> resultCaptor;
+  private ArgumentCaptor<List<ResolvedServerInfoGroup>> resultCaptor;
   @Captor
   private ArgumentCaptor<Status> statusCaptor;
 
@@ -290,10 +290,11 @@ public class DnsNameResolverTest {
   }
 
   private static void assertAnswerMatches(InetAddress[] addrs, int port,
-      List<ResolvedServerInfo> result) {
-    assertEquals(addrs.length, result.size());
+      ResolvedServerInfoGroup result) {
+    assertEquals(addrs.length, result.getResolvedServerInfoList().size());
     for (int i = 0; i < addrs.length; i++) {
-      InetSocketAddress socketAddr = (InetSocketAddress) result.get(i).getAddress();
+      InetSocketAddress socketAddr = (InetSocketAddress) result.getResolvedServerInfoList().get(
+          i).getAddress();
       assertEquals("Addr " + i, port, socketAddr.getPort());
       assertEquals("Addr " + i, addrs[i], socketAddr.getAddress());
     }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -51,6 +51,7 @@ import com.google.protobuf.ByteString;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ResolvedServerInfo;
+import io.grpc.ResolvedServerInfoGroup;
 import io.grpc.Status;
 import io.grpc.TransportManager.InterimTransport;
 import io.grpc.TransportManager;
@@ -431,7 +432,8 @@ public class GrpclbLoadBalancerTest {
     Transport lbTransport = new Transport();
     when(mockTransportManager.getTransport(eq(lbAddressGroup))).thenReturn(lbTransport);
     loadBalancer.handleResolvedAddresses(
-        Collections.singletonList(Collections.singletonList(lbServerInfo)), Attributes.EMPTY);
+        Collections.singletonList(ResolvedServerInfoGroup.builder().add(lbServerInfo).build()),
+        Attributes.EMPTY);
     verify(mockTransportManager).getTransport(eq(lbAddressGroup));
     return lbTransport;
   }


### PR DESCRIPTION
This is a proof of concept of API change in `NameResolver#onUpdate` method: 

```diff
-    void onUpdate(List<? extends List<ResolvedServerInfo>> servers, Attributes config);
+    void onUpdate(List<ResolvedServerInfoGroup> servers, Attributes config);
```

This will let users conveniently pass arbitrary `Attributes` on every level without providing custom list implementation for storing metadata for groups.

/cc @ejona86 @zhangkun83 @jhump 



