### PR TITLE
Introduce a grpc-exp ALPN protocol identifier.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -59,15 +59,20 @@ public class GrpcSslContexts {
 
   /*
    * The experimental "grpc-exp" string identifies gRPC (and by implication
-   * HTTP/2) when used over TLS. This is negotiated in preference to h2 when the
-   * client and server support it, but is not standardized. Support for this may
-   * be removed at any time.
+   * HTTP/2) when used over TLS. This indicates to the server that the client
+   * will only send gRPC traffic on the h2 connection and is negotiated in
+   * preference to h2 when the client and server support it, but is not
+   * standardized. Support for this may be removed at any time.
    */
   private static final String GRPC_EXP_VERSION = "grpc-exp";
 
   // The "h2" string identifies HTTP/2 when used over TLS
   private static final String HTTP2_VERSION = "h2";
 
+  /*
+   * List of ALPN/NPN protocols in order of preference. GRPC_EXP_VERSION
+   * requires that HTTP2_VERSION be present and should be preferenced.
+   */
   static final List<String> NEXT_PROTOCOL_VERSIONS =
       Collections.unmodifiableList(Arrays.asList(GRPC_EXP_VERSION, HTTP2_VERSION));
 

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -32,7 +32,6 @@
 package io.grpc.netty;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Collections.singletonList;
 
 import io.grpc.ExperimentalApi;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
@@ -47,6 +46,9 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Utility for configuring SslContext for gRPC.
@@ -55,8 +57,19 @@ import java.io.File;
 public class GrpcSslContexts {
   private GrpcSslContexts() {}
 
+  /*
+   * The experimental "grpc-exp" string identifies gRPC (and by implication
+   * HTTP/2) when used over TLS. This is negotiated in preference to h2 when the
+   * client and server support it, but is not standardized. Support for this may
+   * be removed at any time.
+   */
+  private static final String GRPC_EXP_VERSION = "grpc-exp";
+
   // The "h2" string identifies HTTP/2 when used over TLS
-  static final String HTTP2_VERSION = "h2";
+  private static final String HTTP2_VERSION = "h2";
+
+  static final List<String> NEXT_PROTOCOL_VERSIONS =
+      Collections.unmodifiableList(Arrays.asList(GRPC_EXP_VERSION, HTTP2_VERSION));
 
   /*
    * These configs use ACCEPT due to limited support in OpenSSL.  Actual protocol enforcement is
@@ -66,19 +79,19 @@ public class GrpcSslContexts {
       Protocol.ALPN,
       SelectorFailureBehavior.NO_ADVERTISE,
       SelectedListenerFailureBehavior.ACCEPT,
-      singletonList(HTTP2_VERSION));
+      NEXT_PROTOCOL_VERSIONS);
 
   private static ApplicationProtocolConfig NPN = new ApplicationProtocolConfig(
       Protocol.NPN,
       SelectorFailureBehavior.NO_ADVERTISE,
       SelectedListenerFailureBehavior.ACCEPT,
-      singletonList(HTTP2_VERSION));
+      NEXT_PROTOCOL_VERSIONS);
 
   private static ApplicationProtocolConfig NPN_AND_ALPN = new ApplicationProtocolConfig(
       Protocol.NPN_AND_ALPN,
       SelectorFailureBehavior.NO_ADVERTISE,
       SelectedListenerFailureBehavior.ACCEPT,
-      singletonList(HTTP2_VERSION));
+      NEXT_PROTOCOL_VERSIONS);
 
   /**
    * Creates a SslContextBuilder with ciphers and APN appropriate for gRPC.
@@ -172,9 +185,10 @@ public class GrpcSslContexts {
     checkArgument(alpnNegotiator != null, "ALPN must be configured");
     checkArgument(alpnNegotiator.protocols() != null && !alpnNegotiator.protocols().isEmpty(),
         "ALPN must be enabled and list HTTP/2 as a supported protocol.");
-    if (!alpnNegotiator.protocols().contains(HTTP2_VERSION)) {
-      throw new IllegalArgumentException("This ALPN config does not support HTTP/2. Expected '"
-          + HTTP2_VERSION + "', but got " + alpnNegotiator.protocols() + '.');
-    }
+    checkArgument(
+        alpnNegotiator.protocols().contains(HTTP2_VERSION),
+        "This ALPN config does not support HTTP/2. Expected %s, but got %s'.",
+        HTTP2_VERSION,
+        alpnNegotiator.protocols());
   }
 }

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -71,7 +71,8 @@ public class GrpcSslContexts {
 
   /*
    * List of ALPN/NPN protocols in order of preference. GRPC_EXP_VERSION
-   * requires that HTTP2_VERSION be present and should be preferenced.
+   * requires that HTTP2_VERSION be present and that GRPC_EXP_VERSION should be
+   * preferenced over HTTP2_VERSION.
    */
   static final List<String> NEXT_PROTOCOL_VERSIONS =
       Collections.unmodifiableList(Arrays.asList(GRPC_EXP_VERSION, HTTP2_VERSION));

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -32,7 +32,7 @@
 package io.grpc.netty;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.netty.GrpcSslContexts.HTTP2_VERSION;
+import static io.grpc.netty.GrpcSslContexts.NEXT_PROTOCOL_VERSIONS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -69,7 +69,6 @@ import java.util.Arrays;
 import java.util.Queue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
@@ -151,7 +150,7 @@ public final class ProtocolNegotiators {
       if (evt instanceof SslHandshakeCompletionEvent) {
         SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
         if (handshakeEvent.isSuccess()) {
-          if (HTTP2_VERSION.equals(sslHandler(ctx.pipeline()).applicationProtocol())) {
+          if (NEXT_PROTOCOL_VERSIONS.contains(sslHandler(ctx.pipeline()).applicationProtocol())) {
             // Successfully negotiated the protocol.
             // Notify about completion and pass down SSLSession in attributes.
             grpcHandler.handleProtocolNegotiationCompleted(
@@ -503,7 +502,7 @@ public final class ProtocolNegotiators {
         SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
         if (handshakeEvent.isSuccess()) {
           SslHandler handler = ctx.pipeline().get(SslHandler.class);
-          if (HTTP2_VERSION.equals(handler.applicationProtocol())) {
+          if (NEXT_PROTOCOL_VERSIONS.contains(handler.applicationProtocol())) {
             // Successfully negotiated the protocol.
             logSslEngineDetails(Level.FINER, ctx, "TLS negotiation succeeded.", null);
 

--- a/netty/src/test/java/io/grpc/netty/GrpcSslContextsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcSslContextsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link io.grpc.netty.GrpcSslContexts}. */
+@RunWith(JUnit4.class)
+public class GrpcSslContextsTest {
+  @Test public void selectApplicationProtocolConfig_grpcExp() {
+    assertTrue(
+        GrpcSslContexts.NEXT_PROTOCOL_VERSIONS.indexOf("grpc-exp") == -1
+            || GrpcSslContexts.NEXT_PROTOCOL_VERSIONS.indexOf("grpc-exp")
+                < GrpcSslContexts.NEXT_PROTOCOL_VERSIONS.indexOf("h2"));
+  }
+}

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -171,11 +171,34 @@ public class ProtocolNegotiatorsTest {
   }
 
   @Test
-  public void tlsHandler_userEventTriggeredSslEvent_supportedProtocol() throws Exception {
+  public void tlsHandler_userEventTriggeredSslEvent_supportedProtocolH2() throws Exception {
     SslHandler goodSslHandler = new SslHandler(engine, false) {
       @Override
       public String applicationProtocol() {
         return "h2";
+      }
+    };
+
+    ChannelHandler handler = new ServerTlsHandler(sslContext, grpcHandler);
+    pipeline.addLast(handler);
+
+    pipeline.replace(SslHandler.class, null, goodSslHandler);
+    channelHandlerCtx = pipeline.context(handler);
+    Object sslEvent = SslHandshakeCompletionEvent.SUCCESS;
+
+    pipeline.fireUserEventTriggered(sslEvent);
+
+    assertTrue(channel.isOpen());
+    ChannelHandlerContext grpcHandlerCtx = pipeline.context(grpcHandler);
+    assertNotNull(grpcHandlerCtx);
+  }
+
+  @Test
+  public void tlsHandler_userEventTriggeredSslEvent_supportedProtocolGrpcExp() throws Exception {
+    SslHandler goodSslHandler = new SslHandler(engine, false) {
+      @Override
+      public String applicationProtocol() {
+        return "grpc-exp";
       }
     };
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
@@ -31,6 +31,7 @@
 
 package io.grpc.okhttp;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import io.grpc.okhttp.internal.ConnectionSpec;
@@ -52,7 +53,12 @@ import javax.net.ssl.SSLSocketFactory;
  */
 final class OkHttpTlsUpgrader {
 
-  private static final List<Protocol> TLS_PROTOCOLS =
+  /*
+   * List of ALPN/NPN protocols in order of preference. GRPC_EXP_VERSION
+   * requires that HTTP2_VERSION be present and should be preferenced.
+   */
+  @VisibleForTesting
+  static final List<Protocol> TLS_PROTOCOLS =
       Collections.unmodifiableList(Arrays.<Protocol>asList(Protocol.GRPC_EXP, Protocol.HTTP_2));
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
@@ -54,8 +54,8 @@ import javax.net.ssl.SSLSocketFactory;
 final class OkHttpTlsUpgrader {
 
   /*
-   * List of ALPN/NPN protocols in order of preference. GRPC_EXP_VERSION
-   * requires that HTTP2_VERSION be present and should be preferenced.
+   * List of ALPN/NPN protocols in order of preference. GRPC_EXP requires that
+   * HTTP_2 be present and that GRPC_EXP should be preferenced over HTTP_2.
    */
   @VisibleForTesting
   static final List<Protocol> TLS_PROTOCOLS =

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
@@ -42,7 +42,6 @@ import java.net.Socket;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -53,9 +52,8 @@ import javax.net.ssl.SSLSocketFactory;
  */
 final class OkHttpTlsUpgrader {
 
-  private static final String HTTP2_PROTOCOL_NAME = "h2";
   private static final List<Protocol> TLS_PROTOCOLS =
-      Collections.unmodifiableList(Arrays.<Protocol>asList(Protocol.HTTP_2));
+      Collections.unmodifiableList(Arrays.<Protocol>asList(Protocol.GRPC_EXP, Protocol.HTTP_2));
 
   /**
    * Upgrades given Socket to be a SSLSocket.
@@ -73,8 +71,10 @@ final class OkHttpTlsUpgrader {
     spec.apply(sslSocket, false);
     String negotiatedProtocol = OkHttpProtocolNegotiator.get().negotiate(
         sslSocket, host, spec.supportsTlsExtensions() ? TLS_PROTOCOLS : null);
-    Preconditions.checkState(HTTP2_PROTOCOL_NAME.equals(negotiatedProtocol),
-        "Only \"h2\" is supported, but negotiated protocol is %s", negotiatedProtocol);
+    Preconditions.checkState(
+        TLS_PROTOCOLS.contains(Protocol.get(negotiatedProtocol)),
+        "Only " + TLS_PROTOCOLS + " are supported, but negotiated protocol is %s",
+        negotiatedProtocol);
 
     if (!OkHostnameVerifier.INSTANCE.verify(host, sslSocket.getSession())) {
       throw new SSLPeerUnverifiedException("Cannot verify hostname: " + host);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
@@ -179,6 +179,26 @@ public class OkHttpProtocolNegotiatorTest {
   }
 
   @Test
+  public void negotiate_preferGrpcExp() throws Exception {
+    // This test doesn't actually verify that grpc-exp is preferred, since the
+    // mocking of getSelectedProtocol() causes the protocol list to be ignored.
+    // The main usefulness of the test is for future changes to
+    // OkHttpProtocolNegotiator, where we can catch any change that would affect
+    // grpc-exp preference.
+    when(platform.getSelectedProtocol(Mockito.<SSLSocket>any())).thenReturn("grpc-exp");
+    OkHttpProtocolNegotiator negotiator = new OkHttpProtocolNegotiator(platform);
+
+    String actual =
+        negotiator.negotiate(sock, "hostname",
+                ImmutableList.of(Protocol.GRPC_EXP, Protocol.HTTP_2));
+
+    assertEquals("grpc-exp", actual);
+    verify(sock).startHandshake();
+    verify(platform).getSelectedProtocol(sock);
+    verify(platform).afterHandshake(sock);
+  }
+
+  @Test
   public void pickTlsExtensionType_securityProvider() throws Exception {
     assertNotNull(Security.getProvider(fakeSecurityProvider.getName()));
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTlsUpgraderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTlsUpgraderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.okhttp;
+
+import static org.junit.Assert.assertTrue;
+
+import io.grpc.okhttp.internal.Protocol;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link io.grpc.okhttp.OkHttpTlsUpgrader}. */
+@RunWith(JUnit4.class)
+public class OkHttpTlsUpgraderTest {
+  @Test public void upgrade_grpcExp() {
+    assertTrue(
+        OkHttpTlsUpgrader.TLS_PROTOCOLS.indexOf(Protocol.GRPC_EXP) == -1
+            || OkHttpTlsUpgrader.TLS_PROTOCOLS.indexOf(Protocol.GRPC_EXP)
+                < OkHttpTlsUpgrader.TLS_PROTOCOLS.indexOf(Protocol.HTTP_2));
+  }
+}

--- a/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Protocol.java
+++ b/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Protocol.java
@@ -70,7 +70,15 @@ public enum Protocol {
    * , present in Java 8+ and Android 5+. Servers that enforce this may send an
    * exception message including the string {@code INADEQUATE_SECURITY}.
    */
-  HTTP_2("h2");
+  HTTP_2("h2"),
+
+  /**
+   * The experimental "grpc-exp" string identifies gRPC (and by implication
+   * HTTP/2) when used over TLS. This is negotiated in preference to h2 when the
+   * client and server support it, but is not standardized. Support for this may
+   * be removed at any time.
+   */
+  GRPC_EXP("grpc-exp");
 
   private final String protocol;
 
@@ -87,6 +95,7 @@ public enum Protocol {
     if (protocol.equals(HTTP_1_0.protocol)) return HTTP_1_0;
     if (protocol.equals(HTTP_1_1.protocol)) return HTTP_1_1;
     if (protocol.equals(HTTP_2.protocol)) return HTTP_2;
+    if (protocol.equals(GRPC_EXP.protocol)) return GRPC_EXP;
     if (protocol.equals(SPDY_3.protocol)) return SPDY_3;
     throw new IOException("Unexpected protocol: " + protocol);
   }

--- a/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Protocol.java
+++ b/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Protocol.java
@@ -74,9 +74,10 @@ public enum Protocol {
 
   /**
    * The experimental "grpc-exp" string identifies gRPC (and by implication
-   * HTTP/2) when used over TLS. This is negotiated in preference to h2 when the
-   * client and server support it, but is not standardized. Support for this may
-   * be removed at any time.
+   * HTTP/2) when used over TLS. This indicates to the server that the client
+   * will only send gRPC traffic on the h2 connection and is negotiated in
+   * preference to h2 when the client and server support it, but is not
+   * standardized. Support for this may be removed at any time.
    */
   GRPC_EXP("grpc-exp");
 


### PR DESCRIPTION
This patch introduces an additional ALPN protocol, grpc-exp, intended to
take preference to h2 and indicate to the server that the connection
contains only gRPC traffic. This allows servers and intermediate boxes
to distinguish gRPC from other HTTP/2 traffic.

The choice of grpc-exp as a protocol identifier indicates that this
scheme is currently experimental and should not be relied upon. The
protocol is not in the IANA TLS registry.

This is the grpc-java equivalent of
https://github.com/grpc/grpc/commit/8cdf17a620a2d0909c1785717d5b3d8cff1248fd.