### PR TITLE
Typo in version number

### DIFF
--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -2,7 +2,7 @@ FROM protoc-artifacts:latest
 
 RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
     git fetch && \
-    git checkout v3.10 && \
+    git checkout v3.1.0 && \
     ./autogen.sh && \
     CXXFLAGS=-m32 ./configure --disable-shared --prefix=/protobuf-32 && \
     make clean && make -j$(nproc) && make -j$(nproc) install"'


### PR DESCRIPTION
Fixes typo overlooked in https://github.com/grpc/grpc-java/pull/2367