### PR TITLE
all: make some api non-experimental for 1.1

### DIFF
--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -234,6 +234,7 @@ public final class CallOptions {
     return newOptions;
   }
 
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
   public static final class Key<T> {
     private final String name;
     private final T defaultValue;
@@ -304,6 +305,7 @@ public final class CallOptions {
    * Get the value for a custom option or its inherent default.
    * @param key Key identifying option
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
   @SuppressWarnings("unchecked")
   public <T> T getOption(Key<T> key) {
     Preconditions.checkNotNull(key, "key");

--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -167,7 +167,6 @@ public final class CallOptions {
    * <a href="https://github.com/grpc/grpc/blob/master/doc/fail_fast.md">'Fail fast'</a>
    * is the default option for gRPC calls and 'wait for ready' is the opposite to it.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1915")
   public CallOptions withWaitForReady() {
     CallOptions newOptions = new CallOptions(this);
     newOptions.waitForReady = true;
@@ -178,7 +177,6 @@ public final class CallOptions {
    * Disables 'wait for ready' feature for the call.
    * This method should be rarely used because the default is without 'wait for ready'.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1915")
   public CallOptions withoutWaitForReady() {
     CallOptions newOptions = new CallOptions(this);
     newOptions.waitForReady = false;
@@ -236,7 +234,6 @@ public final class CallOptions {
     return newOptions;
   }
 
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
   public static final class Key<T> {
     private final String name;
     private final T defaultValue;
@@ -307,7 +304,6 @@ public final class CallOptions {
    * Get the value for a custom option or its inherent default.
    * @param key Key identifying option
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
   @SuppressWarnings("unchecked")
   public <T> T getOption(Key<T> key) {
     Preconditions.checkNotNull(key, "key");
@@ -332,7 +328,6 @@ public final class CallOptions {
    * <a href="https://github.com/grpc/grpc/blob/master/doc/fail_fast.md">'Fail fast'</a>
    * is the default option for gRPC calls and 'wait for ready' is the opposite to it.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1915")
   public boolean isWaitForReady() {
     return waitForReady;
   }

--- a/core/src/main/java/io/grpc/Server.java
+++ b/core/src/main/java/io/grpc/Server.java
@@ -60,7 +60,6 @@ public abstract class Server {
    *
    * @throws IllegalStateException if the server has not yet been started.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1780")
   public int getPort() {
     return -1;
   }

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -148,6 +148,7 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
    * @param key the option being set
    * @param value the value for the key
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
   public final <T> S withOption(CallOptions.Key<T> key, T value) {
     return build(channel, callOptions.withOption(key, value));
   }

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -148,7 +148,6 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
    * @param key the option being set
    * @param value the value for the key
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
   public final <T> S withOption(CallOptions.Key<T> key, T value) {
     return build(channel, callOptions.withOption(key, value));
   }
@@ -171,7 +170,6 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   /**
    * Returns a new stub that uses the 'wait for ready' call option.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1915")
   public final S withWaitForReady() {
     return build(channel, callOptions.withWaitForReady());
   }

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -33,7 +33,6 @@ package io.grpc.stub;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import io.grpc.ExperimentalApi;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
@@ -44,7 +43,6 @@ import io.grpc.Status;
  * Utility functions for adapting {@link ServerCallHandler}s to application service implementation,
  * meant to be used by the generated code.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1790")
 public final class ServerCalls {
 
   private ServerCalls() {


### PR DESCRIPTION
tracking issue: #2518:  {#1915, #1790, #1780}

List of APIs proposed to be non-experimental in 1.1
https://github.com/grpc/grpc-java/issues?q=is%3Aopen+is%3Aissue+label%3A%22experimental+API%22+milestone%3A1.1