### PR TITLE
Power support

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -47,9 +47,7 @@ model {
       }
     }
     gcc(Gcc) {
-      target('ppcle_64'){
-          cppCompiler.executable = "/usr/bin/gcc"
-      }
+      target("ppcle_64")
     }
     clang(Clang) {
     }

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -47,6 +47,9 @@ model {
       }
     }
     gcc(Gcc) {
+      target('ppcle_64'){
+          cppCompiler.executable = "/usr/bin/gcc"
+      }
     }
     clang(Clang) {
     }
@@ -59,11 +62,14 @@ model {
     x86_64 {
       architecture "x86_64"
     }
+    ppcle_64 {
+      architecture "ppcle_64"
+    }
   }
 
   components {
     java_plugin(NativeExecutableSpec) {
-      if (arch in ['x86_32', 'x86_64']) {
+      if (arch in ['x86_32', 'x86_64', 'ppcle_64']) {
         // If arch is not within the defined platforms, we do not specify the
         // targetPlatform so that Gradle will choose what is appropriate.
         targetPlatform arch


### PR DESCRIPTION
Changes required to build grpc-java on ppc64le architecture.

After making these changes, grpc-java still fails for netty-tcnative jar not being available for ppcle_64. So, I built netty-tcnative from source on my system and made grpc-java to point to that. After this, **./gradlew build command does complete successfully.**
For netty-tcnative jar, I've requested netty community to publish a jar for ppcle_64 arch on maven's central repository. https://github.com/netty/netty-tcnative/issues/194.

I've also verified my changes on x86_64 platform to ensure nothing breaks there.