### PR TITLE
core: speed up Status code and message parsing

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/StatusBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/StatusBenchmark.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+/** StatusBenchmark. */
+@State(Scope.Benchmark)
+public class StatusBenchmark {
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public byte[] messageEncodePlain() {
+    return Status.MESSAGE_KEY.toBytes("Unexpected RST in stream");
+  }
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public byte[] messageEncodeEscape() {
+    return Status.MESSAGE_KEY.toBytes("Some Error\nWasabi and Horseradish are the same");
+  }
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public String messageDecodePlain() {
+    return Status.MESSAGE_KEY.parseBytes(
+        "Unexpected RST in stream".getBytes(Charset.forName("US-ASCII")));
+  }
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public String messageDecodeEscape() {
+    return Status.MESSAGE_KEY.parseBytes(
+        "Some Error%10Wasabi and Horseradish are the same".getBytes(Charset.forName("US-ASCII")));
+  }
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public byte[] codeEncode() {
+    return Status.CODE_KEY.toBytes(Status.DATA_LOSS);
+  }
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Status codeDecode() {
+    return Status.CODE_KEY.parseBytes("15".getBytes(Charset.forName("US-ASCII")));
+  }
+}
+

--- a/core/src/main/java/io/grpc/InternalMetadata.java
+++ b/core/src/main/java/io/grpc/InternalMetadata.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import io.grpc.Metadata.Key;
+
+import java.nio.charset.Charset;
+
+/**
+ * Internal {@link Metadata} accessor. This is intended for use by io.grpc.internal, and the
+ * specifically supported transport packages. If you *really* think you need to use this, contact
+ * the gRPC team first.
+ */
+@Internal
+public final class InternalMetadata {
+
+  /**
+   * A specialized plain ASCII marshaller. Both input and output are assumed to be valid header
+   * ASCII.
+   */
+  @Internal
+  public interface TrustedAsciiMarshaller<T> {
+    /**
+     * Serialize a metadata value to a ASCII string that contains only the characters listed in the
+     * class comment of {@link io.grpc.Metadata.AsciiMarshaller}. Otherwise the output may be
+     * considered invalid and discarded by the transport, or the call may fail.
+     *
+     * @param value to serialize
+     * @return serialized version of value, or null if value cannot be transmitted.
+     */
+    byte[] toAsciiString(T value);
+
+    /**
+     * Parse a serialized metadata value from an ASCII string.
+     *
+     * @param serialized value of metadata to parse
+     * @return a parsed instance of type T
+     */
+    T parseAsciiString(byte[] serialized);
+  }
+
+  /**
+   * Copy of StandardCharsets, which is only available on Java 1.7 and above.
+   */
+  public static final Charset US_ASCII = Charset.forName("US-ASCII");
+
+  @Internal
+  public static <T> Key<T> keyOf(String name, TrustedAsciiMarshaller<T> marshaller) {
+    return Metadata.Key.of(name, marshaller);
+  }
+}


### PR DESCRIPTION
This introduces the idea of a "Trusted" Ascii Marshaller, which is
known to always produce valid ASCII byte arrays.  This saves a
surprising amount of garbage, since String conversion involves
creating a new java.lang.StringCoding, and a sun.nio.cs.US_ASCII.

There are other types that can be converted (notably
Http2ClientStream's :status marshaller, which is particularly
wasteful).

Before:
```
Benchmark                              Mode     Cnt     Score    Error  Units
StatusBenchmark.codeDecode           sample  641278    88.889 ±  9.673  ns/op
StatusBenchmark.codeEncode           sample  430800    73.014 ±  1.444  ns/op
StatusBenchmark.messageDecodeEscape  sample  433467   441.078 ± 58.373  ns/op
StatusBenchmark.messageDecodePlain   sample  676526   268.620 ±  7.849  ns/op
StatusBenchmark.messageEncodeEscape  sample  547350  1211.243 ± 29.907  ns/op
StatusBenchmark.messageEncodePlain   sample  419318   223.263 ±  9.673  ns/op
```

After:
```
Benchmark                              Mode     Cnt    Score    Error  Units
StatusBenchmark.codeDecode           sample  442241   48.310 ±  2.409  ns/op
StatusBenchmark.codeEncode           sample  622026   35.475 ±  0.642  ns/op
StatusBenchmark.messageDecodeEscape  sample  595572  312.407 ± 15.870  ns/op
StatusBenchmark.messageDecodePlain   sample  565581   99.090 ±  8.799  ns/op
StatusBenchmark.messageEncodeEscape  sample  479147  201.422 ± 10.765  ns/op
StatusBenchmark.messageEncodePlain   sample  560957   94.722 ±  1.187  ns/op
```

Also fixes #2237

cc: @ejona86 for the fairly complex parsing logic.