### PR TITLE
core: make StatsContextFactory setters protected

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -44,7 +44,6 @@ import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
-import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer2;
 import io.grpc.ManagedChannel;
@@ -259,11 +258,10 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   /**
-   * Override the default stats implementation.  This is meant to be used in tests.
+   * Override the default stats implementation.
    */
   @VisibleForTesting
-  @Internal
-  public T statsContextFactory(StatsContextFactory statsFactory) {
+  protected T statsContextFactory(StatsContextFactory statsFactory) {
     this.statsFactory = statsFactory;
     return thisT();
   }

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -153,11 +153,10 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   }
 
   /**
-   * Override the default stats implementation.  This is meant to be used in tests.
+   * Override the default stats implementation.
    */
   @VisibleForTesting
-  @Internal
-  public T statsContextFactory(StatsContextFactory statsFactory) {
+  protected T statsContextFactory(StatsContextFactory statsFactory) {
     this.statsFactory = statsFactory;
     return thisT();
   }

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.instrumentation.stats.StatsContextFactory;
+
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -51,7 +53,7 @@ import javax.annotation.Nullable;
 /**
  * Common utility methods for tests.
  */
-final class TestUtils {
+public final class TestUtils {
 
   static class MockClientTransportInfo {
     /**
@@ -109,5 +111,21 @@ final class TestUtils {
         .newClientTransport(any(SocketAddress.class), any(String.class), any(String.class));
 
     return captor;
+  }
+
+  /**
+   * Sets a custom {@link StatsContextFactory} for tests.
+   */
+  public static void setStatsContextFactory(
+      AbstractManagedChannelImplBuilder<?> builder, StatsContextFactory factory) {
+    builder.statsContextFactory(factory);
+  }
+
+  /**
+   * Sets a custom {@link StatsContextFactory} for tests.
+   */
+  public static void setStatsContextFactory(
+      AbstractServerImplBuilder<?> builder, StatsContextFactory factory) {
+    builder.statsContextFactory(factory);
   }
 }

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -128,4 +128,7 @@ public final class TestUtils {
       AbstractServerImplBuilder<?> builder, StatsContextFactory factory) {
     builder.statsContextFactory(factory);
   }
+
+  private TestUtils() {
+  }
 }

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -16,6 +16,10 @@ dependencies {
             libraries.mockito,
             libraries.netty_tcnative,
             libraries.oauth_client
+
+    // Tests depend on base class defined by core module.
+    compile project(':grpc-core').sourceSets.test.output
+    testCompile project(':grpc-core').sourceSets.test.output
 }
 
 test {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -152,7 +152,7 @@ public abstract class AbstractInteropTest {
     builder.addService(ServerInterceptors.intercept(
         new TestServiceImpl(testServiceExecutor),
         allInterceptors));
-    builder.statsContextFactory(serverStatsFactory);
+    io.grpc.internal.TestUtils.setStatsContextFactory(builder, serverStatsFactory);
     try {
       server = builder.build().start();
     } catch (IOException ex) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
@@ -61,10 +61,10 @@ public class AutoWindowSizingOnTest extends AbstractInteropTest {
 
   @Override
   protected ManagedChannel createChannel() {
-    return NettyChannelBuilder.forAddress("localhost", getPort())
+    NettyChannelBuilder builder = NettyChannelBuilder.forAddress("localhost", getPort())
         .negotiationType(NegotiationType.PLAINTEXT)
-        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
-        .statsContextFactory(getClientStatsFactory())
-        .build();
+        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
+    io.grpc.internal.TestUtils.setStatsContextFactory(builder, getClientStatsFactory());
+    return builder.build();
   }
 }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -69,13 +69,13 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
 
   @Override
   protected ManagedChannel createChannel() {
-    return NettyChannelBuilder
+    NettyChannelBuilder builder = NettyChannelBuilder
         .forAddress(new LocalAddress("in-process-1"))
         .negotiationType(NegotiationType.PLAINTEXT)
         .channelType(LocalChannel.class)
         .flowControlWindow(65 * 1024)
-        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
-        .statsContextFactory(getClientStatsFactory())
-        .build();
+        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
+    io.grpc.internal.TestUtils.setStatsContextFactory(builder, getClientStatsFactory());
+    return builder.build();
   }
 }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -81,7 +81,7 @@ public class Http2NettyTest extends AbstractInteropTest {
   @Override
   protected ManagedChannel createChannel() {
     try {
-      return NettyChannelBuilder
+      NettyChannelBuilder builder = NettyChannelBuilder
           .forAddress(TestUtils.testServerAddress(getPort()))
           .flowControlWindow(65 * 1024)
           .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
@@ -91,9 +91,9 @@ public class Http2NettyTest extends AbstractInteropTest {
               .trustManager(TestUtils.loadX509Cert("ca.pem"))
               .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
               .sslProvider(SslProvider.OPENSSL)
-              .build())
-          .statsContextFactory(getClientStatsFactory())
-          .build();
+              .build());
+      io.grpc.internal.TestUtils.setStatsContextFactory(builder, getClientStatsFactory());
+      return builder.build();
     } catch (Exception ex) {
       throw new RuntimeException(ex);
     }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -108,9 +108,9 @@ public class Http2OkHttpTest extends AbstractInteropTest {
             .cipherSuites(TestUtils.preferredTestCiphers().toArray(new String[0]))
             .tlsVersions(ConnectionSpec.MODERN_TLS.tlsVersions().toArray(new TlsVersion[0]))
             .build())
-        .statsContextFactory(getClientStatsFactory())
         .overrideAuthority(GrpcUtil.authorityFromHostAndPort(
             TestUtils.TEST_SERVER_HOST, getPort()));
+    io.grpc.internal.TestUtils.setStatsContextFactory(builder, getClientStatsFactory());
     try {
       builder.sslSocketFactory(TestUtils.newSslSocketFactoryForCa(Platform.get().getProvider(),
               TestUtils.loadCert("ca.pem")));

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -148,11 +148,10 @@ public class TransportCompressionTest extends AbstractInteropTest {
 
   @Override
   protected ManagedChannel createChannel() {
-    return NettyChannelBuilder.forAddress("localhost", getPort())
+    NettyChannelBuilder builder = NettyChannelBuilder.forAddress("localhost", getPort())
         .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .decompressorRegistry(decompressors)
         .compressorRegistry(compressors)
-        .statsContextFactory(getClientStatsFactory())
         .intercept(new ClientInterceptor() {
           @Override
           public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
@@ -190,8 +189,9 @@ public class TransportCompressionTest extends AbstractInteropTest {
             };
           }
         })
-        .usePlaintext(true)
-        .build();
+        .usePlaintext(true);
+    io.grpc.internal.TestUtils.setStatsContextFactory(builder,getClientStatsFactory());
+    return builder.build();
   }
 
   /**

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -190,7 +190,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
           }
         })
         .usePlaintext(true);
-    io.grpc.internal.TestUtils.setStatsContextFactory(builder,getClientStatsFactory());
+    io.grpc.internal.TestUtils.setStatsContextFactory(builder, getClientStatsFactory());
     return builder.build();
   }
 


### PR DESCRIPTION
These are only used in internal tests.  In production,
StatsContextFactory is loaded by the "Instrumentation" library and must
be one per process, thus we won't allow setting it on a per-channel or
per-server basis.