### PR TITLE
interop-testing: limit the amount of noise from failing tests

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -40,8 +40,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.ComputeEngineCredentials;
@@ -90,6 +88,8 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -988,5 +988,36 @@ public abstract class AbstractInteropTest {
     Assume.assumeTrue(
         actuallyFreeMemory + " is not sufficient to run this test",
         actuallyFreeMemory >= 64 * 1024 * 1024);
+  }
+
+  /**
+   * Wrapper around {@link Mockito#verify}, to keep log spam down on failure.
+   */
+  private static <T> T verify(T mock, VerificationMode mode) {
+    try {
+      return Mockito.verify(mock, mode);
+    } catch (AssertionError e) {
+      String msg = e.getMessage();
+      if (msg.length() >= 256) {
+        throw new AssertionError(msg.substring(0, 256), e);
+      }
+      throw e;
+    }
+
+  }
+
+  /**
+   * Wrapper around {@link Mockito#verify}, to keep log spam down on failure.
+   */
+  private static void verifyNoMoreInteractions(Object... mocks) {
+    try {
+      Mockito.verifyNoMoreInteractions(mocks);
+    } catch (AssertionError e) {
+      String msg = e.getMessage();
+      if (msg.length() >= 256) {
+        throw new AssertionError(msg.substring(0, 256), e);
+      }
+      throw e;
+    }
   }
 }

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
@@ -32,6 +32,7 @@
 package io.grpc.netty;
 
 import io.grpc.Attributes;
+import io.grpc.Internal;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
@@ -40,6 +41,7 @@ import io.netty.handler.codec.http2.Http2Settings;
 /**
  * gRPC wrapper for {@link Http2ConnectionHandler}.
  */
+@Internal
 public abstract class GrpcHttp2ConnectionHandler extends Http2ConnectionHandler {
   public GrpcHttp2ConnectionHandler(Http2ConnectionDecoder decoder,
       Http2ConnectionEncoder encoder,


### PR DESCRIPTION
When the tests today fail for SSL reasons, the interop test fail loudly.  They dump the expected `verify` calls to the terminal which spams up the screen and doesn't provide any useful info.

