### PR TITLE
all: bump to netty 4.1.7

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ In Maven, you can use the [os-maven-plugin](https://github.com/trustin/os-maven-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork23</version>
+      <version>1.1.33.Fork25</version>
     </dependency>
   </dependencies>
 </project>
@@ -80,7 +80,7 @@ buildscript {
 }
 
 dependencies {
-    compile 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork23'
+    compile 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork25'
 }
 ```
 
@@ -115,7 +115,7 @@ In Maven, you can use the [os-maven-plugin](https://github.com/trustin/os-maven-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>1.1.33.Fork23</version>
+      <version>1.1.33.Fork25</version>
       <classifier>${tcnative.classifier}</classifier>
     </dependency>
   </dependencies>
@@ -183,7 +183,7 @@ if (osdetector.os == "linux" && osdetector.release.isLike("fedora")) {
 }
 
 dependencies {
-    compile 'io.netty:netty-tcnative:1.1.33.Fork23:' + tcnative_classifier
+    compile 'io.netty:netty-tcnative:1.1.33.Fork25:' + tcnative_classifier
 }
 ```
 

--- a/benchmarks/src/jmh/java/io/grpc/netty/OutboundHeadersBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/netty/OutboundHeadersBenchmark.java
@@ -111,7 +111,7 @@ public class OutboundHeadersBenchmark {
     scratchBuffer.clear();
     Http2Headers headers =
         Utils.convertClientHeaders(metadata, scheme, defaultPath, authority, userAgent);
-    headersEncoder.encodeHeaders(headers, scratchBuffer);
+    headersEncoder.encodeHeaders(1, headers, scratchBuffer);
     return scratchBuffer;
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -161,9 +161,9 @@ subprojects {
                 protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.0',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
 
-                netty: 'io.netty:netty-codec-http2:[4.1.6.Final]',
-                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.6.Final' + epoll_suffix,
-                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork23',
+                netty: 'io.netty:netty-codec-http2:[4.1.7.Final]',
+                netty_epoll: 'io.netty:netty-transport-native-epoll:4.1.7.Final' + epoll_suffix,
+                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork25',
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -183,6 +183,7 @@ public final class GrpcUtil {
     switch (httpStatusCode) {
       case HttpURLConnection.HTTP_BAD_REQUEST:  // 400
       case 431: // Request Header Fields Too Large
+        // TODO(carl-mastrangelo): this should be added to the http-grpc-status-mapping.md doc.
         return Status.Code.INTERNAL;
       case HttpURLConnection.HTTP_UNAUTHORIZED:  // 401
         return Status.Code.UNAUTHENTICATED;

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -182,6 +182,7 @@ public final class GrpcUtil {
     }
     switch (httpStatusCode) {
       case HttpURLConnection.HTTP_BAD_REQUEST:  // 400
+      case 431: // Request Header Fields Too Large
         return Status.Code.INTERNAL;
       case HttpURLConnection.HTTP_UNAUTHORIZED:  // 401
         return Status.Code.UNAUTHENTICATED;

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersDecoderTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersDecoderTest.java
@@ -39,7 +39,6 @@ import static org.junit.Assert.assertThat;
 
 import io.grpc.netty.GrpcHttp2HeadersDecoder.GrpcHttp2ClientHeadersDecoder;
 import io.grpc.netty.GrpcHttp2HeadersDecoder.GrpcHttp2ServerHeadersDecoder;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
@@ -49,8 +48,8 @@ import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2HeadersDecoder;
 import io.netty.handler.codec.http2.Http2HeadersEncoder;
 import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
-import io.netty.util.ReferenceCountUtil;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -68,6 +67,15 @@ public class GrpcHttp2HeadersDecoderTest {
     }
   };
 
+  private ByteBuf encodedHeaders;
+
+  @After
+  public void tearDown() {
+    if (encodedHeaders != null) {
+      encodedHeaders.release();
+    }
+  }
+
   @Test
   public void decode_requestHeaders() throws Http2Exception {
     Http2HeadersDecoder decoder = new GrpcHttp2ServerHeadersDecoder(DEFAULT_MAX_HEADER_LIST_SIZE);
@@ -78,7 +86,7 @@ public class GrpcHttp2HeadersDecoderTest {
     headers.add(of(":scheme"), of("https")).add(of(":method"), of("GET"))
         .add(of(":path"), of("index.html")).add(of(":authority"), of("foo.grpc.io"))
         .add(of("custom"), of("header"));
-    ByteBuf encodedHeaders = ReferenceCountUtil.releaseLater(Unpooled.buffer());
+    encodedHeaders = Unpooled.buffer();
     encoder.encodeHeaders(1 /* randomly chosen */, headers, encodedHeaders);
 
     Http2Headers decodedHeaders = decoder.decodeHeaders(3 /* randomly chosen */, encodedHeaders);
@@ -105,7 +113,7 @@ public class GrpcHttp2HeadersDecoderTest {
 
     Http2Headers headers = new DefaultHttp2Headers(false);
     headers.add(of(":status"), of("200")).add(of("custom"), of("header"));
-    ByteBuf encodedHeaders = ReferenceCountUtil.releaseLater(Unpooled.buffer());
+    encodedHeaders = Unpooled.buffer();
     encoder.encodeHeaders(1 /* randomly chosen */, headers, encodedHeaders);
 
     Http2Headers decodedHeaders = decoder.decodeHeaders(3 /* randomly chosen */, encodedHeaders);
@@ -124,7 +132,7 @@ public class GrpcHttp2HeadersDecoderTest {
     Http2HeadersEncoder encoder =
         new DefaultHttp2HeadersEncoder(NEVER_SENSITIVE);
 
-    ByteBuf encodedHeaders = ReferenceCountUtil.releaseLater(Unpooled.buffer());
+    ByteBuf encodedHeaders = Unpooled.buffer();
     encoder.encodeHeaders(1 /* randomly chosen */, new DefaultHttp2Headers(false), encodedHeaders);
 
     Http2Headers decodedHeaders = decoder.decodeHeaders(3 /* randomly chosen */, encodedHeaders);

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersDecoderTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersDecoderTest.java
@@ -79,7 +79,7 @@ public class GrpcHttp2HeadersDecoderTest {
         .add(of(":path"), of("index.html")).add(of(":authority"), of("foo.grpc.io"))
         .add(of("custom"), of("header"));
     ByteBuf encodedHeaders = ReferenceCountUtil.releaseLater(Unpooled.buffer());
-    encoder.encodeHeaders(headers, encodedHeaders);
+    encoder.encodeHeaders(1 /* randomly chosen */, headers, encodedHeaders);
 
     Http2Headers decodedHeaders = decoder.decodeHeaders(3 /* randomly chosen */, encodedHeaders);
     assertEquals(headers.get(of(":scheme")), decodedHeaders.scheme());
@@ -106,7 +106,7 @@ public class GrpcHttp2HeadersDecoderTest {
     Http2Headers headers = new DefaultHttp2Headers(false);
     headers.add(of(":status"), of("200")).add(of("custom"), of("header"));
     ByteBuf encodedHeaders = ReferenceCountUtil.releaseLater(Unpooled.buffer());
-    encoder.encodeHeaders(headers, encodedHeaders);
+    encoder.encodeHeaders(1 /* randomly chosen */, headers, encodedHeaders);
 
     Http2Headers decodedHeaders = decoder.decodeHeaders(3 /* randomly chosen */, encodedHeaders);
     assertEquals(headers.get(of(":status")), decodedHeaders.get(of(":status")));
@@ -125,7 +125,7 @@ public class GrpcHttp2HeadersDecoderTest {
         new DefaultHttp2HeadersEncoder(NEVER_SENSITIVE);
 
     ByteBuf encodedHeaders = ReferenceCountUtil.releaseLater(Unpooled.buffer());
-    encoder.encodeHeaders(new DefaultHttp2Headers(false), encodedHeaders);
+    encoder.encodeHeaders(1 /* randomly chosen */, new DefaultHttp2Headers(false), encodedHeaders);
 
     Http2Headers decodedHeaders = decoder.decodeHeaders(3 /* randomly chosen */, encodedHeaders);
     assertEquals(0, decodedHeaders.size());

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -309,8 +309,8 @@ public class NettyClientTransportTest {
           + " size limit!");
     } catch (Exception e) {
       Throwable rootCause = getRootCause(e);
-      assertTrue(rootCause instanceof StatusException);
-      assertEquals(Status.INTERNAL.getCode(), ((StatusException) rootCause).getStatus().getCode());
+      Status status = ((StatusException) rootCause).getStatus();
+      assertEquals(status.toString(), Status.Code.INTERNAL, status.getCode());
     }
   }
 


### PR DESCRIPTION
too large headers now returns 431.