### PR TITLE
core: rename attributes() -> getAttributes()

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -417,7 +417,7 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
       @Override
       public void setDecompressor(Decompressor decompressor) {}
 
-      @Override public Attributes attributes() {
+      @Override public Attributes getAttributes() {
         return serverStreamAttributes;
       }
 

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -165,7 +165,7 @@ public abstract class AbstractServerStream extends AbstractStream2
     return super.isReady();
   }
 
-  @Override public Attributes attributes() {
+  @Override public Attributes getAttributes() {
     return Attributes.EMPTY;
   }
 

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -193,7 +193,7 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
   @Override
   public Attributes attributes() {
-    return stream.attributes();
+    return stream.getAttributes();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -74,7 +74,7 @@ public interface ServerStream extends Stream {
    *
    * @return Attributes container
    */
-  Attributes attributes();
+  Attributes getAttributes();
 
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -82,7 +82,7 @@ class NettyServerStream extends AbstractServerStream {
   }
 
   @Override
-  public Attributes attributes() {
+  public Attributes getAttributes() {
     return attributes;
   }
 

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -589,8 +589,8 @@ public abstract class AbstractTransportTest {
     ServerStreamListener mockServerStreamListener = serverStreamCreation.listener;
 
     assertEquals("additional attribute value",
-        serverStream.attributes().get(ADDITIONAL_TRANSPORT_ATTR_KEY));
-    assertNotNull(serverStream.attributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
+        serverStream.getAttributes().get(ADDITIONAL_TRANSPORT_ATTR_KEY));
+    assertNotNull(serverStream.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
 
     serverStream.request(1);
     verify(mockClientStreamListener, timeout(TIMEOUT_MS)).onReady();


### PR DESCRIPTION
Make it consistent with its counterpart, `ClientStream#getAttributes()`