### PR TITLE
benchmarks: print gc detail and vm flags for benchmarks

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -54,7 +54,9 @@ configureProtoCompilation()
 def vmArgs = [
         "-server",
         "-Xms2g",
-        "-Xmx2g"
+        "-Xmx2g",
+        "-XX:+PrintGCDetails",
+        "-XX:+PrintFlagsFinal"
 ]
 
 task qps_client(type: CreateStartScripts) {


### PR DESCRIPTION
Intended to see why the benchmarks seem to not be affected by performance related PRs.