### PR TITLE
Rename Dummy to PickFirst load balancer

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -158,7 +158,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   /**
    * Provides a custom {@link LoadBalancer.Factory} for the channel.
    *
-   * <p>If this method is not called, the builder will use {@link DummyLoadBalancerFactory}
+   * <p>If this method is not called, the builder will use {@link PickFirstBalancerFactory}
    * for the channel.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory.java
@@ -47,25 +47,25 @@ import javax.annotation.concurrent.GuardedBy;
  * (currently pick-first) is used for all addresses found.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
-public final class DummyLoadBalancerFactory extends LoadBalancer.Factory {
+public final class PickFirstBalancerFactory extends LoadBalancer.Factory {
 
-  private static final DummyLoadBalancerFactory instance = new DummyLoadBalancerFactory();
+  private static final PickFirstBalancerFactory instance = new PickFirstBalancerFactory();
 
-  private DummyLoadBalancerFactory() {
+  private PickFirstBalancerFactory() {
   }
 
-  public static DummyLoadBalancerFactory getInstance() {
+  public static PickFirstBalancerFactory getInstance() {
     return instance;
   }
 
   @Override
   public <T> LoadBalancer<T> newLoadBalancer(String serviceName, TransportManager<T> tm) {
-    return new DummyLoadBalancer<T>(tm);
+    return new PickFirstBalancer<T>(tm);
   }
 
-  private static class DummyLoadBalancer<T> extends LoadBalancer<T> {
+  private static class PickFirstBalancer<T> extends LoadBalancer<T> {
     private static final Status SHUTDOWN_STATUS =
-        Status.UNAVAILABLE.augmentDescription("DummyLoadBalancer has shut down");
+        Status.UNAVAILABLE.augmentDescription("PickFirstBalancer has shut down");
 
     private final Object lock = new Object();
 
@@ -80,7 +80,7 @@ public final class DummyLoadBalancerFactory extends LoadBalancer.Factory {
 
     private final TransportManager<T> tm;
 
-    private DummyLoadBalancer(TransportManager<T> tm) {
+    private PickFirstBalancer(TransportManager<T> tm) {
       this.tm = tm;
     }
 

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -42,11 +42,11 @@ import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
-import io.grpc.DummyLoadBalancerFactory;
 import io.grpc.LoadBalancer;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
+import io.grpc.PickFirstBalancerFactory;
 import io.grpc.ResolvedServerInfo;
 
 import java.net.SocketAddress;
@@ -254,7 +254,7 @@ public abstract class AbstractManagedChannelImplBuilder
         new ExponentialBackoffPolicy.Provider(),
         nameResolverFactory,
         getNameResolverParams(),
-        firstNonNull(loadBalancerFactory, DummyLoadBalancerFactory.getInstance()),
+        firstNonNull(loadBalancerFactory, PickFirstBalancerFactory.getInstance()),
         transportFactory,
         firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
         firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()),

--- a/core/src/test/java/io/grpc/PickFirstBalancerTest.java
+++ b/core/src/test/java/io/grpc/PickFirstBalancerTest.java
@@ -57,9 +57,9 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Unit test for {@link DummyLoadBalancerFactory}. */
+/** Unit test for {@link PickFirstBalancerFactory}. */
 @RunWith(JUnit4.class)
-public class DummyLoadBalancerTest {
+public class PickFirstBalancerTest {
   private LoadBalancer<Transport> loadBalancer;
 
   private List<List<ResolvedServerInfo>> servers;
@@ -74,7 +74,7 @@ public class DummyLoadBalancerTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    loadBalancer = DummyLoadBalancerFactory.getInstance().newLoadBalancer(
+    loadBalancer = PickFirstBalancerFactory.getInstance().newLoadBalancer(
         "fakeservice", mockTransportManager);
     servers = new ArrayList<List<ResolvedServerInfo>>();
     servers.add(new ArrayList<ResolvedServerInfo>());

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -64,12 +64,12 @@ import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
 import io.grpc.DecompressorRegistry;
-import io.grpc.DummyLoadBalancerFactory;
 import io.grpc.IntegerMarshaller;
 import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.NameResolver;
+import io.grpc.PickFirstBalancerFactory;
 import io.grpc.ResolvedServerInfo;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
@@ -124,7 +124,7 @@ public class ManagedChannelImplTest {
   private final FakeClock timer = new FakeClock();
   private final FakeClock executor = new FakeClock();
   private SpyingLoadBalancerFactory loadBalancerFactory =
-      new SpyingLoadBalancerFactory(DummyLoadBalancerFactory.getInstance());
+      new SpyingLoadBalancerFactory(PickFirstBalancerFactory.getInstance());
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -43,9 +43,9 @@ import static org.mockito.Mockito.when;
 import com.google.common.base.Supplier;
 
 import io.grpc.Attributes;
-import io.grpc.DummyLoadBalancerFactory;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
+
 import io.grpc.ResolvedServerInfo;
 import io.grpc.Status;
 import io.grpc.TransportManager;
@@ -66,7 +66,7 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Unit test for {@link DummyLoadBalancerFactory}. */
+/** Unit test for {@link RoundRobinLoadBalancerFactory}. */
 @RunWith(JUnit4.class)
 public class RoundRobinLoadBalancerTest {
   private LoadBalancer<Transport> loadBalancer;


### PR DESCRIPTION
Renames `DummyLoadBalancer` to `PickFirstLoadBalancer` to better reflect what it actually does.