### PR TITLE
internal/test: make FakeClock more thread-safe

### DIFF
--- a/core/src/test/java/io/grpc/internal/FakeClockTest.java
+++ b/core/src/test/java/io/grpc/internal/FakeClockTest.java
@@ -143,22 +143,32 @@ public class FakeClockTest {
     FakeClock fakeClock = new FakeClock();
     ScheduledExecutorService scheduledExecutorService = fakeClock.getScheduledExecutorService();
 
+    scheduledExecutorService.schedule(newRunnable(), 200L, TimeUnit.MILLISECONDS);
     scheduledExecutorService.execute(newRunnable());
     scheduledExecutorService.schedule(newRunnable(), 0L, TimeUnit.MILLISECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 80L, TimeUnit.MILLISECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 90L, TimeUnit.MILLISECONDS);
     scheduledExecutorService.schedule(newRunnable(), 100L, TimeUnit.MILLISECONDS);
-    scheduledExecutorService.schedule(newRunnable(), 200L, TimeUnit.MILLISECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 110L, TimeUnit.MILLISECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 120L, TimeUnit.MILLISECONDS);
 
-    assertEquals(4, fakeClock.numPendingTasks());
+
+    assertEquals(8, fakeClock.numPendingTasks());
     assertEquals(2, fakeClock.getDueTasks().size());
 
     fakeClock.runDueTasks();
 
-    assertEquals(2, fakeClock.numPendingTasks());
+    assertEquals(6, fakeClock.numPendingTasks());
     assertEquals(0, fakeClock.getDueTasks().size());
 
-    fakeClock.forwardMillis(100L);
+    fakeClock.forwardMillis(90L);
 
-    assertEquals(1, fakeClock.numPendingTasks());
+    assertEquals(4, fakeClock.numPendingTasks());
+    assertEquals(0, fakeClock.getDueTasks().size());
+
+    fakeClock.forwardMillis(20L);
+
+    assertEquals(2, fakeClock.numPendingTasks());
     assertEquals(0, fakeClock.getDueTasks().size());
   }
 


### PR DESCRIPTION
FackeClock used PriorityQueue for storing tasks which is not
thread-safe, and caused flake
https://travis-ci.org/grpc/grpc-java/jobs/179552019

> io.grpc.internal.ClientCallImplTest > deadlineExceededBeforeCallStarted FAILED
>     java.lang.ArrayIndexOutOfBoundsException: -1
>         at java.util.PriorityQueue.removeAt(PriorityQueue.java:619)
>         at java.util.PriorityQueue.remove(PriorityQueue.java:378)
>         at io.grpc.internal.FakeClock$ScheduledTask.cancel(FakeClock.java:89)
>         at io.grpc.internal.ClientCallImpl.removeContextListenerAndCancelDeadlineFuture(ClientCallImpl.java:296)
>         at io.grpc.internal.ClientCallImpl.start(ClientCallImpl.java:250)
>         at io.grpc.internal.ClientCallImplTest.deadlineExceededBeforeCallStarted(ClientCallImplTest.java:615)