### PR TITLE
all: Bump protobuf to 3.0.2, to fix protoc in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: java
 env:
   global:
     - GRADLE_OPTS=-Xmx512m
-    - PROTOBUF_VERSION=3.0.0
+    - PROTOBUF_VERSION=3.0.2
     - LDFLAGS=-L/tmp/protobuf/lib
     - CXXFLAGS=-I/tmp/protobuf/include
     - LD_LIBRARY_PATH=/tmp/protobuf/lib

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -27,13 +27,13 @@ This section is only necessary if you are making changes to the code
 generation. Most users only need to use `skipCodegen=true` as discussed above.
 
 ### Build Protobuf
-The codegen plugin is C++ code and requires protobuf 3.0.0.
+The codegen plugin is C++ code and requires protobuf 3.0.0 or later.
 
 For Linux, Mac and MinGW:
 ```
 $ git clone https://github.com/google/protobuf.git
 $ cd protobuf
-$ git checkout v3.0.0
+$ git checkout v3.0.2
 $ ./autogen.sh
 $ ./configure
 $ make
@@ -72,16 +72,16 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew install ^
-    -PvcProtobufInclude=C:\path\to\protobuf-3.0.0\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.0.0\vsprojects\Release ^
+    -PvcProtobufInclude=C:\path\to\protobuf-3.0.2\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf-3.0.2\vsprojects\Release ^
     -PtargetArch=x86_32
 ```
 
 Since specifying those properties every build is bothersome, you can instead
 create ``<project-root>\gradle.properties`` with contents like:
 ```
-vcProtobufInclude=C:\\path\\to\\protobuf-3.0.0\\src
-vcProtobufLibs=C:\\path\\to\\protobuf-3.0.0\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf-3.0.2\\src
+vcProtobufLibs=C:\\path\\to\\protobuf-3.0.2\\vsprojects\\Release
 targetArch=x86_32
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
           protobuf-java directly, you will be transitively depending on the
           protobuf-java version that grpc depends on.
         -->
-        <protocArtifact>com.google.protobuf:protoc:3.0.0:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
         <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
@@ -128,7 +128,7 @@ protobuf {
     // The version of protoc must match protobuf-java. If you don't depend on
     // protobuf-java directly, you will be transitively depending on the
     // protobuf-java version that grpc depends on.
-    artifact = "com.google.protobuf:protoc:3.0.0"
+    artifact = "com.google.protobuf:protoc:3.0.2"
   }
   plugins {
     grpc {

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -28,7 +28,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.0.0'
+        artifact = 'com.google.protobuf:protoc:3.0.2'
     }
     plugins {
         grpc {

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ subprojects {
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         guavaVersion = '19.0'
-        protobufVersion = '3.0.0'
+        protobufVersion = '3.0.2'
         protobufNanoVersion = '3.0.0-alpha-5'
 
         configureProtoCompilation = {
@@ -153,6 +153,8 @@ subprojects {
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 // swap to ${protobufVersion} after versions align again
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
+                // swap to ${protobufVersion} after versions align again
+                protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",
                 protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.0',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",

--- a/buildscripts/jenkins-pre.bat
+++ b/buildscripts/jenkins-pre.bat
@@ -14,5 +14,5 @@ set ESCWORKSPACE=%WORKSPACE:\=\\%
 
 echo targetArch=x86_32> gradle.properties
 echo failOnWarnings=true>> gradle.properties
-echo vcProtobufLibs=%ESCWORKSPACE%\\grpc-java-helper\\protobuf-3.0.0\\cmake\\build\\Release>> gradle.properties
-echo vcProtobufInclude=%ESCWORKSPACE%\\grpc-java-helper\\protobuf-3.0.0\\cmake\\build\\include>> gradle.properties
+echo vcProtobufLibs=%ESCWORKSPACE%\\grpc-java-helper\\protobuf-%PROTOBUF_VER%\\cmake\\build\\Release>> gradle.properties
+echo vcProtobufInclude=%ESCWORKSPACE%\\grpc-java-helper\\protobuf-%PROTOBUF_VER%\\cmake\\build\\include>> gradle.properties

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -4,7 +4,7 @@ REM 7za is in http://www.7-zip.org/a/7z1507-extra.7z
 REM Prerequisite:
 REM   7za.exe in current directory or PATH
 
-set PROTOBUF_VER=3.0.0
+set PROTOBUF_VER=3.0.2
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (
@@ -25,7 +25,7 @@ set PATH=%PATH%;%cd%\%CMAKE_NAME%\bin
 powershell -command "& { iwr https://github.com/google/protobuf/archive/v%PROTOBUF_VER%.zip -OutFile protobuf.zip }"
 7za X protobuf.zip
 del protobuf.zip
-pushd protobuf-3.0.0\cmake
+pushd protobuf-%PROTOBUF_VER%\cmake
 mkdir build
 cd build
 cmake -Dprotobuf_BUILD_TESTS=OFF ..

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -2,7 +2,7 @@ FROM protoc-artifacts:latest
 
 RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
     git fetch && \
-    git checkout v3.0.0 && \
+    git checkout v3.0.2 && \
     ./autogen.sh && \
     CXXFLAGS=-m32 ./configure --disable-shared --prefix=/protobuf-32 && \
     make clean && make -j$(nproc) && make -j$(nproc) install"'

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -163,7 +163,7 @@ protobuf {
       if (project.hasProperty('protoc-gen-javalite')) {
         path = project['protoc-gen-javalite']
       } else {
-        artifact = "com.google.protobuf:protoc-gen-javalite:${protobufVersion}"
+        artifact = libraries.protoc_lite
       }
     }
     grpc {

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -27,7 +27,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.0.0'
+        artifact = 'com.google.protobuf:protoc:3.0.2'
     }
     plugins {
         javalite {

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.0.0'
+        artifact = 'com.google.protobuf:protoc:3.0.2'
     }
     plugins {
         javalite {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -35,7 +35,7 @@ protobuf {
     // The version of protoc must match protobuf-java. If you don't depend on
     // protobuf-java directly, you will be transitively depending on the
     // protobuf-java version that grpc depends on.
-    artifact = 'com.google.protobuf:protoc:3.0.0'
+    artifact = 'com.google.protobuf:protoc:3.0.2'
   }
   plugins {
     grpc {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -48,7 +48,7 @@
             protobuf-java directly, you will be transitively depending on the
             protobuf-java version that grpc depends on.
           -->
-          <protocArtifact>com.google.protobuf:protoc:3.0.0:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -42,7 +42,7 @@ protobuf {
       if (project.hasProperty('protoc-gen-javalite')) {
         path = project['protoc-gen-javalite']
       } else {
-        artifact = "com.google.protobuf:protoc-gen-javalite:${protobufVersion}"
+        artifact = libraries.protoc_lite
       }
     }
   }


### PR DESCRIPTION
This is a backport, without any manual changes.

protoc no longer builds in 3.0.0 because auto-download of the gmock zip
now fails. 3.0.2 has a fix to autogen:
https://github.com/google/protobuf/commit/bba446bbf2ac7b0b9923d4eb07d5acd0665a8cf0

All that was strictly necessary was to update .travis.yml and
buildscripts/, but it helps our sanity to keep the rest of the protobuf
versions in sync. Lite is left on its existing version, because it did
not see a bump of neither the java library nor the protoc plugin.