### PR TITLE
android: Fix ProGuard rules in Android apps

### DIFF
--- a/android-interop-testing/app/proguard-rules.pro
+++ b/android-interop-testing/app/proguard-rules.pro
@@ -14,3 +14,6 @@
 -dontwarn org.mockito.**
 -dontwarn sun.reflect.**
 -dontwarn android.test.**
+-dontwarn com.google.errorprone.annotations.**
+-keep class io.grpc.internal.DnsNameResolverProvider
+-keep class io.grpc.okhttp.OkHttpChannelProvider

--- a/android-interop-testing/app/proguard-rules.pro
+++ b/android-interop-testing/app/proguard-rules.pro
@@ -14,6 +14,7 @@
 -dontwarn org.mockito.**
 -dontwarn sun.reflect.**
 -dontwarn android.test.**
+# Ignores: can't find referenced class javax.lang.model.element.Modifier
 -dontwarn com.google.errorprone.annotations.**
 -keep class io.grpc.internal.DnsNameResolverProvider
 -keep class io.grpc.okhttp.OkHttpChannelProvider

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.0"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/examples/android/helloworld/app/proguard-rules.pro
+++ b/examples/android/helloworld/app/proguard-rules.pro
@@ -12,6 +12,7 @@
 -dontwarn sun.misc.Unsafe
 -dontwarn com.google.common.**
 -dontwarn okio.**
+# Ignores: can't find referenced class javax.lang.model.element.Modifier
 -dontwarn com.google.errorprone.annotations.**
 -keep class io.grpc.internal.DnsNameResolverProvider
 -keep class io.grpc.okhttp.OkHttpChannelProvider

--- a/examples/android/helloworld/app/proguard-rules.pro
+++ b/examples/android/helloworld/app/proguard-rules.pro
@@ -12,3 +12,6 @@
 -dontwarn sun.misc.Unsafe
 -dontwarn com.google.common.**
 -dontwarn okio.**
+-dontwarn com.google.errorprone.annotations.**
+-keep class io.grpc.internal.DnsNameResolverProvider
+-keep class io.grpc.okhttp.OkHttpChannelProvider

--- a/examples/android/routeguide/app/proguard-rules.pro
+++ b/examples/android/routeguide/app/proguard-rules.pro
@@ -12,6 +12,7 @@
 -dontwarn sun.misc.Unsafe
 -dontwarn com.google.common.**
 -dontwarn okio.**
+# Ignores: can't find referenced class javax.lang.model.element.Modifier
 -dontwarn com.google.errorprone.annotations.**
 -keep class io.grpc.internal.DnsNameResolverProvider
 -keep class io.grpc.okhttp.OkHttpChannelProvider

--- a/examples/android/routeguide/app/proguard-rules.pro
+++ b/examples/android/routeguide/app/proguard-rules.pro
@@ -1,6 +1,6 @@
 # Add project specific ProGuard rules here.
 # By default, the flags in this file are appended to flags specified
-# in /usr/local/google/home/rocking/Android/Sdk/tools/proguard/proguard-android.txt
+# in $ANDROID_HOME/tools/proguard/proguard-android.txt
 # You can edit the include path and order by changing the proguardFiles
 # directive in build.gradle.
 #
@@ -12,4 +12,6 @@
 -dontwarn sun.misc.Unsafe
 -dontwarn com.google.common.**
 -dontwarn okio.**
-
+-dontwarn com.google.errorprone.annotations.**
+-keep class io.grpc.internal.DnsNameResolverProvider
+-keep class io.grpc.okhttp.OkHttpChannelProvider


### PR DESCRIPTION
Fixes #2207. This is actually a workaround. Ideally users shouldn't need
to -keep classes, but it's a bit risky to fix the real issue before 1.1.
The further fix will be done as part of #2633.

The interop app's build.gradle change is necessary to compile with newer
Gradle versions. The com.google.errorprone.annotations was necessary in
order to prevent annotation warnings from failing the build.