### PR TITLE
benchmarks: reuse executor between channels

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
@@ -60,7 +60,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.util.List;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
@@ -165,7 +165,7 @@ final class LoadServer {
     }
   }
 
-  Executor getExecutor(int asyncThreads) {
+  ExecutorService getExecutor(int asyncThreads) {
     // TODO(carl-mastrangelo): This should not be necessary.  I don't know where this should be
     // put.  Move it somewhere else, or remove it if no longer necessary.
     // See: https://github.com/grpc/grpc-java/issues/2119


### PR DESCRIPTION
Perhaps by accident, each LoadClient channel got its own executor
pool rather than sharing between all of them.  The benchmarks are
currently set up with C++ idioms, creating 64 "channels" per
client.  C++ uses one thread per channel, while java does not,
leading to a threading model mismatch.

ForkJoinPool is the current executor because it has good contention
characteristics.   However, FJP is also very sensitive to the
number of actively running tasks.  Too many, and the contention
will go up.  Too few, and threads will repeatedly go to sleep and
wake up.

This change basically makes the FJP shared for all clients in the
same process.  It doesn't try at all to shut it down properly or
be generally useful; it's just a benchmark.  Additionally, this
also groups the Netty and OkHttp specific channel options into
helper functions.  This means OkHttp benchmarks will also use
the correct executor now.

A quick test shows QPS going from ~107kqps to 149kqps.

Fixes: #2406 

FYI: @ctiller @buchgr @louiscryan 