### PR TITLE
core: change method descriptor to be builder based

### DIFF
--- a/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTest.java
+++ b/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTest.java
@@ -111,7 +111,7 @@ public class ClientAuthInterceptorTest {
   @Before
   public void startUp() {
     MockitoAnnotations.initMocks(this);
-    descriptor = MethodDescriptor.newBuilder()
+    descriptor = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodDescriptor.MethodType.UNKNOWN)
         .setFullMethodName("a.service/method")
         .setRequestMarshaller(stringMarshaller)

--- a/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTest.java
+++ b/auth/src/test/java/io/grpc/auth/ClientAuthInterceptorTest.java
@@ -111,8 +111,12 @@ public class ClientAuthInterceptorTest {
   @Before
   public void startUp() {
     MockitoAnnotations.initMocks(this);
-    descriptor = MethodDescriptor.create(
-        MethodDescriptor.MethodType.UNKNOWN, "a.service/method", stringMarshaller, intMarshaller);
+    descriptor = MethodDescriptor.newBuilder()
+        .setType(MethodDescriptor.MethodType.UNKNOWN)
+        .setFullMethodName("a.service/method")
+        .setRequestMarshaller(stringMarshaller)
+        .setResponseMarshaller(intMarshaller)
+        .build();
     when(channel.newCall(same(descriptor), any(CallOptions.class))).thenReturn(call);
     doReturn("localhost:443").when(channel).authority();
     interceptor = new ClientAuthInterceptor(credentials, executor);

--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -127,8 +127,12 @@ public class GoogleAuthLibraryCallCredentialsTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    method = MethodDescriptor.create(
-        MethodDescriptor.MethodType.UNKNOWN, "a.service/method", stringMarshaller, intMarshaller);
+    method = MethodDescriptor.newBuilder()
+        .setType(MethodDescriptor.MethodType.UNKNOWN)
+        .setFullMethodName("a.service/method")
+        .setRequestMarshaller(stringMarshaller)
+        .setResponseMarshaller(intMarshaller)
+        .build();
     expectedUri = new URI("https://testauthority/a.service");
     doAnswer(new Answer<Void>() {
         @Override

--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -127,7 +127,7 @@ public class GoogleAuthLibraryCallCredentialsTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    method = MethodDescriptor.newBuilder()
+    method = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodDescriptor.MethodType.UNKNOWN)
         .setFullMethodName("a.service/method")
         .setRequestMarshaller(stringMarshaller)

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -256,18 +256,20 @@ public abstract class AbstractBenchmark {
     response.writerIndex(response.capacity() - 1);
 
     // Simple method that sends and receives NettyByteBuf
-    unaryMethod = MethodDescriptor.create(MethodType.UNARY,
-        "benchmark/unary",
-        new ByteBufOutputMarshaller(),
-        new ByteBufOutputMarshaller());
-    pingPongMethod = MethodDescriptor.create(MethodType.BIDI_STREAMING,
-        "benchmark/pingPong",
-        new ByteBufOutputMarshaller(),
-        new ByteBufOutputMarshaller());
-    flowControlledStreaming = MethodDescriptor.create(MethodType.BIDI_STREAMING,
-        "benchmark/flowControlledStreaming",
-        new ByteBufOutputMarshaller(),
-        new ByteBufOutputMarshaller());
+    unaryMethod = MethodDescriptor.newBuilder()
+        .setType(MethodType.UNARY)
+        .setFullMethodName("benchmark/unary")
+        .setRequestMarshaller(new ByteBufOutputMarshaller())
+        .setResponseMarshaller(new ByteBufOutputMarshaller())
+        .build();
+
+    pingPongMethod = unaryMethod.toBuilder()
+        .setType(MethodType.BIDI_STREAMING)
+        .setFullMethodName("benchmark/pingPong")
+        .build();
+    flowControlledStreaming = pingPongMethod.toBuilder()
+        .setFullMethodName("benchmark/flowControlledStreaming")
+        .build();
 
     // Server implementation of unary & streaming methods
     serverBuilder.addService(

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/AbstractBenchmark.java
@@ -256,7 +256,7 @@ public abstract class AbstractBenchmark {
     response.writerIndex(response.capacity() - 1);
 
     // Simple method that sends and receives NettyByteBuf
-    unaryMethod = MethodDescriptor.newBuilder()
+    unaryMethod = MethodDescriptor.<ByteBuf, ByteBuf>newBuilder()
         .setType(MethodType.UNARY)
         .setFullMethodName("benchmark/unary")
         .setRequestMarshaller(new ByteBufOutputMarshaller())

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
@@ -90,7 +90,7 @@ public class HandlerRegistryBenchmark {
       for (int methodIndex = 0; methodIndex < methodCountPerService; ++methodIndex) {
         String methodName = randomString();
 
-        MethodDescriptor<Void, Void> methodDescriptor = MethodDescriptor.newBuilder()
+        MethodDescriptor<Void, Void> methodDescriptor = MethodDescriptor.<Void, Void>newBuilder()
             .setType(MethodDescriptor.MethodType.UNKNOWN)
             .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, methodName))
             .setRequestMarshaller(TestMethodDescriptors.noopMarshaller())

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
@@ -38,6 +38,7 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServiceDescriptor;
+import io.grpc.testing.TestMethodDescriptors;
 import io.grpc.util.MutableHandlerRegistry;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -88,13 +89,17 @@ public class HandlerRegistryBenchmark {
           new ServiceDescriptor(serviceName));
       for (int methodIndex = 0; methodIndex < methodCountPerService; ++methodIndex) {
         String methodName = randomString();
-        MethodDescriptor<Object, Object> methodDescriptor = MethodDescriptor.create(
-            MethodDescriptor.MethodType.UNKNOWN,
-            MethodDescriptor.generateFullMethodName(serviceName, methodName), null, null);
+
+        MethodDescriptor<Void, Void> methodDescriptor = MethodDescriptor.newBuilder()
+            .setType(MethodDescriptor.MethodType.UNKNOWN)
+            .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, methodName))
+            .setRequestMarshaller(TestMethodDescriptors.noopMarshaller())
+            .setResponseMarshaller(TestMethodDescriptors.noopMarshaller())
+            .build();
         serviceBuilder.addMethod(methodDescriptor,
-            new ServerCallHandler<Object, Object>() {
+            new ServerCallHandler<Void, Void>() {
               @Override
-              public Listener<Object> startCall(ServerCall<Object, Object> call,
+              public Listener<Void> startCall(ServerCall<Void, Void> call,
                   Metadata headers) {
                 return null;
               }

--- a/benchmarks/src/jmh/java/io/grpc/netty/MethodDescriptorBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/netty/MethodDescriptorBenchmark.java
@@ -66,7 +66,7 @@ public class MethodDescriptorBenchmark {
     }
   };
 
-  MethodDescriptor<Void, Void> method = MethodDescriptor.newBuilder()
+  MethodDescriptor<Void, Void> method = MethodDescriptor.<Void, Void>newBuilder()
       .setType(MethodDescriptor.MethodType.UNARY)
       .setFullMethodName("Service/Method")
       .setRequestMarshaller(marshaller)

--- a/benchmarks/src/jmh/java/io/grpc/netty/MethodDescriptorBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/netty/MethodDescriptorBenchmark.java
@@ -66,8 +66,12 @@ public class MethodDescriptorBenchmark {
     }
   };
 
-  MethodDescriptor<Void, Void> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNARY, "Service/Method", marshaller, marshaller);
+  MethodDescriptor<Void, Void> method = MethodDescriptor.newBuilder()
+      .setType(MethodDescriptor.MethodType.UNARY)
+      .setFullMethodName("Service/Method")
+      .setRequestMarshaller(marshaller)
+      .setResponseMarshaller(marshaller)
+      .build();
 
   InternalMethodDescriptor imd = new InternalMethodDescriptor(InternalKnownTransport.NETTY);
 

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
@@ -77,21 +77,19 @@ final class LoadServer {
    * Generic version of the unary method call.
    */
   static final MethodDescriptor<ByteBuf, ByteBuf> GENERIC_UNARY_METHOD =
-      MethodDescriptor.create(
-          BenchmarkServiceGrpc.METHOD_UNARY_CALL.getType(),
-          BenchmarkServiceGrpc.METHOD_UNARY_CALL.getFullMethodName(),
-          new ByteBufOutputMarshaller(),
-          new ByteBufOutputMarshaller());
+      BenchmarkServiceGrpc.METHOD_UNARY_CALL.toBuilder()
+          .setRequestMarshaller(new ByteBufOutputMarshaller())
+          .setResponseMarshaller(new ByteBufOutputMarshaller())
+          .build();
 
   /**
    * Generic version of the streaming ping-pong method call.
    */
   static final MethodDescriptor<ByteBuf, ByteBuf> GENERIC_STREAMING_PING_PONG_METHOD =
-      MethodDescriptor.create(
-          BenchmarkServiceGrpc.METHOD_STREAMING_CALL.getType(),
-          BenchmarkServiceGrpc.METHOD_STREAMING_CALL.getFullMethodName(),
-          new ByteBufOutputMarshaller(),
-          new ByteBufOutputMarshaller());
+      BenchmarkServiceGrpc.METHOD_STREAMING_CALL.toBuilder()
+          .setRequestMarshaller(new ByteBufOutputMarshaller())
+          .setResponseMarshaller(new ByteBufOutputMarshaller())
+          .build();
 
   private static final Logger log = Logger.getLogger(LoadServer.class.getName());
 

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
@@ -39,6 +39,7 @@ import com.sun.management.OperatingSystemMXBean;
 
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerCall;
@@ -73,22 +74,19 @@ import java.util.logging.Logger;
  */
 final class LoadServer {
 
+  private static final Marshaller<ByteBuf> marshaller = new ByteBufOutputMarshaller();
   /**
    * Generic version of the unary method call.
    */
   static final MethodDescriptor<ByteBuf, ByteBuf> GENERIC_UNARY_METHOD =
-      BenchmarkServiceGrpc.METHOD_UNARY_CALL.toBuilder()
-          .setRequestMarshaller(new ByteBufOutputMarshaller())
-          .setResponseMarshaller(new ByteBufOutputMarshaller())
+      BenchmarkServiceGrpc.METHOD_UNARY_CALL.toBuilder(marshaller, marshaller)
           .build();
 
   /**
    * Generic version of the streaming ping-pong method call.
    */
   static final MethodDescriptor<ByteBuf, ByteBuf> GENERIC_STREAMING_PING_PONG_METHOD =
-      BenchmarkServiceGrpc.METHOD_STREAMING_CALL.toBuilder()
-          .setRequestMarshaller(new ByteBufOutputMarshaller())
-          .setResponseMarshaller(new ByteBufOutputMarshaller())
+      BenchmarkServiceGrpc.METHOD_STREAMING_CALL.toBuilder(marshaller, marshaller)
           .build();
 
   private static final Logger log = Logger.getLogger(LoadServer.class.getName());

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -372,8 +372,19 @@ public final class MethodDescriptor<ReqT, RespT> {
    * Creates a new builder for a {@link MethodDescriptor}.
    */
   @CheckReturnValue
-  public static Builder<?, ?> newBuilder() {
-    return new Builder<Object, Object>();
+  public static <ReqT, RespT> Builder<ReqT, RespT> newBuilder() {
+    return newBuilder(null, null);
+  }
+
+  /**
+   * Creates a new builder for a {@link MethodDescriptor}.
+   */
+  @CheckReturnValue
+  public static <ReqT, RespT> Builder<ReqT, RespT> newBuilder(
+      Marshaller<ReqT> requestMarshaller, Marshaller<RespT> responseMarshaller) {
+    return new Builder<ReqT, RespT>()
+        .setRequestMarshaller(requestMarshaller)
+        .setResponseMarshaller(responseMarshaller);
   }
 
   /**
@@ -381,7 +392,16 @@ public final class MethodDescriptor<ReqT, RespT> {
    */
   @CheckReturnValue
   public Builder<ReqT, RespT> toBuilder() {
-    return newBuilder()
+    return toBuilder(requestMarshaller, responseMarshaller);
+  }
+
+  /**
+   * Turns this descriptor into a builder, replacing the request and response marshallers.
+   */
+  @CheckReturnValue
+  public <NewReqT, NewRespT> Builder<NewReqT, NewRespT> toBuilder(
+      Marshaller<NewReqT> requestMarshaller, Marshaller<NewRespT> responseMarshaller) {
+    return MethodDescriptor.<NewReqT, NewRespT>newBuilder()
         .setRequestMarshaller(requestMarshaller)
         .setResponseMarshaller(responseMarshaller)
         .setType(type)
@@ -408,10 +428,9 @@ public final class MethodDescriptor<ReqT, RespT> {
      * Sets the request marshaller.
      * @param requestMarshaller the marshaller to use.
      */
-    @SuppressWarnings("unchecked")
-    public <T> Builder<T, RespT> setRequestMarshaller(Marshaller<T> requestMarshaller) {
-      this.requestMarshaller = (Marshaller<ReqT>) requestMarshaller;
-      return (Builder<T, RespT>) this;
+    public Builder<ReqT, RespT> setRequestMarshaller(Marshaller<ReqT> requestMarshaller) {
+      this.requestMarshaller = requestMarshaller;
+      return this;
     }
 
     /**

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -38,6 +38,7 @@ import com.google.common.base.Preconditions;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -370,8 +371,23 @@ public final class MethodDescriptor<ReqT, RespT> {
   /**
    * Creates a new builder for a {@link MethodDescriptor}.
    */
+  @CheckReturnValue
   public static Builder<?, ?> newBuilder() {
     return new Builder<Object, Object>();
+  }
+
+  /**
+   * Turns this descriptor into a builder.
+   */
+  @CheckReturnValue
+  public Builder<ReqT, RespT> toBuilder() {
+    return newBuilder()
+        .setRequestMarshaller(requestMarshaller)
+        .setResponseMarshaller(responseMarshaller)
+        .setType(type)
+        .setFullMethodName(fullMethodName)
+        .setIdempotent(idempotent)
+        .setSafe(safe);
   }
 
   /**
@@ -447,6 +463,7 @@ public final class MethodDescriptor<ReqT, RespT> {
     /**
      * Builds the method descriptor.
      */
+    @CheckReturnValue
     public MethodDescriptor<ReqT, RespT> build() {
       return new MethodDescriptor<ReqT, RespT>(
           type,

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -208,7 +208,8 @@ public final class MethodDescriptor<ReqT, RespT> {
   }
 
   private MethodDescriptor(
-      MethodType type, String fullMethodName,
+      MethodType type,
+      String fullMethodName,
       Marshaller<ReqT> requestMarshaller,
       Marshaller<RespT> responseMarshaller,
       boolean idempotent,
@@ -364,5 +365,96 @@ public final class MethodDescriptor<ReqT, RespT> {
       return null;
     }
     return fullMethodName.substring(0, index);
+  }
+
+  /**
+   * Creates a new builder for a {@link MethodDescriptor}.
+   */
+  public static Builder<?, ?> newBuilder() {
+    return new Builder<Object, Object>();
+  }
+
+  /**
+   * A builder for a {@link MethodDescriptor}.
+   */
+  public static final class Builder<ReqT, RespT> {
+
+    private Marshaller<ReqT> requestMarshaller;
+    private Marshaller<RespT> responseMarshaller;
+    private MethodType type;
+    private String fullMethodName;
+    private boolean idempotent;
+    private boolean safe;
+
+    private Builder() {}
+
+    /**
+     * Sets the request marshaller.
+     * @param requestMarshaller the marshaller to use.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Builder<T, RespT> setRequestMarshaller(Marshaller<T> requestMarshaller) {
+      this.requestMarshaller = (Marshaller<ReqT>) requestMarshaller;
+      return (Builder<T, RespT>) this;
+    }
+
+    /**
+     * Sets the response marshaller.
+     * @param responseMarshaller the marshaller to use.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Builder<ReqT, T> setResponseMarshaller(Marshaller<T> responseMarshaller) {
+      this.responseMarshaller = (Marshaller<RespT>) responseMarshaller;
+      return (Builder<ReqT, T>) this;
+    }
+
+    /**
+     * Sets the method type.
+     * @param type the type of the method.
+     */
+    public Builder<ReqT, RespT> setType(MethodType type) {
+      this.type = type;
+      return this;
+    }
+
+    /**
+     * Sets the fully qualified (service and method) method name.
+     * @see MethodDescriptor#generateFullMethodName
+     */
+    public Builder<ReqT, RespT> setFullMethodName(String fullMethodName) {
+      this.fullMethodName = fullMethodName;
+      return this;
+    }
+
+    /**
+     * Sets whether the method is idempotent.  If true, calling this method more than once doesn't
+     * have additional side effects.
+     */
+    public Builder<ReqT, RespT> setIdempotent(boolean idempotent) {
+      this.idempotent = idempotent;
+      return this;
+    }
+
+    /**
+     * Sets whether this method is safe.  If true, calling this method any number of times doesn't
+     * have side effects.
+     */
+    public Builder<ReqT, RespT> setSafe(boolean safe) {
+      this.safe = safe;
+      return this;
+    }
+
+    /**
+     * Builds the method descriptor.
+     */
+    public MethodDescriptor<ReqT, RespT> build() {
+      return new MethodDescriptor<ReqT, RespT>(
+          type,
+          fullMethodName,
+          requestMarshaller,
+          responseMarshaller,
+          idempotent,
+          safe);
+    }
   }
 }

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -413,6 +413,7 @@ public final class MethodDescriptor<ReqT, RespT> {
   /**
    * A builder for a {@link MethodDescriptor}.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2641")
   public static final class Builder<ReqT, RespT> {
 
     private Marshaller<ReqT> requestMarshaller;

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -372,6 +372,7 @@ public final class MethodDescriptor<ReqT, RespT> {
    * Creates a new builder for a {@link MethodDescriptor}.
    */
   @CheckReturnValue
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2641")
   public static <ReqT, RespT> Builder<ReqT, RespT> newBuilder() {
     return newBuilder(null, null);
   }
@@ -380,6 +381,7 @@ public final class MethodDescriptor<ReqT, RespT> {
    * Creates a new builder for a {@link MethodDescriptor}.
    */
   @CheckReturnValue
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2641")
   public static <ReqT, RespT> Builder<ReqT, RespT> newBuilder(
       Marshaller<ReqT> requestMarshaller, Marshaller<RespT> responseMarshaller) {
     return new Builder<ReqT, RespT>()
@@ -391,6 +393,7 @@ public final class MethodDescriptor<ReqT, RespT> {
    * Turns this descriptor into a builder.
    */
   @CheckReturnValue
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2641")
   public Builder<ReqT, RespT> toBuilder() {
     return toBuilder(requestMarshaller, responseMarshaller);
   }
@@ -399,6 +402,7 @@ public final class MethodDescriptor<ReqT, RespT> {
    * Turns this descriptor into a builder, replacing the request and response marshallers.
    */
   @CheckReturnValue
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2641")
   public <NewReqT, NewRespT> Builder<NewReqT, NewRespT> toBuilder(
       Marshaller<NewReqT> requestMarshaller, Marshaller<NewRespT> responseMarshaller) {
     return MethodDescriptor.<NewReqT, NewRespT>newBuilder()

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -438,9 +438,9 @@ public final class MethodDescriptor<ReqT, RespT> {
      * @param responseMarshaller the marshaller to use.
      */
     @SuppressWarnings("unchecked")
-    public <T> Builder<ReqT, T> setResponseMarshaller(Marshaller<T> responseMarshaller) {
-      this.responseMarshaller = (Marshaller<RespT>) responseMarshaller;
-      return (Builder<ReqT, T>) this;
+    public Builder<ReqT, RespT> setResponseMarshaller(Marshaller<RespT> responseMarshaller) {
+      this.responseMarshaller = responseMarshaller;
+      return this;
     }
 
     /**

--- a/core/src/main/java/io/grpc/ServerInterceptors.java
+++ b/core/src/main/java/io/grpc/ServerInterceptors.java
@@ -197,10 +197,8 @@ public final class ServerInterceptors {
     // Wrap the descriptors
     for (final ServerMethodDefinition<?, ?> definition : serviceDef.getMethods()) {
       final MethodDescriptor<?, ?> originalMethodDescriptor = definition.getMethodDescriptor();
-      final MethodDescriptor<T, T> wrappedMethodDescriptor = originalMethodDescriptor.toBuilder()
-          .setRequestMarshaller(marshaller)
-          .setResponseMarshaller(marshaller)
-          .build();
+      final MethodDescriptor<T, T> wrappedMethodDescriptor =
+          originalMethodDescriptor.toBuilder(marshaller, marshaller).build();
       wrappedDescriptors.add(wrappedMethodDescriptor);
       wrappedMethods.add(wrapMethod(definition, wrappedMethodDescriptor));
     }

--- a/core/src/main/java/io/grpc/ServerInterceptors.java
+++ b/core/src/main/java/io/grpc/ServerInterceptors.java
@@ -197,11 +197,10 @@ public final class ServerInterceptors {
     // Wrap the descriptors
     for (final ServerMethodDefinition<?, ?> definition : serviceDef.getMethods()) {
       final MethodDescriptor<?, ?> originalMethodDescriptor = definition.getMethodDescriptor();
-      final MethodDescriptor<T, T> wrappedMethodDescriptor = MethodDescriptor
-          .create(originalMethodDescriptor.getType(),
-              originalMethodDescriptor.getFullMethodName(),
-              marshaller,
-              marshaller);
+      final MethodDescriptor<T, T> wrappedMethodDescriptor = originalMethodDescriptor.toBuilder()
+          .setRequestMarshaller(marshaller)
+          .setResponseMarshaller(marshaller)
+          .build();
       wrappedDescriptors.add(wrappedMethodDescriptor);
       wrappedMethods.add(wrapMethod(definition, wrappedMethodDescriptor));
     }

--- a/core/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/core/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -60,7 +60,7 @@ public class MethodDescriptorTest {
 
   @Test
   public void idempotent() {
-    MethodDescriptor<String,String> descriptor = MethodDescriptor.newBuilder()
+    MethodDescriptor<String,String> descriptor = MethodDescriptor.<String, String>newBuilder()
         .setType(MethodType.SERVER_STREAMING)
         .setFullMethodName("/package.service/method")
         .setRequestMarshaller(new StringMarshaller())
@@ -80,7 +80,7 @@ public class MethodDescriptorTest {
 
   @Test
   public void safe() {
-    MethodDescriptor<String,String> descriptor = MethodDescriptor.newBuilder()
+    MethodDescriptor<String,String> descriptor = MethodDescriptor.<String, String>newBuilder()
         .setType(MethodType.UNARY)
         .setFullMethodName("/package.service/method")
         .setRequestMarshaller(new StringMarshaller())
@@ -98,7 +98,7 @@ public class MethodDescriptorTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void safeAndNonUnary() {
-    MethodDescriptor<String,String> descriptor = MethodDescriptor.newBuilder()
+    MethodDescriptor<String, String> descriptor = MethodDescriptor.<String, String>newBuilder()
         .setType(MethodType.SERVER_STREAMING)
         .setFullMethodName("/package.service/method")
         .setRequestMarshaller(new StringMarshaller())

--- a/core/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/core/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -60,13 +60,18 @@ public class MethodDescriptorTest {
 
   @Test
   public void idempotent() {
-    MethodDescriptor<String,String> descriptor = MethodDescriptor.<String, String>create(
-        MethodType.SERVER_STREAMING, "/package.service/method", new StringMarshaller(),
-        new StringMarshaller());    
+    MethodDescriptor<String,String> descriptor = MethodDescriptor.newBuilder()
+        .setType(MethodType.SERVER_STREAMING)
+        .setFullMethodName("/package.service/method")
+        .setRequestMarshaller(new StringMarshaller())
+        .setResponseMarshaller(new StringMarshaller())
+        .build();
+
     assertFalse(descriptor.isIdempotent());
 
     // Create a new desriptor by setting idempotent to true
-    MethodDescriptor<String, String> newDescriptor = descriptor.withIdempotent(true);
+    MethodDescriptor<String, String> newDescriptor =
+        descriptor.toBuilder().setIdempotent(true).build();
     assertTrue(newDescriptor.isIdempotent());
     // All other fields should staty the same
     assertEquals(MethodType.SERVER_STREAMING, newDescriptor.getType());
@@ -75,13 +80,16 @@ public class MethodDescriptorTest {
 
   @Test
   public void safe() {
-    MethodDescriptor<String,String> descriptor = MethodDescriptor.<String, String>create(
-        MethodType.UNARY, "/package.service/method", new StringMarshaller(),
-        new StringMarshaller());
+    MethodDescriptor<String,String> descriptor = MethodDescriptor.newBuilder()
+        .setType(MethodType.UNARY)
+        .setFullMethodName("/package.service/method")
+        .setRequestMarshaller(new StringMarshaller())
+        .setResponseMarshaller(new StringMarshaller())
+        .build();
     assertFalse(descriptor.isSafe());
 
     // Create a new desriptor by setting safe to true
-    MethodDescriptor<String, String> newDescriptor = descriptor.withSafe(true);
+    MethodDescriptor<String, String> newDescriptor = descriptor.toBuilder().setSafe(true).build();
     assertTrue(newDescriptor.isSafe());
     // All other fields should staty the same
     assertEquals(MethodType.UNARY, newDescriptor.getType());
@@ -90,10 +98,17 @@ public class MethodDescriptorTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void safeAndNonUnary() {
-    MethodDescriptor<String,String> descriptor = MethodDescriptor.<String, String>create(
-        MethodType.SERVER_STREAMING, "/package.service/method", new StringMarshaller(),
-        new StringMarshaller());
-    MethodDescriptor<String, String> newDescriptor = descriptor.withSafe(true);
+    MethodDescriptor<String,String> descriptor = MethodDescriptor.newBuilder()
+        .setType(MethodType.SERVER_STREAMING)
+        .setFullMethodName("/package.service/method")
+        .setRequestMarshaller(new StringMarshaller())
+        .setResponseMarshaller(new StringMarshaller())
+        .build();
+
+
+    MethodDescriptor<String,String> discard = descriptor.toBuilder().setSafe(true).build();
+    // Never reached
+    assert discard == null;
   }
 }
 

--- a/core/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -89,8 +89,12 @@ public class ServerInterceptorsTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    flowMethod = MethodDescriptor.create(
-        MethodType.UNKNOWN, "basic/flow", requestMarshaller, responseMarshaller);
+    flowMethod = MethodDescriptor.newBuilder()
+        .setType(MethodType.UNKNOWN)
+        .setFullMethodName("basic/flow")
+        .setRequestMarshaller(requestMarshaller)
+        .setResponseMarshaller(responseMarshaller)
+        .build();
 
     Mockito.when(handler.startCall(
         Mockito.<ServerCall<String, Integer>>any(), Mockito.<Metadata>any()))
@@ -153,9 +157,8 @@ public class ServerInterceptorsTest {
   public void correctHandlerCalled() {
     @SuppressWarnings("unchecked")
     ServerCallHandler<String, Integer> handler2 = mock(ServerCallHandler.class);
-    MethodDescriptor<String, Integer> flowMethod2 = MethodDescriptor
-        .create(MethodType.UNKNOWN, "basic/flow2",
-            requestMarshaller, responseMarshaller);
+    MethodDescriptor<String, Integer> flowMethod2 =
+        flowMethod.toBuilder().setFullMethodName("basic/flow2").build();
     serviceDefinition = ServerServiceDefinition.builder(
         new ServiceDescriptor("basic", flowMethod, flowMethod2))
         .addMethod(flowMethod, handler)
@@ -335,9 +338,12 @@ public class ServerInterceptorsTest {
       }
     };
 
-    MethodDescriptor<Holder, Holder> wrappedMethod = MethodDescriptor
-        .create(MethodType.UNKNOWN, "basic/wrapped",
-            marshaller, marshaller);
+    MethodDescriptor<Holder, Holder> wrappedMethod = MethodDescriptor.newBuilder()
+        .setType(MethodType.UNKNOWN)
+        .setFullMethodName("basic/wrapped")
+        .setRequestMarshaller(marshaller)
+        .setResponseMarshaller(marshaller)
+        .build();
     ServerServiceDefinition serviceDef = ServerServiceDefinition.builder(
         new ServiceDescriptor("basic", wrappedMethod))
         .addMethod(wrappedMethod, handler2).build();

--- a/core/src/test/java/io/grpc/ServerInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ServerInterceptorsTest.java
@@ -89,7 +89,7 @@ public class ServerInterceptorsTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    flowMethod = MethodDescriptor.newBuilder()
+    flowMethod = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodType.UNKNOWN)
         .setFullMethodName("basic/flow")
         .setRequestMarshaller(requestMarshaller)
@@ -338,7 +338,7 @@ public class ServerInterceptorsTest {
       }
     };
 
-    MethodDescriptor<Holder, Holder> wrappedMethod = MethodDescriptor.newBuilder()
+    MethodDescriptor<Holder, Holder> wrappedMethod = MethodDescriptor.<Holder, Holder>newBuilder()
         .setType(MethodType.UNKNOWN)
         .setFullMethodName("basic/wrapped")
         .setRequestMarshaller(marshaller)

--- a/core/src/test/java/io/grpc/ServerServiceDefinitionTest.java
+++ b/core/src/test/java/io/grpc/ServerServiceDefinitionTest.java
@@ -48,15 +48,16 @@ import java.util.HashSet;
 @RunWith(JUnit4.class)
 public class ServerServiceDefinitionTest {
   private String serviceName = "com.example.service";
-  private MethodDescriptor<String, Integer> method1 = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN,
-      MethodDescriptor.generateFullMethodName(serviceName, "method1"),
-      StringMarshaller.INSTANCE, IntegerMarshaller.INSTANCE);
+  private MethodDescriptor<String, Integer> method1 = MethodDescriptor.newBuilder()
+      .setType(MethodDescriptor.MethodType.UNKNOWN)
+      .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, "method1"))
+      .setRequestMarshaller(StringMarshaller.INSTANCE)
+      .setResponseMarshaller(IntegerMarshaller.INSTANCE)
+      .build();
   private MethodDescriptor<String, Integer> diffMethod1 = method1.withIdempotent(true);
-  private MethodDescriptor<String, Integer> method2 = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN,
-      MethodDescriptor.generateFullMethodName(serviceName, "method2"),
-      StringMarshaller.INSTANCE, IntegerMarshaller.INSTANCE);
+  private MethodDescriptor<String, Integer> method2 = method1.toBuilder()
+      .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, "method2"))
+      .build();
   private ServerCallHandler<String, Integer> methodHandler1
       = new NoopServerCallHandler<String, Integer>();
   private ServerCallHandler<String, Integer> methodHandler2

--- a/core/src/test/java/io/grpc/ServerServiceDefinitionTest.java
+++ b/core/src/test/java/io/grpc/ServerServiceDefinitionTest.java
@@ -48,7 +48,7 @@ import java.util.HashSet;
 @RunWith(JUnit4.class)
 public class ServerServiceDefinitionTest {
   private String serviceName = "com.example.service";
-  private MethodDescriptor<String, Integer> method1 = MethodDescriptor.newBuilder()
+  private MethodDescriptor<String, Integer> method1 = MethodDescriptor.<String, Integer>newBuilder()
       .setType(MethodDescriptor.MethodType.UNKNOWN)
       .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, "method1"))
       .setRequestMarshaller(StringMarshaller.INSTANCE)

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -94,12 +94,13 @@ public class CallCredentialsApplyingTest {
   private static final String USER_AGENT = "testuseragent";
   private static final Attributes.Key<String> ATTR_KEY = Attributes.Key.of("somekey");
   private static final String ATTR_VALUE = "somevalue";
-  private static final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
-      .setType(MethodDescriptor.MethodType.UNKNOWN)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new StringMarshaller())
-      .setResponseMarshaller(new IntegerMarshaller())
-      .build();
+  private static final MethodDescriptor<String, Integer> method =
+      MethodDescriptor.<String, Integer>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNKNOWN)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
   private static final Metadata.Key<String> ORIG_HEADER_KEY =
       Metadata.Key.of("header1", Metadata.ASCII_STRING_MARSHALLER);
   private static final String ORIG_HEADER_VALUE = "some original header value";

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -43,8 +43,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.grpc.Attributes;
-import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallCredentials;
+import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallOptions;
 import io.grpc.IntegerMarshaller;
 import io.grpc.Metadata;
@@ -94,9 +94,12 @@ public class CallCredentialsApplyingTest {
   private static final String USER_AGENT = "testuseragent";
   private static final Attributes.Key<String> ATTR_KEY = Attributes.Key.of("somekey");
   private static final String ATTR_VALUE = "somevalue";
-  private static final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-      new StringMarshaller(), new IntegerMarshaller());
+  private static final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+      .setType(MethodDescriptor.MethodType.UNKNOWN)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new StringMarshaller())
+      .setResponseMarshaller(new IntegerMarshaller())
+      .build();
   private static final Metadata.Key<String> ORIG_HEADER_KEY =
       Metadata.Key.of("header1", Metadata.ASCII_STRING_MARSHALLER);
   private static final String ORIG_HEADER_VALUE = "some original header value";

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -70,12 +70,12 @@ import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
-import io.grpc.internal.testing.StatsTestUtils.FakeStatsContextFactory;
 import io.grpc.internal.testing.StatsTestUtils;
+import io.grpc.internal.testing.StatsTestUtils.FakeStatsContextFactory;
+import io.grpc.testing.TestMethodDescriptors;
 
 import org.junit.After;
 import org.junit.Before;
@@ -107,22 +107,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @RunWith(JUnit4.class)
 public class ClientCallImplTest {
 
-  private static final MethodDescriptor<Void, Void> DESCRIPTOR = MethodDescriptor.create(
-      MethodType.UNARY,
-      "service/method",
-      new TestMarshaller<Void>(),
-      new TestMarshaller<Void>());
-
   private final FakeClock fakeClock = new FakeClock();
   private final ScheduledExecutorService deadlineCancellationExecutor =
       fakeClock.getScheduledExecutorService();
   private final DecompressorRegistry decompressorRegistry =
       DecompressorRegistry.getDefaultInstance().with(new Codec.Gzip(), true);
-  private final MethodDescriptor<Void, Void> method = MethodDescriptor.create(
-      MethodType.UNARY,
-      "service/method",
-      new TestMarshaller<Void>(),
-      new TestMarshaller<Void>());
+  private final MethodDescriptor<Void, Void> method = MethodDescriptor.newBuilder()
+      .setType(MethodType.UNARY)
+      .setFullMethodName("service/method")
+      .setRequestMarshaller(TestMethodDescriptors.noopMarshaller())
+      .setResponseMarshaller(TestMethodDescriptors.noopMarshaller())
+      .build();
 
   private final FakeStatsContextFactory statsCtxFactory = new FakeStatsContextFactory();
   private final StatsContext parentStatsContext = statsCtxFactory.getDefault().with(
@@ -459,7 +454,7 @@ public class ClientCallImplTest {
     Context.current().withValue(testKey, "testValue").attach();
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         CallOptions.DEFAULT,
         statsTraceCtx,
@@ -533,7 +528,7 @@ public class ClientCallImplTest {
     Context previous = cancellableContext.attach();
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         CallOptions.DEFAULT,
         statsTraceCtx,
@@ -563,7 +558,7 @@ public class ClientCallImplTest {
     Context previous = cancellableContext.attach();
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         CallOptions.DEFAULT,
         statsTraceCtx,
@@ -608,7 +603,7 @@ public class ClientCallImplTest {
     CallOptions callOptions = CallOptions.DEFAULT.withDeadlineAfter(0, TimeUnit.SECONDS);
     fakeClock.forwardTime(System.nanoTime(), TimeUnit.NANOSECONDS);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         callOptions,
         statsTraceCtx,
@@ -631,7 +626,7 @@ public class ClientCallImplTest {
     context.attach();
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         MoreExecutors.directExecutor(),
         CallOptions.DEFAULT,
         statsTraceCtx,
@@ -659,7 +654,7 @@ public class ClientCallImplTest {
 
     CallOptions callOpts = CallOptions.DEFAULT.withDeadlineAfter(2, TimeUnit.SECONDS);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         MoreExecutors.directExecutor(),
         callOpts,
         statsTraceCtx,
@@ -687,7 +682,7 @@ public class ClientCallImplTest {
 
     CallOptions callOpts = CallOptions.DEFAULT.withDeadlineAfter(1, TimeUnit.SECONDS);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         MoreExecutors.directExecutor(),
         callOpts,
         statsTraceCtx,
@@ -711,7 +706,7 @@ public class ClientCallImplTest {
   public void expiredDeadlineCancelsStream_CallOptions() {
     fakeClock.forwardTime(System.nanoTime(), TimeUnit.NANOSECONDS);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         MoreExecutors.directExecutor(),
         CallOptions.DEFAULT.withDeadline(Deadline.after(1000, TimeUnit.MILLISECONDS)),
         statsTraceCtx,
@@ -735,7 +730,7 @@ public class ClientCallImplTest {
         .attach();
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         MoreExecutors.directExecutor(),
         CallOptions.DEFAULT,
         statsTraceCtx,
@@ -755,7 +750,7 @@ public class ClientCallImplTest {
     fakeClock.forwardTime(System.nanoTime(), TimeUnit.NANOSECONDS);
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         MoreExecutors.directExecutor(),
         CallOptions.DEFAULT.withDeadline(Deadline.after(1000, TimeUnit.MILLISECONDS)),
         statsTraceCtx,
@@ -779,7 +774,7 @@ public class ClientCallImplTest {
   @Test
   public void timeoutShouldNotBeSet() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         MoreExecutors.directExecutor(),
         CallOptions.DEFAULT,
         statsTraceCtx,
@@ -796,7 +791,7 @@ public class ClientCallImplTest {
   @Test
   public void cancelInOnMessageShouldInvokeStreamCancel() throws Exception {
     final ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         MoreExecutors.directExecutor(),
         CallOptions.DEFAULT,
         statsTraceCtx,
@@ -832,7 +827,7 @@ public class ClientCallImplTest {
     CallOptions callOptions =
         CallOptions.DEFAULT.withMaxInboundMessageSize(1).withMaxOutboundMessageSize(2);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR,
+        method,
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         callOptions,
         statsTraceCtx,
@@ -849,7 +844,7 @@ public class ClientCallImplTest {
   @Test
   public void getAttributes() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        DESCRIPTOR, MoreExecutors.directExecutor(), CallOptions.DEFAULT, statsTraceCtx, provider,
+        method, MoreExecutors.directExecutor(), CallOptions.DEFAULT, statsTraceCtx, provider,
         deadlineCancellationExecutor);
     Attributes attrs =
         Attributes.newBuilder().set(Key.<String>of("fake key"), "fake value").build();
@@ -868,18 +863,6 @@ public class ClientCallImplTest {
     TagValue statusTag = record.tags.get(RpcConstants.RPC_STATUS);
     assertNotNull(statusTag);
     assertEquals(statusCode.toString(), statusTag.toString());
-  }
-
-  private static class TestMarshaller<T> implements Marshaller<T> {
-    @Override
-    public InputStream stream(T value) {
-      return null;
-    }
-
-    @Override
-    public T parse(InputStream stream) {
-      return null;
-    }
   }
 
   private static void assertTimeoutBetween(long timeout, long from, long to) {

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -112,7 +112,7 @@ public class ClientCallImplTest {
       fakeClock.getScheduledExecutorService();
   private final DecompressorRegistry decompressorRegistry =
       DecompressorRegistry.getDefaultInstance().with(new Codec.Gzip(), true);
-  private final MethodDescriptor<Void, Void> method = MethodDescriptor.newBuilder()
+  private final MethodDescriptor<Void, Void> method = MethodDescriptor.<Void, Void>newBuilder()
       .setType(MethodType.UNARY)
       .setFullMethodName("service/method")
       .setRequestMarshaller(TestMethodDescriptors.noopMarshaller())

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransport2Test.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransport2Test.java
@@ -96,12 +96,13 @@ public class DelayedClientTransport2Test {
 
   private static final Attributes.Key<Integer> SHARD_ID = Attributes.Key.of("shard-id");
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
-      .setType(MethodType.UNKNOWN)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new StringMarshaller())
-      .setResponseMarshaller(new IntegerMarshaller())
-      .build();
+  private final MethodDescriptor<String, Integer> method =
+      MethodDescriptor.<String, Integer>newBuilder()
+          .setType(MethodType.UNKNOWN)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
   private final MethodDescriptor<String, Integer> method2 =
       method.toBuilder().setFullMethodName("/service/method").build();
   private final Metadata headers = new Metadata();

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransport2Test.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransport2Test.java
@@ -36,12 +36,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,6 +55,7 @@ import io.grpc.LoadBalancer2.PickResult;
 import io.grpc.LoadBalancer2.SubchannelPicker;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import io.grpc.StringMarshaller;
 
@@ -95,14 +96,14 @@ public class DelayedClientTransport2Test {
 
   private static final Attributes.Key<Integer> SHARD_ID = Attributes.Key.of("shard-id");
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-      new StringMarshaller(), new IntegerMarshaller());
-
-  private final MethodDescriptor<String, Integer> method2 = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method2",
-      new StringMarshaller(), new IntegerMarshaller());
-
+  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+      .setType(MethodType.UNKNOWN)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new StringMarshaller())
+      .setResponseMarshaller(new IntegerMarshaller())
+      .build();
+  private final MethodDescriptor<String, Integer> method2 =
+      method.toBuilder().setFullMethodName("/service/method").build();
   private final Metadata headers = new Metadata();
   private final Metadata headers2 = new Metadata();
 

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -36,11 +36,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -55,6 +55,7 @@ import io.grpc.LoadBalancer2.PickResult;
 import io.grpc.LoadBalancer2.SubchannelPicker;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import io.grpc.StringMarshaller;
 
@@ -91,14 +92,14 @@ public class DelayedClientTransportTest {
 
   private static final Attributes.Key<Integer> SHARD_ID = Attributes.Key.of("shard-id");
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-      new StringMarshaller(), new IntegerMarshaller());
-
-  private final MethodDescriptor<String, Integer> method2 = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method2",
-      new StringMarshaller(), new IntegerMarshaller());
-
+  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+      .setType(MethodType.UNKNOWN)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new StringMarshaller())
+      .setResponseMarshaller(new IntegerMarshaller())
+      .build();
+  private final MethodDescriptor<String, Integer> method2 =
+      method.toBuilder().setFullMethodName("/service/method2").build();
   private final Metadata headers = new Metadata();
   private final Metadata headers2 = new Metadata();
 

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -92,12 +92,13 @@ public class DelayedClientTransportTest {
 
   private static final Attributes.Key<Integer> SHARD_ID = Attributes.Key.of("shard-id");
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
-      .setType(MethodType.UNKNOWN)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new StringMarshaller())
-      .setResponseMarshaller(new IntegerMarshaller())
-      .build();
+  private final MethodDescriptor<String, Integer> method =
+      MethodDescriptor.<String, Integer>newBuilder()
+          .setType(MethodType.UNKNOWN)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
   private final MethodDescriptor<String, Integer> method2 =
       method.toBuilder().setFullMethodName("/service/method2").build();
   private final Metadata headers = new Metadata();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImpl2IdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImpl2IdlenessTest.java
@@ -53,14 +53,15 @@ import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.IntegerMarshaller;
+import io.grpc.LoadBalancer2;
 import io.grpc.LoadBalancer2.Helper;
 import io.grpc.LoadBalancer2.PickResult;
 import io.grpc.LoadBalancer2.Subchannel;
 import io.grpc.LoadBalancer2.SubchannelPicker;
-import io.grpc.LoadBalancer2;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.NameResolver;
 import io.grpc.ResolvedServerInfo;
 import io.grpc.ResolvedServerInfoGroup;
@@ -101,14 +102,17 @@ public class ManagedChannelImpl2IdlenessTest {
   private static final long IDLE_TIMEOUT_SECONDS = 30;
   private ManagedChannelImpl2 channel;
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-      new StringMarshaller(), new IntegerMarshaller());
+  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+      .setType(MethodType.UNKNOWN)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new StringMarshaller())
+      .setResponseMarshaller(new IntegerMarshaller())
+      .build();
 
   private final List<ResolvedServerInfoGroup> servers = Lists.newArrayList();
   private final List<EquivalentAddressGroup> addressGroupList =
       new ArrayList<EquivalentAddressGroup>();
-  
+
   @Mock private ObjectPool<ScheduledExecutorService> timerServicePool;
   @Mock private ObjectPool<Executor> executorPool;
   @Mock private ObjectPool<Executor> oobExecutorPool;
@@ -225,7 +229,7 @@ public class ManagedChannelImpl2IdlenessTest {
     assertEquals(2, executor.runDueTasks());
     verify(mockCallListener, times(2)).onClose(any(Status.class), any(Metadata.class));
   }
-  
+
   @Test
   public void delayedTransportHoldsOffIdleness() throws Exception {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
@@ -351,11 +355,11 @@ public class ManagedChannelImpl2IdlenessTest {
 
   private static class FakeSocketAddress extends SocketAddress {
     final String name;
- 
+
     FakeSocketAddress(String name) {
       this.name = name;
     }
- 
+
     @Override
     public String toString() {
       return "FakeSocketAddress-" + name;

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImpl2IdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImpl2IdlenessTest.java
@@ -102,12 +102,13 @@ public class ManagedChannelImpl2IdlenessTest {
   private static final long IDLE_TIMEOUT_SECONDS = 30;
   private ManagedChannelImpl2 channel;
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
-      .setType(MethodType.UNKNOWN)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new StringMarshaller())
-      .setResponseMarshaller(new IntegerMarshaller())
-      .build();
+  private final MethodDescriptor<String, Integer> method =
+      MethodDescriptor.<String, Integer>newBuilder()
+          .setType(MethodType.UNKNOWN)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
 
   private final List<ResolvedServerInfoGroup> servers = Lists.newArrayList();
   private final List<EquivalentAddressGroup> addressGroupList =

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImpl2Test.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImpl2Test.java
@@ -126,12 +126,13 @@ public class ManagedChannelImpl2Test {
       Collections.<ClientInterceptor>emptyList();
   private static final Attributes NAME_RESOLVER_PARAMS =
       Attributes.newBuilder().set(NameResolver.Factory.PARAMS_DEFAULT_PORT, 447).build();
-  private static final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
-      .setType(MethodType.UNKNOWN)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new StringMarshaller())
-      .setResponseMarshaller(new IntegerMarshaller())
-      .build();
+  private static final MethodDescriptor<String, Integer> method =
+      MethodDescriptor.<String, Integer>newBuilder()
+          .setType(MethodType.UNKNOWN)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
   private static final Attributes.Key<String> SUBCHANNEL_ATTR_KEY =
       Attributes.Key.of("subchannel-attr-key");
   private final String serviceName = "fake.example.com";

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImpl2Test.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImpl2Test.java
@@ -60,8 +60,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 
 import io.grpc.Attributes;
-import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallCredentials;
+import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -80,6 +80,7 @@ import io.grpc.LoadBalancer2.SubchannelPicker;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.NameResolver;
 import io.grpc.ResolvedServerInfo;
 import io.grpc.ResolvedServerInfoGroup;
@@ -125,9 +126,12 @@ public class ManagedChannelImpl2Test {
       Collections.<ClientInterceptor>emptyList();
   private static final Attributes NAME_RESOLVER_PARAMS =
       Attributes.newBuilder().set(NameResolver.Factory.PARAMS_DEFAULT_PORT, 447).build();
-  private static final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-      new StringMarshaller(), new IntegerMarshaller());
+  private static final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+      .setType(MethodType.UNKNOWN)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new StringMarshaller())
+      .setResponseMarshaller(new IntegerMarshaller())
+      .build();
   private static final Attributes.Key<String> SUBCHANNEL_ATTR_KEY =
       Attributes.Key.of("subchannel-attr-key");
   private final String serviceName = "fake.example.com";
@@ -608,7 +612,7 @@ public class ManagedChannelImpl2Test {
             any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class),
             any(StatsTraceContext.class)))
         .thenReturn(mock(ClientStream.class));
-    
+
     goodTransportInfo.listener.transportReady();
     inOrder.verify(mockLoadBalancer).handleSubchannelState(
         same(subchannel), stateInfoCaptor.capture());

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -58,13 +58,14 @@ import io.grpc.IntegerMarshaller;
 import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.NameResolver;
 import io.grpc.ResolvedServerInfo;
 import io.grpc.ResolvedServerInfoGroup;
 import io.grpc.Status;
 import io.grpc.StringMarshaller;
-import io.grpc.TransportManager.OobTransportProvider;
 import io.grpc.TransportManager;
+import io.grpc.TransportManager.OobTransportProvider;
 import io.grpc.internal.TestUtils.MockClientTransportInfo;
 
 import org.junit.After;
@@ -103,14 +104,16 @@ public class ManagedChannelImplIdlenessTest {
   private static final long IDLE_TIMEOUT_SECONDS = 30;
   private ManagedChannelImpl channel;
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-      new StringMarshaller(), new IntegerMarshaller());
-
+  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+      .setType(MethodType.UNKNOWN)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new StringMarshaller())
+      .setResponseMarshaller(new IntegerMarshaller())
+      .build();
   private final List<ResolvedServerInfoGroup> servers = Lists.newArrayList();
   private final List<EquivalentAddressGroup> addressGroupList =
       new ArrayList<EquivalentAddressGroup>();
-  
+
   @Mock private SharedResourceHolder.Resource<ScheduledExecutorService> timerService;
   @Mock private ClientTransportFactory mockTransportFactory;
   @Mock private LoadBalancer<ClientTransport> mockLoadBalancer;
@@ -427,11 +430,11 @@ public class ManagedChannelImplIdlenessTest {
 
   private static class FakeSocketAddress extends SocketAddress {
     final String name;
- 
+
     FakeSocketAddress(String name) {
       this.name = name;
     }
- 
+
     @Override
     public String toString() {
       return "FakeSocketAddress-" + name;

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -104,12 +104,13 @@ public class ManagedChannelImplIdlenessTest {
   private static final long IDLE_TIMEOUT_SECONDS = 30;
   private ManagedChannelImpl channel;
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
-      .setType(MethodType.UNKNOWN)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new StringMarshaller())
-      .setResponseMarshaller(new IntegerMarshaller())
-      .build();
+  private final MethodDescriptor<String, Integer> method =
+      MethodDescriptor.<String, Integer>newBuilder()
+          .setType(MethodType.UNKNOWN)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
   private final List<ResolvedServerInfoGroup> servers = Lists.newArrayList();
   private final List<EquivalentAddressGroup> addressGroupList =
       new ArrayList<EquivalentAddressGroup>();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -56,8 +56,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 
 import io.grpc.Attributes;
-import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallCredentials;
+import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -70,6 +70,7 @@ import io.grpc.IntegerMarshaller;
 import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.NameResolver;
 import io.grpc.PickFirstBalancerFactory;
 import io.grpc.ResolvedServerInfo;
@@ -115,9 +116,12 @@ public class ManagedChannelImplTest {
       Collections.<ClientInterceptor>emptyList();
   private static final Attributes NAME_RESOLVER_PARAMS =
       Attributes.newBuilder().set(NameResolver.Factory.PARAMS_DEFAULT_PORT, 447).build();
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-      new StringMarshaller(), new IntegerMarshaller());
+  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+      .setType(MethodType.UNKNOWN)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new StringMarshaller())
+      .setResponseMarshaller(new IntegerMarshaller())
+      .build();
   private final String serviceName = "fake.example.com";
   private final String authority = serviceName;
   private final String userAgent = "userAgent";

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -116,12 +116,13 @@ public class ManagedChannelImplTest {
       Collections.<ClientInterceptor>emptyList();
   private static final Attributes NAME_RESOLVER_PARAMS =
       Attributes.newBuilder().set(NameResolver.Factory.PARAMS_DEFAULT_PORT, 447).build();
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
-      .setType(MethodType.UNKNOWN)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new StringMarshaller())
-      .setResponseMarshaller(new IntegerMarshaller())
-      .build();
+  private final MethodDescriptor<String, Integer> method =
+      MethodDescriptor.<String, Integer>newBuilder()
+          .setType(MethodType.UNKNOWN)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
   private final String serviceName = "fake.example.com";
   private final String authority = serviceName;
   private final String userAgent = "userAgent";

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -94,12 +94,13 @@ public class ManagedChannelImplTransportManagerTest {
   private static final String USER_AGENT = "mosaic";
 
   private final ExecutorService executor = Executors.newSingleThreadExecutor();
-  private final MethodDescriptor<String, String> method = MethodDescriptor.newBuilder()
-      .setType(MethodType.UNKNOWN)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new StringMarshaller())
-      .setResponseMarshaller(new StringMarshaller())
-      .build();
+  private final MethodDescriptor<String, String> method =
+      MethodDescriptor.<String, String>newBuilder()
+          .setType(MethodType.UNKNOWN)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new StringMarshaller())
+          .build();
 
   private final MethodDescriptor<String, String> method2 = method.toBuilder()
       .setFullMethodName("/service/method2")

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -55,12 +55,13 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.StringMarshaller;
+import io.grpc.TransportManager;
 import io.grpc.TransportManager.InterimTransport;
 import io.grpc.TransportManager.OobTransportProvider;
-import io.grpc.TransportManager;
 import io.grpc.internal.TestUtils.MockClientTransportInfo;
 
 import org.junit.After;
@@ -93,12 +94,16 @@ public class ManagedChannelImplTransportManagerTest {
   private static final String USER_AGENT = "mosaic";
 
   private final ExecutorService executor = Executors.newSingleThreadExecutor();
-  private final MethodDescriptor<String, String> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-      new StringMarshaller(), new StringMarshaller());
-  private final MethodDescriptor<String, String> method2 = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method2",
-      new StringMarshaller(), new StringMarshaller());
+  private final MethodDescriptor<String, String> method = MethodDescriptor.newBuilder()
+      .setType(MethodType.UNKNOWN)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new StringMarshaller())
+      .setResponseMarshaller(new StringMarshaller())
+      .build();
+
+  private final MethodDescriptor<String, String> method2 = method.toBuilder()
+      .setFullMethodName("/service/method2")
+      .build();
   private final CallOptions callOptions = CallOptions.DEFAULT.withAuthority("dummy_value");
   private final CallOptions callOptions2 = CallOptions.DEFAULT.withAuthority("dummy_value2");
   private final StatsTraceContext statsTraceCtx = StatsTraceContext.newClientContext(

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -86,7 +86,7 @@ public class ServerCallImplTest {
   private ServerCallImpl<Long, Long> call;
   private Context.CancellableContext context;
 
-  private final MethodDescriptor<Long, Long> method = MethodDescriptor.newBuilder()
+  private final MethodDescriptor<Long, Long> method = MethodDescriptor.<Long, Long>newBuilder()
       .setType(MethodType.UNARY)
       .setFullMethodName("/service/method")
       .setRequestMarshaller(new LongMarshaller())

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -86,8 +86,12 @@ public class ServerCallImplTest {
   private ServerCallImpl<Long, Long> call;
   private Context.CancellableContext context;
 
-  private final MethodDescriptor<Long, Long> method = MethodDescriptor.create(
-      MethodType.UNARY, "/service/method", new LongMarshaller(), new LongMarshaller());
+  private final MethodDescriptor<Long, Long> method = MethodDescriptor.newBuilder()
+      .setType(MethodType.UNARY)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new LongMarshaller())
+      .setResponseMarshaller(new LongMarshaller())
+      .build();
 
   private final Metadata requestHeaders = new Metadata();
   private final FakeStatsContextFactory statsCtxFactory = new FakeStatsContextFactory();

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -69,7 +69,6 @@ import io.grpc.HandlerRegistry;
 import io.grpc.IntegerMarshaller;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerServiceDefinition;
@@ -380,8 +379,12 @@ public class ServerImplTest {
         = StatsTraceContext.createStatsHeader(statsCtxFactory);
     final AtomicReference<ServerCall<String, Integer>> callReference
         = new AtomicReference<ServerCall<String, Integer>>();
-    MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-        MethodType.UNKNOWN, "Waiter/serve", STRING_MARSHALLER, INTEGER_MARSHALLER);
+    MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+        .setType(MethodDescriptor.MethodType.UNKNOWN)
+        .setFullMethodName("Waiter/serve")
+        .setRequestMarshaller(STRING_MARSHALLER)
+        .setResponseMarshaller(INTEGER_MARSHALLER)
+        .build();
     mutableFallbackRegistry.addService(ServerServiceDefinition.builder(
         new ServiceDescriptor("Waiter", method))
         .addMethod(
@@ -568,9 +571,12 @@ public class ServerImplTest {
   public void exceptionInStartCallPropagatesToStream() throws Exception {
     createAndStartServer(NO_FILTERS);
     final Status status = Status.ABORTED.withDescription("Oh, no!");
-    MethodDescriptor<String, Integer> method = MethodDescriptor
-        .create(MethodType.UNKNOWN, "Waiter/serve",
-            STRING_MARSHALLER, INTEGER_MARSHALLER);
+    MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+        .setType(MethodDescriptor.MethodType.UNKNOWN)
+        .setFullMethodName("Waiter/serve")
+        .setRequestMarshaller(STRING_MARSHALLER)
+        .setResponseMarshaller(INTEGER_MARSHALLER)
+        .build();
     mutableFallbackRegistry.addService(ServerServiceDefinition.builder(
         new ServiceDescriptor("Waiter", method))
         .addMethod(method,
@@ -687,8 +693,12 @@ public class ServerImplTest {
   @Test
   public void testCallContextIsBoundInListenerCallbacks() throws Exception {
     createAndStartServer(NO_FILTERS);
-    MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-        MethodType.UNKNOWN, "Waiter/serve", STRING_MARSHALLER, INTEGER_MARSHALLER);
+    MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+        .setType(MethodDescriptor.MethodType.UNKNOWN)
+        .setFullMethodName("Waiter/serve")
+        .setRequestMarshaller(STRING_MARSHALLER)
+        .setResponseMarshaller(INTEGER_MARSHALLER)
+        .build();
     final AtomicBoolean  onReadyCalled = new AtomicBoolean(false);
     final AtomicBoolean onMessageCalled = new AtomicBoolean(false);
     final AtomicBoolean onHalfCloseCalled = new AtomicBoolean(false);
@@ -766,7 +776,7 @@ public class ServerImplTest {
     streamListener.messageRead(new ByteArrayInputStream(new byte[0]));
     assertEquals(1, executor.runDueTasks());
     assertTrue(onMessageCalled.get());
-    
+
     streamListener.halfClosed();
     assertEquals(1, executor.runDueTasks());
     assertTrue(onHalfCloseCalled.get());
@@ -797,8 +807,13 @@ public class ServerImplTest {
 
     final AtomicReference<ServerCall<String, Integer>> callReference
         = new AtomicReference<ServerCall<String, Integer>>();
-    MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-        MethodType.UNKNOWN, "Waiter/serve", STRING_MARSHALLER, INTEGER_MARSHALLER);
+    MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+        .setType(MethodDescriptor.MethodType.UNKNOWN)
+        .setFullMethodName("Waiter/serve")
+        .setRequestMarshaller(STRING_MARSHALLER)
+        .setResponseMarshaller(INTEGER_MARSHALLER)
+        .build();
+
     mutableFallbackRegistry.addService(ServerServiceDefinition.builder(
         new ServiceDescriptor("Waiter", method))
         .addMethod(method,
@@ -866,8 +881,12 @@ public class ServerImplTest {
   @Test
   public void handlerRegistryPriorities() throws Exception {
     fallbackRegistry = mock(HandlerRegistry.class);
-    MethodDescriptor<String, Integer> method1 = MethodDescriptor.create(
-        MethodType.UNKNOWN, "Service1/Method1", STRING_MARSHALLER, INTEGER_MARSHALLER);
+    MethodDescriptor<String, Integer> method1 = MethodDescriptor.newBuilder()
+        .setType(MethodDescriptor.MethodType.UNKNOWN)
+        .setFullMethodName("Service1/Method1")
+        .setRequestMarshaller(STRING_MARSHALLER)
+        .setResponseMarshaller(INTEGER_MARSHALLER)
+        .build();
     registry = new InternalHandlerRegistry.Builder()
         .addService(ServerServiceDefinition.builder(new ServiceDescriptor("Service1", method1))
             .addMethod(method1, callHandler).build())

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -379,7 +379,7 @@ public class ServerImplTest {
         = StatsTraceContext.createStatsHeader(statsCtxFactory);
     final AtomicReference<ServerCall<String, Integer>> callReference
         = new AtomicReference<ServerCall<String, Integer>>();
-    MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+    MethodDescriptor<String, Integer> method = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodDescriptor.MethodType.UNKNOWN)
         .setFullMethodName("Waiter/serve")
         .setRequestMarshaller(STRING_MARSHALLER)
@@ -571,7 +571,7 @@ public class ServerImplTest {
   public void exceptionInStartCallPropagatesToStream() throws Exception {
     createAndStartServer(NO_FILTERS);
     final Status status = Status.ABORTED.withDescription("Oh, no!");
-    MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+    MethodDescriptor<String, Integer> method = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodDescriptor.MethodType.UNKNOWN)
         .setFullMethodName("Waiter/serve")
         .setRequestMarshaller(STRING_MARSHALLER)
@@ -693,7 +693,7 @@ public class ServerImplTest {
   @Test
   public void testCallContextIsBoundInListenerCallbacks() throws Exception {
     createAndStartServer(NO_FILTERS);
-    MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+    MethodDescriptor<String, Integer> method = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodDescriptor.MethodType.UNKNOWN)
         .setFullMethodName("Waiter/serve")
         .setRequestMarshaller(STRING_MARSHALLER)
@@ -807,7 +807,7 @@ public class ServerImplTest {
 
     final AtomicReference<ServerCall<String, Integer>> callReference
         = new AtomicReference<ServerCall<String, Integer>>();
-    MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+    MethodDescriptor<String, Integer> method = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodDescriptor.MethodType.UNKNOWN)
         .setFullMethodName("Waiter/serve")
         .setRequestMarshaller(STRING_MARSHALLER)
@@ -881,7 +881,7 @@ public class ServerImplTest {
   @Test
   public void handlerRegistryPriorities() throws Exception {
     fallbackRegistry = mock(HandlerRegistry.class);
-    MethodDescriptor<String, Integer> method1 = MethodDescriptor.newBuilder()
+    MethodDescriptor<String, Integer> method1 = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodDescriptor.MethodType.UNKNOWN)
         .setFullMethodName("Service1/Method1")
         .setRequestMarshaller(STRING_MARSHALLER)

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -95,12 +95,13 @@ public class TransportSetTest {
   @Mock private TransportSet.Callback mockTransportSetCallback;
   @Mock private ClientStreamListener mockStreamListener;
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
-      .setType(MethodDescriptor.MethodType.UNKNOWN)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new StringMarshaller())
-      .setResponseMarshaller(new IntegerMarshaller())
-      .build();
+  private final MethodDescriptor<String, Integer> method =
+      MethodDescriptor.<String, Integer>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNKNOWN)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
   private final Metadata headers = new Metadata();
   private final CallOptions waitForReadyCallOptions = CallOptions.DEFAULT.withWaitForReady();
   private final CallOptions failFastCallOptions = CallOptions.DEFAULT;

--- a/core/src/test/java/io/grpc/internal/TransportSetTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportSetTest.java
@@ -95,9 +95,12 @@ public class TransportSetTest {
   @Mock private TransportSet.Callback mockTransportSetCallback;
   @Mock private ClientStreamListener mockStreamListener;
 
-  private final MethodDescriptor<String, Integer> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "/service/method",
-      new StringMarshaller(), new IntegerMarshaller());
+  private final MethodDescriptor<String, Integer> method = MethodDescriptor.newBuilder()
+      .setType(MethodDescriptor.MethodType.UNKNOWN)
+      .setFullMethodName("/service/method")
+      .setRequestMarshaller(new StringMarshaller())
+      .setResponseMarshaller(new IntegerMarshaller())
+      .build();
   private final Metadata headers = new Metadata();
   private final CallOptions waitForReadyCallOptions = CallOptions.DEFAULT.withWaitForReady();
   private final CallOptions failFastCallOptions = CallOptions.DEFAULT;

--- a/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
+++ b/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
@@ -88,7 +88,7 @@ public class MutableHandlerRegistryTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    MethodDescriptor<String, Integer> flowMethod = MethodDescriptor.newBuilder()
+    MethodDescriptor<String, Integer> flowMethod = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodType.UNKNOWN)
         .setFullMethodName("basic/flow")
         .setRequestMarshaller(requestMarshaller)
@@ -177,7 +177,7 @@ public class MutableHandlerRegistryTest {
   public void replaceAndLookup() {
     assertNull(registry.addService(basicServiceDefinition));
     assertNotNull(registry.lookupMethod("basic/flow"));
-    MethodDescriptor<String, Integer> anotherMethod = MethodDescriptor.newBuilder()
+    MethodDescriptor<String, Integer> anotherMethod = MethodDescriptor.<String, Integer>newBuilder()
         .setType(MethodType.UNKNOWN)
         .setFullMethodName("basic/another")
         .setRequestMarshaller(requestMarshaller)

--- a/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
+++ b/core/src/test/java/io/grpc/util/MutableHandlerRegistryTest.java
@@ -88,17 +88,21 @@ public class MutableHandlerRegistryTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    MethodDescriptor<String, Integer> flowMethod = MethodDescriptor
-        .create(MethodType.UNKNOWN, "basic/flow", requestMarshaller, responseMarshaller);
+    MethodDescriptor<String, Integer> flowMethod = MethodDescriptor.newBuilder()
+        .setType(MethodType.UNKNOWN)
+        .setFullMethodName("basic/flow")
+        .setRequestMarshaller(requestMarshaller)
+        .setResponseMarshaller(responseMarshaller)
+        .build();
     basicServiceDefinition = ServerServiceDefinition.builder(
         new ServiceDescriptor("basic", flowMethod))
         .addMethod(flowMethod, flowHandler)
         .build();
 
-    MethodDescriptor<String, Integer> coupleMethod = MethodDescriptor
-        .create(MethodType.UNKNOWN, "multi/couple", requestMarshaller, responseMarshaller);
-    MethodDescriptor<String, Integer> fewMethod = MethodDescriptor
-        .create(MethodType.UNKNOWN, "multi/few", requestMarshaller, responseMarshaller);
+    MethodDescriptor<String, Integer> coupleMethod =
+        flowMethod.toBuilder().setFullMethodName("multi/couple").build();
+    MethodDescriptor<String, Integer> fewMethod =
+        flowMethod.toBuilder().setFullMethodName("multi/few").build();
     multiServiceDefinition = ServerServiceDefinition.builder(
         new ServiceDescriptor("multi", coupleMethod, fewMethod))
         .addMethod(coupleMethod, coupleHandler)
@@ -173,8 +177,12 @@ public class MutableHandlerRegistryTest {
   public void replaceAndLookup() {
     assertNull(registry.addService(basicServiceDefinition));
     assertNotNull(registry.lookupMethod("basic/flow"));
-    MethodDescriptor<String, Integer> anotherMethod = MethodDescriptor
-        .create(MethodType.UNKNOWN, "basic/another", requestMarshaller, responseMarshaller);
+    MethodDescriptor<String, Integer> anotherMethod = MethodDescriptor.newBuilder()
+        .setType(MethodType.UNKNOWN)
+        .setFullMethodName("basic/another")
+        .setRequestMarshaller(requestMarshaller)
+        .setResponseMarshaller(responseMarshaller)
+        .build();
     ServerServiceDefinition replaceServiceDefinition = ServerServiceDefinition.builder(
         new ServiceDescriptor("basic", anotherMethod))
         .addMethod(anotherMethod, flowHandler).build();

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancer2Test.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancer2Test.java
@@ -114,12 +114,13 @@ public class GrpclbLoadBalancer2Test {
       Attributes.Key.of("resolution-attr");
   private static final String SERVICE_AUTHORITY = "api.google.com";
 
-  private static final MethodDescriptor<String, String> TRASH_METHOD = MethodDescriptor.newBuilder()
-      .setType(MethodDescriptor.MethodType.UNARY)
-      .setFullMethodName("/service/trashmethod")
-      .setRequestMarshaller(StringMarshaller.INSTANCE)
-      .setResponseMarshaller(StringMarshaller.INSTANCE)
-      .build();
+  private static final MethodDescriptor<String, String> TRASH_METHOD =
+      MethodDescriptor.<String, String>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName("/service/trashmethod")
+          .setRequestMarshaller(StringMarshaller.INSTANCE)
+          .setResponseMarshaller(StringMarshaller.INSTANCE)
+          .build();
 
   private static class StringMarshaller implements Marshaller<String> {
     static final StringMarshaller INSTANCE = new StringMarshaller();

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancer2Test.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancer2Test.java
@@ -114,9 +114,12 @@ public class GrpclbLoadBalancer2Test {
       Attributes.Key.of("resolution-attr");
   private static final String SERVICE_AUTHORITY = "api.google.com";
 
-  private static final MethodDescriptor<String, String> TRASH_METHOD = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNARY, "/service/trashmethod",
-      new StringMarshaller(), new StringMarshaller());
+  private static final MethodDescriptor<String, String> TRASH_METHOD = MethodDescriptor.newBuilder()
+      .setType(MethodDescriptor.MethodType.UNARY)
+      .setFullMethodName("/service/trashmethod")
+      .setRequestMarshaller(StringMarshaller.INSTANCE)
+      .setResponseMarshaller(StringMarshaller.INSTANCE)
+      .build();
 
   private static class StringMarshaller implements Marshaller<String> {
     static final StringMarshaller INSTANCE = new StringMarshaller();
@@ -179,7 +182,7 @@ public class GrpclbLoadBalancer2Test {
         public StreamObserver<LoadBalanceRequest> balanceLoad(
             final StreamObserver<LoadBalanceResponse> responseObserver) {
           StreamObserver<LoadBalanceRequest> requestObserver =
-              (StreamObserver<LoadBalanceRequest>) mock(StreamObserver.class);
+              mock(StreamObserver.class);
           Answer<Void> closeRpc = new Answer<Void>() {
               @Override
               public Void answer(InvocationOnMock invocation) {

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -99,8 +99,13 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
   private MethodDescriptor.Marshaller<Void> marshaller = mock(MethodDescriptor.Marshaller.class);
 
   // Must be initialized before @Before, because it is used by createStream()
-  private MethodDescriptor<?, ?> methodDescriptor = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNARY, "/testService/test", marshaller, marshaller);
+  private MethodDescriptor<?, ?> methodDescriptor = MethodDescriptor.newBuilder()
+      .setType(MethodDescriptor.MethodType.UNARY)
+      .setFullMethodName("/testService/test")
+      .setRequestMarshaller(marshaller)
+      .setResponseMarshaller(marshaller)
+      .build();
+
 
   @Override
   protected ClientStreamListener listener() {

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -99,7 +99,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
   private MethodDescriptor.Marshaller<Void> marshaller = mock(MethodDescriptor.Marshaller.class);
 
   // Must be initialized before @Before, because it is used by createStream()
-  private MethodDescriptor<?, ?> methodDescriptor = MethodDescriptor.newBuilder()
+  private MethodDescriptor<?, ?> methodDescriptor = MethodDescriptor.<Void, Void>newBuilder()
       .setType(MethodDescriptor.MethodType.UNARY)
       .setFullMethodName("/testService/test")
       .setRequestMarshaller(marshaller)

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -397,12 +397,13 @@ public class NettyClientTransportTest {
 
   private static class Rpc {
     static final String MESSAGE = "hello";
-    static final MethodDescriptor<String, String> METHOD = MethodDescriptor.newBuilder()
-        .setType(MethodDescriptor.MethodType.UNARY)
-        .setFullMethodName("/testService/test")
-        .setRequestMarshaller(StringMarshaller.INSTANCE)
-        .setResponseMarshaller(StringMarshaller.INSTANCE)
-        .build();
+    static final MethodDescriptor<String, String> METHOD =
+        MethodDescriptor.<String, String>newBuilder()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName("/testService/test")
+            .setRequestMarshaller(StringMarshaller.INSTANCE)
+            .setResponseMarshaller(StringMarshaller.INSTANCE)
+            .build();
 
     final ClientStream stream;
     final TestClientStreamListener listener = new TestClientStreamListener();

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -397,9 +397,12 @@ public class NettyClientTransportTest {
 
   private static class Rpc {
     static final String MESSAGE = "hello";
-    static final MethodDescriptor<String, String> METHOD = MethodDescriptor.create(
-            MethodDescriptor.MethodType.UNARY, "/testService/test", StringMarshaller.INSTANCE,
-            StringMarshaller.INSTANCE);
+    static final MethodDescriptor<String, String> METHOD = MethodDescriptor.newBuilder()
+        .setType(MethodDescriptor.MethodType.UNARY)
+        .setFullMethodName("/testService/test")
+        .setRequestMarshaller(StringMarshaller.INSTANCE)
+        .setResponseMarshaller(StringMarshaller.INSTANCE)
+        .build();
 
     final ClientStream stream;
     final TestClientStreamListener listener = new TestClientStreamListener();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -82,8 +82,13 @@ public class OkHttpClientStreamTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    methodDescriptor = MethodDescriptor.create(
-        MethodType.UNARY, "/testService/test", marshaller, marshaller);
+    methodDescriptor = MethodDescriptor.newBuilder()
+        .setType(MethodDescriptor.MethodType.UNARY)
+        .setFullMethodName("/testService/test")
+        .setRequestMarshaller(marshaller)
+        .setResponseMarshaller(marshaller)
+        .build();
+
     stream = new OkHttpClientStream(methodDescriptor, new Metadata(), frameWriter, transport,
         flowController, lock, MAX_MESSAGE_SIZE, "localhost", "userAgent", StatsTraceContext.NOOP);
   }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -82,7 +82,7 @@ public class OkHttpClientStreamTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    methodDescriptor = MethodDescriptor.newBuilder()
+    methodDescriptor = MethodDescriptor.<Void, Void>newBuilder()
         .setType(MethodDescriptor.MethodType.UNARY)
         .setFullMethodName("/testService/test")
         .setRequestMarshaller(marshaller)

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -967,33 +967,21 @@ public class OkHttpClientTransportTest {
 
   @Test
   public void serverStreamingHeadersShouldNotBeFlushed() throws Exception {
-    method = MethodDescriptor.create(
-        MethodType.SERVER_STREAMING,
-        method.getFullMethodName(),
-        TestMethodDescriptors.noopMarshaller(),
-        TestMethodDescriptors.noopMarshaller());
+    method = method.toBuilder().setType(MethodType.SERVER_STREAMING).build();
     shouldHeadersBeFlushed(false);
     shutdownAndVerify();
   }
 
   @Test
   public void clientStreamingHeadersShouldBeFlushed() throws Exception {
-    method = MethodDescriptor.create(
-        MethodType.CLIENT_STREAMING,
-        method.getFullMethodName(),
-        TestMethodDescriptors.noopMarshaller(),
-        TestMethodDescriptors.noopMarshaller());
+    method = method.toBuilder().setType(MethodType.CLIENT_STREAMING).build();
     shouldHeadersBeFlushed(true);
     shutdownAndVerify();
   }
 
   @Test
   public void duplexStreamingHeadersShouldNotBeFlushed() throws Exception {
-    method = MethodDescriptor.create(
-        MethodType.BIDI_STREAMING,
-        method.getFullMethodName(),
-        TestMethodDescriptors.noopMarshaller(),
-        TestMethodDescriptors.noopMarshaller());
+    method = method.toBuilder().setType(MethodType.BIDI_STREAMING).build();
     shouldHeadersBeFlushed(true);
     shutdownAndVerify();
   }

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -82,7 +82,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ClientCallsTest {
 
   private static final MethodDescriptor<Integer, Integer> STREAMING_METHOD =
-      MethodDescriptor.newBuilder()
+      MethodDescriptor.<Integer, Integer>newBuilder()
           .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
           .setFullMethodName("some/method")
           .setRequestMarshaller(new IntegerMarshaller())

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -81,11 +81,13 @@ import java.util.concurrent.atomic.AtomicReference;
 @RunWith(JUnit4.class)
 public class ClientCallsTest {
 
-  private static final MethodDescriptor<Integer, Integer> STREAMING_METHOD = MethodDescriptor
-      .create(
-          MethodDescriptor.MethodType.BIDI_STREAMING,
-          "some/method",
-          new IntegerMarshaller(), new IntegerMarshaller());
+  private static final MethodDescriptor<Integer, Integer> STREAMING_METHOD =
+      MethodDescriptor.newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName("some/method")
+          .setRequestMarshaller(new IntegerMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
 
   private Server server;
   private ManagedChannel channel;

--- a/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
@@ -76,13 +76,13 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @RunWith(JUnit4.class)
 public class ServerCallsTest {
-  static final MethodDescriptor<Integer, Integer> STREAMING_METHOD = MethodDescriptor.newBuilder()
-      .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
-      .setFullMethodName("some/method")
-      .setRequestMarshaller(new IntegerMarshaller())
-      .setResponseMarshaller(new IntegerMarshaller())
-      .build();
-
+  static final MethodDescriptor<Integer, Integer> STREAMING_METHOD =
+      MethodDescriptor.<Integer, Integer>newBuilder()
+          .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+          .setFullMethodName("some/method")
+          .setRequestMarshaller(new IntegerMarshaller())
+          .setResponseMarshaller(new IntegerMarshaller())
+          .build();
 
   static final MethodDescriptor<Integer, Integer> UNARY_METHOD = STREAMING_METHOD.toBuilder()
       .setType(MethodDescriptor.MethodType.UNARY)

--- a/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ServerCallsTest.java
@@ -76,15 +76,18 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @RunWith(JUnit4.class)
 public class ServerCallsTest {
-  static final MethodDescriptor<Integer, Integer> STREAMING_METHOD = MethodDescriptor.create(
-      MethodDescriptor.MethodType.BIDI_STREAMING,
-      "some/method",
-      new IntegerMarshaller(), new IntegerMarshaller());
+  static final MethodDescriptor<Integer, Integer> STREAMING_METHOD = MethodDescriptor.newBuilder()
+      .setType(MethodDescriptor.MethodType.BIDI_STREAMING)
+      .setFullMethodName("some/method")
+      .setRequestMarshaller(new IntegerMarshaller())
+      .setResponseMarshaller(new IntegerMarshaller())
+      .build();
 
-  static final MethodDescriptor<Integer, Integer> UNARY_METHOD = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNARY,
-      "some/unarymethod",
-      new IntegerMarshaller(), new IntegerMarshaller());
+
+  static final MethodDescriptor<Integer, Integer> UNARY_METHOD = STREAMING_METHOD.toBuilder()
+      .setType(MethodDescriptor.MethodType.UNARY)
+      .setFullMethodName("some/unarymethod")
+      .build();
 
   private final ServerCallRecorder serverCall = new ServerCallRecorder();
 

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -129,12 +129,13 @@ public abstract class AbstractTransportTest {
   private InternalServer server;
   private ServerTransport serverTransport;
   private ManagedClientTransport client;
-  private MethodDescriptor<String, String> methodDescriptor = MethodDescriptor.newBuilder()
-      .setType(MethodDescriptor.MethodType.UNKNOWN)
-      .setFullMethodName("service/method")
-      .setRequestMarshaller(StringMarshaller.INSTANCE)
-      .setResponseMarshaller(StringMarshaller.INSTANCE)
-      .build();
+  private MethodDescriptor<String, String> methodDescriptor =
+      MethodDescriptor.<String, String>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNKNOWN)
+          .setFullMethodName("service/method")
+          .setRequestMarshaller(StringMarshaller.INSTANCE)
+          .setResponseMarshaller(StringMarshaller.INSTANCE)
+          .build();
 
   private Metadata.Key<String> asciiKey = Metadata.Key.of(
       "ascii-key", Metadata.ASCII_STRING_MARSHALLER);

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -129,9 +129,13 @@ public abstract class AbstractTransportTest {
   private InternalServer server;
   private ServerTransport serverTransport;
   private ManagedClientTransport client;
-  private MethodDescriptor<String, String> methodDescriptor = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "service/method", StringMarshaller.INSTANCE,
-      StringMarshaller.INSTANCE);
+  private MethodDescriptor<String, String> methodDescriptor = MethodDescriptor.newBuilder()
+      .setType(MethodDescriptor.MethodType.UNKNOWN)
+      .setFullMethodName("service/method")
+      .setRequestMarshaller(StringMarshaller.INSTANCE)
+      .setResponseMarshaller(StringMarshaller.INSTANCE)
+      .build();
+
   private Metadata.Key<String> asciiKey = Metadata.Key.of(
       "ascii-key", Metadata.ASCII_STRING_MARSHALLER);
   private Metadata.Key<String> binaryKey = Metadata.Key.of(

--- a/testing/src/main/java/io/grpc/testing/TestMethodDescriptors.java
+++ b/testing/src/main/java/io/grpc/testing/TestMethodDescriptors.java
@@ -56,11 +56,12 @@ public final class TestMethodDescriptors {
 
   private static MethodDescriptor<Void, Void> noopMethod(
       String serviceName, String methodName) {
-    return MethodDescriptor.create(
-        MethodType.UNARY,
-        MethodDescriptor.generateFullMethodName(serviceName, methodName),
-        noopMarshaller(),
-        noopMarshaller());
+    return MethodDescriptor.newBuilder()
+        .setType(MethodType.UNARY)
+        .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, methodName))
+        .setRequestMarshaller(noopMarshaller())
+        .setResponseMarshaller(noopMarshaller())
+        .build();
   }
 
   /**

--- a/testing/src/main/java/io/grpc/testing/TestMethodDescriptors.java
+++ b/testing/src/main/java/io/grpc/testing/TestMethodDescriptors.java
@@ -56,7 +56,7 @@ public final class TestMethodDescriptors {
 
   private static MethodDescriptor<Void, Void> noopMethod(
       String serviceName, String methodName) {
-    return MethodDescriptor.newBuilder()
+    return MethodDescriptor.<Void, Void>newBuilder()
         .setType(MethodType.UNARY)
         .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, methodName))
         .setRequestMarshaller(noopMarshaller())


### PR DESCRIPTION
This change is not as big as it seems, the core of the change is in MethodDescriptor.

Still to do is to move over generated code, and remove the "with methods"