### PR TITLE
netty: add channel options in NettyChannelBuilder

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -293,7 +293,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
   @Internal
   protected static final class NettyTransportFactory implements ClientTransportFactory {
     private final Class<? extends Channel> channelType;
-    private final Map<ChannelOption<?>, Object> channelOptions;
+    private final Map<ChannelOption<?>, ?> channelOptions;
     private final NegotiationType negotiationType;
     private final ProtocolNegotiator protocolNegotiator;
     private final SslContext sslContext;
@@ -306,7 +306,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
     private boolean closed;
 
     private NettyTransportFactory(
-        Class<? extends Channel> channelType, Map<ChannelOption<?>, Object> channelOptions,
+        Class<? extends Channel> channelType, Map<ChannelOption<?>, ?> channelOptions,
         NegotiationType negotiationType, ProtocolNegotiator protocolNegotiator,
         SslContext sslContext, EventLoopGroup group, int flowControlWindow, int maxMessageSize,
         int maxHeaderListSize) {

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -46,12 +46,15 @@ import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslContext;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
@@ -63,9 +66,13 @@ import javax.net.ssl.SSLException;
 public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<NettyChannelBuilder> {
   public static final int DEFAULT_FLOW_CONTROL_WINDOW = 1048576; // 1MiB
 
+  private final Map<ChannelOption<?>, Object> channelOptions =
+      new HashMap<ChannelOption<?>, Object>();
+
   private NegotiationType negotiationType = NegotiationType.TLS;
   private ProtocolNegotiator protocolNegotiator;
   private Class<? extends Channel> channelType = NioSocketChannel.class;
+
   @Nullable
   private EventLoopGroup eventLoopGroup;
   private SslContext sslContext;
@@ -119,10 +126,19 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
   }
 
   /**
-   * Specify the channel type to use, by default we use {@link NioSocketChannel}.
+   * Specifies the channel type to use, by default we use {@link NioSocketChannel}.
    */
   public final NettyChannelBuilder channelType(Class<? extends Channel> channelType) {
     this.channelType = Preconditions.checkNotNull(channelType, "channelType");
+    return this;
+  }
+
+  /**
+   * Specifies a channel option. As the underlying channel as well as network implementation may
+   * ignore this value applications should consider it a hint.
+   */
+  public final <T> NettyChannelBuilder withOption(ChannelOption<T> option, T value) {
+    channelOptions.put(option, value);
     return this;
   }
 
@@ -190,7 +206,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
   /**
    * Sets the max message size.
    *
-   * @deprecated Use maxInboundMessageSize instead
+   * @deprecated Use {@link #maxInboundMessageSize} instead
    */
   @Deprecated
   public final NettyChannelBuilder maxMessageSize(int maxMessageSize) {
@@ -224,7 +240,8 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
 
   @Override
   protected ClientTransportFactory buildTransportFactory() {
-    return new NettyTransportFactory(channelType, negotiationType, protocolNegotiator, sslContext,
+    return new NettyTransportFactory(
+        channelType, channelOptions, negotiationType, protocolNegotiator, sslContext,
         eventLoopGroup, flowControlWindow, maxInboundMessageSize(), maxHeaderListSize);
   }
 
@@ -276,6 +293,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
   @Internal
   protected static final class NettyTransportFactory implements ClientTransportFactory {
     private final Class<? extends Channel> channelType;
+    private final Map<ChannelOption<?>, Object> channelOptions;
     private final NegotiationType negotiationType;
     private final ProtocolNegotiator protocolNegotiator;
     private final SslContext sslContext;
@@ -287,16 +305,14 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
 
     private boolean closed;
 
-    private NettyTransportFactory(Class<? extends Channel> channelType,
-                                  NegotiationType negotiationType,
-                                  ProtocolNegotiator protocolNegotiator,
-                                  SslContext sslContext,
-                                  EventLoopGroup group,
-                                  int flowControlWindow,
-                                  int maxMessageSize,
-                                  int maxHeaderListSize) {
+    private NettyTransportFactory(
+        Class<? extends Channel> channelType, Map<ChannelOption<?>, Object> channelOptions,
+        NegotiationType negotiationType, ProtocolNegotiator protocolNegotiator,
+        SslContext sslContext, EventLoopGroup group, int flowControlWindow, int maxMessageSize,
+        int maxHeaderListSize) {
       this.channelType = channelType;
       this.negotiationType = negotiationType;
+      this.channelOptions = channelOptions;
       this.protocolNegotiator = protocolNegotiator;
       this.sslContext = sslContext;
       this.flowControlWindow = flowControlWindow;
@@ -323,13 +339,15 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
     }
 
     @Internal  // This is strictly for internal use.  Depend on this at your own peril.
-    public ConnectionClientTransport newClientTransport(SocketAddress serverAddress,
-        String authority, String userAgent, ProtocolNegotiator negotiator) {
+    public ConnectionClientTransport newClientTransport(
+        SocketAddress serverAddress, String authority, String userAgent,
+        ProtocolNegotiator negotiator) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
-      return new NettyClientTransport(serverAddress, channelType, group, negotiator,
-          flowControlWindow, maxMessageSize, maxHeaderListSize, authority, userAgent);
+      return new NettyClientTransport(
+          serverAddress, channelType, channelOptions, group, negotiator, flowControlWindow,
+          maxMessageSize, maxHeaderListSize, authority, userAgent);
     }
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -312,7 +312,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
         int maxHeaderListSize) {
       this.channelType = channelType;
       this.negotiationType = negotiationType;
-      this.channelOptions = channelOptions;
+      this.channelOptions = new HashMap<ChannelOption<?>, Object>(channelOptions);
       this.protocolNegotiator = protocolNegotiator;
       this.sslContext = sslContext;
       this.flowControlWindow = flowControlWindow;

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -33,6 +33,7 @@ package io.grpc.netty;
 
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
 
@@ -51,6 +52,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http2.StreamBufferingEncoder.Http2ChannelClosedException;
@@ -58,14 +60,15 @@ import io.netty.util.AsciiString;
 
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
+import java.util.Map;
 import java.util.concurrent.Executor;
-
 import javax.annotation.Nullable;
 
 /**
  * A Netty-based {@link ConnectionClientTransport} implementation.
  */
 class NettyClientTransport implements ConnectionClientTransport {
+  private final Map<ChannelOption<?>, Object> channelOptions;
   private final SocketAddress address;
   private final Class<? extends Channel> channelType;
   private final EventLoopGroup group;
@@ -84,14 +87,16 @@ class NettyClientTransport implements ConnectionClientTransport {
   /** Since not thread-safe, may only be used from event loop. */
   private ClientTransportLifecycleManager lifecycleManager;
 
-  NettyClientTransport(SocketAddress address, Class<? extends Channel> channelType,
-                       EventLoopGroup group, ProtocolNegotiator negotiator,
-                       int flowControlWindow, int maxMessageSize, int maxHeaderListSize,
-                       String authority, @Nullable String userAgent) {
+  NettyClientTransport(
+      SocketAddress address, Class<? extends Channel> channelType,
+      Map<ChannelOption<?>, Object> channelOptions, EventLoopGroup group,
+      ProtocolNegotiator negotiator, int flowControlWindow, int maxMessageSize,
+      int maxHeaderListSize, String authority, @Nullable String userAgent) {
     this.negotiator = Preconditions.checkNotNull(negotiator, "negotiator");
     this.address = Preconditions.checkNotNull(address, "address");
     this.group = Preconditions.checkNotNull(group, "group");
     this.channelType = Preconditions.checkNotNull(channelType, "channelType");
+    this.channelOptions = Preconditions.checkNotNull(channelOptions, "channelOptions");
     this.flowControlWindow = flowControlWindow;
     this.maxMessageSize = maxMessageSize;
     this.maxHeaderListSize = maxHeaderListSize;
@@ -118,8 +123,9 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers,
-      CallOptions callOptions, StatsTraceContext statsTraceCtx) {
+  public ClientStream newStream(
+      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+      StatsTraceContext statsTraceCtx) {
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
     Preconditions.checkNotNull(statsTraceCtx, "statsTraceCtx");
@@ -139,6 +145,7 @@ class NettyClientTransport implements ConnectionClientTransport {
     return newStream(method, headers, CallOptions.DEFAULT, StatsTraceContext.NOOP);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public Runnable start(Listener transportListener) {
     lifecycleManager = new ClientTransportLifecycleManager(
@@ -155,6 +162,10 @@ class NettyClientTransport implements ConnectionClientTransport {
     if (NioSocketChannel.class.isAssignableFrom(channelType)) {
       b.option(SO_KEEPALIVE, true);
     }
+    for (Map.Entry<ChannelOption<?>, Object> entry : channelOptions.entrySet()) {
+      b.option((ChannelOption<Object>) entry.getKey(), entry.getValue());
+    }
+
     /**
      * We don't use a ChannelInitializer in the client bootstrap because its "initChannel" method
      * is executed in the event loop and we need this handler to be in the pipeline immediately so
@@ -237,6 +248,11 @@ class NettyClientTransport implements ConnectionClientTransport {
     return Attributes.EMPTY;
   }
 
+  @VisibleForTesting
+  Channel channel() {
+    return channel;
+  }
+
   /**
    * Convert ChannelFuture.cause() to a Status, taking into account that all handlers are removed
    * from the pipeline when the channel is closed. Since handlers are removed, you may get an
@@ -261,7 +277,7 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   private NettyClientHandler newHandler() {
-    return NettyClientHandler.newHandler(lifecycleManager, flowControlWindow, maxHeaderListSize,
-        Ticker.systemTicker());
+    return NettyClientHandler
+        .newHandler(lifecycleManager, flowControlWindow, maxHeaderListSize, Ticker.systemTicker());
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -60,6 +60,7 @@ import io.netty.util.AsciiString;
 
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
@@ -96,7 +97,8 @@ class NettyClientTransport implements ConnectionClientTransport {
     this.address = Preconditions.checkNotNull(address, "address");
     this.group = Preconditions.checkNotNull(group, "group");
     this.channelType = Preconditions.checkNotNull(channelType, "channelType");
-    this.channelOptions = Preconditions.checkNotNull(channelOptions, "channelOptions");
+    this.channelOptions = new HashMap<ChannelOption<?>, Object>(
+        Preconditions.checkNotNull(channelOptions, "channelOptions"));
     this.flowControlWindow = flowControlWindow;
     this.maxMessageSize = maxMessageSize;
     this.maxHeaderListSize = maxHeaderListSize;
@@ -163,6 +165,9 @@ class NettyClientTransport implements ConnectionClientTransport {
       b.option(SO_KEEPALIVE, true);
     }
     for (Map.Entry<ChannelOption<?>, ?> entry : channelOptions.entrySet()) {
+      // Every entry in the map is obtained from
+      // NettyChannelBuilder#withOption(ChannelOption<T> option, T value)
+      // so it is safe to pass the key-value pair to b.option().
       b.option((ChannelOption<Object>) entry.getKey(), entry.getValue());
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -60,7 +60,6 @@ import io.netty.util.AsciiString;
 
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
@@ -97,8 +96,7 @@ class NettyClientTransport implements ConnectionClientTransport {
     this.address = Preconditions.checkNotNull(address, "address");
     this.group = Preconditions.checkNotNull(group, "group");
     this.channelType = Preconditions.checkNotNull(channelType, "channelType");
-    this.channelOptions = new HashMap<ChannelOption<?>, Object>(
-        Preconditions.checkNotNull(channelOptions, "channelOptions"));
+    this.channelOptions = Preconditions.checkNotNull(channelOptions, "channelOptions");
     this.flowControlWindow = flowControlWindow;
     this.maxMessageSize = maxMessageSize;
     this.maxHeaderListSize = maxHeaderListSize;

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -68,7 +68,7 @@ import javax.annotation.Nullable;
  * A Netty-based {@link ConnectionClientTransport} implementation.
  */
 class NettyClientTransport implements ConnectionClientTransport {
-  private final Map<ChannelOption<?>, Object> channelOptions;
+  private final Map<ChannelOption<?>, ?> channelOptions;
   private final SocketAddress address;
   private final Class<? extends Channel> channelType;
   private final EventLoopGroup group;
@@ -89,7 +89,7 @@ class NettyClientTransport implements ConnectionClientTransport {
 
   NettyClientTransport(
       SocketAddress address, Class<? extends Channel> channelType,
-      Map<ChannelOption<?>, Object> channelOptions, EventLoopGroup group,
+      Map<ChannelOption<?>, ?> channelOptions, EventLoopGroup group,
       ProtocolNegotiator negotiator, int flowControlWindow, int maxMessageSize,
       int maxHeaderListSize, String authority, @Nullable String userAgent) {
     this.negotiator = Preconditions.checkNotNull(negotiator, "negotiator");
@@ -162,7 +162,7 @@ class NettyClientTransport implements ConnectionClientTransport {
     if (NioSocketChannel.class.isAssignableFrom(channelType)) {
       b.option(SO_KEEPALIVE, true);
     }
-    for (Map.Entry<ChannelOption<?>, Object> entry : channelOptions.entrySet()) {
+    for (Map.Entry<ChannelOption<?>, ?> entry : channelOptions.entrySet()) {
       b.option((ChannelOption<Object>) entry.getKey(), entry.getValue());
     }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -62,7 +62,10 @@ import io.grpc.internal.ServerTransport;
 import io.grpc.internal.ServerTransportListener;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.testing.TestUtils;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -85,7 +88,9 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -101,11 +106,11 @@ public class NettyClientTransportTest {
 
   private final List<NettyClientTransport> transports = new ArrayList<NettyClientTransport>();
   private final NioEventLoopGroup group = new NioEventLoopGroup(1);
+  private final EchoServerListener serverListener = new EchoServerListener();
 
   private InetSocketAddress address;
   private String authority;
   private NettyServer server;
-  private EchoServerListener serverListener = new EchoServerListener();
 
   @Before
   public void setup() throws Exception {
@@ -150,6 +155,22 @@ public class NettyClientTransportTest {
 
     Metadata headers = serverListener.streamListeners.get(0).headers;
     assertEquals(GrpcUtil.getGrpcUserAgent("netty", null), headers.get(USER_AGENT_KEY));
+  }
+
+  @Test
+  public void setTosChannelOption() throws IOException {
+    startServer();
+    Map<ChannelOption<?>, Object> channelOptions = new HashMap<ChannelOption<?>, Object>();
+    // set IP_TOS option
+    int tos = 123;
+    channelOptions.put(ChannelOption.IP_TOS, tos);
+    NettyClientTransport transport = newTransport(channelOptions);
+    transport.start(clientTransportListener);
+
+    // verify IP_TOS has been set
+    ChannelConfig config = transport.channel().config();
+    assertTrue(config instanceof SocketChannelConfig);
+    assertEquals(tos, ((SocketChannelConfig) config).getTrafficClass());
   }
 
   @Test
@@ -308,11 +329,21 @@ public class NettyClientTransportTest {
         DEFAULT_MAX_MESSAGE_SIZE, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, null /* user agent */);
   }
 
-  private NettyClientTransport newTransport(ProtocolNegotiator negotiator,
-      int maxMsgSize, int maxHeaderListSize, String userAgent) {
-    NettyClientTransport transport = new NettyClientTransport(address, NioSocketChannel.class,
-        group, negotiator, DEFAULT_WINDOW_SIZE, maxMsgSize, maxHeaderListSize, authority,
-        userAgent);
+  private NettyClientTransport newTransport(
+      ProtocolNegotiator negotiator, int maxMsgSize, int maxHeaderListSize, String userAgent) {
+    NettyClientTransport transport = new NettyClientTransport(
+        address, NioSocketChannel.class, new HashMap<ChannelOption<?>, Object>(), group, negotiator,
+        DEFAULT_WINDOW_SIZE, maxMsgSize, maxHeaderListSize, authority, userAgent);
+    transports.add(transport);
+    return transport;
+  }
+
+  private NettyClientTransport newTransport(Map<ChannelOption<?>, Object> channelOptions)
+      throws IOException {
+    NettyClientTransport transport = new NettyClientTransport(
+        address, NioSocketChannel.class, channelOptions, group, newNegotiator(),
+        DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
+        authority, null /* user agent */);
     transports.add(transport);
     return transport;
   }
@@ -449,8 +480,8 @@ public class NettyClientTransportTest {
         }
 
         @Override
-        public ServerStreamListener streamCreated(final ServerStream stream, String method,
-                                                  Metadata headers) {
+        public ServerStreamListener streamCreated(
+            ServerStream stream, String method, Metadata headers) {
           EchoServerStreamListener listener = new EchoServerStreamListener(stream, method, headers);
           streamListeners.add(listener);
           return listener;

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -164,7 +164,11 @@ public class NettyClientTransportTest {
     // set SO_LINGER option
     int soLinger = 123;
     channelOptions.put(ChannelOption.SO_LINGER, soLinger);
-    NettyClientTransport transport = newTransport(channelOptions);
+    NettyClientTransport transport = new NettyClientTransport(
+        address, NioSocketChannel.class, channelOptions, group, newNegotiator(),
+        DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
+        authority, null /* user agent */);
+    transports.add(transport);
     transport.start(clientTransportListener);
 
     // verify SO_LINGER has been set
@@ -334,16 +338,6 @@ public class NettyClientTransportTest {
     NettyClientTransport transport = new NettyClientTransport(
         address, NioSocketChannel.class, new HashMap<ChannelOption<?>, Object>(), group, negotiator,
         DEFAULT_WINDOW_SIZE, maxMsgSize, maxHeaderListSize, authority, userAgent);
-    transports.add(transport);
-    return transport;
-  }
-
-  private NettyClientTransport newTransport(Map<ChannelOption<?>, ?> channelOptions)
-      throws IOException {
-    NettyClientTransport transport = new NettyClientTransport(
-        address, NioSocketChannel.class, channelOptions, group, newNegotiator(),
-        DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
-        authority, null /* user agent */);
     transports.add(transport);
     return transport;
   }

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -338,7 +338,7 @@ public class NettyClientTransportTest {
     return transport;
   }
 
-  private NettyClientTransport newTransport(Map<ChannelOption<?>, Object> channelOptions)
+  private NettyClientTransport newTransport(Map<ChannelOption<?>, ?> channelOptions)
       throws IOException {
     NettyClientTransport transport = new NettyClientTransport(
         address, NioSocketChannel.class, channelOptions, group, newNegotiator(),

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -158,19 +158,19 @@ public class NettyClientTransportTest {
   }
 
   @Test
-  public void setTosChannelOption() throws IOException {
+  public void setSoLingerChannelOption() throws IOException {
     startServer();
     Map<ChannelOption<?>, Object> channelOptions = new HashMap<ChannelOption<?>, Object>();
-    // set IP_TOS option
-    int tos = 123;
-    channelOptions.put(ChannelOption.IP_TOS, tos);
+    // set SO_LINGER option
+    int soLinger = 123;
+    channelOptions.put(ChannelOption.SO_LINGER, soLinger);
     NettyClientTransport transport = newTransport(channelOptions);
     transport.start(clientTransportListener);
 
-    // verify IP_TOS has been set
+    // verify SO_LINGER has been set
     ChannelConfig config = transport.channel().config();
     assertTrue(config instanceof SocketChannelConfig);
-    assertEquals(tos, ((SocketChannelConfig) config).getTrafficClass());
+    assertEquals(soLinger, ((SocketChannelConfig) config).getSoLinger());
   }
 
   @Test


### PR DESCRIPTION
Add `withOption(ChannelOption<T> option, T value)` method to
`NettyChannelBuilder`. 
Among other features, this allows user to set a custom TOS.
