### PR TITLE
core/internal: replace make Stream id a primitive

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -48,7 +48,7 @@ import java.util.logging.Logger;
 /**
  * The abstract base class for {@link ClientStream} implementations.
  */
-public abstract class AbstractClientStream<IdT> extends AbstractStream<IdT>
+public abstract class AbstractClientStream extends AbstractStream
     implements ClientStream {
 
   private static final Logger log = Logger.getLogger(AbstractClientStream.class.getName());

--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -43,7 +43,6 @@ import io.grpc.Decompressor;
 
 import java.io.InputStream;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
@@ -51,12 +50,14 @@ import javax.annotation.concurrent.GuardedBy;
  *
  * @param <IdT> type of the unique identifier of this stream.
  */
-public abstract class AbstractStream<IdT> implements Stream {
+public abstract class AbstractStream implements Stream {
   /**
    * The default number of queued bytes for a given stream, below which
    * {@link StreamListener#onReady()} will be called.
    */
   public static final int DEFAULT_ONREADY_THRESHOLD = 32 * 1024;
+
+  public static final int ABSENT_ID = -1;
 
   /**
    * Indicates the phase of the GRPC stream in one direction.
@@ -147,12 +148,11 @@ public abstract class AbstractStream<IdT> implements Stream {
   protected abstract StreamListener listener();
 
   /**
-   * Returns the internal ID for this stream. Note that ID can be {@code null} for client streams
-   * as the transport may defer creating the stream to the remote side until it has a payload or
-   * metadata to send.
+   * Returns the internal ID for this stream. Note that ID can be {@link #ABSENT_ID} for client
+   * streams as the transport may defer creating the stream to the remote side until it has a
+   * payload or metadata to send.
    */
-  @Nullable
-  public abstract IdT id();
+  public abstract int id();
 
   /**
    * The number of queued bytes for a given stream, below which {@link StreamListener#onReady()}

--- a/core/src/main/java/io/grpc/internal/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStream.java
@@ -44,7 +44,7 @@ import javax.annotation.Nullable;
 /**
  * Base implementation for client streams using HTTP2 as the transport.
  */
-public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
+public abstract class Http2ClientStream extends AbstractClientStream {
 
   /**
    * Metadata marshaller for HTTP status lines.

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -84,7 +84,7 @@ public class AbstractClientStreamTest {
   public void cancel_doNotAcceptOk() {
     for (Code code : Code.values()) {
       ClientStreamListener listener = new NoopClientStreamListener();
-      AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+      AbstractClientStream stream = new BaseAbstractClientStream(allocator);
       stream.start(listener);
       if (code != Code.OK) {
         stream.cancel(Status.fromCodeValue(code.value()));
@@ -102,7 +102,7 @@ public class AbstractClientStreamTest {
   @Test
   public void cancel_failsOnNull() {
     ClientStreamListener listener = new NoopClientStreamListener();
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(listener);
     thrown.expect(NullPointerException.class);
 
@@ -111,7 +111,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void cancel_notifiesOnlyOnce() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator) {
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator) {
       @Override
       protected void sendCancel(Status errorStatus) {
         transportReportStatus(errorStatus, true/*stop delivery*/, new Metadata());
@@ -126,7 +126,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void startFailsOnNullListener() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
 
     thrown.expect(NullPointerException.class);
 
@@ -135,7 +135,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void cantCallStartTwice() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(mockListener);
     thrown.expect(IllegalStateException.class);
 
@@ -144,7 +144,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void deframeFailed_notifiesListener() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator) {
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator) {
       @Override
       protected void sendCancel(Status errorStatus) {
         transportReportStatus(errorStatus, true/*stop delivery*/, new Metadata());
@@ -161,7 +161,7 @@ public class AbstractClientStreamTest {
   @Test
   public void inboundDataReceived_failsOnNullFrame() {
     ClientStreamListener listener = new NoopClientStreamListener();
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(listener);
     thrown.expect(NullPointerException.class);
 
@@ -170,7 +170,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void inboundDataReceived_failsOnNoHeaders() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(mockListener);
     stream.inboundPhase(Phase.HEADERS);
 
@@ -182,7 +182,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void inboundHeadersReceived_notifiesListener() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(mockListener);
     Metadata headers = new Metadata();
 
@@ -192,7 +192,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void inboundHeadersReceived_failsOnPhaseStatus() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(mockListener);
     Metadata headers = new Metadata();
     stream.inboundPhase(Phase.STATUS);
@@ -204,7 +204,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void inboundHeadersReceived_succeedsOnPhaseMessage() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(mockListener);
     Metadata headers = new Metadata();
     stream.inboundPhase(Phase.MESSAGE);
@@ -216,7 +216,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void inboundHeadersReceived_acceptsGzipEncoding() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(mockListener);
     Metadata headers = new Metadata();
     headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, new Codec.Gzip().getMessageEncoding());
@@ -227,7 +227,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void inboundHeadersReceived_acceptsIdentityEncoding() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(mockListener);
     Metadata headers = new Metadata();
     headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, Codec.Identity.NONE.getMessageEncoding());
@@ -238,7 +238,7 @@ public class AbstractClientStreamTest {
 
   @Test
   public void rstStreamClosesStream() {
-    AbstractClientStream<Integer> stream = new BaseAbstractClientStream<Integer>(allocator);
+    AbstractClientStream stream = new BaseAbstractClientStream(allocator);
     stream.start(mockListener);
     // The application will call request when waiting for a message, which will in turn call this
     // on the transport thread.
@@ -255,7 +255,7 @@ public class AbstractClientStreamTest {
   /**
    * No-op base class for testing.
    */
-  private static class BaseAbstractClientStream<T> extends AbstractClientStream<T> {
+  private static class BaseAbstractClientStream extends AbstractClientStream {
     protected BaseAbstractClientStream(WritableBufferAllocator allocator) {
       super(allocator, DEFAULT_MAX_MESSAGE_SIZE);
     }
@@ -273,8 +273,8 @@ public class AbstractClientStreamTest {
     protected void sendCancel(Status reason) {}
 
     @Override
-    public T id() {
-      return null;
+    public int id() {
+      return ABSENT_ID;
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/AbstractStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractStreamTest.java
@@ -51,8 +51,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.InputStream;
 
-import javax.annotation.Nullable;
-
 @RunWith(JUnit4.class)
 public class AbstractStreamTest {
   @Mock private StreamListener streamListener;
@@ -74,7 +72,7 @@ public class AbstractStreamTest {
 
   @Test
   public void onStreamAllocated_shouldNotifyReady() {
-    AbstractStream<Object> stream = new AbstractStreamBase<Object>(null);
+    AbstractStream stream = new AbstractStreamBase(null);
 
     stream.onStreamAllocated();
 
@@ -83,7 +81,7 @@ public class AbstractStreamTest {
 
   @Test
   public void setMessageCompression() {
-    AbstractStream<?> as = new AbstractStreamBase<Void>(framer, deframer);
+    AbstractStream as = new AbstractStreamBase(framer, deframer);
     as.setMessageCompression(true);
 
     verify(framer).setMessageCompression(true);
@@ -91,7 +89,7 @@ public class AbstractStreamTest {
 
   @Test
   public void validPhaseTransitions() {
-    AbstractStream<Object> stream = new AbstractStreamBase<Object>(null);
+    AbstractStream stream = new AbstractStreamBase(null);
     Multimap<Phase, Phase> validTransitions = ImmutableMultimap.<Phase, Phase>builder()
         .put(Phase.HEADERS, Phase.HEADERS)
         .put(Phase.HEADERS, Phase.MESSAGE)
@@ -120,7 +118,7 @@ public class AbstractStreamTest {
   /**
    * Base class for testing.
    */
-  private class AbstractStreamBase<IdT> extends AbstractStream<IdT> {
+  private class AbstractStreamBase extends AbstractStream {
     private AbstractStreamBase(WritableBufferAllocator bufferAllocator) {
       super(allocator, DEFAULT_MAX_MESSAGE_SIZE);
     }
@@ -135,9 +133,8 @@ public class AbstractStreamTest {
     }
 
     @Override
-    @Nullable
-    public IdT id() {
-      throw new UnsupportedOperationException();
+    public int id() {
+      return ABSENT_ID;
     }
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -31,6 +31,7 @@
 
 package io.grpc.netty;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
@@ -72,7 +73,7 @@ abstract class NettyClientStream extends Http2ClientStream implements StreamIdHo
   private AsciiString authority;
 
   private Http2Stream http2Stream;
-  private Integer id;
+  private int id;
   private WriteQueue writeQueue;
 
   NettyClientStream(MethodDescriptor<?, ?> method, Metadata headers, Channel channel,
@@ -148,11 +149,12 @@ abstract class NettyClientStream extends Http2ClientStream implements StreamIdHo
   }
 
   @Override
-  public Integer id() {
+  public int id() {
     return id;
   }
 
   public void id(int id) {
+    checkArgument(id != ABSENT_ID, "Can't use absent id");
     this.id = id;
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -166,7 +166,8 @@ class NettyServerStream extends AbstractServerStream {
       super.inboundDataReceived(new NettyReadableBuffer(frame.retain()), endOfStream);
     }
 
-    public Integer id() {
+    @Override
+    public int id() {
       return http2Stream.id();
     }
   }

--- a/netty/src/main/java/io/grpc/netty/StreamIdHolder.java
+++ b/netty/src/main/java/io/grpc/netty/StreamIdHolder.java
@@ -33,5 +33,8 @@ package io.grpc.netty;
 
 /** Container for stream ids. */
 interface StreamIdHolder {
-  public Integer id();
+  /**
+   * Returns the id or {@link io.grpc.internal.AbstractStream#ABSENT_ID}.
+   */
+  int id();
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -299,7 +299,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
 
   @GuardedBy("lock")
   private void startStream(OkHttpClientStream stream) {
-    Preconditions.checkState(stream.id() == null, "StreamId already assigned");
+    Preconditions.checkState(
+        stream.id() == OkHttpClientStream.ABSENT_ID, "StreamId already assigned");
     streams.put(nextStreamId, stream);
     setInUse();
     stream.start(nextStreamId);


### PR DESCRIPTION
More Allocation profiler denoising.  Integer autoboxes a lot.   Saves about 1300 allocations per second.

I used a boolean for presence in Netty, and used the magic value in OkHttp so you can see how they look.    If you prefer one over the other I can unify them.