### PR TITLE
netty: use void promises and improve error handling

### DIFF
--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -186,7 +186,7 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
         fc.initialWindowSize(targetWindow);
         Http2Settings settings = new Http2Settings();
         settings.initialWindowSize(targetWindow);
-        frameWriter().writeSettings(ctx(), settings, ctx().newPromise());
+        frameWriter().writeSettings(ctx(), settings, ctx().voidPromise());
       }
 
     }
@@ -202,7 +202,7 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
     private void sendPing(ChannelHandlerContext ctx) {
       setDataSizeSincePing(0);
       lastPingTime = System.nanoTime();
-      encoder().writePing(ctx, false, payloadBuf.slice(), ctx.newPromise());
+      encoder().writePing(ctx, false, payloadBuf.slice(), ctx.voidPromise());
       pingCount++;
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -385,7 +385,7 @@ class NettyClientHandler extends AbstractNettyHandler {
         logger.fine("Stream IDs have been exhausted for this connection. "
                 + "Initiating graceful shutdown of the connection.");
         lifecycleManager.notifyShutdown(e.getStatus());
-        close(ctx(), ctx().newPromise());
+        close(ctx(), ctx().voidPromise());
       }
       return;
     }
@@ -526,11 +526,11 @@ class NettyClientHandler extends AbstractNettyHandler {
     close(ctx, promise);
     connection().forEachActiveStream(new Http2StreamVisitor() {
       @Override
-      public boolean visit(Http2Stream stream) throws Http2Exception {
+      public boolean visit(Http2Stream stream) {
         NettyClientStream.TransportState clientStream = clientStream(stream);
         if (clientStream != null) {
           clientStream.transportReportStatus(msg.getStatus(), true, new Metadata());
-          resetStream(ctx, stream.id(), Http2Error.CANCEL.code(), ctx.newPromise());
+          resetStream(ctx, stream.id(), Http2Error.CANCEL.code(), ctx.voidPromise());
         }
         stream.close();
         return true;

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -135,8 +135,9 @@ class NettyClientTransport implements ConnectionClientTransport {
       }
     };
     // Write the command requesting the ping
-    handler.getWriteQueue().enqueue(new SendPingCommand(callback, executor), true)
-        .addListener(failureListener);
+    handler.getWriteQueue().enqueue(new SendPingCommand(callback, executor),
+        channel.newPromise().addListener(failureListener),
+        true);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -127,6 +127,9 @@ class NettyServerStream extends AbstractServerStream {
               // Remove the bytes from outbound flow control, optionally notifying
               // the client that they can send more bytes.
               transportState().onSentBytes(numBytes);
+              if (!future.isSuccess()) {
+                transportState().transportReportStatus(Utils.statusFromThrowable(future.cause()));
+              }
             }
           }), flush);
     }

--- a/netty/src/main/java/io/grpc/netty/WriteQueue.java
+++ b/netty/src/main/java/io/grpc/netty/WriteQueue.java
@@ -90,7 +90,7 @@ class WriteQueue {
    *              enqueue will schedule the flush.
    */
   ChannelFuture enqueue(QueuedCommand command, boolean flush) {
-    return enqueue(command, channel.newPromise(), flush);
+    return enqueue(command, channel.voidPromise(), flush);
   }
 
   /**


### PR DESCRIPTION
Changed the write queue to use void promises by default, this brings the advantage that any
failures will be propagated via the channel pipeline automatically and so we don't need to
add a listener checking for errors to every write.

Additionally, improved error reporting in places where we added a listener, but did not check
for errors.

This change requires netty/netty@908464f161385.
