### PR TITLE
Bump protobuf to 3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: java
 env:
   global:
     - GRADLE_OPTS=-Xmx512m
-    - PROTOBUF_VERSION=3.0.2
+    - PROTOBUF_VERSION=3.1.0
     - LDFLAGS=-L/tmp/protobuf/lib
     - CXXFLAGS=-I/tmp/protobuf/include
     - LD_LIBRARY_PATH=/tmp/protobuf/lib

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -33,7 +33,7 @@ For Linux, Mac and MinGW:
 ```
 $ git clone https://github.com/google/protobuf.git
 $ cd protobuf
-$ git checkout v3.0.2
+$ git checkout v3.1.0
 $ ./autogen.sh
 $ ./configure
 $ make
@@ -72,16 +72,16 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew install ^
-    -PvcProtobufInclude=C:\path\to\protobuf-3.0.2\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.0.2\vsprojects\Release ^
+    -PvcProtobufInclude=C:\path\to\protobuf-3.1.0\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf-3.1.0\vsprojects\Release ^
     -PtargetArch=x86_32
 ```
 
 Since specifying those properties every build is bothersome, you can instead
 create ``<project-root>\gradle.properties`` with contents like:
 ```
-vcProtobufInclude=C:\\path\\to\\protobuf-3.0.2\\src
-vcProtobufLibs=C:\\path\\to\\protobuf-3.0.2\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf-3.1.0\\src
+vcProtobufLibs=C:\\path\\to\\protobuf-3.1.0\\vsprojects\\Release
 targetArch=x86_32
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <artifactId>protobuf-maven-plugin</artifactId>
       <version>0.5.0</version>
       <configuration>
-        <!--
-          The version of protoc must match protobuf-java. If you don't depend on
-          protobuf-java directly, you will be transitively depending on the
-          protobuf-java version that grpc depends on.
-        -->
-        <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.1.0:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
         <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
@@ -125,10 +120,7 @@ buildscript {
 
 protobuf {
   protoc {
-    // The version of protoc must match protobuf-java. If you don't depend on
-    // protobuf-java directly, you will be transitively depending on the
-    // protobuf-java version that grpc depends on.
-    artifact = "com.google.protobuf:protoc:3.0.2"
+    artifact = "com.google.protobuf:protoc:3.1.0"
   }
   plugins {
     grpc {

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -28,7 +28,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.0.2'
+        artifact = 'com.google.protobuf:protoc:3.1.0'
     }
     plugins {
         grpc {

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ subprojects {
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         guavaVersion = '19.0'
-        protobufVersion = '3.0.2'
+        protobufVersion = '3.1.0'
         protobufNanoVersion = '3.0.0-alpha-5'
 
         configureProtoCompilation = {

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -4,7 +4,7 @@ REM 7za is in http://www.7-zip.org/a/7z1507-extra.7z
 REM Prerequisite:
 REM   7za.exe in current directory or PATH
 
-set PROTOBUF_VER=3.0.2
+set PROTOBUF_VER=3.1.0
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -2,7 +2,7 @@ FROM protoc-artifacts:latest
 
 RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
     git fetch && \
-    git checkout v3.0.2 && \
+    git checkout v3.10 && \
     ./autogen.sh && \
     CXXFLAGS=-m32 ./configure --disable-shared --prefix=/protobuf-32 && \
     make clean && make -j$(nproc) && make -j$(nproc) install"'

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -27,7 +27,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.0.2'
+        artifact = 'com.google.protobuf:protoc:3.1.0'
     }
     plugins {
         javalite {

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.0.2'
+        artifact = 'com.google.protobuf:protoc:3.1.0'
     }
     plugins {
         javalite {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -32,10 +32,7 @@ dependencies {
 
 protobuf {
   protoc {
-    // The version of protoc must match protobuf-java. If you don't depend on
-    // protobuf-java directly, you will be transitively depending on the
-    // protobuf-java version that grpc depends on.
-    artifact = 'com.google.protobuf:protoc:3.0.2'
+    artifact = 'com.google.protobuf:protoc:3.1.0'
   }
   plugins {
     grpc {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -43,12 +43,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.5.0</version>
         <configuration>
-          <!--
-            The version of protoc must match protobuf-java. If you don't depend on
-            protobuf-java directly, you will be transitively depending on the
-            protobuf-java version that grpc depends on.
-          -->
-          <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:3.1.0:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>


### PR DESCRIPTION
Also removed warnings about protoc version matching runtime, since this
is no longer supposed to be a problem (starting with 3.0.0-beta-4) and
all our tests ran fine when using protoc 3.0.2 with protobuf runtime
3.1.0.

Fixes #2316
