### PR TITLE
core,netty: quick patch for setListener regression

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -193,12 +193,9 @@ public abstract class AbstractServerStream extends AbstractStream2
       this.listener = Preconditions.checkNotNull(listener, "listener");
     }
 
-    /**
-     * Once the stream has actually been initialized, call the listener's onReady callback if
-     * appropriate.
-     */
-    public final void listenerReady() {
-      onStreamAllocated();
+    @Override
+    public final void onStreamAllocated() {
+      super.onStreamAllocated();
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -84,7 +84,7 @@ public abstract class AbstractServerStream extends AbstractStream2
      * Tears down the stream, typically in the event of a timeout. This method may be called
      * multiple times and from any thread.
      *
-     * <p>This is a clone of {@link ServerStream#cancel()}.
+     * <p>This is a clone of {@link ServerStream#cancel(Status)}.
      */
     void cancel(Status status);
   }
@@ -189,10 +189,15 @@ public abstract class AbstractServerStream extends AbstractStream2
      * thread.
      */
     public final void setListener(ServerStreamListener listener) {
+      Preconditions.checkState(this.listener == null, "setListener should be called only once");
       this.listener = Preconditions.checkNotNull(listener, "listener");
+    }
 
-      // Now that the stream has actually been initialized, call the listener's onReady callback if
-      // appropriate.
+    /**
+     * Once the stream has actually been initialized, call the listener's onReady callback if
+     * appropriate.
+     */
+    public final void listenerReady() {
       onStreamAllocated();
     }
 

--- a/core/src/main/java/io/grpc/internal/AbstractStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream2.java
@@ -237,7 +237,7 @@ public abstract class AbstractStream2 implements Stream {
      * StreamListener#onReady()} handler if appropriate. This must be called from the transport
      * thread, since the listener may be called back directly.
      */
-    protected final void onStreamAllocated() {
+    protected void onStreamAllocated() {
       checkState(listener() != null);
       synchronized (onReadyLock) {
         checkState(!allocated, "Already allocated");

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -116,10 +116,10 @@ public class AbstractServerStreamTest {
   @Test
   public void listenerReady_onlyOnce() {
     stream.transportState().setListener(new ServerStreamListenerBase());
-    stream.transportState().listenerReady();
+    stream.transportState().onStreamAllocated();
     thrown.expect(IllegalStateException.class);
 
-    stream.transportState().listenerReady();
+    stream.transportState().onStreamAllocated();
   }
 
 
@@ -127,7 +127,7 @@ public class AbstractServerStreamTest {
   public void listenerReady_readyCalled() {
     ServerStreamListener streamListener = mock(ServerStreamListener.class);
     stream.transportState().setListener(streamListener);
-    stream.transportState().listenerReady();
+    stream.transportState().onStreamAllocated();
 
     verify(streamListener).onReady();
   }

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -107,7 +107,6 @@ public class AbstractServerStreamTest {
 
   @Test
   public void setListener_setOnlyOnce() {
-
     stream.transportState().setListener(new ServerStreamListenerBase());
     thrown.expect(IllegalStateException.class);
 
@@ -115,9 +114,20 @@ public class AbstractServerStreamTest {
   }
 
   @Test
-  public void setListener_readyCalled() {
+  public void listenerReady_onlyOnce() {
+    stream.transportState().setListener(new ServerStreamListenerBase());
+    stream.transportState().listenerReady();
+    thrown.expect(IllegalStateException.class);
+
+    stream.transportState().listenerReady();
+  }
+
+
+  @Test
+  public void listenerReady_readyCalled() {
     ServerStreamListener streamListener = mock(ServerStreamListener.class);
     stream.transportState().setListener(streamListener);
+    stream.transportState().listenerReady();
 
     verify(streamListener).onReady();
   }

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -200,7 +200,7 @@ class NettyServerHandler extends AbstractNettyHandler {
       NettyServerStream stream = new NettyServerStream(ctx.channel(), state, attributes,
           statsTraceCtx);
       transportListener.streamCreated(stream, method, metadata);
-      state.listenerReady();
+      state.onStreamAllocated();
       http2Stream.setProperty(streamKey, state);
 
     } catch (Http2Exception e) {

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -200,6 +200,7 @@ class NettyServerHandler extends AbstractNettyHandler {
       NettyServerStream stream = new NettyServerStream(ctx.channel(), state, attributes,
           statsTraceCtx);
       transportListener.streamCreated(stream, method, metadata);
+      state.listenerReady();
       http2Stream.setProperty(streamKey, state);
 
     } catch (Http2Exception e) {

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -298,6 +298,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     NettyServerStream stream = new NettyServerStream(channel, state, Attributes.EMPTY,
         statsTraceCtx);
     stream.transportState().setListener(serverListener);
+    state.listenerReady();
     verify(serverListener, atLeastOnce()).onReady();
     verifyNoMoreInteractions(serverListener);
     return stream;

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -298,7 +298,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     NettyServerStream stream = new NettyServerStream(channel, state, Attributes.EMPTY,
         statsTraceCtx);
     stream.transportState().setListener(serverListener);
-    state.listenerReady();
+    state.onStreamAllocated();
     verify(serverListener, atLeastOnce()).onReady();
     verifyNoMoreInteractions(serverListener);
     return stream;


### PR DESCRIPTION
resolves grpc/grpc#8715
now that setListener is called prior to
`JumpToApplicationThreadServerStreamListener` being completely ready to
use. We should not call `AbstractStream2#onStreamAllocated()` inside
`setListener()` anymore, but call it after `ServerImpl#streamCreated()`
is completed.