### PR TITLE
core: fix bug when stream listener not set before stream closed

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -279,6 +279,11 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
       }
 
       @Override
+      public void setListener(ServerStreamListener serverStreamListener) {
+        clientStream.setListener(serverStreamListener);
+      }
+
+      @Override
       public void request(int numMessages) {
         boolean onReady = clientStream.serverRequested(numMessages);
         if (onReady) {
@@ -555,13 +560,11 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
         serverStream.setListener(listener);
 
         synchronized (InProcessTransport.this) {
-          ServerStreamListener serverStreamListener = serverTransportListener.streamCreated(
-              serverStream, method.getFullMethodName(), headers);
-          clientStream.setListener(serverStreamListener);
           streams.add(InProcessTransport.InProcessStream.this);
           if (streams.size() == 1) {
             clientTransportListener.transportInUse(true);
           }
+          serverTransportListener.streamCreated(serverStream, method.getFullMethodName(), headers);
         }
       }
 

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -362,8 +362,8 @@ public final class ServerImpl extends io.grpc.Server {
     }
 
     @Override
-    public ServerStreamListener streamCreated(final ServerStream stream, final String methodName,
-        final Metadata headers) {
+    public void streamCreated(
+        final ServerStream stream, final String methodName, final Metadata headers) {
 
       final StatsTraceContext statsTraceCtx = Preconditions.checkNotNull(
           stream.statsTraceContext(), "statsTraceCtx not present from stream");
@@ -380,6 +380,7 @@ public final class ServerImpl extends io.grpc.Server {
 
       final JumpToApplicationThreadServerStreamListener jumpListener
           = new JumpToApplicationThreadServerStreamListener(wrappedExecutor, stream, context);
+      stream.setListener(jumpListener);
       // Run in wrappedExecutor so jumpListener.setListener() is called before any callbacks
       // are delivered, including any errors. Callbacks can still be triggered, but they will be
       // queued.
@@ -417,7 +418,6 @@ public final class ServerImpl extends io.grpc.Server {
             }
           }
         });
-      return jumpListener;
     }
 
     private Context.CancellableContext createContext(

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -76,6 +76,12 @@ public interface ServerStream extends Stream {
    */
   Attributes attributes();
 
+
+  /**
+   * Sets the server stream listener.
+   */
+  void setListener(ServerStreamListener serverStreamListener);
+
   /**
    * The context for recording stats and traces for this stream.
    */

--- a/core/src/main/java/io/grpc/internal/ServerTransportListener.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransportListener.java
@@ -54,10 +54,8 @@ public interface ServerTransportListener {
    * @param stream the newly created stream.
    * @param method the fully qualified method name being called on the server.
    * @param headers containing metadata for the call.
-   * @return a listener for events on the new stream.
    */
-  ServerStreamListener streamCreated(ServerStream stream, String method,
-      Metadata headers);
+  void streamCreated(ServerStream stream, String method, Metadata headers);
 
   /**
    * The transport has finished all handshakes and is ready to process streams.

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -255,6 +255,11 @@ public class AbstractServerStreamTest {
       return state;
     }
 
+    @Override
+    public void setListener(ServerStreamListener serverStreamListener) {
+      state.setListener(serverStreamListener);
+    }
+
     static class TransportState extends AbstractServerStream.TransportState {
       protected TransportState(int maxMessageSize) {
         super(maxMessageSize, StatsTraceContext.NOOP);

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -143,13 +143,13 @@ public class ServerImplTest {
 
   @Captor
   private ArgumentCaptor<Status> statusCaptor;
+  @Captor
+  private ArgumentCaptor<ServerStreamListener> streamListenerCaptor;
 
   @Mock
   private ServerStream stream;
-
   @Mock
   private ServerCall.Listener<String> callListener;
-
   @Mock
   private ServerCallHandler<String, Integer> callHandler;
 
@@ -346,9 +346,8 @@ public class ServerImplTest {
     StatsTraceContext statsTraceCtx =
         transportListener.methodDetermined("Waiter/nonexist", requestHeaders);
     when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
-    ServerStreamListener streamListener
-        = transportListener.streamCreated(stream, "Waiter/nonexist", requestHeaders);
-    assertNotNull(streamListener);
+    transportListener.streamCreated(stream, "Waiter/nonexist", requestHeaders);
+    verify(stream).setListener(isA(ServerStreamListener.class));
     verify(stream, atLeast(1)).statsTraceContext();
 
     executeBarrier(executor).await();
@@ -407,8 +406,9 @@ public class ServerImplTest {
     assertNotNull(statsTraceCtx);
     when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
 
-    ServerStreamListener streamListener
-        = transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(streamListenerCaptor.capture());
+    ServerStreamListener streamListener = streamListenerCaptor.getValue();
     assertNotNull(streamListener);
     verify(stream, atLeast(1)).statsTraceContext();
 
@@ -587,8 +587,9 @@ public class ServerImplTest {
     assertNotNull(statsTraceCtx);
     when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
 
-    ServerStreamListener streamListener
-        = transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(streamListenerCaptor.capture());
+    ServerStreamListener streamListener = streamListenerCaptor.getValue();
     assertNotNull(streamListener);
     verify(stream, atLeast(1)).statsTraceContext();
     verifyNoMoreInteractions(stream);
@@ -751,8 +752,9 @@ public class ServerImplTest {
     assertNotNull(statsTraceCtx);
     when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
 
-    ServerStreamListener streamListener
-        = transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(streamListenerCaptor.capture());
+    ServerStreamListener streamListener = streamListenerCaptor.getValue();
     assertNotNull(streamListener);
 
     streamListener.onReady();
@@ -807,8 +809,9 @@ public class ServerImplTest {
         transportListener.methodDetermined("Waiter/serve", requestHeaders);
     assertNotNull(statsTraceCtx);
     when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
-    ServerStreamListener streamListener
-        = transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(streamListenerCaptor.capture());
+    ServerStreamListener streamListener = streamListenerCaptor.getValue();
     assertNotNull(streamListener);
 
     streamListener.onReady();

--- a/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
@@ -40,15 +40,16 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link InProcess}. */
+/** Unit tests for {@link io.grpc.inprocess}. */
 @RunWith(JUnit4.class)
 public class InProcessTest extends AbstractInteropTest {
-  private static String serverName = "test";
+
+  private static final String SERVER_NAME = "test";
 
   /** Starts the in-process server. */
   @BeforeClass
   public static void startServer() {
-    startStaticServer(InProcessServerBuilder.forName(serverName));
+    startStaticServer(InProcessServerBuilder.forName(SERVER_NAME));
   }
 
   @AfterClass
@@ -58,7 +59,7 @@ public class InProcessTest extends AbstractInteropTest {
 
   @Override
   protected ManagedChannel createChannel() {
-    return InProcessChannelBuilder.forName(serverName)
+    return InProcessChannelBuilder.forName(SERVER_NAME)
         .censusContextFactory(getClientCensusFactory()).build();
   }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.testing.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.integration.Messages.StreamingInputCallRequest;
+import io.grpc.testing.integration.Messages.StreamingInputCallResponse;
+import io.grpc.testing.integration.TestServiceGrpc.TestServiceImplBase;
+import io.grpc.util.MutableHandlerRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Unit tests for {@link io.grpc.inprocess}.
+ * Test more corner usecases, client not playing by the rules, server not playing by the rules, etc.
+ */
+@RunWith(JUnit4.class)
+public class MoreInProcessTest {
+  private static final String UNIQUE_SERVER_NAME =
+      "in-process server for " + MoreInProcessTest.class;
+  @Rule
+  public final Timeout globalTimeout = new Timeout(1000);
+  // use a mutable service registry for later registering the service impl for each test case.
+  private final MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
+  private final Server inProcessServer = InProcessServerBuilder.forName(UNIQUE_SERVER_NAME)
+      .fallbackHandlerRegistry(serviceRegistry).directExecutor().build();
+  private final ManagedChannel inProcessChannel =
+      InProcessChannelBuilder.forName(UNIQUE_SERVER_NAME).directExecutor().build();
+
+  @Before
+  public void setUp() throws Exception {
+    inProcessServer.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    inProcessChannel.shutdown();
+    inProcessServer.shutdown();
+    assertTrue(inProcessChannel.awaitTermination(900, TimeUnit.MILLISECONDS));
+    assertTrue(inProcessServer.awaitTermination(900, TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void asyncClientStreaming_serverResponsePriorToRequest() throws Exception {
+    // implement a service
+    final StreamingInputCallResponse fakeResponse =
+        StreamingInputCallResponse.newBuilder().setAggregatedPayloadSize(100).build();
+    TestServiceImplBase clientStreamingImpl = new TestServiceImplBase() {
+      @Override
+      public StreamObserver<StreamingInputCallRequest> streamingInputCall(
+          StreamObserver<StreamingInputCallResponse> responseObserver) {
+        // send response directly
+        responseObserver.onNext(fakeResponse);
+        responseObserver.onCompleted();
+        return new StreamObserver<StreamingInputCallRequest>() {
+          @Override
+          public void onNext(StreamingInputCallRequest value) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+          }
+
+          @Override
+          public void onCompleted() {
+          }
+        };
+      }
+    };
+    serviceRegistry.addService(clientStreamingImpl);
+    // implement a client
+    final CountDownLatch finishLatch = new CountDownLatch(1);
+    final AtomicReference<StreamingInputCallResponse> responseRef =
+        new AtomicReference<StreamingInputCallResponse>();
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+    StreamObserver<StreamingInputCallResponse> responseObserver =
+        new StreamObserver<StreamingInputCallResponse>() {
+          @Override
+          public void onNext(StreamingInputCallResponse response) {
+            responseRef.set(response);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            throwableRef.set(t);
+            finishLatch.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            finishLatch.countDown();
+          }
+        };
+
+    // make a gRPC call
+    TestServiceGrpc.newStub(inProcessChannel).streamingInputCall(responseObserver);
+
+    assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
+    assertEquals(fakeResponse, responseRef.get());
+    assertNull(throwableRef.get());
+  }
+
+  @Test
+  public void asyncClientStreaming_serverErrorPriorToRequest() throws Exception {
+    // implement a service
+    final Status fakeError = Status.INVALID_ARGUMENT;
+    TestServiceImplBase clientStreamingImpl = new TestServiceImplBase() {
+      @Override
+      public StreamObserver<StreamingInputCallRequest> streamingInputCall(
+          StreamObserver<StreamingInputCallResponse> responseObserver) {
+        // send error directly
+        responseObserver.onError(new StatusRuntimeException(fakeError));
+        responseObserver.onCompleted();
+        return new StreamObserver<StreamingInputCallRequest>() {
+          @Override
+          public void onNext(StreamingInputCallRequest value) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+          }
+
+          @Override
+          public void onCompleted() {
+          }
+        };
+      }
+    };
+    serviceRegistry.addService(clientStreamingImpl);
+    // implement a client
+    final CountDownLatch finishLatch = new CountDownLatch(1);
+    final AtomicReference<StreamingInputCallResponse> responseRef =
+        new AtomicReference<StreamingInputCallResponse>();
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+    StreamObserver<StreamingInputCallResponse> responseObserver =
+        new StreamObserver<StreamingInputCallResponse>() {
+          @Override
+          public void onNext(StreamingInputCallResponse response) {
+            responseRef.set(response);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            throwableRef.set(t);
+            finishLatch.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            finishLatch.countDown();
+          }
+        };
+
+    // make a gRPC call
+    TestServiceGrpc.newStub(inProcessChannel).streamingInputCall(responseObserver);
+
+    assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
+    assertEquals(fakeError.getCode(), Status.fromThrowable(throwableRef.get()).getCode());
+    assertNull(responseRef.get());
+  }
+
+  @Test
+  public void asyncClientStreaming_erroneousServiceImpl() throws Exception {
+    // implement a service
+    TestServiceImplBase clientStreamingImpl = new TestServiceImplBase() {
+      @Override
+      public StreamObserver<StreamingInputCallRequest> streamingInputCall(
+          StreamObserver<StreamingInputCallResponse> responseObserver) {
+        StreamObserver<StreamingInputCallRequest> requestObserver =
+            new StreamObserver<StreamingInputCallRequest>() {
+              @Override
+              public void onNext(StreamingInputCallRequest value) {
+                throw new RuntimeException(
+                    "unexpected error due to careless implementation of serviceImpl");
+              }
+
+              @Override
+              public void onError(Throwable t) {
+              }
+
+              @Override
+              public void onCompleted() {
+              }
+            };
+        return requestObserver;
+      }
+    };
+    serviceRegistry.addService(clientStreamingImpl);
+    // implement a client
+    final CountDownLatch finishLatch = new CountDownLatch(1);
+    final AtomicReference<StreamingInputCallResponse> responseRef =
+        new AtomicReference<StreamingInputCallResponse>();
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+    StreamObserver<StreamingInputCallResponse> responseObserver =
+        new StreamObserver<StreamingInputCallResponse>() {
+          @Override
+          public void onNext(StreamingInputCallResponse response) {
+            responseRef.set(response);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            throwableRef.set(t);
+            finishLatch.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            finishLatch.countDown();
+          }
+        };
+
+    // make a gRPC call
+    TestServiceGrpc.newStub(inProcessChannel).streamingInputCall(responseObserver)
+        .onNext(StreamingInputCallRequest.getDefaultInstance());
+
+    assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
+    assertEquals(Status.UNKNOWN, Status.fromThrowable(throwableRef.get()));
+    assertNull(responseRef.get());
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -47,7 +47,6 @@ import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.ServerTransportListener;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.netty.GrpcHttp2HeadersDecoder.GrpcHttp2ServerHeadersDecoder;
@@ -84,7 +83,6 @@ import io.netty.util.ReferenceCountUtil;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.Nullable;
 
 /**
@@ -201,11 +199,7 @@ class NettyServerHandler extends AbstractNettyHandler {
           this, http2Stream, maxMessageSize, statsTraceCtx);
       NettyServerStream stream = new NettyServerStream(ctx.channel(), state, attributes,
           statsTraceCtx);
-      ServerStreamListener listener = transportListener.streamCreated(stream, method, metadata);
-      // TODO(ejona): this could be racy since stream could have been used before getting here. All
-      // cases appear to be fine, but some are almost only by happenstance and it is difficult to
-      // audit. It would be good to improve the API to be less prone to races.
-      state.setListener(listener);
+      transportListener.streamCreated(stream, method, metadata);
       http2Stream.setProperty(streamKey, state);
 
     } catch (Http2Exception e) {

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -37,6 +37,7 @@ import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.AbstractServerStream;
+import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.WritableBuffer;
 import io.netty.buffer.ByteBuf;
@@ -81,8 +82,14 @@ class NettyServerStream extends AbstractServerStream {
     return sink;
   }
 
-  @Override public Attributes attributes() {
+  @Override
+  public Attributes attributes() {
     return attributes;
+  }
+
+  @Override
+  public void setListener(ServerStreamListener serverStreamListener) {
+    state.setListener(serverStreamListener);
   }
 
   private class Sink implements AbstractServerStream.Sink {

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -474,11 +474,10 @@ public class NettyClientTransportTest {
         }
 
         @Override
-        public ServerStreamListener streamCreated(
-            ServerStream stream, String method, Metadata headers) {
+        public void streamCreated(ServerStream stream, String method, Metadata headers) {
           EchoServerStreamListener listener = new EchoServerStreamListener(stream, method, headers);
+          stream.setListener(listener);
           streamListeners.add(listener);
-          return listener;
         }
 
         @Override

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -1163,11 +1163,10 @@ public abstract class AbstractTransportTest {
     }
 
     @Override
-    public ServerStreamListener streamCreated(ServerStream stream, String method,
-        Metadata headers) {
+    public void streamCreated(ServerStream stream, String method, Metadata headers) {
       ServerStreamListener listener = mock(ServerStreamListener.class);
       streams.add(new StreamCreation(stream, method, headers, listener));
-      return listener;
+      stream.setListener(listener);
     }
 
     @Override


### PR DESCRIPTION
Resolves #1936

Two bugs fixed:
- NPE in `ServerImpl#streamCreated()` when stream listener not set before
  stream closed
- It is possible that `internalCancel()` is called during
  `InProcessClientStream#start()` due to early server `onComplete()` or server `onError()`,
  in this case no need to enlist `streams`, otherwise the channel can not be shutdown by `shutdown()`.