### PR TITLE
core: Make tiny fixes to InUseStateAggregator2 and InternalSubchannel

### DIFF
--- a/core/src/main/java/io/grpc/internal/InUseStateAggregator2.java
+++ b/core/src/main/java/io/grpc/internal/InUseStateAggregator2.java
@@ -75,8 +75,6 @@ abstract class InUseStateAggregator2<T> {
 
   /**
    * Called when the aggregated in-use state has changed to false, which means no object is in use.
-   *
-   * <p>This method is called under the lock returned by {@link #getLock}.
    */
   abstract void handleNotInUse();
 }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -447,7 +447,6 @@ final class InternalSubchannel implements WithLogId {
         log.log(Level.FINE, "[{0}] {1} for {2} is terminated",
             new Object[] {getLogId(), transport.getLogId(), address});
       }
-      boolean terminated = false;
       handleTransportInUseState(transport, false);
       synchronized (lock) {
         transports.remove(transport);


### PR DESCRIPTION
- Remove unused variable terminated from `TransportListener#transportTerminated`
- Do not mention `getLock` in the javadoc of `InUseStateAggregator2#handleNotInUse`