### PR TITLE
protobuf: fast path zero sized messages

### DIFF
--- a/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
+++ b/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
@@ -139,6 +139,8 @@ public class ProtoLiteUtils {
                 throw new RuntimeException("size inaccurate: " + buf.length + " != " + position);
               }
               cis = CodedInputStream.newInstance(buf);
+            } else if (size == 0) {
+              return defaultInstance;
             }
           }
         } catch (IOException e) {


### PR DESCRIPTION
Benchmarks commonly use 0 size messages.  Return the default instance in that case.