### PR TITLE
core: add debug information in MessageDeframer.

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -135,7 +135,7 @@ public abstract class AbstractStream implements Stream {
       StatsTraceContext statsTraceCtx) {
     framer = new MessageFramer(new FramerSink(), bufferAllocator, statsTraceCtx);
     deframer = new MessageDeframer(new DeframerListener(), Codec.Identity.NONE, maxMessageSize,
-        statsTraceCtx);
+        statsTraceCtx, getClass().getName());
   }
 
   protected final void setMaxInboundMessageSizeProtected(int maxSize) {

--- a/core/src/main/java/io/grpc/internal/AbstractStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream2.java
@@ -147,7 +147,8 @@ public abstract class AbstractStream2 implements Stream {
     private boolean deallocated;
 
     protected TransportState(int maxMessageSize, StatsTraceContext statsTraceCtx) {
-      deframer = new MessageDeframer(this, Codec.Identity.NONE, maxMessageSize, statsTraceCtx);
+      deframer = new MessageDeframer(
+          this, Codec.Identity.NONE, maxMessageSize, statsTraceCtx, getClass().getName());
     }
 
     @VisibleForTesting

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -88,7 +88,7 @@ public class MessageDeframerTest {
       "service/method", statsCtxFactory, GrpcUtil.STOPWATCH_SUPPLIER);
 
   private MessageDeframer deframer = new MessageDeframer(listener, Codec.Identity.NONE,
-      DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx);
+      DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, "test");
 
   private ArgumentCaptor<InputStream> messages = ArgumentCaptor.forClass(InputStream.class);
 
@@ -208,7 +208,7 @@ public class MessageDeframerTest {
   @Test
   public void compressed() {
     deframer = new MessageDeframer(listener, new Codec.Gzip(), DEFAULT_MAX_MESSAGE_SIZE,
-        statsTraceCtx);
+        statsTraceCtx, "test");
     deframer.request(1);
 
     byte[] payload = compress(new byte[1000]);
@@ -246,7 +246,7 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_readByteBelowLimit() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx, "test");
 
     while (stream.read() != -1) {}
 
@@ -259,7 +259,7 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_readByteAtLimit() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
 
     while (stream.read() != -1) {}
 
@@ -272,10 +272,10 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_readByteAboveLimit() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
 
     thrown.expect(StatusRuntimeException.class);
-    thrown.expectMessage("INTERNAL: Compressed frame exceeds");
+    thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
 
     while (stream.read() != -1) {}
 
@@ -287,7 +287,7 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_readBelowLimit() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx, "test");
     byte[] buf = new byte[10];
 
     int read = stream.read(buf, 0, buf.length);
@@ -302,7 +302,7 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_readAtLimit() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
     byte[] buf = new byte[10];
 
     int read = stream.read(buf, 0, buf.length);
@@ -317,11 +317,11 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_readAboveLimit() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
     byte[] buf = new byte[10];
 
     thrown.expect(StatusRuntimeException.class);
-    thrown.expectMessage("INTERNAL: Compressed frame exceeds");
+    thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
 
     stream.read(buf, 0, buf.length);
 
@@ -333,7 +333,7 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_skipBelowLimit() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx, "test");
 
     long skipped = stream.skip(4);
 
@@ -348,7 +348,7 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_skipAtLimit() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
 
     long skipped = stream.skip(4);
 
@@ -362,10 +362,10 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_skipAboveLimit() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
 
     thrown.expect(StatusRuntimeException.class);
-    thrown.expectMessage("INTERNAL: Compressed frame exceeds");
+    thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
 
     stream.skip(4);
 
@@ -377,7 +377,7 @@ public class MessageDeframerTest {
   public void sizeEnforcingInputStream_markReset() throws IOException {
     ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
     SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx);
+        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
     // stream currently looks like: |foo
     stream.skip(1); // f|oo
     stream.mark(10); // any large number will work.


### PR DESCRIPTION
So that MessageDeframer would include the class name of the enclosing
stream when emitting errors.  This should give us more information about #2157