### PR TITLE
core: Call onSentBytes only if future is successfull.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -150,9 +150,11 @@ class NettyClientStream extends AbstractClientStream2 {
             channel.newPromise().addListener(new ChannelFutureListener() {
               @Override
               public void operationComplete(ChannelFuture future) throws Exception {
-                // Remove the bytes from outbound flow control, optionally notifying
-                // the client that they can send more bytes.
-                transportState().onSentBytes(numBytes);
+                if (future.isSuccess()) {
+                  // Remove the bytes from outbound flow control, optionally notifying
+                  // the client that they can send more bytes.
+                  transportState().onSentBytes(numBytes);
+                }
               }
             }), flush);
       } else {


### PR DESCRIPTION
TransportState.onSentBytes(int) may be called even if the stream was never allocated.
For example, if opening a stream failed after a DATA frame had already been queued.

This condition is violated often in tests, but unfortunately doesn't make any test fail.