### PR TITLE
core: add Metadata.discardAll()

### DIFF
--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -272,6 +272,16 @@ public final class Metadata {
   }
 
   /**
+   * Remove all values for the given key without returning them.  This is a minor performance
+   * optimization if you do not need the previous values.
+   */
+  @ExperimentalApi
+  public <T> void discardAll(Key<T> key) {
+    List<MetadataEntry> removed = store.remove(key.name());
+    storeCount -= removed != null ? removed.size() : 0;
+  }
+
+  /**
    * Serialize all the metadata entries.
    *
    * <p>It produces serialized names and values interleaved. result[i*2] are names, while

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -145,8 +145,8 @@ public abstract class AbstractServerStream extends AbstractStream2
   }
 
   private void addStatusToTrailers(Metadata trailers, Status status) {
-    trailers.removeAll(Status.CODE_KEY);
-    trailers.removeAll(Status.MESSAGE_KEY);
+    trailers.discardAll(Status.CODE_KEY);
+    trailers.discardAll(Status.MESSAGE_KEY);
     trailers.put(Status.CODE_KEY, status);
     if (status.getDescription() != null) {
       trailers.put(Status.MESSAGE_KEY, status.getDescription());

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -140,12 +140,12 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
   @VisibleForTesting
   static void prepareHeaders(Metadata headers, DecompressorRegistry decompressorRegistry,
       Compressor compressor) {
-    headers.removeAll(MESSAGE_ENCODING_KEY);
+    headers.discardAll(MESSAGE_ENCODING_KEY);
     if (compressor != Codec.Identity.NONE) {
       headers.put(MESSAGE_ENCODING_KEY, compressor.getMessageEncoding());
     }
 
-    headers.removeAll(MESSAGE_ACCEPT_ENCODING_KEY);
+    headers.discardAll(MESSAGE_ACCEPT_ENCODING_KEY);
     String advertisedEncodings = decompressorRegistry.getRawAdvertisedMessageEncodings();
     if (!advertisedEncodings.isEmpty()) {
       headers.put(MESSAGE_ACCEPT_ENCODING_KEY, advertisedEncodings);
@@ -251,7 +251,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
    */
   private static void updateTimeoutHeaders(@Nullable Deadline effectiveDeadline,
       @Nullable Deadline callDeadline, @Nullable Deadline outerCallDeadline, Metadata headers) {
-    headers.removeAll(TIMEOUT_KEY);
+    headers.discardAll(TIMEOUT_KEY);
 
     if (effectiveDeadline == null) {
       return;

--- a/core/src/main/java/io/grpc/internal/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStream.java
@@ -238,8 +238,8 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
    * the application layer.
    */
   private static void stripTransportDetails(Metadata metadata) {
-    metadata.removeAll(HTTP2_STATUS);
-    metadata.removeAll(Status.CODE_KEY);
-    metadata.removeAll(Status.MESSAGE_KEY);
+    metadata.discardAll(HTTP2_STATUS);
+    metadata.discardAll(Status.CODE_KEY);
+    metadata.discardAll(Status.MESSAGE_KEY);
   }
 }

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -104,7 +104,7 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
     checkState(!sendHeadersCalled, "sendHeaders has already been called");
     checkState(!closeCalled, "call is closed");
 
-    headers.removeAll(MESSAGE_ENCODING_KEY);
+    headers.discardAll(MESSAGE_ENCODING_KEY);
     if (compressor == null) {
       compressor = Codec.Identity.NONE;
     } else {
@@ -125,7 +125,7 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
     stream.setCompressor(compressor);
 
-    headers.removeAll(MESSAGE_ACCEPT_ENCODING_KEY);
+    headers.discardAll(MESSAGE_ACCEPT_ENCODING_KEY);
     String advertisedEncodings = decompressorRegistry.getRawAdvertisedMessageEncodings();
     if (!advertisedEncodings.isEmpty()) {
       headers.put(MESSAGE_ACCEPT_ENCODING_KEY, advertisedEncodings);

--- a/core/src/test/java/io/grpc/MetadataTest.java
+++ b/core/src/test/java/io/grpc/MetadataTest.java
@@ -115,6 +115,17 @@ public class MetadataTest {
   }
 
   @Test
+  public void discardAll() {
+    Fish lance = new Fish(LANCE);
+    Metadata metadata = new Metadata();
+
+    metadata.put(KEY, lance);
+    metadata.discardAll(KEY);
+    assertEquals(null, metadata.getAll(KEY));
+    assertEquals(null, metadata.get(KEY));
+  }
+
+  @Test
   public void testGetAllNoRemove() {
     Fish lance = new Fish(LANCE);
     Metadata metadata = new Metadata();

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -105,7 +105,7 @@ abstract class NettyClientStream extends Http2ClientStream implements StreamIdHo
       defaultPath = new AsciiString("/" + method.getFullMethodName());
       methodDescriptorAccessor.setRawMethodName(method, defaultPath);
     }
-    headers.removeAll(GrpcUtil.USER_AGENT_KEY);
+    headers.discardAll(GrpcUtil.USER_AGENT_KEY);
     Http2Headers http2Headers
         = Utils.convertClientHeaders(headers, scheme, defaultPath, authority, userAgent);
     headers = null;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -139,7 +139,7 @@ class OkHttpClientStream extends Http2ClientStream {
   public void start(ClientStreamListener listener) {
     super.start(listener);
     String defaultPath = "/" + method.getFullMethodName();
-    headers.removeAll(GrpcUtil.USER_AGENT_KEY);
+    headers.discardAll(GrpcUtil.USER_AGENT_KEY);
     List<Header> requestHeaders =
         Headers.createRequestHeaders(headers, defaultPath, authority, userAgent);
     headers = null;


### PR DESCRIPTION
Metadata.removeAll creates an iterator for looking through removed
values even if the call doens't use it.  This change adds a similar
method which doesn't create garbage.

This change makes it easier in the future to alter the internals
of Metadata where it may be expensive to return removed values.

Found by using Yourkit.  I personally would have expected the JVM to remove those as dead code, but apparently it does not.