### PR TITLE
core: fix race condition for TransportSet scheduleBackoff

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -321,7 +321,11 @@ class DelayedClientTransport implements ManagedClientTransport {
    */
   void startBackoff(final Status status) {
     synchronized (lock) {
-      Preconditions.checkState(backoffStatus == null);
+      if (shutdown) {
+        return;
+      }
+      Preconditions.checkState(backoffStatus == null,
+          "Error when calling startBackoff: transport is already in backoff period");
       backoffStatus = Status.UNAVAILABLE.withDescription("Channel in TRANSIENT_FAILURE state")
           .withCause(status.asRuntimeException());
       final ArrayList<PendingStream> failFastPendingStreams = new ArrayList<PendingStream>();
@@ -334,14 +338,17 @@ class DelayedClientTransport implements ManagedClientTransport {
             it.remove();
           }
         }
-        streamCreationExecutor.execute(new Runnable() {
+
+        class FailTheFailFastPendingStreams implements Runnable {
           @Override
           public void run() {
             for (PendingStream stream : failFastPendingStreams) {
               stream.setStream(new FailingClientStream(status));
             }
           }
-        });
+        }
+
+        streamCreationExecutor.execute(new FailTheFailFastPendingStreams());
       }
     }
   }
@@ -352,6 +359,8 @@ class DelayedClientTransport implements ManagedClientTransport {
    */
   void endBackoff() {
     synchronized (lock) {
+      Preconditions.checkState(backoffStatus != null,
+          "Error when calling endBackoff: transport is not in backoff period");
       backoffStatus = null;
     }
   }

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -324,4 +324,13 @@ public class DelayedClientTransportTest {
     delayedTransport.newStream(method, headers, waitForReadyCallOptions);
     assertEquals(1, delayedTransport.getPendingStreamsCount());
   }
+
+  @Test public void startBackoff_DoNothingIfAlreadyShutDown() {
+    delayedTransport.shutdown();
+
+    final Status cause = Status.UNAVAILABLE.withDescription("some error when connecting");
+    delayedTransport.startBackoff(cause);
+
+    assertFalse(delayedTransport.isInBackoffPeriod());
+  }
 }


### PR DESCRIPTION
Trying to fix issue  #2188
- Try to keep avoiding the lock issue #2152 and also to avoid race condition #2188.
- Add `checkState` for `endBackoff()`. Could help hit and identify any potential issue related to #2188.
- Make sure `startBackoff()` and `endBackoff()` invoked in the right order.
- Not to schedule endBackoff if transportSet has been shutdown.