### PR TITLE
core: channel connectivity state API and implementation by TransportSet

### DIFF
--- a/core/src/main/java/io/grpc/ConnectivityState.java
+++ b/core/src/main/java/io/grpc/ConnectivityState.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+/**
+ * The connectivity states.
+ *
+ * @see <a href="https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md">
+ * more information</a>
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/28")
+public enum ConnectivityState {
+  /**
+   * The channel is trying to establish a connection and is waiting to make progress on one of the
+   * steps involved in name resolution, TCP connection establishment or TLS handshake. This may be
+   * used as the initial state for channels upon creation.
+   */
+  CONNECTING,
+
+  /**
+   * The channel has successfully established a connection all the way through TLS handshake (or
+   * equivalent) and all subsequent attempt to communicate have succeeded (or are pending without
+   * any known failure ).
+   */
+  READY,
+
+  /**
+   * There has been some transient failure (such as a TCP 3-way handshake timing out or a socket
+   * error). Channels in this state will eventually switch to the CONNECTING state and try to
+   * establish a connection again. Since retries are done with exponential backoff, channels that
+   * fail to connect will start out spending very little time in this state but as the attempts
+   * fail repeatedly, the channel will spend increasingly large amounts of time in this state. For
+   * many non-fatal failures (e.g., TCP connection attempts timing out because the server is not
+   * yet available), the channel may spend increasingly large amounts of time in this state.
+   */
+  TRANSIENT_FAILURE,
+
+  /**
+   * This is the state where the channel is not even trying to create a connection because of a
+   * lack of new or pending RPCs. New RPCs MAY be created in this state. Any attempt to start an
+   * RPC on the channel will push the channel out of this state to connecting. When there has been
+   * no RPC activity on a channel for a configurable IDLE_TIMEOUT, i.e., no new or pending (active)
+   * RPCs for this period, channels that are READY or CONNECTING switch to IDLE. Additionaly,
+   * channels that receive a GOAWAY when there are no active or pending RPCs should also switch to
+   * IDLE to avoid connection overload at servers that are attempting to shed connections.
+   */
+  IDLE,
+
+  /**
+   * This channel has started shutting down. Any new RPCs should fail immediately. Pending RPCs
+   * may continue running till the application cancels them. Channels may enter this state either
+   * because the application explicitly requested a shutdown or if a non-recoverable error has
+   * happened during attempts to connect communicate . (As of 6/12/2015, there are no known errors
+   * (while connecting or communicating) that are classified as non-recoverable) Channels that
+   * enter this state never leave this state.
+   */
+  SHUTDOWN
+}

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -73,4 +73,33 @@ public abstract class ManagedChannel extends Channel {
    * @return whether the channel is terminated, as would be done by {@link #isTerminated()}.
    */
   public abstract boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException;
+
+  /**
+   * Gets the current connectivity state. Note the result may soon become outdated.
+   *
+   * @param requestConnection if {@code true}, the channel will try to make a connection if it is
+   *        currently IDLE
+   *
+   * @throws UnsupportedOperationException if not supported by implementation
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/28")
+  public ConnectivityState getState(boolean requestConnection) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  /**
+   * Registers a one-off callback that will be run if the connectivity state of the channel diverges
+   * from the given {@code source}, which is typically what has just been returned by {@link
+   * #getState}.  If the states are already different, the callback will be called immediately.  The
+   * callback is run in the same executor that runs Call listeners.
+   *
+   * @param source the assumed current state, typically just returned by {@link #getState}
+   * @param callback the one-off callback
+   *
+   * @throws UnsupportedOperationException if not supported by implementation
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/28")
+  public void notifyWhenStateChanged(ConnectivityState source, Runnable callback) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 }

--- a/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
+++ b/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.ConnectivityState;
+
+import java.util.ArrayList;
+import java.util.concurrent.Executor;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Book-keeps the connectivity state and callbacks.
+ */
+@NotThreadSafe
+class ConnectivityStateManager {
+  private ArrayList<StateCallbackEntry> callbacks;
+
+  private ConnectivityState state;
+
+  ConnectivityStateManager(ConnectivityState initialState) {
+    state = initialState;
+  }
+
+  void notifyWhenStateChanged(Runnable callback, Executor executor, ConnectivityState source) {
+    StateCallbackEntry callbackEntry = new StateCallbackEntry(callback, executor);
+    if (state != source) {
+      callbackEntry.runInExecutor();
+    } else {
+      if (callbacks == null) {
+        callbacks = new ArrayList<StateCallbackEntry>();
+      }
+      callbacks.add(callbackEntry);
+    }
+  }
+
+  // TODO(zhangkun83): return a runnable in order to escape transport set lock, in case direct
+  // executor is used?
+  void gotoState(ConnectivityState newState) {
+    if (state != newState) {
+      if (state == ConnectivityState.SHUTDOWN) {
+        throw new IllegalStateException("Cannot transition out of SHUTDOWN to " + newState);
+      }
+      state = newState;
+      if (callbacks == null) {
+        return;
+      }
+      // Swap out callback list before calling them, because a callback may register new callbacks,
+      // if run in direct executor, can cause ConcurrentModificationException.
+      ArrayList<StateCallbackEntry> savedCallbacks = callbacks;
+      callbacks = null;
+      for (StateCallbackEntry callback : savedCallbacks) {
+        callback.runInExecutor();
+      }
+    }
+  }
+
+  ConnectivityState getState() {
+    return state;
+  }
+
+  private static class StateCallbackEntry {
+    final Runnable callback;
+    final Executor executor;
+
+    StateCallbackEntry(Runnable callback, Executor executor) {
+      this.callback = callback;
+      this.executor = executor;
+    }
+
+    void runInExecutor() {
+      executor.execute(callback);
+    }
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import io.grpc.ConnectivityState;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.LinkedList;
+import java.util.concurrent.Executor;
+
+/**
+ * Unit tests for {@link ConnectivityStateManager}.
+ */
+@RunWith(JUnit4.class)
+public class ConnectivityStateManagerTest {
+  private final FakeClock executor = new FakeClock();
+  private final ConnectivityStateManager state =
+      new ConnectivityStateManager(ConnectivityState.IDLE);
+  private final LinkedList<ConnectivityState> sink = new LinkedList<ConnectivityState>();
+
+  @Test
+  public void noCallback() {
+    state.gotoState(ConnectivityState.CONNECTING);
+    assertEquals(ConnectivityState.CONNECTING, state.getState());
+    state.gotoState(ConnectivityState.TRANSIENT_FAILURE);
+    assertEquals(ConnectivityState.TRANSIENT_FAILURE, state.getState());
+  }
+
+  @Test
+  public void registerCallbackBeforeStateChanged() {
+    state.gotoState(ConnectivityState.CONNECTING);
+    assertEquals(ConnectivityState.CONNECTING, state.getState());
+
+    state.notifyWhenStateChanged(new Runnable() {
+        @Override
+        public void run() {
+          sink.add(state.getState());
+        }
+      }, executor.scheduledExecutorService, ConnectivityState.CONNECTING);
+
+    assertEquals(0, executor.numPendingTasks());
+    state.gotoState(ConnectivityState.TRANSIENT_FAILURE);
+    // Make sure the callback is run in the executor
+    assertEquals(0, sink.size());
+    assertEquals(1, executor.runDueTasks());
+    assertEquals(0, executor.numPendingTasks());
+    assertEquals(1, sink.size());
+    assertEquals(ConnectivityState.TRANSIENT_FAILURE, sink.poll());
+  }
+  
+  @Test
+  public void registerCallbackAfterStateChanged() {
+    state.gotoState(ConnectivityState.CONNECTING);
+    assertEquals(ConnectivityState.CONNECTING, state.getState());
+
+    state.notifyWhenStateChanged(new Runnable() {
+        @Override
+        public void run() {
+          sink.add(state.getState());
+        }
+      }, executor.scheduledExecutorService, ConnectivityState.IDLE);
+
+    // Make sure the callback is run in the executor
+    assertEquals(0, sink.size());
+    assertEquals(1, executor.runDueTasks());
+    assertEquals(0, executor.numPendingTasks());
+    assertEquals(1, sink.size());
+    assertEquals(ConnectivityState.CONNECTING, sink.poll());
+  }
+
+  @Test
+  public void callbackOnlyCalledOnTransition() {
+    state.notifyWhenStateChanged(new Runnable() {
+        @Override
+        public void run() {
+          sink.add(state.getState());
+        }
+      }, executor.scheduledExecutorService, ConnectivityState.IDLE);
+
+    state.gotoState(ConnectivityState.IDLE);
+    assertEquals(0, executor.numPendingTasks());
+    assertEquals(0, sink.size());
+  }
+
+  @Test
+  public void callbacksAreOneShot() {
+    Runnable callback = new Runnable() {
+        @Override
+        public void run() {
+          sink.add(state.getState());
+        }
+      };
+
+    state.notifyWhenStateChanged(callback, executor.scheduledExecutorService,
+        ConnectivityState.IDLE);
+    // First transition triggers the callback
+    state.gotoState(ConnectivityState.CONNECTING);
+    assertEquals(1, executor.runDueTasks());
+    assertEquals(1, sink.size());
+    assertEquals(ConnectivityState.CONNECTING, sink.poll());
+    assertEquals(0, executor.numPendingTasks());
+
+    // Second transition doesn't trigger the callback
+    state.gotoState(ConnectivityState.TRANSIENT_FAILURE);
+    assertEquals(0, sink.size());
+    assertEquals(0, executor.numPendingTasks());
+
+    // Register another callback
+    state.notifyWhenStateChanged(callback, executor.scheduledExecutorService,
+        ConnectivityState.TRANSIENT_FAILURE);
+
+    state.gotoState(ConnectivityState.READY);
+    state.gotoState(ConnectivityState.IDLE);
+    // Callback loses the race with the second stage change
+    assertEquals(1, executor.runDueTasks());
+    assertEquals(1, sink.size());
+    // It will see the second state
+    assertEquals(ConnectivityState.IDLE, sink.poll());
+    assertEquals(0, executor.numPendingTasks());
+  }
+
+  @Test
+  public void multipleCallbacks() {
+    final LinkedList<String> callbackRuns = new LinkedList<String>();
+    state.notifyWhenStateChanged(new Runnable() {
+        @Override
+        public void run() {
+          sink.add(state.getState());
+          callbackRuns.add("callback1");
+        }
+      }, executor.scheduledExecutorService, ConnectivityState.IDLE);
+    state.notifyWhenStateChanged(new Runnable() {
+        @Override
+        public void run() {
+          sink.add(state.getState());
+          callbackRuns.add("callback2");
+        }
+      }, executor.scheduledExecutorService, ConnectivityState.IDLE);
+    state.notifyWhenStateChanged(new Runnable() {
+        @Override
+        public void run() {
+          sink.add(state.getState());
+          callbackRuns.add("callback3");
+        }
+      }, executor.scheduledExecutorService, ConnectivityState.READY);
+
+    // callback3 is run immediately because the source state is already different from the current
+    // state.
+    assertEquals(1, executor.runDueTasks());
+    assertEquals(1, callbackRuns.size());
+    assertEquals("callback3", callbackRuns.poll());
+    assertEquals(1, sink.size());
+    assertEquals(ConnectivityState.IDLE, sink.poll());
+
+    // Now change the state.
+    state.gotoState(ConnectivityState.CONNECTING);
+    assertEquals(2, executor.runDueTasks());
+    assertEquals(2, callbackRuns.size());
+    assertEquals("callback1", callbackRuns.poll());
+    assertEquals("callback2", callbackRuns.poll());
+    assertEquals(2, sink.size());
+    assertEquals(ConnectivityState.CONNECTING, sink.poll());
+    assertEquals(ConnectivityState.CONNECTING, sink.poll());
+
+    assertEquals(0, executor.numPendingTasks());
+  }
+
+  private Runnable newRecursiveCallback(final Executor executor) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        sink.add(state.getState());
+        state.notifyWhenStateChanged(newRecursiveCallback(executor), executor, state.getState());
+      }
+    };
+  }
+
+  @Test
+  public void registerCallbackFromCallback() {
+    state.notifyWhenStateChanged(newRecursiveCallback(executor.scheduledExecutorService),
+        executor.scheduledExecutorService, state.getState());
+
+    state.gotoState(ConnectivityState.CONNECTING);
+    assertEquals(1, executor.runDueTasks());
+    assertEquals(0, executor.numPendingTasks());
+    assertEquals(1, sink.size());
+    assertEquals(ConnectivityState.CONNECTING, sink.poll());
+
+    state.gotoState(ConnectivityState.READY);
+    assertEquals(1, executor.runDueTasks());
+    assertEquals(0, executor.numPendingTasks());
+    assertEquals(1, sink.size());
+    assertEquals(ConnectivityState.READY, sink.poll());
+  }
+
+  @Test
+  public void registerCallbackFromCallbackDirectExecutor() {
+    state.notifyWhenStateChanged(newRecursiveCallback(MoreExecutors.directExecutor()),
+        MoreExecutors.directExecutor(), state.getState());
+
+    state.gotoState(ConnectivityState.CONNECTING);
+    assertEquals(1, sink.size());
+    assertEquals(ConnectivityState.CONNECTING, sink.poll());
+
+    state.gotoState(ConnectivityState.READY);
+    assertEquals(1, sink.size());
+    assertEquals(ConnectivityState.READY, sink.poll());
+  }
+}


### PR DESCRIPTION
This is the first step of #28. Spec is [here](https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md).

The state API is added to ManagedChannel. TransportSet is changed to extend ManagedChannel, which would allow a LoadBalancer to 1) listen to the connectivity state of a TransportSet, and 2) shutdown a TransportSet, as required by the upcoming new LoadBalancer API outlined in #1600.

Please review the PR as a whole.