### PR TITLE
testing: Move echo interceptors out of TestUtils

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -145,9 +145,7 @@ public abstract class AbstractInteropTest {
     List<ServerInterceptor> allInterceptors = ImmutableList.<ServerInterceptor>builder()
         .add(TestUtils.recordServerCallInterceptor(serverCallCapture))
         .add(TestUtils.recordRequestHeadersInterceptor(requestHeadersCapture))
-        .add(TestUtils.echoRequestHeadersInterceptor(Util.METADATA_KEY))
-        .add(TestUtils.echoRequestMetadataInHeaders(Util.ECHO_INITIAL_METADATA_KEY))
-        .add(TestUtils.echoRequestMetadataInTrailers(Util.ECHO_TRAILING_METADATA_KEY))
+        .addAll(TestServiceImpl.interceptors())
         .add(interceptors)
         .build();
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -146,9 +146,7 @@ public class TestServiceServer {
         .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .addService(ServerInterceptors.intercept(
             new TestServiceImpl(executor),
-            TestUtils.echoRequestHeadersInterceptor(Util.METADATA_KEY),
-            TestUtils.echoRequestMetadataInHeaders(Util.ECHO_INITIAL_METADATA_KEY),
-            TestUtils.echoRequestMetadataInTrailers(Util.ECHO_TRAILING_METADATA_KEY)))
+            TestServiceImpl.interceptors()))
         .build().start();
   }
 

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -34,12 +34,10 @@ package io.grpc.testing;
 import static com.google.common.base.Charsets.UTF_8;
 
 import io.grpc.ExperimentalApi;
-import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-import io.grpc.Status;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedWriter;
@@ -59,11 +57,8 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLContext;
@@ -79,92 +74,7 @@ public class TestUtils {
   public static final String TEST_SERVER_HOST = "foo.test.google.fr";
 
   /**
-   * Echo the request headers from a client into response headers and trailers. Useful for
-   * testing end-to-end metadata propagation.
-   */
-  public static ServerInterceptor echoRequestHeadersInterceptor(final Metadata.Key<?>... keys) {
-    final Set<Metadata.Key<?>> keySet = new HashSet<Metadata.Key<?>>(Arrays.asList(keys));
-    return new ServerInterceptor() {
-      @Override
-      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
-          ServerCall<ReqT, RespT> call,
-          final Metadata requestHeaders,
-          ServerCallHandler<ReqT, RespT> next) {
-        return next.startCall(new SimpleForwardingServerCall<ReqT, RespT>(call) {
-              @Override
-              public void sendHeaders(Metadata responseHeaders) {
-                responseHeaders.merge(requestHeaders, keySet);
-                super.sendHeaders(responseHeaders);
-              }
-
-              @Override
-              public void close(Status status, Metadata trailers) {
-                trailers.merge(requestHeaders, keySet);
-                super.close(status, trailers);
-              }
-            }, requestHeaders);
-      }
-    };
-  }
-
-  /**
-   * Echoes request headers with the specified key(s) from a client into response headers only.
-   */
-  public static ServerInterceptor echoRequestMetadataInHeaders(final Metadata.Key<?>... keys) {
-    final Set<Metadata.Key<?>> keySet = new HashSet<Metadata.Key<?>>(Arrays.asList(keys));
-    return new ServerInterceptor() {
-      @Override
-      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
-          ServerCall<ReqT, RespT> call,
-          final Metadata requestHeaders,
-          ServerCallHandler<ReqT, RespT> next) {
-        return next.startCall(new SimpleForwardingServerCall<ReqT, RespT>(call) {
-          @Override
-          public void sendHeaders(Metadata responseHeaders) {
-            responseHeaders.merge(requestHeaders, keySet);
-            super.sendHeaders(responseHeaders);
-          }
-
-          @Override
-          public void close(Status status, Metadata trailers) {
-            super.close(status, trailers);
-          }
-        }, requestHeaders);
-      }
-    };
-  }
-
-  /**
-   * Echoes request headers with the specified key(s) from a client into response trailers only.
-   */
-  public static ServerInterceptor echoRequestMetadataInTrailers(final Metadata.Key<?>... keys) {
-    final Set<Metadata.Key<?>> keySet = new HashSet<Metadata.Key<?>>(Arrays.asList(keys));
-    return new ServerInterceptor() {
-      @Override
-      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
-          ServerCall<ReqT, RespT> call,
-          final Metadata requestHeaders,
-          ServerCallHandler<ReqT, RespT> next) {
-        return next.startCall(new SimpleForwardingServerCall<ReqT, RespT>(call) {
-          @Override
-          public void sendHeaders(Metadata responseHeaders) {
-            super.sendHeaders(responseHeaders);
-          }
-
-          @Override
-          public void close(Status status, Metadata trailers) {
-            trailers.merge(requestHeaders, keySet);
-            super.close(status, trailers);
-          }
-        }, requestHeaders);
-      }
-    };
-  }
-
-  /**
-   * Capture the request headers from a client. Useful for testing metadata propagation without
-   * requiring that it be symmetric on client and server, as with
-   * {@link #echoRequestHeadersInterceptor}.
+   * Capture the request headers from a client. Useful for testing metadata propagation.
    */
   public static ServerInterceptor recordRequestHeadersInterceptor(
       final AtomicReference<Metadata> headersCapture) {


### PR DESCRIPTION
The interceptors are quite specific, and probably not helpful for
current testing strategies. They really are only useful for interop
testing. Moving them to interop-testing avoids them appearing to be in a
public API (even if that API is experimental).

No functional changes were made; just code movement.