### PR TITLE
benchmarks: Avoid sending a message after half close

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
@@ -403,11 +403,13 @@ class LoadClient {
               @Override
               public void onNext(Messages.SimpleResponse value) {
                 delay(System.nanoTime() - now);
-                requestObserver.get().onNext(simpleRequest);
-                now = System.nanoTime();
                 if (shutdown) {
                   requestObserver.get().onCompleted();
+                  // Must not send another request.
+                  return;
                 }
+                requestObserver.get().onNext(simpleRequest);
+                now = System.nanoTime();
               }
 
               @Override


### PR DESCRIPTION
This doesn't impact test behavior per-se, but causes it to produce less
useless log output of the form:

```
java.lang.IllegalStateException: call was half-closed
	at com.google.common.base.Preconditions.checkState(Preconditions.java:174)
	at io.grpc.internal.ClientCallImpl.sendMessage(ClientCallImpl.java:380)
	at io.grpc.stub.ClientCalls$CallToStreamObserverAdapter.onNext(ClientCalls.java:299)
	at io.grpc.benchmarks.driver.LoadClient$AsyncPingPongWorker$1.onNext(LoadClient.java:406)
	at io.grpc.benchmarks.driver.LoadClient$AsyncPingPongWorker$1.onNext(LoadClient.java:400)
	at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onMessage(ClientCalls.java:382)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessageRead.runInContext(ClientCallImpl.java:473)
	... 7 more
```

Fixes #2372