### PR TITLE
core: Add lockless SingleProducerSerializingExecutor

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
+    id "me.champeau.gradle.jmh" version "0.3.0"
 }
 
 description = 'gRPC: Core'
@@ -13,6 +14,13 @@ dependencies {
 // Configure the animal sniffer plugin
 animalsniffer {
     signature = "org.codehaus.mojo.signature:java16:+@signature"
+}
+
+jmh {
+    jmhVersion = '1.13'
+    warmupIterations = 10
+    iterations = 10
+    fork = 3
 }
 
 javadoc.exclude 'io/grpc/internal/**'

--- a/core/src/jmh/java/io/grpc/internal/SerializingExecutorBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/SerializingExecutorBenchmark.java
@@ -49,8 +49,13 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * SerializingExecutor benchmark.
+ *
+ * <p>Since this is a microbenchmark, don't actually believe the numbers in a strict sense. Instead,
+ * it is a gauge that the code is behaving roughly as expected, to increase confidence that our
+ * understanding of the code is correct (and will behave as expected in other cases). Even more
+ * helpfully it pushes the implementation, which should weed out many multithreading bugs.
  */
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class SerializingExecutorBenchmark {
 
   @Param({"CLASSIC", "SINGLE_PRODUCER"})

--- a/core/src/jmh/java/io/grpc/internal/SerializingExecutorBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/SerializingExecutorBenchmark.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * SerializingExecutor benchmark.
+ */
+@State(Scope.Benchmark)
+public class SerializingExecutorBenchmark {
+
+  @Param({"CLASSIC", "SINGLE_PRODUCER"})
+  public Type type;
+
+  public enum Type {
+    CLASSIC, SINGLE_PRODUCER
+  }
+
+  private ExecutorService executorService;
+  private Executor executor;
+
+  private static class IncrRunnable implements Runnable {
+    int val;
+
+    @Override
+    public void run() {
+      val++;
+    }
+  }
+
+  private final IncrRunnable incrRunnable = new IncrRunnable();
+
+  private final Phaser phaser = new Phaser(2);
+  private final Runnable phaserRunnable = new Runnable() {
+    @Override
+    public void run() {
+      phaser.arrive();
+    }
+  };
+
+  @Setup
+  public void setUp() {
+    executorService = Executors.newSingleThreadExecutor();
+    switch (type) {
+      case CLASSIC:
+        executor = new SerializingExecutor(executorService);
+        break;
+      case SINGLE_PRODUCER:
+        executor = new SingleProducerSerializingExecutor(executorService);
+        break;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  @TearDown
+  public void tearDown() throws Exception {
+    executorService.shutdownNow();
+    if (!executorService.awaitTermination(1, TimeUnit.SECONDS)) {
+      throw new RuntimeException("executor failed to shut down in a timely fashion");
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void oneRunnableLatency() throws Exception {
+    executor.execute(phaserRunnable);
+    phaser.arriveAndAwaitAdvance();
+  }
+
+  /**
+   * Queue many runnables, to better see queuing/consumption cost instead of just context switch.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void manyRunnables() throws Exception {
+    incrRunnable.val = 0;
+    for (int i = 0; i < 500; i++) {
+      executor.execute(incrRunnable);
+    }
+    executor.execute(phaserRunnable);
+    phaser.arriveAndAwaitAdvance();
+    if (incrRunnable.val != 500) {
+      throw new AssertionError();
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -102,7 +102,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
     // See https://github.com/grpc/grpc-java/issues/368
     this.callExecutor = executor == directExecutor()
         ? new SerializeReentrantCallsDirectExecutor()
-        : new SerializingExecutor(executor);
+        : new SingleProducerSerializingExecutor(executor);
     // Propagate the context from the thread which initiated the call to all callbacks.
     this.context = Context.current();
     this.unaryRequest = method.getType() == MethodType.UNARY

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -335,7 +335,7 @@ public final class ServerImpl extends io.grpc.Server {
       if (executor == directExecutor()) {
         wrappedExecutor = new SerializeReentrantCallsDirectExecutor();
       } else {
-        wrappedExecutor = new SerializingExecutor(executor);
+        wrappedExecutor = new SingleProducerSerializingExecutor(executor);
       }
 
       final JumpToApplicationThreadServerStreamListener jumpListener

--- a/core/src/main/java/io/grpc/internal/SingleProducerSerializingExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SingleProducerSerializingExecutor.java
@@ -52,7 +52,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public final class SingleProducerSerializingExecutor implements Executor {
   private static final Logger log =
-      Logger.getLogger(SerializingExecutor.class.getName());
+      Logger.getLogger(SingleProducerSerializingExecutor.class.getName());
   private static final
       AtomicReferenceFieldUpdater<SingleProducerSerializingExecutor, LinkedRunnable> tailUpdater =
       AtomicReferenceFieldUpdater.newUpdater(

--- a/core/src/main/java/io/grpc/internal/SingleProducerSerializingExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SingleProducerSerializingExecutor.java
@@ -108,9 +108,9 @@ public final class SingleProducerSerializingExecutor implements Executor {
         // when it discovers tail has changed.
         cachedTail.next = new LinkedRunnable(r);
         if (!tailCompareAndSet(cachedTail, cachedTail.next)) {
-          // 'next' is guaranteed not to be read, since tail hasn't been updated. Clearing the field
-          // has little practice use, other than calling attention to the fact that the field is not
-          // read.
+          // 'next' is guaranteed not to be read, since tail hasn't been updated and TaskRunner does
+          // not go past the current tail. Clearing the field has little practice use, other than
+          // calling attention to the fact that the field is not read.
           cachedTail.next = null;
           // Try again. The only explanation for this failure is TaskRunner exited (or someone is
           // misusing the class via multiple producers).

--- a/core/src/main/java/io/grpc/internal/SingleProducerSerializingExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SingleProducerSerializingExecutor.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Executor ensuring that all {@link Runnable} tasks submitted are executed in order
+ * using the provided {@link Executor}, and serially such that no two will ever be
+ * running at the same time.
+ *
+ * <p>This executor is not thread-safe. It handles synchronization with running tasks, but {@link
+ * #execute} may not be called concurrently by multiple threads.
+ */
+@NotThreadSafe
+public final class SingleProducerSerializingExecutor implements Executor {
+  private static final Logger log =
+      Logger.getLogger(SerializingExecutor.class.getName());
+  private static final
+      AtomicReferenceFieldUpdater<SingleProducerSerializingExecutor, LinkedRunnable> tailUpdater =
+      AtomicReferenceFieldUpdater.newUpdater(
+          SingleProducerSerializingExecutor.class, LinkedRunnable.class, "tail");
+
+  /** Underlying executor that all submitted Runnable objects are run on. */
+  private final Executor executor;
+  /**
+   * If {@code null}, TaskRunner is not scheduled or running. This is the actual tail of the queue,
+   * independent of whether {@link LinkedRunnable#next} is non-{@code null}.
+   *
+   * <p>Although it might seem like we could use a single-producer, single-consumer queue, it's a
+   * bit more complex than that because we also have to manage starting and restarting the consumer.
+   * So we still require the producer and consumer to write to a single shared location.
+   */
+  private volatile LinkedRunnable tail;
+  /** The object that actually runs the Runnables submitted, reused. */
+  private final TaskRunner taskRunner = new TaskRunner();
+
+  /**
+   * Creates a SerializingExecutor, running tasks using {@code executor}.
+   *
+   * @param executor Executor in which tasks should be run. Must not be null.
+   */
+  public SingleProducerSerializingExecutor(Executor executor) {
+    this.executor = Preconditions.checkNotNull(executor, "executor");
+  }
+
+  private boolean tailCompareAndSet(LinkedRunnable expect, LinkedRunnable update) {
+    return tailUpdater.compareAndSet(this, expect, update);
+  }
+
+  /**
+   * Runs the given runnable strictly after all Runnables that were submitted before it, and using
+   * the {@code executor} passed to the constructor.
+   */
+  @Override
+  public void execute(Runnable r) {
+    Preconditions.checkNotNull(r, "runnable");
+    while (true) {
+      LinkedRunnable cachedTail = tail;
+      if (cachedTail == null) { // TaskRunnable not running.
+        cachedTail = new LinkedRunnable(r);
+        if (!tailCompareAndSet(null, cachedTail)) {
+          // Impossible, since TaskRunnable isn't running and we assume single producer.
+          throw new AssertionError();
+        }
+        taskRunner.schedule(cachedTail);
+        return;
+      } else {
+        // Must set 'next' before changing 'tail', so that the volatile 'write' to tail publishes
+        // the write to 'next'. It also makes the LinkedRunnable available to TaskRunner immediately
+        // when it discovers tail has changed.
+        cachedTail.next = new LinkedRunnable(r);
+        if (!tailCompareAndSet(cachedTail, cachedTail.next)) {
+          // 'next' is guaranteed not to be read, since tail hasn't been updated. Clearing the field
+          // has little practice use, other than calling attention to the fact that the field is not
+          // read.
+          cachedTail.next = null;
+          // Try again. The only explanation for this failure is TaskRunner exited (or someone is
+          // misusing the class via multiple producers).
+          if (tail != null) {
+            throw new AssertionError();
+          }
+          continue;
+        }
+        return;
+      }
+    }
+  }
+
+  private static class LinkedRunnable implements Runnable {
+    private final Runnable runnable;
+    /**
+     * The next runnable in the queue. This value is only changed from null to non-null by
+     * execute(), and from non-null to null by TaskRunner.
+     *
+     * <p>It does not need to be volatile because:
+     * <ol>
+     *   <li>{@code TaskRunner} never advances in the queue past 'tail'. Thus, this object is
+     *   essentially published safely via the volatile 'tail'.
+     *
+     *   <li>Since this is a LinkedRunnable, the final {@link #runnable} field is safe to use from
+     *   {@link #run()}. Final fields and the objects they reference are guaranteed to be properly
+     *   published even without synchronization, if a reference to the containing object is
+     *   observed. See JLS§17.5.
+     * </ol>
+     */
+    LinkedRunnable next;
+
+    public LinkedRunnable(Runnable runnable) {
+      this.runnable = runnable;
+    }
+
+    public void run() {
+      runnable.run();
+    }
+  }
+
+  /**
+   * Task that actually runs the Runnables. The head of the queue must be set before execution. This
+   * is the only reference to the head of the queue, such that it is the only code that can iterate
+   * over the full queue. It executes entries in the queue until it is empty, sets tail=null, and
+   * then returns. This allows the current worker thread to return to the original pool.
+   */
+  private class TaskRunner implements Runnable {
+    private LinkedRunnable head;
+
+    void schedule(LinkedRunnable newHead) {
+      if (head != null) {
+        throw new AssertionError();
+      }
+      head = newHead;
+      try {
+        executor.execute(this);
+      } catch (Throwable t) {
+        // It is possible that 'newHead' is still queued and tail==newHead. But that will trick
+        // execute() into thinking TaskRunner is running (we assume it isn't) which would prevent
+        // all future Runnables from being run. So we clear all state and propagate the exception so
+        // that if our caller deems it recoverable we won't be permanently stuck.
+        tail = null;
+        head = null; // Prevent retaining garbage
+        Throwables.propagateIfPossible(t);
+        throw new AssertionError(t);
+      }
+    }
+
+    @Override
+    public void run() {
+      LinkedRunnable head = this.head;
+      this.head = null; // Prevent retaining garbage after the method returns
+
+      LinkedRunnable cachedTail = tail;
+      while (true) {
+        try {
+          head.run();
+        } catch (Throwable t) {
+          if (head == tail && tailCompareAndSet(head, null)) {
+            // Queue exhausted. No need to reschedule. Just let exception propagate.
+          } else {
+            head = Preconditions.checkNotNull(head.next, "head.next");
+            try {
+              schedule(head);
+            } catch (Throwable t2) {
+              log.log(Level.SEVERE, "Exception while re-scheduling due to exception", t2);
+            }
+          }
+          Throwables.propagateIfPossible(t);
+          throw new AssertionError(t);
+        }
+        // Do not advance in the queue past tail, even if head.next != null, otherwise we could win
+        // a spectatular race by executing head.next before execute() has CAS tail. Then we would be
+        // forced to spin-loop waiting for execute() to catch up; there would be no more work queued
+        // and we couldn't set tail=null and return, because then execute() would reschedule without
+        // knowing the runnable had already been executed.
+        if (head == cachedTail && head == (cachedTail = tail)) {
+          if (tailCompareAndSet(head, null)) {
+            break;
+          } else {
+            cachedTail = tail;
+          }
+        }
+        LinkedRunnable prevHead = head;
+        head = Preconditions.checkNotNull(head.next, "head.next");
+        prevHead.next = null; // Prevent GC nepotism
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/SingleTransportChannel.java
+++ b/core/src/main/java/io/grpc/internal/SingleTransportChannel.java
@@ -75,7 +75,7 @@ final class SingleTransportChannel extends Channel {
   public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
       MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
     return new ClientCallImpl<RequestT, ResponseT>(methodDescriptor,
-        new SerializingExecutor(executor), callOptions, transportProvider,
+        new SingleProducerSerializingExecutor(executor), callOptions, transportProvider,
         deadlineCancellationExecutor);
   }
 

--- a/core/src/test/java/io/grpc/internal/SingleProducerSerializingExecutorTest.java
+++ b/core/src/test/java/io/grpc/internal/SingleProducerSerializingExecutorTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+/** Unit tests for {@link SingleProducerSerializingExecutor}. */
+@RunWith(JUnit4.class)
+public class SingleProducerSerializingExecutorTest {
+  private SingleExecutor singleExecutor = new SingleExecutor();
+  private SingleProducerSerializingExecutor executor =
+      new SingleProducerSerializingExecutor(singleExecutor);
+  private List<Integer> runs = new ArrayList<Integer>();
+  private Runnable runnable = new Runnable() {
+    // TODO
+    @Override
+    public void run() {}
+  };
+
+
+  private class AddToRuns implements Runnable {
+    private final int val;
+
+    public AddToRuns(int val) {
+      this.val = val;
+    }
+
+    @Override
+    public void run() {
+      runs.add(val);
+    }
+  }
+
+  @Test
+  public void testSerial() {
+    executor.execute(new AddToRuns(1));
+    assertEquals(Collections.<Integer>emptyList(), runs);
+    singleExecutor.drain();
+    assertEquals(Arrays.asList(1), runs);
+
+    executor.execute(new AddToRuns(2));
+    assertEquals(Arrays.asList(1), runs);
+    singleExecutor.drain();
+    assertEquals(Arrays.asList(1, 2), runs);
+  }
+
+  @Test
+  public void testParallel() {
+    executor.execute(new AddToRuns(1));
+    executor.execute(new AddToRuns(2));
+    executor.execute(new AddToRuns(3));
+    assertEquals(Collections.<Integer>emptyList(), runs);
+    singleExecutor.drain();
+    assertEquals(Arrays.asList(1, 2, 3), runs);
+  }
+
+  @Test
+  public void testReentrant() {
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        executor.execute(new AddToRuns(3));
+        runs.add(1);
+      }
+    });
+    executor.execute(new AddToRuns(2));
+    singleExecutor.drain();
+    assertEquals(Arrays.asList(1, 2, 3), runs);
+  }
+
+  @Test
+  public void testFirstRunnableThrows() {
+    final RuntimeException ex = new RuntimeException();
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        runs.add(1);
+        throw ex;
+      }
+    });
+    executor.execute(new AddToRuns(2));
+    executor.execute(new AddToRuns(3));
+    try {
+      singleExecutor.drain();
+      fail("expected exception");
+    } catch (RuntimeException e) {
+      assertSame(ex, e);
+    }
+    assertEquals(Arrays.asList(1), runs);
+    singleExecutor.drain();
+    assertEquals(Arrays.asList(1, 2, 3), runs);
+  }
+
+  @Test
+  public void testLastRunnableThrows() {
+    final RuntimeException ex = new RuntimeException();
+    executor.execute(new AddToRuns(1));
+    executor.execute(new AddToRuns(2));
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        runs.add(3);
+        throw ex;
+      }
+    });
+    try {
+      singleExecutor.drain();
+      fail("expected exception");
+    } catch (RuntimeException e) {
+      assertSame(ex, e);
+    }
+    assertEquals(Arrays.asList(1, 2, 3), runs);
+
+    // Scheduling more still works
+    executor.execute(new AddToRuns(4));
+    assertEquals(Arrays.asList(1, 2, 3), runs);
+    singleExecutor.drain();
+    assertEquals(Arrays.asList(1, 2, 3, 4), runs);
+  }
+
+  @Test
+  public void testFirstExecuteThrows() {
+    final RuntimeException ex = new RuntimeException();
+    ForwardingExecutor forwardingExecutor = new ForwardingExecutor(new Executor() {
+      @Override
+      public void execute(Runnable r) {
+        throw ex;
+      }
+    });
+    executor = new SingleProducerSerializingExecutor(forwardingExecutor);
+    try {
+      executor.execute(new AddToRuns(1));
+      fail("expected exception");
+    } catch (RuntimeException e) {
+      assertSame(ex, e);
+    }
+    assertEquals(Collections.<Integer>emptyList(), runs);
+
+    forwardingExecutor.executor = singleExecutor;
+    executor.execute(new AddToRuns(2));
+    executor.execute(new AddToRuns(3));
+    assertEquals(Collections.<Integer>emptyList(), runs);
+    singleExecutor.drain();
+    assertEquals(Arrays.asList(2, 3), runs);
+  }
+
+  @Test
+  public void testExecuteThrowsAfterRunnableThrows() {
+    ForwardingExecutor forwardingExecutor = new ForwardingExecutor(singleExecutor);
+    executor = new SingleProducerSerializingExecutor(forwardingExecutor);
+    final RuntimeException ex = new RuntimeException();
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        throw ex;
+      }
+    });
+    executor.execute(new AddToRuns(1));
+    class ThrowingExecutor implements Executor {
+      int invocations;
+
+      @Override
+      public void execute(Runnable r) {
+        invocations++;
+        throw new RuntimeException();
+      }
+    }
+
+    ThrowingExecutor throwingExecutor = new ThrowingExecutor();
+    forwardingExecutor.executor = throwingExecutor;
+    try {
+      singleExecutor.drain();
+      fail("expected exception");
+    } catch (RuntimeException e) {
+      assertSame(ex, e);
+    }
+    assertEquals(1, throwingExecutor.invocations);
+  }
+
+  @Test
+  public void testDirect() {
+    executor = new SingleProducerSerializingExecutor(MoreExecutors.directExecutor());
+    executor.execute(new AddToRuns(1));
+    assertEquals(Arrays.asList(1), runs);
+    executor.execute(new AddToRuns(2));
+    assertEquals(Arrays.asList(1, 2), runs);
+    executor.execute(new AddToRuns(3));
+    assertEquals(Arrays.asList(1, 2, 3), runs);
+  }
+
+  @Test
+  public void testDirectReentrant() {
+    executor = new SingleProducerSerializingExecutor(MoreExecutors.directExecutor());
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        executor.execute(new AddToRuns(2));
+        runs.add(1);
+      }
+    });
+    assertEquals(Arrays.asList(1, 2), runs);
+    executor.execute(new AddToRuns(3));
+    assertEquals(Arrays.asList(1, 2, 3), runs);
+  }
+
+  private static class SingleExecutor implements Executor {
+    private Runnable runnable;
+
+    @Override
+    public void execute(Runnable r) {
+      if (runnable != null) {
+        fail("Already have runnable scheduled");
+      }
+      runnable = r;
+    }
+
+    public void drain() {
+      if (runnable != null) {
+        Runnable r = runnable;
+        runnable = null;
+        r.run();
+      }
+    }
+  }
+
+  private static class ForwardingExecutor implements Executor {
+    Executor executor;
+
+    public ForwardingExecutor(Executor executor) {
+      this.executor = executor;
+    }
+
+    @Override
+    public void execute(Runnable r) {
+      executor.execute(r);
+    }
+  }
+}


### PR DESCRIPTION
This is very low priority, and I'm not quite sure what benefits we need
for the change to be "worth it."

Although it is nice it is faster for many runnables, we are primarily
concerned with avoiding the lock to reduce tail latency. It uses more
memory with its linked list than SerializingExecutor (which uses array
queue), but in the future we can allow callers to provide a
LinkedRunnable (to SerializeReentrantCallsDirectExecutor as well) and
not incur an allocation each execute().

For maybe about 10% performance penality and additional complexity, the
algorithm should be able to be extended to multi-producer (via CAS on
'next'). But we don't have a strong need for multi-producer, so we favor
avoiding even more complexity.

Fixes #2122

```
Benchmark                                                 (type)    Mode Cnt      Score     Error  Units
SerializingExecutorBenchmark.manyRunnables               CLASSIC  sample 458258  65360.652 ± 129.949  ns/op
SerializingExecutorBenchmark.manyRunnables       SINGLE_PRODUCER  sample 480660  30988.375 ±  80.705  ns/op
SerializingExecutorBenchmark.oneRunnableLatency          CLASSIC  sample 629954  11756.902 ± 443.787  ns/op
SerializingExecutorBenchmark.oneRunnableLatency  SINGLE_PRODUCER  sample 629660  11413.764 ±  60.949  ns/op
```
