### PR TITLE
interop-testing: Add status_code_and_message interop test

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -927,16 +927,16 @@ public abstract class AbstractInteropTest {
 
   @Test(timeout = 10000)
   public void statusCodeAndMessage() throws Exception {
-    final int errorCode = 2;
-    final String errorMessage = "test status message";
-    final EchoStatus responseStatus = EchoStatus.newBuilder()
+    int errorCode = 2;
+    String errorMessage = "test status message";
+    EchoStatus responseStatus = EchoStatus.newBuilder()
         .setCode(errorCode)
         .setMessage(errorMessage)
         .build();
-    final SimpleRequest simpleRequest = SimpleRequest.newBuilder()
+    SimpleRequest simpleRequest = SimpleRequest.newBuilder()
         .setResponseStatus(responseStatus)
         .build();
-    final StreamingOutputCallRequest streamingRequest = StreamingOutputCallRequest.newBuilder()
+    StreamingOutputCallRequest streamingRequest = StreamingOutputCallRequest.newBuilder()
         .setResponseStatus(responseStatus)
         .build();
 
@@ -954,7 +954,8 @@ public abstract class AbstractInteropTest {
 
     // Test FullDuplexCall
     @SuppressWarnings("unchecked")
-    StreamObserver<StreamingOutputCallResponse> responseObserver = mock(StreamObserver.class);
+    StreamObserver<StreamingOutputCallResponse> responseObserver =
+        (StreamObserver<StreamingOutputCallResponse>) mock(StreamObserver.class);
     StreamObserver<StreamingOutputCallRequest> requestObserver
         = asyncStub.fullDuplexCall(responseObserver);
     requestObserver.onNext(streamingRequest);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -877,6 +877,7 @@ public abstract class AbstractInteropTest {
     StreamObserver<StreamingOutputCallRequest> requestObserver
         = asyncStub.fullDuplexCall(responseObserver);
     requestObserver.onNext(streamingRequest);
+    requestObserver.onCompleted();
 
     ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
     verify(responseObserver, timeout(operationTimeoutMillis())).onError(captor.capture());
@@ -886,6 +887,7 @@ public abstract class AbstractInteropTest {
     if (metricsExpected()) {
       assertClientMetrics("grpc.testing.TestService/FullDuplexCall", Status.Code.UNKNOWN);
     }
+
   }
 
   /** Sends an rpc to an unimplemented method within TestService. */

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -48,6 +48,7 @@ public enum TestCases {
   JWT_TOKEN_CREDS("JWT-based auth"),
   OAUTH2_AUTH_TOKEN("raw oauth2 access token auth"),
   PER_RPC_CREDS("per rpc raw oauth2 access token auth"),
+  STATUS_CODE_AND_MESSAGE("request error code and message"),
   UNIMPLEMENTED_METHOD("call an unimplemented RPC method"),
   UNIMPLEMENTED_SERVICE("call an unimplemented RPC service"),
   CANCEL_AFTER_BEGIN("cancel stream after starting it"),

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -263,6 +263,11 @@ public class TestServiceClient {
         break;
       }
 
+      case STATUS_CODE_AND_MESSAGE: {
+        tester.statusCodeAndMessage();
+        break;
+      }
+
       case UNIMPLEMENTED_METHOD: {
         tester.unimplementedMethod();
         break;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -31,6 +31,7 @@
 
 package io.grpc.testing.integration;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Queues;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.EmptyProtos;
@@ -318,9 +319,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
      * Allows the service to cancel the remaining responses.
      */
     public synchronized void cancel() {
-      if (cancelled) {
-        throw new IllegalStateException("Dispatcher already cancelled");
-      }
+      Preconditions.checkState(!cancelled, "Dispatcher already cancelled");
       chunks.clear();
       cancelled = true;
     }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -207,8 +207,10 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
 
       @Override
       public void onCompleted() {
-        // Tell the dispatcher that all input has been received.
-        dispatcher.completeInput();
+        if (!dispatcher.isCancelled()) {
+          // Tell the dispatcher that all input has been received.
+          dispatcher.completeInput();
+        }
       }
 
       @Override
@@ -321,6 +323,10 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
       }
       chunks.clear();
       cancelled = true;
+    }
+
+    public synchronized boolean isCancelled() {
+      return cancelled;
     }
 
     /**

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
@@ -57,9 +57,9 @@ public class TestCasesTest {
     // names of testcases as defined in the interop spec
     String[] testCases = {"empty_unary", "large_unary", "client_streaming", "server_streaming",
       "ping_pong", "empty_stream", "compute_engine_creds", "service_account_creds",
-      "jwt_token_creds", "oauth2_auth_token", "per_rpc_creds", "unimplemented_method",
-      "unimplemented_service", "cancel_after_begin", "cancel_after_first_response",
-      "timeout_on_sleeping_server"};
+      "jwt_token_creds", "oauth2_auth_token", "per_rpc_creds", "status_code_and_message",
+      "unimplemented_method", "unimplemented_service", "cancel_after_begin",
+      "cancel_after_first_response", "timeout_on_sleeping_server"};
 
     assertEquals(testCases.length, TestCases.values().length);
 


### PR DESCRIPTION
This implements the [status_code_and_message](https://github.com/grpc/grpc/blob/f29de2619476622e61c894559f8885ca3cc8971c/doc/interop-test-descriptions.md#status_code_and_message)  interop test (#1993, https://github.com/grpc/grpc/issues/8481)