### PR TITLE
	core: ServerImpl returns shared resources at termination

### DIFF
--- a/core/src/main/java/io/grpc/Server.java
+++ b/core/src/main/java/io/grpc/Server.java
@@ -49,7 +49,8 @@ public abstract class Server {
    *
    * @return {@code this} object
    * @throws IllegalStateException if already started
-   * @throws IOException if unable to bind
+   * @throws IOException if unable to bind.  {@link #shutdown} or {@link #shutdownNow} still needs
+   *         to be called to release any resource that may have been acquired by the server
    */
   public abstract Server start() throws IOException;
 

--- a/core/src/main/java/io/grpc/Server.java
+++ b/core/src/main/java/io/grpc/Server.java
@@ -49,8 +49,7 @@ public abstract class Server {
    *
    * @return {@code this} object
    * @throws IllegalStateException if already started
-   * @throws IOException if unable to bind.  {@link #shutdown} or {@link #shutdownNow} still needs
-   *         to be called to release any resource that may have been acquired by the server
+   * @throws IOException if unable to bind
    */
   public abstract Server start() throws IOException;
 

--- a/core/src/main/java/io/grpc/internal/ObjectPool.java
+++ b/core/src/main/java/io/grpc/internal/ObjectPool.java
@@ -31,6 +31,9 @@
 
 package io.grpc.internal;
 
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
 public interface ObjectPool<T> {
   /**
    * Get an object from the pool.

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -36,7 +36,6 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.grpc.Contexts.statusFromCancelled;
 import static io.grpc.Status.DEADLINE_EXCEEDED;
 import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
-import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import com.google.common.base.Preconditions;
@@ -64,7 +63,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -88,10 +86,9 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
   private static final ServerStreamListener NOOP_LISTENER = new NoopListener();
 
   private final LogId logId = LogId.allocate(getClass().getName());
+  private final ObjectPool<? extends Executor> executorPool;
   /** Executor for application processing. Safe to read after {@link #start()}. */
   private Executor executor;
-  /** Safe to read after {@link #start()}. */
-  private boolean usingSharedExecutor;
   private final InternalHandlerRegistry registry;
   private final HandlerRegistry fallbackRegistry;
   private final List<ServerTransportFilter> transportFilters;
@@ -111,7 +108,8 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
   @GuardedBy("lock") private final Collection<ServerTransport> transports =
       new HashSet<ServerTransport>();
 
-  private final ScheduledExecutorService timeoutService = SharedResourceHolder.get(TIMER_SERVICE);
+  private final ObjectPool<ScheduledExecutorService> timeoutServicePool;
+  private ScheduledExecutorService timeoutService;
   private final Context rootContext;
 
   private final DecompressorRegistry decompressorRegistry;
@@ -126,12 +124,15 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
    *        doesn't have the method
    * @param executor to call methods on behalf of remote clients
    */
-  ServerImpl(Executor executor, InternalHandlerRegistry registry, HandlerRegistry fallbackRegistry,
+  ServerImpl(ObjectPool<? extends Executor> executorPool,
+      ObjectPool<ScheduledExecutorService> timeoutServicePool,
+      InternalHandlerRegistry registry, HandlerRegistry fallbackRegistry,
       InternalServer transportServer, Context rootContext,
       DecompressorRegistry decompressorRegistry, CompressorRegistry compressorRegistry,
       List<ServerTransportFilter> transportFilters, StatsContextFactory statsFactory,
       Supplier<Stopwatch> stopwatchSupplier) {
-    this.executor = executor;
+    this.executorPool = Preconditions.checkNotNull(executorPool, "executorPool");
+    this.timeoutServicePool = Preconditions.checkNotNull(timeoutServicePool, "timeoutServicePool");
     this.registry = Preconditions.checkNotNull(registry, "registry");
     this.fallbackRegistry = Preconditions.checkNotNull(fallbackRegistry, "fallbackRegistry");
     this.transportServer = Preconditions.checkNotNull(transportServer, "transportServer");
@@ -158,10 +159,8 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
     synchronized (lock) {
       checkState(!started, "Already started");
       checkState(!shutdown, "Shutting down");
-      usingSharedExecutor = executor == null;
-      if (usingSharedExecutor) {
-        executor = SharedResourceHolder.get(GrpcUtil.SHARED_CHANNEL_EXECUTOR);
-      }
+      timeoutService = Preconditions.checkNotNull(timeoutServicePool.getObject(), "timeoutService");
+      executor = Preconditions.checkNotNull(executorPool.getObject(), "executor");
       // Start and wait for any port to actually be bound.
       transportServer.start(new ServerListenerImpl());
       started = true;
@@ -213,10 +212,6 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
     }
     if (shutdownTransportServer) {
       transportServer.shutdown();
-    }
-    SharedResourceHolder.release(TIMER_SERVICE, timeoutService);
-    if (usingSharedExecutor) {
-      SharedResourceHolder.release(GrpcUtil.SHARED_CHANNEL_EXECUTOR, (ExecutorService) executor);
     }
     return this;
   }
@@ -307,6 +302,8 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
           throw new AssertionError("Server already terminated");
         }
         terminated = true;
+        timeoutServicePool.returnObject(timeoutService);
+        executorPool.returnObject(executor);
         // TODO(carl-mastrangelo): move this outside the synchronized block.
         lock.notifyAll();
       }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -159,10 +159,10 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
     synchronized (lock) {
       checkState(!started, "Already started");
       checkState(!shutdown, "Shutting down");
-      timeoutService = Preconditions.checkNotNull(timeoutServicePool.getObject(), "timeoutService");
-      executor = Preconditions.checkNotNull(executorPool.getObject(), "executor");
       // Start and wait for any port to actually be bound.
       transportServer.start(new ServerListenerImpl());
+      timeoutService = Preconditions.checkNotNull(timeoutServicePool.getObject(), "timeoutService");
+      executor = Preconditions.checkNotNull(executorPool.getObject(), "executor");
       started = true;
       return this;
     }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -302,8 +302,12 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
           throw new AssertionError("Server already terminated");
         }
         terminated = true;
-        timeoutServicePool.returnObject(timeoutService);
-        executorPool.returnObject(executor);
+        if (timeoutService != null) {
+          timeoutService = timeoutServicePool.returnObject(timeoutService);
+        }
+        if (executor != null) {
+          executor = executorPool.returnObject(executor);
+        }
         // TODO(carl-mastrangelo): move this outside the synchronized block.
         lock.notifyAll();
       }

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -338,10 +338,8 @@ public class ServerImplTest {
     } catch (IOException e) {
       assertSame(ex, e);
     }
-    verifyExecutorsAcquired();
-    verifyExecutorsNotReturned();
-    server.shutdown();
-    verifyExecutorsReturned();
+    verifyNoMoreInteractions(executorPool);
+    verifyNoMoreInteractions(timerPool);
   }
 
   @Test


### PR DESCRIPTION
Previously it does it at shutdown, which was wrong because executor may
still be used before the server is terminated.

Resolves #2034

Uses ObjectPool to make this change testable.  Cleans up test and makes
it mostly single-threaded, except for two deadlock tests that have to be
multi-threaded.