### PR TITLE
core: fix a discrepency in state transition.

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -78,6 +78,12 @@ public abstract class AbstractManagedChannelImplBuilder
   static final long IDLE_MODE_MAX_TIMEOUT_DAYS = 30;
 
   /**
+   * The default idle timeout.
+   */
+  @VisibleForTesting
+  static final long IDLE_MODE_DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(30);
+
+  /**
    * An idle timeout smaller than this would be capped to it.
    */
   @VisibleForTesting
@@ -110,7 +116,7 @@ public abstract class AbstractManagedChannelImplBuilder
   @Nullable
   private CompressorRegistry compressorRegistry;
 
-  private long idleTimeoutMillis = ManagedChannelImpl.IDLE_TIMEOUT_MILLIS_DISABLE;
+  private long idleTimeoutMillis = IDLE_MODE_DEFAULT_TIMEOUT_MILLIS;
 
   protected AbstractManagedChannelImplBuilder(String target) {
     this.target = Preconditions.checkNotNull(target, "target");

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -75,7 +75,8 @@ public class AbstractManagedChannelImplBuilderTest {
 
     Builder builder = new Builder();
 
-    assertEquals(ManagedChannelImpl.IDLE_TIMEOUT_MILLIS_DISABLE, builder.getIdleTimeoutMillis());
+    assertEquals(AbstractManagedChannelImplBuilder.IDLE_MODE_DEFAULT_TIMEOUT_MILLIS,
+        builder.getIdleTimeoutMillis());
 
     builder.idleTimeout(Long.MAX_VALUE, TimeUnit.DAYS);
     assertEquals(ManagedChannelImpl.IDLE_TIMEOUT_MILLIS_DISABLE, builder.getIdleTimeoutMillis());


### PR DESCRIPTION
Channel state API doesn't allow a TRANSIENT_FAILURE->IDLE edge.
Change TransportSet to always transition to CONNECTING after
TRANSIENT_FAILURE.

This behavior, combined with that it never uses IDLE_TIMEOUT to
transition from READY to IDLE, effectively makes TransportSet
Channel-state API-compliant under an infinite IDLE_TIMEOUT.

Also set the default IDLE_TIMEOUT to 30min.

This would affect #1600 in the sense that RR LB won't need to react to
request for reconnect for addresses seeing TRANSIENT_FAILUREs.