### PR TITLE
core: support sending request message using GET verb for server caching

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -132,7 +132,7 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
       final Status capturedStatus = shutdownStatus;
       return new NoopClientStream() {
         @Override
-        public void start(ClientStreamListener listener) {
+        public void start(ClientStreamListener listener, Metadata headers) {
           listener.closed(capturedStatus, new Metadata());
         }
       };
@@ -235,13 +235,11 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
     private final InProcessServerStream serverStream = new InProcessServerStream();
     private final InProcessClientStream clientStream = new InProcessClientStream();
     private final StatsTraceContext serverStatsTraceContext;
-    private final Metadata headers;
     private final MethodDescriptor<?, ?> method;
 
     private InProcessStream(MethodDescriptor<?, ?> method, Metadata headers,
         StatsTraceContext serverStatsTraceContext) {
       this.method = checkNotNull(method, "method");
-      this.headers = checkNotNull(headers, "headers");
       this.serverStatsTraceContext =
           checkNotNull(serverStatsTraceContext, "serverStatsTraceContext");
     }
@@ -551,7 +549,7 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
       }
 
       @Override
-      public void start(ClientStreamListener listener) {
+      public void start(ClientStreamListener listener, Metadata headers) {
         serverStream.setListener(listener);
 
         synchronized (InProcessTransport.this) {

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -139,7 +139,7 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
     }
     StatsTraceContext serverStatsTraceContext = serverTransportListener.methodDetermined(
         method.getFullMethodName(), headers);
-    return new InProcessStream(method, headers, serverStatsTraceContext).clientStream;
+    return new InProcessStream(method, serverStatsTraceContext).clientStream;
   }
 
   @Override
@@ -198,6 +198,11 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
   }
 
   @Override
+  public boolean supportGetMethod() {
+    return false;
+  }
+
+  @Override
   public String toString() {
     return getLogId() + "(" + name + ")";
   }
@@ -237,7 +242,7 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
     private final StatsTraceContext serverStatsTraceContext;
     private final MethodDescriptor<?, ?> method;
 
-    private InProcessStream(MethodDescriptor<?, ?> method, Metadata headers,
+    private InProcessStream(MethodDescriptor<?, ?> method,
         StatsTraceContext serverStatsTraceContext) {
       this.method = checkNotNull(method, "method");
       this.serverStatsTraceContext =

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -78,7 +78,7 @@ public abstract class AbstractClientStream extends AbstractStream
    * this method after they have been created.
    */
   @Override
-  public void start(ClientStreamListener listener) {
+  public void start(ClientStreamListener listener, Metadata headers) {
     checkState(this.listener == null, "stream already started");
     this.listener = checkNotNull(listener, "listener");
   }

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
@@ -104,7 +104,7 @@ public abstract class AbstractClientStream2 extends AbstractStream2
   protected abstract TransportState transportState();
 
   @Override
-  public void start(ClientStreamListener listener) {
+  public void start(ClientStreamListener listener, Metadata headers) {
     transportState().setListener(listener);
   }
 

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -37,7 +37,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
-import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
 
@@ -83,12 +82,11 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
 
     @Override
     public ClientStream newStream(
-        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
-        StatsTraceContext statsTraceCtx) {
+        MethodDescriptor<?, ?> method, CallOptions callOptions, StatsTraceContext statsTraceCtx) {
       CallCredentials creds = callOptions.getCredentials();
       if (creds != null) {
         MetadataApplierImpl applier = new MetadataApplierImpl(
-            delegate, method, headers, callOptions, statsTraceCtx);
+            delegate, method, callOptions, statsTraceCtx);
         Attributes.Builder effectiveAttrsBuilder = Attributes.newBuilder()
             .set(CallCredentials.ATTR_AUTHORITY, authority)
             .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
@@ -100,7 +98,7 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
             firstNonNull(callOptions.getExecutor(), appExecutor), applier);
         return applier.returnStream();
       } else {
-        return delegate.newStream(method, headers, callOptions, statsTraceCtx);
+        return delegate.newStream(method, callOptions, statsTraceCtx);
       }
     }
   }

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -417,10 +417,10 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
     Preconditions.checkState(stream != null, "Not started");
     Preconditions.checkState(!cancelCalled, "call was cancelled");
     Preconditions.checkState(!halfCloseCalled, "call already half-closed");
+    halfCloseCalled = true;
     if (useGetMethod) {
       startStream();
     }
-    halfCloseCalled = true;
     stream.halfClose();
   }
 

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -226,7 +226,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT>
           && transport.supportGetMethod();
       Context origContext = context.attach();
       try {
-        stream = transport.newStream(method, headers, callOptions, statsTraceCtx);
+        stream = transport.newStream(method, callOptions, statsTraceCtx);
       } finally {
         context.detach(origContext);
       }

--- a/core/src/main/java/io/grpc/internal/ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ClientStream.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import io.grpc.Metadata;
 import io.grpc.Status;
 
 /**
@@ -72,6 +73,7 @@ public interface ClientStream extends Stream {
    * <p>This method should not throw any exceptions.
    *
    * @param listener non-{@code null} listener of stream events
+   * @param headers to send at the beginning of the call
    */
-  void start(ClientStreamListener listener);
+  void start(ClientStreamListener listener, Metadata headers);
 }

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -85,6 +85,10 @@ public interface ClientTransport {
 
   /**
    * Returns true if the transport can send unary requests using GET.
+   *
+   * <p>GET will only be used for sending unary requests which are both safe and idempotent. The
+   * encoded request message will be put in the request header. By supporting this, transports are
+   * required to be able to use GET verb and encode the header in base64 encoding.
    */
   boolean supportGetMethod();
 

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -32,7 +32,6 @@
 package io.grpc.internal;
 
 import io.grpc.CallOptions;
-import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 
 import java.util.concurrent.Executor;
@@ -58,17 +57,16 @@ public interface ClientTransport {
    * <p>This method is called under the {@link io.grpc.Context} of the {@link io.grpc.ClientCall}.
    *
    * @param method the descriptor of the remote method to be called for this stream.
-   * @param headers to send at the beginning of the call
    * @param callOptions runtime options of the call
    * @param statsTraceCtx carries stats and tracing information
    * @return the newly created stream.
    */
   // TODO(nmittler): Consider also throwing for stopping.
-  ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
+  ClientStream newStream(MethodDescriptor<?, ?> method, CallOptions callOptions,
       StatsTraceContext statsTraceCtx);
 
   // TODO(zdapeng): Remove two-argument version in favor of four-argument overload.
-  ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers);
+  ClientStream newStream(MethodDescriptor<?, ?> method);
 
   /**
    * Pings a remote endpoint. When an acknowledgement is received, the given callback will be

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -84,6 +84,11 @@ public interface ClientTransport {
   void ping(PingCallback callback, Executor executor);
 
   /**
+   * Returns true if the transport can send unary requests using GET.
+   */
+  boolean supportGetMethod();
+
+  /**
    * A callback that is invoked when the acknowledgement to a {@link #ping} is received. Exactly one
    * of the two methods should be called per {@link #ping}.
    */

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -215,6 +215,11 @@ class DelayedClientTransport implements ManagedClientTransport {
     // If savedPendingStreams == null, transportTerminated() has already been called in shutdown().
   }
 
+  @Override
+  public boolean supportGetMethod() {
+    return false;
+  }
+
   /**
    * Transfers all the pending and future streams and pings to the given transport.
    *

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -157,7 +157,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public void start(ClientStreamListener listener) {
+  public void start(ClientStreamListener listener, Metadata headers) {
     checkState(this.listener == null, "already started");
 
     Status savedError;
@@ -177,13 +177,14 @@ class DelayedStream implements ClientStream {
     }
 
     if (savedPassThrough) {
-      realStream.start(listener);
+      realStream.start(listener, headers);
     } else {
       final ClientStreamListener finalListener = listener;
+      final Metadata finalHeaders = headers;
       delayOrExecute(new Runnable() {
         @Override
         public void run() {
-          realStream.start(finalListener);
+          realStream.start(finalListener, finalHeaders);
         }
       });
     }

--- a/core/src/main/java/io/grpc/internal/FailingClientStream.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientStream.java
@@ -53,7 +53,7 @@ class FailingClientStream extends NoopClientStream {
   }
 
   @Override
-  public void start(ClientStreamListener listener) {
+  public void start(ClientStreamListener listener, Metadata headers) {
     Preconditions.checkState(!started, "already started");
     started = true;
     listener.closed(error, new Metadata());

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -73,4 +73,9 @@ class FailingClientTransport implements ClientTransport {
         }
       });
   }
+
+  @Override
+  public boolean supportGetMethod() {
+    return false;
+  }
 }

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -35,7 +35,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import io.grpc.CallOptions;
-import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
@@ -55,14 +54,14 @@ class FailingClientTransport implements ClientTransport {
   }
 
   @Override
-  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers,
+  public ClientStream newStream(MethodDescriptor<?, ?> method,
       CallOptions callOptions, StatsTraceContext statsTraceCtx) {
     return new FailingClientStream(error);
   }
 
   @Override
-  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
-    return newStream(method, headers, CallOptions.DEFAULT, StatsTraceContext.NOOP);
+  public ClientStream newStream(MethodDescriptor<?, ?> method) {
+    return newStream(method, CallOptions.DEFAULT, StatsTraceContext.NOOP);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -87,5 +87,10 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
     return getClass().getSimpleName() + "[" + delegate().toString() + "]";
   }
 
+  @Override
+  public boolean supportGetMethod() {
+    return false;
+  }
+
   protected abstract ConnectionClientTransport delegate();
 }

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -33,7 +33,6 @@ package io.grpc.internal;
 
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
-import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
@@ -57,14 +56,13 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
 
   @Override
   public ClientStream newStream(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
-      StatsTraceContext statsTraceCtx) {
-    return delegate().newStream(method, headers, callOptions, statsTraceCtx);
+      MethodDescriptor<?, ?> method, CallOptions callOptions, StatsTraceContext statsTraceCtx) {
+    return delegate().newStream(method, callOptions, statsTraceCtx);
   }
 
   @Override
-  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
-    return delegate().newStream(method, headers);
+  public ClientStream newStream(MethodDescriptor<?, ?> method) {
+    return delegate().newStream(method);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -99,6 +99,12 @@ public final class GrpcUtil {
           Metadata.Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER);
 
   /**
+   * {@link io.grpc.Metadata.Key} for the request payload request header.
+   */
+  public static final Metadata.Key<byte[]> GRPC_PAYLOAD_BIN_KEY =
+          Metadata.Key.of("grpc-payload-bin", Metadata.BINARY_BYTE_MARSHALLER);
+
+  /**
    * The default port for plain-text connections.
    */
   public static final int DEFAULT_PORT_PLAINTEXT = 80;

--- a/core/src/main/java/io/grpc/internal/NoopClientStream.java
+++ b/core/src/main/java/io/grpc/internal/NoopClientStream.java
@@ -33,6 +33,7 @@ package io.grpc.internal;
 
 import io.grpc.Compressor;
 import io.grpc.Decompressor;
+import io.grpc.Metadata;
 import io.grpc.Status;
 
 import java.io.InputStream;
@@ -47,7 +48,7 @@ public class NoopClientStream implements ClientStream {
   public void setAuthority(String authority) {}
 
   @Override
-  public void start(ClientStreamListener listener) {}
+  public void start(ClientStreamListener listener, Metadata headers) {}
 
   @Override
   public void request(int numMessages) {}

--- a/core/src/test/java/io/grpc/internal/AbstractClientStream2Test.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStream2Test.java
@@ -84,7 +84,7 @@ public class AbstractClientStream2Test {
     for (Code code : Code.values()) {
       ClientStreamListener listener = new NoopClientStreamListener();
       AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-      stream.start(listener);
+      stream.start(listener, new Metadata());
       if (code != Code.OK) {
         stream.cancel(Status.fromCodeValue(code.value()));
       } else {
@@ -102,7 +102,7 @@ public class AbstractClientStream2Test {
   public void cancel_failsOnNull() {
     ClientStreamListener listener = new NoopClientStreamListener();
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     thrown.expect(NullPointerException.class);
 
     stream.cancel(null);
@@ -118,7 +118,7 @@ public class AbstractClientStream2Test {
         state.transportReportStatus(errorStatus, true/*stop delivery*/, new Metadata());
       }
       }, statsTraceCtx);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
 
     stream.cancel(Status.DEADLINE_EXCEEDED);
     stream.cancel(Status.DEADLINE_EXCEEDED);
@@ -132,23 +132,23 @@ public class AbstractClientStream2Test {
 
     thrown.expect(NullPointerException.class);
 
-    stream.start(null);
+    stream.start(null, new Metadata());
   }
 
   @Test
   public void cantCallStartTwice() {
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     thrown.expect(IllegalStateException.class);
 
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
   }
 
   @Test
   public void inboundDataReceived_failsOnNullFrame() {
     ClientStreamListener listener = new NoopClientStreamListener();
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     thrown.expect(NullPointerException.class);
 
     stream.transportState().inboundDataReceived(null);
@@ -157,7 +157,7 @@ public class AbstractClientStream2Test {
   @Test
   public void inboundDataReceived_failsOnNoHeaders() {
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
 
     stream.transportState().inboundDataReceived(ReadableBuffers.empty());
 
@@ -168,7 +168,7 @@ public class AbstractClientStream2Test {
   @Test
   public void inboundHeadersReceived_notifiesListener() {
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     Metadata headers = new Metadata();
 
     stream.transportState().inboundHeadersReceived(headers);
@@ -178,7 +178,7 @@ public class AbstractClientStream2Test {
   @Test
   public void inboundHeadersReceived_failsIfStatusReported() {
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     stream.transportState().transportReportStatus(Status.CANCELLED, false, new Metadata());
 
     thrown.expect(IllegalStateException.class);
@@ -188,7 +188,7 @@ public class AbstractClientStream2Test {
   @Test
   public void inboundHeadersReceived_acceptsGzipEncoding() {
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     Metadata headers = new Metadata();
     headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, new Codec.Gzip().getMessageEncoding());
 
@@ -199,7 +199,7 @@ public class AbstractClientStream2Test {
   @Test
   public void inboundHeadersReceived_acceptsIdentityEncoding() {
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     Metadata headers = new Metadata();
     headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, Codec.Identity.NONE.getMessageEncoding());
 
@@ -210,7 +210,7 @@ public class AbstractClientStream2Test {
   @Test
   public void rstStreamClosesStream() {
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     // The application will call request when waiting for a message, which will in turn call this
     // on the transport thread.
     stream.transportState().requestMessagesFromDeframer(1);

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -85,7 +85,7 @@ public class AbstractClientStreamTest {
     for (Code code : Code.values()) {
       ClientStreamListener listener = new NoopClientStreamListener();
       AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-      stream.start(listener);
+      stream.start(listener, new Metadata());
       if (code != Code.OK) {
         stream.cancel(Status.fromCodeValue(code.value()));
       } else {
@@ -103,7 +103,7 @@ public class AbstractClientStreamTest {
   public void cancel_failsOnNull() {
     ClientStreamListener listener = new NoopClientStreamListener();
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     thrown.expect(NullPointerException.class);
 
     stream.cancel(null);
@@ -117,7 +117,7 @@ public class AbstractClientStreamTest {
         transportReportStatus(errorStatus, true/*stop delivery*/, new Metadata());
       }
     };
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
 
     stream.cancel(Status.DEADLINE_EXCEEDED);
 
@@ -130,16 +130,16 @@ public class AbstractClientStreamTest {
 
     thrown.expect(NullPointerException.class);
 
-    stream.start(null);
+    stream.start(null, new Metadata());
   }
 
   @Test
   public void cantCallStartTwice() {
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     thrown.expect(IllegalStateException.class);
 
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
   }
 
   @Test
@@ -150,7 +150,7 @@ public class AbstractClientStreamTest {
         transportReportStatus(errorStatus, true/*stop delivery*/, new Metadata());
       }
     };
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
 
     stream.deframeFailed(new RuntimeException("something bad"));
 
@@ -162,7 +162,7 @@ public class AbstractClientStreamTest {
   public void inboundDataReceived_failsOnNullFrame() {
     ClientStreamListener listener = new NoopClientStreamListener();
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     thrown.expect(NullPointerException.class);
 
     stream.inboundDataReceived(null);
@@ -171,7 +171,7 @@ public class AbstractClientStreamTest {
   @Test
   public void inboundDataReceived_failsOnNoHeaders() {
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     stream.inboundPhase(Phase.HEADERS);
 
     stream.inboundDataReceived(ReadableBuffers.empty());
@@ -183,7 +183,7 @@ public class AbstractClientStreamTest {
   @Test
   public void inboundHeadersReceived_notifiesListener() {
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     Metadata headers = new Metadata();
 
     stream.inboundHeadersReceived(headers);
@@ -193,7 +193,7 @@ public class AbstractClientStreamTest {
   @Test
   public void inboundHeadersReceived_failsOnPhaseStatus() {
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     Metadata headers = new Metadata();
     stream.inboundPhase(Phase.STATUS);
 
@@ -205,7 +205,7 @@ public class AbstractClientStreamTest {
   @Test
   public void inboundHeadersReceived_succeedsOnPhaseMessage() {
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     Metadata headers = new Metadata();
     stream.inboundPhase(Phase.MESSAGE);
 
@@ -217,7 +217,7 @@ public class AbstractClientStreamTest {
   @Test
   public void inboundHeadersReceived_acceptsGzipEncoding() {
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     Metadata headers = new Metadata();
     headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, new Codec.Gzip().getMessageEncoding());
 
@@ -228,7 +228,7 @@ public class AbstractClientStreamTest {
   @Test
   public void inboundHeadersReceived_acceptsIdentityEncoding() {
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     Metadata headers = new Metadata();
     headers.put(GrpcUtil.MESSAGE_ENCODING_KEY, Codec.Identity.NONE.getMessageEncoding());
 
@@ -239,7 +239,7 @@ public class AbstractClientStreamTest {
   @Test
   public void rstStreamClosesStream() {
     AbstractClientStream stream = new BaseAbstractClientStream(allocator);
-    stream.start(mockListener);
+    stream.start(mockListener, new Metadata());
     // The application will call request when waiting for a message, which will in turn call this
     // on the transport thread.
     stream.requestMessagesFromDeframer(1);

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -158,7 +158,7 @@ public class ClientCallImplTest {
     MockitoAnnotations.initMocks(this);
     assertNotNull(censusCtx);
     when(provider.get(any(CallOptions.class))).thenReturn(transport);
-    when(transport.newStream(any(MethodDescriptor.class), any(Metadata.class),
+    when(transport.newStream(any(MethodDescriptor.class),
             any(CallOptions.class), any(StatsTraceContext.class))).thenReturn(stream);
   }
 
@@ -307,8 +307,9 @@ public class ClientCallImplTest {
     call.start(callListener, new Metadata());
 
     ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass(Metadata.class);
-    verify(transport).newStream(eq(method), metadataCaptor.capture(), same(CallOptions.DEFAULT),
+    verify(transport).newStream(eq(method), same(CallOptions.DEFAULT),
         same(statsTraceCtx));
+    verify(stream).start(any(ClientStreamListener.class), metadataCaptor.capture());
     Metadata actual = metadataCaptor.getValue();
 
     Set<String> acceptedEncodings =
@@ -346,7 +347,7 @@ public class ClientCallImplTest {
 
     call.start(callListener, metadata);
 
-    verify(transport).newStream(same(method), same(metadata), same(callOptions),
+    verify(transport).newStream(same(method), same(callOptions),
         same(statsTraceCtx));
   }
 
@@ -615,7 +616,7 @@ public class ClientCallImplTest {
         deadlineCancellationExecutor)
             .setDecompressorRegistry(decompressorRegistry);
     call.start(callListener, new Metadata());
-    verify(transport, times(0)).newStream(any(MethodDescriptor.class), any(Metadata.class));
+    verify(transport, times(0)).newStream(any(MethodDescriptor.class));
     verify(callListener, timeout(1000)).onClose(statusCaptor.capture(), any(Metadata.class));
     assertEquals(Status.Code.DEADLINE_EXCEEDED, statusCaptor.getValue().getCode());
     assertStatusInStats(Status.Code.DEADLINE_EXCEEDED);

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -56,7 +56,6 @@ import com.google.census.CensusContext;
 import com.google.census.RpcConstants;
 import com.google.census.TagValue;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 
@@ -842,6 +841,7 @@ public class ClientCallImplTest {
         statsTraceCtx,
         provider,
         deadlineCancellationExecutor);
+    when(transport.supportGetMethod()).thenReturn(true);
     call.start(callListener, new Metadata());
     // call.start should not trigger stream.start
     verify(stream, times(0)).start(any(ClientStreamListener.class), any(Metadata.class));
@@ -855,8 +855,7 @@ public class ClientCallImplTest {
     verify(stream).start(listenerArgumentCaptor.capture(), headersCaptor.capture());
     Metadata headers = headersCaptor.getValue();
     // The request payload is sent over the headers.
-    assertArrayEquals(BaseEncoding.base64().encode("request-payload".getBytes()).getBytes(),
-        headers.get(Metadata.Key.of("grpc-payload-bin", Metadata.BINARY_BYTE_MARSHALLER)));
+    assertArrayEquals("request-payload".getBytes(), headers.get(GrpcUtil.GRPC_PAYLOAD_BIN_KEY));
 
     ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
     streamListener.onReady();

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -142,7 +142,7 @@ public class DelayedClientTransportTest {
   @Test public void streamStartThenSetTransport() {
     assertFalse(delayedTransport.hasPendingStreams());
     ClientStream stream = delayedTransport.newStream(method, headers, callOptions, statsTraceCtx);
-    stream.start(streamListener);
+    stream.start(streamListener, headers);
     assertEquals(1, delayedTransport.getPendingStreamsCount());
     assertTrue(delayedTransport.hasPendingStreams());
     assertTrue(stream instanceof DelayedStream);
@@ -153,7 +153,7 @@ public class DelayedClientTransportTest {
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions),
         same(statsTraceCtx));
-    verify(mockRealStream).start(listenerCaptor.capture());
+    verify(mockRealStream).start(listenerCaptor.capture(), same(headers));
     verifyNoMoreInteractions(streamListener);
     listenerCaptor.getValue().onReady();
     verify(streamListener).onReady();
@@ -172,8 +172,8 @@ public class DelayedClientTransportTest {
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions),
         same(statsTraceCtx));
-    stream.start(streamListener);
-    verify(mockRealStream).start(same(streamListener));
+    stream.start(streamListener, headers);
+    verify(mockRealStream).start(same(streamListener), same(headers));
   }
 
   @Test public void transportTerminatedThenSetTransport() {
@@ -191,11 +191,11 @@ public class DelayedClientTransportTest {
     verify(transportListener).transportTerminated();
     ClientStream stream = delayedTransport.newStream(method, headers, callOptions, statsTraceCtx);
     assertEquals(0, delayedTransport.getPendingStreamsCount());
-    stream.start(streamListener);
+    stream.start(streamListener, headers);
     assertFalse(stream instanceof DelayedStream);
     verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions),
         same(statsTraceCtx));
-    verify(mockRealStream).start(same(streamListener));
+    verify(mockRealStream).start(same(streamListener), same(headers));
   }
 
   @Test public void setTransportThenShutdownNowThenNewStream() {
@@ -205,11 +205,11 @@ public class DelayedClientTransportTest {
     verify(transportListener).transportTerminated();
     ClientStream stream = delayedTransport.newStream(method, headers, callOptions, statsTraceCtx);
     assertEquals(0, delayedTransport.getPendingStreamsCount());
-    stream.start(streamListener);
+    stream.start(streamListener, headers);
     assertFalse(stream instanceof DelayedStream);
     verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions),
         same(statsTraceCtx));
-    verify(mockRealStream).start(same(streamListener));
+    verify(mockRealStream).start(same(streamListener), same(headers));
   }
 
   @Test public void cancelStreamWithoutSetTransport() {
@@ -223,7 +223,7 @@ public class DelayedClientTransportTest {
 
   @Test public void startThenCancelStreamWithoutSetTransport() {
     ClientStream stream = delayedTransport.newStream(method, new Metadata());
-    stream.start(streamListener);
+    stream.start(streamListener, new Metadata());
     assertEquals(1, delayedTransport.getPendingStreamsCount());
     stream.cancel(Status.CANCELLED);
     assertEquals(0, delayedTransport.getPendingStreamsCount());
@@ -275,14 +275,14 @@ public class DelayedClientTransportTest {
     verify(transportListener).transportShutdown(any(Status.class));
     verify(transportListener).transportTerminated();
     ClientStream stream = delayedTransport.newStream(method, new Metadata());
-    stream.start(streamListener);
+    stream.start(streamListener, new Metadata());
     verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
     assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
   }
 
   @Test public void startStreamThenShutdownNow() {
     ClientStream stream = delayedTransport.newStream(method, new Metadata());
-    stream.start(streamListener);
+    stream.start(streamListener, new Metadata());
     delayedTransport.shutdownNow(Status.UNAVAILABLE);
     verify(transportListener).transportShutdown(any(Status.class));
     verify(transportListener).transportTerminated();
@@ -295,7 +295,7 @@ public class DelayedClientTransportTest {
     verify(transportListener).transportShutdown(any(Status.class));
     verify(transportListener).transportTerminated();
     ClientStream stream = delayedTransport.newStream(method, new Metadata());
-    stream.start(streamListener);
+    stream.start(streamListener, new Metadata());
     verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
     assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
   }
@@ -306,7 +306,7 @@ public class DelayedClientTransportTest {
     final CallOptions waitForReadyCallOptions = CallOptions.DEFAULT.withWaitForReady();
     final ClientStream ffStream = delayedTransport.newStream(method, headers, failFastCallOptions,
         statsTraceCtx);
-    ffStream.start(streamListener);
+    ffStream.start(streamListener, new Metadata());
     delayedTransport.newStream(method, headers, waitForReadyCallOptions, statsTraceCtx);
     delayedTransport.newStream(method, headers, failFastCallOptions, statsTraceCtx);
     assertEquals(3, delayedTransport.getPendingStreamsCount());
@@ -332,7 +332,7 @@ public class DelayedClientTransportTest {
 
     final ClientStream ffStream = delayedTransport.newStream(method, headers, failFastCallOptions,
         statsTraceCtx);
-    ffStream.start(streamListener);
+    ffStream.start(streamListener, new Metadata());
     assertEquals(0, delayedTransport.getPendingStreamsCount());
     verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
     assertEquals(cause, Status.fromThrowable(statusCaptor.getValue().getCause()));

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -259,7 +259,7 @@ public class ManagedChannelImplTest {
         statsTraceCtxCaptor.capture());
     assertEquals(censusCtxFactory.pollContextOrFail(),
         statsTraceCtxCaptor.getValue().getCensusContext());
-    verify(mockStream).start(streamListenerCaptor.capture());
+    verify(mockStream).start(streamListenerCaptor.capture(), same(headers));
     verify(mockStream).setCompressor(isA(Compressor.class));
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
 
@@ -276,7 +276,7 @@ public class ManagedChannelImplTest {
     assertEquals(censusCtxFactory.pollContextOrFail(),
         statsTraceCtxCaptor.getValue().getCensusContext());
 
-    verify(mockStream2).start(streamListenerCaptor.capture());
+    verify(mockStream2).start(streamListenerCaptor.capture(), same(headers2));
     ClientStreamListener streamListener2 = streamListenerCaptor.getValue();
     Metadata trailers = new Metadata();
     streamListener2.closed(Status.CANCELLED, trailers);
@@ -353,7 +353,7 @@ public class ManagedChannelImplTest {
     verify(mockTransport).newStream(same(method), same(headers), same(CallOptions.DEFAULT),
         any(StatsTraceContext.class));
 
-    verify(mockStream).start(streamListenerCaptor.capture());
+    verify(mockStream).start(streamListenerCaptor.capture(), same(headers));
     verify(mockStream).setCompressor(isA(Compressor.class));
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
 
@@ -419,7 +419,7 @@ public class ManagedChannelImplTest {
     transportListener.transportReady();
     executor.runDueTasks();
 
-    verify(mockStream).start(streamListenerCaptor.capture());
+    verify(mockStream).start(streamListenerCaptor.capture(), same(headers));
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
 
     // ShutdownNow
@@ -540,7 +540,7 @@ public class ManagedChannelImplTest {
 
     verify(mockTransport).newStream(same(method), same(headers), same(options),
         any(StatsTraceContext.class));
-    verify(mockStream).start(streamListenerCaptor.capture());
+    verify(mockStream).start(streamListenerCaptor.capture(), same(headers));
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
     Metadata trailers = new Metadata();
     assertEquals(0, callExecutor.numPendingTasks());

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -241,7 +241,7 @@ public class ManagedChannelImplTest {
     when(mockTransportFactory.newClientTransport(
             any(SocketAddress.class), any(String.class), any(String.class)))
         .thenReturn(mockTransport);
-    when(mockTransport.newStream(same(method), same(headers), same(CallOptions.DEFAULT),
+    when(mockTransport.newStream(same(method), same(CallOptions.DEFAULT),
             any(StatsTraceContext.class)))
         .thenReturn(mockStream);
     call.start(mockCallListener, headers);
@@ -255,7 +255,7 @@ public class ManagedChannelImplTest {
     transportListener.transportReady();
     executor.runDueTasks();
 
-    verify(mockTransport).newStream(same(method), same(headers), same(CallOptions.DEFAULT),
+    verify(mockTransport).newStream(same(method), same(CallOptions.DEFAULT),
         statsTraceCtxCaptor.capture());
     assertEquals(censusCtxFactory.pollContextOrFail(),
         statsTraceCtxCaptor.getValue().getCensusContext());
@@ -267,11 +267,11 @@ public class ManagedChannelImplTest {
     ClientCall<String, Integer> call2 = channel.newCall(method, CallOptions.DEFAULT);
     ClientStream mockStream2 = mock(ClientStream.class);
     Metadata headers2 = new Metadata();
-    when(mockTransport.newStream(same(method), same(headers2), same(CallOptions.DEFAULT),
+    when(mockTransport.newStream(same(method), same(CallOptions.DEFAULT),
             any(StatsTraceContext.class)))
         .thenReturn(mockStream2);
     call2.start(mockCallListener2, headers2);
-    verify(mockTransport).newStream(same(method), same(headers2), same(CallOptions.DEFAULT),
+    verify(mockTransport, times(2)).newStream(same(method), same(CallOptions.DEFAULT),
         statsTraceCtxCaptor.capture());
     assertEquals(censusCtxFactory.pollContextOrFail(),
         statsTraceCtxCaptor.getValue().getCensusContext());
@@ -336,7 +336,7 @@ public class ManagedChannelImplTest {
     when(mockTransportFactory.newClientTransport(
             any(SocketAddress.class), any(String.class), any(String.class)))
         .thenReturn(mockTransport);
-    when(mockTransport.newStream(same(method), same(headers), same(CallOptions.DEFAULT),
+    when(mockTransport.newStream(same(method), same(CallOptions.DEFAULT),
             any(StatsTraceContext.class)))
         .thenReturn(mockStream);
     call.start(mockCallListener, headers);
@@ -350,7 +350,7 @@ public class ManagedChannelImplTest {
     transportListener.transportReady();
     executor.runDueTasks();
 
-    verify(mockTransport).newStream(same(method), same(headers), same(CallOptions.DEFAULT),
+    verify(mockTransport).newStream(same(method), same(CallOptions.DEFAULT),
         any(StatsTraceContext.class));
 
     verify(mockStream).start(streamListenerCaptor.capture(), same(headers));
@@ -407,7 +407,7 @@ public class ManagedChannelImplTest {
     // Create transport and call
     ClientStream mockStream = mock(ClientStream.class);
     Metadata headers = new Metadata();
-    when(mockTransport.newStream(same(method), same(headers), same(CallOptions.DEFAULT),
+    when(mockTransport.newStream(same(method), same(CallOptions.DEFAULT),
             any(StatsTraceContext.class)))
         .thenReturn(mockStream);
     call.start(mockCallListener, headers);
@@ -469,7 +469,7 @@ public class ManagedChannelImplTest {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     Metadata headers = new Metadata();
     ClientStream mockStream = mock(ClientStream.class);
-    when(mockTransport.newStream(same(method), same(headers))).thenReturn(mockStream);
+    when(mockTransport.newStream(same(method))).thenReturn(mockStream);
     call.start(mockCallListener, headers);
     timer.runDueTasks();
     executor.runDueTasks();
@@ -519,7 +519,7 @@ public class ManagedChannelImplTest {
   public void callOptionsExecutor() {
     Metadata headers = new Metadata();
     ClientStream mockStream = mock(ClientStream.class);
-    when(mockTransport.newStream(same(method), same(headers), any(CallOptions.class),
+    when(mockTransport.newStream(same(method), any(CallOptions.class),
             any(StatsTraceContext.class)))
         .thenReturn(mockStream);
     FakeClock callExecutor = new FakeClock();
@@ -538,7 +538,7 @@ public class ManagedChannelImplTest {
     // Real streams are started in the channel's executor
     assertEquals(1, executor.runDueTasks());
 
-    verify(mockTransport).newStream(same(method), same(headers), same(options),
+    verify(mockTransport).newStream(same(method), same(options),
         any(StatsTraceContext.class));
     verify(mockStream).start(streamListenerCaptor.capture(), same(headers));
     ClientStreamListener streamListener = streamListenerCaptor.getValue();
@@ -672,7 +672,7 @@ public class ManagedChannelImplTest {
     final ConnectionClientTransport goodTransport = mock(ConnectionClientTransport.class);
     final ConnectionClientTransport badTransport = mock(ConnectionClientTransport.class);
     when(goodTransport.newStream(
-            any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+            any(MethodDescriptor.class), any(CallOptions.class),
             any(StatsTraceContext.class)))
         .thenReturn(mock(ClientStream.class));
     when(mockTransportFactory.newClientTransport(
@@ -711,10 +711,10 @@ public class ManagedChannelImplTest {
     goodTransportListenerCaptor.getValue().transportReady();
     executor.runDueTasks();
 
-    verify(goodTransport).newStream(same(method), same(headers), same(CallOptions.DEFAULT),
+    verify(goodTransport).newStream(same(method), same(CallOptions.DEFAULT),
         any(StatsTraceContext.class));
     // The bad transport was never used.
-    verify(badTransport, times(0)).newStream(any(MethodDescriptor.class), any(Metadata.class));
+    verify(badTransport, times(0)).newStream(any(MethodDescriptor.class));
   }
 
   /**
@@ -771,8 +771,8 @@ public class ManagedChannelImplTest {
     verify(mockCallListener).onClose(statusCaptor.capture(), any(Metadata.class));
     assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
     // No real stream was ever created
-    verify(transport1, times(0)).newStream(any(MethodDescriptor.class), any(Metadata.class));
-    verify(transport2, times(0)).newStream(any(MethodDescriptor.class), any(Metadata.class));
+    verify(transport1, times(0)).newStream(any(MethodDescriptor.class));
+    verify(transport2, times(0)).newStream(any(MethodDescriptor.class));
   }
 
   /**
@@ -797,11 +797,11 @@ public class ManagedChannelImplTest {
     final ConnectionClientTransport transport1 = mock(ConnectionClientTransport.class);
     final ConnectionClientTransport transport2 = mock(ConnectionClientTransport.class);
     when(transport1.newStream(
-            any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+            any(MethodDescriptor.class), any(CallOptions.class),
             any(StatsTraceContext.class)))
         .thenReturn(mock(ClientStream.class));
     when(transport2.newStream(
-            any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+            any(MethodDescriptor.class), any(CallOptions.class),
             any(StatsTraceContext.class)))
         .thenReturn(mock(ClientStream.class));
     when(mockTransportFactory.newClientTransport(same(addr1), any(String.class), any(String.class)))
@@ -824,7 +824,7 @@ public class ManagedChannelImplTest {
     transportListenerCaptor.getValue().transportReady();
     executor.runDueTasks();
 
-    verify(transport1).newStream(same(method), same(headers), same(CallOptions.DEFAULT),
+    verify(transport1).newStream(same(method), same(CallOptions.DEFAULT),
         any(StatsTraceContext.class));
     transportListenerCaptor.getValue().transportShutdown(Status.UNAVAILABLE);
 
@@ -837,7 +837,7 @@ public class ManagedChannelImplTest {
     transportListenerCaptor.getValue().transportReady();
     executor.runDueTasks();
 
-    verify(transport2).newStream(same(method), same(headers), same(CallOptions.DEFAULT),
+    verify(transport2).newStream(same(method), same(CallOptions.DEFAULT),
         any(StatsTraceContext.class));
   }
 
@@ -884,7 +884,7 @@ public class ManagedChannelImplTest {
           return mock(ClientStream.class);
         }
       }).when(transport).newStream(
-          any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+          any(MethodDescriptor.class), any(CallOptions.class),
           any(StatsTraceContext.class));
 
     // First call will be on delayed transport.  Only newCall() is run within the expected context,
@@ -918,12 +918,12 @@ public class ManagedChannelImplTest {
     assertEquals(SecurityLevel.NONE,
         attrsCaptor.getValue().get(CallCredentials.ATTR_SECURITY_LEVEL));
     verify(transport, never()).newStream(
-        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        any(MethodDescriptor.class), any(CallOptions.class),
         any(StatsTraceContext.class));
 
     // newStream() is called after apply() is called
     applierCaptor.getValue().apply(new Metadata());
-    verify(transport).newStream(same(method), any(Metadata.class), same(callOptions),
+    verify(transport).newStream(same(method), same(callOptions),
         any(StatsTraceContext.class));
     assertEquals("testValue", testKey.get(newStreamContexts.poll()));
     // The context should not live beyond the scope of newStream() and applyRequestMetadata()
@@ -944,12 +944,12 @@ public class ManagedChannelImplTest {
         attrsCaptor.getValue().get(CallCredentials.ATTR_SECURITY_LEVEL));
     // This is from the first call
     verify(transport).newStream(
-        any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
+        any(MethodDescriptor.class), any(CallOptions.class),
         any(StatsTraceContext.class));
 
     // Still, newStream() is called after apply() is called
     applierCaptor.getValue().apply(new Metadata());
-    verify(transport, times(2)).newStream(same(method), any(Metadata.class), same(callOptions),
+    verify(transport, times(2)).newStream(same(method), same(callOptions),
         any(StatsTraceContext.class));
     assertEquals("testValue", testKey.get(newStreamContexts.poll()));
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -313,14 +313,14 @@ public class ManagedChannelImplTransportManagerTest {
     assertTrue(transport instanceof DelayedClientTransport);
     ClientStream s1 = transport.newStream(method, new Metadata());
     ClientStreamListener sl1 = mock(ClientStreamListener.class);
-    s1.start(sl1);
+    s1.start(sl1, new Metadata());
 
     // Shutting down the channel will shutdown the interim transport, thus refusing further streams,
     // but will continue existing streams.
     channel.shutdown();
     ClientStream s2 = transport.newStream(method, new Metadata());
     ClientStreamListener sl2 = mock(ClientStreamListener.class);
-    s2.start(sl2);
+    s2.start(sl2, new Metadata());
     verify(sl2).closed(any(Status.class), any(Metadata.class));
     verify(sl1, times(0)).closed(any(Status.class), any(Metadata.class));
     assertFalse(channel.isTerminated());
@@ -330,7 +330,7 @@ public class ManagedChannelImplTransportManagerTest {
     ClientTransport transportAfterShutdown = tm.createInterimTransport().transport();
     ClientStream s3 = transportAfterShutdown.newStream(method, new Metadata());
     ClientStreamListener sl3 = mock(ClientStreamListener.class);
-    s3.start(sl3);
+    s3.start(sl3, new Metadata());
     verify(sl3).closed(any(Status.class), any(Metadata.class));
 
     // Closing the interim transport with error will terminate the interim transport, which in turn
@@ -393,7 +393,7 @@ public class ManagedChannelImplTransportManagerTest {
     assertTrue(transport instanceof DelayedClientTransport);
     ClientStream s1 = transport.newStream(method, new Metadata());
     ClientStreamListener sl1 = mock(ClientStreamListener.class);
-    s1.start(sl1);
+    s1.start(sl1, new Metadata());
 
     // Shutting down the channel will shutdownNow the interim transport, thus kill existing streams.
     channel.shutdownNow();

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.grpc.CallOptions;
-import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 
 import org.mockito.invocation.InvocationOnMock;
@@ -85,7 +84,7 @@ final class TestUtils {
       @Override
       public ConnectionClientTransport answer(InvocationOnMock invocation) throws Throwable {
         final ConnectionClientTransport mockTransport = mock(ConnectionClientTransport.class);
-        when(mockTransport.newStream(any(MethodDescriptor.class), any(Metadata.class),
+        when(mockTransport.newStream(any(MethodDescriptor.class),
                 any(CallOptions.class), any(StatsTraceContext.class)))
             .thenReturn(mock(ClientStream.class));
         // Save the listener

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -138,7 +138,7 @@ public class TransportSetTest {
     int onAllAddressesFailed = 0;
 
     // First attempt
-    transportSet.obtainActiveTransport().newStream(method, new Metadata(), waitForReadyCallOptions,
+    transportSet.obtainActiveTransport().newStream(method, waitForReadyCallOptions,
         statsTraceCtx);
     assertEquals(ConnectivityState.CONNECTING, transportSet.getState(false));
     verify(mockTransportFactory, times(++transportsCreated))
@@ -227,7 +227,7 @@ public class TransportSetTest {
     assertEquals(ConnectivityState.CONNECTING, transportSet.getState(false));
     verify(mockTransportFactory, times(++transportsAddr1))
         .newClientTransport(addr1, AUTHORITY, USER_AGENT);
-    delayedTransport1.newStream(method, new Metadata(), waitForReadyCallOptions, statsTraceCtx);
+    delayedTransport1.newStream(method, waitForReadyCallOptions, statsTraceCtx);
     // Let this one fail without success
     transports.poll().listener.transportShutdown(Status.UNAVAILABLE);
     assertEquals(ConnectivityState.CONNECTING, transportSet.getState(false));
@@ -322,7 +322,7 @@ public class TransportSetTest {
         (DelayedClientTransport) transportSet.obtainActiveTransport();
     assertEquals(ConnectivityState.CONNECTING, transportSet.getState(false));
     assertNotSame(delayedTransport5, delayedTransport6);
-    delayedTransport6.newStream(method, headers, waitForReadyCallOptions, statsTraceCtx);
+    delayedTransport6.newStream(method, waitForReadyCallOptions, statsTraceCtx);
     verify(mockBackoffPolicyProvider, times(backoffReset)).get();
     verify(mockTransportFactory, times(++transportsAddr1))
         .newClientTransport(addr1, AUTHORITY, USER_AGENT);
@@ -389,14 +389,14 @@ public class TransportSetTest {
     assertFalse(delayedTransport.isInBackoffPeriod());
 
     // Create a new fail fast stream.
-    ClientStream ffStream = delayedTransport.newStream(method, headers, failFastCallOptions,
+    ClientStream ffStream = delayedTransport.newStream(method, failFastCallOptions,
         statsTraceCtx);
     ffStream.start(mockStreamListener, headers);
     // Verify it is queued.
     assertEquals(++pendingStreamsCount, delayedTransport.getPendingStreamsCount());
     failFastPendingStreamsCount++;
     // Create a new non fail fast stream.
-    delayedTransport.newStream(method, headers, waitForReadyCallOptions, statsTraceCtx);
+    delayedTransport.newStream(method, waitForReadyCallOptions, statsTraceCtx);
     // Verify it is queued.
     assertEquals(++pendingStreamsCount, delayedTransport.getPendingStreamsCount());
 
@@ -408,12 +408,12 @@ public class TransportSetTest {
     assertEquals(pendingStreamsCount, delayedTransport.getPendingStreamsCount());
 
     // Create a new fail fast stream.
-    delayedTransport.newStream(method, headers, failFastCallOptions, statsTraceCtx);
+    delayedTransport.newStream(method, failFastCallOptions, statsTraceCtx);
     // Verify it is queued.
     assertEquals(++pendingStreamsCount, delayedTransport.getPendingStreamsCount());
     failFastPendingStreamsCount++;
     // Create a new non fail fast stream
-    delayedTransport.newStream(method, headers, waitForReadyCallOptions, statsTraceCtx);
+    delayedTransport.newStream(method, waitForReadyCallOptions, statsTraceCtx);
     // Verify it is queued.
     assertEquals(++pendingStreamsCount, delayedTransport.getPendingStreamsCount());
 
@@ -431,11 +431,11 @@ public class TransportSetTest {
     verify(mockStreamListener).closed(same(failureStatus), any(Metadata.class));
 
     // Create a new fail fast stream.
-    delayedTransport.newStream(method, headers, failFastCallOptions, statsTraceCtx);
+    delayedTransport.newStream(method, failFastCallOptions, statsTraceCtx);
     // Verify it is not queued.
     assertEquals(pendingStreamsCount, delayedTransport.getPendingStreamsCount());
     // Create a new non fail fast stream
-    delayedTransport.newStream(method, headers, waitForReadyCallOptions, statsTraceCtx);
+    delayedTransport.newStream(method, waitForReadyCallOptions, statsTraceCtx);
     // Verify it is queued.
     assertEquals(++pendingStreamsCount, delayedTransport.getPendingStreamsCount());
 
@@ -445,7 +445,7 @@ public class TransportSetTest {
     assertFalse(delayedTransport.isInBackoffPeriod());
 
     // Create a new fail fast stream.
-    delayedTransport.newStream(method, headers, failFastCallOptions, statsTraceCtx);
+    delayedTransport.newStream(method, failFastCallOptions, statsTraceCtx);
     // Verify it is queued.
     assertEquals(++pendingStreamsCount, delayedTransport.getPendingStreamsCount());
     failFastPendingStreamsCount++;
@@ -467,7 +467,7 @@ public class TransportSetTest {
         .newClientTransport(addr, AUTHORITY, USER_AGENT);
 
     // First attempt
-    transportSet.obtainActiveTransport().newStream(method, new Metadata());
+    transportSet.obtainActiveTransport().newStream(method);
     assertEquals(ConnectivityState.CONNECTING, transportSet.getState(false));
     verify(mockTransportFactory, times(++transportsCreated))
         .newClientTransport(addr, AUTHORITY, USER_AGENT);
@@ -490,7 +490,7 @@ public class TransportSetTest {
     assertEquals(ConnectivityState.IDLE, transportSet.getState(false));
 
     // Request immediately
-    transportSet.obtainActiveTransport().newStream(method, new Metadata(), waitForReadyCallOptions,
+    transportSet.obtainActiveTransport().newStream(method, waitForReadyCallOptions,
         statsTraceCtx);
     assertEquals(ConnectivityState.CONNECTING, transportSet.getState(false));
     verify(mockTransportFactory, times(++transportsCreated))
@@ -518,7 +518,7 @@ public class TransportSetTest {
     pick = transportSet.obtainActiveTransport();
     assertTrue(pick instanceof DelayedClientTransport);
     // Start a stream, which will be pending in the delayed transport
-    ClientStream pendingStream = pick.newStream(method, headers, waitForReadyCallOptions,
+    ClientStream pendingStream = pick.newStream(method, waitForReadyCallOptions,
         statsTraceCtx);
     pendingStream.start(mockStreamListener, headers);
 
@@ -544,9 +544,9 @@ public class TransportSetTest {
     transportInfo.listener.transportReady();
     assertEquals(ConnectivityState.SHUTDOWN, transportSet.getState(false));
     verify(transportInfo.transport, times(0)).newStream(
-        any(MethodDescriptor.class), any(Metadata.class));
+        any(MethodDescriptor.class));
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(transportInfo.transport).newStream(same(method), same(headers),
+    verify(transportInfo.transport).newStream(same(method),
         same(waitForReadyCallOptions), any(StatsTraceContext.class));
     verify(transportInfo.transport).shutdown();
     transportInfo.listener.transportShutdown(Status.UNAVAILABLE);
@@ -645,7 +645,7 @@ public class TransportSetTest {
     assertEquals(ConnectivityState.CONNECTING, transportSet.getState(true));
     assertEquals(ConnectivityState.CONNECTING, transportSet.getState(true));
 
-    transportSet.obtainActiveTransport().newStream(method, new Metadata(), waitForReadyCallOptions,
+    transportSet.obtainActiveTransport().newStream(method, waitForReadyCallOptions,
         statsTraceCtx);
     assertEquals(ConnectivityState.CONNECTING, transportSet.getState(true));
 
@@ -704,7 +704,7 @@ public class TransportSetTest {
     int notInUse = 0;
 
     verify(mockTransportSetCallback, never()).onInUse(any(TransportSet.class));
-    transportSet.obtainActiveTransport().newStream(method, new Metadata(), waitForReadyCallOptions,
+    transportSet.obtainActiveTransport().newStream(method, waitForReadyCallOptions,
         statsTraceCtx);
     verify(mockTransportSetCallback, times(++inUse)).onInUse(transportSet);
 
@@ -718,7 +718,7 @@ public class TransportSetTest {
     // Delayed transport calls newStream() on the real transport in the executor
     fakeExecutor.runDueTasks();
     verify(t0.transport).newStream(
-        same(method), any(Metadata.class), same(waitForReadyCallOptions),
+        same(method), same(waitForReadyCallOptions),
         any(StatsTraceContext.class));
     verify(mockTransportSetCallback, times(inUse)).onInUse(transportSet);
     t0.listener.transportInUse(true);
@@ -734,14 +734,14 @@ public class TransportSetTest {
     t0.listener.transportShutdown(Status.UNAVAILABLE);
 
     // Creates a new transport
-    transportSet.obtainActiveTransport().newStream(method, new Metadata(), waitForReadyCallOptions,
+    transportSet.obtainActiveTransport().newStream(method, waitForReadyCallOptions,
         statsTraceCtx);
     MockClientTransportInfo t1 = transports.poll();
     t1.listener.transportReady();
     // Delayed transport calls newStream() on the real transport in the executor
     fakeExecutor.runDueTasks();
     verify(t1.transport).newStream(
-        same(method), any(Metadata.class), same(waitForReadyCallOptions),
+        same(method), same(waitForReadyCallOptions),
         any(StatsTraceContext.class));
     t1.listener.transportInUse(true);
     // No turbulance from the race mentioned eariler, because t0 has been in-use
@@ -779,7 +779,7 @@ public class TransportSetTest {
 
     // Attempt and fail, scheduleBackoff should be triggered,
     // and transportSet.shutdown should be triggered by setup
-    transportSet.obtainActiveTransport().newStream(method, new Metadata(), waitForReadyCallOptions,
+    transportSet.obtainActiveTransport().newStream(method, waitForReadyCallOptions,
         statsTraceCtx);
     transports.poll().listener.transportShutdown(Status.UNAVAILABLE);
     verify(mockTransportSetCallback, times(1)).onAllAddressesFailed();

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -391,7 +391,7 @@ public class TransportSetTest {
     // Create a new fail fast stream.
     ClientStream ffStream = delayedTransport.newStream(method, headers, failFastCallOptions,
         statsTraceCtx);
-    ffStream.start(mockStreamListener);
+    ffStream.start(mockStreamListener, headers);
     // Verify it is queued.
     assertEquals(++pendingStreamsCount, delayedTransport.getPendingStreamsCount());
     failFastPendingStreamsCount++;
@@ -520,7 +520,7 @@ public class TransportSetTest {
     // Start a stream, which will be pending in the delayed transport
     ClientStream pendingStream = pick.newStream(method, headers, waitForReadyCallOptions,
         statsTraceCtx);
-    pendingStream.start(mockStreamListener);
+    pendingStream.start(mockStreamListener, headers);
 
     // Shut down TransportSet before the transport is created. Further call to
     // obtainActiveTransport() gets failing transports

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -75,7 +75,7 @@ class NettyClientStream extends AbstractClientStream2 {
   private final AsciiString scheme;
   private final AsciiString userAgent;
 
-  NettyClientStream(TransportState state, MethodDescriptor<?, ?> method, Metadata headers,
+  NettyClientStream(TransportState state, MethodDescriptor<?, ?> method,
       Channel channel, AsciiString authority, AsciiString scheme,
       AsciiString userAgent, StatsTraceContext statsTraceCtx) {
     super(new NettyWritableBufferAllocator(channel.alloc()), statsTraceCtx);

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -222,6 +222,11 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   @Override
+  public boolean supportGetMethod() {
+    return false;
+  }
+
+  @Override
   public String toString() {
     return getLogId() + "(" + address + ")";
   }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -38,7 +38,6 @@ import com.google.common.base.Ticker;
 
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
-import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
@@ -118,10 +117,9 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers,
+  public ClientStream newStream(MethodDescriptor<?, ?> method,
       CallOptions callOptions, StatsTraceContext statsTraceCtx) {
     Preconditions.checkNotNull(method, "method");
-    Preconditions.checkNotNull(headers, "headers");
     Preconditions.checkNotNull(statsTraceCtx, "statsTraceCtx");
     return new NettyClientStream(
         new NettyClientStream.TransportState(handler, maxMessageSize, statsTraceCtx) {
@@ -130,13 +128,13 @@ class NettyClientTransport implements ConnectionClientTransport {
             return NettyClientTransport.this.statusFromFailedFuture(f);
           }
         },
-        method, headers, channel, authority, negotiationHandler.scheme(), userAgent,
+        method, channel, authority, negotiationHandler.scheme(), userAgent,
         statsTraceCtx);
   }
 
   @Override
-  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
-    return newStream(method, headers, CallOptions.DEFAULT, StatsTraceContext.NOOP);
+  public ClientStream newStream(MethodDescriptor<?, ?> method) {
+    return newStream(method, CallOptions.DEFAULT, StatsTraceContext.NOOP);
   }
 
   @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -360,7 +360,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     listener = mock(ClientStreamListener.class);
 
     stream = new NettyClientStream(new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE),
-        methodDescriptor, new Metadata(), channel, AsciiString.of("localhost"),
+        methodDescriptor, channel, AsciiString.of("localhost"),
         AsciiString.of("http"), AsciiString.of("agent"), StatsTraceContext.NOOP);
     stream.start(listener, new Metadata());
     stream().transportState().setId(STREAM_ID);
@@ -380,7 +380,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     when(writeQueue.enqueue(any(QueuedCommand.class), any(boolean.class))).thenReturn(future);
 
     stream = new NettyClientStream(new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE),
-        methodDescriptor, new Metadata(), channel, AsciiString.of("localhost"),
+        methodDescriptor, channel, AsciiString.of("localhost"),
         AsciiString.of("http"), AsciiString.of("good agent"), StatsTraceContext.NOOP);
     stream.start(listener, new Metadata());
 
@@ -404,7 +404,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     }).when(writeQueue).enqueue(any(QueuedCommand.class), any(ChannelPromise.class), anyBoolean());
     when(writeQueue.enqueue(any(QueuedCommand.class), anyBoolean())).thenReturn(future);
     NettyClientStream stream = new NettyClientStream(
-        new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE), methodDescriptor, new Metadata(),
+        new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE), methodDescriptor,
         channel, AsciiString.of("localhost"), AsciiString.of("http"), AsciiString.of("agent"),
         StatsTraceContext.NOOP);
     stream.start(listener, new Metadata());

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -362,7 +362,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     stream = new NettyClientStream(new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE),
         methodDescriptor, new Metadata(), channel, AsciiString.of("localhost"),
         AsciiString.of("http"), AsciiString.of("agent"), StatsTraceContext.NOOP);
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream().transportState().setId(STREAM_ID);
     verify(listener, never()).onReady();
     assertFalse(stream.isReady());
@@ -382,7 +382,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     stream = new NettyClientStream(new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE),
         methodDescriptor, new Metadata(), channel, AsciiString.of("localhost"),
         AsciiString.of("http"), AsciiString.of("good agent"), StatsTraceContext.NOOP);
-    stream.start(listener);
+    stream.start(listener, new Metadata());
 
     ArgumentCaptor<CreateStreamCommand> cmdCap = ArgumentCaptor.forClass(CreateStreamCommand.class);
     verify(writeQueue).enqueue(cmdCap.capture(), eq(false));
@@ -407,7 +407,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE), methodDescriptor, new Metadata(),
         channel, AsciiString.of("localhost"), AsciiString.of("http"), AsciiString.of("agent"),
         StatsTraceContext.NOOP);
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.transportState().setId(STREAM_ID);
     stream.transportState().setHttp2Stream(http2Stream);
     reset(listener);

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -350,7 +350,7 @@ public class NettyClientTransportTest {
 
     Rpc(NettyClientTransport transport, Metadata headers) {
       stream = transport.newStream(METHOD, headers);
-      stream.start(listener);
+      stream.start(listener, headers);
       stream.request(1);
       stream.writeMessage(new ByteArrayInputStream(MESSAGE.getBytes(UTF_8)));
       stream.flush();

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -349,7 +349,7 @@ public class NettyClientTransportTest {
     }
 
     Rpc(NettyClientTransport transport, Metadata headers) {
-      stream = transport.newStream(METHOD, headers);
+      stream = transport.newStream(METHOD);
       stream.start(listener, headers);
       stream.request(1);
       stream.writeMessage(new ByteArrayInputStream(MESSAGE.getBytes(UTF_8)));

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -101,7 +101,6 @@ class OkHttpClientStream extends Http2ClientStream {
       StatsTraceContext statsTraceCtx) {
     super(new OkHttpWritableBufferAllocator(), maxMessageSize, statsTraceCtx);
     this.method = method;
-    this.headers = headers;
     this.frameWriter = frameWriter;
     this.transport = transport;
     this.outboundFlow = outboundFlow;
@@ -136,13 +135,12 @@ class OkHttpClientStream extends Http2ClientStream {
   }
 
   @Override
-  public void start(ClientStreamListener listener) {
-    super.start(listener);
+  public void start(ClientStreamListener listener, Metadata headers) {
+    super.start(listener, headers);
     String defaultPath = "/" + method.getFullMethodName();
     headers.discardAll(GrpcUtil.USER_AGENT_KEY);
     List<Header> requestHeaders =
         Headers.createRequestHeaders(headers, defaultPath, authority, userAgent);
-    headers = null;
     synchronized (lock) {
       this.requestHeaders = requestHeaders;
       transport.streamReadyToStart(this);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -90,7 +90,6 @@ class OkHttpClientStream extends Http2ClientStream {
 
   OkHttpClientStream(
       MethodDescriptor<?, ?> method,
-      Metadata headers,
       AsyncFrameWriter frameWriter,
       OkHttpClientTransport transport,
       OutboundFlowController outboundFlow,

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -271,18 +271,16 @@ class OkHttpClientTransport implements ConnectionClientTransport {
 
   @Override
   public OkHttpClientStream newStream(final MethodDescriptor<?, ?> method,
-      final Metadata headers, CallOptions callOptions, StatsTraceContext statsTraceCtx) {
+      CallOptions callOptions, StatsTraceContext statsTraceCtx) {
     Preconditions.checkNotNull(method, "method");
-    Preconditions.checkNotNull(headers, "headers");
     Preconditions.checkNotNull(statsTraceCtx, "statsTraceCtx");
-    return new OkHttpClientStream(method, headers, frameWriter, OkHttpClientTransport.this,
+    return new OkHttpClientStream(method, frameWriter, OkHttpClientTransport.this,
         outboundFlow, lock, maxMessageSize, defaultAuthority, userAgent, statsTraceCtx);
   }
 
   @Override
-  public OkHttpClientStream newStream(final MethodDescriptor<?, ?> method, final Metadata
-      headers) {
-    return newStream(method, headers, CallOptions.DEFAULT, StatsTraceContext.NOOP);
+  public OkHttpClientStream newStream(final MethodDescriptor<?, ?> method) {
+    return newStream(method, CallOptions.DEFAULT, StatsTraceContext.NOOP);
   }
 
   @GuardedBy("lock")

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -440,6 +440,11 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   }
 
   @Override
+  public boolean supportGetMethod() {
+    return false;
+  }
+
+  @Override
   public String toString() {
     return getLogId() + "(" + address + ")";
   }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -84,7 +84,7 @@ public class OkHttpClientStreamTest {
     MockitoAnnotations.initMocks(this);
     methodDescriptor = MethodDescriptor.create(
         MethodType.UNARY, "/testService/test", marshaller, marshaller);
-    stream = new OkHttpClientStream(methodDescriptor, new Metadata(), frameWriter, transport,
+    stream = new OkHttpClientStream(methodDescriptor, frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, "localhost", "userAgent", StatsTraceContext.NOOP);
   }
 
@@ -140,7 +140,7 @@ public class OkHttpClientStreamTest {
   public void start_userAgentRemoved() {
     Metadata metaData = new Metadata();
     metaData.put(GrpcUtil.USER_AGENT_KEY, "misbehaving-application");
-    stream = new OkHttpClientStream(methodDescriptor, metaData, frameWriter, transport,
+    stream = new OkHttpClientStream(methodDescriptor, frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
         StatsTraceContext.NOOP);
     stream.start(new BaseClientStreamListener(), new Metadata());
@@ -155,7 +155,7 @@ public class OkHttpClientStreamTest {
   public void start_headerFieldOrder() {
     Metadata metaData = new Metadata();
     metaData.put(GrpcUtil.USER_AGENT_KEY, "misbehaving-application");
-    stream = new OkHttpClientStream(methodDescriptor, metaData, frameWriter, transport,
+    stream = new OkHttpClientStream(methodDescriptor, frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
         StatsTraceContext.NOOP);
     stream.start(new BaseClientStreamListener(), new Metadata());

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -102,7 +102,7 @@ public class OkHttpClientStreamTest {
         statusRef.set(status);
         assertTrue(Thread.holdsLock(lock));
       }
-    });
+    }, new Metadata());
 
     stream.sendCancel(Status.CANCELLED);
 
@@ -111,7 +111,7 @@ public class OkHttpClientStreamTest {
 
   @Test
   public void sendCancel_started() {
-    stream.start(new BaseClientStreamListener());
+    stream.start(new BaseClientStreamListener(), new Metadata());
     stream.start(1234);
     Mockito.doAnswer(new Answer<Void>() {
       @Override
@@ -128,7 +128,7 @@ public class OkHttpClientStreamTest {
 
   @Test
   public void start_alreadyCancelled() {
-    stream.start(new BaseClientStreamListener());
+    stream.start(new BaseClientStreamListener(), new Metadata());
     stream.sendCancel(Status.CANCELLED);
 
     stream.start(1234);
@@ -143,7 +143,7 @@ public class OkHttpClientStreamTest {
     stream = new OkHttpClientStream(methodDescriptor, metaData, frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
         StatsTraceContext.NOOP);
-    stream.start(new BaseClientStreamListener());
+    stream.start(new BaseClientStreamListener(), new Metadata());
     stream.start(3);
 
     verify(frameWriter).synStream(eq(false), eq(false), eq(3), eq(0), headersCaptor.capture());
@@ -158,7 +158,7 @@ public class OkHttpClientStreamTest {
     stream = new OkHttpClientStream(methodDescriptor, metaData, frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
         StatsTraceContext.NOOP);
-    stream.start(new BaseClientStreamListener());
+    stream.start(new BaseClientStreamListener(), new Metadata());
     stream.start(3);
 
     verify(frameWriter).synStream(eq(false), eq(false), eq(3), eq(0), headersCaptor.capture());

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -206,7 +206,7 @@ public class OkHttpClientTransportTest {
     startTransport(3, null, true, 1, null);
 
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(1);
     assertContainStream(3);
@@ -231,10 +231,10 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
-    OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream1 = clientTransport.newStream(method);
     stream1.start(listener1, new Metadata());
     stream1.request(1);
-    OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream2 = clientTransport.newStream(method);
     stream2.start(listener2, new Metadata());
     stream2.request(1);
     assertEquals(2, activeStreamCount());
@@ -257,7 +257,7 @@ public class OkHttpClientTransportTest {
   public void nextFrameReturnFalse() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(1);
     frameReader.nextFrameAtEndOfStream();
@@ -274,7 +274,7 @@ public class OkHttpClientTransportTest {
     final int numMessages = 10;
     final String message = "Hello Client";
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(numMessages);
     assertContainStream(3);
@@ -323,7 +323,7 @@ public class OkHttpClientTransportTest {
   public void invalidInboundHeadersCancelStream() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(1);
     assertContainStream(3);
@@ -346,7 +346,7 @@ public class OkHttpClientTransportTest {
   public void invalidInboundTrailersPropagateToMetadata() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(1);
     assertContainStream(3);
@@ -365,7 +365,7 @@ public class OkHttpClientTransportTest {
   public void readStatus() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     assertContainStream(3);
     frameHandler().headers(true, true, 3, 0, grpcResponseTrailers(), HeadersMode.HTTP_20_HEADERS);
@@ -378,7 +378,7 @@ public class OkHttpClientTransportTest {
   public void receiveReset() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     assertContainStream(3);
     frameHandler().rstStream(3, ErrorCode.PROTOCOL_ERROR);
@@ -393,7 +393,7 @@ public class OkHttpClientTransportTest {
   public void cancelStream() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     getStream(3).cancel(Status.CANCELLED);
     verify(frameWriter, timeout(TIME_OUT_MS)).rstStream(eq(3), eq(ErrorCode.CANCEL));
@@ -407,7 +407,7 @@ public class OkHttpClientTransportTest {
   public void addDefaultUserAgent() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     Header userAgentHeader = new Header(GrpcUtil.USER_AGENT_KEY.name(),
             GrpcUtil.getGrpcUserAgent("okhttp", null));
@@ -425,7 +425,7 @@ public class OkHttpClientTransportTest {
   public void overrideDefaultUserAgent() throws Exception {
     startTransport(3, null, true, DEFAULT_MAX_MESSAGE_SIZE, "fakeUserAgent");
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     List<Header> expectedHeaders = Arrays.asList(SCHEME_HEADER, METHOD_HEADER,
         new Header(Header.TARGET_AUTHORITY, "notarealauthority:80"),
@@ -443,7 +443,7 @@ public class OkHttpClientTransportTest {
   public void cancelStreamForDeadlineExceeded() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     getStream(3).cancel(Status.DEADLINE_EXCEEDED);
     verify(frameWriter, timeout(TIME_OUT_MS)).rstStream(eq(3), eq(ErrorCode.CANCEL));
@@ -456,7 +456,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     final String message = "Hello Server";
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     assertEquals(12, input.available());
@@ -476,11 +476,11 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
-    OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream1 = clientTransport.newStream(method);
     stream1.start(listener1, new Metadata());
     stream1.request(2);
 
-    OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream2 = clientTransport.newStream(method);
     stream2.start(listener2, new Metadata());
     stream2.request(2);
     assertEquals(2, activeStreamCount());
@@ -540,7 +540,7 @@ public class OkHttpClientTransportTest {
   public void windowUpdateWithInboundFlowControl() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     int messageLength = Utils.DEFAULT_WINDOW_SIZE / 2 + 1;
     byte[] fakeMessage = new byte[messageLength];
@@ -572,7 +572,7 @@ public class OkHttpClientTransportTest {
   public void outboundFlowControl() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     // The first message should be sent out.
     int messageLength = Utils.DEFAULT_WINDOW_SIZE / 2 + 1;
@@ -608,7 +608,7 @@ public class OkHttpClientTransportTest {
   public void outboundFlowControlWithInitialWindowSizeChange() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     int messageLength = 20;
     setInitialWindowSize(HEADER_LENGTH + 10);
@@ -654,9 +654,9 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
-    OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream1 = clientTransport.newStream(method);
     stream1.start(listener1, new Metadata());
-    OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream2 = clientTransport.newStream(method);
     stream2.start(listener2, new Metadata());
     assertEquals(2, activeStreamCount());
     clientTransport.shutdown();
@@ -682,10 +682,10 @@ public class OkHttpClientTransportTest {
     // start 2 streams.
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
-    OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream1 = clientTransport.newStream(method);
     stream1.start(listener1, new Metadata());
     stream1.request(1);
-    OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream2 = clientTransport.newStream(method);
     stream2.start(listener2, new Metadata());
     stream2.request(1);
     assertEquals(2, activeStreamCount());
@@ -740,7 +740,7 @@ public class OkHttpClientTransportTest {
     initTransport(startId);
 
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(1);
 
@@ -775,10 +775,10 @@ public class OkHttpClientTransportTest {
     setMaxConcurrentStreams(1);
     final MockStreamListener listener1 = new MockStreamListener();
     final MockStreamListener listener2 = new MockStreamListener();
-    OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream1 = clientTransport.newStream(method);
     stream1.start(listener1, new Metadata());
     // The second stream should be pending.
-    OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream2 = clientTransport.newStream(method);
     stream2.start(listener2, new Metadata());
     String sentMessage = "hello";
     InputStream input = new ByteArrayInputStream(sentMessage.getBytes(UTF_8));
@@ -812,7 +812,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     setMaxConcurrentStreams(0);
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     waitForStreamPending(1);
     stream.sendCancel(Status.CANCELLED);
@@ -830,10 +830,10 @@ public class OkHttpClientTransportTest {
     setMaxConcurrentStreams(1);
     final MockStreamListener listener1 = new MockStreamListener();
     final MockStreamListener listener2 = new MockStreamListener();
-    OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream1 = clientTransport.newStream(method);
     stream1.start(listener1, new Metadata());
     // The second stream should be pending.
-    OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream2 = clientTransport.newStream(method);
     stream2.start(listener2, new Metadata());
 
     waitForStreamPending(1);
@@ -858,7 +858,7 @@ public class OkHttpClientTransportTest {
     setMaxConcurrentStreams(0);
     final MockStreamListener listener = new MockStreamListener();
     // The second stream should be pending.
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     waitForStreamPending(1);
 
@@ -881,13 +881,13 @@ public class OkHttpClientTransportTest {
     final MockStreamListener listener2 = new MockStreamListener();
     final MockStreamListener listener3 = new MockStreamListener();
 
-    OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream1 = clientTransport.newStream(method);
     stream1.start(listener1, new Metadata());
 
     // The second and third stream should be pending.
-    OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream2 = clientTransport.newStream(method);
     stream2.start(listener2, new Metadata());
-    OkHttpClientStream stream3 = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream3 = clientTransport.newStream(method);
     stream3.start(listener3, new Metadata());
 
     waitForStreamPending(2);
@@ -910,7 +910,7 @@ public class OkHttpClientTransportTest {
   public void receivingWindowExceeded() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(1);
 
@@ -961,7 +961,7 @@ public class OkHttpClientTransportTest {
   private void shouldHeadersBeFlushed(boolean shouldBeFlushed) throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     verify(frameWriter, timeout(TIME_OUT_MS)).synStream(
         eq(false), eq(false), eq(3), eq(0), Matchers.anyListOf(Header.class));
@@ -977,7 +977,7 @@ public class OkHttpClientTransportTest {
   public void receiveDataWithoutHeader() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(1);
     Buffer buffer = createMessageFrame(new byte[1]);
@@ -998,7 +998,7 @@ public class OkHttpClientTransportTest {
   public void receiveDataWithoutHeaderAndTrailer() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(1);
     Buffer buffer = createMessageFrame(new byte[1]);
@@ -1019,7 +1019,7 @@ public class OkHttpClientTransportTest {
   public void receiveLongEnoughDataWithoutHeaderAndTrailer() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.request(1);
     Buffer buffer = createMessageFrame(new byte[1000]);
@@ -1039,7 +1039,7 @@ public class OkHttpClientTransportTest {
   public void receiveDataForUnknownStreamUpdateConnectionWindow() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.cancel(Status.CANCELLED);
 
@@ -1065,7 +1065,7 @@ public class OkHttpClientTransportTest {
   public void receiveWindowUpdateForUnknownStream() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     stream.cancel(Status.CANCELLED);
     // This should be ignored.
@@ -1084,7 +1084,7 @@ public class OkHttpClientTransportTest {
   public void shouldBeInitiallyReady() throws Exception {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     assertTrue(stream.isReady());
     assertTrue(listener.isOnReadyCalled());
@@ -1100,7 +1100,7 @@ public class OkHttpClientTransportTest {
     int messageLength = AbstractStream.DEFAULT_ONREADY_THRESHOLD - HEADER_LENGTH - 1;
     setInitialWindowSize(0);
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     assertTrue(stream.isReady());
     // Be notified at the beginning.
@@ -1244,7 +1244,7 @@ public class OkHttpClientTransportTest {
     initTransportAndDelayConnected();
     final String message = "Hello Server";
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     stream.writeMessage(input);
@@ -1269,7 +1269,7 @@ public class OkHttpClientTransportTest {
     initTransportAndDelayConnected();
     final String message = "Hello Server";
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     stream.writeMessage(input);
@@ -1286,7 +1286,7 @@ public class OkHttpClientTransportTest {
   public void shutdownDuringConnecting() throws Exception {
     initTransportAndDelayConnected();
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     clientTransport.shutdown();
     allowTransportConnected();
@@ -1340,7 +1340,7 @@ public class OkHttpClientTransportTest {
     assertTrue(status.getCause().toString(), status.getCause() instanceof IOException);
 
     MockStreamListener streamListener = new MockStreamListener();
-    clientTransport.newStream(method, new Metadata()).start(streamListener, new Metadata());
+    clientTransport.newStream(method).start(streamListener, new Metadata());
     streamListener.waitUntilStreamClosed();
     assertEquals(Status.UNAVAILABLE.getCode(), streamListener.status.getCode());
   }
@@ -1374,7 +1374,7 @@ public class OkHttpClientTransportTest {
 
   private void assertNewStreamFail() throws Exception {
     MockStreamListener listener = new MockStreamListener();
-    OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
+    OkHttpClientStream stream = clientTransport.newStream(method);
     stream.start(listener, new Metadata());
     listener.waitUntilStreamClosed();
     assertFalse(listener.status.isOk());

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -207,7 +207,7 @@ public class OkHttpClientTransportTest {
 
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(1);
     assertContainStream(3);
     frameHandler().headers(false, false, 3, 0, grpcResponseHeaders(), HeadersMode.HTTP_20_HEADERS);
@@ -232,10 +232,10 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
-    stream1.start(listener1);
+    stream1.start(listener1, new Metadata());
     stream1.request(1);
     OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
-    stream2.start(listener2);
+    stream2.start(listener2, new Metadata());
     stream2.request(1);
     assertEquals(2, activeStreamCount());
     assertContainStream(3);
@@ -258,7 +258,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(1);
     frameReader.nextFrameAtEndOfStream();
     listener.waitUntilStreamClosed();
@@ -275,7 +275,7 @@ public class OkHttpClientTransportTest {
     final String message = "Hello Client";
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(numMessages);
     assertContainStream(3);
     frameHandler().headers(false, false, 3, 0, grpcResponseHeaders(), HeadersMode.HTTP_20_HEADERS);
@@ -324,7 +324,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(1);
     assertContainStream(3);
     // Headers block without correct content type or status
@@ -347,7 +347,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(1);
     assertContainStream(3);
     // Headers block with EOS without correct content type or status
@@ -366,7 +366,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     assertContainStream(3);
     frameHandler().headers(true, true, 3, 0, grpcResponseTrailers(), HeadersMode.HTTP_20_HEADERS);
     listener.waitUntilStreamClosed();
@@ -379,7 +379,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     assertContainStream(3);
     frameHandler().rstStream(3, ErrorCode.PROTOCOL_ERROR);
     listener.waitUntilStreamClosed();
@@ -394,7 +394,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     getStream(3).cancel(Status.CANCELLED);
     verify(frameWriter, timeout(TIME_OUT_MS)).rstStream(eq(3), eq(ErrorCode.CANCEL));
     listener.waitUntilStreamClosed();
@@ -408,7 +408,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     Header userAgentHeader = new Header(GrpcUtil.USER_AGENT_KEY.name(),
             GrpcUtil.getGrpcUserAgent("okhttp", null));
     List<Header> expectedHeaders = Arrays.asList(SCHEME_HEADER, METHOD_HEADER,
@@ -426,7 +426,7 @@ public class OkHttpClientTransportTest {
     startTransport(3, null, true, DEFAULT_MAX_MESSAGE_SIZE, "fakeUserAgent");
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     List<Header> expectedHeaders = Arrays.asList(SCHEME_HEADER, METHOD_HEADER,
         new Header(Header.TARGET_AUTHORITY, "notarealauthority:80"),
         new Header(Header.TARGET_PATH, "/fakemethod"),
@@ -444,7 +444,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     getStream(3).cancel(Status.DEADLINE_EXCEEDED);
     verify(frameWriter, timeout(TIME_OUT_MS)).rstStream(eq(3), eq(ErrorCode.CANCEL));
     listener.waitUntilStreamClosed();
@@ -457,7 +457,7 @@ public class OkHttpClientTransportTest {
     final String message = "Hello Server";
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     assertEquals(12, input.available());
     stream.writeMessage(input);
@@ -477,11 +477,11 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
-    stream1.start(listener1);
+    stream1.start(listener1, new Metadata());
     stream1.request(2);
 
     OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
-    stream2.start(listener2);
+    stream2.start(listener2, new Metadata());
     stream2.request(2);
     assertEquals(2, activeStreamCount());
     stream1 = getStream(3);
@@ -541,7 +541,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     int messageLength = Utils.DEFAULT_WINDOW_SIZE / 2 + 1;
     byte[] fakeMessage = new byte[messageLength];
 
@@ -573,7 +573,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     // The first message should be sent out.
     int messageLength = Utils.DEFAULT_WINDOW_SIZE / 2 + 1;
     InputStream input = new ByteArrayInputStream(new byte[messageLength]);
@@ -609,7 +609,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     int messageLength = 20;
     setInitialWindowSize(HEADER_LENGTH + 10);
     InputStream input = new ByteArrayInputStream(new byte[messageLength]);
@@ -655,9 +655,9 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
-    stream1.start(listener1);
+    stream1.start(listener1, new Metadata());
     OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
-    stream2.start(listener2);
+    stream2.start(listener2, new Metadata());
     assertEquals(2, activeStreamCount());
     clientTransport.shutdown();
 
@@ -683,10 +683,10 @@ public class OkHttpClientTransportTest {
     MockStreamListener listener1 = new MockStreamListener();
     MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
-    stream1.start(listener1);
+    stream1.start(listener1, new Metadata());
     stream1.request(1);
     OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
-    stream2.start(listener2);
+    stream2.start(listener2, new Metadata());
     stream2.request(1);
     assertEquals(2, activeStreamCount());
 
@@ -741,7 +741,7 @@ public class OkHttpClientTransportTest {
 
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(1);
 
     // New stream should be failed.
@@ -776,10 +776,10 @@ public class OkHttpClientTransportTest {
     final MockStreamListener listener1 = new MockStreamListener();
     final MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
-    stream1.start(listener1);
+    stream1.start(listener1, new Metadata());
     // The second stream should be pending.
     OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
-    stream2.start(listener2);
+    stream2.start(listener2, new Metadata());
     String sentMessage = "hello";
     InputStream input = new ByteArrayInputStream(sentMessage.getBytes(UTF_8));
     assertEquals(5, input.available());
@@ -813,7 +813,7 @@ public class OkHttpClientTransportTest {
     setMaxConcurrentStreams(0);
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     waitForStreamPending(1);
     stream.sendCancel(Status.CANCELLED);
     // The second cancel should be an no-op.
@@ -831,10 +831,10 @@ public class OkHttpClientTransportTest {
     final MockStreamListener listener1 = new MockStreamListener();
     final MockStreamListener listener2 = new MockStreamListener();
     OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
-    stream1.start(listener1);
+    stream1.start(listener1, new Metadata());
     // The second stream should be pending.
     OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
-    stream2.start(listener2);
+    stream2.start(listener2, new Metadata());
 
     waitForStreamPending(1);
     assertEquals(1, activeStreamCount());
@@ -859,7 +859,7 @@ public class OkHttpClientTransportTest {
     final MockStreamListener listener = new MockStreamListener();
     // The second stream should be pending.
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     waitForStreamPending(1);
 
     clientTransport.shutdown();
@@ -882,13 +882,13 @@ public class OkHttpClientTransportTest {
     final MockStreamListener listener3 = new MockStreamListener();
 
     OkHttpClientStream stream1 = clientTransport.newStream(method, new Metadata());
-    stream1.start(listener1);
+    stream1.start(listener1, new Metadata());
 
     // The second and third stream should be pending.
     OkHttpClientStream stream2 = clientTransport.newStream(method, new Metadata());
-    stream2.start(listener2);
+    stream2.start(listener2, new Metadata());
     OkHttpClientStream stream3 = clientTransport.newStream(method, new Metadata());
-    stream3.start(listener3);
+    stream3.start(listener3, new Metadata());
 
     waitForStreamPending(2);
     assertEquals(1, activeStreamCount());
@@ -911,7 +911,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(1);
 
     frameHandler().headers(false, false, 3, 0, grpcResponseHeaders(), HeadersMode.HTTP_20_HEADERS);
@@ -962,7 +962,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     verify(frameWriter, timeout(TIME_OUT_MS)).synStream(
         eq(false), eq(false), eq(3), eq(0), Matchers.anyListOf(Header.class));
     if (shouldBeFlushed) {
@@ -978,7 +978,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(1);
     Buffer buffer = createMessageFrame(new byte[1]);
     frameHandler().data(false, 3, buffer, (int) buffer.size());
@@ -999,7 +999,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(1);
     Buffer buffer = createMessageFrame(new byte[1]);
     frameHandler().data(false, 3, buffer, (int) buffer.size());
@@ -1020,7 +1020,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.request(1);
     Buffer buffer = createMessageFrame(new byte[1000]);
     frameHandler().data(false, 3, buffer, (int) buffer.size());
@@ -1040,7 +1040,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.cancel(Status.CANCELLED);
 
     Buffer buffer = createMessageFrame(
@@ -1066,7 +1066,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     stream.cancel(Status.CANCELLED);
     // This should be ignored.
     frameHandler().windowUpdate(3, 73);
@@ -1085,7 +1085,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     assertTrue(stream.isReady());
     assertTrue(listener.isOnReadyCalled());
     stream.cancel(Status.CANCELLED);
@@ -1101,7 +1101,7 @@ public class OkHttpClientTransportTest {
     setInitialWindowSize(0);
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     assertTrue(stream.isReady());
     // Be notified at the beginning.
     assertTrue(listener.isOnReadyCalled());
@@ -1245,7 +1245,7 @@ public class OkHttpClientTransportTest {
     final String message = "Hello Server";
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     stream.writeMessage(input);
     stream.flush();
@@ -1270,7 +1270,7 @@ public class OkHttpClientTransportTest {
     final String message = "Hello Server";
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     InputStream input = new ByteArrayInputStream(message.getBytes(UTF_8));
     stream.writeMessage(input);
     stream.flush();
@@ -1287,7 +1287,7 @@ public class OkHttpClientTransportTest {
     initTransportAndDelayConnected();
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     clientTransport.shutdown();
     allowTransportConnected();
 
@@ -1340,7 +1340,7 @@ public class OkHttpClientTransportTest {
     assertTrue(status.getCause().toString(), status.getCause() instanceof IOException);
 
     MockStreamListener streamListener = new MockStreamListener();
-    clientTransport.newStream(method, new Metadata()).start(streamListener);
+    clientTransport.newStream(method, new Metadata()).start(streamListener, new Metadata());
     streamListener.waitUntilStreamClosed();
     assertEquals(Status.UNAVAILABLE.getCode(), streamListener.status.getCode());
   }
@@ -1375,7 +1375,7 @@ public class OkHttpClientTransportTest {
   private void assertNewStreamFail() throws Exception {
     MockStreamListener listener = new MockStreamListener();
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
-    stream.start(listener);
+    stream.start(listener, new Metadata());
     listener.waitUntilStreamClosed();
     assertFalse(listener.status.isOk());
   }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -198,7 +198,7 @@ public abstract class AbstractTransportTest {
     // Netty channel.
 
     ClientStream stream = client.newStream(methodDescriptor, new Metadata());
-    stream.start(mockClientStreamListener);
+    stream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     stream.flush();
@@ -219,7 +219,7 @@ public abstract class AbstractTransportTest {
     // Test that the channel is still usable i.e. we can receive headers from the server on a
     // new stream.
     stream = client.newStream(methodDescriptor, new Metadata());
-    stream.start(mockClientStreamListener2);
+    stream.start(mockClientStreamListener2, new Metadata());
     serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverStreamCreation.stream.writeHeaders(new Metadata());
@@ -300,7 +300,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -351,7 +351,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -382,7 +382,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -428,7 +428,7 @@ public abstract class AbstractTransportTest {
     runIfNotNull(client.start(mockClientTransportListener));
     // Stream prevents termination
     ClientStream stream = client.newStream(methodDescriptor, new Metadata());
-    stream.start(mockClientStreamListener);
+    stream.start(mockClientStreamListener, new Metadata());
     client.shutdown();
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportShutdown(any(Status.class));
     ClientTransport.PingCallback mockPingCallback = mock(ClientTransport.PingCallback.class);
@@ -469,12 +469,12 @@ public abstract class AbstractTransportTest {
     runIfNotNull(client.start(mockClientTransportListener));
     // Stream prevents termination
     ClientStream stream = client.newStream(methodDescriptor, new Metadata());
-    stream.start(mockClientStreamListener);
+    stream.start(mockClientStreamListener, new Metadata());
     client.shutdown();
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportShutdown(any(Status.class));
     ClientStream stream2 = client.newStream(methodDescriptor, new Metadata());
     ClientStreamListener mockClientStreamListener2 = mock(ClientStreamListener.class);
-    stream2.start(mockClientStreamListener2);
+    stream2.start(mockClientStreamListener2, new Metadata());
     verify(mockClientStreamListener2, timeout(TIMEOUT_MS))
         .closed(statusCaptor.capture(), any(Metadata.class));
     assertCodeEquals(Status.UNAVAILABLE, statusCaptor.getValue());
@@ -503,7 +503,7 @@ public abstract class AbstractTransportTest {
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportTerminated();
     Thread.sleep(100);
     ClientStream stream = client.newStream(methodDescriptor, new Metadata());
-    stream.start(mockClientStreamListener);
+    stream.start(mockClientStreamListener, new Metadata());
     verify(mockClientStreamListener, timeout(TIMEOUT_MS))
         .closed(statusCaptor.capture(), any(Metadata.class));
     verify(mockClientTransportListener, never()).transportInUse(anyBoolean());
@@ -516,14 +516,14 @@ public abstract class AbstractTransportTest {
     client = newClientTransport(server);
     runIfNotNull(client.start(mockClientTransportListener));
     ClientStream stream1 = client.newStream(methodDescriptor, new Metadata());
-    stream1.start(mockClientStreamListener);
+    stream1.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     StreamCreation serverStreamCreation1
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     ClientStream stream2 = client.newStream(methodDescriptor, new Metadata());
-    stream2.start(mockClientStreamListener);
+    stream2.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation2
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
@@ -544,10 +544,10 @@ public abstract class AbstractTransportTest {
     client = newClientTransport(server);
     runIfNotNull(client.start(mockClientTransportListener));
     ClientStream stream1 = client.newStream(methodDescriptor, new Metadata());
-    stream1.start(mockClientStreamListener);
+    stream1.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     ClientStream stream2 = client.newStream(methodDescriptor, new Metadata());
-    stream2.start(mockClientStreamListener);
+    stream2.start(mockClientStreamListener, new Metadata());
 
     stream1.cancel(Status.CANCELLED);
     verify(mockClientTransportListener, never()).transportInUse(false);
@@ -577,7 +577,7 @@ public abstract class AbstractTransportTest {
 
     clientHeadersCopy.merge(clientHeaders);
     ClientStream clientStream = client.newStream(methodDescriptor, clientHeaders);
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, clientHeaders);
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     assertEquals(methodDescriptor.getFullMethodName(), serverStreamCreation.method);
@@ -656,7 +656,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     ServerStream serverStream = serverStreamCreation.stream;
@@ -688,7 +688,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     ServerStream serverStream = serverStreamCreation.stream;
@@ -718,7 +718,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     ServerStream serverStream = serverStreamCreation.stream;
@@ -755,7 +755,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     ServerStream serverStream = serverStreamCreation.stream;
@@ -783,7 +783,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
@@ -836,7 +836,7 @@ public abstract class AbstractTransportTest {
       @Override
       public void onReady() {
       }
-    });
+    }, new Metadata());
     clientStream.halfClose();
     clientStream.request(1);
 
@@ -868,7 +868,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     ServerStream serverStream = serverStreamCreation.stream;
@@ -905,7 +905,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     assertEquals(methodDescriptor.getFullMethodName(), serverStreamCreation.method);
@@ -1065,7 +1065,7 @@ public abstract class AbstractTransportTest {
     runIfNotNull(client.start(mock(ManagedClientTransport.Listener.class)));
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
     ClientStreamListener mockClientStreamListener = mock(ClientStreamListener.class);
-    clientStream.start(mockClientStreamListener);
+    clientStream.start(mockClientStreamListener, new Metadata());
 
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -197,7 +197,7 @@ public abstract class AbstractTransportTest {
     // after having sent a RST_STREAM to the server. Previously, this would have broken the
     // Netty channel.
 
-    ClientStream stream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream stream = client.newStream(methodDescriptor);
     stream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -218,7 +218,7 @@ public abstract class AbstractTransportTest {
 
     // Test that the channel is still usable i.e. we can receive headers from the server on a
     // new stream.
-    stream = client.newStream(methodDescriptor, new Metadata());
+    stream = client.newStream(methodDescriptor);
     stream.start(mockClientStreamListener2, new Metadata());
     serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -299,7 +299,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     StreamCreation serverStreamCreation
@@ -350,7 +350,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     StreamCreation serverStreamCreation
@@ -381,7 +381,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     StreamCreation serverStreamCreation
@@ -427,7 +427,7 @@ public abstract class AbstractTransportTest {
     client = newClientTransport(server);
     runIfNotNull(client.start(mockClientTransportListener));
     // Stream prevents termination
-    ClientStream stream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream stream = client.newStream(methodDescriptor);
     stream.start(mockClientStreamListener, new Metadata());
     client.shutdown();
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportShutdown(any(Status.class));
@@ -468,11 +468,11 @@ public abstract class AbstractTransportTest {
     client = newClientTransport(server);
     runIfNotNull(client.start(mockClientTransportListener));
     // Stream prevents termination
-    ClientStream stream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream stream = client.newStream(methodDescriptor);
     stream.start(mockClientStreamListener, new Metadata());
     client.shutdown();
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportShutdown(any(Status.class));
-    ClientStream stream2 = client.newStream(methodDescriptor, new Metadata());
+    ClientStream stream2 = client.newStream(methodDescriptor);
     ClientStreamListener mockClientStreamListener2 = mock(ClientStreamListener.class);
     stream2.start(mockClientStreamListener2, new Metadata());
     verify(mockClientStreamListener2, timeout(TIMEOUT_MS))
@@ -502,7 +502,7 @@ public abstract class AbstractTransportTest {
     client.shutdown();
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportTerminated();
     Thread.sleep(100);
-    ClientStream stream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream stream = client.newStream(methodDescriptor);
     stream.start(mockClientStreamListener, new Metadata());
     verify(mockClientStreamListener, timeout(TIMEOUT_MS))
         .closed(statusCaptor.capture(), any(Metadata.class));
@@ -515,14 +515,14 @@ public abstract class AbstractTransportTest {
     server.start(serverListener);
     client = newClientTransport(server);
     runIfNotNull(client.start(mockClientTransportListener));
-    ClientStream stream1 = client.newStream(methodDescriptor, new Metadata());
+    ClientStream stream1 = client.newStream(methodDescriptor);
     stream1.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     StreamCreation serverStreamCreation1
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    ClientStream stream2 = client.newStream(methodDescriptor, new Metadata());
+    ClientStream stream2 = client.newStream(methodDescriptor);
     stream2.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation2
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -543,10 +543,10 @@ public abstract class AbstractTransportTest {
     server.start(serverListener);
     client = newClientTransport(server);
     runIfNotNull(client.start(mockClientTransportListener));
-    ClientStream stream1 = client.newStream(methodDescriptor, new Metadata());
+    ClientStream stream1 = client.newStream(methodDescriptor);
     stream1.start(mockClientStreamListener, new Metadata());
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportInUse(true);
-    ClientStream stream2 = client.newStream(methodDescriptor, new Metadata());
+    ClientStream stream2 = client.newStream(methodDescriptor);
     stream2.start(mockClientStreamListener, new Metadata());
 
     stream1.cancel(Status.CANCELLED);
@@ -576,7 +576,7 @@ public abstract class AbstractTransportTest {
     Metadata clientHeadersCopy = new Metadata();
 
     clientHeadersCopy.merge(clientHeaders);
-    ClientStream clientStream = client.newStream(methodDescriptor, clientHeaders);
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, clientHeaders);
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -655,7 +655,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -687,7 +687,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -717,7 +717,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -754,7 +754,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -782,7 +782,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -814,7 +814,7 @@ public abstract class AbstractTransportTest {
     serverTransport = serverTransportListener.transport;
 
     final SettableFuture<Boolean> closedCalled = SettableFuture.create();
-    final ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    final ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(new ClientStreamListener() {
       @Override
       public void headersRead(Metadata headers) {
@@ -867,7 +867,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -904,7 +904,7 @@ public abstract class AbstractTransportTest {
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
 
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     clientStream.start(mockClientStreamListener, new Metadata());
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -1063,7 +1063,7 @@ public abstract class AbstractTransportTest {
   private void doPingPong(MockServerListener serverListener) throws InterruptedException {
     ManagedClientTransport client = newClientTransport(server);
     runIfNotNull(client.start(mock(ManagedClientTransport.Listener.class)));
-    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata());
+    ClientStream clientStream = client.newStream(methodDescriptor);
     ClientStreamListener mockClientStreamListener = mock(ClientStreamListener.class);
     clientStream.start(mockClientStreamListener, new Metadata());
 


### PR DESCRIPTION
It only works for unary request which is both safe and idempotent.

It's not guaranteed to work for various reason like lack of server side support or request message is too long.
Applications should use their own judgement
