### PR TITLE
travis: Remove old comment for broken OS X caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,6 @@ osx_image: xcode7
 notifications:
   email: false
 
-# Caching does not work for public repositories with OS X:
-# https://github.com/travis-ci/travis-ci/issues/4011
 cache:
   directories:
     - /tmp/protobuf-${PROTOBUF_VERSION}


### PR DESCRIPTION
Commit 80f73a4a was in response to OS X receiving caching support.
Caches began being saved shortly after and they've been working since.
The official announcment was
https://blog.travis-ci.com/2016-05-03-caches-are-coming-to-everyone