### PR TITLE
stub: make NoopStreamObserver public

### DIFF
--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
@@ -47,6 +47,7 @@ import io.grpc.examples.routeguide.RouteGuideClient.TestHelper;
 import io.grpc.examples.routeguide.RouteGuideGrpc.RouteGuideImplBase;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.NoopStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.MutableHandlerRegistry;
 
@@ -340,19 +341,7 @@ public class RouteGuideClientTest {
             responseObserver.onNext(response);
             responseObserver.onCompleted();
 
-            return new StreamObserver<Point>() {
-              @Override
-              public void onNext(Point value) {
-              }
-
-              @Override
-              public void onError(Throwable t) {
-              }
-
-              @Override
-              public void onCompleted() {
-              }
-            };
+            return new NoopStreamObserver<Point>();
           }
         };
     serviceRegistry.addService(recordRouteImpl);
@@ -383,21 +372,7 @@ public class RouteGuideClientTest {
           public StreamObserver<Point> recordRoute(StreamObserver<RouteSummary> responseObserver) {
             // send an error immediately
             responseObserver.onError(fakeError);
-
-            StreamObserver<Point> requestObserver = new StreamObserver<Point>() {
-              @Override
-              public void onNext(Point value) {
-              }
-
-              @Override
-              public void onError(Throwable t) {
-              }
-
-              @Override
-              public void onCompleted() {
-              }
-            };
-            return requestObserver;
+            return new NoopStreamObserver<Point>();
           }
         };
     serviceRegistry.addService(recordRouteImpl);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -41,6 +41,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.NoopStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.integration.Messages.StreamingInputCallRequest;
 import io.grpc.testing.integration.Messages.StreamingInputCallResponse;
@@ -101,19 +102,7 @@ public class MoreInProcessTest {
         // send response directly
         responseObserver.onNext(fakeResponse);
         responseObserver.onCompleted();
-        return new StreamObserver<StreamingInputCallRequest>() {
-          @Override
-          public void onNext(StreamingInputCallRequest value) {
-          }
-
-          @Override
-          public void onError(Throwable t) {
-          }
-
-          @Override
-          public void onCompleted() {
-          }
-        };
+        return new NoopStreamObserver<StreamingInputCallRequest>();
       }
     };
     serviceRegistry.addService(clientStreamingImpl);
@@ -160,19 +149,7 @@ public class MoreInProcessTest {
         // send error directly
         responseObserver.onError(new StatusRuntimeException(fakeError));
         responseObserver.onCompleted();
-        return new StreamObserver<StreamingInputCallRequest>() {
-          @Override
-          public void onNext(StreamingInputCallRequest value) {
-          }
-
-          @Override
-          public void onError(Throwable t) {
-          }
-
-          @Override
-          public void onCompleted() {
-          }
-        };
+        return new NoopStreamObserver<StreamingInputCallRequest>();
       }
     };
     serviceRegistry.addService(clientStreamingImpl);

--- a/stub/src/main/java/io/grpc/stub/NoopStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/NoopStreamObserver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.stub;
+
+/**
+ * No-op implementation of StreamObserver. Used in abstract stubs for default implementations of
+ * methods which throws UNIMPLEMENTED error and tests.
+ */
+public class NoopStreamObserver<V> implements StreamObserver<V> {
+  @Override
+  public void onNext(V value) {
+  }
+
+  @Override
+  public void onError(Throwable t) {
+  }
+
+  @Override
+  public void onCompleted() {
+  }
+}

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -393,22 +393,4 @@ public final class ServerCalls {
     asyncUnimplementedUnaryCall(methodDescriptor, responseObserver);
     return new NoopStreamObserver<T>();
   }
-
-  /**
-   * No-op implementation of StreamObserver. Used in abstract stubs for default implementations of
-   * methods which throws UNIMPLEMENTED error and tests.
-   */
-  static class NoopStreamObserver<V> implements StreamObserver<V> {
-    @Override
-    public void onNext(V value) {
-    }
-
-    @Override
-    public void onError(Throwable t) {
-    }
-
-    @Override
-    public void onCompleted() {
-    }
-  }
 }

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -53,7 +53,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
-import io.grpc.stub.ServerCalls.NoopStreamObserver;
 import io.grpc.stub.ServerCallsTest.IntegerMarshaller;
 import io.grpc.testing.NoopClientCall;
 
@@ -407,7 +406,7 @@ public class ClientCallsTest {
                     semaphore.release();
                   }
                 });
-                return new ServerCalls.NoopStreamObserver<Integer>() {
+                return new NoopStreamObserver<Integer>() {
                   @Override
                   public void onCompleted() {
                     serverCallObserver.onCompleted();

--- a/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
@@ -117,7 +117,7 @@ public class ServerCallsTest {
                   }
                 });
                 invokeCalled.set(true);
-                return new ServerCalls.NoopStreamObserver<Integer>();
+                return new NoopStreamObserver<Integer>();
               }
             });
     ServerCall.Listener<Integer> callListener =
@@ -151,7 +151,7 @@ public class ServerCallsTest {
               @Override
               public StreamObserver<Integer> invoke(StreamObserver<Integer> responseObserver) {
                 callObserver.set((ServerCallStreamObserver<Integer>) responseObserver);
-                return new ServerCalls.NoopStreamObserver<Integer>();
+                return new NoopStreamObserver<Integer>();
               }
             });
     ServerCall.Listener<Integer> callListener =
@@ -179,7 +179,7 @@ public class ServerCallsTest {
               @Override
               public StreamObserver<Integer> invoke(StreamObserver<Integer> responseObserver) {
                 callObserver.set((ServerCallStreamObserver<Integer>) responseObserver);
-                return new ServerCalls.NoopStreamObserver<Integer>();
+                return new NoopStreamObserver<Integer>();
               }
             });
     ServerCall.Listener<Integer> callListener =
@@ -207,7 +207,7 @@ public class ServerCallsTest {
               @Override
               public StreamObserver<Integer> invoke(StreamObserver<Integer> responseObserver) {
                 callObserver.set((ServerCallStreamObserver<Integer>) responseObserver);
-                return new ServerCalls.NoopStreamObserver<Integer>();
+                return new NoopStreamObserver<Integer>();
               }
             });
     ServerCall.Listener<Integer> callListener =
@@ -231,7 +231,7 @@ public class ServerCallsTest {
                 ServerCallStreamObserver<Integer> serverCallObserver =
                     (ServerCallStreamObserver<Integer>) responseObserver;
                 serverCallObserver.disableAutoInboundFlowControl();
-                return new ServerCalls.NoopStreamObserver<Integer>();
+                return new NoopStreamObserver<Integer>();
               }
             });
     ServerCall.Listener<Integer> callListener =
@@ -321,7 +321,7 @@ public class ServerCallsTest {
                     semaphore.release();
                   }
                 });
-                return new ServerCalls.NoopStreamObserver<Integer>() {
+                return new NoopStreamObserver<Integer>() {
                   @Override
                   public void onCompleted() {
                     serverCallObserver.onCompleted();


### PR DESCRIPTION
This no-op thing is widely used so make it public.