### PR TITLE
core: promote experimental methods in MethodDescriptor

### DIFF
--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -197,7 +197,6 @@ public class MethodDescriptor<ReqT, RespT> {
    * @param requestMarshaller the marshaller used to encode and decode requests
    * @param responseMarshaller the marshaller used to encode and decode responses
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
   public static <RequestT, ResponseT> MethodDescriptor<RequestT, ResponseT> create(
       MethodType type, String fullMethodName,
       Marshaller<RequestT> requestMarshaller,
@@ -343,7 +342,6 @@ public class MethodDescriptor<ReqT, RespT> {
    * @param fullServiceName the fully qualified service name that is prefixed with the package name
    * @param methodName the short method name
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
   public static String generateFullMethodName(String fullServiceName, String methodName) {
     return fullServiceName + "/" + methodName;
   }
@@ -353,7 +351,6 @@ public class MethodDescriptor<ReqT, RespT> {
    * {@code null} if the input is malformed, but you cannot rely on it for the validity of the
    * input.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1774")
   @Nullable
   public static String extractFullServiceName(String fullMethodName) {
     int index = fullMethodName.lastIndexOf('/');

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -31,6 +31,8 @@
 
 package io.grpc;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.base.Preconditions;
 
 import java.io.InputStream;
@@ -343,7 +345,9 @@ public class MethodDescriptor<ReqT, RespT> {
    * @param methodName the short method name
    */
   public static String generateFullMethodName(String fullServiceName, String methodName) {
-    return fullServiceName + "/" + methodName;
+    return checkNotNull(fullServiceName, "fullServiceName")
+        + "/"
+        + checkNotNull(methodName, "methodName");
   }
 
   /**
@@ -353,7 +357,7 @@ public class MethodDescriptor<ReqT, RespT> {
    */
   @Nullable
   public static String extractFullServiceName(String fullMethodName) {
-    int index = fullMethodName.lastIndexOf('/');
+    int index = checkNotNull(fullMethodName, "fullMethodName").lastIndexOf('/');
     if (index == -1) {
       return null;
     }


### PR DESCRIPTION
* `create` is being used from generated code, so really it isn't experimental.  To remove it now, would break stubs generated at 1.0.x.

* `generateFullMethodName` is non experimental for the same reason

* `extractFullServiceName` is more nuanced.  It is referenced by packages `util` and `auth`, which may be at earlier versions of gRPC than core is at.  If someone was using util:1.0.0 with core:1.n.m, they would expect it to work.  Importantly, the methods that call `extractFullServiceName` are themselves not experimental, which would seems to unintentionally promote them.  

If we did want to get rid of these, at best we could mark them deprecated and hope that no one calls them again.
