### PR TITLE
core,protobuf: Add simple argument introspection for methods

### DIFF
--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -147,6 +147,34 @@ public class MethodDescriptor<ReqT, RespT> {
     public T parse(InputStream stream);
   }
 
+  /** A marshaller that supports retrieving it's type parameter {@code T} at runtime. */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2222")
+  public interface ReflectableMarshaller<T> extends Marshaller<T> {
+    /**
+     * Returns the {@code Class} that this marshaller serializes and deserializes. If inheritance is
+     * allowed, this is the base class or interface for all supported classes.
+     *
+     * @return non-{@code null} base class for all objects produced and consumed by this marshaller
+     */
+    public Class<T> getMessageClass();
+  }
+
+  /** A marshaller that uses a fixed instance of the type it produces. */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2222")
+  public interface PrototypeMarshaller<T> extends ReflectableMarshaller<T> {
+    /**
+     * An instance of the expected message type, typically used as a schema and helper for producing
+     * other message instances. The {@code null} value may be a special value for the marshaller
+     * (like the equivalent of {@link Void}), so it is a valid return value. {@code null} does
+     * <em>not</em> mean "unsupported" or "unknown".
+     *
+     * <p>It is generally expected this would return the same instance each invocation, but it is
+     * not a requirement.
+     */
+    @Nullable
+    public T getMessagePrototype();
+  }
+
   /**
    * Creates a new {@code MethodDescriptor}.
    *
@@ -228,6 +256,20 @@ public class MethodDescriptor<ReqT, RespT> {
    */
   public InputStream streamResponse(RespT response) {
     return responseMarshaller.stream(response);
+  }
+
+  /**
+   * Returns the marshaller for the request type. Allows introspection of the request marshaller.
+   */
+  public Marshaller<ReqT> getRequestMarshaller() {
+    return requestMarshaller;
+  }
+
+  /**
+   * Returns the marshaller for the response type. Allows introspection of the response marshaller.
+   */
+  public Marshaller<RespT> getResponseMarshaller() {
+    return responseMarshaller;
   }
 
   /**

--- a/protobuf-lite/src/test/java/io/grpc/protobuf/lite/ProtoLiteUtilsTest.java
+++ b/protobuf-lite/src/test/java/io/grpc/protobuf/lite/ProtoLiteUtilsTest.java
@@ -47,6 +47,7 @@ import com.google.protobuf.Type;
 import io.grpc.Drainable;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.MethodDescriptor.PrototypeMarshaller;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
@@ -116,6 +117,14 @@ public class ProtoLiteUtilsTest {
     // Enum's name and Type's name are both strings with tag 1.
     Enum altProto = Enum.newBuilder().setName(proto.getName()).build();
     assertEquals(proto, marshaller.parse(enumMarshaller.stream(altProto)));
+  }
+
+  @Test
+  public void introspection() throws Exception {
+    Marshaller<Enum> enumMarshaller = ProtoLiteUtils.marshaller(Enum.getDefaultInstance());
+    PrototypeMarshaller<Enum> prototypeMarshaller = (PrototypeMarshaller<Enum>) enumMarshaller;
+    assertSame(Enum.getDefaultInstance(), prototypeMarshaller.getMessagePrototype());
+    assertSame(Enum.class, prototypeMarshaller.getMessageClass());
   }
 
   @Test


### PR DESCRIPTION
The cast required in protobuf makes me question how much I like
ReflectableMarshaller, but it seems to be pretty sound and the cast is
more an artifact of generics than the API.

Nano and Thrift were purposefully not updated, since getting just the
class requires making a new message instance. That seems a bit lame. It
probably is no burden to create an instance to get the class, and it may
not be too hard to improve the factory to provide class information, but
didn't want to bother at this point. Especially since nano users are
unlikely to need the introspection functionality.