### PR TITLE
PoC: Reduce allocations & copies deserializing protobuf.

### DIFF
--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -19,7 +19,8 @@ description = 'gRPC: Protobuf Lite'
 dependencies {
     compile project(':grpc-core'),
             libraries.protobuf_lite,
-            libraries.guava
+            libraries.guava,
+            libraries.netty
 
     testProtobuf libraries.protobuf
 }


### PR DESCRIPTION
This is a proof of concept that aims to reduce the allocations and copies when deserializing protobufs.

- 62e4913: byte[] are pooled using netty's memory allocator. This avoids repeated zeroing of byte arrays and garbage creation. This gives about 10% througput improvement on SINGLE_THROUGHPUT (1MiB msgs) and MULTI_THROUGHPUT(64KiB msgs). It's a complete hack, would need to integrate this into the Netty layer properly.
- d378962: `CodedInputStream` has a package private factory method that allows one to specify that a buffer is immutable. Using this method via reflection gives another ~20% throughput improvement on large messages, as it avoids a copy inside protobuf [1].

Combined gains for large (64KiB - 1MiB) messages seem substantial. I get 30 - 40% higher throughput using two 8 core cloud VMs. Time spend in GC is reduced from ~25% to <1%. The allocations outside of TLABs are more than halfed. That's especially important, as those need a global lock for allocation.

[1] https://github.com/google/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/CodedInputStream.java#L510

Thoughts @nmittler @carl-mastrangelo @ejona86 @louiscryan ?