### PR TITLE
testing: make all of StreamRecorder threadsafe

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -302,8 +302,8 @@ public abstract class AbstractInteropTest {
       requestObserver.onNext(request);
     }
     requestObserver.onCompleted();
-    assertEquals(goldenResponse, responseObserver.firstValue().get());
-    responseObserver.awaitCompletion();
+    responseObserver.awaitCompletion(10000, TimeUnit.MILLISECONDS);
+    assertEquals(goldenResponse, responseObserver.firstValue());
   }
 
   @Test(timeout = 10000)

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -269,7 +269,7 @@ public abstract class AbstractInteropTest {
     asyncStub.streamingOutputCall(request, recorder);
     recorder.awaitCompletion();
     assertSuccess(recorder);
-    assertEquals(goldenResponses, recorder.getValues());
+    assertEquals(goldenResponses, new ArrayList<StreamingOutputCallResponse>(recorder.getValues()));
   }
 
   @Test(timeout = 10000)
@@ -387,7 +387,7 @@ public abstract class AbstractInteropTest {
         asyncStub.streamingInputCall(responseObserver);
     requestObserver.onError(new RuntimeException());
     responseObserver.awaitCompletion();
-    assertEquals(Arrays.<StreamingInputCallResponse>asList(), responseObserver.getValues());
+    assertTrue(responseObserver.getValues().isEmpty());
     assertEquals(Status.Code.CANCELLED,
         Status.fromThrowable(responseObserver.getError()).getCode());
 
@@ -456,9 +456,11 @@ public abstract class AbstractInteropTest {
     requestStream.onCompleted();
     recorder.awaitCompletion();
     assertSuccess(recorder);
-    assertEquals(responseSizes.size() * numRequests, recorder.getValues().size());
-    for (int ix = 0; ix < recorder.getValues().size(); ++ix) {
-      StreamingOutputCallResponse response = recorder.getValues().get(ix);
+    List<StreamingOutputCallResponse> responses =
+        new ArrayList<StreamingOutputCallResponse>(recorder.getValues());
+    assertEquals(responseSizes.size() * numRequests, responses.size());
+    for (int ix = 0; ix < responses.size(); ++ix) {
+      StreamingOutputCallResponse response = responses.get(ix);
       assertEquals(COMPRESSABLE, response.getPayload().getType());
       int length = response.getPayload().getBody().size();
       int expectedSize = responseSizes.get(ix % responseSizes.size());
@@ -466,8 +468,7 @@ public abstract class AbstractInteropTest {
     }
 
     if (metricsExpected()) {
-      assertMetrics("grpc.testing.TestService/FullDuplexCall", Status.Code.OK, requests,
-          recorder.getValues());
+      assertMetrics("grpc.testing.TestService/FullDuplexCall", Status.Code.OK, requests, responses);
     }
   }
 
@@ -498,7 +499,7 @@ public abstract class AbstractInteropTest {
     assertSuccess(recorder);
     assertEquals(responseSizes.size() * numRequests, recorder.getValues().size());
     for (int ix = 0; ix < recorder.getValues().size(); ++ix) {
-      StreamingOutputCallResponse response = recorder.getValues().get(ix);
+      StreamingOutputCallResponse response = recorder.getValues().remove();
       assertEquals(COMPRESSABLE, response.getPayload().getType());
       int length = response.getPayload().getBody().size();
       int expectedSize = responseSizes.get(ix % responseSizes.size());

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -32,6 +32,7 @@
 package io.grpc.testing.integration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -63,6 +64,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 
@@ -137,10 +139,9 @@ public class Http2OkHttpTest extends AbstractInteropTest {
         asyncStub.fullDuplexCall(recorder);
     Messages.StreamingOutputCallRequest request = requestBuilder.build();
     requestStream.onNext(request);
-    recorder.firstValue().get();
     requestStream.onError(new Exception("failed"));
-
-    recorder.awaitCompletion();
+    recorder.awaitCompletion(10000, TimeUnit.MILLISECONDS);
+    assertNotNull(recorder.firstValue());
 
     assertEquals(EMPTY, blockingStub.emptyCall(EMPTY));
   }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -32,7 +32,6 @@
 package io.grpc.testing.integration;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -139,9 +138,9 @@ public class Http2OkHttpTest extends AbstractInteropTest {
         asyncStub.fullDuplexCall(recorder);
     Messages.StreamingOutputCallRequest request = requestBuilder.build();
     requestStream.onNext(request);
+    recorder.getValues().take();
     requestStream.onError(new Exception("failed"));
     recorder.awaitCompletion(10000, TimeUnit.MILLISECONDS);
-    assertNotNull(recorder.firstValue());
 
     assertEquals(EMPTY, blockingStub.emptyCall(EMPTY));
   }

--- a/testing/src/main/java/io/grpc/testing/StreamRecorder.java
+++ b/testing/src/main/java/io/grpc/testing/StreamRecorder.java
@@ -34,10 +34,9 @@ package io.grpc.testing;
 import io.grpc.ExperimentalApi;
 import io.grpc.stub.StreamObserver;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -60,7 +59,7 @@ public class StreamRecorder<T> implements StreamObserver<T> {
   }
 
   private final CountDownLatch latch = new CountDownLatch(1);
-  private final List<T> results = Collections.synchronizedList(new ArrayList<T>());
+  private final BlockingQueue<T> results = new LinkedBlockingQueue<T>();
   private final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
   private final AtomicReference<T> firstValue = new AtomicReference<T>();
 
@@ -100,8 +99,8 @@ public class StreamRecorder<T> implements StreamObserver<T> {
   /**
    * Returns the current set of received values.
    */
-  public List<T> getValues() {
-    return Collections.unmodifiableList(results);
+  public BlockingQueue<T> getValues() {
+    return results;
   }
 
   /**


### PR DESCRIPTION
As seen on a recent jenkins build:

```
java.lang.NullPointerException: t
    at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:228)
    at io.grpc.Status.fromThrowable(Status.java:405)
    at io.grpc.testing.integration.AbstractInteropTest.deadlineExceededServerStreaming(AbstractInteropTest.java:745)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.FailOnTimeout$StatementThread.run(FailOnTimeout.java:74)
```

Looking into this failure, it look the error is not synchronized like the rest of the class.  Remove any doubt by making it safe.  Additionally, remove the dep on Guava by using AtomicRef instead of Futures.
