### PR TITLE
core: make ServiceDescriptor check input values

### DIFF
--- a/core/src/main/java/io/grpc/ServerServiceDefinition.java
+++ b/core/src/main/java/io/grpc/ServerServiceDefinition.java
@@ -59,8 +59,8 @@ public final class ServerServiceDefinition {
   private ServerServiceDefinition(
       ServiceDescriptor serviceDescriptor, Map<String, ServerMethodDefinition<?, ?>> methods) {
     this.serviceDescriptor = checkNotNull(serviceDescriptor, "serviceDescriptor");
-    this.methods = Collections.unmodifiableMap(
-        new HashMap<String, ServerMethodDefinition<?, ?>>(methods));
+    this.methods =
+        Collections.unmodifiableMap(new HashMap<String, ServerMethodDefinition<?, ?>>(methods));
   }
 
   /**

--- a/core/src/main/java/io/grpc/ServiceDescriptor.java
+++ b/core/src/main/java/io/grpc/ServiceDescriptor.java
@@ -105,7 +105,7 @@ public final class ServiceDescriptor {
       String methodServiceName =
           MethodDescriptor.extractFullServiceName(method.getFullMethodName());
       checkArgument(serviceName.equals(methodServiceName),
-          "service names %s !=%s", methodServiceName, serviceName);
+          "service names %s != %s", methodServiceName, serviceName);
       checkArgument(allNames.add(method.getFullMethodName()),
           "duplicate name %s", method.getFullMethodName());
     }

--- a/core/src/main/java/io/grpc/ServiceDescriptor.java
+++ b/core/src/main/java/io/grpc/ServiceDescriptor.java
@@ -31,12 +31,16 @@
 
 package io.grpc;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -66,6 +70,8 @@ public final class ServiceDescriptor {
   public ServiceDescriptor(String name, Object marshallerDescriptor,
                            Collection<MethodDescriptor<?, ?>> methods) {
     this.name = Preconditions.checkNotNull(name, "name");
+    Preconditions.checkNotNull(methods, "methods");
+    validateMethodNames(name, methods);
     this.marshallerDescriptor = marshallerDescriptor;
     this.methods = Collections.unmodifiableList(new ArrayList<MethodDescriptor<?, ?>>(methods));
   }
@@ -91,5 +97,17 @@ public final class ServiceDescriptor {
   @Nullable
   public Object getMarshallerDescriptor() {
     return marshallerDescriptor;
+  }
+
+  static void validateMethodNames(String serviceName, Collection<MethodDescriptor<?, ?>> methods) {
+    Set<String> allNames = new HashSet<String>(methods.size());
+    for (MethodDescriptor<?, ?> method : methods) {
+      String methodServiceName =
+          MethodDescriptor.extractFullServiceName(method.getFullMethodName());
+      checkArgument(serviceName.equals(methodServiceName),
+          "service names %s !=%s", methodServiceName, serviceName);
+      checkArgument(allNames.add(method.getFullMethodName()),
+          "duplicate name %s", method.getFullMethodName());
+    }
   }
 }

--- a/core/src/test/java/io/grpc/ServiceDescriptorTest.java
+++ b/core/src/test/java/io/grpc/ServiceDescriptorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc;
+
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.testing.TestMethodDescriptors;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Tests for {@link ServiceDescriptor}.
+ */
+@RunWith(JUnit4.class)
+public class ServiceDescriptorTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void failsOnNullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+
+    new ServiceDescriptor(null, Collections.emptyList());
+  }
+
+  @Test
+  public void failsOnNullMethods() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("methods");
+
+    new ServiceDescriptor("name", (Collection<MethodDescriptor<?, ?>>)null);
+  }
+
+  @Test
+  public void failsOnNonMatchingNames() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("service names");
+
+    new ServiceDescriptor("name", Collections.<MethodDescriptor<?, ?>>singletonList(
+        MethodDescriptor.create(
+            MethodType.UNARY,
+            MethodDescriptor.generateFullMethodName("wrongservice", "method"),
+            TestMethodDescriptors.noopMarshaller(),
+            TestMethodDescriptors.noopMarshaller())));
+  }
+
+  @Test
+  public void failsOnNonDuplicateNames() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("duplicate");
+
+    new ServiceDescriptor("name", Arrays.<MethodDescriptor<?, ?>>asList(
+        MethodDescriptor.create(
+            MethodType.UNARY,
+            MethodDescriptor.generateFullMethodName("name", "method"),
+            TestMethodDescriptors.noopMarshaller(),
+            TestMethodDescriptors.noopMarshaller()),
+        MethodDescriptor.create(
+            MethodType.UNARY,
+            MethodDescriptor.generateFullMethodName("name", "method"),
+            TestMethodDescriptors.noopMarshaller(),
+            TestMethodDescriptors.noopMarshaller())));
+  }
+}


### PR DESCRIPTION
Fixes: #2357 

Slightly different than the validation from `ServerServiceDefinition` since it has a more complicated use case.  We can unify these after 1.1