### PR TITLE
benchmarks: Reduce excessive memory usage of histograms. Fixes #2278

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/Utils.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/Utils.java
@@ -87,8 +87,9 @@ public final class Utils {
 
   // The histogram can record values between 1 microsecond and 1 min.
   public static final long HISTOGRAM_MAX_VALUE = 60000000L;
-  // Value quantization will be no larger than 1/10^3 = 0.1%.
-  public static final int HISTOGRAM_PRECISION = 3;
+
+  // Value quantization will be no more than 1%. See the README of HdrHistogram for more details.
+  public static final int HISTOGRAM_PRECISION = 2;
 
   public static final int DEFAULT_FLOW_CONTROL_WINDOW =
       NettyChannelBuilder.DEFAULT_FLOW_CONTROL_WINDOW;


### PR DESCRIPTION
Reduce the histogram precision from 3 significant digits to 1.
For example, this allows to distinquish between the  99.8th and
the 99.9th percentile, but not the 99.9th and the 99.91th percentile.

As a result, the memory usage of one histogram object is reduced dramatically:
From roughly ~130KiB to ~3KiB per histogram.