### PR TITLE
compiler: reduce synchronzed invocation

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -269,25 +269,15 @@ public class BenchmarkServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new BenchmarkServiceDescriptorSupplier(),
         METHOD_UNARY_CALL,
         METHOD_STREAMING_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -274,7 +274,7 @@ public class BenchmarkServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(BenchmarkServiceGrpc.class) {
+      synchronized (BenchmarkServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -269,25 +269,22 @@ public class BenchmarkServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(BenchmarkServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new BenchmarkServiceDescriptorSupplier(),
+              METHOD_UNARY_CALL,
+              METHOD_STREAMING_CALL);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new BenchmarkServiceDescriptorSupplier(),
-        METHOD_UNARY_CALL,
-        METHOD_STREAMING_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -271,14 +271,23 @@ public class BenchmarkServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new BenchmarkServiceDescriptorSupplier(),
-          METHOD_UNARY_CALL,
-          METHOD_STREAMING_CALL);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new BenchmarkServiceDescriptorSupplier(),
+        METHOD_UNARY_CALL,
+        METHOD_STREAMING_CALL);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -269,15 +269,25 @@ public class BenchmarkServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new BenchmarkServiceDescriptorSupplier(),
         METHOD_UNARY_CALL,
         METHOD_STREAMING_CALL);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -387,17 +387,27 @@ public class WorkerServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new WorkerServiceDescriptorSupplier(),
         METHOD_RUN_SERVER,
         METHOD_RUN_CLIENT,
         METHOD_CORE_COUNT,
         METHOD_QUIT_WORKER);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -387,27 +387,17 @@ public class WorkerServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new WorkerServiceDescriptorSupplier(),
         METHOD_RUN_SERVER,
         METHOD_RUN_CLIENT,
         METHOD_CORE_COUNT,
         METHOD_QUIT_WORKER);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -387,27 +387,24 @@ public class WorkerServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(WorkerServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new WorkerServiceDescriptorSupplier(),
+              METHOD_RUN_SERVER,
+              METHOD_RUN_CLIENT,
+              METHOD_CORE_COUNT,
+              METHOD_QUIT_WORKER);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new WorkerServiceDescriptorSupplier(),
-        METHOD_RUN_SERVER,
-        METHOD_RUN_CLIENT,
-        METHOD_CORE_COUNT,
-        METHOD_QUIT_WORKER);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -392,7 +392,7 @@ public class WorkerServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(WorkerServiceGrpc.class) {
+      synchronized (WorkerServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -389,16 +389,25 @@ public class WorkerServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new WorkerServiceDescriptorSupplier(),
-          METHOD_RUN_SERVER,
-          METHOD_RUN_CLIENT,
-          METHOD_CORE_COUNT,
-          METHOD_QUIT_WORKER);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new WorkerServiceDescriptorSupplier(),
+        METHOD_RUN_SERVER,
+        METHOD_RUN_CLIENT,
+        METHOD_CORE_COUNT,
+        METHOD_QUIT_WORKER);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -922,7 +922,7 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
   p->Indent();
   p->Print(
       *vars,
-      "synchronized($service_class_name$.class) {\n");
+      "synchronized ($service_class_name$.class) {\n");
   p->Indent();
   p->Print("result = serviceDescriptor;\n");
   p->Print("if (result == null) {\n");

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -909,35 +909,11 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
 
   p->Print(
       *vars,
-      "private static $ServiceDescriptor$ serviceDescriptor;\n\n");
-
+      "private static final class LazyServiceDescriptorHolder {\n");
+  p->Indent();
   p->Print(
       *vars,
-      "public static $ServiceDescriptor$ getServiceDescriptor() {\n");
-  p->Indent();
-  p->Print("if (serviceDescriptor != null) {\n");
-  p->Indent();
-  p->Print("return serviceDescriptor;\n");
-  p->Outdent();
-  p->Print("}\n");
-  p->Print("return newServiceDescriptor();\n");
-  p->Outdent();
-  p->Print("}\n\n");
-
-  p->Print(
-      *vars,
-      "private static synchronized $ServiceDescriptor$ newServiceDescriptor() {\n");
-  p->Indent();
-  p->Print("if (serviceDescriptor != null) {\n");
-  p->Indent();
-  p->Print("return serviceDescriptor;\n");
-  p->Outdent();
-  p->Print("}\n");
-  // use a copy to avoid serviceDescriptor being assigned to an address at the beginning of
-  // the execution of the constructor rather than the completion of it for some JVMs
-  p->Print(
-      *vars,
-      "$ServiceDescriptor$ serviceDescriptorCopy = new $ServiceDescriptor$(\n");
+      "static final $ServiceDescriptor$ SERVICE_DESCRIPTOR = new $ServiceDescriptor$(\n");
   p->Indent();
   p->Indent();
   p->Print("SERVICE_NAME");
@@ -954,8 +930,14 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
   p->Print(");\n");
   p->Outdent();
   p->Outdent();
-  p->Print("serviceDescriptor = serviceDescriptorCopy;\n");
-  p->Print("return serviceDescriptor;\n");
+  p->Outdent();
+  p->Print("}\n\n");
+
+  p->Print(
+      *vars,
+      "public static $ServiceDescriptor$ getServiceDescriptor() {\n");
+  p->Indent();
+  p->Print("return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;\n");
   p->Outdent();
   p->Print("}\n");
 }

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -905,44 +905,47 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
     p->Print(*vars, "}\n");
     p->Outdent();
     p->Print(*vars, "}\n\n");
-
-    p->Print(
-            *vars,
-            "private static $ServiceDescriptor$ serviceDescriptor;\n\n");
-
-    p->Print(
-        *vars,
-        "public static synchronized $ServiceDescriptor$ getServiceDescriptor() {\n");
-    p->Indent();
-    p->Print("if (serviceDescriptor == null) {\n");
-    p->Indent();
-    p->Print(
-        *vars,
-        "serviceDescriptor = new $ServiceDescriptor$(SERVICE_NAME,\n");
-    p->Indent();
-    p->Indent();
-    p->Print(
-        *vars,
-        "new $proto_descriptor_supplier$()");
-    p->Outdent();
-    p->Outdent();
-  } else {
-    p->Print(
-      *vars,
-      "private static $ServiceDescriptor$ serviceDescriptor;\n\n");
-    p->Print(
-        *vars,
-        "public static synchronized $ServiceDescriptor$ getServiceDescriptor() {\n");
-    p->Indent();
-    p->Print("if (serviceDescriptor == null) {\n");
-    p->Indent();
-    p->Print(
-        *vars,
-        "serviceDescriptor = new $ServiceDescriptor$(SERVICE_NAME");
   }
 
+  p->Print(
+      *vars,
+      "private static $ServiceDescriptor$ serviceDescriptor;\n\n");
+
+  p->Print(
+      *vars,
+      "public static $ServiceDescriptor$ getServiceDescriptor() {\n");
+  p->Indent();
+  p->Print("if (serviceDescriptor != null) {\n");
+  p->Indent();
+  p->Print("return serviceDescriptor;\n");
+  p->Outdent();
+  p->Print("}\n");
+  p->Print("return newServiceDescriptor();\n");
+  p->Outdent();
+  p->Print("}\n\n");
+
+  p->Print(
+      *vars,
+      "private static synchronized $ServiceDescriptor$ newServiceDescriptor() {\n");
+  p->Indent();
+  p->Print("if (serviceDescriptor != null) {\n");
+  p->Indent();
+  p->Print("return serviceDescriptor;\n");
+  p->Outdent();
+  p->Print("}\n");
+  // use a copy to avoid serviceDescriptor being assigned to an address at the beginning of
+  // the execution of the constructor rather than the completion of it for some JVMs
+  p->Print(
+      *vars,
+      "$ServiceDescriptor$ serviceDescriptorCopy = new $ServiceDescriptor$(\n");
   p->Indent();
   p->Indent();
+  p->Print("SERVICE_NAME");
+  if (flavor == ProtoFlavor::NORMAL) {
+    p->Print(
+        *vars,
+        ",\nnew $proto_descriptor_supplier$()");
+  }
   for (int i = 0; i < service->method_count(); ++i) {
     const MethodDescriptor* method = service->method(i);
     (*vars)["method_field_name"] = MethodPropertiesFieldName(method);
@@ -951,8 +954,8 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
   p->Print(");\n");
   p->Outdent();
   p->Outdent();
-  p->Outdent();
-  p->Print("}\n\nreturn serviceDescriptor;\n");
+  p->Print("serviceDescriptor = serviceDescriptorCopy;\n");
+  p->Print("return serviceDescriptor;\n");
   p->Outdent();
   p->Print("}\n");
 }

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -909,35 +909,28 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
 
   p->Print(
       *vars,
-      "private static $ServiceDescriptor$ serviceDescriptor;\n\n");
+      "private static volatile $ServiceDescriptor$ serviceDescriptor;\n\n");
 
   p->Print(
       *vars,
       "public static $ServiceDescriptor$ getServiceDescriptor() {\n");
   p->Indent();
-  p->Print("if (serviceDescriptor != null) {\n");
+  p->Print(
+      *vars,
+      "$ServiceDescriptor$ result = serviceDescriptor;\n");
+  p->Print("if (result == null) {\n");
   p->Indent();
-  p->Print("return serviceDescriptor;\n");
-  p->Outdent();
-  p->Print("}\n");
-  p->Print("return newServiceDescriptor();\n");
-  p->Outdent();
-  p->Print("}\n\n");
+  p->Print(
+      *vars,
+      "synchronized($service_class_name$.class) {\n");
+  p->Indent();
+  p->Print("result = serviceDescriptor;\n");
+  p->Print("if (result == null) {\n");
+  p->Indent();
 
   p->Print(
       *vars,
-      "private static synchronized $ServiceDescriptor$ newServiceDescriptor() {\n");
-  p->Indent();
-  p->Print("if (serviceDescriptor != null) {\n");
-  p->Indent();
-  p->Print("return serviceDescriptor;\n");
-  p->Outdent();
-  p->Print("}\n");
-  // use a copy to avoid serviceDescriptor being assigned to an address at the beginning of
-  // the execution of the constructor rather than the completion of it for some JVMs
-  p->Print(
-      *vars,
-      "$ServiceDescriptor$ serviceDescriptorCopy = new $ServiceDescriptor$(\n");
+      "serviceDescriptor = result = new $ServiceDescriptor$(\n");
   p->Indent();
   p->Indent();
   p->Print("SERVICE_NAME");
@@ -954,8 +947,14 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
   p->Print(");\n");
   p->Outdent();
   p->Outdent();
-  p->Print("serviceDescriptor = serviceDescriptorCopy;\n");
-  p->Print("return serviceDescriptor;\n");
+
+  p->Outdent();
+  p->Print("}\n");
+  p->Outdent();
+  p->Print("}\n");
+  p->Outdent();
+  p->Print("}\n");
+  p->Print("return result;\n");
   p->Outdent();
   p->Print("}\n");
 }

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -909,11 +909,35 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
 
   p->Print(
       *vars,
-      "private static final class LazyServiceDescriptorHolder {\n");
-  p->Indent();
+      "private static $ServiceDescriptor$ serviceDescriptor;\n\n");
+
   p->Print(
       *vars,
-      "static final $ServiceDescriptor$ SERVICE_DESCRIPTOR = new $ServiceDescriptor$(\n");
+      "public static $ServiceDescriptor$ getServiceDescriptor() {\n");
+  p->Indent();
+  p->Print("if (serviceDescriptor != null) {\n");
+  p->Indent();
+  p->Print("return serviceDescriptor;\n");
+  p->Outdent();
+  p->Print("}\n");
+  p->Print("return newServiceDescriptor();\n");
+  p->Outdent();
+  p->Print("}\n\n");
+
+  p->Print(
+      *vars,
+      "private static synchronized $ServiceDescriptor$ newServiceDescriptor() {\n");
+  p->Indent();
+  p->Print("if (serviceDescriptor != null) {\n");
+  p->Indent();
+  p->Print("return serviceDescriptor;\n");
+  p->Outdent();
+  p->Print("}\n");
+  // use a copy to avoid serviceDescriptor being assigned to an address at the beginning of
+  // the execution of the constructor rather than the completion of it for some JVMs
+  p->Print(
+      *vars,
+      "$ServiceDescriptor$ serviceDescriptorCopy = new $ServiceDescriptor$(\n");
   p->Indent();
   p->Indent();
   p->Print("SERVICE_NAME");
@@ -930,14 +954,8 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
   p->Print(");\n");
   p->Outdent();
   p->Outdent();
-  p->Outdent();
-  p->Print("}\n\n");
-
-  p->Print(
-      *vars,
-      "public static $ServiceDescriptor$ getServiceDescriptor() {\n");
-  p->Indent();
-  p->Print("return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;\n");
+  p->Print("serviceDescriptor = serviceDescriptorCopy;\n");
+  p->Print("return serviceDescriptor;\n");
   p->Outdent();
   p->Print("}\n");
 }

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -432,20 +432,8 @@ public class TestServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new TestServiceDescriptorSupplier(),
         METHOD_UNARY_CALL,
@@ -453,7 +441,9 @@ public class TestServiceGrpc {
         METHOD_STREAMING_INPUT_CALL,
         METHOD_FULL_BIDI_CALL,
         METHOD_HALF_BIDI_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -437,7 +437,7 @@ public class TestServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(TestServiceGrpc.class) {
+      synchronized (TestServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -434,17 +434,26 @@ public class TestServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new TestServiceDescriptorSupplier(),
-          METHOD_UNARY_CALL,
-          METHOD_STREAMING_OUTPUT_CALL,
-          METHOD_STREAMING_INPUT_CALL,
-          METHOD_FULL_BIDI_CALL,
-          METHOD_HALF_BIDI_CALL);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new TestServiceDescriptorSupplier(),
+        METHOD_UNARY_CALL,
+        METHOD_STREAMING_OUTPUT_CALL,
+        METHOD_STREAMING_INPUT_CALL,
+        METHOD_FULL_BIDI_CALL,
+        METHOD_HALF_BIDI_CALL);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -432,28 +432,25 @@ public class TestServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(TestServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new TestServiceDescriptorSupplier(),
+              METHOD_UNARY_CALL,
+              METHOD_STREAMING_OUTPUT_CALL,
+              METHOD_STREAMING_INPUT_CALL,
+              METHOD_FULL_BIDI_CALL,
+              METHOD_HALF_BIDI_CALL);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new TestServiceDescriptorSupplier(),
-        METHOD_UNARY_CALL,
-        METHOD_STREAMING_OUTPUT_CALL,
-        METHOD_STREAMING_INPUT_CALL,
-        METHOD_FULL_BIDI_CALL,
-        METHOD_HALF_BIDI_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -432,8 +432,20 @@ public class TestServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new TestServiceDescriptorSupplier(),
         METHOD_UNARY_CALL,
@@ -441,9 +453,7 @@ public class TestServiceGrpc {
         METHOD_STREAMING_INPUT_CALL,
         METHOD_FULL_BIDI_CALL,
         METHOD_HALF_BIDI_CALL);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -430,7 +430,7 @@ public class TestServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(TestServiceGrpc.class) {
+      synchronized (TestServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -425,17 +425,27 @@ public class TestServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         METHOD_UNARY_CALL,
         METHOD_STREAMING_OUTPUT_CALL,
         METHOD_STREAMING_INPUT_CALL,
         METHOD_FULL_BIDI_CALL,
         METHOD_HALF_BIDI_CALL);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -425,27 +425,24 @@ public class TestServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(TestServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              METHOD_UNARY_CALL,
+              METHOD_STREAMING_OUTPUT_CALL,
+              METHOD_STREAMING_INPUT_CALL,
+              METHOD_FULL_BIDI_CALL,
+              METHOD_HALF_BIDI_CALL);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        METHOD_UNARY_CALL,
-        METHOD_STREAMING_OUTPUT_CALL,
-        METHOD_STREAMING_INPUT_CALL,
-        METHOD_FULL_BIDI_CALL,
-        METHOD_HALF_BIDI_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -425,27 +425,17 @@ public class TestServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         METHOD_UNARY_CALL,
         METHOD_STREAMING_OUTPUT_CALL,
         METHOD_STREAMING_INPUT_CALL,
         METHOD_FULL_BIDI_CALL,
         METHOD_HALF_BIDI_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -427,16 +427,25 @@ public class TestServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          METHOD_UNARY_CALL,
-          METHOD_STREAMING_OUTPUT_CALL,
-          METHOD_STREAMING_INPUT_CALL,
-          METHOD_FULL_BIDI_CALL,
-          METHOD_HALF_BIDI_CALL);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        METHOD_UNARY_CALL,
+        METHOD_STREAMING_OUTPUT_CALL,
+        METHOD_STREAMING_INPUT_CALL,
+        METHOD_FULL_BIDI_CALL,
+        METHOD_HALF_BIDI_CALL);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -503,27 +503,24 @@ public class TestServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(TestServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              METHOD_UNARY_CALL,
+              METHOD_STREAMING_OUTPUT_CALL,
+              METHOD_STREAMING_INPUT_CALL,
+              METHOD_FULL_BIDI_CALL,
+              METHOD_HALF_BIDI_CALL);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        METHOD_UNARY_CALL,
-        METHOD_STREAMING_OUTPUT_CALL,
-        METHOD_STREAMING_INPUT_CALL,
-        METHOD_FULL_BIDI_CALL,
-        METHOD_HALF_BIDI_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -503,27 +503,17 @@ public class TestServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         METHOD_UNARY_CALL,
         METHOD_STREAMING_OUTPUT_CALL,
         METHOD_STREAMING_INPUT_CALL,
         METHOD_FULL_BIDI_CALL,
         METHOD_HALF_BIDI_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -503,17 +503,27 @@ public class TestServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         METHOD_UNARY_CALL,
         METHOD_STREAMING_OUTPUT_CALL,
         METHOD_STREAMING_INPUT_CALL,
         METHOD_FULL_BIDI_CALL,
         METHOD_HALF_BIDI_CALL);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -508,7 +508,7 @@ public class TestServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(TestServiceGrpc.class) {
+      synchronized (TestServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -505,16 +505,25 @@ public class TestServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          METHOD_UNARY_CALL,
-          METHOD_STREAMING_OUTPUT_CALL,
-          METHOD_STREAMING_INPUT_CALL,
-          METHOD_FULL_BIDI_CALL,
-          METHOD_HALF_BIDI_CALL);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        METHOD_UNARY_CALL,
+        METHOD_STREAMING_OUTPUT_CALL,
+        METHOD_STREAMING_INPUT_CALL,
+        METHOD_FULL_BIDI_CALL,
+        METHOD_HALF_BIDI_CALL);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -200,24 +200,21 @@ public class LoadBalancerGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(LoadBalancerGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new LoadBalancerDescriptorSupplier(),
+              METHOD_BALANCE_LOAD);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new LoadBalancerDescriptorSupplier(),
-        METHOD_BALANCE_LOAD);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -202,13 +202,22 @@ public class LoadBalancerGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new LoadBalancerDescriptorSupplier(),
-          METHOD_BALANCE_LOAD);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new LoadBalancerDescriptorSupplier(),
+        METHOD_BALANCE_LOAD);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -205,7 +205,7 @@ public class LoadBalancerGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(LoadBalancerGrpc.class) {
+      synchronized (LoadBalancerGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -200,24 +200,14 @@ public class LoadBalancerGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new LoadBalancerDescriptorSupplier(),
         METHOD_BALANCE_LOAD);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -200,14 +200,24 @@ public class LoadBalancerGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new LoadBalancerDescriptorSupplier(),
         METHOD_BALANCE_LOAD);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -210,24 +210,21 @@ public class HealthGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(HealthGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new HealthDescriptorSupplier(),
+              METHOD_CHECK);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new HealthDescriptorSupplier(),
-        METHOD_CHECK);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -210,24 +210,14 @@ public class HealthGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new HealthDescriptorSupplier(),
         METHOD_CHECK);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -210,14 +210,24 @@ public class HealthGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new HealthDescriptorSupplier(),
         METHOD_CHECK);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -212,13 +212,22 @@ public class HealthGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new HealthDescriptorSupplier(),
-          METHOD_CHECK);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new HealthDescriptorSupplier(),
+        METHOD_CHECK);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -215,7 +215,7 @@ public class HealthGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(HealthGrpc.class) {
+      synchronized (HealthGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -207,7 +207,7 @@ public class ServerReflectionGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(ServerReflectionGrpc.class) {
+      synchronized (ServerReflectionGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -202,24 +202,14 @@ public class ServerReflectionGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new ServerReflectionDescriptorSupplier(),
         METHOD_SERVER_REFLECTION_INFO);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -202,14 +202,24 @@ public class ServerReflectionGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new ServerReflectionDescriptorSupplier(),
         METHOD_SERVER_REFLECTION_INFO);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -202,24 +202,21 @@ public class ServerReflectionGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(ServerReflectionGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new ServerReflectionDescriptorSupplier(),
+              METHOD_SERVER_REFLECTION_INFO);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new ServerReflectionDescriptorSupplier(),
-        METHOD_SERVER_REFLECTION_INFO);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -204,13 +204,22 @@ public class ServerReflectionGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new ServerReflectionDescriptorSupplier(),
-          METHOD_SERVER_REFLECTION_INFO);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new ServerReflectionDescriptorSupplier(),
+        METHOD_SERVER_REFLECTION_INFO);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -210,24 +210,21 @@ public class DynamicServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(DynamicServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new DynamicServiceDescriptorSupplier(),
+              METHOD_METHOD);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new DynamicServiceDescriptorSupplier(),
-        METHOD_METHOD);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -212,13 +212,22 @@ public class DynamicServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new DynamicServiceDescriptorSupplier(),
-          METHOD_METHOD);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new DynamicServiceDescriptorSupplier(),
+        METHOD_METHOD);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -210,14 +210,24 @@ public class DynamicServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new DynamicServiceDescriptorSupplier(),
         METHOD_METHOD);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -215,7 +215,7 @@ public class DynamicServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(DynamicServiceGrpc.class) {
+      synchronized (DynamicServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -210,24 +210,14 @@ public class DynamicServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new DynamicServiceDescriptorSupplier(),
         METHOD_METHOD);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -210,24 +210,14 @@ public class ReflectableServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new ReflectableServiceDescriptorSupplier(),
         METHOD_METHOD);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -212,13 +212,22 @@ public class ReflectableServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new ReflectableServiceDescriptorSupplier(),
-          METHOD_METHOD);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new ReflectableServiceDescriptorSupplier(),
+        METHOD_METHOD);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -210,24 +210,21 @@ public class ReflectableServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(ReflectableServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new ReflectableServiceDescriptorSupplier(),
+              METHOD_METHOD);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new ReflectableServiceDescriptorSupplier(),
-        METHOD_METHOD);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -210,14 +210,24 @@ public class ReflectableServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new ReflectableServiceDescriptorSupplier(),
         METHOD_METHOD);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -215,7 +215,7 @@ public class ReflectableServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(ReflectableServiceGrpc.class) {
+      synchronized (ReflectableServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -278,15 +278,25 @@ public class MetricsServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new MetricsServiceDescriptorSupplier(),
         METHOD_GET_ALL_GAUGES,
         METHOD_GET_GAUGE);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -278,25 +278,22 @@ public class MetricsServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(MetricsServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new MetricsServiceDescriptorSupplier(),
+              METHOD_GET_ALL_GAUGES,
+              METHOD_GET_GAUGE);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new MetricsServiceDescriptorSupplier(),
-        METHOD_GET_ALL_GAUGES,
-        METHOD_GET_GAUGE);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -283,7 +283,7 @@ public class MetricsServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(MetricsServiceGrpc.class) {
+      synchronized (MetricsServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -278,25 +278,15 @@ public class MetricsServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new MetricsServiceDescriptorSupplier(),
         METHOD_GET_ALL_GAUGES,
         METHOD_GET_GAUGE);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -280,14 +280,23 @@ public class MetricsServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new MetricsServiceDescriptorSupplier(),
-          METHOD_GET_ALL_GAUGES,
-          METHOD_GET_GAUGE);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new MetricsServiceDescriptorSupplier(),
+        METHOD_GET_ALL_GAUGES,
+        METHOD_GET_GAUGE);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -276,25 +276,15 @@ public class ReconnectServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new ReconnectServiceDescriptorSupplier(),
         METHOD_START,
         METHOD_STOP);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -276,25 +276,22 @@ public class ReconnectServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(ReconnectServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new ReconnectServiceDescriptorSupplier(),
+              METHOD_START,
+              METHOD_STOP);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new ReconnectServiceDescriptorSupplier(),
-        METHOD_START,
-        METHOD_STOP);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -276,15 +276,25 @@ public class ReconnectServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new ReconnectServiceDescriptorSupplier(),
         METHOD_START,
         METHOD_STOP);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -281,7 +281,7 @@ public class ReconnectServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(ReconnectServiceGrpc.class) {
+      synchronized (ReconnectServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -278,14 +278,23 @@ public class ReconnectServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new ReconnectServiceDescriptorSupplier(),
-          METHOD_START,
-          METHOD_STOP);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new ReconnectServiceDescriptorSupplier(),
+        METHOD_START,
+        METHOD_STOP);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -563,30 +563,27 @@ public class TestServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(TestServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new TestServiceDescriptorSupplier(),
+              METHOD_EMPTY_CALL,
+              METHOD_UNARY_CALL,
+              METHOD_STREAMING_OUTPUT_CALL,
+              METHOD_STREAMING_INPUT_CALL,
+              METHOD_FULL_DUPLEX_CALL,
+              METHOD_HALF_DUPLEX_CALL,
+              METHOD_UNIMPLEMENTED_CALL);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new TestServiceDescriptorSupplier(),
-        METHOD_EMPTY_CALL,
-        METHOD_UNARY_CALL,
-        METHOD_STREAMING_OUTPUT_CALL,
-        METHOD_STREAMING_INPUT_CALL,
-        METHOD_FULL_DUPLEX_CALL,
-        METHOD_HALF_DUPLEX_CALL,
-        METHOD_UNIMPLEMENTED_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -568,7 +568,7 @@ public class TestServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(TestServiceGrpc.class) {
+      synchronized (TestServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -563,8 +563,20 @@ public class TestServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new TestServiceDescriptorSupplier(),
         METHOD_EMPTY_CALL,
@@ -574,9 +586,7 @@ public class TestServiceGrpc {
         METHOD_FULL_DUPLEX_CALL,
         METHOD_HALF_DUPLEX_CALL,
         METHOD_UNIMPLEMENTED_CALL);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -563,20 +563,8 @@ public class TestServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new TestServiceDescriptorSupplier(),
         METHOD_EMPTY_CALL,
@@ -586,7 +574,9 @@ public class TestServiceGrpc {
         METHOD_FULL_DUPLEX_CALL,
         METHOD_HALF_DUPLEX_CALL,
         METHOD_UNIMPLEMENTED_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -565,19 +565,28 @@ public class TestServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new TestServiceDescriptorSupplier(),
-          METHOD_EMPTY_CALL,
-          METHOD_UNARY_CALL,
-          METHOD_STREAMING_OUTPUT_CALL,
-          METHOD_STREAMING_INPUT_CALL,
-          METHOD_FULL_DUPLEX_CALL,
-          METHOD_HALF_DUPLEX_CALL,
-          METHOD_UNIMPLEMENTED_CALL);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new TestServiceDescriptorSupplier(),
+        METHOD_EMPTY_CALL,
+        METHOD_UNARY_CALL,
+        METHOD_STREAMING_OUTPUT_CALL,
+        METHOD_STREAMING_INPUT_CALL,
+        METHOD_FULL_DUPLEX_CALL,
+        METHOD_HALF_DUPLEX_CALL,
+        METHOD_UNIMPLEMENTED_CALL);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -242,24 +242,14 @@ public class UnimplementedServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+  private static final class LazyServiceDescriptorHolder {
+    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new UnimplementedServiceDescriptorSupplier(),
         METHOD_UNIMPLEMENTED_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+  }
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -247,7 +247,7 @@ public class UnimplementedServiceGrpc {
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
     io.grpc.ServiceDescriptor result = serviceDescriptor;
     if (result == null) {
-      synchronized(UnimplementedServiceGrpc.class) {
+      synchronized (UnimplementedServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = new io.grpc.ServiceDescriptor(

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -244,13 +244,22 @@ public class UnimplementedServiceGrpc {
 
   private static io.grpc.ServiceDescriptor serviceDescriptor;
 
-  public static synchronized io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor == null) {
-      serviceDescriptor = new io.grpc.ServiceDescriptor(SERVICE_NAME,
-          new UnimplementedServiceDescriptorSupplier(),
-          METHOD_UNIMPLEMENTED_CALL);
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
     }
+    return newServiceDescriptor();
+  }
 
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
+        SERVICE_NAME,
+        new UnimplementedServiceDescriptorSupplier(),
+        METHOD_UNIMPLEMENTED_CALL);
+    serviceDescriptor = serviceDescriptorCopy;
     return serviceDescriptor;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -242,14 +242,24 @@ public class UnimplementedServiceGrpc {
     }
   }
 
-  private static final class LazyServiceDescriptorHolder {
-    static final io.grpc.ServiceDescriptor SERVICE_DESCRIPTOR = new io.grpc.ServiceDescriptor(
+  private static io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    return newServiceDescriptor();
+  }
+
+  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
+    if (serviceDescriptor != null) {
+      return serviceDescriptor;
+    }
+    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
         SERVICE_NAME,
         new UnimplementedServiceDescriptorSupplier(),
         METHOD_UNIMPLEMENTED_CALL);
-  }
-
-  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    return LazyServiceDescriptorHolder.SERVICE_DESCRIPTOR;
+    serviceDescriptor = serviceDescriptorCopy;
+    return serviceDescriptor;
   }
 }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -242,24 +242,21 @@ public class UnimplementedServiceGrpc {
     }
   }
 
-  private static io.grpc.ServiceDescriptor serviceDescriptor;
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
 
   public static io.grpc.ServiceDescriptor getServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized(UnimplementedServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = new io.grpc.ServiceDescriptor(
+              SERVICE_NAME,
+              new UnimplementedServiceDescriptorSupplier(),
+              METHOD_UNIMPLEMENTED_CALL);
+        }
+      }
     }
-    return newServiceDescriptor();
-  }
-
-  private static synchronized io.grpc.ServiceDescriptor newServiceDescriptor() {
-    if (serviceDescriptor != null) {
-      return serviceDescriptor;
-    }
-    io.grpc.ServiceDescriptor serviceDescriptorCopy = new io.grpc.ServiceDescriptor(
-        SERVICE_NAME,
-        new UnimplementedServiceDescriptorSupplier(),
-        METHOD_UNIMPLEMENTED_CALL);
-    serviceDescriptor = serviceDescriptorCopy;
-    return serviceDescriptor;
+    return result;
   }
 }


### PR DESCRIPTION
not necessary to synchronze every time calling
getServiceDescriptor(), if the descriptor has been created already;

go with the double-checked locking idom
http://www.oracle.com/technetwork/articles/javase/bloch-effective-08-qa-140880.html
https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java
