### PR TITLE
core: fix a benign data race in NoopCensusContextFactory.

### DIFF
--- a/core/src/main/java/io/grpc/internal/NoopCensusContextFactory.java
+++ b/core/src/main/java/io/grpc/internal/NoopCensusContextFactory.java
@@ -40,7 +40,7 @@ import com.google.census.TagValue;
 import java.nio.ByteBuffer;
 
 public final class NoopCensusContextFactory extends CensusContextFactory {
-  private static final ByteBuffer SERIALIZED_BYTES = ByteBuffer.allocate(0).asReadOnlyBuffer();
+  private static final byte[] SERIALIZED_BYTES = new byte[0];
   private static final CensusContext DEFAULT_CONTEXT = new NoopCensusContext();
   private static final CensusContext.Builder BUILDER = new NoopContextBuilder();
 
@@ -72,7 +72,7 @@ public final class NoopCensusContextFactory extends CensusContextFactory {
 
     @Override
     public ByteBuffer serialize() {
-      return SERIALIZED_BYTES;
+      return ByteBuffer.wrap(SERIALIZED_BYTES).asReadOnlyBuffer();
     }
   }
 


### PR DESCRIPTION
NoopCensusContextFactory used to use a shared zero-sized ByteBuffer,
which has mutable states like positions and thus is not thread-safe.
Sharing it means it will be used by all calls thus may be used from
different threads, which makes TSAN unhappy in tests.

Resolves #2377