### PR TITLE
interop-testing: No census asserts for standalone client

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -314,7 +314,6 @@ public class TestServiceClient {
             .flowControlWindow(65 * 1024)
             .negotiationType(useTls ? NegotiationType.TLS : NegotiationType.PLAINTEXT)
             .sslContext(sslContext)
-            .censusContextFactory(getClientCensusFactory())
             .build();
       } else {
         OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress(serverHost, serverPort);
@@ -336,6 +335,12 @@ public class TestServiceClient {
         }
         return builder.build();
       }
+    }
+
+    @Override
+    protected boolean metricsExpected() {
+      // Server-side metrics won't be found, because server is a separate process.
+      return false;
     }
   }
 


### PR DESCRIPTION
This prevents an assertion in the cross-language interop test suite:
```
Exception in thread "main" java.lang.AssertionError: No record found
	at io.grpc.testing.integration.AbstractInteropTest.assertServerMetrics(AbstractInteropTest.java:1176)
	at io.grpc.testing.integration.AbstractInteropTest.assertMetrics(AbstractInteropTest.java:1120)
	at io.grpc.testing.integration.AbstractInteropTest.largeUnary(AbstractInteropTest.java:228)
	at io.grpc.testing.integration.TestServiceClient.runTest(TestServiceClient.java:215)
	at io.grpc.testing.integration.TestServiceClient.run(TestServiceClient.java:199)
	at io.grpc.testing.integration.TestServiceClient.main(TestServiceClient.java:84)
```