### PR TITLE
core: add ServerTransportFilter

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -74,6 +74,13 @@ public final class Attributes {
   }
 
   /**
+   * Create a new builder that is pre-populated with the content from a given container.
+   */
+  public static Builder newBuilder(Attributes base) {
+    return newBuilder().setAll(base);
+  }
+
+  /**
    * Create a new builder.
    */
   public static Builder newBuilder() {

--- a/core/src/main/java/io/grpc/Grpc.java
+++ b/core/src/main/java/io/grpc/Grpc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,50 +29,32 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.internal;
+package io.grpc;
 
 import io.grpc.Attributes;
-import io.grpc.Metadata;
-import io.grpc.Status;
+
+import java.net.SocketAddress;
+import javax.net.ssl.SSLSession;
 
 /**
- * Extension of {@link Stream} to support server-side termination semantics.
- *
- * <p>An implementation doesn't need to be thread-safe. All methods are expected to execute quickly.
+ * Stuff that are part of the public API but are not bound to particular classes, e.g., static
+ * methods, constants, attribute and context keys.
  */
-public interface ServerStream extends Stream {
+public final class Grpc {
+  private Grpc() {
+  }
 
   /**
-   * Writes custom metadata as headers on the response stream sent to the client. This method may
-   * only be called once and cannot be called after calls to {@link Stream#writeMessage}
-   * or {@link #close}.
-   *
-   * @param headers to send to client.
+   * Attribute key for the remote address of a transport.
    */
-  void writeHeaders(Metadata headers);
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
+  public static final Attributes.Key<SocketAddress> TRANSPORT_ATTR_REMOTE_ADDR =
+          Attributes.Key.of("remote-addr");
 
   /**
-   * Closes the stream for both reading and writing. A status code of
-   * {@link io.grpc.Status.Code#OK} implies normal termination of the
-   * stream. Any other value implies abnormal termination.
-   *
-   * @param status details of the closure
-   * @param trailers an additional block of metadata to pass to the client on stream closure.
+   * Attribute key for SSL session of a transport.
    */
-  void close(Status status, Metadata trailers);
-
-
-  /**
-   * Tears down the stream, typically in the event of a timeout. This method may be called multiple
-   * times and from any thread.
-   */
-  void cancel(Status status);
-
-  /**
-   * Attributes describing stream.  This is inherited from the transport attributes, and used
-   * as the basis of {@link io.grpc.ServerCall#attributes}.
-   *
-   * @return Attributes container
-   */
-  Attributes attributes();
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
+  public static final Attributes.Key<SSLSession> TRANSPORT_ATTR_SSL_SESSION =
+          Attributes.Key.of("ssl-session");
 }

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -86,6 +86,13 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   public abstract T addService(BindableService bindableService);
 
   /**
+   * Adds a {@link ServerTransportFilter}. The order of filters being added is the order they will
+   * be executed.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2132")
+  public abstract T addTransportFilter(ServerTransportFilter filter);
+
+  /**
    * Sets a fallback handler registry that will be looked up in if a method is not found in the
    * primary registry.
    */

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -59,17 +59,24 @@ public abstract class ServerCall<ReqT, RespT> {
   /**
    * {@link Attributes.Key} for the remote address of server call attributes
    * {@link ServerCall#attributes()}
+   *
+   * @deprecated use the equivalent {@link io.grpc.Grpc#TRANSPORT_ATTR_REMOTE_ADDR} instead
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
+  @Deprecated
   public static final Attributes.Key<SocketAddress> REMOTE_ADDR_KEY =
-          Attributes.Key.of("remote-addr");
+      Grpc.TRANSPORT_ATTR_REMOTE_ADDR;
+
   /**
    * {@link Attributes.Key} for the SSL session of server call attributes
    * {@link ServerCall#attributes()}
+   *
+   * @deprecated use the equivalent {@link io.grpc.Grpc#TRANSPORT_ATTR_SSL_SESSION} instead
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
+  @Deprecated
   public static final Attributes.Key<SSLSession> SSL_SESSION_KEY =
-          Attributes.Key.of("ssl-session");
+      Grpc.TRANSPORT_ATTR_SSL_SESSION;
 
   /**
    * Callbacks for consuming incoming RPC messages.
@@ -221,8 +228,11 @@ public abstract class ServerCall<ReqT, RespT> {
   }
 
   /**
-   * Returns properties of a single call. This is a generic container which can contain any kind of
-   * information describing call like for example remote address, TLS information (OU etc.)
+   * Returns properties of a single call.
+   *
+   * <p>Attributes originate from the transport and can be altered by {@link ServerTransportFilter}.
+   * {@link Grpc} defines commonly used attributes, while the availability of them in a particular
+   * {@code ServerCall} is not guaranteed.
    *
    * @return Attributes container
    */

--- a/core/src/main/java/io/grpc/ServerTransportFilter.java
+++ b/core/src/main/java/io/grpc/ServerTransportFilter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+/**
+ * Listens on server transport life-cycle events, with the capability to read and/or change
+ * transport attributes.  Attributes returned by this filter will be merged into {@link
+ * ServerCall#attributes}.
+ *
+ * <p>Multiple filters maybe registered to a server, in which case the output of a filter is the
+ * input of the next filter.  For example, what returned by {@link #transportReady} of a filter is
+ * passed to the same method of the next filter, and the last filter's return value is the effective
+ * transport attributes.  A filter should modify the passed-in attributes instead of creating one
+ * from scratch.
+ *
+ * <p>{@link Grpc} defines commonly used attributes.
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/2132")
+public abstract class ServerTransportFilter {
+  /**
+   * Called when a transport is ready to process streams.  All necessary handshakes, e.g., TLS
+   * handshake, are done at this point.
+   *
+   * <p>Note the implementation should always inherit the passed-in attributes using {@code
+   * Attributes.newBuilder(transportAttrs)}, instead of creating one from scratch.
+   *
+   * @param transportAttrs current transport attributes
+   *
+   * @return new transport attributes. Default implementation returns the passed-in attributes
+   *         intact.
+   */
+  public Attributes transportReady(Attributes transportAttrs) {
+    return transportAttrs;
+  }
+
+  /**
+   * Called when a transport is terminated.  Default implementation is no-op.
+   *
+   * @param transportAttrs the effective transport attributes, which is what returned by {@link
+   * #transportReady} of the last executed filter.
+   */
+  public void transportTerminated(Attributes transportAttrs) {
+  }
+}

--- a/core/src/main/java/io/grpc/internal/ServerTransportListener.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransportListener.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import io.grpc.Attributes;
 import io.grpc.Metadata;
 
 /**
@@ -49,6 +50,15 @@ public interface ServerTransportListener {
    */
   ServerStreamListener streamCreated(ServerStream stream, String method,
       Metadata headers);
+
+  /**
+   * The transport has finished all handshakes and is ready to process streams.
+   *
+   * @param attributes transport attributes
+   *
+   * @return the effective transport attributes that is used as the basis of call attributes
+   */
+  Attributes transportReady(Attributes attributes);
 
   /**
    * The transport completed shutting down. All resources have been released.

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -57,6 +57,7 @@ import com.google.protobuf.EmptyProtos.Empty;
 
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Server;
@@ -942,7 +943,7 @@ public abstract class AbstractInteropTest {
     stub.unaryCall(SimpleRequest.getDefaultInstance());
 
     HostAndPort remoteAddress = HostAndPort.fromString(serverCallCapture.get().attributes()
-            .get(ServerCall.REMOTE_ADDR_KEY).toString());
+            .get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR).toString());
     assertEquals(expectedRemoteAddress, remoteAddress.getHostText());
   }
 
@@ -955,7 +956,7 @@ public abstract class AbstractInteropTest {
 
     List<Certificate> certificates = Lists.newArrayList();
     SSLSession sslSession =
-        serverCallCapture.get().attributes().get(ServerCall.SSL_SESSION_KEY);
+        serverCallCapture.get().attributes().get(Grpc.TRANSPORT_ATTR_SSL_SESSION);
     try {
       certificates = Arrays.asList(sslSession.getPeerCertificates());
     } catch (SSLPeerUnverifiedException e) {

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -153,15 +153,15 @@ public final class ProtocolNegotiators {
         SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
         if (handshakeEvent.isSuccess()) {
           if (HTTP2_VERSION.equals(sslHandler(ctx.pipeline()).applicationProtocol())) {
-            // Successfully negotiated the protocol. Replace this handler with
-            // the GRPC handler.
-            ctx.pipeline().replace(this, null, grpcHandler);
-
             // TODO(lukaszx0) Short term solution. Long term we want to plumb this through
             // ProtocolNegotiator.Handler and pass the handler into NettyClientHandler and
             // NettyServerHandler (https://github.com/grpc/grpc-java/issues/1556)
             Attribute<SSLSession> sslSessionAttr = ctx.channel().attr(Utils.SSL_SESSION_ATTR_KEY);
+
             sslSessionAttr.set(sslHandler(ctx.pipeline()).engine().getSession());
+            // Successfully negotiated the protocol. Replace this handler with
+            // the GRPC handler.
+            ctx.pipeline().replace(this, null, grpcHandler);
           } else {
             fail(ctx, new Exception(
                 "Failed protocol negotiation: Unable to find compatible protocol."));

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.fail;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.SettableFuture;
 
+import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
@@ -439,6 +440,11 @@ public class NettyClientTransportTest {
           EchoServerStreamListener listener = new EchoServerStreamListener(stream, method, headers);
           streamListeners.add(listener);
           return listener;
+        }
+
+        @Override
+        public Attributes transportReady(Attributes transportAttrs) {
+          return transportAttrs;
         }
 
         @Override

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.io.ByteStreams;
 
+import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -118,7 +119,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
         any(String.class),
         any(Metadata.class)))
         .thenReturn(streamListener);
-
+    when(transportListener.transportReady(any(Attributes.class))).thenReturn(Attributes.EMPTY);
     initChannel();
 
     // Simulate receipt of the connection preface

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ListMultimap;
 
+import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.ServerStreamListener;
@@ -292,7 +293,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     when(writeQueue.enqueue(any(QueuedCommand.class), anyBoolean())).thenReturn(future);
     NettyServerStream.TransportState state =
         new NettyServerStream.TransportState(handler, http2Stream, DEFAULT_MAX_MESSAGE_SIZE);
-    NettyServerStream stream = new NettyServerStream(channel, state);
+    NettyServerStream stream = new NettyServerStream(channel, state, Attributes.EMPTY);
     stream.transportState().setListener(serverListener);
     verify(serverListener, atLeastOnce()).onReady();
     verifyNoMoreInteractions(serverListener);


### PR DESCRIPTION
Called whenever a ServerTransport is ready and terminated. Has the ability to filter transport attributes, which `ServerCall.attributes()` are based on. Related changes:

- Attribute keys for remote address and SSL session are now moved from `ServerCall` to a neutral place `io.grpc.Grpc`, because they can also be used from `ServerTransportFilter`, and probably will be used on the client-side too.
- Added `transportReady()` to `ServerTransportListener`.

Resolves #2132 

/cc @lukaszx0 
