### PR TITLE
core: Only use scheduled executor for timer tasks

### DIFF
--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -404,9 +404,7 @@ public class ManagedChannelImplIdlenessTest {
   }
 
   private void forceExitIdleMode() {
-    channel.exitIdleMode();
-    // NameResolver is started in the scheduled executor
-    timer.runDueTasks();
+    channel.exitIdleModeAndGetLb();
   }
 
   private ClientTransport channelTmGetTransportUnwrapped(EquivalentAddressGroup addressGroup) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -167,9 +167,7 @@ public class ManagedChannelImplTest {
         ManagedChannelImpl.IDLE_TIMEOUT_MILLIS_DISABLE,
         executor.getScheduledExecutorService(), userAgent, interceptors, statsCtxFactory);
     // Force-exit the initial idle-mode
-    channel.exitIdleMode();
-    // Will start NameResolver in the scheduled executor
-    assertEquals(1, timer.runDueTasks());
+    channel.exitIdleModeAndGetLb();
   }
 
   @Before

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTransportManagerTest.java
@@ -147,7 +147,7 @@ public class ManagedChannelImplTransportManagerTest {
     ArgumentCaptor<TransportManager<ClientTransport>> tmCaptor
         = ArgumentCaptor.forClass(null);
     // Force Channel to exit the initial idleness to get NameResolver and LoadBalancer created.
-    channel.exitIdleMode();
+    channel.exitIdleModeAndGetLb();
     verify(mockNameResolverFactory).newNameResolver(any(URI.class), any(Attributes.class));
     verify(mockLoadBalancerFactory).newLoadBalancer(anyString(), tmCaptor.capture());
     tm = tmCaptor.getValue();


### PR DESCRIPTION
This removes an abuse of scheduled executor in ManagedChannelImpl. The executor
was used to avoid deadlocking. Now we run the work on the same thread, but
delay it until locks have been released.

There is no need to fix ManagedChannelImpl2. Due to its different
threading model it didn't have need to abuse the scheduledExecutor.

Fixes #2444

----

This is a cherry-pick of #2459 from v1.0.x to master. `ManagedChannelImpl` had conflicts that were manually resolved. They primarily related to the addition of `graceLoadBalancer` which is in master.