### PR TITLE
Rename attributes() to getAttributes() to make it consistent

### DIFF
--- a/core/src/main/java/io/grpc/PartialForwardingServerCall.java
+++ b/core/src/main/java/io/grpc/PartialForwardingServerCall.java
@@ -80,7 +80,7 @@ abstract class PartialForwardingServerCall<ReqT, RespT> extends ServerCall<ReqT,
 
   @Override
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1779")
-  public Attributes attributes() {
-    return delegate().attributes();
+  public Attributes getAttributes() {
+    return delegate().getAttributes();
   }
 }

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -58,7 +58,7 @@ import javax.net.ssl.SSLSession;
 public abstract class ServerCall<ReqT, RespT> {
   /**
    * {@link Attributes.Key} for the remote address of server call attributes
-   * {@link ServerCall#attributes()}
+   * {@link ServerCall#getAttributes()}
    *
    * @deprecated use the equivalent {@link io.grpc.Grpc#TRANSPORT_ATTR_REMOTE_ADDR} instead
    */
@@ -69,7 +69,7 @@ public abstract class ServerCall<ReqT, RespT> {
 
   /**
    * {@link Attributes.Key} for the SSL session of server call attributes
-   * {@link ServerCall#attributes()}
+   * {@link ServerCall#getAttributes()}
    *
    * @deprecated use the equivalent {@link io.grpc.Grpc#TRANSPORT_ATTR_SSL_SESSION} instead
    */
@@ -237,10 +237,18 @@ public abstract class ServerCall<ReqT, RespT> {
    * @return Attributes container
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1779")
-  public Attributes attributes() {
+  public Attributes getAttributes() {
     return Attributes.EMPTY;
   }
 
+  /**
+   * @deprecated use {@link #getAttributes()} instead.
+   */
+  @Deprecated
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1779")
+  public Attributes attributes() {
+    return getAttributes();
+  }
 
   /**
    * The {@link MethodDescriptor} for the call.

--- a/core/src/main/java/io/grpc/ServerTransportFilter.java
+++ b/core/src/main/java/io/grpc/ServerTransportFilter.java
@@ -34,7 +34,7 @@ package io.grpc;
 /**
  * Listens on server transport life-cycle events, with the capability to read and/or change
  * transport attributes.  Attributes returned by this filter will be merged into {@link
- * ServerCall#attributes}.
+ * ServerCall#getAttributes}.
  *
  * <p>Multiple filters maybe registered to a server, in which case the output of a filter is the
  * input of the next filter.  For example, what returned by {@link #transportReady} of a filter is

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -192,7 +192,7 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
   }
 
   @Override
-  public Attributes attributes() {
+  public Attributes getAttributes() {
     return stream.attributes();
   }
 

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -70,7 +70,7 @@ public interface ServerStream extends Stream {
 
   /**
    * Attributes describing stream.  This is inherited from the transport attributes, and used
-   * as the basis of {@link io.grpc.ServerCall#attributes}.
+   * as the basis of {@link io.grpc.ServerCall#getAttributes}.
    *
    * @return Attributes container
    */

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1241,19 +1241,19 @@ public abstract class AbstractInteropTest {
     }
   }
 
-  /** Helper for asserting remote address {@link io.grpc.ServerCall#attributes()} */
+  /** Helper for asserting remote address {@link io.grpc.ServerCall#getAttributes()} */
   protected void assertRemoteAddr(String expectedRemoteAddress) {
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel)
             .withDeadlineAfter(5, TimeUnit.SECONDS);
 
     stub.unaryCall(SimpleRequest.getDefaultInstance());
 
-    HostAndPort remoteAddress = HostAndPort.fromString(serverCallCapture.get().attributes()
+    HostAndPort remoteAddress = HostAndPort.fromString(serverCallCapture.get().getAttributes()
             .get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR).toString());
     assertEquals(expectedRemoteAddress, remoteAddress.getHost());
   }
 
-  /** Helper for asserting TLS info in SSLSession {@link io.grpc.ServerCall#attributes()} */
+  /** Helper for asserting TLS info in SSLSession {@link io.grpc.ServerCall#getAttributes()} */
   protected void assertX500SubjectDn(String tlsInfo) {
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel)
             .withDeadlineAfter(5, TimeUnit.SECONDS);
@@ -1262,7 +1262,7 @@ public abstract class AbstractInteropTest {
 
     List<Certificate> certificates = Lists.newArrayList();
     SSLSession sslSession =
-        serverCallCapture.get().attributes().get(Grpc.TRANSPORT_ATTR_SSL_SESSION);
+        serverCallCapture.get().getAttributes().get(Grpc.TRANSPORT_ATTR_SSL_SESSION);
     try {
       certificates = Arrays.asList(sslSession.getPeerCertificates());
     } catch (SSLPeerUnverifiedException e) {

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -180,7 +180,7 @@ public class TestUtils {
 
   /**
    * Capture the request attributes. Useful for testing ServerCalls.
-   * {@link ServerCall#attributes()}
+   * {@link ServerCall#getAttributes()}
    */
   public static ServerInterceptor recordServerCallInterceptor(
       final AtomicReference<ServerCall<?, ?>> serverCallCapture) {


### PR DESCRIPTION
Make it consistent with everything else. Addresses https://github.com/grpc/grpc-java/issues/1779 and https://github.com/grpc/grpc-java/pull/2526#discussion_r96547749

/cc @ejona86 @dapengzhang0 