### PR TITLE
compiler: whitelist USER32.DLL.

### DIFF
--- a/compiler/check-artifact.sh
+++ b/compiler/check-artifact.sh
@@ -96,7 +96,7 @@ checkDependencies ()
   echo "Checking dependencies of $1"
   if [[ "$OS" == windows ]]; then
     dump_cmd='objdump -x '"$1"' | fgrep "DLL Name"'
-    white_list="KERNEL32\.dll\|msvcrt\.dll"
+    white_list="KERNEL32\.dll\|msvcrt\.dll\|USER32\.dll"
   elif [[ "$OS" == linux ]]; then
     dump_cmd='ldd '"$1"
     if [[ "$ARCH" == x86_32 ]]; then


### PR DESCRIPTION
The 32-bit windows grpc codegen built with protobuf 3.0.2 depends on
USER32.DLL, while the previous release built with protobuf 3.0.0 didn't.
Both protobuf and grpc codegen are built under msys2-mingw32.

"objdump -x libprotobuf-10.dll | grep DLL" also shows the USER32.DLL
dependency being brought by protobuf:

3.0.0

 DLL Name: KERNEL32.dll
 DLL Name: msvcrt.dll
 DLL Name: zlib1.dll
 DLL Name: libgcc_s_dw2-1.dll
 DLL Name: libstdc++-6.dll

3.0.2

 DLL Name: KERNEL32.dll
 DLL Name: msvcrt.dll
 DLL Name: USER32.dll
 DLL Name: zlib1.dll
 DLL Name: libgcc_s_dw2-1.dll
 DLL Name: libstdc++-6.dll

While unexpected, USER32.dll is shipped with Windows so having such
dependency shouldn't cause any trouble.