### PR TITLE
core: reverse dependency from core/internal classes, so that it is now one directional.

### DIFF
--- a/core/src/main/java/io/grpc/InternalKnownTransport.java
+++ b/core/src/main/java/io/grpc/InternalKnownTransport.java
@@ -33,6 +33,8 @@ package io.grpc;
 
 /**
  * All known transports.
+ *
+ * <p>Make sure to update MethodDescriptor.rawMethodNames if this is changed.
  */
 @Internal
 public enum InternalKnownTransport {

--- a/core/src/main/java/io/grpc/InternalMetadata.java
+++ b/core/src/main/java/io/grpc/InternalMetadata.java
@@ -46,27 +46,11 @@ public final class InternalMetadata {
   /**
    * A specialized plain ASCII marshaller. Both input and output are assumed to be valid header
    * ASCII.
+   *
+   * <p>Extended here to break the dependency.
    */
   @Internal
-  public interface TrustedAsciiMarshaller<T> {
-    /**
-     * Serialize a metadata value to a ASCII string that contains only the characters listed in the
-     * class comment of {@link io.grpc.Metadata.AsciiMarshaller}. Otherwise the output may be
-     * considered invalid and discarded by the transport, or the call may fail.
-     *
-     * @param value to serialize
-     * @return serialized version of value, or null if value cannot be transmitted.
-     */
-    byte[] toAsciiString(T value);
-
-    /**
-     * Parse a serialized metadata value from an ASCII string.
-     *
-     * @param serialized value of metadata to parse
-     * @return a parsed instance of type T
-     */
-    T parseAsciiString(byte[] serialized);
-  }
+  public interface TrustedAsciiMarshaller<T> extends Metadata.TrustedAsciiMarshaller<T> {}
 
   /**
    * Copy of StandardCharsets, which is only available on Java 1.7 and above.
@@ -78,7 +62,6 @@ public final class InternalMetadata {
   public static <T> Key<T> keyOf(String name, TrustedAsciiMarshaller<T> marshaller) {
     return Metadata.Key.of(name, marshaller);
   }
-
 
   @Internal
   public static Metadata newMetadata(byte[]... binaryValues) {

--- a/core/src/main/java/io/grpc/InternalMethodDescriptor.java
+++ b/core/src/main/java/io/grpc/InternalMethodDescriptor.java
@@ -46,10 +46,10 @@ public final class InternalMethodDescriptor {
   }
 
   public Object geRawMethodName(MethodDescriptor<?, ?> md) {
-    return md.getRawMethodName(transport);
+    return md.getRawMethodName(transport.ordinal());
   }
 
   public void setRawMethodName(MethodDescriptor<?, ?> md, Object o) {
-    md.setRawMethodName(transport, o);
+    md.setRawMethodName(transport.ordinal(), o);
   }
 }

--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -39,8 +39,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
 
-import io.grpc.InternalMetadata.TrustedAsciiMarshaller;
-
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -784,5 +782,29 @@ public final class Metadata {
     T parseBytes(byte[] serialized) {
       return marshaller.parseAsciiString(serialized);
     }
+  }
+
+  /**
+   * A specialized plain ASCII marshaller. Both input and output are assumed to be valid header
+   * ASCII.
+   */
+  interface TrustedAsciiMarshaller<T> {
+    /**
+     * Serialize a metadata value to a ASCII string that contains only the characters listed in the
+     * class comment of {@link io.grpc.Metadata.AsciiMarshaller}. Otherwise the output may be
+     * considered invalid and discarded by the transport, or the call may fail.
+     *
+     * @param value to serialize
+     * @return serialized version of value, or null if value cannot be transmitted.
+     */
+    byte[] toAsciiString(T value);
+
+    /**
+     * Parse a serialized metadata value from an ASCII string.
+     *
+     * @param serialized value of metadata to parse
+     * @return a parsed instance of type T
+     */
+    T parseAsciiString(byte[] serialized);
   }
 }

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -57,15 +57,16 @@ public class MethodDescriptor<ReqT, RespT> {
   private final boolean idempotent;
   private final boolean safe;
 
-  private final AtomicReferenceArray<Object> rawMethodNames =
-      new AtomicReferenceArray<Object>(InternalKnownTransport.values().length);
+  // Must be set to InternalKnownTransport.values().length
+  // Not referenced to break the dependency.
+  private final AtomicReferenceArray<Object> rawMethodNames = new AtomicReferenceArray<Object>(1);
 
-  final Object getRawMethodName(InternalKnownTransport t) {
-    return rawMethodNames.get(t.ordinal());
+  final Object getRawMethodName(int transportOrdinal) {
+    return rawMethodNames.get(transportOrdinal);
   }
 
-  final void setRawMethodName(InternalKnownTransport t, Object o) {
-    rawMethodNames.lazySet(t.ordinal(), o);
+  final void setRawMethodName(int transportOrdinal, Object o) {
+    rawMethodNames.lazySet(transportOrdinal, o);
   }
 
   /**


### PR DESCRIPTION

This makes it possible to split out the io.grpc.Internal* classes into their own bazel build target.