### PR TITLE
core: stop "testing" from depending on "core"'s test.

### DIFF
--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -36,8 +36,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.instrumentation.stats.StatsContextFactory;
-
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -53,7 +51,7 @@ import javax.annotation.Nullable;
 /**
  * Common utility methods for tests.
  */
-public final class TestUtils {
+final class TestUtils {
 
   static class MockClientTransportInfo {
     /**
@@ -111,22 +109,6 @@ public final class TestUtils {
         .newClientTransport(any(SocketAddress.class), any(String.class), any(String.class));
 
     return captor;
-  }
-
-  /**
-   * Sets a custom {@link StatsContextFactory} for tests.
-   */
-  public static void setStatsContextFactory(
-      AbstractManagedChannelImplBuilder<?> builder, StatsContextFactory factory) {
-    builder.statsContextFactory(factory);
-  }
-
-  /**
-   * Sets a custom {@link StatsContextFactory} for tests.
-   */
-  public static void setStatsContextFactory(
-      AbstractServerImplBuilder<?> builder, StatsContextFactory factory) {
-    builder.statsContextFactory(factory);
   }
 
   private TestUtils() {

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -16,10 +16,6 @@ dependencies {
             libraries.mockito,
             libraries.netty_tcnative,
             libraries.oauth_client
-
-    // Tests depend on base class defined by core module.
-    compile project(':grpc-core').sourceSets.test.output
-    testCompile project(':grpc-core').sourceSets.test.output
 }
 
 test {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -152,7 +152,7 @@ public abstract class AbstractInteropTest {
     builder.addService(ServerInterceptors.intercept(
         new TestServiceImpl(testServiceExecutor),
         allInterceptors));
-    io.grpc.internal.TestUtils.setStatsContextFactory(builder, serverStatsFactory);
+    io.grpc.internal.TestingAccessor.setStatsContextFactory(builder, serverStatsFactory);
     try {
       server = builder.build().start();
     } catch (IOException ex) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -75,7 +75,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
         .channelType(LocalChannel.class)
         .flowControlWindow(65 * 1024)
         .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
-    io.grpc.internal.TestUtils.setStatsContextFactory(builder, getClientStatsFactory());
+    io.grpc.internal.TestingAccessor.setStatsContextFactory(builder, getClientStatsFactory());
     return builder.build();
   }
 }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -92,7 +92,7 @@ public class Http2NettyTest extends AbstractInteropTest {
               .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
               .sslProvider(SslProvider.OPENSSL)
               .build());
-      io.grpc.internal.TestUtils.setStatsContextFactory(builder, getClientStatsFactory());
+      io.grpc.internal.TestingAccessor.setStatsContextFactory(builder, getClientStatsFactory());
       return builder.build();
     } catch (Exception ex) {
       throw new RuntimeException(ex);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -110,7 +110,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
             .build())
         .overrideAuthority(GrpcUtil.authorityFromHostAndPort(
             TestUtils.TEST_SERVER_HOST, getPort()));
-    io.grpc.internal.TestUtils.setStatsContextFactory(builder, getClientStatsFactory());
+    io.grpc.internal.TestingAccessor.setStatsContextFactory(builder, getClientStatsFactory());
     try {
       builder.sslSocketFactory(TestUtils.newSslSocketFactoryForCa(Platform.get().getProvider(),
               TestUtils.loadCert("ca.pem")));

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -190,7 +190,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
           }
         })
         .usePlaintext(true);
-    io.grpc.internal.TestUtils.setStatsContextFactory(builder, getClientStatsFactory());
+    io.grpc.internal.TestingAccessor.setStatsContextFactory(builder, getClientStatsFactory());
     return builder.build();
   }
 

--- a/testing/src/main/java/io/grpc/internal/TestingAccessor.java
+++ b/testing/src/main/java/io/grpc/internal/TestingAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,42 +29,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.testing.integration;
+package io.grpc.internal;
 
-import io.grpc.ManagedChannel;
-import io.grpc.netty.HandlerSettings;
-import io.grpc.netty.NegotiationType;
-import io.grpc.netty.NettyChannelBuilder;
-import io.grpc.netty.NettyServerBuilder;
+import com.google.instrumentation.stats.StatsContextFactory;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-@RunWith(JUnit4.class)
-public class AutoWindowSizingOnTest extends AbstractInteropTest {
-
-  @BeforeClass
-  public static void turnOnAutoWindow() {
-    HandlerSettings.enable(true);
-    HandlerSettings.autoWindowOn(true);
-    startStaticServer(
-        NettyServerBuilder.forPort(0)
-            .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE));
+/**
+ * Test helper that allows accessing package-private stuff.
+ */
+public final class TestingAccessor {
+  /**
+   * Sets a custom {@link StatsContextFactory} for tests.
+   */
+  public static void setStatsContextFactory(
+      AbstractManagedChannelImplBuilder<?> builder, StatsContextFactory factory) {
+    builder.statsContextFactory(factory);
   }
 
-  @AfterClass
-  public static void shutdown() {
-    stopStaticServer();
+  /**
+   * Sets a custom {@link StatsContextFactory} for tests.
+   */
+  public static void setStatsContextFactory(
+      AbstractServerImplBuilder<?> builder, StatsContextFactory factory) {
+    builder.statsContextFactory(factory);
   }
 
-  @Override
-  protected ManagedChannel createChannel() {
-    NettyChannelBuilder builder = NettyChannelBuilder.forAddress("localhost", getPort())
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
-    io.grpc.internal.TestingAccessor.setStatsContextFactory(builder, getClientStatsFactory());
-    return builder.build();
+  private TestingAccessor() {
   }
 }


### PR DESCRIPTION
Because "core"'s test source already depends on "testing", e.g.,
`core/src/test/java/io/grpc/internal/ServerCallImplTest.java` uses
`testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java`,
which forms a circular dependency.

This change moves the StatsContext setter accessors from "core"'s test
source to "testing".

Resolves #2651 