### PR TITLE
core,netty: add a log id to the server and server transports

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -84,9 +84,10 @@ import javax.annotation.concurrent.GuardedBy;
  * <p>Starting the server starts the underlying transport for servicing requests. Stopping the
  * server stops servicing new requests and waits for all connections to terminate.
  */
-public final class ServerImpl extends io.grpc.Server {
+public final class ServerImpl extends io.grpc.Server implements WithLogId {
   private static final ServerStreamListener NOOP_LISTENER = new NoopListener();
 
+  private final LogId logId = LogId.allocate(getClass().getName());
   /** Executor for application processing. Safe to read after {@link #start()}. */
   private Executor executor;
   /** Safe to read after {@link #start()}. */
@@ -481,6 +482,11 @@ public final class ServerImpl extends io.grpc.Server {
       }
       return call.newServerStreamListener(listener);
     }
+  }
+
+  @Override
+  public LogId getLogId() {
+    return logId;
   }
 
   private static class NoopListener implements ServerStreamListener {

--- a/core/src/main/java/io/grpc/internal/ServerTransport.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransport.java
@@ -34,7 +34,7 @@ package io.grpc.internal;
 import io.grpc.Status;
 
 /** An inbound connection. */
-public interface ServerTransport {
+public interface ServerTransport extends WithLogId {
   /**
    * Initiates an orderly shutdown of the transport. Existing streams continue, but new streams will
    * eventually begin failing. New streams "eventually" begin failing because shutdown may need to

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -77,8 +77,8 @@ import io.grpc.ServerTransportFilter;
 import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
 import io.grpc.StringMarshaller;
-import io.grpc.internal.testing.CensusTestUtils.FakeCensusContextFactory;
 import io.grpc.internal.testing.CensusTestUtils;
+import io.grpc.internal.testing.CensusTestUtils.FakeCensusContextFactory;
 import io.grpc.util.MutableHandlerRegistry;
 
 import org.junit.After;
@@ -953,6 +953,11 @@ public class ServerImplTest {
     @Override
     public void shutdownNow(Status status) {
       listener.transportTerminated();
+    }
+
+    @Override
+    public LogId getLogId() {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -34,6 +34,7 @@ package io.grpc.netty;
 import com.google.common.base.Preconditions;
 
 import io.grpc.Status;
+import io.grpc.internal.LogId;
 import io.grpc.internal.ServerTransport;
 import io.grpc.internal.ServerTransportListener;
 import io.netty.channel.Channel;
@@ -50,6 +51,7 @@ import java.util.logging.Logger;
 class NettyServerTransport implements ServerTransport {
   private static final Logger log = Logger.getLogger(NettyServerTransport.class.getName());
 
+  private final LogId logId = LogId.allocate(getClass().getName());
   private final Channel channel;
   private final ProtocolNegotiator protocolNegotiator;
   private final int maxStreams;
@@ -101,6 +103,11 @@ class NettyServerTransport implements ServerTransport {
     if (channel.isOpen()) {
       channel.writeAndFlush(new ForcefulCloseCommand(reason));
     }
+  }
+
+  @Override
+  public LogId getLogId() {
+    return logId;
   }
 
   /**


### PR DESCRIPTION
This will act as the loggable name for channel/subchannel tracing but for the server side.  Servers/Transports will each get a unique ID from this as well.