### PR TITLE
Implement setListener in AbstractServerStream.

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -170,6 +170,11 @@ public abstract class AbstractServerStream extends AbstractStream2
   }
 
   @Override
+  public final void setListener(ServerStreamListener serverStreamListener) {
+    transportState().setListener(serverStreamListener);
+  }
+
+  @Override
   public StatsTraceContext statsTraceContext() {
     return statsTraceCtx;
   }

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -265,11 +265,6 @@ public class AbstractServerStreamTest {
       return state;
     }
 
-    @Override
-    public void setListener(ServerStreamListener serverStreamListener) {
-      state.setListener(serverStreamListener);
-    }
-
     static class TransportState extends AbstractServerStream.TransportState {
       protected TransportState(int maxMessageSize) {
         super(maxMessageSize, StatsTraceContext.NOOP);

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -37,7 +37,6 @@ import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.AbstractServerStream;
-import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.WritableBuffer;
 import io.netty.buffer.ByteBuf;
@@ -85,11 +84,6 @@ class NettyServerStream extends AbstractServerStream {
   @Override
   public Attributes attributes() {
     return attributes;
-  }
-
-  @Override
-  public void setListener(ServerStreamListener serverStreamListener) {
-    state.setListener(serverStreamListener);
   }
 
   private class Sink implements AbstractServerStream.Sink {


### PR DESCRIPTION
It seems to have been an unintended side effect of #1656 to require subclasses of AbstractServerStream to implement setListener, despite the class already maintaining the state in transportState.

If this was actually intended, then instead this Javadoc would need an update:
https://github.com/anuraaga/grpc-java/blob/77686e80a0b3da70d99602c53f7e13e6f555443b/core/src/main/java/io/grpc/internal/AbstractServerStream.java#L44