### PR TITLE
Remove UTF-8 symbols in example to simplify compilation for most people.

### DIFF
--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -296,12 +296,13 @@ public class RouteGuideServer {
       double lon1 = RouteGuideUtil.getLongitude(start);
       double lon2 = RouteGuideUtil.getLongitude(end);
       int r = 6371000; // metres
-      double φ1 = toRadians(lat1);
-      double φ2 = toRadians(lat2);
-      double Δφ = toRadians(lat2 - lat1);
-      double Δλ = toRadians(lon2 - lon1);
+      double phi1 = toRadians(lat1);
+      double phi2 = toRadians(lat2);
+      double deltaPhi = toRadians(lat2 - lat1);
+      double deltaLambda = toRadians(lon2 - lon1);
 
-      double a = sin(Δφ / 2) * sin(Δφ / 2) + cos(φ1) * cos(φ2) * sin(Δλ / 2) * sin(Δλ / 2);
+      double a = sin(deltaPhi / 2) * sin(deltaPhi / 2)
+	       + cos(phi1) * cos(phi2) * sin(deltaLambda / 2) * sin(deltaLambda / 2);
       double c = 2 * atan2(sqrt(a), sqrt(1 - a));
 
       return r * c;

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -302,7 +302,7 @@ public class RouteGuideServer {
       double deltaLambda = toRadians(lon2 - lon1);
 
       double a = sin(deltaPhi / 2) * sin(deltaPhi / 2)
-	       + cos(phi1) * cos(phi2) * sin(deltaLambda / 2) * sin(deltaLambda / 2);
+      + cos(phi1) * cos(phi2) * sin(deltaLambda / 2) * sin(deltaLambda / 2);
       double c = 2 * atan2(sqrt(a), sqrt(1 - a));
 
       return r * c;

--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -302,7 +302,7 @@ public class RouteGuideServer {
       double deltaLambda = toRadians(lon2 - lon1);
 
       double a = sin(deltaPhi / 2) * sin(deltaPhi / 2)
-      + cos(phi1) * cos(phi2) * sin(deltaLambda / 2) * sin(deltaLambda / 2);
+          + cos(phi1) * cos(phi2) * sin(deltaLambda / 2) * sin(deltaLambda / 2);
       double c = 2 * atan2(sqrt(a), sqrt(1 - a));
 
       return r * c;


### PR DESCRIPTION
gRPC 1.0.0
java 1.8.0_102

[RouteGuideServer.java](https://github.com/grpc/grpc-java/blob/master/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java) contains UTF-8 symbols, which is fancy and all but I think it is a ´looking for trouble´-feature within a grpc-java example file, which is usually the first encounter of people with gRPC. It is a bit inconvenient that I have to apply a fix such as finding out that I have to add a gradle.properties file with ´compileJava.options.encoding = 'UTF-8'´. How about removing the UTF-8 characters to give people a good head-start into gRPC? Basically it is done by simply replacing the calcDistance method:

	/**
     * Calculate the distance between two points using the "haversine" formula.
     * This code was taken from http://www.movable-type.co.uk/scripts/latlong.html.
     *
     * @param start The starting point
     * @param end The end point
     * @return The distance between the points in meters
     */
    private static double calcDistance(Point start, Point end) {
      double lat1 = RouteGuideUtil.getLatitude(start);
      double lat2 = RouteGuideUtil.getLatitude(end);
      double lon1 = RouteGuideUtil.getLongitude(start);
      double lon2 = RouteGuideUtil.getLongitude(end);
      int r = 6371000; // metres
      double phi1 = toRadians(lat1);
      double phi2 = toRadians(lat2);
      double deltaPhi = toRadians(lat2 - lat1);
      double deltaLambda = toRadians(lon2 - lon1);

      double a = sin(deltaPhi / 2) * sin(deltaPhi / 2) + cos(phi1) * cos(phi2) * sin(deltaLambda / 2) * sin(deltaLambda / 2);
      double c = 2 * atan2(sqrt(a), sqrt(1 - a));

      return r * c;
    }


The pull request would resolve issues such as this one  https://github.com/grpc/grpc-java/issues/2394 in the future.
