### PR TITLE
all: use a proper log id which can reference channels, subchannels, a…

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -44,7 +44,7 @@ import io.grpc.Status;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ConnectionClientTransport;
-import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.LogId;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.NoopClientStream;
 import io.grpc.internal.ServerStream;
@@ -71,6 +71,7 @@ import javax.annotation.concurrent.ThreadSafe;
 class InProcessTransport implements ServerTransport, ConnectionClientTransport {
   private static final Logger log = Logger.getLogger(InProcessTransport.class.getName());
 
+  private final LogId logId = LogId.allocate(getClass().getName());
   private final String name;
   private ServerTransportListener serverTransportListener;
   private Attributes serverStreamAttributes;
@@ -203,8 +204,8 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
   }
 
   @Override
-  public String getLogId() {
-    return GrpcUtil.getLogId(this);
+  public LogId getLogId() {
+    return logId;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -63,6 +63,9 @@ import javax.annotation.concurrent.GuardedBy;
  * streams are transferred to the given transport, thus this transport won't own any stream.
  */
 class DelayedClientTransport implements ManagedClientTransport {
+
+  private final LogId lodId = LogId.allocate(getClass().getName());
+
   private final Object lock = new Object();
 
   private final Executor streamCreationExecutor;
@@ -455,9 +458,10 @@ class DelayedClientTransport implements ManagedClientTransport {
     }
   }
 
+  // TODO(carl-mastrangelo): remove this once the Subchannel change is in.
   @Override
-  public final String getLogId() {
-    return GrpcUtil.getLogId(this);
+  public LogId getLogId() {
+    return lodId;
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -535,13 +535,6 @@ public final class GrpcUtil {
     }
   }
 
-  /**
-   * The canonical implementation of {@link WithLogId#getLogId}.
-   */
-  public static String getLogId(WithLogId subject) {
-    return subject.getClass().getSimpleName() + "@" + Integer.toHexString(subject.hashCode());
-  }
-
   private GrpcUtil() {}
 
   private static String getImplementationVersion() {

--- a/core/src/main/java/io/grpc/internal/LogId.java
+++ b/core/src/main/java/io/grpc/internal/LogId.java
@@ -31,61 +31,39 @@
 
 package io.grpc.internal;
 
-import io.grpc.Attributes;
-import io.grpc.CallOptions;
-import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
-import io.grpc.Status;
+import java.util.concurrent.atomic.AtomicLong;
 
-import java.util.concurrent.Executor;
+/**
+ * A loggable ID, unique for the duration of the program.
+ */
+public final class LogId {
+  private static final AtomicLong idAlloc = new AtomicLong();
 
-abstract class ForwardingConnectionClientTransport implements ConnectionClientTransport {
-  @Override
-  public Runnable start(Listener listener) {
-    return delegate().start(listener);
+  /**
+   * @param tag a loggable tag associated with this ID.
+   */
+  public static LogId allocate(String tag) {
+    return new LogId(tag, idAlloc.incrementAndGet());
   }
 
-  @Override
-  public void shutdown() {
-    delegate().shutdown();
+  private final String tag;
+  private final long id;
+
+  private LogId(String tag, long id) {
+    this.tag = tag;
+    this.id = id;
   }
 
-  @Override
-  public void shutdownNow(Status status) {
-    delegate().shutdownNow(status);
+  public long getId() {
+    return id;
   }
 
-  @Override
-  public ClientStream newStream(
-      MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions,
-      StatsTraceContext statsTraceCtx) {
-    return delegate().newStream(method, headers, callOptions, statsTraceCtx);
-  }
-
-  @Override
-  public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
-    return delegate().newStream(method, headers);
-  }
-
-  @Override
-  public void ping(PingCallback callback, Executor executor) {
-    delegate().ping(callback, executor);
-  }
-
-  @Override
-  public LogId getLogId() {
-    return delegate().getLogId();
-  }
-
-  @Override
-  public Attributes getAttrs() {
-    return delegate().getAttrs();
+  public String getTag() {
+    return tag;
   }
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "[" + delegate().toString() + "]";
+    return tag + "-" + id;
   }
-
-  protected abstract ConnectionClientTransport delegate();
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -130,6 +130,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   private final Executor executor;
   private final boolean usingSharedExecutor;
   private final Object lock = new Object();
+  private final LogId logId = LogId.allocate(getClass().getName());
 
   private final DecompressorRegistry decompressorRegistry;
   private final CompressorRegistry compressorRegistry;
@@ -745,8 +746,8 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   };
 
   @Override
-  public String getLogId() {
-    return GrpcUtil.getLogId(this);
+  public LogId getLogId() {
+    return logId;
   }
 
   private static class NameResolverListenerImpl implements NameResolver.Listener {

--- a/core/src/main/java/io/grpc/internal/TransportSet.java
+++ b/core/src/main/java/io/grpc/internal/TransportSet.java
@@ -73,6 +73,7 @@ final class TransportSet extends ManagedChannel implements WithLogId {
 
   private final CountDownLatch terminatedLatch = new CountDownLatch(1);
   private final Object lock = new Object();
+  private final LogId logId = LogId.allocate(getClass().getName());
   private final EquivalentAddressGroup addressGroup;
   private final String authority;
   private final String userAgent;
@@ -352,8 +353,8 @@ final class TransportSet extends ManagedChannel implements WithLogId {
   }
 
   @Override
-  public String getLogId() {
-    return GrpcUtil.getLogId(this);
+  public LogId getLogId() {
+    return logId;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/WithLogId.java
+++ b/core/src/main/java/io/grpc/internal/WithLogId.java
@@ -43,5 +43,5 @@ public interface WithLogId {
    * <p>The subclasses of this interface usually want to include the log ID in their {@link
    * #toString} results.
    */
-  String getLogId();
+  LogId getLogId();
 }

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -422,7 +422,7 @@ public class InternalSubchannelTest {
     // No scheduled tasks that would ever try to reconnect ...
     assertEquals(0, fakeClock.numPendingTasks());
     assertEquals(0, fakeExecutor.numPendingTasks());
-    
+
     // ... until it's requested.
     internalSubchannel.obtainActiveTransport();
     assertExactCallbackInvokes("onStateChange:CONNECTING");
@@ -434,7 +434,7 @@ public class InternalSubchannelTest {
   public void shutdownWhenReady() throws Exception {
     SocketAddress addr = mock(SocketAddress.class);
     createInternalSubchannel(addr);
-    
+
     internalSubchannel.obtainActiveTransport();
     MockClientTransportInfo transportInfo = transports.poll();
     transportInfo.listener.transportReady();
@@ -528,7 +528,7 @@ public class InternalSubchannelTest {
   public void shutdownNow() throws Exception {
     SocketAddress addr = mock(SocketAddress.class);
     createInternalSubchannel(addr);
-    
+
     internalSubchannel.obtainActiveTransport();
     MockClientTransportInfo t1 = transports.poll();
     t1.listener.transportReady();
@@ -565,8 +565,8 @@ public class InternalSubchannelTest {
   @Test
   public void logId() {
     createInternalSubchannel(mock(SocketAddress.class));
-    assertEquals("InternalSubchannel@" + Integer.toHexString(internalSubchannel.hashCode()),
-        internalSubchannel.getLogId());
+
+    assertNotNull(internalSubchannel.getLogId());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -690,8 +690,8 @@ public class TransportSetTest {
   @Test
   public void logId() {
     createTransportSet(mock(SocketAddress.class));
-    assertEquals("TransportSet@" + Integer.toHexString(transportSet.hashCode()),
-        transportSet.getLogId());
+
+    assertNotNull(transportSet.getLogId());
   }
 
   @Test

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -46,6 +46,7 @@ import io.grpc.internal.ClientStream;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
+import io.grpc.internal.LogId;
 import io.grpc.internal.StatsTraceContext;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
@@ -62,12 +63,14 @@ import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.Map;
 import java.util.concurrent.Executor;
+
 import javax.annotation.Nullable;
 
 /**
  * A Netty-based {@link ConnectionClientTransport} implementation.
  */
 class NettyClientTransport implements ConnectionClientTransport {
+  private final LogId logId = LogId.allocate(getClass().getName());
   private final Map<ChannelOption<?>, ?> channelOptions;
   private final SocketAddress address;
   private final Class<? extends Channel> channelType;
@@ -241,8 +244,8 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public String getLogId() {
-    return GrpcUtil.getLogId(this);
+  public LogId getLogId() {
+    return logId;
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -51,6 +51,7 @@ import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
 import io.grpc.internal.KeepAliveManager;
+import io.grpc.internal.LogId;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.StatsTraceContext;
@@ -140,6 +141,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   private AsyncFrameWriter frameWriter;
   private OutboundFlowController outboundFlow;
   private final Object lock = new Object();
+  private final LogId logId = LogId.allocate(getClass().getName());
   @GuardedBy("lock")
   private int nextStreamId;
   @GuardedBy("lock")
@@ -445,8 +447,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public String getLogId() {
-    return GrpcUtil.getLogId(this);
+  public LogId getLogId() {
+    return logId;
   }
 
   /**


### PR DESCRIPTION
…nd transports