### PR TITLE
core: rename getAttr() and use standard getAttributes()

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -209,7 +209,7 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
   }
 
   @Override
-  public Attributes getAttrs() {
+  public Attributes getAttributes() {
     return Attributes.EMPTY;
   }
 

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -92,7 +92,7 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
         Attributes.Builder effectiveAttrsBuilder = Attributes.newBuilder()
             .set(CallCredentials.ATTR_AUTHORITY, authority)
             .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
-            .setAll(delegate.getAttrs());
+            .setAll(delegate.getAttributes());
         if (callOptions.getAuthority() != null) {
           effectiveAttrsBuilder.set(CallCredentials.ATTR_AUTHORITY, callOptions.getAuthority());
         }

--- a/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
@@ -44,5 +44,5 @@ public interface ConnectionClientTransport extends ManagedClientTransport {
    * Returns a set of attributes, which may vary depending on the state of the transport. The keys
    * should define in what states they will be present.
    */
-  Attributes getAttrs();
+  Attributes getAttributes();
 }

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -78,8 +78,8 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
   }
 
   @Override
-  public Attributes getAttrs() {
-    return delegate().getAttrs();
+  public Attributes getAttributes() {
+    return delegate().getAttributes();
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -131,7 +131,7 @@ public class CallCredentialsApplyingTest {
   @Test
   public void parameterPropagation_base() {
     Attributes transportAttrs = Attributes.newBuilder().set(ATTR_KEY, ATTR_VALUE).build();
-    when(mockTransport.getAttrs()).thenReturn(transportAttrs);
+    when(mockTransport.getAttributes()).thenReturn(transportAttrs);
 
     transport.newStream(method, origHeaders, callOptions, statsTraceCtx);
 
@@ -151,7 +151,7 @@ public class CallCredentialsApplyingTest {
         .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
         .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
         .build();
-    when(mockTransport.getAttrs()).thenReturn(transportAttrs);
+    when(mockTransport.getAttributes()).thenReturn(transportAttrs);
 
     transport.newStream(method, origHeaders, callOptions, statsTraceCtx);
 
@@ -171,7 +171,7 @@ public class CallCredentialsApplyingTest {
         .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
         .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
         .build();
-    when(mockTransport.getAttrs()).thenReturn(transportAttrs);
+    when(mockTransport.getAttributes()).thenReturn(transportAttrs);
     Executor anotherExecutor = mock(Executor.class);
 
     transport.newStream(method, origHeaders,
@@ -189,7 +189,7 @@ public class CallCredentialsApplyingTest {
 
   @Test
   public void applyMetadata_inline() {
-    when(mockTransport.getAttrs()).thenReturn(Attributes.EMPTY);
+    when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -213,7 +213,7 @@ public class CallCredentialsApplyingTest {
   @Test
   public void fail_inline() {
     final Status error = Status.FAILED_PRECONDITION.withDescription("channel not secure for creds");
-    when(mockTransport.getAttrs()).thenReturn(Attributes.EMPTY);
+    when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -233,7 +233,7 @@ public class CallCredentialsApplyingTest {
 
   @Test
   public void applyMetadata_delayed() {
-    when(mockTransport.getAttrs()).thenReturn(Attributes.EMPTY);
+    when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
 
     // Will call applyRequestMetadata(), which is no-op.
     DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions,
@@ -256,7 +256,7 @@ public class CallCredentialsApplyingTest {
 
   @Test
   public void fail_delayed() {
-    when(mockTransport.getAttrs()).thenReturn(Attributes.EMPTY);
+    when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
 
     // Will call applyRequestMetadata(), which is no-op.
     DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions,

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImpl2Test.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImpl2Test.java
@@ -1039,7 +1039,7 @@ public class ManagedChannelImpl2Test {
         same(socketAddress), eq(authority), eq(userAgent));
     MockClientTransportInfo transportInfo = transports.poll();
     final ConnectionClientTransport transport = transportInfo.transport;
-    when(transport.getAttrs()).thenReturn(Attributes.EMPTY);
+    when(transport.getAttributes()).thenReturn(Attributes.EMPTY);
     doAnswer(new Answer<ClientStream>() {
         @Override
         public ClientStream answer(InvocationOnMock in) throws Throwable {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -874,7 +874,7 @@ public class ManagedChannelImplTest {
           any(MetadataApplier.class));
 
     final ConnectionClientTransport transport = mock(ConnectionClientTransport.class);
-    when(transport.getAttrs()).thenReturn(Attributes.EMPTY);
+    when(transport.getAttributes()).thenReturn(Attributes.EMPTY);
     when(mockTransportFactory.newClientTransport(any(SocketAddress.class), any(String.class),
             any(String.class))).thenReturn(transport);
     doAnswer(new Answer<ClientStream>() {

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -268,7 +268,7 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public Attributes getAttrs() {
+  public Attributes getAttributes() {
     // TODO(zhangkun83): fill channel security attributes
     return Attributes.EMPTY;
   }

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -333,7 +333,7 @@ public class NettyClientTransportTest {
           }
         });
 
-    assertEquals(Attributes.EMPTY, transport.getAttrs());
+    assertEquals(Attributes.EMPTY, transport.getAttributes());
 
     transports.clear();
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -524,7 +524,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public Attributes getAttrs() {
+  public Attributes getAttributes() {
     // TODO(zhangkun83): fill channel security attributes
     return Attributes.EMPTY;
   }


### PR DESCRIPTION
Makes it consistent across the board - it's `getAttributes` all the way down.

/cc @ejona86 