### PR TITLE
core,netty: add onConnection() to ClientStreamListener; add getAttrs() to ClientCall

### DIFF
--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -34,6 +34,7 @@ package io.grpc;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Set;
@@ -71,6 +72,21 @@ public final class Attributes {
    */
   public Set<Key<?>> keys() {
     return Collections.unmodifiableSet(data.keySet());
+  }
+
+  /**
+   * Returns a new Attributes instance that contains only the given keys in the filter.
+   */
+  public Attributes filterIn(Collection<Key<?>> filter) {
+    Builder builder = new Builder();
+    for (Key<?> key : filter) {
+      if (data.containsKey(key)) {
+        @SuppressWarnings("unchecked") // type can be ignored here.
+        Key<Object> objKey = (Key<Object>) key;
+        builder.set(objKey, data.get(key));
+      }
+    }
+    return builder.build();
   }
 
   /**
@@ -164,7 +180,7 @@ public final class Attributes {
       return this;
     }
 
-    public <T> Builder setAll(Attributes other) {
+    public Builder setAll(Attributes other) {
       product.data.putAll(other.data);
       return this;
     }
@@ -178,5 +194,9 @@ public final class Attributes {
       product = null;
       return result;
     }
+  }
+
+  public interface Provider {
+    Attributes getAttrs();
   }
 }

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -252,4 +252,12 @@ public abstract class ClientCall<ReqT, RespT> {
   public void setMessageCompression(boolean enabled) {
     // noop
   }
+
+  /**
+   * Its overriding method returns a set of attributes, which may vary depending on the particular
+   * implementation and the state of the call, channel, or transport at the moment.
+   */
+  public Attributes getAttrs() {
+    return Attributes.EMPTY;
+  }
 }

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
@@ -31,7 +31,6 @@
 
 package io.grpc.internal;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import io.grpc.Metadata;
@@ -169,8 +168,7 @@ public abstract class AbstractClientStream2 extends AbstractStream2
       super(maxMessageSize, statsTraceCtx);
     }
 
-    @VisibleForTesting
-    public final void setListener(ClientStreamListener listener) {
+    public void setListener(ClientStreamListener listener) {
       Preconditions.checkState(this.listener == null, "Already called setListener");
       this.listener = Preconditions.checkNotNull(listener, "listener");
     }

--- a/core/src/main/java/io/grpc/internal/ClientStreamListener.java
+++ b/core/src/main/java/io/grpc/internal/ClientStreamListener.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
@@ -61,4 +62,13 @@ public interface ClientStreamListener extends StreamListener {
    * @param trailers trailing metadata
    */
   void closed(Status status, Metadata trailers);
+
+  /**
+   * Called only when a {@link ConnectionClientTransport} starts a new stream with this listener
+   * and there are/will be attributes that the transport would like to share with API's of higher
+   * level than transport layer.  The callback may not be called at all.
+   *
+   * <p>Must return immediately.  Must not throw RuntimeException.
+   */
+  void onConnection(Attributes.Provider transportAttrsProvider);
 }

--- a/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
@@ -32,6 +32,9 @@
 package io.grpc.internal;
 
 import io.grpc.Attributes;
+import io.grpc.Attributes.Key;
+
+import java.util.Collection;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -45,4 +48,10 @@ public interface ConnectionClientTransport extends ManagedClientTransport {
    * should define in what states they will be present.
    */
   Attributes getAttrs();
+
+  /**
+   * The key for an attribute that includes a collection of keys for the attributes that are
+   * accessible for application.
+   */
+  Key<Collection<Key<?>>> APPLICATION_FILTER = Key.<Collection<Key<?>>>of("APPLICATION_FILTER");
 }

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -36,6 +36,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import io.grpc.Attributes;
 import io.grpc.Compressor;
 import io.grpc.Decompressor;
 import io.grpc.Metadata;
@@ -392,6 +393,20 @@ class DelayedStream implements ClientStream {
           realListener.closed(status, trailers);
         }
       });
+    }
+
+    @Override
+    public void onConnection(final Attributes.Provider transportAttrsProvider) {
+      if (passThrough) {
+        realListener.onConnection(transportAttrsProvider);
+      } else {
+        delayOrExecute(new Runnable() {
+          @Override
+          public void run() {
+            realListener.onConnection(transportAttrsProvider);
+          }
+        });
+      }
     }
 
     public void drainPendingCallbacks() {

--- a/core/src/test/java/io/grpc/AttributesTest.java
+++ b/core/src/test/java/io/grpc/AttributesTest.java
@@ -32,16 +32,21 @@
 package io.grpc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+
+import io.grpc.Attributes.Key;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Arrays;
+
 /** Unit tests for {@link Attributes}. */
 @RunWith(JUnit4.class)
 public class AttributesTest {
-  private static Attributes.Key<String> YOLO_KEY = Attributes.Key.of("yolo");
+  private static Key<String> YOLO_KEY = Key.<String>of("yolo");
 
   @Test
   public void buildAttributes() {
@@ -64,5 +69,24 @@ public class AttributesTest {
   @Test
   public void empty() {
     assertEquals(0, Attributes.EMPTY.keys().size());
+  }
+
+  @Test
+  public void filterIn() {
+    Key<String> key1 = Key.<String>of("key1");
+    Key<String> key2 = Key.<String>of("key2");
+    Key<Object> key3 = Key.<Object>of("key3");
+    Key<Object> key4 = Key.<Object>of("key4");
+    Attributes attrs = Attributes.newBuilder()
+        .set(key1, "val1").set(key2, "val2").set(key3, "val3").set(key4, "val4")
+        .build();
+
+    @SuppressWarnings("unchecked") // type params are inhomogeneous but doesn't matter
+    Attributes newAttrs = attrs.filterIn(Arrays.asList(key2, key3));
+
+    assertNull(newAttrs.get(key1));
+    assertEquals("val2", newAttrs.get(key2));
+    assertEquals("val3", newAttrs.get(key3));
+    assertNull(newAttrs.get(key4));
   }
 }

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -58,6 +58,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 
+import io.grpc.Attributes;
+import io.grpc.Attributes.Key;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Codec;
@@ -822,6 +824,34 @@ public class ClientCallImplTest {
     assertEquals(Status.CANCELLED.getCode(), status.getCode());
     assertEquals("foo", status.getDescription());
     assertSame(cause, status.getCause());
+  }
+
+  @Test
+  public void onConnectionTriggered() {
+    DelayedExecutor executor = new DelayedExecutor();
+    ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
+        method,
+        executor,
+        CallOptions.DEFAULT,
+        statsTraceCtx,
+        provider,
+        deadlineCancellationExecutor);
+    call.start(callListener, new Metadata());
+    verify(stream).start(listenerArgumentCaptor.capture());
+    final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
+    final Attributes attributes =
+        Attributes.newBuilder().set(Key.<String>of("fakeKey"), "fakeValue").build();
+
+    streamListener.onConnection(
+        new Attributes.Provider() {
+          @Override
+          public Attributes getAttrs() {
+            return attributes;
+          }
+        }
+    );
+
+    assertEquals(attributes, call.getAttrs());
   }
 
   private void assertStatusInStats(Status.Code statusCode) {

--- a/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
+++ b/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
@@ -51,4 +52,7 @@ class NoopClientStreamListener implements ClientStreamListener {
 
   @Override
   public void closed(Status status, Metadata trailers) {}
+
+  @Override
+  public void onConnection(Attributes.Provider transportAttrsProvider) {}
 }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -38,15 +38,18 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
 
 import io.grpc.Attributes;
+import io.grpc.Attributes.Key;
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientStream;
+import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
 import io.grpc.internal.StatsTraceContext;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -60,6 +63,7 @@ import io.netty.util.AsciiString;
 
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
@@ -86,6 +90,7 @@ class NettyClientTransport implements ConnectionClientTransport {
   private Channel channel;
   /** Since not thread-safe, may only be used from event loop. */
   private ClientTransportLifecycleManager lifecycleManager;
+  private Attributes attributesForTest;
 
   NettyClientTransport(
       SocketAddress address, Class<? extends Channel> channelType,
@@ -134,6 +139,22 @@ class NettyClientTransport implements ConnectionClientTransport {
           @Override
           protected Status statusFromFailedFuture(ChannelFuture f) {
             return NettyClientTransport.this.statusFromFailedFuture(f);
+          }
+
+          @Override
+          public void setListener(ClientStreamListener listener) {
+            super.setListener(listener);
+            final Collection<Key<?>> filter = NettyClientTransport.this.getAttrs()
+                .get(ConnectionClientTransport.APPLICATION_FILTER);
+            if (filter != null) {
+              listener.onConnection(new Attributes.Provider() {
+                @Override
+                public Attributes getAttrs() {
+                  // filter out security related attributes as the value is passed to application
+                  return NettyClientTransport.this.getAttrs().filterIn(filter);
+                }
+              });
+            }
           }
         },
         method, headers, channel, authority, negotiationHandler.scheme(), userAgent,
@@ -247,8 +268,18 @@ class NettyClientTransport implements ConnectionClientTransport {
 
   @Override
   public Attributes getAttrs() {
+    if (attributesForTest != null) {
+      return attributesForTest;
+    }
     // TODO(zhangkun83): fill channel security attributes
-    return Attributes.EMPTY;
+    return Attributes.newBuilder().setAll(negotiator.attributes()).build();
+  }
+
+  /**
+   * For test only.
+   */
+  void setAttrsForTest(Attributes attributes) {
+    attributesForTest = attributes;
   }
 
   @VisibleForTesting

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
@@ -31,7 +31,9 @@
 
 package io.grpc.netty;
 
+import io.grpc.Attributes;
 import io.grpc.Internal;
+
 import io.netty.channel.ChannelHandler;
 import io.netty.util.AsciiString;
 
@@ -56,4 +58,9 @@ public interface ProtocolNegotiator {
    * has completed successfully, the provided handler is installed.
    */
   Handler newHandler(GrpcHttp2ConnectionHandler handler);
+
+  /**
+   * Returns a set of attributes, which varies depending on the negotiator implementation.
+   */
+  Attributes attributes();
 }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -42,6 +42,7 @@ import io.grpc.Grpc;
 import io.grpc.Internal;
 import io.grpc.Status;
 import io.grpc.internal.GrpcUtil;
+
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
@@ -106,6 +107,11 @@ public final class ProtocolNegotiators {
 
         return new PlaintextHandler();
       }
+
+      @Override
+      public Attributes attributes() {
+        return Attributes.EMPTY;
+      }
     };
   }
 
@@ -118,6 +124,11 @@ public final class ProtocolNegotiators {
       @Override
       public Handler newHandler(GrpcHttp2ConnectionHandler handler) {
         return new ServerTlsHandler(sslContext, handler);
+      }
+
+      @Override
+      public Attributes attributes() {
+        return Attributes.EMPTY;
       }
     };
   }
@@ -251,6 +262,11 @@ public final class ProtocolNegotiators {
       };
       return new BufferUntilTlsNegotiatedHandler(sslBootstrap, handler);
     }
+
+    @Override
+    public Attributes attributes() {
+      return Attributes.EMPTY;
+    }
   }
 
   /**
@@ -270,6 +286,11 @@ public final class ProtocolNegotiators {
           new HttpClientUpgradeHandler(httpClientCodec, upgradeCodec, 1000);
       return new BufferingHttp2UpgradeHandler(upgrader);
     }
+
+    @Override
+    public Attributes attributes() {
+      return Attributes.EMPTY;
+    }
   }
 
   /**
@@ -285,6 +306,11 @@ public final class ProtocolNegotiators {
     @Override
     public Handler newHandler(GrpcHttp2ConnectionHandler handler) {
       return new BufferUntilChannelActiveHandler(handler);
+    }
+
+    @Override
+    public Attributes attributes() {
+      return Attributes.EMPTY;
     }
   }
 

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -35,12 +35,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import io.grpc.Attributes;
 import io.grpc.netty.ProtocolNegotiators.ServerTlsHandler;
 import io.grpc.netty.ProtocolNegotiators.TlsNegotiator;
 import io.grpc.testing.TestUtils;
+
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -67,6 +70,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
+/** Tests for {@link ProtocolNegotiators}.*/
 @RunWith(JUnit4.class)
 public class ProtocolNegotiatorsTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
@@ -251,5 +255,16 @@ public class ProtocolNegotiatorsTest {
     // invalid.
     assertEquals("bad_host:1234", negotiator.getHost());
     assertEquals(-1, negotiator.getPort());
+  }
+
+  @Test
+  public void attributes() throws Exception {
+    SslContext ctx = GrpcSslContexts.forClient().build();
+
+    assertSame(Attributes.EMPTY, ProtocolNegotiators.plaintext().attributes());
+    assertSame(Attributes.EMPTY, ProtocolNegotiators.plaintextUpgrade().attributes());
+    assertSame(Attributes.EMPTY, ProtocolNegotiators.serverPlaintext().attributes());
+    assertSame(Attributes.EMPTY, ProtocolNegotiators.serverTls(ctx) .attributes());
+    assertSame(Attributes.EMPTY, ProtocolNegotiators.tls(ctx, "bad_host:1234") .attributes());
   }
 }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -37,7 +37,9 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
@@ -86,6 +88,7 @@ public class OkHttpClientStreamTest {
         MethodType.UNARY, "/testService/test", marshaller, marshaller);
     stream = new OkHttpClientStream(methodDescriptor, new Metadata(), frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, "localhost", "userAgent", StatsTraceContext.NOOP);
+    when(transport.getAttrs()).thenReturn(Attributes.EMPTY);
   }
 
   @Test
@@ -187,6 +190,10 @@ public class OkHttpClientStreamTest {
 
     @Override
     public void closed(Status status, Metadata trailers) {}
+
+    @Override
+    public void onConnection(Attributes.Provider transportAttrsProvider) {
+    }
   }
 }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -65,6 +65,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 
+import io.grpc.Attributes.Provider;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
@@ -1508,6 +1509,10 @@ public class OkHttpClientTransportTest {
       this.status = status;
       this.trailers = trailers;
       closed.countDown();
+    }
+
+    @Override
+    public void onConnection(Provider transportAttrsProvider) {
     }
 
     @Override


### PR DESCRIPTION
add `onConnection(Attributes transportAttrs)` API to
`ClientStreamListener` and add `getAttrs()` to `ClientCall` to be able to share transport
information such as socket TOS with higher lever API's, on the event
that an RPC picks up an active transport that is ready to use.

For the moment, the `onConnection` will not be invoked at all unless that it is of Netty transport and that the transport attributes have non-trivial keys that are in the `ConnectionClientTransport#APPLICATION_FILTER`