### PR TITLE
Port PickFirst & RoundRobin LBs to v2 API

### DIFF
--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
@@ -90,9 +90,12 @@ public final class PickFirstBalancerFactory2 extends LoadBalancer2.Factory {
 
     @Override
     public void handleNameResolutionError(Status error) {
-      // NB(lukaszx0) Whether we should propagate the error unconditionally is arguable.
-      // It's fine for time being, but we should probably shutdown and discard subchannel if there
-      // is one. Otherwise we end up keeping a connection that you will never use.
+      if (subchannel != null) {
+        subchannel.shutdown();
+        subchannel = null;
+      }
+      // NB(lukaszx0) Whether we should propagate the error unconditionally is arguable. It's fine
+      // for time being.
       helper.updatePicker(new Picker(PickResult.withError(error)));
     }
 

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
@@ -120,9 +120,12 @@ public final class PickFirstBalancerFactory2 extends LoadBalancer2.Factory {
       checkState(lastStateRef != null, "subchannel should have LAST_STATE attribute set");
 
       PickResult pickResult;
-      if (subchannel != this.subchannel || currentState == SHUTDOWN || currentState == CONNECTING) {
+      if (subchannel != this.subchannel || currentState == SHUTDOWN) {
+        return;
+      } else if (currentState == CONNECTING) {
         pickResult = PickResult.withNoResult();
-      } else if (lastStateRef.get() == TRANSIENT_FAILURE || currentState == READY || currentState == IDLE) {
+      } else if (lastStateRef.get() == TRANSIENT_FAILURE || currentState == READY
+          || currentState == IDLE) {
         pickResult = PickResult.withSubchannel(subchannel);
       } else if (currentState == TRANSIENT_FAILURE) {
         pickResult = PickResult.withError(stateInfo.getStatus());

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
@@ -34,9 +34,9 @@ package io.grpc;
 import static io.grpc.ConnectivityState.SHUTDOWN;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 
 import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -134,7 +134,7 @@ public final class PickFirstBalancerFactory2 extends LoadBalancer2.Factory {
      */
     private static EquivalentAddressGroup flattenResolvedServerInfoGroupsIntoEquivalentAddressGroup(
         List<ResolvedServerInfoGroup> groupList) {
-      List<SocketAddress> addrs = Lists.newArrayList();
+      List<SocketAddress> addrs = new ArrayList<SocketAddress>();
       for (ResolvedServerInfoGroup group : groupList) {
         for (ResolvedServerInfo srv : group.getResolvedServerInfoList()) {
           addrs.add(srv.getAddress());

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
@@ -45,13 +45,13 @@ import java.util.List;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 public final class PickFirstBalancerFactory2 extends LoadBalancer2.Factory {
 
-  private static final PickFirstBalancerFactory2 instance = new PickFirstBalancerFactory2();
+  private static final PickFirstBalancerFactory2 INSTANCE = new PickFirstBalancerFactory2();
 
   private PickFirstBalancerFactory2() {
   }
 
   public static PickFirstBalancerFactory2 getInstance() {
-    return instance;
+    return INSTANCE;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
@@ -98,19 +98,14 @@ public final class PickFirstBalancerFactory2 extends LoadBalancer2.Factory {
 
       PickResult pickResult;
       switch (stateInfo.getState()) {
-        case CONNECTING:
-          pickResult = null; // Reuse pick result from IDLE state.
-          break;
         case READY:
+        case IDLE:
           pickResult = PickResult.withSubchannel(subchannel);
           break;
         case TRANSIENT_FAILURE:
           pickResult = PickResult.withError(stateInfo.getStatus());
           break;
-        case IDLE:
-          subchannel.requestConnection();
-          pickResult = PickResult.withNoResult();
-          break;
+        case CONNECTING:
         case SHUTDOWN:
           pickResult = PickResult.withNoResult();
           break;

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
@@ -90,6 +90,9 @@ public final class PickFirstBalancerFactory2 extends LoadBalancer2.Factory {
 
     @Override
     public void handleNameResolutionError(Status error) {
+      // NB(lukaszx0) Whether we should propagate the error unconditionally is arguable.
+      // It's fine for time being, but we should probably shutdown and discard subchannel if there
+      // is one. Otherwise we end up keeping a connection that you will never use.
       helper.updatePicker(new Picker(PickResult.withError(error)));
     }
 

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+/**
+ * A {@link LoadBalancer} that provides no load balancing mechanism over the
+ * addresses from the {@link NameResolver}.  The channel's default behavior
+ * (currently pick-first) is used for all addresses found.
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
+public final class PickFirstBalancerFactory2 extends LoadBalancer2.Factory {
+
+  private static final PickFirstBalancerFactory2 instance = new PickFirstBalancerFactory2();
+
+  private PickFirstBalancerFactory2() {
+  }
+
+  public static PickFirstBalancerFactory2 getInstance() {
+    return instance;
+  }
+
+  @Override
+  public LoadBalancer2 newLoadBalancer(LoadBalancer2.Helper helper) {
+    return new PickFirstBalancer(helper);
+  }
+
+  @VisibleForTesting
+  static class PickFirstBalancer extends LoadBalancer2 {
+    private final Helper helper;
+    private Subchannel subchannel;
+
+    public PickFirstBalancer(Helper helper) {
+      this.helper = helper;
+    }
+
+    @Override
+    public void handleResolvedAddresses(List<ResolvedServerInfoGroup> servers,
+        Attributes attributes) {
+      // Flatten servers list received from name resolver into single address group. This means that
+      // as far as load balancer is concerned, there's virtually one single server with multiple
+      // addresses so the connection will be created only for the first address (pick first).
+      EquivalentAddressGroup newEag =
+          flattenResolvedServerInfoGroupsIntoEquivalentAddressGroup(servers);
+      if (subchannel == null || !newEag.equals(subchannel.getAddresses())) {
+        if (subchannel != null) {
+          subchannel.shutdown();
+        }
+        subchannel = helper.createSubchannel(newEag, attributes);
+        helper.updatePicker(new Picker(PickResult.withSubchannel(subchannel)));
+      }
+    }
+
+    @Override
+    public void handleNameResolutionError(Status error) {
+      helper.updatePicker(new Picker(PickResult.withError(error)));
+    }
+
+    @Override
+    public void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
+      if (subchannel != this.subchannel || stateInfo.getState() == ConnectivityState.SHUTDOWN) {
+        return;
+      }
+
+      PickResult pickResult;
+      switch (stateInfo.getState()) {
+        case TRANSIENT_FAILURE:
+          pickResult = PickResult.withError(stateInfo.getStatus());
+          break;
+        case READY:
+          pickResult = PickResult.withSubchannel(subchannel);
+          break;
+        case IDLE:
+          subchannel.requestConnection();
+          pickResult = PickResult.withSubchannel(subchannel);
+          break;
+        default:
+          pickResult = PickResult.withNoResult();
+      }
+
+      helper.updatePicker(new Picker(pickResult));
+    }
+
+    @Override
+    public void shutdown() {
+      if (subchannel != null) {
+        subchannel.shutdown();
+      }
+    }
+
+    /**
+     * Flattens list of ResolvedServerInfoGroup objects into one EquivalentAddressGroup object.
+     */
+    private static EquivalentAddressGroup flattenResolvedServerInfoGroupsIntoEquivalentAddressGroup(
+        List<ResolvedServerInfoGroup> groupList) {
+      List<SocketAddress> addrs = Lists.newArrayList();
+      for (ResolvedServerInfoGroup group : groupList) {
+        for (ResolvedServerInfo srv : group.getResolvedServerInfoList()) {
+          addrs.add(srv.getAddress());
+        }
+      }
+      return new EquivalentAddressGroup(addrs);
+    }
+
+  }
+
+  /**
+   * No-op picker which doesn't add any custom picking logic. It just passes already known result
+   * received in constructor.
+   */
+  @VisibleForTesting
+  static class Picker extends LoadBalancer2.SubchannelPicker {
+    private final LoadBalancer2.PickResult result;
+
+    Picker(LoadBalancer2.PickResult result) {
+      this.result = result;
+    }
+
+    @Override
+    public LoadBalancer2.PickResult pickSubchannel(Attributes affinity, Metadata headers) {
+      return result;
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/ResolvedServerInfo.java
+++ b/core/src/main/java/io/grpc/ResolvedServerInfo.java
@@ -124,8 +124,4 @@ public final class ResolvedServerInfo {
   public int hashCode() {
     return Objects.hashCode(address, attributes);
   }
-
-  public EquivalentAddressGroup toEquivalentAddressGroup() {
-    return new EquivalentAddressGroup(address);
-  }
 }

--- a/core/src/main/java/io/grpc/ResolvedServerInfo.java
+++ b/core/src/main/java/io/grpc/ResolvedServerInfo.java
@@ -124,4 +124,8 @@ public final class ResolvedServerInfo {
   public int hashCode() {
     return Objects.hashCode(address, attributes);
   }
+
+  public EquivalentAddressGroup toEquivalentAddressGroup() {
+    return new EquivalentAddressGroup(address);
+  }
 }

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.ConnectivityState.IDLE;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import io.grpc.Attributes;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.ExperimentalApi;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer2;
+import io.grpc.LoadBalancer2.PickResult;
+import io.grpc.LoadBalancer2.Subchannel;
+import io.grpc.LoadBalancer2.SubchannelPicker;
+import io.grpc.Metadata;
+import io.grpc.NameResolver;
+import io.grpc.ResolvedServerInfo;
+import io.grpc.ResolvedServerInfoGroup;
+import io.grpc.Status;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.Nullable;
+
+/**
+ * A {@link LoadBalancer} that provides round-robin load balancing mechanism over the
+ * addresses from the {@link NameResolver}.  The sub-lists received from the name resolver
+ * are considered to be an {@link EquivalentAddressGroup} and each of these sub-lists is
+ * what is then balanced across.
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
+public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
+  private static final RoundRobinLoadBalancerFactory2 instance =
+      new RoundRobinLoadBalancerFactory2();
+
+  private RoundRobinLoadBalancerFactory2() {
+  }
+
+  public static RoundRobinLoadBalancerFactory2 getInstance() {
+    return instance;
+  }
+
+  @Override
+  public LoadBalancer2 newLoadBalancer(LoadBalancer2.Helper helper) {
+    return new RoundRobinLoadBalancer(helper);
+  }
+
+  @VisibleForTesting
+  static class RoundRobinLoadBalancer extends LoadBalancer2 {
+    private final Helper helper;
+    private final BiMap<EquivalentAddressGroup, Subchannel> subchannels = HashBiMap.create();
+
+    @VisibleForTesting
+    static final Attributes.Key<AtomicReference<ConnectivityStateInfo>> STATE_INFO =
+        Attributes.Key.of("state-info");
+
+    public RoundRobinLoadBalancer(Helper helper) {
+      this.helper = helper;
+    }
+
+    @Override
+    public void handleResolvedAddresses(List<ResolvedServerInfoGroup> servers,
+        Attributes attributes) {
+      // Make immutable copy of current keys to avoid ConcurrentModificationException when removing
+      // adresses from the subchannels map.
+      Set<EquivalentAddressGroup> currentAddrs = ImmutableSet.copyOf(subchannels.keySet());
+      Set<EquivalentAddressGroup> latestAddrs =
+          resolvedServerInfoGroupToEquivalentAddressGroup(servers);
+      Set<EquivalentAddressGroup> addedAddrs = Sets.difference(latestAddrs, currentAddrs);
+      Set<EquivalentAddressGroup> removedAddrs = Sets.difference(currentAddrs, latestAddrs);
+
+      // NB(lukaszx0): we don't merge `attributes` with `subchannelAttr` because subchannel doesn't
+      // need them. They're describing the resolved server list but we're not taking any action
+      // based on this information.
+      Attributes subchannelAttrs = Attributes.newBuilder()
+          // NB(lukaszx0): because attributes are immutable we can't set new value for the key
+          // after creation but since we can mutate the values we leverge that and set
+          // AtomicReference which will allow mutating state info for given channel.
+          .set(STATE_INFO, new AtomicReference<ConnectivityStateInfo>(
+              ConnectivityStateInfo.forNonError(IDLE)))
+          .build();
+
+      // Create new subchannels for new addresses.
+      for (EquivalentAddressGroup addressGroup : addedAddrs) {
+        Subchannel subchannel = checkNotNull(helper.createSubchannel(addressGroup, subchannelAttrs),
+            "subchannel");
+        subchannels.put(addressGroup, subchannel);
+        subchannel.requestConnection();
+      }
+
+      // Shutdown subchannels for removed addresses.
+      for (EquivalentAddressGroup addressGroup : removedAddrs) {
+        Subchannel subchannel = subchannels.remove(addressGroup);
+        subchannel.shutdown();
+      }
+
+      updatePicker(getAggregatedError());
+    }
+
+    @Override
+    public void handleNameResolutionError(Status error) {
+      updatePicker(error);
+    }
+
+    @Override
+    public void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
+      if (!subchannels.inverse().containsKey(subchannel)) {
+        return;
+      }
+      if (stateInfo.getState() == IDLE) {
+        subchannel.requestConnection();
+      }
+      getSubchannelStateInfoRef(subchannel).set(stateInfo);
+      updatePicker(getAggregatedError());
+    }
+
+    @Override
+    public void shutdown() {
+      for (Subchannel subchannel : getSubchannels()) {
+        subchannel.shutdown();
+      }
+    }
+
+    /**
+     * Updates picker with the list of active subchannels (state != TRANSIENT_ERROR).
+     */
+    private void updatePicker(@Nullable Status error) {
+      List<Subchannel> activeList = filterFailingSubchannels(getSubchannels());
+      helper.updatePicker(new Picker(activeList, error));
+    }
+
+    /**
+     * Filters out failing subchannels (state == TRANSIENT_ERROR).
+     */
+    private static List<Subchannel> filterFailingSubchannels(Collection<Subchannel> subchannels) {
+      List<Subchannel> nonFailingSubchannels = Lists.newArrayList();
+      for (Subchannel subchannel : subchannels) {
+        if (getSubchannelStateInfoRef(subchannel).get().getState() != TRANSIENT_FAILURE) {
+          nonFailingSubchannels.add(subchannel);
+        }
+      }
+      return nonFailingSubchannels;
+    }
+
+    /**
+     * Converts list of {@link ResolvedServerInfoGroup} to {@link EquivalentAddressGroup} set.
+     */
+    private static Set<EquivalentAddressGroup> resolvedServerInfoGroupToEquivalentAddressGroup(
+        List<ResolvedServerInfoGroup> groupList) {
+      Set<EquivalentAddressGroup> addrs = Sets.newHashSet();
+      for (ResolvedServerInfoGroup group : groupList) {
+        for (ResolvedServerInfo server : group.getResolvedServerInfoList()) {
+          addrs.add(server.toEquivalentAddressGroup());
+        }
+      }
+      return addrs;
+    }
+
+    /**
+     * If all subchannels are TRANSIENT_FAILURE, return the Status associated with an arbitrary
+     * subchannel otherwise, return null.
+     */
+    @Nullable
+    private Status getAggregatedError() {
+      Status status = null;
+      for (Subchannel subchannel : getSubchannels()) {
+        ConnectivityStateInfo stateInfo = getSubchannelStateInfoRef(subchannel).get();
+        if (stateInfo.getState() != TRANSIENT_FAILURE) {
+          return null;
+        } else {
+          status = stateInfo.getStatus();
+        }
+      }
+      return status;
+    }
+
+    @VisibleForTesting
+    Collection<Subchannel> getSubchannels() {
+      return subchannels.values();
+    }
+
+    private static AtomicReference<ConnectivityStateInfo> getSubchannelStateInfoRef(
+        Subchannel subchannel) {
+      return checkNotNull(subchannel.getAttributes().get(STATE_INFO), "STATE_INFO");
+    }
+  }
+
+  @VisibleForTesting
+  static class Picker extends SubchannelPicker {
+    final Iterator<Subchannel> subchannelIterator;
+    @Nullable
+    final Status status;
+
+    Picker(Iterable<Subchannel> iterable, @Nullable Status status) {
+      this.subchannelIterator = Iterables.cycle(iterable).iterator();
+      checkArgument(subchannelIterator.hasNext() || status != null,
+          "status must be present if iterable is empty");
+      this.status = status;
+    }
+
+    @Override
+    public PickResult pickSubchannel(Attributes affinity, Metadata headers) {
+      // This will be true only if it's empty
+      if (subchannelIterator.hasNext()) {
+        return PickResult.withSubchannel(subchannelIterator.next());
+      } else {
+        return PickResult.withError(status);
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
@@ -108,9 +108,7 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
     @Override
     public void handleResolvedAddresses(List<ResolvedServerInfoGroup> servers,
         Attributes attributes) {
-      // Make immutable copy of current keys to avoid ConcurrentModificationException when removing
-      // adresses from the subchannels map.
-      Set<EquivalentAddressGroup> currentAddrs = Collections.unmodifiableSet(subchannels.keySet());
+      Set<EquivalentAddressGroup> currentAddrs = subchannels.keySet();
       Set<EquivalentAddressGroup> latestAddrs =
           resolvedServerInfoGroupToEquivalentAddressGroup(servers);
       Set<EquivalentAddressGroup> addedAddrs = setsDifference(latestAddrs, currentAddrs);

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
@@ -37,12 +37,6 @@ import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 import io.grpc.Attributes;
 import io.grpc.ConnectivityStateInfo;
@@ -59,9 +53,15 @@ import io.grpc.ResolvedServerInfo;
 import io.grpc.ResolvedServerInfoGroup;
 import io.grpc.Status;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -94,7 +94,8 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
   @VisibleForTesting
   static class RoundRobinLoadBalancer extends LoadBalancer2 {
     private final Helper helper;
-    private final BiMap<EquivalentAddressGroup, Subchannel> subchannels = HashBiMap.create();
+    private final Map<EquivalentAddressGroup, Subchannel> subchannels =
+        new HashMap<EquivalentAddressGroup, Subchannel>();
 
     @VisibleForTesting
     static final Attributes.Key<AtomicReference<ConnectivityStateInfo>> STATE_INFO =
@@ -109,11 +110,11 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
         Attributes attributes) {
       // Make immutable copy of current keys to avoid ConcurrentModificationException when removing
       // adresses from the subchannels map.
-      Set<EquivalentAddressGroup> currentAddrs = ImmutableSet.copyOf(subchannels.keySet());
+      Set<EquivalentAddressGroup> currentAddrs = Collections.unmodifiableSet(subchannels.keySet());
       Set<EquivalentAddressGroup> latestAddrs =
           resolvedServerInfoGroupToEquivalentAddressGroup(servers);
-      Set<EquivalentAddressGroup> addedAddrs = Sets.difference(latestAddrs, currentAddrs);
-      Set<EquivalentAddressGroup> removedAddrs = Sets.difference(currentAddrs, latestAddrs);
+      Set<EquivalentAddressGroup> addedAddrs = setsDifference(latestAddrs, currentAddrs);
+      Set<EquivalentAddressGroup> removedAddrs = setsDifference(currentAddrs, latestAddrs);
 
       // NB(lukaszx0): we don't merge `attributes` with `subchannelAttr` because subchannel doesn't
       // need them. They're describing the resolved server list but we're not taking any action
@@ -150,7 +151,7 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
 
     @Override
     public void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
-      if (!subchannels.inverse().containsKey(subchannel)) {
+      if (!subchannels.containsValue(subchannel)) {
         return;
       }
       if (stateInfo.getState() == IDLE) {
@@ -180,7 +181,7 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
      */
     private static List<Subchannel> filterNonFailingSubchannels(
         Collection<Subchannel> subchannels) {
-      List<Subchannel> readySubchannels = Lists.newArrayList();
+      List<Subchannel> readySubchannels = new ArrayList<Subchannel>();
       for (Subchannel subchannel : subchannels) {
         if (getSubchannelStateInfoRef(subchannel).get().getState() == READY) {
           readySubchannels.add(subchannel);
@@ -194,7 +195,7 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
      */
     private static Set<EquivalentAddressGroup> resolvedServerInfoGroupToEquivalentAddressGroup(
         List<ResolvedServerInfoGroup> groupList) {
-      Set<EquivalentAddressGroup> addrs = Sets.newHashSet();
+      Set<EquivalentAddressGroup> addrs = new HashSet<EquivalentAddressGroup>();
       for (ResolvedServerInfoGroup group : groupList) {
         for (ResolvedServerInfo server : group.getResolvedServerInfoList()) {
           addrs.add(new EquivalentAddressGroup(server.getAddress()));
@@ -230,6 +231,12 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
         Subchannel subchannel) {
       return checkNotNull(subchannel.getAttributes().get(STATE_INFO), "STATE_INFO");
     }
+
+    private static <T> Set<T> setsDifference(Set<T> a, Set<T> b) {
+      Set<T> aCopy = new HashSet<T>(a);
+      aCopy.removeAll(b);
+      return aCopy;
+    }
   }
 
   @VisibleForTesting
@@ -243,7 +250,7 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
 
     Picker(List<Subchannel> list, @Nullable Status status) {
       this.empty = list.isEmpty();
-      this.subchannelIterator = Iterables.cycle(list).iterator();
+      this.subchannelIterator = new CycleIterator<Subchannel>(list);
       this.status = status;
     }
 
@@ -258,6 +265,38 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
           return PickResult.withError(status);
         }
         return PickResult.withNoResult();
+      }
+    }
+
+    private static final class CycleIterator<T> implements Iterator<T> {
+      private final List<T> list;
+      private int index;
+
+      public CycleIterator(List<T> list) {
+        this.list = list;
+      }
+
+      @Override
+      public boolean hasNext() {
+        return !list.isEmpty();
+      }
+
+      @Override
+      public T next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        T val = list.get(index);
+        index++;
+        if (index >= list.size()) {
+          index -= list.size();
+        }
+        return val;
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
       }
     }
   }

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
@@ -197,7 +197,7 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
       Set<EquivalentAddressGroup> addrs = Sets.newHashSet();
       for (ResolvedServerInfoGroup group : groupList) {
         for (ResolvedServerInfo server : group.getResolvedServerInfoList()) {
-          addrs.add(server.toEquivalentAddressGroup());
+          addrs.add(new EquivalentAddressGroup(server.getAddress()));
         }
       }
       return addrs;

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
@@ -239,15 +239,17 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
     @Nullable
     final Status status;
 
-    Picker(Iterable<Subchannel> iterable, @Nullable Status status) {
-      this.subchannelIterator = Iterables.cycle(iterable).iterator();
+    private final boolean empty;
+
+    Picker(List<Subchannel> list, @Nullable Status status) {
+      this.empty = list.isEmpty();
+      this.subchannelIterator = Iterables.cycle(list).iterator();
       this.status = status;
     }
 
     @Override
     public PickResult pickSubchannel(Attributes affinity, Metadata headers) {
-      // This will be true only if it's empty
-      if (subchannelIterator.hasNext()) {
+      if (!empty) {
         synchronized (this) {
           return PickResult.withSubchannel(subchannelIterator.next());
         }

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
@@ -75,14 +75,14 @@ import javax.annotation.Nullable;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
-  private static final RoundRobinLoadBalancerFactory2 instance =
+  private static final RoundRobinLoadBalancerFactory2 INSTANCE =
       new RoundRobinLoadBalancerFactory2();
 
   private RoundRobinLoadBalancerFactory2() {
   }
 
   public static RoundRobinLoadBalancerFactory2 getInstance() {
-    return instance;
+    return INSTANCE;
   }
 
   @Override

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -205,7 +205,7 @@ public class PickFirstLoadBalancer2Test {
     loadBalancer.handleSubchannelState(subchannel,
         ConnectivityStateInfo.forNonError(ConnectivityState.READY));
     inOrder.verify(mockHelper).updatePicker(pickerCaptor.capture());
-    assertEquals(PickResult.withSubchannel(subchannel).getSubchannel(),
+    assertEquals(subchannel,
         pickerCaptor.getValue().pickSubchannel(Attributes.EMPTY, new Metadata()).getSubchannel());
 
     verifyNoMoreInteractions(mockHelper);
@@ -235,6 +235,9 @@ public class PickFirstLoadBalancer2Test {
         eq(Attributes.EMPTY));
     inOrder.verify(mockHelper).updatePicker(pickerCaptor.capture());
 
+    assertEquals(mockSubchannel,
+        pickerCaptor.getValue().pickSubchannel(Attributes.EMPTY, new Metadata()).getSubchannel());
+
     assertEquals(pickerCaptor.getValue().pickSubchannel(Attributes.EMPTY, new Metadata()),
         pickerCaptor.getValue().pickSubchannel(Attributes.EMPTY, new Metadata()));
 
@@ -244,10 +247,10 @@ public class PickFirstLoadBalancer2Test {
   @Test
   public void nameResolutionErrorWithStateChanges() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
-    Status error = Status.NOT_FOUND.withDescription("nameResolutionError");
 
     loadBalancer.handleSubchannelState(mockSubchannel,
         ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
+    Status error = Status.NOT_FOUND.withDescription("nameResolutionError");
     loadBalancer.handleNameResolutionError(error);
     inOrder.verify(mockHelper).updatePicker(pickerCaptor.capture());
 
@@ -258,13 +261,14 @@ public class PickFirstLoadBalancer2Test {
 
     loadBalancer.handleSubchannelState(mockSubchannel,
         ConnectivityStateInfo.forNonError(ConnectivityState.READY));
-    loadBalancer.handleNameResolutionError(error);
+    Status error2 = Status.NOT_FOUND.withDescription("nameResolutionError2");
+    loadBalancer.handleNameResolutionError(error2);
     inOrder.verify(mockHelper).updatePicker(pickerCaptor.capture());
 
     pickResult = pickerCaptor.getValue().pickSubchannel(Attributes.EMPTY,
         new Metadata());
     assertEquals(null, pickResult.getSubchannel());
-    assertEquals(error, pickResult.getStatus());
+    assertEquals(error2, pickResult.getStatus());
 
     verifyNoMoreInteractions(mockHelper);
   }

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -189,9 +189,6 @@ public class PickFirstLoadBalancer2Test {
     loadBalancer.handleSubchannelState(mockSubchannel,
         ConnectivityStateInfo.forNonError(ConnectivityState.READY));
 
-    verify(mockHelper).updatePicker(pickerCaptor.capture());
-    assertEquals(PickResult.withNoResult(),
-        pickerCaptor.getValue().pickSubchannel(affinity, new Metadata()));
     verifyNoMoreInteractions(mockHelper);
   }
 
@@ -220,7 +217,6 @@ public class PickFirstLoadBalancer2Test {
     assertEquals(PickResult.withSubchannel(subchannel).getSubchannel(), pickerCaptor.getAllValues()
         .get(3).pickSubchannel(Attributes.EMPTY, new Metadata()).getSubchannel());
 
-    verifyNoMoreInteractions(subchannel);
     verifyNoMoreInteractions(mockHelper);
   }
 

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -244,28 +244,27 @@ public class PickFirstLoadBalancer2Test {
   @Test
   public void nameResolutionErrorWithStateChanges() throws Exception {
     InOrder inOrder = inOrder(mockHelper);
+    Status error = Status.NOT_FOUND.withDescription("nameResolutionError");
 
     loadBalancer.handleSubchannelState(mockSubchannel,
         ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
-    loadBalancer.handleNameResolutionError(Status.NOT_FOUND.withDescription("nameResolutionError"));
+    loadBalancer.handleNameResolutionError(error);
     inOrder.verify(mockHelper).updatePicker(pickerCaptor.capture());
 
     PickResult pickResult = pickerCaptor.getValue().pickSubchannel(Attributes.EMPTY,
         new Metadata());
     assertEquals(null, pickResult.getSubchannel());
-    assertEquals(Status.NOT_FOUND.getCode(), pickResult.getStatus().getCode());
-    assertEquals("nameResolutionError", pickResult.getStatus().getDescription());
+    assertEquals(error, pickResult.getStatus());
 
     loadBalancer.handleSubchannelState(mockSubchannel,
         ConnectivityStateInfo.forNonError(ConnectivityState.READY));
-    loadBalancer.handleNameResolutionError(Status.NOT_FOUND.withDescription("nameResolutionError"));
+    loadBalancer.handleNameResolutionError(error);
     inOrder.verify(mockHelper).updatePicker(pickerCaptor.capture());
 
     pickResult = pickerCaptor.getValue().pickSubchannel(Attributes.EMPTY,
         new Metadata());
     assertEquals(null, pickResult.getSubchannel());
-    assertEquals(Status.NOT_FOUND.getCode(), pickResult.getStatus().getCode());
-    assertEquals("nameResolutionError", pickResult.getStatus().getDescription());
+    assertEquals(error, pickResult.getStatus());
 
     verifyNoMoreInteractions(mockHelper);
   }

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -212,6 +212,17 @@ public class PickFirstLoadBalancer2Test {
     verifyNoMoreInteractions(mockHelper);
   }
 
+  @Test
+  public void nameResolutionError() throws Exception {
+    loadBalancer.handleNameResolutionError(Status.UNKNOWN);
+    verify(mockHelper).updatePicker(pickerCaptor.capture());
+    PickResult pickResult = pickerCaptor.getValue().pickSubchannel(Attributes.EMPTY,
+        new Metadata());
+    assertEquals(null, pickResult.getSubchannel());
+    assertEquals(Status.UNKNOWN, pickResult.getStatus());
+    verifyNoMoreInteractions(mockHelper);
+  }
+
   private static class FakeSocketAddress extends SocketAddress {
     final String name;
 

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -208,12 +208,13 @@ public class PickFirstLoadBalancer2Test {
 
   @Test
   public void nameResolutionError() throws Exception {
-    loadBalancer.handleNameResolutionError(Status.UNKNOWN);
+    loadBalancer.handleNameResolutionError(Status.NOT_FOUND.withDescription("nameResolutionError"));
     verify(mockHelper).updatePicker(pickerCaptor.capture());
     PickResult pickResult = pickerCaptor.getValue().pickSubchannel(Attributes.EMPTY,
         new Metadata());
     assertEquals(null, pickResult.getSubchannel());
-    assertEquals(Status.UNKNOWN, pickResult.getStatus());
+    assertEquals(Status.NOT_FOUND.getCode(), pickResult.getStatus().getCode());
+    assertEquals("nameResolutionError", pickResult.getStatus().getDescription());
     verifyNoMoreInteractions(mockHelper);
   }
 

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -31,8 +31,6 @@
 
 package io.grpc;
 
-import static io.grpc.ConnectivityState.IDLE;
-import static io.grpc.PickFirstBalancerFactory2.PickFirstBalancer.LAST_STATE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -66,7 +64,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.net.SocketAddress;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 
 /** Unit test for {@link PickFirstBalancerFactory2}. */
@@ -98,9 +95,6 @@ public class PickFirstLoadBalancer2Test {
     }
 
     when(mockSubchannel.getAddresses()).thenReturn(new EquivalentAddressGroup(socketAddresses));
-    when(mockSubchannel.getAttributes()).thenReturn(Attributes.newBuilder()
-        .set(LAST_STATE, new AtomicReference<ConnectivityState>(IDLE))
-        .build());
     when(mockHelper.createSubchannel(any(EquivalentAddressGroup.class), any(Attributes.class)))
         .thenReturn(mockSubchannel);
 

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -197,9 +197,9 @@ public class PickFirstLoadBalancer2Test {
     loadBalancer.handleSubchannelState(subchannel,
         ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
     loadBalancer.handleSubchannelState(subchannel,
-        ConnectivityStateInfo.forNonError(ConnectivityState.READY));
-    loadBalancer.handleSubchannelState(subchannel,
         ConnectivityStateInfo.forNonError(ConnectivityState.IDLE));
+    loadBalancer.handleSubchannelState(subchannel,
+        ConnectivityStateInfo.forNonError(ConnectivityState.READY));
 
     verify(mockHelper, times(3)).updatePicker(pickerCaptor.capture());
     verify(subchannel, times(1)).requestConnection();

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+
+import io.grpc.LoadBalancer2.Helper;
+import io.grpc.LoadBalancer2.PickResult;
+import io.grpc.LoadBalancer2.Subchannel;
+import io.grpc.PickFirstBalancerFactory2.Picker;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+
+/** Unit test for {@link PickFirstBalancerFactory2}. */
+@RunWith(JUnit4.class)
+public class PickFirstLoadBalancer2Test {
+  private LoadBalancer2 loadBalancer;
+  private List<ResolvedServerInfoGroup> servers = Lists.newArrayList();
+  private List<SocketAddress> socketAddresses = Lists.newArrayList();
+  private static Attributes.Key<String> MAJOR_KEY = Attributes.Key.of("major-key");
+  private Attributes affinity = Attributes.newBuilder().set(MAJOR_KEY, "I got the keys").build();
+
+  @Captor
+  private ArgumentCaptor<EquivalentAddressGroup> eagCaptor;
+  @Captor
+  private ArgumentCaptor<Picker> pickerCaptor;
+  @Mock
+  private Helper mockHelper;
+  @Mock
+  private Subchannel mockSubchannel;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    for (int i = 0; i < 3; i++) {
+      SocketAddress addr = new FakeSocketAddress("server" + i);
+      servers.add(ResolvedServerInfoGroup.builder().add(new ResolvedServerInfo(addr)).build());
+      socketAddresses.add(addr);
+    }
+
+    when(mockSubchannel.getAddresses()).thenReturn(new EquivalentAddressGroup(socketAddresses));
+    when(mockHelper.createSubchannel(any(EquivalentAddressGroup.class), any(Attributes.class)))
+        .thenReturn(mockSubchannel);
+
+    loadBalancer = PickFirstBalancerFactory2.getInstance().newLoadBalancer(mockHelper);
+  }
+
+  @Test
+  public void pickAfterResolved() throws Exception {
+    loadBalancer.handleResolvedAddresses(servers, affinity);
+
+    verify(mockHelper).createSubchannel(eagCaptor.capture(), eq(affinity));
+    verify(mockHelper).updatePicker(pickerCaptor.capture());
+
+    assertEquals(new EquivalentAddressGroup(socketAddresses), eagCaptor.getValue());
+    assertEquals(pickerCaptor.getValue().pickSubchannel(affinity, new Metadata()),
+        pickerCaptor.getValue().pickSubchannel(affinity, new Metadata()));
+
+    verifyNoMoreInteractions(mockHelper);
+  }
+
+
+  @Test
+  public void pickAfterResolvedAndUnchanged() throws Exception {
+    loadBalancer.handleResolvedAddresses(servers, affinity);
+    loadBalancer.handleResolvedAddresses(servers, affinity);
+
+    verify(mockHelper, times(1)).createSubchannel(any(EquivalentAddressGroup.class),
+        any(Attributes.class));
+    verify(mockHelper, times(1)).updatePicker(isA(Picker.class));
+
+    verifyNoMoreInteractions(mockHelper);
+  }
+
+  @Test
+  public void pickAfterResolvedAndChanged() throws Exception {
+    SocketAddress socketAddr = new FakeSocketAddress("newserver");
+    List<SocketAddress> newSocketAddresses = Lists.newArrayList(socketAddr);
+    List<ResolvedServerInfoGroup> newServers = Lists.newArrayList(
+        ResolvedServerInfoGroup.builder().add(new ResolvedServerInfo(socketAddr)).build());
+
+    final Subchannel oldSubchannel = mock(Subchannel.class);
+    final EquivalentAddressGroup oldEag = new EquivalentAddressGroup(socketAddresses);
+    when(oldSubchannel.getAddresses()).thenReturn(oldEag);
+
+    final Subchannel newSubchannel = mock(Subchannel.class);
+    final EquivalentAddressGroup newEag = new EquivalentAddressGroup(newSocketAddresses);
+    when(newSubchannel.getAddresses()).thenReturn(newEag);
+
+    when(mockHelper.createSubchannel(any(EquivalentAddressGroup.class), any(Attributes.class)))
+        .then(new Answer<Subchannel>() {
+          @Override
+          public Subchannel answer(InvocationOnMock invocation) throws Throwable {
+            Object[] args = invocation.getArguments();
+            EquivalentAddressGroup eag = (EquivalentAddressGroup) args[0];
+            if (eag.equals(oldEag)) {
+              return oldSubchannel;
+            } else if (eag.equals(newEag)) {
+              return newSubchannel;
+            }
+            throw new IllegalArgumentException();
+          }
+        });
+
+    loadBalancer.handleResolvedAddresses(servers, affinity);
+    loadBalancer.handleResolvedAddresses(newServers, affinity);
+
+    verify(mockHelper, times(2)).createSubchannel(eagCaptor.capture(), eq(affinity));
+    verify(mockHelper, times(2)).updatePicker(pickerCaptor.capture());
+
+    assertEquals(socketAddresses, eagCaptor.getAllValues().get(0).getAddresses());
+    assertEquals(newSocketAddresses, eagCaptor.getAllValues().get(1).getAddresses());
+
+    Subchannel subchannel = pickerCaptor.getAllValues().get(0).pickSubchannel(
+        affinity, new Metadata()).getSubchannel();
+    assertEquals(oldSubchannel, subchannel);
+
+    Subchannel subchannel2 = pickerCaptor.getAllValues().get(1).pickSubchannel(affinity,
+        new Metadata()).getSubchannel();
+    assertEquals(newSubchannel, subchannel2);
+    verify(subchannel2, never()).shutdown();
+
+    verifyNoMoreInteractions(mockHelper);
+  }
+
+  @Test
+  public void stateChangeBeforeResolution() throws Exception {
+    loadBalancer.handleSubchannelState(mockSubchannel,
+        ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+
+    verifyNoMoreInteractions(mockSubchannel);
+    verifyNoMoreInteractions(mockHelper);
+  }
+
+  @Test
+  public void pickAfterStateChangeAfterResolution() throws Exception {
+    loadBalancer.handleResolvedAddresses(servers, affinity);
+    verify(mockHelper).updatePicker(pickerCaptor.capture());
+    Subchannel subchannel = pickerCaptor.getValue().pickSubchannel(affinity,
+        new Metadata()).getSubchannel();
+    reset(mockHelper);
+
+    loadBalancer.handleSubchannelState(subchannel,
+        ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE));
+    loadBalancer.handleSubchannelState(subchannel,
+        ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+    loadBalancer.handleSubchannelState(subchannel,
+        ConnectivityStateInfo.forNonError(ConnectivityState.IDLE));
+
+    verify(mockHelper, times(3)).updatePicker(pickerCaptor.capture());
+    verify(subchannel, times(1)).requestConnection();
+
+    assertEquals(Status.UNAVAILABLE,
+        pickerCaptor.getAllValues().get(1).pickSubchannel(Attributes.EMPTY,
+            new Metadata()).getStatus());
+    assertEquals(Status.OK, pickerCaptor.getAllValues().get(2).pickSubchannel(Attributes.EMPTY,
+        new Metadata()).getStatus());
+    assertEquals(PickResult.withSubchannel(subchannel).getSubchannel(), pickerCaptor.getAllValues()
+        .get(3).pickSubchannel(Attributes.EMPTY, new Metadata()).getSubchannel());
+
+    verifyNoMoreInteractions(subchannel);
+    verifyNoMoreInteractions(mockHelper);
+  }
+
+  private static class FakeSocketAddress extends SocketAddress {
+    final String name;
+
+    FakeSocketAddress(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return "FakeSocketAddress-" + name;
+    }
+  }
+}

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -39,14 +39,11 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
-
-import com.sun.tools.javac.comp.Attr;
 
 import io.grpc.LoadBalancer2.Helper;
 import io.grpc.LoadBalancer2.PickResult;

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -202,7 +202,6 @@ public class PickFirstLoadBalancer2Test {
         ConnectivityStateInfo.forNonError(ConnectivityState.READY));
 
     verify(mockHelper, times(3)).updatePicker(pickerCaptor.capture());
-    verify(subchannel, times(1)).requestConnection();
 
     assertEquals(Status.UNAVAILABLE,
         pickerCaptor.getAllValues().get(1).pickSubchannel(Attributes.EMPTY,

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancer2Test.java
@@ -74,7 +74,9 @@ public class PickFirstLoadBalancer2Test {
   private PickFirstBalancer loadBalancer;
   private List<ResolvedServerInfoGroup> servers = Lists.newArrayList();
   private List<SocketAddress> socketAddresses = Lists.newArrayList();
-  private Attributes affinity = Attributes.EMPTY;
+
+  private static Attributes.Key<String> FOO = Attributes.Key.of("foo");
+  private Attributes affinity = Attributes.newBuilder().set(FOO, "bar").build();
 
   @Captor
   private ArgumentCaptor<EquivalentAddressGroup> eagCaptor;

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancer2Test.java
@@ -65,7 +65,6 @@ import io.grpc.Status;
 import io.grpc.util.RoundRobinLoadBalancerFactory2.Picker;
 import io.grpc.util.RoundRobinLoadBalancerFactory2.RoundRobinLoadBalancer;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancer2Test.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.ConnectivityState.IDLE;
+import static io.grpc.util.RoundRobinLoadBalancerFactory2.RoundRobinLoadBalancer.STATE_INFO;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer2.Helper;
+import io.grpc.LoadBalancer2.Subchannel;
+import io.grpc.Metadata;
+import io.grpc.ResolvedServerInfo;
+import io.grpc.ResolvedServerInfoGroup;
+import io.grpc.Status;
+import io.grpc.util.RoundRobinLoadBalancerFactory2.Picker;
+import io.grpc.util.RoundRobinLoadBalancerFactory2.RoundRobinLoadBalancer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Unit test for {@link RoundRobinLoadBalancerFactory2}. */
+@RunWith(JUnit4.class)
+public class RoundRobinLoadBalancer2Test {
+  private RoundRobinLoadBalancer loadBalancer;
+  private Map<ResolvedServerInfoGroup, EquivalentAddressGroup> servers = Maps.newHashMap();
+  private Map<EquivalentAddressGroup, Subchannel> subchannels = Maps.newLinkedHashMap();
+  private static Attributes.Key<String> MAJOR_KEY = Attributes.Key.of("major-key");
+  private Attributes affinity = Attributes.newBuilder().set(MAJOR_KEY, "I got the keys").build();
+  private Attributes subchannelInitialAttrs = Attributes.newBuilder().set(STATE_INFO,
+      new AtomicReference<ConnectivityStateInfo>(
+          ConnectivityStateInfo.forNonError(IDLE))).build();
+
+  @Captor
+  private ArgumentCaptor<Picker> pickerCaptor;
+  @Captor
+  private ArgumentCaptor<Attributes> attrsCaptor;
+  @Mock
+  private Helper mockHelper;
+  @Mock
+  private Subchannel mockSubchannel;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    for (int i = 0; i < 3; i++) {
+      SocketAddress addr = new FakeSocketAddress("server" + i);
+      EquivalentAddressGroup eag = new EquivalentAddressGroup(addr);
+      servers.put(ResolvedServerInfoGroup.builder().add(new ResolvedServerInfo(addr)).build(), eag);
+      subchannels.put(eag, createMockSubchannel());
+    }
+
+    when(mockHelper.createSubchannel(any(EquivalentAddressGroup.class), any(Attributes.class)))
+        .then(new Answer<Subchannel>() {
+          @Override
+          public Subchannel answer(InvocationOnMock invocation) throws Throwable {
+            Object[] args = invocation.getArguments();
+            return subchannels.get(args[0]);
+          }
+        });
+
+    loadBalancer = (RoundRobinLoadBalancer) RoundRobinLoadBalancerFactory2.getInstance()
+        .newLoadBalancer(mockHelper);
+  }
+
+  @Test
+  public void pickAfterResolved() throws Exception {
+    loadBalancer.handleResolvedAddresses(Lists.newArrayList(servers.keySet()), affinity);
+
+    verify(mockHelper, times(3)).createSubchannel(any(EquivalentAddressGroup.class),
+        any(Attributes.class));
+
+    for (Subchannel subchannel : subchannels.values()) {
+      verify(subchannel).requestConnection();
+      verify(subchannel, never()).shutdown();
+    }
+
+    verify(mockHelper, times(1)).updatePicker(pickerCaptor.capture());
+
+    Iterator<Subchannel> subchannelIterator = pickerCaptor.getValue().subchannelIterator;
+    assertTrue(Lists.newArrayList(subchannelIterator.next(), subchannelIterator.next(),
+        subchannelIterator.next()).containsAll(subchannels.values()));
+
+    verifyNoMoreInteractions(mockHelper);
+  }
+
+  @Test
+  public void pickAfterResolvedUpdatedHosts() throws Exception {
+    Subchannel removedSubchannel = mock(Subchannel.class);
+    Subchannel oldSubchannel = mock(Subchannel.class);
+    Subchannel newSubchannel = mock(Subchannel.class);
+
+    for (Subchannel subchannel : Lists.newArrayList(removedSubchannel, oldSubchannel,
+        newSubchannel)) {
+      when(subchannel.getAttributes()).thenReturn(subchannelInitialAttrs);
+    }
+
+    FakeSocketAddress removedAddr = new FakeSocketAddress("removed");
+    FakeSocketAddress oldAddr = new FakeSocketAddress("old");
+    FakeSocketAddress newAddr = new FakeSocketAddress("new");
+
+    final Map<EquivalentAddressGroup, Subchannel> subchannels2 = Maps.newHashMap();
+    subchannels2.put(new EquivalentAddressGroup(removedAddr), removedSubchannel);
+    subchannels2.put(new EquivalentAddressGroup(oldAddr), oldSubchannel);
+
+    List<ResolvedServerInfoGroup> currentServers = Lists.newArrayList(
+        ResolvedServerInfoGroup.builder()
+            .add(new ResolvedServerInfo(removedAddr))
+            .add(new ResolvedServerInfo(oldAddr))
+            .build());
+
+    when(mockHelper.createSubchannel(any(EquivalentAddressGroup.class), any(Attributes.class)))
+        .then(new Answer<Subchannel>() {
+          @Override
+          public Subchannel answer(InvocationOnMock invocation) throws Throwable {
+            Object[] args = invocation.getArguments();
+            return subchannels2.get(args[0]);
+          }
+        });
+
+    loadBalancer.handleResolvedAddresses(currentServers, affinity);
+
+    verify(mockHelper, times(1)).updatePicker(pickerCaptor.capture());
+    verify(removedSubchannel, times(1)).requestConnection();
+    verify(oldSubchannel, times(1)).requestConnection();
+
+    assertThat(loadBalancer.getSubchannels()).containsExactly(removedSubchannel,
+        oldSubchannel);
+
+    subchannels2.clear();
+    subchannels2.put(new EquivalentAddressGroup(oldAddr), oldSubchannel);
+    subchannels2.put(new EquivalentAddressGroup(newAddr), newSubchannel);
+
+    List<ResolvedServerInfoGroup> latestServers = Lists.newArrayList(
+        ResolvedServerInfoGroup.builder()
+            .add(new ResolvedServerInfo(oldAddr))
+            .add(new ResolvedServerInfo(newAddr))
+            .build());
+
+    loadBalancer.handleResolvedAddresses(latestServers, affinity);
+
+    verify(newSubchannel, times(1)).requestConnection();
+    verify(removedSubchannel, times(1)).shutdown();
+
+    assertThat(loadBalancer.getSubchannels()).containsExactly(oldSubchannel,
+        newSubchannel);
+
+    verify(mockHelper, times(3)).createSubchannel(any(EquivalentAddressGroup.class),
+        any(Attributes.class));
+    verify(mockHelper, times(2)).updatePicker(pickerCaptor.capture());
+
+    verifyNoMoreInteractions(mockHelper);
+  }
+
+  @Test
+  public void pickAfterStateChangeBeforeResolution() throws Exception {
+    loadBalancer.handleSubchannelState(mockSubchannel,
+        ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+    verifyNoMoreInteractions(mockSubchannel);
+    verifyNoMoreInteractions(mockHelper);
+  }
+
+  @Test
+  public void pickAfterStateChangeAndResolutionError() throws Exception {
+    loadBalancer.handleSubchannelState(mockSubchannel,
+        ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+    verifyNoMoreInteractions(mockSubchannel);
+    verifyNoMoreInteractions(mockHelper);
+  }
+
+  @Test
+  public void pickAfterStateChange() throws Exception {
+    when(mockHelper.createSubchannel(any(EquivalentAddressGroup.class), any(Attributes.class)))
+        .then(new Answer<Subchannel>() {
+          @Override
+          public Subchannel answer(InvocationOnMock invocation) throws Throwable {
+            return createMockSubchannel();
+          }
+        });
+    loadBalancer.handleResolvedAddresses(Lists.newArrayList(servers.keySet()), Attributes.EMPTY);
+    verify(mockHelper, times(1)).updatePicker(isA(Picker.class));
+
+    Subchannel subchannel = loadBalancer.getSubchannels().iterator().next();
+    AtomicReference<ConnectivityStateInfo> subchannelStateInfo = subchannel.getAttributes().get(
+        STATE_INFO);
+
+    assertThat(subchannelStateInfo.get()).isEqualTo(ConnectivityStateInfo.forNonError(IDLE));
+
+    loadBalancer.handleSubchannelState(subchannel,
+        ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+
+    assertThat(subchannelStateInfo.get()).isEqualTo(
+        ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+
+    loadBalancer.handleSubchannelState(subchannel,
+        ConnectivityStateInfo.forTransientFailure(Status.UNKNOWN));
+
+    assertThat(subchannelStateInfo.get()).isEqualTo(
+        ConnectivityStateInfo.forTransientFailure(Status.UNKNOWN));
+  }
+
+  @Test
+  public void pickerRoundRobin() throws Exception {
+    Subchannel subchannel = mock(Subchannel.class);
+    Subchannel subchannel1 = mock(Subchannel.class);
+    Subchannel subchannel2 = mock(Subchannel.class);
+
+    Picker picker = new Picker(Collections.unmodifiableList(
+        Lists.<Subchannel>newArrayList(subchannel, subchannel1, subchannel2)), null);
+
+    assertEquals(subchannel,
+        picker.pickSubchannel(Attributes.EMPTY, new Metadata()).getSubchannel());
+    assertEquals(subchannel1,
+        picker.pickSubchannel(Attributes.EMPTY, new Metadata()).getSubchannel());
+    assertEquals(subchannel2,
+        picker.pickSubchannel(Attributes.EMPTY, new Metadata()).getSubchannel());
+    assertEquals(subchannel,
+        picker.pickSubchannel(Attributes.EMPTY, new Metadata()).getSubchannel());
+  }
+
+  @Test
+  public void pickerEmptyList() throws Exception {
+    Picker picker = new Picker(Lists.<Subchannel>newArrayList(), Status.UNKNOWN);
+
+    assertEquals(null, picker.pickSubchannel(Attributes.EMPTY, new Metadata()).getSubchannel());
+    assertEquals(Status.UNKNOWN,
+        picker.pickSubchannel(Attributes.EMPTY, new Metadata()).getStatus());
+  }
+
+  private Subchannel createMockSubchannel() {
+    Subchannel subchannel = mock(Subchannel.class);
+    when(subchannel.getAttributes()).thenReturn(subchannelInitialAttrs);
+    return subchannel;
+  }
+
+  private static class FakeSocketAddress extends SocketAddress {
+    final String name;
+
+    FakeSocketAddress(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return "FakeSocketAddress-" + name;
+    }
+  }
+}

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancer2Test.java
@@ -194,7 +194,7 @@ public class RoundRobinLoadBalancer2Test {
     inOrder.verify(mockHelper).updatePicker(pickerCaptor.capture());
     Picker picker = pickerCaptor.getValue();
     assertNull(picker.status);
-    assertThat(picker.getList()).containsAllOf(removedSubchannel, oldSubchannel);
+    assertThat(picker.getList()).containsExactly(removedSubchannel, oldSubchannel);
 
     verify(removedSubchannel, times(1)).requestConnection();
     verify(oldSubchannel, times(1)).requestConnection();
@@ -226,7 +226,7 @@ public class RoundRobinLoadBalancer2Test {
 
     picker = pickerCaptor.getValue();
     assertNull(picker.status);
-    assertThat(picker.getList()).containsAllOf(oldSubchannel, newSubchannel);
+    assertThat(picker.getList()).containsExactly(oldSubchannel, newSubchannel);
 
     verifyNoMoreInteractions(mockHelper);
   }

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancer2Test.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancer2Test.java
@@ -62,6 +62,7 @@ import io.grpc.Status;
 import io.grpc.util.RoundRobinLoadBalancerFactory2.Picker;
 import io.grpc.util.RoundRobinLoadBalancerFactory2.RoundRobinLoadBalancer;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -91,6 +92,8 @@ public class RoundRobinLoadBalancer2Test {
 
   @Captor
   private ArgumentCaptor<Picker> pickerCaptor;
+  @Captor
+  private ArgumentCaptor<EquivalentAddressGroup> eagCaptor;
   @Captor
   private ArgumentCaptor<Attributes> attrsCaptor;
   @Mock
@@ -131,11 +134,10 @@ public class RoundRobinLoadBalancer2Test {
         .build());
     loadBalancer.handleResolvedAddresses(Lists.newArrayList(servers.keySet()), affinity);
 
-
-
-    verify(mockHelper, times(3)).createSubchannel(any(EquivalentAddressGroup.class),
+    verify(mockHelper, times(3)).createSubchannel(eagCaptor.capture(),
         any(Attributes.class));
 
+    assertThat(eagCaptor.getAllValues()).containsAllIn(subchannels.keySet());
     for (Subchannel subchannel : subchannels.values()) {
       verify(subchannel).requestConnection();
       verify(subchannel, never()).shutdown();


### PR DESCRIPTION
This PR ports existing `PickFirst` and `RoundRobin` LBs to use v2 API.

@ejona86 @zhangkun83 @kkaneda @maniksurtani 