### PR TITLE
V1.0.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ In Maven, you can use the [os-maven-plugin](https://github.com/trustin/os-maven-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork19</version>
+      <version>1.1.33.Fork23</version>
     </dependency>
   </dependencies>
 </project>
@@ -80,7 +80,7 @@ buildscript {
 }
 
 dependencies {
-    compile 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork19'
+    compile 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork23'
 }
 ```
 
@@ -115,7 +115,7 @@ In Maven, you can use the [os-maven-plugin](https://github.com/trustin/os-maven-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>1.1.33.Fork19</version>
+      <version>1.1.33.Fork23</version>
       <classifier>${tcnative.classifier}</classifier>
     </dependency>
   </dependencies>
@@ -183,7 +183,7 @@ if (osdetector.os == "linux" && osdetector.release.isLike("fedora")) {
 }
 
 dependencies {
-    compile 'io.netty:netty-tcnative:1.1.33.Fork19:' + tcnative_classifier
+    compile 'io.netty:netty-tcnative:1.1.33.Fork23:' + tcnative_classifier
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -159,9 +159,9 @@ subprojects {
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.0',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
 
-                netty: 'io.netty:netty-codec-http2:[4.1.3.Final]',
-                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.3.Final' + epoll_suffix,
-                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork19',
+                netty: 'io.netty:netty-codec-http2:[4.1.6.Final]',
+                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.6.Final' + epoll_suffix,
+                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork23',
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -271,6 +271,11 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
       }
 
       @Override
+      public void setListener(ServerStreamListener serverStreamListener) {
+        clientStream.setListener(serverStreamListener);
+      }
+
+      @Override
       public void request(int numMessages) {
         boolean onReady = clientStream.serverRequested(numMessages);
         if (onReady) {
@@ -542,13 +547,11 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
         serverStream.setListener(listener);
 
         synchronized (InProcessTransport.this) {
-          ServerStreamListener serverStreamListener = serverTransportListener.streamCreated(
-              serverStream, method.getFullMethodName(), headers);
-          clientStream.setListener(serverStreamListener);
           streams.add(InProcessTransport.InProcessStream.this);
           if (streams.size() == 1) {
             clientTransportListener.transportInUse(true);
           }
+          serverTransportListener.streamCreated(serverStream, method.getFullMethodName(), headers);
         }
       }
 

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -85,7 +85,7 @@ public abstract class AbstractServerStream extends AbstractStream2
      * Tears down the stream, typically in the event of a timeout. This method may be called
      * multiple times and from any thread.
      *
-     * <p>This is a clone of {@link ServerStream#cancel()}.
+     * <p>This is a clone of {@link ServerStream#cancel(Status)}.
      */
     void cancel(Status status);
   }
@@ -177,11 +177,13 @@ public abstract class AbstractServerStream extends AbstractStream2
      * thread.
      */
     public final void setListener(ServerStreamListener listener) {
-      this.listener = Preconditions.checkNotNull(listener);
+      Preconditions.checkState(this.listener == null, "setListener should be called only once");
+      this.listener = Preconditions.checkNotNull(listener, "listener");
+    }
 
-      // Now that the stream has actually been initialized, call the listener's onReady callback if
-      // appropriate.
-      onStreamAllocated();
+    @Override
+    public final void onStreamAllocated() {
+      super.onStreamAllocated();
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/AbstractStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream2.java
@@ -224,7 +224,7 @@ public abstract class AbstractStream2 implements Stream {
      * StreamListener#onReady()} handler if appropriate. This must be called from the transport
      * thread, since the listener may be called back directly.
      */
-    protected final void onStreamAllocated() {
+    protected void onStreamAllocated() {
       checkState(listener() != null);
       synchronized (onReadyLock) {
         checkState(!allocated, "Already allocated");

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -187,7 +187,7 @@ public final class GrpcUtil {
     }
     if (httpStatusCode < 300) {
       // 2xx
-      return Status.OK;
+      return Status.UNKNOWN;
     }
     return Status.UNKNOWN;
   }

--- a/core/src/main/java/io/grpc/internal/Http2ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStream.java
@@ -69,7 +69,7 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
   private Status transportError;
   private Metadata transportErrorMetadata;
   private Charset errorCharset = Charsets.UTF_8;
-  private boolean contentTypeChecked;
+  private boolean headersReceived;
 
   protected Http2ClientStream(WritableBufferAllocator bufferAllocator,
                               int maxMessageSize) {
@@ -84,28 +84,37 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
   protected void transportHeadersReceived(Metadata headers) {
     Preconditions.checkNotNull(headers);
     if (transportError != null) {
-      // Already received a transport error so just augment it.
-      transportError = transportError.augmentDescription(headers.toString());
+      // Already received a transport error so just augment it. Something is really, really strange.
+      transportError = transportError.augmentDescription("headers: " + headers);
       return;
     }
-    Status httpStatus = statusFromHttpStatus(headers);
-    if (httpStatus == null) {
-      transportError = Status.INTERNAL.withDescription(
-          "received non-terminal headers with no :status");
-    } else if (!httpStatus.isOk()) {
-      transportError = httpStatus;
-    } else {
-      transportError = checkContentType(headers);
-    }
-    if (transportError != null) {
-      // Note we don't immediately report the transport error, instead we wait for more data on the
-      // stream so we can accumulate more detail into the error before reporting it.
-      transportError = transportError.augmentDescription("\n" + headers);
-      transportErrorMetadata = headers;
-      errorCharset = extractCharset(headers);
-    } else {
+    try {
+      if (headersReceived) {
+        transportError = Status.INTERNAL.withDescription("Received headers twice");
+        return;
+      }
+      Integer httpStatus = headers.get(HTTP2_STATUS);
+      if (httpStatus != null && httpStatus >= 100 && httpStatus < 200) {
+        // Ignore the headers. See RFC 7540 §8.1
+        return;
+      }
+      headersReceived = true;
+
+      transportError = validateInitialMetadata(headers);
+      if (transportError != null) {
+        return;
+      }
+
       stripTransportDetails(headers);
       inboundHeadersReceived(headers);
+    } finally {
+      if (transportError != null) {
+        // Note we don't immediately report the transport error, instead we wait for more data on
+        // the stream so we can accumulate more detail into the error before reporting it.
+        transportError = transportError.augmentDescription("headers: " + headers);
+        transportErrorMetadata = headers;
+        errorCharset = extractCharset(headers);
+      }
     }
   }
 
@@ -150,15 +159,15 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
    * @param trailers the received terminal trailer metadata
    */
   protected void transportTrailersReceived(Metadata trailers) {
-    Preconditions.checkNotNull(trailers);
-    if (transportError != null) {
-      // Already received a transport error so just augment it.
-      transportError = transportError.augmentDescription(trailers.toString());
-    } else {
-      transportError = checkContentType(trailers);
-      transportErrorMetadata = trailers;
+    Preconditions.checkNotNull(trailers, "trailers");
+    if (transportError == null && !headersReceived) {
+      transportError = validateInitialMetadata(trailers);
+      if (transportError != null) {
+        transportErrorMetadata = trailers;
+      }
     }
     if (transportError != null) {
+      transportError = transportError.augmentDescription("trailers: " + trailers);
       inboundTransportError(transportError, transportErrorMetadata);
       sendCancel(Status.CANCELLED);
     } else {
@@ -168,50 +177,44 @@ public abstract class Http2ClientStream extends AbstractClientStream<Integer> {
     }
   }
 
-  private static Status statusFromHttpStatus(Metadata metadata) {
-    Integer httpStatus = metadata.get(HTTP2_STATUS);
-    if (httpStatus != null) {
-      Status status = GrpcUtil.httpStatusToGrpcStatus(httpStatus);
-      return status.isOk() ? status
-          : status.augmentDescription("extracted status from HTTP :status " + httpStatus);
-    }
-    return null;
-  }
-
   /**
    * Extract the response status from trailers.
    */
   private Status statusFromTrailers(Metadata trailers) {
     Status status = trailers.get(Status.CODE_KEY);
-    if (status == null) {
-      status = statusFromHttpStatus(trailers);
-      if (status == null || status.isOk()) {
-        status = Status.UNKNOWN.withDescription("missing GRPC status in response");
-      } else {
-        status = status.withDescription(
-            "missing GRPC status, inferred error from HTTP status code");
-      }
+    if (status != null) {
+      return status.withDescription(trailers.get(Status.MESSAGE_KEY));
     }
-    String message = trailers.get(Status.MESSAGE_KEY);
-    if (message != null) {
-      status = status.augmentDescription(message);
+    // No status; something is broken. Try to provide a resonanable error.
+    if (headersReceived) {
+      return Status.UNKNOWN.withDescription("missing GRPC status in response");
     }
-    return status;
+    Integer httpStatus = trailers.get(HTTP2_STATUS);
+    if (httpStatus != null) {
+      status = GrpcUtil.httpStatusToGrpcStatus(httpStatus);
+    } else {
+      status = Status.INTERNAL.withDescription("missing HTTP status code");
+    }
+    return status.augmentDescription(
+        "missing GRPC status, inferred error from HTTP status code");
   }
 
   /**
-   * Inspect the content type field from received headers or trailers and return an error Status if
-   * content type is invalid or not present. Returns null if no error was found.
+   * Inspect initial headers to make sure they conform to HTTP and gRPC, returning a {@code Status}
+   * on failure.
+   *
+   * @return status with description of failure, or {@code null} when valid
    */
   @Nullable
-  private Status checkContentType(Metadata headers) {
-    if (contentTypeChecked) {
-      return null;
+  private Status validateInitialMetadata(Metadata headers) {
+    Integer httpStatus = headers.get(HTTP2_STATUS);
+    if (httpStatus == null) {
+      return Status.INTERNAL.withDescription("Missing HTTP status code");
     }
-    contentTypeChecked = true;
     String contentType = headers.get(GrpcUtil.CONTENT_TYPE_KEY);
     if (!GrpcUtil.isGrpcContentType(contentType)) {
-      return Status.INTERNAL.withDescription("Invalid content-type: " + contentType);
+      return GrpcUtil.httpStatusToGrpcStatus(httpStatus)
+          .augmentDescription("invalid content-type: " + contentType);
     }
     return null;
   }

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -241,12 +241,13 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
         try {
           message.close();
         } catch (IOException e) {
+          throw new RuntimeException(e);
+        } finally {
           if (t != null) {
             // TODO(carl-mastrangelo): Maybe log e here.
             Throwables.propagateIfPossible(t);
             throw new RuntimeException(t);
           }
-          throw new RuntimeException(e);
         }
       }
     }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -325,8 +325,8 @@ public final class ServerImpl extends io.grpc.Server {
     }
 
     @Override
-    public ServerStreamListener streamCreated(final ServerStream stream, final String methodName,
-        final Metadata headers) {
+    public void streamCreated(
+        final ServerStream stream, final String methodName, final Metadata headers) {
       final Context.CancellableContext context = createContext(stream, headers);
       final Executor wrappedExecutor;
       // This is a performance optimization that avoids the synchronization and queuing overhead
@@ -339,6 +339,7 @@ public final class ServerImpl extends io.grpc.Server {
 
       final JumpToApplicationThreadServerStreamListener jumpListener
           = new JumpToApplicationThreadServerStreamListener(wrappedExecutor, stream, context);
+      stream.setListener(jumpListener);
       // Run in wrappedExecutor so jumpListener.setListener() is called before any callbacks
       // are delivered, including any errors. Callbacks can still be triggered, but they will be
       // queued.
@@ -372,7 +373,6 @@ public final class ServerImpl extends io.grpc.Server {
             }
           }
         });
-      return jumpListener;
     }
 
     private Context.CancellableContext createContext(final ServerStream stream, Metadata headers) {

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -74,4 +74,9 @@ public interface ServerStream extends Stream {
    * @return Attributes container
    */
   Attributes attributes();
+
+  /**
+   * Sets the server stream listener.
+   */
+  void setListener(ServerStreamListener serverStreamListener);
 }

--- a/core/src/main/java/io/grpc/internal/ServerTransportListener.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransportListener.java
@@ -45,10 +45,8 @@ public interface ServerTransportListener {
    * @param stream the newly created stream.
    * @param method the fully qualified method name being called on the server.
    * @param headers containing metadata for the call.
-   * @return a listener for events on the new stream.
    */
-  ServerStreamListener streamCreated(ServerStream stream, String method,
-      Metadata headers);
+  void streamCreated(ServerStream stream, String method, Metadata headers);
 
   /**
    * The transport completed shutting down. All resources have been released.

--- a/core/src/main/java/io/grpc/internal/SharedResourceHolder.java
+++ b/core/src/main/java/io/grpc/internal/SharedResourceHolder.java
@@ -32,7 +32,6 @@
 package io.grpc.internal;
 
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.util.IdentityHashMap;
 import java.util.concurrent.Executors;
@@ -65,10 +64,8 @@ public final class SharedResourceHolder {
       new ScheduledExecutorFactory() {
         @Override
         public ScheduledExecutorService createScheduledExecutor() {
-          return Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()
-              .setDaemon(true)
-              .setNameFormat("grpc-shared-destroyer-%d")
-              .build());
+          return Executors.newSingleThreadScheduledExecutor(
+              GrpcUtil.getThreadFactory("grpc-shared-destroyer-%d", true));
         }
       });
 

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -107,7 +107,6 @@ public class AbstractServerStreamTest {
 
   @Test
   public void setListener_setOnlyOnce() {
-
     stream.transportState().setListener(new ServerStreamListenerBase());
     thrown.expect(IllegalStateException.class);
 
@@ -115,9 +114,20 @@ public class AbstractServerStreamTest {
   }
 
   @Test
-  public void setListener_readyCalled() {
+  public void listenerReady_onlyOnce() {
+    stream.transportState().setListener(new ServerStreamListenerBase());
+    stream.transportState().onStreamAllocated();
+    thrown.expect(IllegalStateException.class);
+
+    stream.transportState().onStreamAllocated();
+  }
+
+
+  @Test
+  public void listenerReady_readyCalled() {
     ServerStreamListener streamListener = mock(ServerStreamListener.class);
     stream.transportState().setListener(streamListener);
+    stream.transportState().onStreamAllocated();
 
     verify(streamListener).onReady();
   }

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -255,6 +255,11 @@ public class AbstractServerStreamTest {
       return state;
     }
 
+    @Override
+    public void setListener(ServerStreamListener serverStreamListener) {
+      state.setListener(serverStreamListener);
+    }
+
     static class TransportState extends AbstractServerStream.TransportState {
       protected TransportState(int maxMessageSize) {
         super(maxMessageSize);

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -290,6 +291,42 @@ public class ServerCallImplTest {
     streamListener.messageRead(method.streamRequest(1234L));
 
     verify(callListener).onMessage(1234L);
+  }
+
+  @Test
+  public void streamListener_unexpectedRuntimeException() {
+    ServerStreamListenerImpl<Long> streamListener =
+        new ServerCallImpl.ServerStreamListenerImpl<Long>(
+            call, callListener, context, statsTraceCtx);
+    doThrow(new RuntimeException("unexpected exception"))
+        .when(callListener)
+        .onMessage(any(Long.class));
+
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("unexpected exception");
+    streamListener.messageRead(method.streamRequest(1234L));
+  }
+
+  private void checkStats(Status.Code statusCode) {
+    CensusTestUtils.MetricsRecord record = censusCtxFactory.pollRecord();
+    assertNotNull(record);
+    TagValue statusTag = record.tags.get(RpcConstants.RPC_STATUS);
+    assertNotNull(statusTag);
+    assertEquals(statusCode.toString(), statusTag.toString());
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_REQUEST_BYTES));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_RESPONSE_BYTES));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
+    // The test doesn't invoke MessageFramer and MessageDeframer which keep the sizes.
+    // Thus the sizes reported to stats would be zero.
+    assertEquals(0,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_SERVER_REQUEST_BYTES));
+    assertEquals(0,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_SERVER_RESPONSE_BYTES));
+    assertEquals(0,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
+    assertEquals(0,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
   }
 
   private static class LongMarshaller implements Marshaller<Long> {

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -77,6 +77,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -121,12 +122,15 @@ public class ServerImplTest {
   private ServerImpl server = new ServerImpl(executor, registry, fallbackRegistry, transportServer,
       SERVER_CONTEXT, decompressorRegistry, compressorRegistry);
 
+  @Captor
+  private ArgumentCaptor<Status> statusCaptor;
+  @Captor
+  private ArgumentCaptor<ServerStreamListener> streamListenerCaptor;
+
   @Mock
   private ServerStream stream;
-
   @Mock
   private ServerCall.Listener<String> callListener;
-
   @Mock
   private ServerCallHandler<String, Integer> callHandler;
 
@@ -338,8 +342,9 @@ public class ServerImplTest {
 
     Metadata requestHeaders = new Metadata();
     requestHeaders.put(metadataKey, "value");
-    ServerStreamListener streamListener
-        = transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(streamListenerCaptor.capture());
+    ServerStreamListener streamListener = streamListenerCaptor.getValue();
     assertNotNull(streamListener);
 
     executeBarrier(executor).await();
@@ -406,8 +411,10 @@ public class ServerImplTest {
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
 
-    ServerStreamListener streamListener
-        = transportListener.streamCreated(stream, "Waiter/serve", new Metadata());
+    Metadata requestHeaders = new Metadata();
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(streamListenerCaptor.capture());
+    ServerStreamListener streamListener = streamListenerCaptor.getValue();
     assertNotNull(streamListener);
     verifyNoMoreInteractions(stream);
 
@@ -558,8 +565,10 @@ public class ServerImplTest {
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
 
-    ServerStreamListener streamListener
-        = transportListener.streamCreated(stream, "Waiter/serve", new Metadata());
+    Metadata requestHeaders = new Metadata();
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(streamListenerCaptor.capture());
+    ServerStreamListener streamListener = streamListenerCaptor.getValue();
     assertNotNull(streamListener);
 
     streamListener.onReady();
@@ -604,9 +613,10 @@ public class ServerImplTest {
             }).build());
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-
-    ServerStreamListener streamListener
-        = transportListener.streamCreated(stream, "Waiter/serve", new Metadata());
+    Metadata requestHeaders = new Metadata();
+    transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).setListener(streamListenerCaptor.capture());
+    ServerStreamListener streamListener = streamListenerCaptor.getValue();
     assertNotNull(streamListener);
 
     streamListener.onReady();

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -45,6 +45,7 @@ import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
+import io.grpc.okhttp.internal.Platform;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.StreamRecorder;
 import io.grpc.testing.TestUtils;
@@ -60,6 +61,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -109,7 +111,8 @@ public class Http2OkHttpTest extends AbstractInteropTest {
         .overrideAuthority(GrpcUtil.authorityFromHostAndPort(
             TestUtils.TEST_SERVER_HOST, getPort()));
     try {
-      builder.sslSocketFactory(TestUtils.newSslSocketFactoryForCa(TestUtils.loadCert("ca.pem")));
+      builder.sslSocketFactory(TestUtils.newSslSocketFactoryForCa(Platform.get().getProvider(),
+              new FileInputStream(TestUtils.loadCert("ca.pem"))));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -149,7 +152,8 @@ public class Http2OkHttpTest extends AbstractInteropTest {
         .overrideAuthority(GrpcUtil.authorityFromHostAndPort(
             "I.am.a.bad.hostname", getPort()));
     ManagedChannel channel = builder.sslSocketFactory(
-        TestUtils.newSslSocketFactoryForCa(TestUtils.loadCert("ca.pem"))).build();
+        TestUtils.newSslSocketFactoryForCa(Platform.get().getProvider(),
+            new FileInputStream(TestUtils.loadCert("ca.pem")))).build();
     TestServiceGrpc.TestServiceBlockingStub blockingStub =
         TestServiceGrpc.newBlockingStub(channel);
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
@@ -40,15 +40,16 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link InProcess}. */
+/** Unit tests for {@link io.grpc.inprocess}. */
 @RunWith(JUnit4.class)
 public class InProcessTest extends AbstractInteropTest {
-  private static String serverName = "test";
+
+  private static final String SERVER_NAME = "test";
 
   /** Starts the in-process server. */
   @BeforeClass
   public static void startServer() {
-    startStaticServer(InProcessServerBuilder.forName(serverName));
+    startStaticServer(InProcessServerBuilder.forName(SERVER_NAME));
   }
 
   @AfterClass
@@ -58,6 +59,6 @@ public class InProcessTest extends AbstractInteropTest {
 
   @Override
   protected ManagedChannel createChannel() {
-    return InProcessChannelBuilder.forName(serverName).build();
+    return InProcessChannelBuilder.forName(SERVER_NAME).build();
   }
 }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.testing.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.integration.Messages.StreamingInputCallRequest;
+import io.grpc.testing.integration.Messages.StreamingInputCallResponse;
+import io.grpc.testing.integration.TestServiceGrpc.TestServiceImplBase;
+import io.grpc.util.MutableHandlerRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Unit tests for {@link io.grpc.inprocess}.
+ * Test more corner usecases, client not playing by the rules, server not playing by the rules, etc.
+ */
+@RunWith(JUnit4.class)
+public class MoreInProcessTest {
+  private static final String UNIQUE_SERVER_NAME =
+      "in-process server for " + MoreInProcessTest.class;
+  @Rule
+  public final Timeout globalTimeout = new Timeout(1000);
+  // use a mutable service registry for later registering the service impl for each test case.
+  private final MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
+  private final Server inProcessServer = InProcessServerBuilder.forName(UNIQUE_SERVER_NAME)
+      .fallbackHandlerRegistry(serviceRegistry).directExecutor().build();
+  private final ManagedChannel inProcessChannel =
+      InProcessChannelBuilder.forName(UNIQUE_SERVER_NAME).directExecutor().build();
+
+  @Before
+  public void setUp() throws Exception {
+    inProcessServer.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    inProcessChannel.shutdown();
+    inProcessServer.shutdown();
+    assertTrue(inProcessChannel.awaitTermination(900, TimeUnit.MILLISECONDS));
+    assertTrue(inProcessServer.awaitTermination(900, TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void asyncClientStreaming_serverResponsePriorToRequest() throws Exception {
+    // implement a service
+    final StreamingInputCallResponse fakeResponse =
+        StreamingInputCallResponse.newBuilder().setAggregatedPayloadSize(100).build();
+    TestServiceImplBase clientStreamingImpl = new TestServiceImplBase() {
+      @Override
+      public StreamObserver<StreamingInputCallRequest> streamingInputCall(
+          StreamObserver<StreamingInputCallResponse> responseObserver) {
+        // send response directly
+        responseObserver.onNext(fakeResponse);
+        responseObserver.onCompleted();
+        return new StreamObserver<StreamingInputCallRequest>() {
+          @Override
+          public void onNext(StreamingInputCallRequest value) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+          }
+
+          @Override
+          public void onCompleted() {
+          }
+        };
+      }
+    };
+    serviceRegistry.addService(clientStreamingImpl.bindService());
+    // implement a client
+    final CountDownLatch finishLatch = new CountDownLatch(1);
+    final AtomicReference<StreamingInputCallResponse> responseRef =
+        new AtomicReference<StreamingInputCallResponse>();
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+    StreamObserver<StreamingInputCallResponse> responseObserver =
+        new StreamObserver<StreamingInputCallResponse>() {
+          @Override
+          public void onNext(StreamingInputCallResponse response) {
+            responseRef.set(response);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            throwableRef.set(t);
+            finishLatch.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            finishLatch.countDown();
+          }
+        };
+
+    // make a gRPC call
+    TestServiceGrpc.newStub(inProcessChannel).streamingInputCall(responseObserver);
+
+    assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
+    assertEquals(fakeResponse, responseRef.get());
+    assertNull(throwableRef.get());
+  }
+
+  @Test
+  public void asyncClientStreaming_serverErrorPriorToRequest() throws Exception {
+    // implement a service
+    final Status fakeError = Status.INVALID_ARGUMENT;
+    TestServiceImplBase clientStreamingImpl = new TestServiceImplBase() {
+      @Override
+      public StreamObserver<StreamingInputCallRequest> streamingInputCall(
+          StreamObserver<StreamingInputCallResponse> responseObserver) {
+        // send error directly
+        responseObserver.onError(new StatusRuntimeException(fakeError));
+        responseObserver.onCompleted();
+        return new StreamObserver<StreamingInputCallRequest>() {
+          @Override
+          public void onNext(StreamingInputCallRequest value) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+          }
+
+          @Override
+          public void onCompleted() {
+          }
+        };
+      }
+    };
+    serviceRegistry.addService(clientStreamingImpl.bindService());
+    // implement a client
+    final CountDownLatch finishLatch = new CountDownLatch(1);
+    final AtomicReference<StreamingInputCallResponse> responseRef =
+        new AtomicReference<StreamingInputCallResponse>();
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+    StreamObserver<StreamingInputCallResponse> responseObserver =
+        new StreamObserver<StreamingInputCallResponse>() {
+          @Override
+          public void onNext(StreamingInputCallResponse response) {
+            responseRef.set(response);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            throwableRef.set(t);
+            finishLatch.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            finishLatch.countDown();
+          }
+        };
+
+    // make a gRPC call
+    TestServiceGrpc.newStub(inProcessChannel).streamingInputCall(responseObserver);
+
+    assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
+    assertEquals(fakeError.getCode(), Status.fromThrowable(throwableRef.get()).getCode());
+    assertNull(responseRef.get());
+  }
+
+  @Test
+  public void asyncClientStreaming_erroneousServiceImpl() throws Exception {
+    // implement a service
+    TestServiceImplBase clientStreamingImpl = new TestServiceImplBase() {
+      @Override
+      public StreamObserver<StreamingInputCallRequest> streamingInputCall(
+          StreamObserver<StreamingInputCallResponse> responseObserver) {
+        StreamObserver<StreamingInputCallRequest> requestObserver =
+            new StreamObserver<StreamingInputCallRequest>() {
+              @Override
+              public void onNext(StreamingInputCallRequest value) {
+                throw new RuntimeException(
+                    "unexpected error due to careless implementation of serviceImpl");
+              }
+
+              @Override
+              public void onError(Throwable t) {
+              }
+
+              @Override
+              public void onCompleted() {
+              }
+            };
+        return requestObserver;
+      }
+    };
+    serviceRegistry.addService(clientStreamingImpl.bindService());
+    // implement a client
+    final CountDownLatch finishLatch = new CountDownLatch(1);
+    final AtomicReference<StreamingInputCallResponse> responseRef =
+        new AtomicReference<StreamingInputCallResponse>();
+    final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+    StreamObserver<StreamingInputCallResponse> responseObserver =
+        new StreamObserver<StreamingInputCallResponse>() {
+          @Override
+          public void onNext(StreamingInputCallResponse response) {
+            responseRef.set(response);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            throwableRef.set(t);
+            finishLatch.countDown();
+          }
+
+          @Override
+          public void onCompleted() {
+            finishLatch.countDown();
+          }
+        };
+
+    // make a gRPC call
+    TestServiceGrpc.newStub(inProcessChannel).streamingInputCall(responseObserver)
+        .onNext(StreamingInputCallRequest.getDefaultInstance());
+
+    assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
+    assertEquals(Status.UNKNOWN, Status.fromThrowable(throwableRef.get()));
+    assertNull(responseRef.get());
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -60,7 +60,6 @@ import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
 import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.DefaultHttp2HeadersDecoder;
 import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
-import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionAdapter;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
@@ -71,7 +70,6 @@ import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2FrameReader;
 import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2Headers;
-import io.netty.handler.codec.http2.Http2HeadersDecoder;
 import io.netty.handler.codec.http2.Http2InboundFrameLogger;
 import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
 import io.netty.handler.codec.http2.Http2Settings;
@@ -115,8 +113,12 @@ class NettyClientHandler extends AbstractNettyHandler {
                                        int flowControlWindow, int maxHeaderListSize,
                                        Ticker ticker) {
     Preconditions.checkArgument(maxHeaderListSize > 0, "maxHeaderListSize must be positive");
-    Http2HeadersDecoder headersDecoder = new DefaultHttp2HeadersDecoder(
-        maxHeaderListSize, Http2CodecUtil.DEFAULT_HEADER_TABLE_SIZE, true, 32);
+    DefaultHttp2HeadersDecoder headersDecoder = new DefaultHttp2HeadersDecoder(true, 32);
+    try {
+      headersDecoder.headerTable().maxHeaderListSize(maxHeaderListSize);
+    } catch (Http2Exception e) {
+      throw new RuntimeException(e);
+    }
     Http2FrameReader frameReader = new DefaultHttp2FrameReader(headersDecoder);
     Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
     Http2Connection connection = new DefaultHttp2Connection(false);

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -46,7 +46,6 @@ import com.google.common.base.Preconditions;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.ServerTransportListener;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
@@ -81,7 +80,6 @@ import io.netty.util.ReferenceCountUtil;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.Nullable;
 
 /**
@@ -195,15 +193,8 @@ class NettyServerHandler extends AbstractNettyHandler {
       NettyServerStream stream = new NettyServerStream(ctx.channel(), state);
 
       Metadata metadata = Utils.convertHeaders(headers);
-
-      ServerStreamListener listener =
-          transportListener.streamCreated(stream, method, metadata);
-      // TODO(ejona): this could be racy since stream could have been used before getting here. All
-      // cases appear to be fine, but some are almost only by happenstance and it is difficult to
-      // audit. It would be good to improve the API to be less prone to races.
-      state.setListener(listener);
+      transportListener.streamCreated(stream, method, metadata);
       http2Stream.setProperty(streamKey, state);
-
     } catch (Http2Exception e) {
       throw e;
     } catch (Throwable e) {

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -194,6 +194,7 @@ class NettyServerHandler extends AbstractNettyHandler {
 
       Metadata metadata = Utils.convertHeaders(headers);
       transportListener.streamCreated(stream, method, metadata);
+      state.onStreamAllocated();
       http2Stream.setProperty(streamKey, state);
     } catch (Http2Exception e) {
       throw e;

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -60,7 +60,6 @@ import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
 import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.DefaultHttp2HeadersDecoder;
 import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
-import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
@@ -72,7 +71,6 @@ import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2FrameReader;
 import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2Headers;
-import io.netty.handler.codec.http2.Http2HeadersDecoder;
 import io.netty.handler.codec.http2.Http2InboundFrameLogger;
 import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
 import io.netty.handler.codec.http2.Http2Settings;
@@ -107,8 +105,12 @@ class NettyServerHandler extends AbstractNettyHandler {
                                        int maxMessageSize) {
     Preconditions.checkArgument(maxHeaderListSize > 0, "maxHeaderListSize must be positive");
     Http2FrameLogger frameLogger = new Http2FrameLogger(LogLevel.DEBUG, NettyServerHandler.class);
-    Http2HeadersDecoder headersDecoder = new DefaultHttp2HeadersDecoder(
-        maxHeaderListSize, Http2CodecUtil.DEFAULT_HEADER_TABLE_SIZE, true, 32);
+    DefaultHttp2HeadersDecoder headersDecoder = new DefaultHttp2HeadersDecoder(true, 32);
+    try {
+      headersDecoder.headerTable().maxHeaderListSize(maxHeaderListSize);
+    } catch (Http2Exception e) {
+      throw new RuntimeException(e);
+    }
     Http2FrameReader frameReader = new Http2InboundFrameLogger(
         new DefaultHttp2FrameReader(headersDecoder), frameLogger);
     Http2FrameWriter frameWriter =

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -38,6 +38,7 @@ import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.internal.AbstractServerStream;
+import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.WritableBuffer;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -82,7 +83,8 @@ class NettyServerStream extends AbstractServerStream {
     return sink;
   }
 
-  @Override public Attributes attributes() {
+  @Override
+  public Attributes attributes() {
     return attributes;
   }
 
@@ -97,6 +99,11 @@ class NettyServerStream extends AbstractServerStream {
         .set(ServerCall.REMOTE_ADDR_KEY, channel.remoteAddress())
         .set(ServerCall.SSL_SESSION_KEY, sslSession)
         .build();
+  }
+
+  @Override
+  public void setListener(ServerStreamListener serverStreamListener) {
+    state.setListener(serverStreamListener);
   }
 
   private class Sink implements AbstractServerStream.Sink {
@@ -182,6 +189,7 @@ class NettyServerStream extends AbstractServerStream {
       super.inboundDataReceived(new NettyReadableBuffer(frame.retain()), endOfStream);
     }
 
+    @Override
     public Integer id() {
       return http2Stream.id();
     }

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -292,7 +292,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass(Metadata.class);
     verify(listener).closed(captor.capture(), metadataCaptor.capture());
     Status status = captor.getValue();
-    assertEquals(Status.Code.INTERNAL, status.getCode());
+    assertEquals(Status.Code.UNKNOWN, status.getCode());
     assertTrue(status.getDescription().contains("content-type"));
     assertEquals("application/bad", metadataCaptor.getValue()
         .get(Metadata.Key.of("Content-Type", Metadata.ASCII_STRING_MARSHALLER)));

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -273,8 +273,8 @@ public class NettyClientTransportTest {
           + " size limit!");
     } catch (Exception e) {
       Throwable rootCause = getRootCause(e);
-      assertTrue(rootCause.getMessage(),
-          rootCause.getMessage().contains("Header size exceeded max allowed size (1)"));
+      assertTrue(rootCause instanceof StatusException);
+      assertEquals(Status.INTERNAL.getCode(), ((StatusException) rootCause).getStatus().getCode());
     }
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -434,11 +434,10 @@ public class NettyClientTransportTest {
       return new ServerTransportListener() {
 
         @Override
-        public ServerStreamListener streamCreated(final ServerStream stream, String method,
-                                                  Metadata headers) {
+        public void streamCreated(ServerStream stream, String method, Metadata headers) {
           EchoServerStreamListener listener = new EchoServerStreamListener(stream, method, headers);
+          stream.setListener(listener);
           streamListeners.add(listener);
-          return listener;
         }
 
         @Override

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -48,9 +48,9 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 import com.google.common.io.ByteStreams;
 
@@ -100,24 +100,30 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   private static final int STREAM_ID = 3;
 
   @Mock
-  private ServerTransportListener transportListener;
-
-  @Mock
   private ServerStreamListener streamListener;
+
+  private final ServerTransportListener transportListener = spy(new ServerTransportListenerImpl());
 
   private NettyServerStream stream;
 
   private int flowControlWindow = DEFAULT_WINDOW_SIZE;
   private int maxConcurrentStreams = Integer.MAX_VALUE;
 
+  private class ServerTransportListenerImpl implements ServerTransportListener {
+
+    @Override
+    public void streamCreated(ServerStream stream, String method, Metadata headers) {
+      stream.setListener(streamListener);
+    }
+
+    @Override
+    public void transportTerminated() {
+    }
+  }
+
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-
-    when(transportListener.streamCreated(any(ServerStream.class),
-        any(String.class),
-        any(Metadata.class)))
-        .thenReturn(streamListener);
 
     initChannel();
 

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -294,6 +294,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
         new NettyServerStream.TransportState(handler, http2Stream, DEFAULT_MAX_MESSAGE_SIZE);
     NettyServerStream stream = new NettyServerStream(channel, state);
     stream.transportState().setListener(serverListener);
+    state.onStreamAllocated();
     verify(serverListener, atLeastOnce()).onReady();
     verifyNoMoreInteractions(serverListener);
     return stream;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
@@ -33,10 +33,14 @@ package io.grpc.okhttp;
 
 import io.grpc.Internal;
 import io.grpc.ManagedChannelProvider;
+import io.grpc.internal.GrpcUtil;
 
-/** Provider for {@link OkHttpChannelBuilder} instances. */
+/**
+ * Provider for {@link OkHttpChannelBuilder} instances.
+ */
 @Internal
 public final class OkHttpChannelProvider extends ManagedChannelProvider {
+
   @Override
   public boolean isAvailable() {
     return true;
@@ -44,7 +48,7 @@ public final class OkHttpChannelProvider extends ManagedChannelProvider {
 
   @Override
   public int priority() {
-    return isAndroid() ? 8 : 3;
+    return (GrpcUtil.IS_RESTRICTED_APPENGINE || isAndroid()) ? 8 : 3;
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -734,7 +734,9 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     @Override
     public void run() {
       String threadName = Thread.currentThread().getName();
-      Thread.currentThread().setName("OkHttpClientTransport");
+      if (!GrpcUtil.IS_RESTRICTED_APPENGINE) {
+        Thread.currentThread().setName("OkHttpClientTransport");
+      }
       try {
         // Read until the underlying socket closes.
         while (frameReader.nextFrame(this)) {
@@ -757,8 +759,10 @@ class OkHttpClientTransport implements ConnectionClientTransport {
           log.log(Level.INFO, "Exception closing frame reader", ex);
         }
         listener.transportTerminated();
-        // Restore the original thread name.
-        Thread.currentThread().setName(threadName);
+        if (!GrpcUtil.IS_RESTRICTED_APPENGINE) {
+          // Restore the original thread name.
+          Thread.currentThread().setName(threadName);
+        }
       }
     }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -1413,7 +1413,8 @@ public class OkHttpClientTransportTest {
   private List<Header> grpcResponseTrailers() {
     return ImmutableList.of(
         new Header(Status.CODE_KEY.name(), "0"),
-        // Adding Content-Type for testing responses with only a single HEADERS frame.
+        // Adding Content-Type and :status for testing responses with only a single HEADERS frame.
+        new Header(":status", "200"),
         CONTENT_TYPE_HEADER);
   }
 

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -1147,11 +1147,10 @@ public abstract class AbstractTransportTest {
     }
 
     @Override
-    public ServerStreamListener streamCreated(ServerStream stream, String method,
-        Metadata headers) {
+    public void streamCreated(ServerStream stream, String method, Metadata headers) {
       ServerStreamListener listener = mock(ServerStreamListener.class);
       streams.add(new StreamCreation(stream, method, headers, listener));
-      return listener;
+      stream.setListener(listener);
     }
 
     @Override

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -51,6 +51,8 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -246,7 +248,16 @@ public class TestUtils {
   /**
    * Creates an SSLSocketFactory which contains {@code certChainFile} as its only root certificate.
    */
-  public static SSLSocketFactory newSslSocketFactoryForCa(InputStream certChain) throws Exception {
+  public static SSLSocketFactory newSslSocketFactoryForCa(
+      InputStream certChain) throws Exception {
+    return newSslSocketFactoryForCa(Security.getProviders()[0], certChain);
+  }
+
+  /**
+   * Creates an SSLSocketFactory which contains {@code certChainFile} as its only root certificate.
+   */
+  public static SSLSocketFactory newSslSocketFactoryForCa(Provider provider,
+      InputStream certChain) throws Exception {
     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null, null);
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
@@ -259,7 +270,7 @@ public class TestUtils {
     TrustManagerFactory trustManagerFactory =
         TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
     trustManagerFactory.init(ks);
-    SSLContext context = SSLContext.getInstance("TLS");
+    SSLContext context = SSLContext.getInstance("TLS", provider);
     context.init(null, trustManagerFactory.getTrustManagers(), null);
     return context.getSocketFactory();
   }


### PR DESCRIPTION
Backport various fixes:

Make the OkHTTP transport AppEngine friendly
https://github.com/grpc/grpc-java/pull/1817/commits/f52b4e52cdb72b703ea9baa07e3b1fa5c24a6d52

core: Fix a bug for exception handling at messageRead
https://github.com/grpc/grpc-java/commit/abb4a2a3935d3f462504c9e762b545215632360f

netty: Upgrade to 4.1.6 and tcnative Fork23
https://github.com/grpc/grpc-java/commit/6fa63a6371a90c32f5f9b7784c7bd851ab317ff5

core: Update HTTP status to gRPC status mapping
https://github.com/grpc/grpc-java/pull/2362/commits/78107a69c0b64cbbbe6392a696fdc59597b97126

core: fix bug when stream listener not set before stream closed
https://github.com/grpc/grpc-java/commit/0e27eef1683f7e501f6bdf458f641283dab623b1

core,netty: quick patch for setListener regression
https://github.com/grpc/grpc-java/commit/0d694c80ee0075b506e545c5ab1d412104eb6e26