### PR TITLE
core: reimplement Metadata to avoid allocation.

### DIFF
--- a/core/src/main/java/io/grpc/InternalMetadata.java
+++ b/core/src/main/java/io/grpc/InternalMetadata.java
@@ -71,10 +71,27 @@ public final class InternalMetadata {
   /**
    * Copy of StandardCharsets, which is only available on Java 1.7 and above.
    */
+  @Internal
   public static final Charset US_ASCII = Charset.forName("US-ASCII");
 
   @Internal
   public static <T> Key<T> keyOf(String name, TrustedAsciiMarshaller<T> marshaller) {
     return Metadata.Key.of(name, marshaller);
+  }
+
+
+  @Internal
+  public static Metadata newMetadata(byte[]... binaryValues) {
+    return new Metadata(binaryValues);
+  }
+
+  @Internal
+  public static Metadata newMetadata(int usedNames, byte[]... binaryValues) {
+    return new Metadata(usedNames, binaryValues);
+  }
+
+  @Internal
+  public static byte[][] serialize(Metadata md) {
+    return md.serialize();
   }
 }

--- a/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
+++ b/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
@@ -35,6 +35,7 @@ import static com.google.common.base.Charsets.US_ASCII;
 
 import com.google.common.io.BaseEncoding;
 
+import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 
 import java.util.Arrays;
@@ -61,7 +62,11 @@ public final class TransportFrameUtil {
    * @return the interleaved keys and values.
    */
   public static byte[][] toHttp2Headers(Metadata headers) {
-    byte[][] serializedHeaders = headers.serialize();
+    byte[][] serializedHeaders = InternalMetadata.serialize(headers);
+    // TODO(carl-mastrangelo): eventually remove this once all callers are updated.
+    if (serializedHeaders == null) {
+      return new byte[][]{};
+    }
     int k = 0;
     for (int i = 0; i < serializedHeaders.length; i += 2) {
       byte[] key = serializedHeaders[i];

--- a/core/src/test/java/io/grpc/MetadataTest.java
+++ b/core/src/test/java/io/grpc/MetadataTest.java
@@ -38,7 +38,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -126,12 +125,20 @@ public class MetadataTest {
   }
 
   @Test
+  public void discardAll_empty() {
+    Metadata metadata = new Metadata();
+    metadata.discardAll(KEY);
+    assertEquals(null, metadata.getAll(KEY));
+    assertEquals(null, metadata.get(KEY));
+  }
+
+  @Test
   public void testGetAllNoRemove() {
     Fish lance = new Fish(LANCE);
     Metadata metadata = new Metadata();
     metadata.put(KEY, lance);
     Iterator<Fish> i = metadata.getAll(KEY).iterator();
-    assertSame(lance, i.next());
+    assertEquals(lance, i.next());
 
     thrown.expect(UnsupportedOperationException.class);
     i.remove();
@@ -142,20 +149,18 @@ public class MetadataTest {
     Fish lance = new Fish(LANCE);
     Metadata metadata = new Metadata();
     metadata.put(KEY, lance);
-    // Should be able to read same instance out
-    assertSame(lance, metadata.get(KEY));
+    assertEquals(lance, metadata.get(KEY));
     Iterator<Fish> fishes = metadata.<Fish>getAll(KEY).iterator();
     assertTrue(fishes.hasNext());
-    assertSame(fishes.next(), lance);
+    assertEquals(fishes.next(), lance);
     assertFalse(fishes.hasNext());
     byte[][] serialized = metadata.serialize();
     assertEquals(2, serialized.length);
     assertEquals(new String(serialized[0], US_ASCII), "test-bin");
     assertArrayEquals(LANCE_BYTES, serialized[1]);
-    assertSame(lance, metadata.get(KEY));
-    // Serialized instance should be cached too
-    assertSame(serialized[0], metadata.serialize()[0]);
-    assertSame(serialized[1], metadata.serialize()[1]);
+    assertEquals(lance, metadata.get(KEY));
+    assertEquals(serialized[0], metadata.serialize()[0]);
+    assertEquals(serialized[1], metadata.serialize()[1]);
   }
 
   @Test
@@ -164,7 +169,7 @@ public class MetadataTest {
     Fish lance = raw.get(KEY);
     assertEquals(lance, new Fish(LANCE));
     // Reading again should return the same parsed instance
-    assertSame(lance, raw.get(KEY));
+    assertEquals(lance, raw.get(KEY));
   }
 
   @Test
@@ -199,7 +204,7 @@ public class MetadataTest {
 
     Iterator<Fish> fishes = h1.<Fish>getAll(KEY).iterator();
     assertTrue(fishes.hasNext());
-    assertSame(fishes.next(), lance);
+    assertEquals(fishes.next(), lance);
     assertFalse(fishes.hasNext());
   }
 
@@ -242,15 +247,27 @@ public class MetadataTest {
     Metadata h = new Metadata();
     h.put(KEY, new Fish("binary"));
     h.put(Metadata.Key.of("test", Metadata.ASCII_STRING_MARSHALLER), "ascii");
-    assertEquals("Metadata({test-bin=[Fish(binary)], test=[ascii]})", h.toString());
+    assertEquals("Metadata(test-bin=YmluYXJ5,test=ascii)", h.toString());
 
     Metadata t = new Metadata();
     t.put(Metadata.Key.of("test", Metadata.ASCII_STRING_MARSHALLER), "ascii");
-    assertEquals("Metadata({test=[ascii]})", t.toString());
+    assertEquals("Metadata(test=ascii)", t.toString());
 
     t = new Metadata("test".getBytes(US_ASCII), "ascii".getBytes(US_ASCII),
         "test-bin".getBytes(US_ASCII), "binary".getBytes(US_ASCII));
-    assertEquals("Metadata({test=[ascii], test-bin=[[98, 105, 110, 97, 114, 121]]})", t.toString());
+    assertEquals("Metadata(test=ascii,test-bin=YmluYXJ5)", t.toString());
+  }
+
+  @Test
+  public void verifyToString_usingBinary() {
+    Metadata h = new Metadata();
+    h.put(KEY, new Fish("binary"));
+    h.put(Metadata.Key.of("test", Metadata.ASCII_STRING_MARSHALLER), "ascii");
+    assertEquals("Metadata(test-bin=YmluYXJ5,test=ascii)", h.toString());
+
+    Metadata t = new Metadata();
+    t.put(Metadata.Key.of("test", Metadata.ASCII_STRING_MARSHALLER), "ascii");
+    assertEquals("Metadata(test=ascii)", t.toString());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/TransportFrameUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportFrameUtilTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.fail;
 
 import com.google.common.io.BaseEncoding;
 
+import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.Metadata.BinaryMarshaller;
 import io.grpc.Metadata.Key;
@@ -110,7 +111,7 @@ public class TransportFrameUtilTest {
     headers.put(BINARY_STRING_WITHOUT_SUFFIX, NONCOMPLIANT_ASCII_STRING);
     byte[][] http2Headers = TransportFrameUtil.toHttp2Headers(headers);
     byte[][] rawSerialized = TransportFrameUtil.toRawSerializedHeaders(http2Headers);
-    Metadata recoveredHeaders = new Metadata(rawSerialized);
+    Metadata recoveredHeaders = InternalMetadata.newMetadata(rawSerialized);
     assertEquals(COMPLIANT_ASCII_STRING, recoveredHeaders.get(PLAIN_STRING));
     assertEquals(NONCOMPLIANT_ASCII_STRING, recoveredHeaders.get(BINARY_STRING));
     assertNull(recoveredHeaders.get(BINARY_STRING_WITHOUT_SUFFIX));

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -40,6 +40,7 @@ import static io.netty.util.CharsetUtil.UTF_8;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.GrpcUtil;
@@ -91,9 +92,10 @@ class Utils {
 
   public static Metadata convertHeaders(Http2Headers http2Headers) {
     if (http2Headers instanceof GrpcHttp2InboundHeaders) {
-      return new Metadata(((GrpcHttp2InboundHeaders) http2Headers).namesAndValues());
+      GrpcHttp2InboundHeaders h = (GrpcHttp2InboundHeaders) http2Headers;
+      return InternalMetadata.newMetadata(h.numHeaders(), h.namesAndValues());
     }
-    return new Metadata(convertHeadersToArray(http2Headers));
+    return InternalMetadata.newMetadata(convertHeadersToArray(http2Headers));
   }
 
   private static byte[][] convertHeadersToArray(Http2Headers http2Headers) {
@@ -141,9 +143,10 @@ class Utils {
 
   public static Metadata convertTrailers(Http2Headers http2Headers) {
     if (http2Headers instanceof GrpcHttp2InboundHeaders) {
-      return new Metadata(((GrpcHttp2InboundHeaders) http2Headers).namesAndValues());
+      GrpcHttp2InboundHeaders h = (GrpcHttp2InboundHeaders) http2Headers;
+      return InternalMetadata.newMetadata(h.numHeaders(), h.namesAndValues());
     }
-    return new Metadata(convertHeadersToArray(http2Headers));
+    return InternalMetadata.newMetadata(convertHeadersToArray(http2Headers));
   }
 
   public static Http2Headers convertTrailers(Metadata trailers, boolean headersSent) {

--- a/okhttp/src/main/java/io/grpc/okhttp/Utils.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Utils.java
@@ -33,6 +33,7 @@ package io.grpc.okhttp;
 
 import com.google.common.base.Preconditions;
 
+import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.internal.TransportFrameUtil;
 import io.grpc.okhttp.internal.CipherSuite;
@@ -49,11 +50,11 @@ class Utils {
   static final int CONNECTION_STREAM_ID = 0;
 
   public static Metadata convertHeaders(List<Header> http2Headers) {
-    return new Metadata(convertHeadersToArray(http2Headers));
+    return InternalMetadata.newMetadata(convertHeadersToArray(http2Headers));
   }
 
   public static Metadata convertTrailers(List<Header> http2Headers) {
-    return new Metadata(convertHeadersToArray(http2Headers));
+    return InternalMetadata.newMetadata(convertHeadersToArray(http2Headers));
   }
 
   private static byte[][] convertHeadersToArray(List<Header> http2Headers) {

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -572,14 +572,17 @@ public abstract class AbstractTransportTest {
     clientHeaders.put(asciiKey, "dupvalue");
     clientHeaders.put(asciiKey, "dupvalue");
     clientHeaders.put(binaryKey, "äbinaryclient");
+    Metadata clientHeadersCopy = new Metadata();
+
+    clientHeadersCopy.merge(clientHeaders);
     ClientStream clientStream = client.newStream(methodDescriptor, clientHeaders);
     clientStream.start(mockClientStreamListener);
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     assertEquals(methodDescriptor.getFullMethodName(), serverStreamCreation.method);
-    assertEquals(Lists.newArrayList(clientHeaders.getAll(asciiKey)),
+    assertEquals(Lists.newArrayList(clientHeadersCopy.getAll(asciiKey)),
         Lists.newArrayList(serverStreamCreation.headers.getAll(asciiKey)));
-    assertEquals(Lists.newArrayList(clientHeaders.getAll(binaryKey)),
+    assertEquals(Lists.newArrayList(clientHeadersCopy.getAll(binaryKey)),
         Lists.newArrayList(serverStreamCreation.headers.getAll(binaryKey)));
     ServerStream serverStream = serverStreamCreation.stream;
     ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
@@ -605,11 +608,13 @@ public abstract class AbstractTransportTest {
     serverHeaders.put(asciiKey, "dupvalue");
     serverHeaders.put(asciiKey, "dupvalue");
     serverHeaders.put(binaryKey, "äbinaryserver");
+    Metadata serverHeadersCopy = new Metadata();
+    serverHeadersCopy.merge(serverHeaders);
     serverStream.writeHeaders(serverHeaders);
     verify(mockClientStreamListener, timeout(TIMEOUT_MS)).headersRead(metadataCaptor.capture());
-    assertEquals(Lists.newArrayList(serverHeaders.getAll(asciiKey)),
+    assertEquals(Lists.newArrayList(serverHeadersCopy.getAll(asciiKey)),
         Lists.newArrayList(metadataCaptor.getValue().getAll(asciiKey)));
-    assertEquals(Lists.newArrayList(serverHeaders.getAll(binaryKey)),
+    assertEquals(Lists.newArrayList(serverHeadersCopy.getAll(binaryKey)),
         Lists.newArrayList(metadataCaptor.getValue().getAll(binaryKey)));
 
     clientStream.request(1);


### PR DESCRIPTION
Key things:

* This moves metadata closer to being in the same format as Netty's headers.
* Expectation is that there will be very few or no headers, so use linear time algorithms
* All validation is done in the marshallers.
* Keep a reference to the object.  This will be used when the eventual canonicalization happens.

Proper benchmarks to come, initial results look good.