### PR TITLE
Interop test cases: Unimplemented method and unimplemented service

### DIFF
--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -85,6 +85,15 @@ public class TestServiceGrpc {
               "grpc.testing.TestService", "HalfDuplexCall"),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()),
           io.grpc.protobuf.ProtoUtils.marshaller(io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()));
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL =
+      io.grpc.MethodDescriptor.create(
+          io.grpc.MethodDescriptor.MethodType.UNARY,
+          generateFullMethodName(
+              "grpc.testing.TestService", "UnimplementedCall"),
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()),
+          io.grpc.protobuf.ProtoUtils.marshaller(com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()));
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -184,6 +193,17 @@ public class TestServiceGrpc {
       return asyncUnimplementedStreamingCall(METHOD_HALF_DUPLEX_CALL, responseObserver);
     }
 
+    /**
+     * <pre>
+     * The test server will not implement this method. It will be used
+     * to test the behavior when clients call unimplemented methods.
+     * </pre>
+     */
+    public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_UNIMPLEMENTED_CALL, responseObserver);
+    }
+
     @java.lang.Override public io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -228,6 +248,13 @@ public class TestServiceGrpc {
                 io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
                   this, METHODID_HALF_DUPLEX_CALL)))
+          .addMethod(
+            METHOD_UNIMPLEMENTED_CALL,
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.google.protobuf.EmptyProtos.Empty,
+                com.google.protobuf.EmptyProtos.Empty>(
+                  this, METHODID_UNIMPLEMENTED_CALL)))
           .build();
     }
   }
@@ -326,6 +353,18 @@ public class TestServiceGrpc {
       return asyncBidiStreamingCall(
           getChannel().newCall(METHOD_HALF_DUPLEX_CALL, getCallOptions()), responseObserver);
     }
+
+    /**
+     * <pre>
+     * The test server will not implement this method. It will be used
+     * to test the behavior when clients call unimplemented methods.
+     * </pre>
+     */
+    public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
+        io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(METHOD_UNIMPLEMENTED_CALL, getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -381,6 +420,17 @@ public class TestServiceGrpc {
       return blockingServerStreamingCall(
           getChannel(), METHOD_STREAMING_OUTPUT_CALL, getCallOptions(), request);
     }
+
+    /**
+     * <pre>
+     * The test server will not implement this method. It will be used
+     * to test the behavior when clients call unimplemented methods.
+     * </pre>
+     */
+    public com.google.protobuf.EmptyProtos.Empty unimplementedCall(com.google.protobuf.EmptyProtos.Empty request) {
+      return blockingUnaryCall(
+          getChannel(), METHOD_UNIMPLEMENTED_CALL, getCallOptions(), request);
+    }
   }
 
   /**
@@ -426,14 +476,27 @@ public class TestServiceGrpc {
       return futureUnaryCall(
           getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     * The test server will not implement this method. It will be used
+     * to test the behavior when clients call unimplemented methods.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> unimplementedCall(
+        com.google.protobuf.EmptyProtos.Empty request) {
+      return futureUnaryCall(
+          getChannel().newCall(METHOD_UNIMPLEMENTED_CALL, getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_EMPTY_CALL = 0;
   private static final int METHODID_UNARY_CALL = 1;
   private static final int METHODID_STREAMING_OUTPUT_CALL = 2;
-  private static final int METHODID_STREAMING_INPUT_CALL = 3;
-  private static final int METHODID_FULL_DUPLEX_CALL = 4;
-  private static final int METHODID_HALF_DUPLEX_CALL = 5;
+  private static final int METHODID_UNIMPLEMENTED_CALL = 3;
+  private static final int METHODID_STREAMING_INPUT_CALL = 4;
+  private static final int METHODID_FULL_DUPLEX_CALL = 5;
+  private static final int METHODID_HALF_DUPLEX_CALL = 6;
 
   private static class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -463,6 +526,10 @@ public class TestServiceGrpc {
         case METHODID_STREAMING_OUTPUT_CALL:
           serviceImpl.streamingOutputCall((io.grpc.testing.integration.Messages.StreamingOutputCallRequest) request,
               (io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse>) responseObserver);
+          break;
+        case METHODID_UNIMPLEMENTED_CALL:
+          serviceImpl.unimplementedCall((com.google.protobuf.EmptyProtos.Empty) request,
+              (io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -499,7 +566,8 @@ public class TestServiceGrpc {
           METHOD_STREAMING_OUTPUT_CALL,
           METHOD_STREAMING_INPUT_CALL,
           METHOD_FULL_DUPLEX_CALL,
-          METHOD_HALF_DUPLEX_CALL);
+          METHOD_HALF_DUPLEX_CALL,
+          METHOD_UNIMPLEMENTED_CALL);
     }
 
     return serviceDescriptor;

--- a/interop-testing/src/generated/main/java/io/grpc/testing/integration/Test.java
+++ b/interop-testing/src/generated/main/java/io/grpc/testing/integration/Test.java
@@ -26,7 +26,7 @@ public final class Test {
       "\n&io/grpc/testing/integration/test.proto" +
       "\022\014grpc.testing\032\'io/grpc/testing/integrat" +
       "ion/empty.proto\032*io/grpc/testing/integra" +
-      "tion/messages.proto2\273\004\n\013TestService\0225\n\tE" +
+      "tion/messages.proto2\372\004\n\013TestService\0225\n\tE" +
       "mptyCall\022\023.grpc.testing.Empty\032\023.grpc.tes" +
       "ting.Empty\022F\n\tUnaryCall\022\033.grpc.testing.S" +
       "impleRequest\032\034.grpc.testing.SimpleRespon" +
@@ -40,14 +40,15 @@ public final class Test {
       ").grpc.testing.StreamingOutputCallRespon" +
       "se(\0010\001\022i\n\016HalfDuplexCall\022(.grpc.testing." +
       "StreamingOutputCallRequest\032).grpc.testin" +
-      "g.StreamingOutputCallResponse(\0010\0012U\n\024Uni" +
-      "mplementedService\022=\n\021UnimplementedCall\022\023" +
-      ".grpc.testing.Empty\032\023.grpc.testing.Empty",
-      "2\177\n\020ReconnectService\0221\n\005Start\022\023.grpc.tes" +
-      "ting.Empty\032\023.grpc.testing.Empty\0228\n\004Stop\022" +
-      "\023.grpc.testing.Empty\032\033.grpc.testing.Reco" +
-      "nnectInfoB\035\n\033io.grpc.testing.integration" +
-      "b\006proto3"
+      "g.StreamingOutputCallResponse(\0010\001\022=\n\021Uni" +
+      "mplementedCall\022\023.grpc.testing.Empty\032\023.gr" +
+      "pc.testing.Empty2U\n\024UnimplementedService",
+      "\022=\n\021UnimplementedCall\022\023.grpc.testing.Emp" +
+      "ty\032\023.grpc.testing.Empty2\177\n\020ReconnectServ" +
+      "ice\0221\n\005Start\022\023.grpc.testing.Empty\032\023.grpc" +
+      ".testing.Empty\0228\n\004Stop\022\023.grpc.testing.Em" +
+      "pty\032\033.grpc.testing.ReconnectInfoB\035\n\033io.g" +
+      "rpc.testing.integrationb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -843,9 +843,25 @@ public abstract class AbstractInteropTest {
     verifyNoMoreInteractions(responseObserver);
   }
 
-  /** Sends an rpc to an unimplemented method on the server. */
+  /** Sends an rpc to an unimplemented method within TestService. */
   @Test(timeout = 10000)
   public void unimplementedMethod() {
+    try {
+      blockingStub.unimplementedCall(Empty.getDefaultInstance());
+      fail();
+    } catch (StatusRuntimeException e) {
+      assertEquals(Status.UNIMPLEMENTED.getCode(), e.getStatus().getCode());
+    }
+
+    if (metricsExpected()) {
+      assertClientMetrics("grpc.testing.TestService/UnimplementedCall",
+          Status.Code.UNIMPLEMENTED);
+    }
+  }
+
+  /** Sends an rpc to an unimplemented service on the server. */
+  @Test(timeout = 10000)
+  public void unimplementedService() {
     UnimplementedServiceGrpc.UnimplementedServiceBlockingStub stub =
         UnimplementedServiceGrpc.newBlockingStub(channel);
     try {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -452,6 +452,11 @@ public class StressTestClient {
           break;
         }
 
+        case UNIMPLEMENTED_SERVICE: {
+          tester.unimplementedService();
+          break;
+        }
+
         case CANCEL_AFTER_BEGIN: {
           tester.cancelAfterBegin();
           break;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -49,6 +49,7 @@ public enum TestCases {
   OAUTH2_AUTH_TOKEN("raw oauth2 access token auth"),
   PER_RPC_CREDS("per rpc raw oauth2 access token auth"),
   UNIMPLEMENTED_METHOD("call an unimplemented RPC method"),
+  UNIMPLEMENTED_SERVICE("call an unimplemented RPC service"),
   CANCEL_AFTER_BEGIN("cancel stream after starting it"),
   CANCEL_AFTER_FIRST_RESPONSE("cancel on first response"),
   TIMEOUT_ON_SLEEPING_SERVER("timeout before receiving a response");

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -267,6 +267,11 @@ public class TestServiceClient {
         break;
       }
 
+      case UNIMPLEMENTED_SERVICE: {
+        tester.unimplementedService();
+        break;
+      }
+
       case CANCEL_AFTER_BEGIN: {
         tester.cancelAfterBegin();
         break;

--- a/interop-testing/src/main/proto/io/grpc/testing/integration/test.proto
+++ b/interop-testing/src/main/proto/io/grpc/testing/integration/test.proto
@@ -70,6 +70,10 @@ service TestService {
   // first request.
   rpc HalfDuplexCall(stream StreamingOutputCallRequest)
       returns (stream StreamingOutputCallResponse);
+
+  // The test server will not implement this method. It will be used
+  // to test the behavior when clients call unimplemented methods.
+  rpc UnimplementedCall(grpc.testing.Empty) returns (grpc.testing.Empty);
 }
 
 // A simple service NOT implemented at servers so clients can test for

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
@@ -58,7 +58,8 @@ public class TestCasesTest {
     String[] testCases = {"empty_unary", "large_unary", "client_streaming", "server_streaming",
       "ping_pong", "empty_stream", "compute_engine_creds", "service_account_creds",
       "jwt_token_creds", "oauth2_auth_token", "per_rpc_creds", "unimplemented_method",
-      "cancel_after_begin", "cancel_after_first_response", "timeout_on_sleeping_server"};
+      "unimplemented_service", "cancel_after_begin", "cancel_after_first_response",
+      "timeout_on_sleeping_server"};
 
     assertEquals(testCases.length, TestCases.values().length);
 


### PR DESCRIPTION
Added unimplemented_method interop test case.

Renamed the existing unimplemented_method test case to unimplemented_service, in line with the [interop test descriptions](https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md).