### PR TITLE
interop-testing: apply --server_host_override regardless of flag order

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -142,6 +142,7 @@ public class StressTestClient {
   @VisibleForTesting
   void parseArgs(String[] args) {
     boolean usage = false;
+    String serverAddresses = "";
     for (String arg : args) {
       if (!arg.startsWith("--")) {
         System.err.println("All arguments must start with '--': " + arg);
@@ -161,8 +162,8 @@ public class StressTestClient {
       }
       String value = parts[1];
       if ("server_addresses".equals(key)) {
-        addresses = parseServerAddresses(value);
-        usage = addresses.isEmpty();
+        // May need to apply server host overrides to the addresses, so delay processing
+        serverAddresses = value;
       } else if ("server_host_override".equals(key)) {
         serverHostOverride = value;
       } else if ("use_tls".equals(key)) {
@@ -184,6 +185,11 @@ public class StressTestClient {
         usage = true;
         break;
       }
+    }
+
+    if (!serverAddresses.isEmpty()) {
+      addresses = parseServerAddresses(serverAddresses);
+      usage = addresses.isEmpty();
     }
 
     if (usage) {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/StressTestClient.java
@@ -187,7 +187,7 @@ public class StressTestClient {
       }
     }
 
-    if (!serverAddresses.isEmpty()) {
+    if (!usage && !serverAddresses.isEmpty()) {
       addresses = parseServerAddresses(serverAddresses);
       usage = addresses.isEmpty();
     }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -115,6 +115,17 @@ public class StressTestClientTest {
     assertEquals(9090, client.metricsPort());
   }
 
+  @Test
+  public void serverHostOverrideShouldBeApplied() {
+    StressTestClient client = new StressTestClient();
+    client.parseArgs(new String[] {
+        "--server_addresses=localhost:8080",
+        "--server_host_override=foo.test.google.fr",
+    });
+
+    assertEquals("foo.test.google.fr", client.addresses().get(0).getHostName());
+  }
+
   @Test(timeout = 5000)
   public void gaugesShouldBeExported() throws Exception {
 


### PR DESCRIPTION
interop-testing: apply --server_host_override regardless of flag order in the stress test client

The previous PR incorrectly failed to apply --server_host_override unless it was set before the --server_address flag.