### PR TITLE
netty: use memory efficient slice in Buffer

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyReadableBuffer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyReadableBuffer.java
@@ -93,8 +93,7 @@ class NettyReadableBuffer extends AbstractReadableBuffer {
 
   @Override
   public NettyReadableBuffer readBytes(int length) {
-    // The ByteBuf returned by readSlice() stores a reference to buffer but does not call retain().
-    return new NettyReadableBuffer(buffer.readSlice(length).retain());
+    return new NettyReadableBuffer(buffer.readRetainedSlice(length));
   }
 
   @Override


### PR DESCRIPTION
This depends on the 4.1.6 update.