### PR TITLE
examples: address ErrorProne and warnings.

### DIFF
--- a/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
+++ b/examples/src/main/java/io/grpc/examples/routeguide/RouteGuideServer.java
@@ -290,7 +290,7 @@ public class RouteGuideServer {
      * @param end The end point
      * @return The distance between the points in meters
      */
-    private static double calcDistance(Point start, Point end) {
+    private static int calcDistance(Point start, Point end) {
       double lat1 = RouteGuideUtil.getLatitude(start);
       double lat2 = RouteGuideUtil.getLatitude(end);
       double lon1 = RouteGuideUtil.getLongitude(start);
@@ -305,7 +305,7 @@ public class RouteGuideServer {
           + cos(phi1) * cos(phi2) * sin(deltaLambda / 2) * sin(deltaLambda / 2);
       double c = 2 * atan2(sqrt(a), sqrt(1 - a));
 
-      return r * c;
+      return (int) r * c;
     }
   }
 }

--- a/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldClientTest.java
+++ b/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldClientTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
@@ -72,7 +71,7 @@ public class HelloWorldClientTest {
     String uniqueServerName = "fake server for " + getClass();
     fakeServer = InProcessServerBuilder
         .forName(uniqueServerName).directExecutor().addService(serviceImpl).build().start();
-    ManagedChannelBuilder channelBuilder =
+    InProcessChannelBuilder channelBuilder =
         InProcessChannelBuilder.forName(uniqueServerName).directExecutor();
     client = new HelloWorldClient(channelBuilder);
   }


### PR DESCRIPTION
Discovered when importing grpc to internal repo:

1. ErrorProne: Compound assignments from floating point to integral
types hide dangerous casts.

2. found raw type: io.grpc.ManagedChannelBuilder missing type arguments
  for generic class io.grpc.ManagedChannelBuilder<T>