### PR TITLE
Implement connection attempt timeout

### DIFF
--- a/context/src/test/java/io/grpc/FakeDeadline.java
+++ b/context/src/test/java/io/grpc/FakeDeadline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,27 +29,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.internal;
+package io.grpc;
 
-import javax.annotation.Nullable;
+import com.google.common.base.Ticker;
+
+import java.util.concurrent.TimeUnit;
 
 /**
- * Determines how long to wait before doing some action (typically a retry, or a reconnect).
+ * A testing tool that produces {@link Deadline} instances that is based on a custom time ticker.
  */
-interface BackoffPolicy {
-  interface Provider {
-    BackoffPolicy get();
+public class FakeDeadline {
+
+  /**
+   * Create a deadline that will expire at the specified offset from a custom/fake ticker clock.
+   */
+  public static Deadline after(long duration, TimeUnit units, final Ticker ticker) {
+    Deadline.Ticker tkr =
+        new Deadline.Ticker() {
+          @Override
+          public long read() {
+            return ticker.read();
+          }
+        };
+    return Deadline.after(duration, units, tkr);
   }
-
-  /**
-   * Returns the number of milliseconds to wait.
-   */
-  long nextBackoffMillis();
-
-  /**
-   * Returns the timeout milliseconds for connection attempt. Zero timeout means infinity.
-   */
-  @Nullable
-  long currentTimeoutMills();
 }
-

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -36,6 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Compressor;
+import io.grpc.Deadline;
 import io.grpc.Decompressor;
 import io.grpc.Grpc;
 import io.grpc.Metadata;
@@ -90,7 +91,7 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
 
   @CheckReturnValue
   @Override
-  public synchronized Runnable start(ManagedClientTransport.Listener listener) {
+  public synchronized Runnable start(ManagedClientTransport.Listener listener, Deadline deadline) {
     this.clientTransportListener = listener;
     InProcessServer server = InProcessServer.findServer(name);
     if (server != null) {

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -52,6 +52,7 @@ import io.grpc.NameResolverProvider;
 import io.grpc.PickFirstBalancerFactory;
 import io.grpc.ResolvedServerInfo;
 import io.grpc.ResolvedServerInfoGroup;
+import io.grpc.internal.SharedResourceHolder.Resource;
 
 import java.net.SocketAddress;
 import java.net.URI;
@@ -62,6 +63,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -91,6 +93,8 @@ public abstract class AbstractManagedChannelImplBuilder
    */
   @VisibleForTesting
   static final long IDLE_MODE_MIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(1);
+
+  protected Resource<ScheduledExecutorService> timerService = GrpcUtil.TIMER_SERVICE;
 
   @Nullable
   private Executor executor;
@@ -281,7 +285,7 @@ public abstract class AbstractManagedChannelImplBuilder
         transportFactory,
         firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
         firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()),
-        GrpcUtil.TIMER_SERVICE, GrpcUtil.STOPWATCH_SUPPLIER, idleTimeoutMillis,
+        timerService, GrpcUtil.STOPWATCH_SUPPLIER, idleTimeoutMillis,
         executor, userAgent, interceptors,
         firstNonNull(censusFactory,
             firstNonNull(Census.getCensusContextFactory(), NoopCensusContextFactory.INSTANCE)));

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -38,6 +38,7 @@ import com.google.common.base.Suppliers;
 
 import io.grpc.CallOptions;
 import io.grpc.Context;
+import io.grpc.Deadline;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -96,7 +97,7 @@ class DelayedClientTransport implements ManagedClientTransport {
   }
 
   @Override
-  public Runnable start(Listener listener) {
+  public Runnable start(Listener listener, Deadline deadline) {
     this.listener = Preconditions.checkNotNull(listener, "listener");
     return null;
   }
@@ -218,7 +219,7 @@ class DelayedClientTransport implements ManagedClientTransport {
   /**
    * Transfers all the pending and future streams and pings to the given transport.
    *
-   * <p>May only be called after {@link #start(Listener)}.
+   * <p>May only be called after {@link #start}.
    *
    * <p>{@code transport} will be used for all future calls to {@link #newStream}, even if this
    * transport is {@link #shutdown}.

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -33,6 +33,7 @@ package io.grpc.internal;
 
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.Deadline;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -41,8 +42,8 @@ import java.util.concurrent.Executor;
 
 abstract class ForwardingConnectionClientTransport implements ConnectionClientTransport {
   @Override
-  public Runnable start(Listener listener) {
-    return delegate().start(listener);
+  public Runnable start(Listener listener, Deadline deadline) {
+    return delegate().start(listener, deadline);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -720,23 +720,26 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
 
     InterimTransportImpl() {
       delayedTransport = new DelayedClientTransport(executor);
-      delayedTransport.start(new ManagedClientTransport.Listener() {
-          @Override public void transportShutdown(Status status) {}
+      delayedTransport.start(
+          new ManagedClientTransport.Listener() {
+            @Override public void transportShutdown(Status status) {}
 
-          @Override public void transportTerminated() {
-            synchronized (lock) {
-              delayedTransports.remove(delayedTransport);
-              maybeTerminateChannel();
+            @Override public void transportTerminated() {
+              synchronized (lock) {
+                delayedTransports.remove(delayedTransport);
+                maybeTerminateChannel();
+              }
+              inUseStateAggregator.updateObjectInUse(delayedTransport, false);
             }
-            inUseStateAggregator.updateObjectInUse(delayedTransport, false);
-          }
 
-          @Override public void transportReady() {}
+            @Override public void transportReady() {}
 
-          @Override public void transportInUse(boolean inUse) {
-            inUseStateAggregator.updateObjectInUse(delayedTransport, inUse);
-          }
-        });
+            @Override public void transportInUse(boolean inUse) {
+              inUseStateAggregator.updateObjectInUse(delayedTransport, inUse);
+            }
+          },
+          null);
+
       boolean savedShutdown;
       synchronized (lock) {
         delayedTransports.add(delayedTransport);

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import io.grpc.Deadline;
 import io.grpc.Status;
 
 import javax.annotation.CheckReturnValue;
@@ -59,12 +60,13 @@ public interface ManagedClientTransport extends ClientTransport, WithLogId {
    * run. This method and the returned {@code Runnable} should not throw any exceptions.
    *
    * @param listener non-{@code null} listener of transport events
+   * @param deadline deadline for connection attempt timeout
    * @return a {@link Runnable} that is executed after-the-fact by the original caller, typically
    *     after locks are released
    */
   @CheckReturnValue
   @Nullable
-  Runnable start(Listener listener);
+  Runnable start(Listener listener, @Nullable Deadline deadline);
 
   /**
    * Initiates an orderly shutdown of the transport.  Existing streams continue, but the transport

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -113,7 +113,7 @@ public class DelayedClientTransportTest {
     when(mockRealTransport2.newStream(same(method2), same(headers2), same(callOptions2),
             same(statsTraceCtx2)))
         .thenReturn(mockRealStream2);
-    delayedTransport.start(transportListener);
+    delayedTransport.start(transportListener, null);
   }
 
   @After public void noMorePendingTasks() {

--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -193,6 +193,13 @@ public final class FakeClock {
   }
 
   /**
+   * Returns the ticker that the fake clock uses.
+   */
+  public Ticker getTicker() {
+    return ticker;
+  }
+
+  /**
    * Provides a partially implemented instance of {@link ScheduledExecutorService} that uses the
    * fake clock ticker for testing.
    */

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -359,7 +359,12 @@ public class ManagedChannelImplIdlenessTest {
       return new BackoffPolicy() {
         @Override
         public long nextBackoffMillis() {
-          return 1;
+          return 1L;
+        }
+
+        @Override
+        public long currentTimeoutMills() {
+          return 0L;
         }
       };
     }

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.grpc.CallOptions;
+import io.grpc.Deadline;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 
@@ -96,7 +97,8 @@ final class TestUtils {
                 mockTransport, (ManagedClientTransport.Listener) invocation.getArguments()[0]));
             return null;
           }
-        }).when(mockTransport).start(any(ManagedClientTransport.Listener.class));
+        }).when(mockTransport)
+            .start(any(ManagedClientTransport.Listener.class), any(Deadline.class));
         return mockTransport;
       }
     }).when(mockTransportFactory)

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -39,13 +39,17 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
 
+import io.grpc.Deadline;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.internal.ClientTransport.PingCallback;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
+import io.grpc.internal.SharedResourceHolder;
+import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.netty.GrpcHttp2HeadersDecoder.GrpcHttp2ClientHeadersDecoder;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -81,8 +85,12 @@ import io.netty.handler.logging.LogLevel;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * Client-side Netty handler for GRPC processing. All event handlers are executed entirely within
@@ -104,13 +112,21 @@ class NettyClientHandler extends AbstractNettyHandler {
           Status.UNAVAILABLE.withDescription("Stream IDs have been exhausted");
   private static final long USER_PING_PAYLOAD = 1111;
 
+  private final Object lock = new Object();
   private final Http2Connection.PropertyKey streamKey;
   private final ClientTransportLifecycleManager lifecycleManager;
+  private final Resource<ScheduledExecutorService> timerService;
   private final Ticker ticker;
+
+  @GuardedBy("lock")
+  private Boolean watchdogCanceled;
+
   private WriteQueue clientWriteQueue;
   private Http2Ping ping;
+  private ScheduledFuture<?> deadlineWatchdog;
 
   static NettyClientHandler newHandler(ClientTransportLifecycleManager lifecycleManager,
+                                       Resource<ScheduledExecutorService> timerService,
                                        int flowControlWindow, int maxHeaderListSize,
                                        Ticker ticker) {
     Preconditions.checkArgument(maxHeaderListSize > 0, "maxHeaderListSize must be positive");
@@ -119,8 +135,8 @@ class NettyClientHandler extends AbstractNettyHandler {
     Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
     Http2Connection connection = new DefaultHttp2Connection(false);
 
-    return newHandler(
-        connection, frameReader, frameWriter, lifecycleManager, flowControlWindow, ticker);
+    return newHandler(connection, frameReader, frameWriter, lifecycleManager, timerService,
+        flowControlWindow, ticker);
   }
 
   @VisibleForTesting
@@ -128,6 +144,7 @@ class NettyClientHandler extends AbstractNettyHandler {
                                        Http2FrameReader frameReader,
                                        Http2FrameWriter frameWriter,
                                        ClientTransportLifecycleManager lifecycleManager,
+                                       Resource<ScheduledExecutorService> timerService,
                                        int flowControlWindow,
                                        Ticker ticker) {
     Preconditions.checkNotNull(connection, "connection");
@@ -155,15 +172,18 @@ class NettyClientHandler extends AbstractNettyHandler {
     settings.initialWindowSize(flowControlWindow);
     settings.maxConcurrentStreams(0);
 
-    return new NettyClientHandler(decoder, encoder, settings, lifecycleManager, ticker);
+    return new NettyClientHandler(
+        decoder, encoder, settings, lifecycleManager, timerService, ticker);
   }
 
   private NettyClientHandler(Http2ConnectionDecoder decoder,
                              StreamBufferingEncoder encoder, Http2Settings settings,
                              ClientTransportLifecycleManager lifecycleManager,
+                             Resource<ScheduledExecutorService> timerService,
                              Ticker ticker) {
     super(decoder, encoder, settings);
     this.lifecycleManager = lifecycleManager;
+    this.timerService = timerService;
     this.ticker = ticker;
 
     // Set the frame listener on the decoder.
@@ -586,12 +606,50 @@ class NettyClientHandler extends AbstractNettyHandler {
     return stream;
   }
 
+  /**
+   * This is called exactly once.
+   */
+  void startDeadlineWatchdog(Runnable onTimeout, Deadline deadline) {
+    Preconditions.checkArgument(deadline != null, "deadline");
+    synchronized (lock) {
+      if (watchdogCanceled != null) {
+        // watchdog canceled already before it even started
+        Preconditions.checkState(watchdogCanceled, "watchdogCanceled");
+        return;
+      }
+      watchdogCanceled = Boolean.FALSE;
+      ScheduledExecutorService scheduler = SharedResourceHolder.get(timerService);
+      deadlineWatchdog = scheduler.schedule(
+          onTimeout, deadline.timeRemaining(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
+      SharedResourceHolder.release(timerService, scheduler);
+    }
+  }
+
+  /**
+   * This is called at most once, when the SETTINGS frame is received.
+   */
+  private void cancelDeadlineWatchdog() {
+    synchronized (lock) {
+      if (watchdogCanceled == null) {
+        // watchdog not even started (yet)
+        watchdogCanceled = Boolean.TRUE;
+        return;
+      }
+    }
+    Preconditions.checkNotNull(deadlineWatchdog, "deadlineWatchdog");
+    Preconditions.checkState(!watchdogCanceled, "watchdogCanceled");
+    // Do not forcefully interrupt. As the SETTINGS frame is received, the watchdog can not actually
+    // abort anything.
+    deadlineWatchdog.cancel(false);
+  }
+
   private class FrameListener extends Http2FrameAdapter {
     private boolean firstSettings = true;
 
     @Override
     public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) {
       if (firstSettings) {
+        cancelDeadlineWatchdog();
         firstSettings = false;
         lifecycleManager.notifyReady();
       }

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -536,7 +536,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     };
 
     return NettyClientHandler.newHandler(connection, frameReader(), frameWriter(),
-        lifecycleManager, flowControlWindow, ticker);
+        lifecycleManager, GrpcUtil.TIMER_SERVICE, flowControlWindow, ticker);
   }
 
   @Override

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
+                project(':grpc-context').sourceSets.test.output,
                 project(':grpc-testing'),
                 project(':grpc-netty')
 }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -188,7 +188,7 @@ public abstract class AbstractTransportTest {
   public void frameAfterRstStreamShouldNotBreakClientChannel() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -238,7 +238,7 @@ public abstract class AbstractTransportTest {
     server = null;
 
     InOrder inOrder = inOrder(mockClientTransportListener);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportTerminated();
     inOrder.verify(mockClientTransportListener).transportShutdown(statusCaptor.capture());
     assertCodeEquals(Status.UNAVAILABLE, statusCaptor.getValue());
@@ -252,7 +252,7 @@ public abstract class AbstractTransportTest {
     server.start(serverListener);
     client = newClientTransport(server);
     InOrder inOrder = inOrder(mockClientTransportListener);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     client.shutdown();
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportTerminated();
     inOrder.verify(mockClientTransportListener).transportShutdown(statusCaptor.capture());
@@ -266,7 +266,7 @@ public abstract class AbstractTransportTest {
     server.start(serverListener);
     client = newClientTransport(server);
     InOrder inOrder = inOrder(mockClientTransportListener);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportReady();
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -294,7 +294,7 @@ public abstract class AbstractTransportTest {
   public void openStreamPreventsTermination() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -345,7 +345,7 @@ public abstract class AbstractTransportTest {
   public void shutdownNowKillsClientStream() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -376,7 +376,7 @@ public abstract class AbstractTransportTest {
   public void shutdownNowKillsServerStream() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -409,7 +409,7 @@ public abstract class AbstractTransportTest {
   public void ping() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     ClientTransport.PingCallback mockPingCallback = mock(ClientTransport.PingCallback.class);
     try {
       client.ping(mockPingCallback, MoreExecutors.directExecutor());
@@ -425,7 +425,7 @@ public abstract class AbstractTransportTest {
   public void ping_duringShutdown() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     // Stream prevents termination
     ClientStream stream = client.newStream(methodDescriptor, new Metadata());
     stream.start(mockClientStreamListener);
@@ -446,7 +446,7 @@ public abstract class AbstractTransportTest {
   public void ping_afterTermination() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportReady();
     client.shutdown();
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportTerminated();
@@ -466,7 +466,7 @@ public abstract class AbstractTransportTest {
   public void newStream_duringShutdown() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     // Stream prevents termination
     ClientStream stream = client.newStream(methodDescriptor, new Metadata());
     stream.start(mockClientStreamListener);
@@ -497,7 +497,7 @@ public abstract class AbstractTransportTest {
     // dealing with afterTermination is harder than duringShutdown.
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportReady();
     client.shutdown();
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportTerminated();
@@ -514,7 +514,7 @@ public abstract class AbstractTransportTest {
   public void transportInUse_normalClose() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     ClientStream stream1 = client.newStream(methodDescriptor, new Metadata());
     stream1.start(mockClientStreamListener);
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
@@ -542,7 +542,7 @@ public abstract class AbstractTransportTest {
   public void transportInUse_clientCancel() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     ClientStream stream1 = client.newStream(methodDescriptor, new Metadata());
     stream1.start(mockClientStreamListener);
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
@@ -563,7 +563,7 @@ public abstract class AbstractTransportTest {
   public void basicStream() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -650,7 +650,7 @@ public abstract class AbstractTransportTest {
   public void zeroMessageStream() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -682,7 +682,7 @@ public abstract class AbstractTransportTest {
   public void earlyServerClose_withServerHeaders() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -712,7 +712,7 @@ public abstract class AbstractTransportTest {
   public void earlyServerClose_noServerHeaders() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -749,7 +749,7 @@ public abstract class AbstractTransportTest {
   public void earlyServerClose_serverFailure() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -777,7 +777,7 @@ public abstract class AbstractTransportTest {
   public void clientCancel() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -808,7 +808,7 @@ public abstract class AbstractTransportTest {
   public void clientCancelFromWithinMessageRead() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -862,7 +862,7 @@ public abstract class AbstractTransportTest {
   public void serverCancel() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -899,7 +899,7 @@ public abstract class AbstractTransportTest {
   public void flowControlPushBack() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    runIfNotNull(client.start(mockClientTransportListener, null));
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -1062,7 +1062,7 @@ public abstract class AbstractTransportTest {
    */
   private void doPingPong(MockServerListener serverListener) throws InterruptedException {
     ManagedClientTransport client = newClientTransport(server);
-    runIfNotNull(client.start(mock(ManagedClientTransport.Listener.class)));
+    runIfNotNull(client.start(mock(ManagedClientTransport.Listener.class), null));
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
     ClientStreamListener mockClientStreamListener = mock(ClientStreamListener.class);
     clientStream.start(mockClientStreamListener);


### PR DESCRIPTION
## Implement connection attempt timeout
- Time for a connection attempt is the period of time starting from `transport#start()` is invoked and ending at the transport listener calls `transportReady()`. It includes the time for establishing socket, SSL handshake, and HTTP/2 frame settings. Time for name resolving is not considered as part of connection time in this implementation. Before this implementation, there was no specific timeout policy for connection attempt. There was always OS level default socket timeout but it varies (typically more than one or two minutes).
- For the single address case, the timeout policy follows exactly the same semantics as that in
  [back-off policy](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md).
- For the case of multiple addresses `(addr_1, addr_2, ..., addr_n)` in an EAG, apply the following principles:
  - (Equal Opportunity) Try connection attempts in sequential and cyclic order.
  - (Avoidance of Flooding) The time interval between the `k-th` and `(k+1)-th` attempt for the same address `addr_m` should be no less than `Min(INITIAL_BACKOFF*MULTIPLIER^(k-1), MAX_BACKOFF)` up to jitters.
  - (Efficiency) Start next attempt as early as possible if the above two principles are qualified.
- In current implementation, connection attempts do not have overlapping time, i.e., not partially in parallel. Connection attempt for `addr_{m+1}` does not start until that for `addr_m` has failed.
- Timeout for `InprocessTransport` is ignored.
### Example

Suppose that there are four addresses `(addr_1, addr_2, addr_3, addr_4)` in an EAG, that connection attempt for `addr_1` failed immediately, that `addr_2` is a blackhole, and that connection attempt for `addr_2` timed out. Then `addr_3` is more worth trying than `addr_1` again because we already know that `addr_1` has failed once. This is the Equal Opportunity principle. And we should not increase backoff time by multiplying `MULTIPLIER` right now because we haven't tried the same address for a second time yet, we are not flooding. This is the Efficiency principle.
