### PR TITLE
readme: Downgrade protoc to 3.0.2 to match grpc-protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <artifactId>protobuf-maven-plugin</artifactId>
       <version>0.5.0</version>
       <configuration>
-        <protocArtifact>com.google.protobuf:protoc:3.1.0:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
         <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.3:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
@@ -123,7 +123,7 @@ buildscript {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.1.0"
+    artifact = "com.google.protobuf:protoc:3.0.2"
   }
   plugins {
     grpc {


### PR DESCRIPTION
Protobuf runtime 3.0.2 is included transitively via grpc-protobuf
v1.0.3. Protoc doesn't have to match the version identically, but must
not be newer than the runtime. We must wait until v1.1 release of grpc
to bump protobuf version in the readme.

Fixes #2578 

CC @saturnism