### PR TITLE
Add Attributes#withKey(Key<T>, T)

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -74,6 +74,15 @@ public final class Attributes {
   }
 
   /**
+   * Returns attributes with new key added.
+   *
+   * @return new Attributes object with the new Key.
+   */
+  public <T> Attributes withKey(Key<T> key, T value) {
+    return newBuilder(this).set(key, value).build();
+  }
+
+  /**
    * Create a new builder that is pre-populated with the content from a given container.
    */
   public static Builder newBuilder(Attributes base) {

--- a/core/src/test/java/io/grpc/AttributesTest.java
+++ b/core/src/test/java/io/grpc/AttributesTest.java
@@ -32,6 +32,7 @@
 package io.grpc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
@@ -42,6 +43,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AttributesTest {
   private static Attributes.Key<String> YOLO_KEY = Attributes.Key.of("yolo");
+  private static Attributes.Key<String> MAJOR_KEY = Attributes.Key.of("major-key");
 
   @Test
   public void buildAttributes() {
@@ -64,5 +66,17 @@ public class AttributesTest {
   @Test
   public void empty() {
     assertEquals(0, Attributes.EMPTY.keys().size());
+  }
+
+  @Test
+  public void withKey() {
+    Attributes attrs = Attributes.newBuilder()
+        .set(YOLO_KEY, "sup")
+        .build();
+    Attributes attrs2 = attrs.withKey(MAJOR_KEY, "I got the keys");
+
+    assertNotEquals(attrs, attrs2);
+    assertEquals(1, attrs.keys().size());
+    assertEquals(2, attrs2.keys().size());
   }
 }

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -500,10 +500,7 @@ public class ServerImplTest {
               .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, remoteAddr)
               .build(), attrs);
           readyCallbackCalled.incrementAndGet();
-          return Attributes.newBuilder(attrs)
-              .set(key1, "yalayala")
-              .set(key2, "blabla")
-              .build();
+          return attrs.withKey(key1, "yalayala").withKey(key2, "blabla");
         }
 
         @Override
@@ -521,10 +518,7 @@ public class ServerImplTest {
               .set(key2, "blabla")
               .build(), attrs);
           readyCallbackCalled.incrementAndGet();
-          return Attributes.newBuilder(attrs)
-              .set(key1, "ouch")
-              .set(key3, "puff")
-              .build();
+          return attrs.withKey(key1, "ouch").withKey(key3, "puff");
         }
 
         @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -168,9 +168,8 @@ class NettyServerHandler extends AbstractNettyHandler {
   @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
     serverWriteQueue = new WriteQueue(ctx.channel());
-    attributes = transportListener.transportReady(Attributes.newBuilder(protocolNegotationAttrs)
-        .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
-        .build());
+    attributes = transportListener.transportReady(protocolNegotationAttrs
+        .withKey(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress()));
     super.handlerAdded(ctx);
   }
 


### PR DESCRIPTION
Convenience method for adding new key to existing attributes object.

Reduces boiler plate of writing:

  `attrs2 = Attributes.newBuilder(attrs).set(key, value).build();`

To just:

  `attrs2 = attrs.withKey(attrs);`

Similar to the `with*()` methods we have in `Context` class.