### PR TITLE
Restricted App Engine auth workaround

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -36,9 +36,11 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_KEEPALIVE_TIMEOUT_NANOS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+
 import com.squareup.okhttp.CipherSuite;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.TlsVersion;
+
 import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
 import io.grpc.Internal;
@@ -50,6 +52,7 @@ import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.okhttp.internal.Platform;
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.GeneralSecurityException;
@@ -57,6 +60,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSocketFactory;
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -56,13 +56,19 @@ import io.grpc.okhttp.internal.Platform;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
 
 /** Convenience class for building channels with the OkHttp transport. */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1785")
@@ -255,7 +261,7 @@ public class OkHttpChannelBuilder extends
       case TLS:
         try {
           if (sslSocketFactory == null) {
-            sslSocketFactory = Platform.getSslContext().getSocketFactory();
+            sslSocketFactory = getSslContext().getSocketFactory();
           }
           return sslSocketFactory;
         } catch (GeneralSecurityException gse) {
@@ -266,6 +272,29 @@ public class OkHttpChannelBuilder extends
       default:
         throw new RuntimeException("Unknown negotiation type: " + negotiationType);
     }
+  }
+
+  private static SSLContext getSslContext() throws NoSuchAlgorithmException {
+    if (GrpcUtil.IS_RESTRICTED_APPENGINE) {
+      try {
+        SSLContext tlsContext = SSLContext.getInstance("TLS", Platform.get().getProvider());
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, null);
+        KeyManagerFactory keyManagerFactory =
+            KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, null);
+        TrustManagerFactory trustManagerFactory =
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init((KeyStore) null);
+        tlsContext.init(
+            null,
+            trustManagerFactory.getTrustManagers(),
+            SecureRandom.getInstance("SHA1PRNG", Platform.get().getProvider()));
+        return tlsContext;
+      } catch (Exception ex) {
+      }
+    }
+    return SSLContext.getInstance("Default", Platform.get().getProvider());
   }
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -36,11 +36,9 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_KEEPALIVE_TIMEOUT_NANOS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-
 import com.squareup.okhttp.CipherSuite;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.TlsVersion;
-
 import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
 import io.grpc.Internal;
@@ -52,7 +50,6 @@ import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.okhttp.internal.Platform;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.GeneralSecurityException;
@@ -60,9 +57,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
 /** Convenience class for building channels with the OkHttp transport. */
@@ -256,8 +251,7 @@ public class OkHttpChannelBuilder extends
       case TLS:
         try {
           if (sslSocketFactory == null) {
-            SSLContext sslContext = SSLContext.getInstance("Default", Platform.get().getProvider());
-            sslSocketFactory = sslContext.getSocketFactory();
+            sslSocketFactory = Platform.getSslContext().getSocketFactory();
           }
           return sslSocketFactory;
         } catch (GeneralSecurityException gse) {

--- a/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Platform.java
+++ b/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Platform.java
@@ -29,21 +29,16 @@ import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
-import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
-import java.security.SecureRandom;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
-import javax.net.ssl.TrustManagerFactory;
-
 import okio.Buffer;
 
 /**
@@ -133,29 +128,6 @@ public class Platform {
   public void connectSocket(Socket socket, InetSocketAddress address,
       int connectTimeout) throws IOException {
     socket.connect(address, connectTimeout);
-  }
-
-  public static SSLContext getSslContext() throws NoSuchAlgorithmException {
-    if (GrpcUtil.IS_RESTRICTED_APPENGINE) {
-      try {
-        SSLContext tlsContext = SSLContext.getInstance("TLS", Platform.get().getProvider());
-        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        keyStore.load(null, null);
-        KeyManagerFactory keyManagerFactory =
-            KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        keyManagerFactory.init(keyStore, null);
-        TrustManagerFactory trustManagerFactory =
-            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        trustManagerFactory.init((KeyStore) null);
-        tlsContext.init(
-            null,
-            trustManagerFactory.getTrustManagers(),
-            SecureRandom.getInstance("SHA1PRNG", Platform.get().getProvider()));
-        return tlsContext;
-      } catch (Exception ex) {
-      }
-    }
-    return SSLContext.getInstance("Default", Platform.get().getProvider());
   }
 
   /** Attempt to match the host runtime to a capable Platform implementation. */

--- a/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Platform.java
+++ b/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Platform.java
@@ -38,10 +38,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManagerFactory;
+
 import okio.Buffer;
 
 /**

--- a/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Platform.java
+++ b/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Platform.java
@@ -29,16 +29,19 @@ import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
+import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
+import java.security.SecureRandom;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManagerFactory;
 import okio.Buffer;
 
 /**
@@ -128,6 +131,29 @@ public class Platform {
   public void connectSocket(Socket socket, InetSocketAddress address,
       int connectTimeout) throws IOException {
     socket.connect(address, connectTimeout);
+  }
+
+  public static SSLContext getSslContext() throws NoSuchAlgorithmException {
+    if (GrpcUtil.IS_RESTRICTED_APPENGINE) {
+      try {
+        SSLContext tlsContext = SSLContext.getInstance("TLS", Platform.get().getProvider());
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, null);
+        KeyManagerFactory keyManagerFactory =
+            KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, null);
+        TrustManagerFactory trustManagerFactory =
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init((KeyStore) null);
+        tlsContext.init(
+            null,
+            trustManagerFactory.getTrustManagers(),
+            SecureRandom.getInstance("SHA1PRNG", Platform.get().getProvider()));
+        return tlsContext;
+      } catch (Exception ex) {
+      }
+    }
+    return SSLContext.getInstance("Default", Platform.get().getProvider());
   }
 
   /** Attempt to match the host runtime to a capable Platform implementation. */


### PR DESCRIPTION
Currently in App Engine java7, using gRPC fails because of a system property read permission issue: 

```java.security.AccessControlException: access denied ("java.util.PropertyPermission" "javax.net.ssl.keyStore" "read")```

This workaround avoids the system property read in the restricted App Engine environment (credits to Les and Louis for finding this workaround).