### PR TITLE
core: fix API breakage in ServerBuilder

### DIFF
--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -93,7 +93,9 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * be executed.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2132")
-  public abstract T addTransportFilter(ServerTransportFilter filter);
+  public T addTransportFilter(ServerTransportFilter filter) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Sets a fallback handler registry that will be looked up in if a method is not found in the


### PR DESCRIPTION
PR #2218 added an abstract method to ServerBuilder.  Since this is a public API, implementations of ServerBuilder could break when upgrading.  