### PR TITLE
examples: fix bound method not same instance as that in service descriptor

### DIFF
--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
@@ -67,7 +67,7 @@ public class HelloJsonServer {
 
   private void start() throws IOException {
     server = ServerBuilder.forPort(port)
-        .addService(bindService(new GreeterImpl()))
+        .addService(new GreeterImpl())
         .build()
         .start();
     logger.info("Server started, listening on " + port);
@@ -114,20 +114,21 @@ public class HelloJsonServer {
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
     }
-  }
 
-  private ServerServiceDefinition bindService(final GreeterImplBase serviceImpl) {
-    return io.grpc.ServerServiceDefinition
-        .builder(GreeterGrpc.getServiceDescriptor())
-        .addMethod(HelloJsonClient.HelloJsonStub.METHOD_SAY_HELLO,
-            asyncUnaryCall(
-              new UnaryMethod<HelloRequest, HelloReply>() {
-                @Override
-                public void invoke(
-                    HelloRequest request, StreamObserver<HelloReply> responseObserver) {
-                  serviceImpl.sayHello(request, responseObserver);
-                }
-              }))
-        .build();
+    @Override
+    public ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition
+          .builder(GreeterGrpc.getServiceDescriptor().getName())
+          .addMethod(HelloJsonClient.HelloJsonStub.METHOD_SAY_HELLO,
+              asyncUnaryCall(
+                  new UnaryMethod<HelloRequest, HelloReply>() {
+                    @Override
+                    public void invoke(
+                        HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+                      sayHello(request, responseObserver);
+                    }
+                  }))
+          .build();
+    }
   }
 }


### PR DESCRIPTION
Fix the following issue.
HelloJsonServer fails to start:
````
Exception in thread "main" java.lang.IllegalStateException: Bound method for helloworld.Greeter/SayHello not same instance as method in service descriptor
	at io.grpc.ServerServiceDefinition$Builder.build(ServerServiceDefinition.java:156)
	at io.grpc.examples.advanced.HelloJsonServer.bindService(HelloJsonServer.java:131)
	at io.grpc.examples.advanced.HelloJsonServer.start(HelloJsonServer.java:70)
	at io.grpc.examples.advanced.HelloJsonServer.main(HelloJsonServer.java:105)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
````