### PR TITLE
core: make max message size part of the public API

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -195,7 +195,35 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T idleTimeout(long value, TimeUnit unit);
 
   /**
+   * Sets the maximum message size allowed to be received on the channel. If not called,
+   * defaults to 4 MiB. The default provides protection to clients who haven't considered the
+   * possibility of receiving large messages while trying to be large enough to not be hit in normal
+   * usage.
+   *
+   * <p>This method is advisory, and implementations may decide to not enforce this.  Currently,
+   * the only known transport to not enforce this is {@code InProcessTransport}.
+   *
+   * @param max the maximum number of bytes a single message can be.
+   *
+   * @throws IllegalArgumentException if max is negative.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2307")
+  public T maxInboundMessageSize(int max) {
+    // intentional nop
+    return thisT();
+  }
+
+  /**
    * Builds a channel using the given parameters.
    */
   public abstract ManagedChannel build();
+
+  /**
+   * Returns the correctly typed version of the builder.
+   */
+  protected final T thisT() {
+    @SuppressWarnings("unchecked")
+    T thisT = (T) this;
+    return thisT;
+  }
 }

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -73,6 +73,12 @@ public class InProcessChannelBuilder extends
     super.censusContextFactory(NoopCensusContextFactory.INSTANCE);
   }
 
+  @Override
+  public final InProcessChannelBuilder maxInboundMessageSize(int max) {
+    // TODO(carl-mastrangelo): maybe throw an exception since this not enforced?
+    return super.maxInboundMessageSize(max);
+  }
+
   /**
    * Does nothing.
    */

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -121,6 +121,20 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private long idleTimeoutMillis = IDLE_MODE_DEFAULT_TIMEOUT_MILLIS;
 
+  private int maxInboundMessageSize = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
+
+  // Can be overriden by subclasses.
+  @Override
+  public T maxInboundMessageSize(int max) {
+    checkArgument(max >= 0, "negative max");
+    maxInboundMessageSize = max;
+    return thisT();
+  }
+
+  protected final int maxInboundMessageSize() {
+    return maxInboundMessageSize;
+  }
+
   @Nullable
   private CensusContextFactory censusFactory;
 
@@ -200,12 +214,6 @@ public abstract class AbstractManagedChannelImplBuilder
   public final T compressorRegistry(CompressorRegistry registry) {
     this.compressorRegistry = registry;
     return thisT();
-  }
-
-  private T thisT() {
-    @SuppressWarnings("unchecked")
-    T thisT = (T) this;
-    return thisT;
   }
 
   @Override

--- a/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
@@ -63,7 +63,7 @@ public class AutoWindowSizingOnTest extends AbstractInteropTest {
   protected ManagedChannel createChannel() {
     return NettyChannelBuilder.forAddress("localhost", getPort())
         .negotiationType(NegotiationType.PLAINTEXT)
-        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .censusContextFactory(getClientCensusFactory())
         .build();
   }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -74,7 +74,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
         .negotiationType(NegotiationType.PLAINTEXT)
         .channelType(LocalChannel.class)
         .flowControlWindow(65 * 1024)
-        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .censusContextFactory(getClientCensusFactory())
         .build();
   }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -84,7 +84,7 @@ public class Http2NettyTest extends AbstractInteropTest {
       return NettyChannelBuilder
           .forAddress(TestUtils.testServerAddress(getPort()))
           .flowControlWindow(65 * 1024)
-          .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+          .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(GrpcSslContexts
               .forClient()
               .keyManager(TestUtils.loadCert("client.pem"), TestUtils.loadCert("client.key"))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -103,7 +103,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
   @Override
   protected ManagedChannel createChannel() {
     OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("127.0.0.1", getPort())
-        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .connectionSpec(new ConnectionSpec.Builder(OkHttpChannelBuilder.DEFAULT_CONNECTION_SPEC)
             .cipherSuites(TestUtils.preferredTestCiphers().toArray(new String[0]))
             .tlsVersions(ConnectionSpec.MODERN_TLS.tlsVersions().toArray(new TlsVersion[0]))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -149,7 +149,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
   @Override
   protected ManagedChannel createChannel() {
     return NettyChannelBuilder.forAddress("localhost", getPort())
-        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .decompressorRegistry(decompressors)
         .compressorRegistry(compressors)
         .censusContextFactory(getClientCensusFactory())

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -32,7 +32,6 @@
 package io.grpc.netty;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -71,7 +70,6 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
   private EventLoopGroup eventLoopGroup;
   private SslContext sslContext;
   private int flowControlWindow = DEFAULT_FLOW_CONTROL_WINDOW;
-  private int maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
   private int maxHeaderListSize = GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE;
 
   /**
@@ -190,14 +188,13 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
   }
 
   /**
-   * Sets the maximum message size allowed to be received on the channel. If not called,
-   * defaults to 4 MiB. The default provides protection to clients who haven't considered the
-   * possibility of receiving large messages while trying to be large enough to not be hit in normal
-   * usage.
+   * Sets the max message size.
+   *
+   * @deprecated Use maxInboundMessageSize instead
    */
+  @Deprecated
   public final NettyChannelBuilder maxMessageSize(int maxMessageSize) {
-    checkArgument(maxMessageSize >= 0, "maxMessageSize must be >= 0");
-    this.maxMessageSize = maxMessageSize;
+    maxInboundMessageSize(maxMessageSize);
     return this;
   }
 
@@ -228,7 +225,7 @@ public class NettyChannelBuilder extends AbstractManagedChannelImplBuilder<Netty
   @Override
   protected ClientTransportFactory buildTransportFactory() {
     return new NettyTransportFactory(channelType, negotiationType, protocolNegotiator, sslContext,
-        eventLoopGroup, flowControlWindow, maxMessageSize, maxHeaderListSize);
+        eventLoopGroup, flowControlWindow, maxInboundMessageSize(), maxHeaderListSize);
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -31,10 +31,8 @@
 
 package io.grpc.okhttp;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.internal.GrpcUtil.DEFAULT_KEEPALIVE_DELAY_NANOS;
 import static io.grpc.internal.GrpcUtil.DEFAULT_KEEPALIVE_TIMEOUT_NANOS;
-import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -119,7 +117,6 @@ public class OkHttpChannelBuilder extends
   private SSLSocketFactory sslSocketFactory;
   private ConnectionSpec connectionSpec = DEFAULT_CONNECTION_SPEC;
   private NegotiationType negotiationType = NegotiationType.TLS;
-  private int maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
   private boolean enableKeepAlive;
   private long keepAliveDelayNanos;
   private long keepAliveTimeoutNanos;
@@ -216,18 +213,6 @@ public class OkHttpChannelBuilder extends
   }
 
   /**
-   * Sets the maximum message size allowed to be received on the channel. If not called,
-   * defaults to 4 MiB. The default provides protection to clients who haven't considered the
-   * possibility of receiving large messages while trying to be large enough to not be hit in normal
-   * usage.
-   */
-  public final OkHttpChannelBuilder maxMessageSize(int maxMessageSize) {
-    checkArgument(maxMessageSize >= 0, "maxMessageSize must be >= 0");
-    this.maxMessageSize = maxMessageSize;
-    return this;
-  }
-
-  /**
    * Equivalent to using {@link #negotiationType(NegotiationType)} with {@code PLAINTEXT}.
    */
   @Override
@@ -243,8 +228,8 @@ public class OkHttpChannelBuilder extends
   @Override
   protected final ClientTransportFactory buildTransportFactory() {
     return new OkHttpTransportFactory(transportExecutor,
-        createSocketFactory(), connectionSpec, maxMessageSize, enableKeepAlive, keepAliveDelayNanos,
-        keepAliveTimeoutNanos);
+        createSocketFactory(), connectionSpec, maxInboundMessageSize(), enableKeepAlive,
+        keepAliveDelayNanos, keepAliveTimeoutNanos);
   }
 
   @Override


### PR DESCRIPTION
This seems to come up every so often, so make it part of the API.  It seems like a reasonable thing to have, and is better than having to cast the builder.

Actually getting the max message size is still limitted, but it might be worth exposing it in a later PR.