### PR TITLE
doc: link to IDE-specific docs for os-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ For protobuf-based codegen, you can put your proto files in the `src/main/proto`
 and `src/test/proto` directories along with an appropriate plugin.
 
 For protobuf-based codegen integrated with the Maven build system, you can use
-[protobuf-maven-plugin][]:
+[protobuf-maven-plugin][] (Eclipse and NetBeans users should also look at
+`os-maven-plugin`'s
+[IDE documentation](https://github.com/trustin/os-maven-plugin#issues-with-eclipse-m2e-or-other-ides)):
 ```xml
 <build>
   <extensions>


### PR DESCRIPTION
This is similar to #2417. The URL in this PR is a link. The text comes before the snippet so that it will more likely be read. The text coming after the snippet is most reasonable grammatically, but when I previewed it it seemed almost guaranteed to be ignored. Moving it before the snippet makes it awkward, but it seems worth it.

CC @paulvi