### PR TITLE
examples: don't use System.lineSeparator if unsupported

### DIFF
--- a/examples/android/helloworld/app/src/main/java/io/grpc/helloworldexample/HelloworldActivity.java
+++ b/examples/android/helloworld/app/src/main/java/io/grpc/helloworldexample/HelloworldActivity.java
@@ -109,7 +109,7 @@ public class HelloworldActivity extends ActionBarActivity {
                 PrintWriter pw = new PrintWriter(sw);
                 e.printStackTrace(pw);
                 pw.flush();
-                return "Failed... : " + System.lineSeparator() + sw;
+                return String.format("Failed... : %n%s", sw);
             }
         }
 


### PR DESCRIPTION
Fixes: #2425