### PR TITLE
core: handle a race in DelayedClientTransport.

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport2.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport2.java
@@ -1,0 +1,540 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+import io.grpc.CallOptions;
+import io.grpc.Context;
+import io.grpc.LoadBalancer2;
+import io.grpc.LoadBalancer2.PickResult;
+import io.grpc.LoadBalancer2.Subchannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * A client transport that queues requests before a real transport is available. When a backing
+ * transport supplier is later provided, this class delegates to the transports from it.
+ *
+ * <p>This transport owns the streams that it has created before {@link #setTransport} is
+ * called. When {@link #setTransport} is called, the ownership of pending streams and subsequent new
+ * streams are transferred to the given transport, thus this transport won't own any stream.
+ */
+class DelayedClientTransport implements ManagedClientTransport {
+
+  private final LogId lodId = LogId.allocate(getClass().getName());
+
+  private final Object lock = new Object();
+
+  private final Executor streamCreationExecutor;
+
+  private Listener listener;
+  /** 'lock' must be held when assigning to transportSupplier. */
+  private volatile Supplier<ClientTransport> transportSupplier;
+
+  @GuardedBy("lock")
+  private Collection<PendingStream> pendingStreams = new LinkedHashSet<PendingStream>();
+
+  // TODO(zhangkun83): remove it once LBv2 refactor is done.  In practice ping() is only called on
+  // real transports.
+  @GuardedBy("lock")
+  private Collection<PendingPing> pendingPings = new ArrayList<PendingPing>();
+
+  /**
+   * When shutdown == true and pendingStreams == null, then the transport is considered terminated.
+   */
+  @GuardedBy("lock")
+  private boolean shutdown;
+
+  /**
+   * The delayed client transport will come into a back-off interval if it fails to establish a real
+   * transport for all addresses, namely the channel is in TRANSIENT_FAILURE. When in a back-off
+   * interval, {@code backoffStatus != null}.
+   *
+   * <p>If the transport is in a back-off interval, then all fail fast streams (including the
+   * pending as well as new ones) will fail immediately. New non-fail fast streams can be created as
+   * {@link PendingStream} and will keep pending during this back-off period.
+   */
+  @GuardedBy("lock")
+  @Nullable
+  private Status backoffStatus;
+
+  DelayedClientTransport(Executor streamCreationExecutor) {
+    this.streamCreationExecutor = streamCreationExecutor;
+  }
+
+  @Override
+  public final Runnable start(Listener listener) {
+    this.listener = Preconditions.checkNotNull(listener, "listener");
+    return null;
+  }
+
+  /**
+   * If the transport has acquired a transport {@link Supplier}, then returned stream is delegated
+   * from its supplier.
+   *
+   * <p>If the new stream to be created is with fail fast call option and the delayed transport is
+   * in a back-off interval, then a {@link FailingClientStream} is returned.
+   *
+   * <p>If it is not the above cases and the delayed transport is not shutdown, then a
+   * {@link PendingStream} is returned; if the transport is shutdown, then a
+   * {@link FailingClientStream} is returned.
+   */
+  @Override
+  public final ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers,
+      CallOptions callOptions, StatsTraceContext statsTraceCtx) {
+    Supplier<ClientTransport> supplier = transportSupplier;
+    if (supplier == null) {
+      synchronized (lock) {
+        // Check again, since it may have changed while waiting for lock
+        supplier = transportSupplier;
+        if (supplier == null && !shutdown) {
+          if (backoffStatus != null && !callOptions.isWaitForReady()) {
+            return new FailingClientStream(backoffStatus);
+          }
+          PendingStream pendingStream = new PendingStream(method, headers, callOptions,
+              statsTraceCtx);
+          pendingStreams.add(pendingStream);
+          if (pendingStreams.size() == 1) {
+            listener.transportInUse(true);
+          }
+          return pendingStream;
+        }
+      }
+    }
+    if (supplier != null) {
+      return supplier.get().newStream(method, headers, callOptions, statsTraceCtx);
+    }
+    return new FailingClientStream(Status.UNAVAILABLE.withDescription("transport shutdown"));
+  }
+
+  @Override
+  public final ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
+    return newStream(method, headers, CallOptions.DEFAULT, StatsTraceContext.NOOP);
+  }
+
+  @Override
+  public final void ping(final PingCallback callback, Executor executor) {
+    Supplier<ClientTransport> supplier = transportSupplier;
+    if (supplier == null) {
+      synchronized (lock) {
+        // Check again, since it may have changed while waiting for lock
+        supplier = transportSupplier;
+        if (supplier == null && !shutdown) {
+          PendingPing pendingPing = new PendingPing(callback, executor);
+          pendingPings.add(pendingPing);
+          return;
+        }
+      }
+    }
+    if (supplier != null) {
+      supplier.get().ping(callback, executor);
+      return;
+    }
+    executor.execute(new Runnable() {
+        @Override public void run() {
+          callback.onFailure(
+              Status.UNAVAILABLE.withDescription("transport shutdown").asException());
+        }
+      });
+  }
+
+  /**
+   * Prevents creating any new streams until {@link #setTransport} is called. Buffered streams are
+   * not failed, so if {@link #shutdown} is called when {@link #setTransport} has not been called,
+   * you still need to call {@link #setTransport} to make this transport terminated.
+   */
+  @Override
+  public final void shutdown() {
+    synchronized (lock) {
+      if (shutdown) {
+        return;
+      }
+      shutdown = true;
+      listener.transportShutdown(
+          Status.UNAVAILABLE.withDescription("Channel requested transport to shut down"));
+      if (pendingStreams == null || pendingStreams.isEmpty()) {
+        pendingStreams = null;
+        listener.transportTerminated();
+      }
+    }
+  }
+
+  /**
+   * Shuts down this transport and cancels all streams that it owns, hence immediately terminates
+   * this transport.
+   */
+  @Override
+  public final void shutdownNow(Status status) {
+    shutdown();
+    Collection<PendingStream> savedPendingStreams = null;
+    synchronized (lock) {
+      if (pendingStreams != null) {
+        savedPendingStreams = pendingStreams;
+        pendingStreams = null;
+      }
+    }
+    if (savedPendingStreams != null) {
+      for (PendingStream stream : savedPendingStreams) {
+        stream.cancel(status);
+      }
+      listener.transportTerminated();
+    }
+    // If savedPendingStreams == null, transportTerminated() has already been called in shutdown().
+  }
+
+  /**
+   * Transfers all the pending and future streams and pings to the given transport.
+   *
+   * <p>May only be called after {@link #start(Listener)}.
+   *
+   * <p>{@code transport} will be used for all future calls to {@link #newStream}, even if this
+   * transport is {@link #shutdown}.
+   */
+  public final void setTransport(ClientTransport transport) {
+    Preconditions.checkArgument(this != transport,
+        "delayed transport calling setTransport on itself");
+    setTransportSupplier(Suppliers.ofInstance(transport));
+  }
+
+  /**
+   * Transfers all the pending and future streams and pings to the transports from the given {@link
+   * Supplier}.
+   *
+   * <p>May only be called after {@link #start}. No effect if already called.
+   *
+   * <p>Each stream or ping will result in an invocation to {@link Supplier#get} once. The supplier
+   * will be used for all future calls to {@link #newStream}, even if this transport is {@link
+   * #shutdown}.
+   */
+  public final void setTransportSupplier(final Supplier<ClientTransport> supplier) {
+    synchronized (lock) {
+      if (transportSupplier != null) {
+        return;
+      }
+      Preconditions.checkState(listener != null, "start() not called");
+      transportSupplier = Preconditions.checkNotNull(supplier, "supplier");
+      for (PendingPing ping : pendingPings) {
+        ping.createRealPing(supplier.get());
+      }
+      pendingPings = null;
+      if (shutdown && pendingStreams != null) {
+        listener.transportTerminated();
+      }
+      if (pendingStreams != null && !pendingStreams.isEmpty()) {
+        final Collection<PendingStream> savedPendingStreams = pendingStreams;
+        // createRealStream may be expensive. It will start real streams on the transport. If there
+        // are pending requests, they will be serialized too, which may be expensive. Since we are
+        // now on transport thread, we need to offload the work to an executor.
+        streamCreationExecutor.execute(new Runnable() {
+            @Override public void run() {
+              for (final PendingStream stream : savedPendingStreams) {
+                stream.createRealStream(supplier.get());
+              }
+              // TODO(zhangkun83): some transports (e.g., netty) may have a short delay between
+              // stream.start() and transportInUse(true). If netty's transportInUse(true) is called
+              // after the delayed transport's transportInUse(false), the channel may have a brief
+              // period where all transports are not in-use, and may go to IDLE mode unexpectedly if
+              // the IDLE timeout is shorter (e.g., 0) than that brief period. Maybe we should
+              // have a minimum IDLE timeout?
+              synchronized (lock) {
+                listener.transportInUse(false);
+              }
+            }
+        });
+      }
+      pendingStreams = null;
+      if (!shutdown) {
+        listener.transportReady();
+      }
+    }
+  }
+
+  public final boolean hasPendingStreams() {
+    synchronized (lock) {
+      return pendingStreams != null && !pendingStreams.isEmpty();
+    }
+  }
+
+  @VisibleForTesting
+  final int getPendingStreamsCount() {
+    synchronized (lock) {
+      return pendingStreams == null ? 0 : pendingStreams.size();
+    }
+  }
+
+  /**
+   * True return value indicates that the delayed transport is in a back-off interval (in
+   * TRANSIENT_FAILURE), that all fail fast streams (including pending as well as new ones) should
+   * fail immediately, and that non-fail fast streams can be created as {@link PendingStream} and
+   * should keep pending during this back-off period.
+   */
+  // TODO(zhangkun83): remove it once the LBv2 refactor is done.
+  @VisibleForTesting
+  final boolean isInBackoffPeriod() {
+    synchronized (lock) {
+      return backoffStatus != null;
+    }
+  }
+
+  /**
+   * Is only called at the beginning of {@link TransportSet#scheduleBackoff}.
+   *
+   * <p>Does jobs at the beginning of the back-off:
+   *
+   * <p>sets {@link #backoffStatus};
+   *
+   * <p>sets all pending streams with a fail fast call option of the delayed transport as
+   * {@link FailingClientStream}s, and removes them from the list of pending streams of the
+   * transport.
+   *
+   * @param status the causal status for triggering back-off.
+   */
+  // TODO(zhangkun83): remove it once the LBv2 refactor is done.
+  final void startBackoff(final Status status) {
+    synchronized (lock) {
+      if (shutdown) {
+        return;
+      }
+      Preconditions.checkState(backoffStatus == null,
+          "Error when calling startBackoff: transport is already in backoff period");
+      backoffStatus = Status.UNAVAILABLE.withDescription("Channel in TRANSIENT_FAILURE state")
+          .withCause(status.asRuntimeException());
+      final ArrayList<PendingStream> failFastPendingStreams = new ArrayList<PendingStream>();
+      if (pendingStreams != null && !pendingStreams.isEmpty()) {
+        final Iterator<PendingStream> it = pendingStreams.iterator();
+        while (it.hasNext()) {
+          PendingStream stream = it.next();
+          if (!stream.callOptions.isWaitForReady()) {
+            failFastPendingStreams.add(stream);
+            it.remove();
+          }
+        }
+
+        class FailTheFailFastPendingStreams implements Runnable {
+          @Override
+          public void run() {
+            for (PendingStream stream : failFastPendingStreams) {
+              stream.setStream(new FailingClientStream(status));
+            }
+          }
+        }
+
+        streamCreationExecutor.execute(new FailTheFailFastPendingStreams());
+      }
+    }
+  }
+
+  /**
+   * Is only called at the beginning of the callback function of {@code endOfCurrentBackoff} in the
+   * {@link TransportSet#scheduleBackoff} method.
+   */
+  // TODO(zhangkun83): remove it once the LBv2 refactor is done.
+  final void endBackoff() {
+    synchronized (lock) {
+      Preconditions.checkState(backoffStatus != null,
+          "Error when calling endBackoff: transport is not in backoff period");
+      backoffStatus = null;
+    }
+  }
+
+  /**
+   * Use the picker to try picking a transport for every pending stream and pending ping, proceed
+   * the stream or ping if the pick is successful, otherwise keep it pending.
+   *
+   * <p>If new pending streams are created while reprocess() is in progress, there is no guarantee
+   * that the pending streams will or will not be processed by this picker.
+   *
+   * <p>This method <strong>must not</strong> be called concurrently, either with itself or with
+   * {@link #setTransportSupplier}/{@link #setTransport}.
+   */
+  final void reprocess(LoadBalancer2.SubchannelPicker picker) {
+    ArrayList<PendingStream> toProcess;
+    ArrayList<PendingStream> toRemove = new ArrayList<PendingStream>();
+    synchronized (lock) {
+      if (pendingStreams == null || pendingStreams.isEmpty()) {
+        return;
+      }
+      toProcess = new ArrayList<PendingStream>(pendingStreams);
+    }
+
+    for (final PendingStream stream : toProcess) {
+      PickResult pickResult = picker.pickSubchannel(
+          stream.callOptions.getAffinity(), stream.headers);
+      final ClientTransport realTransport;
+      Subchannel subchannel = pickResult.getSubchannel();
+      if (subchannel != null) {
+        realTransport = ((SubchannelImpl) subchannel).obtainActiveTransport();
+      } else {
+        realTransport = null;
+      }
+      if (realTransport != null) {
+        Executor executor = streamCreationExecutor;
+        // createRealStream may be expensive. It will start real streams on the transport. If
+        // there are pending requests, they will be serialized too, which may be expensive. Since
+        // we are now on transport thread, we need to offload the work to an executor.
+        if (stream.callOptions.getExecutor() != null) {
+          executor = stream.callOptions.getExecutor();
+        }
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+              stream.createRealStream(realTransport);
+            }
+          });
+        toRemove.add(stream);
+      } else if (!pickResult.getStatus().isOk() && !stream.callOptions.isWaitForReady()) {
+        stream.setStream(new FailingClientStream(pickResult.getStatus()));
+        toRemove.add(stream);
+      }  // other cases: stay pending
+    }
+
+    synchronized (lock) {
+      // Between this synchronized and the previous one:
+      //   - Streams may have been cancelled, which may turn pendingStreams into emptiness.
+      //   - shutdown() may be called, which may turn pendingStreams into null.
+      if (pendingStreams == null || pendingStreams.isEmpty()) {
+        return;
+      }
+      pendingStreams.removeAll(toRemove);
+      if (pendingStreams.isEmpty()) {
+        // There may be a brief gap between delayed transport clearing in-use state, and first real
+        // transport starting streams and setting in-use state.  During the gap the whole channel's
+        // in-use state may be false. However, it shouldn't cause spurious switching to idleness
+        // (which would shutdown the transports and LoadBalancer) because the gap should be shorter
+        // than IDLE_MODE_DEFAULT_TIMEOUT_MILLIS (1 second).
+        listener.transportInUse(false);
+        if (shutdown) {
+          pendingStreams = null;
+          listener.transportTerminated();
+        } else {
+          // Because delayed transport is long-lived, we take this opportunity to down-size the
+          // hashmap.
+          pendingStreams = new LinkedHashSet<PendingStream>();
+        }
+      }
+    }
+  }
+
+  // TODO(carl-mastrangelo): remove this once the Subchannel change is in.
+  @Override
+  public LogId getLogId() {
+    return lodId;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  final Supplier<ClientTransport> getTransportSupplier() {
+    return transportSupplier;
+  }
+
+  private class PendingStream extends DelayedStream {
+    private final MethodDescriptor<?, ?> method;
+    private final Metadata headers;
+    private final CallOptions callOptions;
+    private final Context context;
+    private final StatsTraceContext statsTraceCtx;
+
+    private PendingStream(MethodDescriptor<?, ?> method, Metadata headers,
+        CallOptions callOptions, StatsTraceContext statsTraceCtx) {
+      this.method = method;
+      this.headers = headers;
+      this.callOptions = callOptions;
+      this.context = Context.current();
+      this.statsTraceCtx = statsTraceCtx;
+    }
+
+    private void createRealStream(ClientTransport transport) {
+      ClientStream realStream;
+      Context origContext = context.attach();
+      try {
+        realStream = transport.newStream(method, headers, callOptions, statsTraceCtx);
+      } finally {
+        context.detach(origContext);
+      }
+      setStream(realStream);
+    }
+
+    @Override
+    public void cancel(Status reason) {
+      super.cancel(reason);
+      synchronized (lock) {
+        if (pendingStreams != null) {
+          boolean justRemovedAnElement = pendingStreams.remove(this);
+          if (pendingStreams.isEmpty() && justRemovedAnElement) {
+            listener.transportInUse(false);
+            if (shutdown) {
+              pendingStreams = null;
+              listener.transportTerminated();
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private static class PendingPing {
+    private final PingCallback callback;
+    private final Executor executor;
+
+    public PendingPing(PingCallback callback, Executor executor) {
+      this.callback = callback;
+      this.executor = executor;
+    }
+
+    public void createRealPing(ClientTransport transport) {
+      try {
+        transport.ping(callback, executor);
+      } catch (final UnsupportedOperationException ex) {
+        executor.execute(new Runnable() {
+          @Override
+          public void run() {
+            callback.onFailure(ex);
+          }
+        });
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport2.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport2.java
@@ -81,9 +81,9 @@ final class DelayedClientTransport2 implements ManagedClientTransport {
   /**
    * The last picker that {@link #reprocess} has used.
    */
-  // "lock" must be held when assigning to lastPicker
+  @GuardedBy("lock")
   @Nullable
-  private volatile SubchannelPicker lastPicker;
+  private SubchannelPicker lastPicker;
 
   DelayedClientTransport2(Executor streamCreationExecutor) {
     this.streamCreationExecutor = streamCreationExecutor;
@@ -105,14 +105,13 @@ final class DelayedClientTransport2 implements ManagedClientTransport {
   @Override
   public final ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers,
       CallOptions callOptions, StatsTraceContext statsTraceCtx) {
-    SubchannelPicker picker = lastPicker;
-    if (picker == null) {
-      synchronized (lock) {
-        // Check again, since it may have changed while waiting for lock
-        picker = lastPicker;
-        if (picker == null && !shutdown) {
+    SubchannelPicker picker = null;
+    synchronized (lock) {
+      if (!shutdown) {
+        if (lastPicker == null) {
           return createPendingStream(method, headers, callOptions, statsTraceCtx);
         }
+        picker = lastPicker;
       }
     }
     if (picker != null) {
@@ -123,9 +122,13 @@ final class DelayedClientTransport2 implements ManagedClientTransport {
         if (transport != null) {
           return transport.newStream(method, headers, callOptions, statsTraceCtx);
         }
-        // This picker's conclusion is "buffer".  If there hasn't been a newer picker set (possible
-        // race with reprocess()), we will buffer it.  Otherwise, will try with the new picker.
+        // This picker's conclusion is "buffer".  If there hasn't been a newer picker set
+        // (possible race with reprocess()), we will buffer it.  Otherwise, will try with the new
+        // picker.
         synchronized (lock) {
+          if (shutdown) {
+            break;
+          }
           if (picker == lastPicker) {
             return createPendingStream(method, headers, callOptions, statsTraceCtx);
           }
@@ -133,7 +136,8 @@ final class DelayedClientTransport2 implements ManagedClientTransport {
         }
       }
     }
-    return new FailingClientStream(Status.UNAVAILABLE.withDescription("transport shutdown"));
+    return new FailingClientStream(Status.UNAVAILABLE.withDescription(
+            "Channel has shutdown (reported by delayed transport)"));
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransport2Test.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransport2Test.java
@@ -1,0 +1,511 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Supplier;
+
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.IntegerMarshaller;
+import io.grpc.LoadBalancer2.PickResult;
+import io.grpc.LoadBalancer2.SubchannelPicker;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StringMarshaller;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.Executor;
+
+/**
+ * Unit tests for {@link DelayedClientTransport}.
+ */
+@RunWith(JUnit4.class)
+public class DelayedClientTransportTest {
+  @Mock private ManagedClientTransport.Listener transportListener;
+  @Mock private ClientTransport mockRealTransport;
+  @Mock private ClientTransport mockRealTransport2;
+  @Mock private ClientStream mockRealStream;
+  @Mock private ClientStream mockRealStream2;
+  @Mock private ClientStreamListener streamListener;
+  @Mock private ClientTransport.PingCallback pingCallback;
+  @Mock private Executor mockExecutor;
+  @Captor private ArgumentCaptor<Status> statusCaptor;
+  @Captor private ArgumentCaptor<ClientStreamListener> listenerCaptor;
+
+  private static final Attributes.Key<Integer> SHARD_ID = Attributes.Key.of("shard-id");
+
+  private final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
+      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
+      new StringMarshaller(), new IntegerMarshaller());
+
+  private final MethodDescriptor<String, Integer> method2 = MethodDescriptor.create(
+      MethodDescriptor.MethodType.UNKNOWN, "/service/method2",
+      new StringMarshaller(), new IntegerMarshaller());
+
+  private final Metadata headers = new Metadata();
+  private final Metadata headers2 = new Metadata();
+
+  private final CallOptions callOptions = CallOptions.DEFAULT.withAuthority("dummy_value");
+  private final CallOptions callOptions2 = CallOptions.DEFAULT.withAuthority("dummy_value2");
+  private final StatsTraceContext statsTraceCtx = StatsTraceContext.newClientContext(
+      method.getFullMethodName(), NoopCensusContextFactory.INSTANCE,
+      GrpcUtil.STOPWATCH_SUPPLIER);
+  private final StatsTraceContext statsTraceCtx2 = StatsTraceContext.newClientContext(
+      method2.getFullMethodName(), NoopCensusContextFactory.INSTANCE,
+      GrpcUtil.STOPWATCH_SUPPLIER);
+
+  private final FakeClock fakeExecutor = new FakeClock();
+
+  private final DelayedClientTransport delayedTransport =
+      new DelayedClientTransport(fakeExecutor.getScheduledExecutorService());
+
+  @Before public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    when(mockRealTransport.newStream(same(method), same(headers), same(callOptions),
+            same(statsTraceCtx)))
+        .thenReturn(mockRealStream);
+    when(mockRealTransport2.newStream(same(method2), same(headers2), same(callOptions2),
+            same(statsTraceCtx2)))
+        .thenReturn(mockRealStream2);
+    delayedTransport.start(transportListener);
+  }
+
+  @After public void noMorePendingTasks() {
+    assertEquals(0, fakeExecutor.numPendingTasks());
+  }
+
+  @Test public void transportsAreUsedInOrder() {
+    delayedTransport.newStream(method, headers, callOptions, statsTraceCtx);
+    delayedTransport.newStream(method2, headers2, callOptions2, statsTraceCtx2);
+    assertEquals(0, fakeExecutor.numPendingTasks());
+    delayedTransport.setTransportSupplier(new Supplier<ClientTransport>() {
+        final Iterator<ClientTransport> it =
+            Arrays.asList(mockRealTransport, mockRealTransport2).iterator();
+
+        @Override public ClientTransport get() {
+          return it.next();
+        }
+      });
+    assertEquals(1, fakeExecutor.runDueTasks());
+    verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions),
+        same(statsTraceCtx));
+    verify(mockRealTransport2).newStream(same(method2), same(headers2), same(callOptions2),
+        same(statsTraceCtx2));
+  }
+
+  @Test public void streamStartThenSetTransport() {
+    assertFalse(delayedTransport.hasPendingStreams());
+    ClientStream stream = delayedTransport.newStream(method, headers, callOptions, statsTraceCtx);
+    stream.start(streamListener);
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    assertTrue(delayedTransport.hasPendingStreams());
+    assertTrue(stream instanceof DelayedStream);
+    assertEquals(0, fakeExecutor.numPendingTasks());
+    delayedTransport.setTransport(mockRealTransport);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    assertFalse(delayedTransport.hasPendingStreams());
+    assertEquals(1, fakeExecutor.runDueTasks());
+    verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions),
+        same(statsTraceCtx));
+    verify(mockRealStream).start(listenerCaptor.capture());
+    verifyNoMoreInteractions(streamListener);
+    listenerCaptor.getValue().onReady();
+    verify(streamListener).onReady();
+    verifyNoMoreInteractions(streamListener);
+  }
+
+  @Test public void newStreamThenSetTransportThenShutdown() {
+    ClientStream stream = delayedTransport.newStream(method, headers, callOptions, statsTraceCtx);
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    assertTrue(stream instanceof DelayedStream);
+    delayedTransport.setTransport(mockRealTransport);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    assertEquals(1, fakeExecutor.runDueTasks());
+    verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions),
+        same(statsTraceCtx));
+    stream.start(streamListener);
+    verify(mockRealStream).start(same(streamListener));
+  }
+
+  @Test public void transportTerminatedThenSetTransport() {
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    delayedTransport.setTransport(mockRealTransport);
+    verifyNoMoreInteractions(transportListener);
+  }
+
+  @Test public void setTransportThenShutdownThenNewStream() {
+    delayedTransport.setTransport(mockRealTransport);
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    ClientStream stream = delayedTransport.newStream(method, headers, callOptions, statsTraceCtx);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    stream.start(streamListener);
+    assertFalse(stream instanceof DelayedStream);
+    verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions),
+        same(statsTraceCtx));
+    verify(mockRealStream).start(same(streamListener));
+  }
+
+  @Test public void setTransportThenShutdownNowThenNewStream() {
+    delayedTransport.setTransport(mockRealTransport);
+    delayedTransport.shutdownNow(Status.UNAVAILABLE);
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    ClientStream stream = delayedTransport.newStream(method, headers, callOptions, statsTraceCtx);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    stream.start(streamListener);
+    assertFalse(stream instanceof DelayedStream);
+    verify(mockRealTransport).newStream(same(method), same(headers), same(callOptions),
+        same(statsTraceCtx));
+    verify(mockRealStream).start(same(streamListener));
+  }
+
+  @Test public void cancelStreamWithoutSetTransport() {
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    stream.cancel(Status.CANCELLED);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verifyNoMoreInteractions(mockRealTransport);
+    verifyNoMoreInteractions(mockRealStream);
+  }
+
+  @Test public void startThenCancelStreamWithoutSetTransport() {
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    stream.start(streamListener);
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    stream.cancel(Status.CANCELLED);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verify(streamListener).closed(same(Status.CANCELLED), any(Metadata.class));
+    verifyNoMoreInteractions(mockRealTransport);
+    verifyNoMoreInteractions(mockRealStream);
+  }
+
+  @Test public void newStreamThenShutdownTransportThenCancelStream() {
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener, times(0)).transportTerminated();
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+    stream.cancel(Status.CANCELLED);
+    verify(transportListener).transportTerminated();
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verifyNoMoreInteractions(mockRealTransport);
+    verifyNoMoreInteractions(mockRealStream);
+  }
+
+  @Test public void setTransportThenShutdownThenPing() {
+    delayedTransport.setTransport(mockRealTransport);
+    delayedTransport.shutdown();
+    delayedTransport.ping(pingCallback, mockExecutor);
+    verify(mockRealTransport).ping(same(pingCallback), same(mockExecutor));
+  }
+
+  @Test public void pingThenSetTransport() {
+    delayedTransport.ping(pingCallback, mockExecutor);
+    delayedTransport.setTransport(mockRealTransport);
+    verify(mockRealTransport).ping(same(pingCallback), same(mockExecutor));
+  }
+
+  @Test public void shutdownThenPing() {
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    delayedTransport.ping(pingCallback, mockExecutor);
+    verifyNoMoreInteractions(pingCallback);
+    ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(mockExecutor).execute(runnableCaptor.capture());
+    runnableCaptor.getValue().run();
+    verify(pingCallback).onFailure(any(Throwable.class));
+  }
+
+  @Test public void shutdownThenNewStream() {
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    stream.start(streamListener);
+    verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
+  }
+
+  @Test public void startStreamThenShutdownNow() {
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    stream.start(streamListener);
+    delayedTransport.shutdownNow(Status.UNAVAILABLE);
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
+  }
+
+  @Test public void shutdownNowThenNewStream() {
+    delayedTransport.shutdownNow(Status.UNAVAILABLE);
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    stream.start(streamListener);
+    verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
+  }
+
+  @Test public void startBackOff_ClearsFailFastPendingStreams() {
+    final Status cause = Status.UNAVAILABLE.withDescription("some error when connecting");
+    final CallOptions failFastCallOptions = CallOptions.DEFAULT;
+    final CallOptions waitForReadyCallOptions = CallOptions.DEFAULT.withWaitForReady();
+    final ClientStream ffStream = delayedTransport.newStream(method, headers, failFastCallOptions,
+        statsTraceCtx);
+    ffStream.start(streamListener);
+    delayedTransport.newStream(method, headers, waitForReadyCallOptions, statsTraceCtx);
+    delayedTransport.newStream(method, headers, failFastCallOptions, statsTraceCtx);
+    assertEquals(3, delayedTransport.getPendingStreamsCount());
+
+    delayedTransport.startBackoff(cause);
+    assertTrue(delayedTransport.isInBackoffPeriod());
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+
+    // Fail fast stream not failed yet.
+    verify(streamListener, never()).closed(any(Status.class), any(Metadata.class));
+
+    fakeExecutor.runDueTasks();
+    // Now fail fast stream failed.
+    verify(streamListener).closed(same(cause), any(Metadata.class));
+  }
+
+  @Test public void startBackOff_FailsFutureFailFastStreams() {
+    final Status cause = Status.UNAVAILABLE.withDescription("some error when connecting");
+    final CallOptions failFastCallOptions = CallOptions.DEFAULT;
+    final CallOptions waitForReadyCallOptions = CallOptions.DEFAULT.withWaitForReady();
+    delayedTransport.startBackoff(cause);
+    assertTrue(delayedTransport.isInBackoffPeriod());
+
+    final ClientStream ffStream = delayedTransport.newStream(method, headers, failFastCallOptions,
+        statsTraceCtx);
+    ffStream.start(streamListener);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(cause, Status.fromThrowable(statusCaptor.getValue().getCause()));
+
+    delayedTransport.newStream(method, headers, waitForReadyCallOptions, statsTraceCtx);
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+  }
+
+  @Test public void startBackoff_DoNothingIfAlreadyShutDown() {
+    delayedTransport.shutdown();
+
+    final Status cause = Status.UNAVAILABLE.withDescription("some error when connecting");
+    delayedTransport.startBackoff(cause);
+
+    assertFalse(delayedTransport.isInBackoffPeriod());
+  }
+
+  @Test public void reprocess() {
+    Attributes affinity1 = Attributes.newBuilder().set(SHARD_ID, 1).build();
+    Attributes affinity2 = Attributes.newBuilder().set(SHARD_ID, 2).build();
+    CallOptions failFastCallOptions = CallOptions.DEFAULT.withAffinity(affinity1);
+    CallOptions waitForReadyCallOptions =
+        CallOptions.DEFAULT.withWaitForReady().withAffinity(affinity2);
+
+    SubchannelImpl subchannel1 = mock(SubchannelImpl.class);
+    SubchannelImpl subchannel2 = mock(SubchannelImpl.class);
+    SubchannelImpl subchannel3 = mock(SubchannelImpl.class);
+    when(mockRealTransport.newStream(any(MethodDescriptor.class), any(Metadata.class),
+            any(CallOptions.class), same(statsTraceCtx))).thenReturn(mockRealStream);
+    when(mockRealTransport2.newStream(any(MethodDescriptor.class), any(Metadata.class),
+            any(CallOptions.class), same(statsTraceCtx))).thenReturn(mockRealStream2);
+    when(subchannel1.obtainActiveTransport()).thenReturn(mockRealTransport);
+    when(subchannel2.obtainActiveTransport()).thenReturn(mockRealTransport2);
+    when(subchannel3.obtainActiveTransport()).thenReturn(null);
+
+    // Fail-fast streams
+    DelayedStream ff1 = (DelayedStream) delayedTransport.newStream(
+        method, headers, failFastCallOptions, statsTraceCtx);
+    verify(transportListener).transportInUse(true);
+    DelayedStream ff2 = (DelayedStream) delayedTransport.newStream(
+        method2, headers2, failFastCallOptions, statsTraceCtx);
+    DelayedStream ff3 = (DelayedStream) delayedTransport.newStream(
+        method, headers, failFastCallOptions, statsTraceCtx);
+    DelayedStream ff4 = (DelayedStream) delayedTransport.newStream(
+        method2, headers2, failFastCallOptions, statsTraceCtx);
+
+    // Wait-for-ready streams
+    FakeClock wfr3Executor = new FakeClock();
+    DelayedStream wfr1 = (DelayedStream) delayedTransport.newStream(
+        method, headers, waitForReadyCallOptions, statsTraceCtx);
+    DelayedStream wfr2 = (DelayedStream) delayedTransport.newStream(
+        method2, headers2, waitForReadyCallOptions, statsTraceCtx);
+    DelayedStream wfr3 = (DelayedStream) delayedTransport.newStream(
+        method, headers,
+        waitForReadyCallOptions.withExecutor(wfr3Executor.getScheduledExecutorService()),
+        statsTraceCtx);
+    DelayedStream wfr4 = (DelayedStream) delayedTransport.newStream(
+        method2, headers2, waitForReadyCallOptions, statsTraceCtx);
+    assertEquals(8, delayedTransport.getPendingStreamsCount());
+
+    // First reprocess(). Some will proceed, some will fail and the rest will stay buffered.
+    SubchannelPicker picker = mock(SubchannelPicker.class);
+    when(picker.pickSubchannel(any(Attributes.class), any(Metadata.class))).thenReturn(
+        // For the fail-fast streams
+        PickResult.withSubchannel(subchannel1),    // ff1: proceed
+        PickResult.withError(Status.UNAVAILABLE),  // ff2: fail
+        PickResult.withSubchannel(subchannel3),    // ff3: stay
+        PickResult.withNoResult(),                 // ff4: stay
+        // For the wait-for-ready streams
+        PickResult.withSubchannel(subchannel2),           // wfr1: proceed
+        PickResult.withError(Status.RESOURCE_EXHAUSTED),  // wfr2: stay
+        PickResult.withSubchannel(subchannel3),           // wfr3: stay
+        PickResult.withNoResult());                       // wfr4: stay
+    InOrder inOrder = inOrder(picker);
+    delayedTransport.reprocess(picker);
+
+    assertEquals(5, delayedTransport.getPendingStreamsCount());
+    inOrder.verify(picker).pickSubchannel(affinity1, headers);  // ff1
+    inOrder.verify(picker).pickSubchannel(affinity1, headers2);  // ff2
+    inOrder.verify(picker).pickSubchannel(affinity1, headers);  // ff3
+    inOrder.verify(picker).pickSubchannel(affinity1, headers2);  // ff4
+    inOrder.verify(picker).pickSubchannel(affinity2, headers);  // wfr1
+    inOrder.verify(picker).pickSubchannel(affinity2, headers2);  // wfr2
+    inOrder.verify(picker).pickSubchannel(affinity2, headers);  // wfr3
+    inOrder.verify(picker).pickSubchannel(affinity2, headers2);  // wfr4
+    inOrder.verifyNoMoreInteractions();
+    // Make sure that real transport creates streams in the executor
+    verify(mockRealTransport, never()).newStream(any(MethodDescriptor.class),
+        any(Metadata.class), any(CallOptions.class), any(StatsTraceContext.class));
+    verify(mockRealTransport2, never()).newStream(any(MethodDescriptor.class),
+        any(Metadata.class), any(CallOptions.class), any(StatsTraceContext.class));
+    fakeExecutor.runDueTasks();
+    assertEquals(0, fakeExecutor.numPendingTasks());
+    // ff1 and wfr1 went through
+    verify(mockRealTransport).newStream(method, headers, failFastCallOptions, statsTraceCtx);
+    verify(mockRealTransport2).newStream(method, headers, waitForReadyCallOptions, statsTraceCtx);
+    assertSame(mockRealStream, ff1.getRealStream());
+    assertSame(mockRealStream2, wfr1.getRealStream());
+    // The ff2 has failed due to picker returning an error
+    assertSame(Status.UNAVAILABLE, ((FailingClientStream) ff2.getRealStream()).getError());
+    // Other streams are still buffered
+    assertNull(ff3.getRealStream());
+    assertNull(ff4.getRealStream());
+    assertNull(wfr2.getRealStream());
+    assertNull(wfr3.getRealStream());
+    assertNull(wfr4.getRealStream());
+
+    // Second reprocess(). All will proceed.
+    picker = mock(SubchannelPicker.class);
+    when(picker.pickSubchannel(any(Attributes.class), any(Metadata.class))).thenReturn(
+        PickResult.withSubchannel(subchannel1),  // ff3
+        PickResult.withSubchannel(subchannel2),  // ff4
+        PickResult.withSubchannel(subchannel2),  // wfr2
+        PickResult.withSubchannel(subchannel1),  // wfr3
+        PickResult.withSubchannel(subchannel2));  // wfr4
+    inOrder = inOrder(picker);
+    assertEquals(0, wfr3Executor.numPendingTasks());
+    verify(transportListener, never()).transportInUse(false);
+
+    delayedTransport.reprocess(picker);
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verify(transportListener).transportInUse(false);
+    inOrder.verify(picker).pickSubchannel(affinity1, headers);  // ff3
+    inOrder.verify(picker).pickSubchannel(affinity1, headers2);  // ff4
+    inOrder.verify(picker).pickSubchannel(affinity2, headers2);  // wfr2
+    inOrder.verify(picker).pickSubchannel(affinity2, headers);  // wfr3
+    inOrder.verify(picker).pickSubchannel(affinity2, headers2);  // wfr4
+    inOrder.verifyNoMoreInteractions();
+    fakeExecutor.runDueTasks();
+    assertEquals(0, fakeExecutor.numPendingTasks());
+    assertSame(mockRealStream, ff3.getRealStream());
+    assertSame(mockRealStream2, ff4.getRealStream());
+    assertSame(mockRealStream2, wfr2.getRealStream());
+    assertSame(mockRealStream2, wfr4.getRealStream());
+
+    // If there is an executor in the CallOptions, it will be used to create the real tream.
+    assertNull(wfr3.getRealStream());
+    wfr3Executor.runDueTasks();
+    assertSame(mockRealStream, wfr3.getRealStream());
+
+    // Make sure the delayed transport still accepts new streams
+    DelayedStream wfr5 = (DelayedStream) delayedTransport.newStream(
+        method, headers, waitForReadyCallOptions, statsTraceCtx);
+    assertNull(wfr5.getRealStream());
+    assertEquals(1, delayedTransport.getPendingStreamsCount());
+
+    // wfr5 will stop delayed transport from terminating
+    delayedTransport.shutdown();
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener, never()).transportTerminated();
+    // ... until it's gone
+    delayedTransport.reprocess(picker);
+    fakeExecutor.runDueTasks();
+    assertEquals(0, delayedTransport.getPendingStreamsCount());
+    verify(transportListener).transportTerminated();
+  }
+
+  @Test
+  public void reprocess_NoPendingStream() {
+    SubchannelPicker picker = mock(SubchannelPicker.class);
+    delayedTransport.reprocess(picker);
+    verifyNoMoreInteractions(picker);
+    verifyNoMoreInteractions(transportListener);
+  }
+}


### PR DESCRIPTION
Consider the following sequence:
1. Channel is created.  Picker is initially null
2. Channel has a new RPC.  Because picker is null, the delayed
transport is picked, but newStream() is not called yet.
3. LoadBalancer updates a new picker to Channel.  Channel runs
reprocess() but does nothing because no pending stream is there.
4. newStream() called on the delayed transport.

In previous implementation, newStream() on step 4 will not see the
picker.  It will only use the next picker.

After this change, delayed transport would save the latest picker and
use it on newStream(), which is the desired behavior.