### PR TITLE
examples: fix dependencies

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,11 +23,13 @@ repositories {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.1.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+def protobufVersion = '3.0.0'
 
 dependencies {
   compile "io.grpc:grpc-netty:${grpcVersion}"
   compile "io.grpc:grpc-protobuf:${grpcVersion}"
   compile "io.grpc:grpc-stub:${grpcVersion}"
+  compile "com.google.protobuf:protobuf-java:${protobufVersion}"
 }
 
 protobuf {
@@ -35,7 +37,7 @@ protobuf {
     // The version of protoc must match protobuf-java. If you don't depend on
     // protobuf-java directly, you will be transitively depending on the
     // protobuf-java version that grpc depends on.
-    artifact = 'com.google.protobuf:protoc:3.0.0'
+    artifact = "com.google.protobuf:protoc:${protobufVersion}"
   }
   plugins {
     grpc {

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'examples'
-include 'thrift'

--- a/examples/thrift/build.gradle
+++ b/examples/thrift/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   compile "io.grpc:grpc-stub:${grpcVersion}"
   compile "io.grpc:grpc-thrift:${grpcVersion}"
   compile "io.grpc:grpc-netty:${grpcVersion}"
+  compile "org.apache.thrift:libthrift:0.9.3"
 }
 
 String generatedSourcePath = "${projectDir}/src/generated"


### PR DESCRIPTION
- add missing dependency for v1.1.0-SNAPSHOT (not needed for v1.0.0 though)
  `com.google.protobuf:protobuf-java`

- add missing dependency for `examples/thrift`
  `org.apache.thrift:libthrift`

- remove `examples/thrift` project in `examples/setting.gradle` for two reasons:
 * with `examples/thrift` project, one need build `:grpc-thrift` project first and then copy `grpc-thrift-1.1.0-SNAPSHOT.jar` to the local maven repo as it is not available in maven central repo. This step is not straightforward for users who typically just want to build `examples` without `examples/thrift`;
 * thrift is not in `examples/pom.xml` either.