### PR TITLE
Provide base implementation for load balancer

### DIFF
--- a/core/src/main/java/io/grpc/AbstractLoadBalancer.java
+++ b/core/src/main/java/io/grpc/AbstractLoadBalancer.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import com.google.common.base.Supplier;
+
+import java.util.List;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
+@ThreadSafe
+public abstract class AbstractLoadBalancer<TransportT> extends LoadBalancer<TransportT> {
+  private static final Status SHUTDOWN_STATUS =
+      Status.UNAVAILABLE.augmentDescription("Load balancer has shut down");
+
+  private final Object lock = new Object();
+
+  @GuardedBy("lock")
+  private TransportPicker<TransportT> transportPicker;
+  @GuardedBy("lock")
+  private TransportManager.InterimTransport<TransportT> interimTransport;
+  @GuardedBy("lock")
+  private Status nameResolutionError;
+  @GuardedBy("lock")
+  private boolean closed;
+
+  protected final TransportManager<TransportT> tm;
+
+  protected AbstractLoadBalancer(TransportManager<TransportT> tm) {
+    this.tm = tm;
+  }
+
+  /**
+   * Factory method which creates and returns {@link TransportPicker}.
+   */
+  protected abstract TransportPicker<TransportT> createTransportPicker(
+      List<ResolvedServerInfoGroup> servers);
+
+  @Override
+  public TransportT pickTransport(Attributes affinity) {
+    TransportPicker<TransportT> transportPickerCopy;
+    synchronized (lock) {
+      if (closed) {
+        return tm.createFailingTransport(SHUTDOWN_STATUS);
+      }
+      if (transportPicker == null) {
+        if (nameResolutionError != null) {
+          return tm.createFailingTransport(nameResolutionError);
+        }
+        if (interimTransport == null) {
+          interimTransport = tm.createInterimTransport();
+        }
+        return interimTransport.transport();
+      }
+      transportPickerCopy = transportPicker;
+    }
+    return transportPickerCopy.pickTransport(affinity);
+  }
+
+  @Override
+  public void handleResolvedAddresses(final List<ResolvedServerInfoGroup> updatedServers,
+      final Attributes attributes) {
+    TransportManager.InterimTransport<TransportT> savedInterimTransport;
+    final TransportPicker<TransportT> transportPickerCopy;
+    synchronized (lock) {
+      if (closed) {
+        return;
+      }
+      transportPicker = createTransportPicker(updatedServers);
+      transportPickerCopy = transportPicker;
+      nameResolutionError = null;
+      savedInterimTransport = interimTransport;
+      interimTransport = null;
+    }
+    if (savedInterimTransport != null) {
+      savedInterimTransport.closeWithRealTransports(new Supplier<TransportT>() {
+        @Override
+        public TransportT get() {
+          return transportPickerCopy.pickTransport(attributes);
+        }
+      });
+    }
+  }
+
+  @Override
+  public void handleNameResolutionError(Status error) {
+    TransportManager.InterimTransport<TransportT> savedInterimTransport;
+    synchronized (lock) {
+      if (closed) {
+        return;
+      }
+      error = error.augmentDescription("Name resolution failed");
+      savedInterimTransport = interimTransport;
+      interimTransport = null;
+      nameResolutionError = error;
+    }
+    if (savedInterimTransport != null) {
+      savedInterimTransport.closeWithError(error);
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    TransportManager.InterimTransport<TransportT> savedInterimTransport;
+    synchronized (lock) {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      savedInterimTransport = interimTransport;
+      interimTransport = null;
+    }
+    if (savedInterimTransport != null) {
+      savedInterimTransport.closeWithError(SHUTDOWN_STATUS);
+    }
+  }
+
+}
+

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory.java
@@ -54,19 +54,21 @@ public final class PickFirstBalancerFactory extends LoadBalancer.Factory {
 
   @Override
   public <T> LoadBalancer<T> newLoadBalancer(String serviceName, TransportManager<T> tm) {
-    return new PickFirstBalancer<T>(tm);
+    return new SimpleLoadBalancer<T>(tm, new PickFirstBalancerFactory.PickFirstTransportPickerFactory<T>(tm));
   }
 
-  private static class PickFirstBalancer<T> extends AbstractLoadBalancer<T> {
-    private PickFirstBalancer(TransportManager<T> tm) {
-      super(tm);
+  private static class PickFirstTransportPickerFactory<T> implements TransportPicker.Factory<T> {
+    private final TransportManager<T> tm;
+
+    public PickFirstTransportPickerFactory(TransportManager<T> tm) {
+      this.tm = tm;
     }
 
     @Override
-    protected TransportPicker<T> createTransportPicker(List<ResolvedServerInfoGroup> servers,
-        Attributes initialAttributes) {
+    public TransportPicker<T> create(List<ResolvedServerInfoGroup> updatedServers,
+        Attributes attributes) {
       final EquivalentAddressGroup equivalentAddressGroup =
-          resolvedServerInfoToEquivalentAddressGroup(servers);
+          resolvedServerInfoToEquivalentAddressGroup(updatedServers);
       // The simplest possible picker, just delegates to transport manager converted server list.
       return new TransportPicker<T>() {
         @Override

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory.java
@@ -63,13 +63,14 @@ public final class PickFirstBalancerFactory extends LoadBalancer.Factory {
     }
 
     @Override
-    protected TransportPicker<T> createTransportPicker(List<ResolvedServerInfoGroup> servers) {
+    protected TransportPicker<T> createTransportPicker(List<ResolvedServerInfoGroup> servers,
+        Attributes initialAttributes) {
       final EquivalentAddressGroup equivalentAddressGroup =
           resolvedServerInfoToEquivalentAddressGroup(servers);
-      // Picker in this case is very simple, anonymous class will suffice.
+      // The simplest possible picker, just delegates to transport manager converted server list.
       return new TransportPicker<T>() {
         @Override
-        public T pickTransport(Attributes affinity) {
+        public T pickTransport(Attributes affinityAttributes) {
           return tm.getTransport(equivalentAddressGroup);
         }
       };

--- a/core/src/main/java/io/grpc/TransportPicker.java
+++ b/core/src/main/java/io/grpc/TransportPicker.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+public abstract class TransportPicker<TransportT> {
+  public abstract TransportT pickTransport(Attributes affinity);
+}

--- a/core/src/main/java/io/grpc/TransportPicker.java
+++ b/core/src/main/java/io/grpc/TransportPicker.java
@@ -31,6 +31,17 @@
 
 package io.grpc;
 
-public abstract class TransportPicker<TransportT> {
-  public abstract TransportT pickTransport(Attributes affinity);
+/**
+ * Provides a simplified abstraction of transport picking used by {@link AbstractLoadBalancer}.
+ *
+ * @param <TransportT> transport type
+ */
+public interface TransportPicker<TransportT> {
+  /**
+   * Pick a transport that Channel will use for next RPC.
+   *
+   * @param affinityAttributes attributes for affinity-based routing.
+   * @return selected transport.
+   */
+  TransportT pickTransport(Attributes affinityAttributes);
 }

--- a/core/src/main/java/io/grpc/TransportPicker.java
+++ b/core/src/main/java/io/grpc/TransportPicker.java
@@ -31,8 +31,10 @@
 
 package io.grpc;
 
+import java.util.List;
+
 /**
- * Provides a simplified abstraction of transport picking used by {@link AbstractLoadBalancer}.
+ * Provides a simplified abstraction of transport picking used by {@link SimpleLoadBalancer}.
  *
  * @param <TransportT> transport type
  */
@@ -44,4 +46,22 @@ public interface TransportPicker<TransportT> {
    * @return selected transport.
    */
   TransportT pickTransport(Attributes affinityAttributes);
+
+  /**
+   * Factory for creating {@link TransportPicker} instances.
+   *
+   * @param <TransportT> transport type.
+   */
+  interface Factory<TransportT> {
+    /**
+     * Factory method returning {@link TransportPicker} which is responsible for transport
+     * selection.
+     *
+     * @param servers immutable list of servers returned from {@link NameResolver}.
+     * @param initialAttributes metadata attributes returned from {@link NameResolver}.
+     * @return TransportPicker object for given transport type.
+     */
+    TransportPicker<TransportT> create(List<ResolvedServerInfoGroup> servers,
+        Attributes initialAttributes);
+  }
 }

--- a/core/src/main/java/io/grpc/internal/RoundRobinServerList.java
+++ b/core/src/main/java/io/grpc/internal/RoundRobinServerList.java
@@ -54,7 +54,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Manages a list of server addresses to round-robin on.
  */
 @ThreadSafe
-public class RoundRobinServerList<T> extends TransportPicker<T> {
+public class RoundRobinServerList<T> implements TransportPicker<T> {
   private final TransportManager<T> tm;
   private final List<EquivalentAddressGroup> list;
   private final Iterator<EquivalentAddressGroup> cyclingIter;
@@ -68,8 +68,11 @@ public class RoundRobinServerList<T> extends TransportPicker<T> {
       tm.createFailingTransport(Status.UNAVAILABLE.withDescription("Throttled by LB"));
   }
 
+  /**
+   * Implements {@link TransportPicker} api.
+   */
   @Override
-  public T pickTransport(Attributes affinity) {
+  public T pickTransport(Attributes affinityAttributes) {
     return getTransportForNextServer();
   }
 

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory.java
@@ -32,6 +32,7 @@
 package io.grpc.util;
 
 import io.grpc.AbstractLoadBalancer;
+import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
@@ -72,8 +73,8 @@ public final class RoundRobinLoadBalancerFactory extends LoadBalancer.Factory {
     }
 
     @Override
-    protected TransportPicker<T> createTransportPicker(
-        List<ResolvedServerInfoGroup> updatedServers) {
+    protected TransportPicker<T> createTransportPicker(List<ResolvedServerInfoGroup> updatedServers,
+        Attributes initialAttributes) {
       RoundRobinServerList.Builder<T> listBuilder = new RoundRobinServerList.Builder<T>(tm);
       for (ResolvedServerInfoGroup servers : updatedServers) {
         if (servers.getResolvedServerInfoList().isEmpty()) {


### PR DESCRIPTION
A lot of boilerplate is required to implement `LoadBalancer` interface, and arguably, this isn't necessarily something that end-user should be concerned about and even now we have two load balancer impls in core (`PickFirst`, `RoundRobin`) which are nearly the same with very small differences in actual transport picking logic.

I propose introducing `AbstractLoadBalancer` which takes care of all the boilerplate and reduces methods required to implement 3rd party LB only to two - one factory-like, and one responsible for transport picking.

This is a proof of concept which is missing javadocs and would use some polishing.

@ejona86 @zhangkun83 what do you think? /cc @jhump @maniksurtani 