### PR TITLE
core: DelayedStream cancels provided stream if not using it.

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -218,7 +218,7 @@ class DelayedClientTransport implements ManagedClientTransport {
     }
     if (savedPendingStreams != null) {
       for (PendingStream stream : savedPendingStreams) {
-        stream.cancel(status);
+        stream.cancelInternal(status);
       }
       listener.transportTerminated();
     }
@@ -477,6 +477,12 @@ class DelayedClientTransport implements ManagedClientTransport {
     private final Context context;
     private final StatsTraceContext statsTraceCtx;
 
+    private final Object pendingStreamLock = new Object();
+    @GuardedBy("pendingStreamLock")
+    private boolean started;
+    @GuardedBy("pendingStreamLock")
+    private Status pendingCancelReason;
+
     private PendingStream(MethodDescriptor<?, ?> method, Metadata headers,
         CallOptions callOptions, StatsTraceContext statsTraceCtx) {
       this.method = method;
@@ -497,8 +503,32 @@ class DelayedClientTransport implements ManagedClientTransport {
       setStream(realStream);
     }
 
+    // This may be called concurrently with other methods on the stream
+    private void cancelInternal(Status reason) {
+      synchronized (pendingStreamLock) {
+        if (!started) {
+          pendingCancelReason = reason;
+          return;
+        }
+      }
+      cancel(reason);
+    }
+
     @Override
-    public void cancel(Status reason) {
+    public final void start(ClientStreamListener listener) {
+      Status savedPendingCancelReason;
+      synchronized (pendingStreamLock) {
+        started = true;
+        savedPendingCancelReason = pendingCancelReason;
+      }
+      super.start(listener);
+      if (savedPendingCancelReason != null) {
+        cancel(savedPendingCancelReason);
+      }
+    }
+
+    @Override
+    public final void cancel(Status reason) {
       super.cancel(reason);
       synchronized (lock) {
         if (pendingStreams != null) {

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -275,7 +275,12 @@ class DelayedStream implements ClientStream {
     }
   }
 
-  // When this method returns, passThrough is guaranteed to be true
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When this method returns, passThrough is guaranteed to be true.  This method may be called
+   * concurrently with other methods.
+   */
   @Override
   public void cancel(final Status reason) {
     checkNotNull(reason, "reason");

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -56,6 +56,21 @@ import javax.annotation.concurrent.GuardedBy;
  * necessary.
  */
 class DelayedStream implements ClientStream {
+  @VisibleForTesting
+  static final ClientStreamListener NOOP_STREAM_LISTENER = new ClientStreamListener() {
+      @Override
+      public void messageRead(InputStream message) {}
+
+      @Override
+      public void onReady() {}
+
+      @Override
+      public void headersRead(Metadata headers) {}
+
+      @Override
+      public void closed(Status status, Metadata trailers) {}
+    };
+
   /** {@code true} once realStream is valid and all pending calls have been drained. */
   private volatile boolean passThrough;
   /**
@@ -73,7 +88,7 @@ class DelayedStream implements ClientStream {
   private DelayedStreamListener delayedListener;
 
   @Override
-  public void setMaxInboundMessageSize(final int maxSize) {
+  public final void setMaxInboundMessageSize(final int maxSize) {
     if (passThrough) {
       realStream.setMaxInboundMessageSize(maxSize);
     } else {
@@ -87,7 +102,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public void setMaxOutboundMessageSize(final int maxSize) {
+  public final void setMaxOutboundMessageSize(final int maxSize) {
     if (passThrough) {
       realStream.setMaxOutboundMessageSize(maxSize);
     } else {
@@ -103,19 +118,40 @@ class DelayedStream implements ClientStream {
   /**
    * Transfers all pending and future requests and mutations to the given stream.
    *
-   * <p>No-op if either this method or {@link #cancel} have already been called.
+   * <p>This method must be called at most once.  Extraneous calls will throw and end up cancelling
+   * the given streams.
+   *
+   * <p>If {@link #cancel} has been called, this method will cancel the given stream.
    */
   // When this method returns, passThrough is guaranteed to be true
   final void setStream(ClientStream stream) {
+    ClientStream savedRealStream;
+    Status savedError;
     synchronized (this) {
-      // If realStream != null, then either setStream() or cancel() has been called.
-      if (realStream != null) {
-        return;
+      savedRealStream = realStream;
+      savedError = error;
+      if (savedRealStream == null) {
+        realStream = checkNotNull(stream, "stream");
       }
-      realStream = checkNotNull(stream, "stream");
     }
 
-    drainPendingCalls();
+    if (savedRealStream == null) {
+      drainPendingCalls();
+    } else {
+      // If realStream was not null, then either setStream() or cancel() must had been called,
+      // we will cancel and discard the given stream.
+      // ClientStream.cancel() must be called after start()
+      stream.start(NOOP_STREAM_LISTENER);
+      if (savedError != null) {
+        stream.cancel(savedError);
+      } else {
+        // If cancel() were called, error must have been non-null.
+        IllegalStateException exception = new IllegalStateException(
+            "DelayedStream.setStream() is called more than once");
+        stream.cancel(Status.CANCELLED.withCause(exception));
+        throw exception;
+      }
+    }
   }
 
   /**
@@ -173,7 +209,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public void setAuthority(final String authority) {
+  public final void setAuthority(final String authority) {
     checkState(listener == null, "May only be called before start");
     checkNotNull(authority, "authority");
     delayOrExecute(new Runnable() {
@@ -188,22 +224,15 @@ class DelayedStream implements ClientStream {
   public void start(ClientStreamListener listener) {
     checkState(this.listener == null, "already started");
 
-    Status savedError;
     boolean savedPassThrough;
     synchronized (this) {
       this.listener = checkNotNull(listener, "listener");
-      // If error != null, then cancel() has been called and was unable to close the listener
-      savedError = error;
+      assert error == null;
       savedPassThrough = passThrough;
       if (!savedPassThrough) {
         listener = delayedListener = new DelayedStreamListener(listener);
       }
     }
-    if (savedError != null) {
-      listener.closed(savedError, new Metadata());
-      return;
-    }
-
     if (savedPassThrough) {
       realStream.start(listener);
     } else {
@@ -218,7 +247,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public void writeMessage(final InputStream message) {
+  public final void writeMessage(final InputStream message) {
     checkNotNull(message, "message");
     if (passThrough) {
       realStream.writeMessage(message);
@@ -233,7 +262,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public void flush() {
+  public final void flush() {
     if (passThrough) {
       realStream.flush();
     } else {
@@ -253,12 +282,12 @@ class DelayedStream implements ClientStream {
     boolean delegateToRealStream = true;
     ClientStreamListener listenerToClose = null;
     synchronized (this) {
-      // If realStream != null, then either setStream() or cancel() has been called
+      if (listener == null) {
+        throw new IllegalStateException("cancel() must be called after start()");
+      }
       if (realStream == null) {
         realStream = NoopClientStream.INSTANCE;
         delegateToRealStream = false;
-
-        // If listener == null, then start() will later call listener with 'error'
         listenerToClose = listener;
         error = reason;
       }
@@ -271,15 +300,13 @@ class DelayedStream implements ClientStream {
         }
       });
     } else {
-      if (listenerToClose != null) {
-        listenerToClose.closed(reason, new Metadata());
-      }
+      listenerToClose.closed(reason, new Metadata());
       drainPendingCalls();
     }
   }
 
   @Override
-  public void halfClose() {
+  public final void halfClose() {
     delayOrExecute(new Runnable() {
       @Override
       public void run() {
@@ -289,7 +316,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public void request(final int numMessages) {
+  public final void request(final int numMessages) {
     if (passThrough) {
       realStream.request(numMessages);
     } else {
@@ -303,7 +330,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public void setCompressor(final Compressor compressor) {
+  public final void setCompressor(final Compressor compressor) {
     checkNotNull(compressor, "compressor");
     delayOrExecute(new Runnable() {
       @Override
@@ -314,7 +341,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public void setDecompressor(Decompressor decompressor) {
+  public final void setDecompressor(Decompressor decompressor) {
     checkNotNull(decompressor, "decompressor");
     // This method being called only makes sense after setStream() has been called (but not
     // necessarily returned), but there is not necessarily a happens-before relationship. This
@@ -327,7 +354,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public boolean isReady() {
+  public final boolean isReady() {
     if (passThrough) {
       return realStream.isReady();
     } else {
@@ -336,7 +363,7 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public void setMessageCompression(final boolean enable) {
+  public final void setMessageCompression(final boolean enable) {
     if (passThrough) {
       realStream.setMessageCompression(enable);
     } else {

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -226,6 +226,7 @@ public class DelayedClientTransportTest {
   @Test public void cancelStreamWithoutSetTransport() {
     ClientStream stream = delayedTransport.newStream(method, new Metadata());
     assertEquals(1, delayedTransport.getPendingStreamsCount());
+    stream.start(streamListener);
     stream.cancel(Status.CANCELLED);
     assertEquals(0, delayedTransport.getPendingStreamsCount());
     verifyNoMoreInteractions(mockRealTransport);
@@ -249,6 +250,7 @@ public class DelayedClientTransportTest {
     verify(transportListener).transportShutdown(any(Status.class));
     verify(transportListener, times(0)).transportTerminated();
     assertEquals(1, delayedTransport.getPendingStreamsCount());
+    stream.start(streamListener);
     stream.cancel(Status.CANCELLED);
     verify(transportListener).transportTerminated();
     assertEquals(0, delayedTransport.getPendingStreamsCount());
@@ -286,6 +288,16 @@ public class DelayedClientTransportTest {
     verify(transportListener).transportShutdown(any(Status.class));
     verify(transportListener).transportTerminated();
     ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    stream.start(streamListener);
+    verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());
+  }
+
+  @Test public void newStreamThenShutdownNow() {
+    ClientStream stream = delayedTransport.newStream(method, new Metadata());
+    delayedTransport.shutdownNow(Status.UNAVAILABLE);
+    verify(transportListener).transportShutdown(any(Status.class));
+    verify(transportListener).transportTerminated();
     stream.start(streamListener);
     verify(streamListener).closed(statusCaptor.capture(), any(Metadata.class));
     assertEquals(Status.Code.UNAVAILABLE, statusCaptor.getValue().getCode());

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -31,10 +31,11 @@
 
 package io.grpc.internal;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -75,6 +76,7 @@ public class DelayedStreamTest {
   @Mock private ClientStreamListener listener;
   @Mock private ClientStream realStream;
   @Captor private ArgumentCaptor<ClientStreamListener> listenerCaptor;
+  @Captor private ArgumentCaptor<Status> statusCaptor;
   private DelayedStream stream = new DelayedStream();
 
   @Before
@@ -114,6 +116,8 @@ public class DelayedStreamTest {
   @Test
   public void setStream_sendsAllMessages() {
     stream.start(listener);
+    stream.setMaxInboundMessageSize(9897);
+    stream.setMaxOutboundMessageSize(5586);
     stream.setCompressor(Codec.Identity.NONE);
 
     stream.setMessageCompression(true);
@@ -125,6 +129,8 @@ public class DelayedStreamTest {
     stream.setStream(realStream);
     stream.setDecompressor(Codec.Identity.NONE);
 
+    verify(realStream).setMaxInboundMessageSize(9897);
+    verify(realStream).setMaxOutboundMessageSize(5586);
     verify(realStream).setCompressor(Codec.Identity.NONE);
     verify(realStream).setDecompressor(Codec.Identity.NONE);
 
@@ -202,10 +208,14 @@ public class DelayedStreamTest {
   }
 
   @Test
-  public void startThenCancelled() {
+  public void startCancelThenSetStream() {
     stream.start(listener);
-    stream.cancel(Status.CANCELLED);
-    verify(listener).closed(eq(Status.CANCELLED), any(Metadata.class));
+    Status status = Status.CANCELLED.withDescription("Yes do it");
+    stream.cancel(status);
+    verify(listener).closed(same(status), any(Metadata.class));
+    stream.setStream(realStream);
+    verify(realStream).start(same(DelayedStream.NOOP_STREAM_LISTENER));
+    verify(realStream).cancel(status);
   }
 
   @Test
@@ -229,8 +239,44 @@ public class DelayedStreamTest {
   @Test
   public void setStreamThenCancelled() {
     stream.setStream(realStream);
-    stream.cancel(Status.CANCELLED);
-    verify(realStream).cancel(same(Status.CANCELLED));
+    try {
+      stream.cancel(Status.CANCELLED);
+      fail("Should have thrown");
+    } catch (IllegalStateException e) {
+      assertEquals("cancel() must be called after start()", e.getMessage());
+    }
+    stream.start(listener);
+    verify(realStream).start(same(listener));
+    verifyNoMoreInteractions(realStream);
+    verifyNoMoreInteractions(listener);
+  }
+
+  @Test
+  public void cancelThenSetStream() {
+    try {
+      stream.cancel(Status.CANCELLED);
+      fail("Should have thrown");
+    } catch (IllegalStateException e) {
+      assertEquals("cancel() must be called after start()", e.getMessage());
+    }
+    stream.setStream(realStream);
+    stream.start(listener);
+    stream.isReady();
+    verify(realStream).start(same(listener));
+    verify(realStream).isReady();
+    verifyNoMoreInteractions(realStream);
+  }
+
+  @Test
+  public void setStreamThensetMaxMessageSizes() {
+    InOrder inOrder = inOrder(realStream);
+    stream.setStream(realStream);
+    stream.setMaxInboundMessageSize(9897);
+    inOrder.verify(realStream).setMaxInboundMessageSize(9897);
+    stream.setMaxOutboundMessageSize(5586);
+    inOrder.verify(realStream).setMaxOutboundMessageSize(5586);
+    stream.start(listener);
+    inOrder.verify(realStream).start(same(listener));
   }
 
   @Test
@@ -238,33 +284,36 @@ public class DelayedStreamTest {
     stream.start(listener);
     stream.setStream(realStream);
     verify(realStream).start(any(ClientStreamListener.class));
-    stream.setStream(mock(ClientStream.class));
+    ClientStream realStream2 = mock(ClientStream.class);
+    InOrder inOrder = inOrder(realStream2);
+    try {
+      stream.setStream(realStream2);
+      fail("Should have thrown");
+    } catch (IllegalStateException e) {
+      assertEquals("DelayedStream.setStream() is called more than once", e.getMessage());
+    }
+    inOrder.verify(realStream2).start(same(DelayedStream.NOOP_STREAM_LISTENER));
+    inOrder.verify(realStream2).cancel(statusCaptor.capture());
+    assertEquals(Status.Code.CANCELLED, statusCaptor.getValue().getCode());
     stream.flush();
     verify(realStream).flush();
-  }
-
-  @Test
-  public void cancelThenSetStream() {
-    stream.cancel(Status.CANCELLED);
-    stream.setStream(realStream);
-    stream.start(listener);
-    stream.isReady();
     verifyNoMoreInteractions(realStream);
   }
 
   @Test
   public void cancel_beforeStart() {
     Status status = Status.CANCELLED.withDescription("that was quick");
-    stream.cancel(status);
+    try {
+      stream.cancel(status);
+      fail("Should have thrown");
+    } catch (IllegalStateException e) {
+      assertEquals("cancel() must be called after start()", e.getMessage());
+    }
     stream.start(listener);
-    verify(listener).closed(same(status), any(Metadata.class));
-  }
-
-  @Test
-  public void cancelledThenStart() {
-    stream.cancel(Status.CANCELLED);
-    stream.start(listener);
-    verify(listener).closed(eq(Status.CANCELLED), any(Metadata.class));
+    verifyNoMoreInteractions(listener);
+    stream.setStream(realStream);
+    verify(realStream).start(any(ClientStreamListener.class));
+    verifyNoMoreInteractions(realStream);
   }
 
   @Test


### PR DESCRIPTION
Resolves #1537

Also disallow cancel() before start().
DelayedClientTransport.shutdownNow() races with stream start(), thus it
shouldn't call cancel() directly.  It would delay the cancellation until
the stream is started.