### PR TITLE
context: expose Ticker interface and testing method

### DIFF
--- a/context/src/main/java/io/grpc/Deadline.java
+++ b/context/src/main/java/io/grpc/Deadline.java
@@ -55,20 +55,20 @@ public final class Deadline implements Comparable<Deadline> {
     return new Deadline(SystemTicker.INSTANCE, units.toNanos(duration), true);
   }
 
-  public static Deadline after(long duration, TimeUnit units, DeadlineTicker ticker) {
+  public static Deadline after(long duration, TimeUnit units, Ticker ticker) {
     checkNotNull(units, "units");
     return new Deadline(ticker, units.toNanos(duration), true);
   }
 
-  private final DeadlineTicker ticker;
+  private final Ticker ticker;
   private final long deadlineNanos;
   private volatile boolean expired;
 
-  private Deadline(DeadlineTicker ticker, long offset, boolean baseInstantAlreadyExpired) {
+  private Deadline(Ticker ticker, long offset, boolean baseInstantAlreadyExpired) {
     this(ticker, ticker.read(), offset, baseInstantAlreadyExpired);
   }
 
-  private Deadline(DeadlineTicker ticker, long baseInstant, long offset,
+  private Deadline(Ticker ticker, long baseInstant, long offset,
       boolean baseInstantAlreadyExpired) {
     this.ticker = ticker;
     // Clamp to range [MIN_OFFSET, MAX_OFFSET]
@@ -170,8 +170,7 @@ public final class Deadline implements Comparable<Deadline> {
     }
     Deadline that = (Deadline) obj;
     return this.deadlineNanos == that.deadlineNanos
-        && this.ticker == that.ticker
-        && this.expired == that.expired;
+        && ticker.equals(that.ticker);
   }
 
   /**
@@ -179,9 +178,7 @@ public final class Deadline implements Comparable<Deadline> {
    */
   @Override
   public int hashCode() {
-    return ((int)(deadlineNanos ^ (deadlineNanos >>> 32)))
-        ^ (expired ? 1231 : 1237)
-        ^ ticker.hashCode();
+    return ((int)(deadlineNanos ^ (deadlineNanos >>> 32))) ^ ticker.hashCode();
   }
 
   /**
@@ -189,12 +186,12 @@ public final class Deadline implements Comparable<Deadline> {
    *
    * <p>This is public for testing purposes.
    */
-  public interface DeadlineTicker {
+  public interface Ticker {
     /** Returns the number of nanoseconds since this source's epoch. */
     long read();
   }
 
-  private enum SystemTicker implements DeadlineTicker {
+  private enum SystemTicker implements Ticker {
     INSTANCE;
 
     @Override

--- a/context/src/main/java/io/grpc/Deadline.java
+++ b/context/src/main/java/io/grpc/Deadline.java
@@ -52,7 +52,7 @@ public final class Deadline implements Comparable<Deadline> {
    */
   public static Deadline after(long duration, TimeUnit units) {
     checkNotNull(units, "units");
-    return new Deadline(SystemTicker.INTANCE, units.toNanos(duration), true);
+    return new Deadline(SystemTicker.INSTANCE, units.toNanos(duration), true);
   }
 
   public static Deadline after(long duration, TimeUnit units, DeadlineTicker ticker) {
@@ -174,7 +174,7 @@ public final class Deadline implements Comparable<Deadline> {
   }
 
   private enum SystemTicker implements DeadlineTicker {
-    INTANCE;
+    INSTANCE;
 
     @Override
     public long read() {

--- a/context/src/main/java/io/grpc/Deadline.java
+++ b/context/src/main/java/io/grpc/Deadline.java
@@ -163,6 +163,27 @@ public final class Deadline implements Comparable<Deadline> {
     return 0;
   }
 
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof Deadline)) {
+      return false;
+    }
+    Deadline that = (Deadline) obj;
+    return this.deadlineNanos == that.deadlineNanos
+        && this.ticker == that.ticker
+        && this.expired == that.expired;
+  }
+
+  /**
+   * It is not expected that this will be used, but is added for completeness.
+   */
+  @Override
+  public int hashCode() {
+    return ((int)(deadlineNanos ^ (deadlineNanos >>> 32)))
+        ^ (expired ? 1231 : 1237)
+        ^ ticker.hashCode();
+  }
+
   /**
    * Time source representing nanoseconds since fixed but arbitrary point in time.
    *

--- a/context/src/main/java/io/grpc/Deadline.java
+++ b/context/src/main/java/io/grpc/Deadline.java
@@ -55,8 +55,7 @@ public final class Deadline implements Comparable<Deadline> {
     return new Deadline(SystemTicker.INTANCE, units.toNanos(duration), true);
   }
 
-  //For testing
-  public static Deadline forTest(long duration, TimeUnit units, DeadlineTicker ticker) {
+  public static Deadline after(long duration, TimeUnit units, DeadlineTicker ticker) {
     checkNotNull(units, "units");
     return new Deadline(ticker, units.toNanos(duration), true);
   }

--- a/context/src/test/java/io/grpc/DeadlineTest.java
+++ b/context/src/test/java/io/grpc/DeadlineTest.java
@@ -267,7 +267,7 @@ public class DeadlineTest {
     assertEquals("12000 ns from now", d.toString());
   }
 
-  private static class FakeTicker implements Deadline.DeadlineTicker {
+  private static class FakeTicker implements Deadline.Ticker {
     private long time;
 
     @Override

--- a/context/src/test/java/io/grpc/DeadlineTest.java
+++ b/context/src/test/java/io/grpc/DeadlineTest.java
@@ -79,7 +79,7 @@ public class DeadlineTest {
   public void defaultTickerIsSystemTicker() {
     Deadline d = Deadline.after(0, TimeUnit.SECONDS);
     ticker.reset(System.nanoTime());
-    Deadline reference = Deadline.after(0, TimeUnit.SECONDS, ticker);
+    Deadline reference = Deadline.forTest(0, TimeUnit.SECONDS, ticker);
     // Allow inaccuracy to account for system time advancing during test.
     assertAbout(deadline()).that(d).isWithin(1, TimeUnit.SECONDS).of(reference);
   }
@@ -87,9 +87,9 @@ public class DeadlineTest {
   @Test
   public void timeCanOverflow() {
     ticker.reset(Long.MAX_VALUE);
-    Deadline d = Deadline.after(10, TimeUnit.DAYS, ticker);
+    Deadline d = Deadline.forTest(10, TimeUnit.DAYS, ticker);
     assertEquals(10, d.timeRemaining(TimeUnit.DAYS));
-    assertTrue(Deadline.after(0, TimeUnit.DAYS, ticker).isBefore(d));
+    assertTrue(Deadline.forTest(0, TimeUnit.DAYS, ticker).isBefore(d));
     assertFalse(d.isExpired());
 
     ticker.increment(10, TimeUnit.DAYS);
@@ -99,19 +99,19 @@ public class DeadlineTest {
   @Test
   public void timeCanUnderflow() {
     ticker.reset(Long.MIN_VALUE);
-    Deadline d = Deadline.after(-10, TimeUnit.DAYS, ticker);
+    Deadline d = Deadline.forTest(-10, TimeUnit.DAYS, ticker);
     assertEquals(-10, d.timeRemaining(TimeUnit.DAYS));
-    assertTrue(d.isBefore(Deadline.after(0, TimeUnit.DAYS, ticker)));
+    assertTrue(d.isBefore(Deadline.forTest(0, TimeUnit.DAYS, ticker)));
     assertTrue(d.isExpired());
   }
 
   @Test
   public void deadlineClamps() {
-    Deadline d = Deadline.after(-300 * 365, TimeUnit.DAYS, ticker);
-    Deadline d2 = Deadline.after(300 * 365, TimeUnit.DAYS, ticker);
+    Deadline d = Deadline.forTest(-300 * 365, TimeUnit.DAYS, ticker);
+    Deadline d2 = Deadline.forTest(300 * 365, TimeUnit.DAYS, ticker);
     assertTrue(d.isBefore(d2));
 
-    Deadline d3 = Deadline.after(-200 * 365, TimeUnit.DAYS, ticker);
+    Deadline d3 = Deadline.forTest(-200 * 365, TimeUnit.DAYS, ticker);
     // d and d3 are equal
     assertFalse(d.isBefore(d3));
     assertFalse(d3.isBefore(d));
@@ -119,13 +119,13 @@ public class DeadlineTest {
 
   @Test
   public void immediateDeadlineIsExpired() {
-    Deadline deadline = Deadline.after(0, TimeUnit.SECONDS, ticker);
+    Deadline deadline = Deadline.forTest(0, TimeUnit.SECONDS, ticker);
     assertTrue(deadline.isExpired());
   }
 
   @Test
   public void shortDeadlineEventuallyExpires() throws Exception {
-    Deadline d = Deadline.after(100, TimeUnit.MILLISECONDS, ticker);
+    Deadline d = Deadline.forTest(100, TimeUnit.MILLISECONDS, ticker);
     assertTrue(d.timeRemaining(TimeUnit.NANOSECONDS) > 0);
     assertFalse(d.isExpired());
     ticker.increment(101, TimeUnit.MILLISECONDS);
@@ -136,22 +136,24 @@ public class DeadlineTest {
 
   @Test
   public void deadlineMatchesLongValue() {
-    assertEquals(10, Deadline.after(10, TimeUnit.MINUTES, ticker).timeRemaining(TimeUnit.MINUTES));
+    assertEquals(
+        10,
+        Deadline.forTest(10, TimeUnit.MINUTES, ticker).timeRemaining(TimeUnit.MINUTES));
   }
 
   @Test
   public void pastDeadlineIsExpired() {
-    Deadline d = Deadline.after(-1, TimeUnit.SECONDS, ticker);
+    Deadline d = Deadline.forTest(-1, TimeUnit.SECONDS, ticker);
     assertTrue(d.isExpired());
     assertEquals(-1000, d.timeRemaining(TimeUnit.MILLISECONDS));
   }
 
   @Test
   public void deadlineDoesNotOverflowOrUnderflow() {
-    Deadline after = Deadline.after(Long.MAX_VALUE, TimeUnit.NANOSECONDS, ticker);
+    Deadline after = Deadline.forTest(Long.MAX_VALUE, TimeUnit.NANOSECONDS, ticker);
     assertFalse(after.isExpired());
 
-    Deadline before = Deadline.after(-Long.MAX_VALUE, TimeUnit.NANOSECONDS, ticker);
+    Deadline before = Deadline.forTest(-Long.MAX_VALUE, TimeUnit.NANOSECONDS, ticker);
     assertTrue(before.isExpired());
 
     assertTrue(before.isBefore(after));
@@ -159,14 +161,14 @@ public class DeadlineTest {
 
   @Test
   public void beforeExpiredDeadlineIsExpired() {
-    Deadline base = Deadline.after(0, TimeUnit.SECONDS, ticker);
+    Deadline base = Deadline.forTest(0, TimeUnit.SECONDS, ticker);
     assertTrue(base.isExpired());
     assertTrue(base.offset(-1, TimeUnit.SECONDS).isExpired());
   }
 
   @Test
   public void beforeNotExpiredDeadlineMayBeExpired() {
-    Deadline base = Deadline.after(10, TimeUnit.SECONDS, ticker);
+    Deadline base = Deadline.forTest(10, TimeUnit.SECONDS, ticker);
     assertFalse(base.isExpired());
     assertFalse(base.offset(-1, TimeUnit.SECONDS).isExpired());
     assertTrue(base.offset(-11, TimeUnit.SECONDS).isExpired());
@@ -174,7 +176,7 @@ public class DeadlineTest {
 
   @Test
   public void afterExpiredDeadlineMayBeExpired() {
-    Deadline base = Deadline.after(-10, TimeUnit.SECONDS, ticker);
+    Deadline base = Deadline.forTest(-10, TimeUnit.SECONDS, ticker);
     assertTrue(base.isExpired());
     assertTrue(base.offset(1, TimeUnit.SECONDS).isExpired());
     assertFalse(base.offset(11, TimeUnit.SECONDS).isExpired());
@@ -182,13 +184,13 @@ public class DeadlineTest {
 
   @Test
   public void zeroOffsetIsSameDeadline() {
-    Deadline base = Deadline.after(0, TimeUnit.SECONDS, ticker);
+    Deadline base = Deadline.forTest(0, TimeUnit.SECONDS, ticker);
     assertSame(base, base.offset(0, TimeUnit.SECONDS));
   }
 
   @Test
   public void runOnEventualExpirationIsExecuted() throws Exception {
-    Deadline base = Deadline.after(50, TimeUnit.MICROSECONDS, ticker);
+    Deadline base = Deadline.forTest(50, TimeUnit.MICROSECONDS, ticker);
     ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
     final AtomicBoolean executed = new AtomicBoolean();
     base.runOnExpiration(
@@ -207,7 +209,7 @@ public class DeadlineTest {
 
   @Test
   public void runOnAlreadyExpiredIsExecutedOnExecutor() throws Exception {
-    Deadline base = Deadline.after(0, TimeUnit.MICROSECONDS, ticker);
+    Deadline base = Deadline.forTest(0, TimeUnit.MICROSECONDS, ticker);
     ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
     final AtomicBoolean executed = new AtomicBoolean();
     base.runOnExpiration(
@@ -226,46 +228,46 @@ public class DeadlineTest {
 
   @Test
   public void toString_exact() {
-    Deadline d = Deadline.after(0, TimeUnit.MILLISECONDS, ticker);
+    Deadline d = Deadline.forTest(0, TimeUnit.MILLISECONDS, ticker);
     assertEquals("0 ns from now", d.toString());
   }
 
   @Test
   public void toString_after() {
-    Deadline d = Deadline.after(-1, TimeUnit.MINUTES, ticker);
+    Deadline d = Deadline.forTest(-1, TimeUnit.MINUTES, ticker);
     assertEquals("-60000000000 ns from now", d.toString());
   }
 
   @Test
   public void compareTo_greater() {
-    Deadline d1 = Deadline.after(10, TimeUnit.SECONDS, ticker);
+    Deadline d1 = Deadline.forTest(10, TimeUnit.SECONDS, ticker);
     ticker.increment(1, TimeUnit.NANOSECONDS);
-    Deadline d2 = Deadline.after(10, TimeUnit.SECONDS, ticker);
+    Deadline d2 = Deadline.forTest(10, TimeUnit.SECONDS, ticker);
     Truth.assertThat(d2).isGreaterThan(d1);
   }
 
   @Test
   public void compareTo_less() {
-    Deadline d1 = Deadline.after(10, TimeUnit.SECONDS, ticker);
+    Deadline d1 = Deadline.forTest(10, TimeUnit.SECONDS, ticker);
     ticker.increment(1, TimeUnit.NANOSECONDS);
-    Deadline d2 = Deadline.after(10, TimeUnit.SECONDS, ticker);
+    Deadline d2 = Deadline.forTest(10, TimeUnit.SECONDS, ticker);
     Truth.assertThat(d1).isLessThan(d2);
   }
 
   @Test
   public void compareTo_same() {
-    Deadline d1 = Deadline.after(10, TimeUnit.SECONDS, ticker);
-    Deadline d2 = Deadline.after(10, TimeUnit.SECONDS, ticker);
+    Deadline d1 = Deadline.forTest(10, TimeUnit.SECONDS, ticker);
+    Deadline d2 = Deadline.forTest(10, TimeUnit.SECONDS, ticker);
     Truth.assertThat(d1).isEquivalentAccordingToCompareTo(d2);
   }
 
   @Test
   public void toString_before() {
-    Deadline d = Deadline.after(12, TimeUnit.MICROSECONDS, ticker);
+    Deadline d = Deadline.forTest(12, TimeUnit.MICROSECONDS, ticker);
     assertEquals("12000 ns from now", d.toString());
   }
 
-  private static class FakeTicker extends Deadline.Ticker {
+  private static class FakeTicker implements Deadline.DeadlineTicker {
     private long time;
 
     @Override

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -58,8 +58,8 @@ import java.util.concurrent.TimeUnit;
 public class CallOptionsTest {
   private String sampleAuthority = "authority";
   private String sampleCompressor = "compressor";
-  private Deadline.Ticker ticker = new FakeTicker();
-  private Deadline sampleDeadline = Deadline.after(1, NANOSECONDS, ticker);
+  private Deadline.DeadlineTicker ticker = new FakeTicker();
+  private Deadline sampleDeadline = Deadline.forTest(1, NANOSECONDS, ticker);
   private Key<String> sampleKey = Attributes.Key.of("sample");
   private Attributes sampleAffinity = Attributes.newBuilder().set(sampleKey, "blah").build();
   private CallCredentials sampleCreds = mock(CallCredentials.class);
@@ -240,7 +240,7 @@ public class CallOptionsTest {
         && Objects.equal(o1.getCredentials(), o2.getCredentials());
   }
 
-  private static class FakeTicker extends Deadline.Ticker {
+  private static class FakeTicker implements Deadline.DeadlineTicker {
     private long time;
 
     @Override

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeUnit;
 public class CallOptionsTest {
   private String sampleAuthority = "authority";
   private String sampleCompressor = "compressor";
-  private Deadline.DeadlineTicker ticker = new FakeTicker();
+  private Deadline.Ticker ticker = new FakeTicker();
   private Deadline sampleDeadline = Deadline.after(1, NANOSECONDS, ticker);
   private Key<String> sampleKey = Attributes.Key.of("sample");
   private Attributes sampleAffinity = Attributes.newBuilder().set(sampleKey, "blah").build();
@@ -240,7 +240,7 @@ public class CallOptionsTest {
         && Objects.equal(o1.getCredentials(), o2.getCredentials());
   }
 
-  private static class FakeTicker implements Deadline.DeadlineTicker {
+  private static class FakeTicker implements Deadline.Ticker {
     private long time;
 
     @Override

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -59,7 +59,7 @@ public class CallOptionsTest {
   private String sampleAuthority = "authority";
   private String sampleCompressor = "compressor";
   private Deadline.DeadlineTicker ticker = new FakeTicker();
-  private Deadline sampleDeadline = Deadline.forTest(1, NANOSECONDS, ticker);
+  private Deadline sampleDeadline = Deadline.after(1, NANOSECONDS, ticker);
   private Key<String> sampleKey = Attributes.Key.of("sample");
   private Attributes sampleAffinity = Attributes.newBuilder().set(sampleKey, "blah").build();
   private CallCredentials sampleCreds = mock(CallCredentials.class);


### PR DESCRIPTION
The motivation is to make it easier for users to test their
deadlines.  Currently, only packages in io.grpc can set up tests
to use a fake ticker, while all other packages have to rely on the
System ticker.  This makes tests that compare deadlines flaky.

This exposes an interface in the context package for testing.
The previous abstract class was made to match the Guava version,
so for outside users to be able to continue using Guava, it
cannot be an abstract class.

The `baseInstant` has been left private, since I think it is still
easy to test deadlines without having access to it.

Fixes #2531