### PR TITLE
benchmarks: Do not set done to true when HistogramFuture#get

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
@@ -380,7 +380,6 @@ public class AsyncClient {
         throw new CancellationException();
       }
 
-      done = true;
       return histogram;
     }
 


### PR DESCRIPTION
IIUC, `done` should be set to true when we reach the code.