### PR TITLE
core: fix race condition for TransportSet scheduleBackoff

### DIFF
--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -324,4 +324,13 @@ public class DelayedClientTransportTest {
     delayedTransport.newStream(method, headers, waitForReadyCallOptions);
     assertEquals(1, delayedTransport.getPendingStreamsCount());
   }
+
+  @Test public void startBackoff_DoNothingIfAlreadyShutDown() {
+    delayedTransport.shutdown();
+
+    final Status cause = Status.UNAVAILABLE.withDescription("some error when connecting");
+    delayedTransport.startBackoff(cause);
+
+    assertFalse(delayedTransport.isInBackoffPeriod());
+  }
 }


### PR DESCRIPTION
Trying to fix issue  #2188
- Try to keep avoiding the lock issue #2152 and also to avoid race condition #2188.
- Add `checkState` for `endBackoff()`. Could help hit and identify any potential issue related to #2188.
- Make sure `startBackoff()` and `endBackoff()` invoked in the right order.
- Not to schedule endBackoff if transportSet has been shutdown.