### PR TITLE
context: fix race condition in Context

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -120,7 +120,7 @@ public class Context {
    */
   public static final Context ROOT = new Context(null);
 
-  private static Storage storage;
+  private static volatile Storage storage;
 
   private static synchronized Storage initializeStorage() {
     if (storage != null) {
@@ -141,10 +141,11 @@ public class Context {
 
   // For testing
   static Storage storage() {
-    if (storage == null) {
+    Storage s = storage;
+    if (s == null) {
       return initializeStorage();
     }
-    return storage;
+    return s;
   }
 
   /**


### PR DESCRIPTION
As seen here:

```
  Write of size 8 at 0x7ff22a3359f0 by thread T52 (mutexes: write M938296775443437872):
    #0 io.grpc.Context.initializeStorage()Lio/grpc/Context$Storage; (Context.java:138)  
    #1 io.grpc.Context.storage()Lio/grpc/Context$Storage; (Context.java:145)  
    #2 io.grpc.Context.current()Lio/grpc/Context; (Context.java:174)  
    #3 io.grpc.internal.ClientCallImpl.<init>(Lio/grpc/MethodDescriptor;Ljava/util/concurrent/Executor;Lio/grpc/CallOptions;Lio/grpc/internal/StatsTraceContext;Lio/grpc/internal/ClientCallImpl$ClientTransportProvider;Ljava/util/concurrent/ScheduledExecutorService;)V (ClientCallImpl.java:109)  
    #4 io.grpc.internal.ManagedChannelImpl$RealChannel.newCall(Lio/grpc/MethodDescriptor;Lio/grpc/CallOptions;)Lio/grpc/ClientCall; (ManagedChannelImpl.java:625)  
    #5 io.grpc.internal.ManagedChannelImpl.newCall(Lio/grpc/MethodDescriptor;Lio/grpc/CallOptions;)Lio/grpc/ClientCall; (ManagedChannelImpl.java:592)  
    #6 io.grpc.testing.integration.TestServiceGrpc$TestServiceStub.streamingOutputCall(Lio/grpc/testing/integration/Messages$StreamingOutputCallRequest;Lio/grpc/stub/StreamObserver;)V (TestServiceGrpc.java:315)  
    #7 io.grpc.testing.integration.ConcurrencyTest$ClientWorker.run()V (ConcurrencyTest.java:138)  
    #8 java.util.concurrent.ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V (ThreadPoolExecutor.java:1142)  
    #9 java.util.concurrent.ThreadPoolExecutor$Worker.run()V (ThreadPoolExecutor.java:617)  
    #10 java.lang.Thread.run()V (Thread.java:745)  
    #11 (Generated Stub)  

  Previous read of size 8 at 0x7ff22a3359f0 by thread T81:
    #0 io.grpc.Context.storage()Lio/grpc/Context$Storage; (Context.java:144)  
    #1 io.grpc.Context.current()Lio/grpc/Context; (Context.java:174)  
    #2 io.grpc.internal.ClientCallImpl.<init>(Lio/grpc/MethodDescriptor;Ljava/util/concurrent/Executor;Lio/grpc/CallOptions;Lio/grpc/internal/StatsTraceContext;Lio/grpc/internal/ClientCallImpl$ClientTransportProvider;Ljava/util/concurrent/ScheduledExecutorService;)V (ClientCallImpl.java:109)  
    #3 io.grpc.internal.ManagedChannelImpl$RealChannel.newCall(Lio/grpc/MethodDescriptor;Lio/grpc/CallOptions;)Lio/grpc/ClientCall; (ManagedChannelImpl.java:625)  
    #4 io.grpc.internal.ManagedChannelImpl.newCall(Lio/grpc/MethodDescriptor;Lio/grpc/CallOptions;)Lio/grpc/ClientCall; (ManagedChannelImpl.java:592)  
    #5 io.grpc.testing.integration.TestServiceGrpc$TestServiceStub.streamingOutputCall(Lio/grpc/testing/integration/Messages$StreamingOutputCallRequest;Lio/grpc/stub/StreamObserver;)V (TestServiceGrpc.java:315)  
    #6 io.grpc.testing.integration.ConcurrencyTest$ClientWorker.run()V (ConcurrencyTest.java:138)  
    #7 java.util.concurrent.ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V (ThreadPoolExecutor.java:1142)  
    #8 java.util.concurrent.ThreadPoolExecutor$Worker.run()V (ThreadPoolExecutor.java:617)  
    #9 java.lang.Thread.run()V (Thread.java:745)  
    #10 (Generated Stub)  

```