### PR TITLE
interop-testing: new stress test client command line options

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -49,17 +49,24 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.StatusException;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NegotiationType;
+import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
+import io.grpc.testing.TestUtils;
+
+import io.netty.handler.ssl.SslContext;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -109,6 +116,15 @@ public class StressTestClient {
   private List<InetSocketAddress> addresses =
       singletonList(new InetSocketAddress("localhost", 8080));
   private List<TestCaseWeightPair> testCaseWeightPairs = new ArrayList<TestCaseWeightPair>();
+
+  private String serverAddresses;
+  private String serverHost = "localhost";
+  private int serverPort = 0;
+  private String serverHostOverride;
+  private boolean useTls = false;
+  private boolean useTestCa = false;
+  private String testCase;
+  private String testCases;
   private int durationSecs = -1;
   private int channelsPerServer = 1;
   private int stubsPerChannel = 1;
@@ -150,10 +166,21 @@ public class StressTestClient {
       }
       String value = parts[1];
       if ("server_addresses".equals(key)) {
-        addresses = parseServerAddresses(value);
-        usage = addresses.isEmpty();
+        serverAddresses = value;
+      } else if ("server_host".equals(key)) {
+        serverHost = value;
+      } else if ("server_port".equals(key)) {
+        serverPort = Integer.parseInt(value);
+      } else if ("server_host_override".equals(key)) {
+        serverHostOverride = value;
+      } else if ("use_tls".equals(key)) {
+        useTls = Boolean.parseBoolean(value);
+      } else if ("use_test_ca".equals(key)) {
+        useTestCa = Boolean.parseBoolean(value);
+      } else if ("test_case".equals(key)) {
+        testCase = value;
       } else if ("test_cases".equals(key)) {
-        testCaseWeightPairs = parseTestCases(value);
+        testCases = value;
       } else if ("test_duration_secs".equals(key)) {
         durationSecs = Integer.valueOf(value);
       } else if ("num_channels_per_server".equals(key)) {
@@ -168,18 +195,49 @@ public class StressTestClient {
         break;
       }
     }
+
+    if (!usage) {
+      if (testCase != null) {
+        testCaseWeightPairs = parseTestCases(testCase + ":100");
+      } else if (testCases != null) {
+        testCaseWeightPairs = parseTestCases(testCases);
+      }
+    }
+
+    if (!usage) {
+      if (serverPort != 0) {
+        addresses = parseServerAddresses(serverHost + ":" + serverPort);
+        usage = addresses.isEmpty();
+      } else if (serverAddresses != null) {
+        addresses = parseServerAddresses(serverAddresses);
+        usage = addresses.isEmpty();
+      }
+    }
+
     if (usage) {
       StressTestClient c = new StressTestClient();
       System.err.println(
           "Usage: [ARGS...]"
               + "\n"
+              + "\n  --server_host=HOST             Server to connect to. Default " + c.serverHost
+              + "\n  --server_port=PORT             Port to connect to. Default " + c.serverPort
+              + "\n  --server_host_override=HOST    Claimed identification expected of server."
+              + "\n                                 Defaults to server host"
               + "\n  --server_addresses=<name_1>:<port_1>,<name_2>:<port_2>...<name_N>:<port_N>"
+              + "\n    This option is ignored if server_port is specified."
               + "\n    Default: " + serverAddressesToString(c.addresses)
+              + "\n  --test_case=TESTCASE"
+              + "\n    Valid Testcases:"
+              + validTestCasesHelpText()
               + "\n  --test_cases=<testcase_1:w_1>,<testcase_2:w_2>...<testcase_n:w_n>"
               + "\n    List of <testcase,weight> tuples. Weight is the relative frequency at which"
               + " testcase is run."
+              + "\n    This option is ignored if test_case is specified."
               + "\n    Valid Testcases:"
               + validTestCasesHelpText()
+              + "\n  --use_tls=true|false           Whether to use TLS. Default " + c.useTls
+              + "\n  --use_test_ca=true|false       Whether to trust our fake CA."
+              + " Default " + c.useTestCa
               + "\n  --test_duration_secs=SECONDS   '-1' for no limit. Default: " + c.durationSecs
               + "\n  --num_channels_per_server=INT  Number of connections to each server address."
               + " Default: " + c.channelsPerServer
@@ -278,13 +336,23 @@ public class StressTestClient {
     return metricsServer.getPort();
   }
 
-  private static List<InetSocketAddress> parseServerAddresses(String addressesStr) {
+  private List<InetSocketAddress> parseServerAddresses(String addressesStr) {
     List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>();
 
     for (List<String> namePort : parseCommaSeparatedTuples(addressesStr)) {
+      InetAddress address;
       String name = namePort.get(0);
       int port = Integer.valueOf(namePort.get(1));
-      addresses.add(new InetSocketAddress(name, port));
+      try {
+        address = InetAddress.getByName(name);
+        if (serverHostOverride != null) {
+          // Force the hostname to match the cert the server uses.
+          address = InetAddress.getByAddress(serverHostOverride, address.getAddress());
+        }
+      } catch (UnknownHostException ex) {
+        throw new RuntimeException(ex);
+      }
+      addresses.add(new InetSocketAddress(address, port));
     }
 
     return addresses;
@@ -316,9 +384,19 @@ public class StressTestClient {
     return tuples;
   }
 
-  private static ManagedChannel createChannel(InetSocketAddress address) {
-    return ManagedChannelBuilder.forAddress(address.getHostName(), address.getPort())
-        .usePlaintext(true)
+  private ManagedChannel createChannel(InetSocketAddress address) {
+    SslContext sslContext = null;
+    if (useTestCa) {
+      try {
+        sslContext = GrpcSslContexts.forClient().trustManager(
+            TestUtils.loadCert("ca.pem")).build();
+      } catch (Exception ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+    return NettyChannelBuilder.forAddress(address)
+        .negotiationType(useTls ? NegotiationType.TLS : NegotiationType.PLAINTEXT)
+        .sslContext(sslContext)
         .build();
   }
 
@@ -583,6 +661,21 @@ public class StressTestClient {
   @VisibleForTesting
   List<InetSocketAddress> addresses() {
     return Collections.unmodifiableList(addresses);
+  }
+
+  @VisibleForTesting
+  String serverHostOverride() {
+    return serverHostOverride;
+  }
+
+  @VisibleForTesting
+  boolean useTls() {
+    return useTls;
+  }
+
+  @VisibleForTesting
+  boolean useTestCa() {
+    return useTestCa;
   }
 
   @VisibleForTesting

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -117,14 +117,9 @@ public class StressTestClient {
       singletonList(new InetSocketAddress("localhost", 8080));
   private List<TestCaseWeightPair> testCaseWeightPairs = new ArrayList<TestCaseWeightPair>();
 
-  private String serverAddresses;
-  private String serverHost = "localhost";
-  private int serverPort = 0;
   private String serverHostOverride;
   private boolean useTls = false;
   private boolean useTestCa = false;
-  private String testCase;
-  private String testCases;
   private int durationSecs = -1;
   private int channelsPerServer = 1;
   private int stubsPerChannel = 1;
@@ -166,21 +161,16 @@ public class StressTestClient {
       }
       String value = parts[1];
       if ("server_addresses".equals(key)) {
-        serverAddresses = value;
-      } else if ("server_host".equals(key)) {
-        serverHost = value;
-      } else if ("server_port".equals(key)) {
-        serverPort = Integer.parseInt(value);
+        addresses = parseServerAddresses(value);
+        usage = addresses.isEmpty();
       } else if ("server_host_override".equals(key)) {
         serverHostOverride = value;
       } else if ("use_tls".equals(key)) {
         useTls = Boolean.parseBoolean(value);
       } else if ("use_test_ca".equals(key)) {
         useTestCa = Boolean.parseBoolean(value);
-      } else if ("test_case".equals(key)) {
-        testCase = value;
       } else if ("test_cases".equals(key)) {
-        testCases = value;
+        testCaseWeightPairs = parseTestCases(value);
       } else if ("test_duration_secs".equals(key)) {
         durationSecs = Integer.valueOf(value);
       } else if ("num_channels_per_server".equals(key)) {
@@ -196,43 +186,18 @@ public class StressTestClient {
       }
     }
 
-    if (!usage) {
-      if (testCase != null) {
-        testCaseWeightPairs = parseTestCases(testCase + ":100");
-      } else if (testCases != null) {
-        testCaseWeightPairs = parseTestCases(testCases);
-      }
-    }
-
-    if (!usage) {
-      if (serverPort != 0) {
-        addresses = parseServerAddresses(serverHost + ":" + serverPort);
-        usage = addresses.isEmpty();
-      } else if (serverAddresses != null) {
-        addresses = parseServerAddresses(serverAddresses);
-        usage = addresses.isEmpty();
-      }
-    }
-
     if (usage) {
       StressTestClient c = new StressTestClient();
       System.err.println(
           "Usage: [ARGS...]"
               + "\n"
-              + "\n  --server_host=HOST             Server to connect to. Default " + c.serverHost
-              + "\n  --server_port=PORT             Port to connect to. Default " + c.serverPort
               + "\n  --server_host_override=HOST    Claimed identification expected of server."
               + "\n                                 Defaults to server host"
               + "\n  --server_addresses=<name_1>:<port_1>,<name_2>:<port_2>...<name_N>:<port_N>"
-              + "\n    This option is ignored if server_port is specified."
               + "\n    Default: " + serverAddressesToString(c.addresses)
-              + "\n  --test_case=TESTCASE"
-              + "\n    Valid Testcases:"
-              + validTestCasesHelpText()
               + "\n  --test_cases=<testcase_1:w_1>,<testcase_2:w_2>...<testcase_n:w_n>"
               + "\n    List of <testcase,weight> tuples. Weight is the relative frequency at which"
               + " testcase is run."
-              + "\n    This option is ignored if test_case is specified."
               + "\n    Valid Testcases:"
               + validTestCasesHelpText()
               + "\n  --use_tls=true|false           Whether to use TLS. Default " + c.useTls

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -201,8 +201,9 @@ public class StressTestClient {
               + "\n    Valid Testcases:"
               + validTestCasesHelpText()
               + "\n  --use_tls=true|false           Whether to use TLS. Default: " + c.useTls
-              + "\n  --use_test_ca=true|false       Whether to trust our fake CA."
-              + " Default: " + c.useTestCa
+              + "\n  --use_test_ca=true|false       Whether to trust our fake CA. Requires"
+              + " --use_tls=true"
+              + "\n                                 to have effect. Default: " + c.useTestCa
               + "\n  --test_duration_secs=SECONDS   '-1' for no limit. Default: " + c.durationSecs
               + "\n  --num_channels_per_server=INT  Number of connections to each server address."
               + " Default: " + c.channelsPerServer

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -200,9 +200,9 @@ public class StressTestClient {
               + " testcase is run."
               + "\n    Valid Testcases:"
               + validTestCasesHelpText()
-              + "\n  --use_tls=true|false           Whether to use TLS. Default " + c.useTls
+              + "\n  --use_tls=true|false           Whether to use TLS. Default: " + c.useTls
               + "\n  --use_test_ca=true|false       Whether to trust our fake CA."
-              + " Default " + c.useTestCa
+              + " Default: " + c.useTestCa
               + "\n  --test_duration_secs=SECONDS   '-1' for no limit. Default: " + c.durationSecs
               + "\n  --num_channels_per_server=INT  Number of connections to each server address."
               + " Default: " + c.channelsPerServer

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -166,7 +166,8 @@ public class TestServiceClient {
           + "\n    Valid options:"
           + validTestCasesHelpText()
           + "\n  --use_tls=true|false        Whether to use TLS. Default " + c.useTls
-          + "\n  --use_test_ca=true|false    Whether to trust our fake CA. Default " + c.useTestCa
+          + "\n  --use_test_ca=true|false    Whether to trust our fake CA. Requires --use_tls=true "
+          + "\n                              to have effect. Default " + c.useTestCa
           + "\n  --use_okhttp=true|false     Whether to use OkHttp instead of Netty. Default "
             + c.useOkHttp
           + "\n  --default_service_account   Email of GCE default service account. Default "

--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -115,25 +115,6 @@ public class StressTestClientTest {
     assertEquals(9090, client.metricsPort());
   }
 
-  @Test
-  public void interopStyleFlagsTakePrecedence() {
-    StressTestClient client = new StressTestClient();
-    client.parseArgs(new String[] {
-        "--server_addresses=[0:0:0:0:0:0:0:1]:8080",
-        "--test_cases=empty_unary:20,large_unary:50,server_streaming:30",
-        "--test_case=empty_stream",
-        "--server_host=localhost",
-        "--server_port=8081"
-    });
-
-    List<InetSocketAddress> addresses = Arrays.asList(new InetSocketAddress("localhost", 8081));
-    assertEquals(addresses, client.addresses());
-
-    List<TestCaseWeightPair> testCases = Arrays.asList(
-            new TestCaseWeightPair(TestCases.EMPTY_STREAM, 100));
-    assertEquals(testCases, client.testCaseWeightPairs());
-  }
-
   @Test(timeout = 5000)
   public void gaugesShouldBeExported() throws Exception {
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -90,7 +90,10 @@ public class StressTestClientTest {
         "--test_duration_secs=20",
         "--num_channels_per_server=10",
         "--num_stubs_per_channel=5",
-        "--metrics_port=9090"
+        "--metrics_port=9090",
+        "--server_host_override=foo.test.google.fr",
+        "--use_tls=true",
+        "--use_test_ca=true"
     });
 
     List<InetSocketAddress> addresses = Arrays.asList(new InetSocketAddress("localhost", 8080),
@@ -103,10 +106,32 @@ public class StressTestClientTest {
         new TestCaseWeightPair(TestCases.SERVER_STREAMING, 30));
     assertEquals(testCases, client.testCaseWeightPairs());
 
+    assertEquals("foo.test.google.fr", client.serverHostOverride());
+    assertTrue(client.useTls());
+    assertTrue(client.useTestCa());
     assertEquals(20, client.durationSecs());
     assertEquals(10, client.channelsPerServer());
     assertEquals(5, client.stubsPerChannel());
     assertEquals(9090, client.metricsPort());
+  }
+
+  @Test
+  public void interopStyleFlagsTakePrecedence() {
+    StressTestClient client = new StressTestClient();
+    client.parseArgs(new String[] {
+        "--server_addresses=[0:0:0:0:0:0:0:1]:8080",
+        "--test_cases=empty_unary:20,large_unary:50,server_streaming:30",
+        "--test_case=empty_stream",
+        "--server_host=localhost",
+        "--server_port=8081"
+    });
+
+    List<InetSocketAddress> addresses = Arrays.asList(new InetSocketAddress("localhost", 8081));
+    assertEquals(addresses, client.addresses());
+
+    List<TestCaseWeightPair> testCases = Arrays.asList(
+            new TestCaseWeightPair(TestCases.EMPTY_STREAM, 100));
+    assertEquals(testCases, client.testCaseWeightPairs());
   }
 
   @Test(timeout = 5000)


### PR DESCRIPTION
interop-testing: add command-line flags to stress test client to be consistent with interop client.

https://github.com/grpc/grpc/pull/8437 did this for C++

@makdharma FYI