### PR TITLE
core: Only use scheduled executor for timer tasks

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -165,8 +165,8 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
 
         @Override
         @GuardedBy("lock")
-        void handleInUse() {
-          exitIdleMode();
+        Runnable handleInUse() {
+          return exitIdleMode();
         }
 
         @GuardedBy("lock")
@@ -220,32 +220,46 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   /**
    * Make the channel exit idle mode, if it's in it. Return a LoadBalancer that can be used for
    * making new requests. Return null if the channel is shutdown.
-   *
-   * <p>May be called under the lock.
    */
   @VisibleForTesting
-  LoadBalancer<ClientTransport> exitIdleMode() {
+  LoadBalancer<ClientTransport> exitIdleModeAndGetLb() {
+    Runnable runnable;
+    LoadBalancer<ClientTransport> balancer;
+    synchronized (lock) {
+      runnable = exitIdleMode();
+      balancer = loadBalancer;
+    }
+    if (runnable != null) {
+      runnable.run();
+    }
+    return balancer;
+  }
+
+  /**
+   * Make the channel exit idle mode, if it's in it. If the returned runnable is non-{@code null},
+   * then it should be executed by the caller after releasing {@code lock}.
+   */
+  @GuardedBy("lock")
+  private Runnable exitIdleMode() {
     final LoadBalancer<ClientTransport> balancer;
     final NameResolver resolver;
-    synchronized (lock) {
-      if (shutdown) {
-        return null;
-      }
-      if (inUseStateAggregator.isInUse()) {
-        cancelIdleTimer();
-      } else {
-        // exitIdleMode() may be called outside of inUseStateAggregator, which may still in
-        // "not-in-use" state. If it's the case, we start the timer which will be soon cancelled if
-        // the aggregator receives actual uses.
-        rescheduleIdleTimer();
-      }
-      if (loadBalancer != null) {
-        return loadBalancer;
-      }
-      balancer = loadBalancerFactory.newLoadBalancer(nameResolver.getServiceAuthority(), tm);
-      this.loadBalancer = balancer;
-      resolver = this.nameResolver;
+    if (shutdown) {
+      return null;
     }
+    if (inUseStateAggregator.isInUse()) {
+      cancelIdleTimer();
+    } else {
+      // exitIdleMode() may be called outside of inUseStateAggregator, which may still in
+      // "not-in-use" state. If it's the case, we start the timer which will be soon cancelled if
+      // the aggregator receives actual uses.
+      rescheduleIdleTimer();
+    }
+    if (loadBalancer != null) {
+      return null;
+    }
+    balancer = loadBalancerFactory.newLoadBalancer(nameResolver.getServiceAuthority(), tm);
+    this.loadBalancer = balancer;
+    resolver = this.nameResolver;
     class NameResolverStartTask implements Runnable {
       @Override
       public void run() {
@@ -255,8 +269,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       }
     }
 
-    scheduledExecutor.execute(new NameResolverStartTask());
-    return balancer;
+    return new NameResolverStartTask();
   }
 
   @GuardedBy("lock")
@@ -294,7 +307,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   private final ClientTransportProvider transportProvider = new ClientTransportProvider() {
     @Override
     public ClientTransport get(CallOptions callOptions) {
-      LoadBalancer<ClientTransport> balancer = exitIdleMode();
+      LoadBalancer<ClientTransport> balancer = exitIdleModeAndGetLb();
       if (balancer == null) {
         return SHUTDOWN_TRANSPORT;
       }
@@ -618,13 +631,14 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
                 }
 
                 @Override
-                public void onInUse(TransportSet ts) {
-                  inUseStateAggregator.updateObjectInUse(ts, true);
+                public Runnable onInUse(TransportSet ts) {
+                  return inUseStateAggregator.updateObjectInUse(ts, true);
                 }
 
                 @Override
                 public void onNotInUse(TransportSet ts) {
-                  inUseStateAggregator.updateObjectInUse(ts, false);
+                  Runnable r = inUseStateAggregator.updateObjectInUse(ts, false);
+                  assert r == null;
                 }
               });
           if (log.isLoggable(Level.FINE)) {
@@ -709,13 +723,17 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
               delayedTransports.remove(delayedTransport);
               maybeTerminateChannel();
             }
-            inUseStateAggregator.updateObjectInUse(delayedTransport, false);
+            Runnable r = inUseStateAggregator.updateObjectInUse(delayedTransport, false);
+            assert r == null;
           }
 
           @Override public void transportReady() {}
 
           @Override public void transportInUse(boolean inUse) {
-            inUseStateAggregator.updateObjectInUse(delayedTransport, inUse);
+            Runnable r = inUseStateAggregator.updateObjectInUse(delayedTransport, inUse);
+            if (r != null) {
+              r.run();
+            }
           }
         });
       boolean savedShutdown;

--- a/core/src/main/java/io/grpc/internal/TransportSet.java
+++ b/core/src/main/java/io/grpc/internal/TransportSet.java
@@ -110,8 +110,8 @@ final class TransportSet implements WithLogId {
         }
 
         @Override
-        void handleInUse() {
-          callback.onInUse(TransportSet.this);
+        Runnable handleInUse() {
+          return callback.onInUse(TransportSet.this);
         }
 
         @Override
@@ -370,7 +370,10 @@ final class TransportSet implements WithLogId {
 
     @Override
     public void transportInUse(boolean inUse) {
-      inUseStateAggregator.updateObjectInUse(transport, inUse);
+      Runnable r = inUseStateAggregator.updateObjectInUse(transport, inUse);
+      if (r != null) {
+        r.run();
+      }
     }
 
     @Override
@@ -379,7 +382,8 @@ final class TransportSet implements WithLogId {
     @Override
     public void transportTerminated() {
       boolean runCallback = false;
-      inUseStateAggregator.updateObjectInUse(transport, false);
+      Runnable r = inUseStateAggregator.updateObjectInUse(transport, false);
+      assert r == null;
       synchronized (lock) {
         transports.remove(transport);
         if (shutdown && transports.isEmpty()) {
@@ -519,9 +523,13 @@ final class TransportSet implements WithLogId {
 
     /**
      * Called when the TransportSet's in-use state has changed to true, which means at least one
-     * transport is in use. This method is called under a lock thus externally synchronized.
+     * transport is in use. This method is called under a lock thus externally synchronized. If the
+     * return value is non-{@code null}, the runnable will be executed after releasing the lock.
      */
-    public void onInUse(TransportSet ts) { }
+    @CheckReturnValue
+    public Runnable onInUse(TransportSet ts) {
+      return null;
+    }
 
     /**
      * Called when the TransportSet's in-use state has changed to false, which means no transport is

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -338,9 +338,7 @@ public class ManagedChannelImplIdlenessTest {
   }
 
   private void forceExitIdleMode() {
-    channel.exitIdleMode();
-    // NameResolver is started in the scheduled executor
-    timer.runDueTasks();
+    channel.exitIdleModeAndGetLb();
   }
 
   private ClientTransport channelTmGetTransportUnwrapped(EquivalentAddressGroup addressGroup) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -151,9 +151,7 @@ public class ManagedChannelImplTest {
         ManagedChannelImpl.IDLE_TIMEOUT_MILLIS_DISABLE,
         executor.scheduledExecutorService, userAgent, interceptors);
     // Force-exit the initial idle-mode
-    channel.exitIdleMode();
-    // Will start NameResolver in the scheduled executor
-    assertEquals(1, timer.runDueTasks());
+    channel.exitIdleModeAndGetLb();
   }
 
   @Before

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -140,7 +140,7 @@ public class ManagedChannelImplTransportManagerTest {
     ArgumentCaptor<TransportManager<ClientTransport>> tmCaptor
         = ArgumentCaptor.forClass(null);
     // Force Channel to exit the initial idleness to get NameResolver and LoadBalancer created.
-    channel.exitIdleMode();
+    channel.exitIdleModeAndGetLb();
     verify(mockNameResolverFactory).newNameResolver(any(URI.class), any(Attributes.class));
     verify(mockLoadBalancerFactory).newLoadBalancer(anyString(), tmCaptor.capture());
     tm = tmCaptor.getValue();


### PR DESCRIPTION
This is a "backport" for v1.0.x, even though we don't yet have the fix on master. The fix
will probably have to be rewritten for master after the LB API changes settle. When I
submit this change GitHub will close #2444, but I'll just reopen it for tracking progress on
master.

This removes an abuse of scheduled executor in ManagedChannelImpl. The executor
was used to avoid deadlocking. Now we run the work on the same thread, but
delay it until locks have been released.

Fixes #2444