### PR TITLE
travis: Use default OS X image (xcode7.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,6 @@ os:
   - linux
   - osx
 
-# This image comes with jdk8
-osx_image: xcode7
-
 notifications:
   email: false
 


### PR DESCRIPTION
The xcode7 image is being retired on Nov 28th[1]. The default has been
7+ for a while now[2]. I assume 7+ all have JDK 8, so using the default
seems safe.

1. https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/
2. https://blog.travis-ci.com/2016-09-15-new-default-osx-image-coming/