### PR TITLE
netty: fix static data race on handler settings

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
@@ -47,6 +47,7 @@ public class AutoWindowSizingOnTest extends AbstractInteropTest {
 
   @BeforeClass
   public static void turnOnAutoWindow() {
+    HandlerSettings.enable(true);
     HandlerSettings.autoWindowOn(true);
     startStaticServer(
         NettyServerBuilder.forPort(0)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
@@ -94,6 +94,7 @@ public class NettyFlowControlTest {
 
   @BeforeClass
   public static void setUp() {
+    HandlerSettings.enable(true);
     HandlerSettings.autoWindowOn(true);
   }
 


### PR DESCRIPTION
As seen here:

```
  Write of size 8 at 0x7f0046595478 by thread T101 (mutexes: write M590111189888139032):
    #0 io.grpc.netty.HandlerSettings.setAutoWindow(Lio/grpc/netty/AbstractNettyHandler;)V (HandlerSettings.java:53)  
    #1 io.grpc.netty.NettyClientTransport.start(Lio/grpc/internal/ManagedClientTransport$Listener;)Ljava/lang/Runnable; (NettyClientTransport.java:148)  
    #2 io.grpc.internal.ForwardingConnectionClientTransport.start(Lio/grpc/internal/ManagedClientTransport$Listener;)Ljava/lang/Runnable; (ForwardingConnectionClientTransport.java:45)  
    #3 io.grpc.internal.TransportSet.startNewTransport(Lio/grpc/internal/DelayedClientTransport;)Ljava/lang/Runnable; (TransportSet.java:234)  
    #4 io.grpc.internal.TransportSet.obtainActiveTransport()Lio/grpc/internal/ClientTransport; (TransportSet.java:204)  
    #5 io.grpc.internal.ManagedChannelImpl$3.getTransport(Lio/grpc/EquivalentAddressGroup;)Lio/grpc/internal/ClientTransport; (ManagedChannelImpl.java:721)  
    #6 io.grpc.internal.ManagedChannelImpl$3.getTransport(Lio/grpc/EquivalentAddressGroup;)Ljava/lang/Object; (ManagedChannelImpl.java:660)  
    #7 io.grpc.PickFirstBalancerFactory$PickFirstBalancer$1.get()Ljava/lang/Object; (PickFirstBalancerFactory.java:132)  
    #8 io.grpc.internal.DelayedClientTransport$2.run()V (DelayedClientTransport.java:264)  

  Previous write of size 8 at 0x7f0046595478 by thread T94 (mutexes: write M576881865974269888):
    #0 io.grpc.netty.HandlerSettings.setAutoWindow(Lio/grpc/netty/AbstractNettyHandler;)V (HandlerSettings.java:53)  
    #1 io.grpc.netty.NettyClientTransport.start(Lio/grpc/internal/ManagedClientTransport$Listener;)Ljava/lang/Runnable; (NettyClientTransport.java:148)  
    #2 io.grpc.internal.ForwardingConnectionClientTransport.start(Lio/grpc/internal/ManagedClientTransport$Listener;)Ljava/lang/Runnable; (ForwardingConnectionClientTransport.java:45)  
    #3 io.grpc.internal.TransportSet.startNewTransport(Lio/grpc/internal/DelayedClientTransport;)Ljava/lang/Runnable; (TransportSet.java:234)  
    #4 io.grpc.internal.TransportSet.obtainActiveTransport()Lio/grpc/internal/ClientTransport; (TransportSet.java:204)  
    #5 io.grpc.internal.ManagedChannelImpl$3.getTransport(Lio/grpc/EquivalentAddressGroup;)Lio/grpc/internal/ClientTransport; (ManagedChannelImpl.java:721)  
    #6 io.grpc.internal.ManagedChannelImpl$3.getTransport(Lio/grpc/EquivalentAddressGroup;)Ljava/lang/Object; (ManagedChannelImpl.java:660)  
    #7 io.grpc.PickFirstBalancerFactory$PickFirstBalancer$1.get()Ljava/lang/Object; (PickFirstBalancerFactory.java:132)  
    #8 io.grpc.internal.DelayedClientTransport$2.run()V (DelayedClientTransport.java:264)  

```