### PR TITLE
core: open up LBv2 APIs for early adopters

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer2.java
+++ b/core/src/main/java/io/grpc/LoadBalancer2.java
@@ -44,8 +44,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * channel a usable subchannel when asked.  This is the new interface that will replace {@link
  * LoadBalancer}.
  *
- * <p><strong>Warning: this is still in developement.  Consult gRPC team before starting any related
- * work.</strong>
+ * <p><strong>IMPORTANT NOTICE FOR IMPLEMENTORS: </strong>The name of this class is temporary.  It
+ * will be renamed to {@code LoadBalancer} eventually.  Make sure you have read through <a
+ * href="https://github.com/grpc/grpc-java/issues/2656" target="_blank">#2656</a> to understand the
+ * transition path.
  *
  * <h3>Overview</h3>
  *
@@ -62,7 +64,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>{@link Helper Helper} is implemented by gRPC library and provided to {@link Factory
  * Factory}. It provides functionalities that a {@code LoadBalancer2} implementation would typically
- * need.</li>
+ * need.
  *
  * <h3>Channel Executor</h3>
  *
@@ -110,7 +112,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * the pattern above.  It may be possible to implement in a different way, but that would usually
  * result in more complicated threading.
  */
-@Internal
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 @NotThreadSafe
 public abstract class LoadBalancer2 {
   /**

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -159,9 +159,28 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    *
    * <p>If this method is not called, the builder will use {@link PickFirstBalancerFactory}
    * for the channel.
+   *
+   * <p>This overrides what was set by {@link #loadBalancerFactory(LoadBalancer2.Factory)}.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
   public abstract T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory);
+
+  /**
+   * Provides a custom {@link LoadBalancer2.Factory} for the channel.
+   *
+   * <p>If this method is not called, the builder will use {@link PickFirstBalancerFactory}
+   * for the channel.
+   *
+   * <p>This overrides what was set by {@link #loadBalancerFactory(LoadBalancer.Factory)}.
+   *
+   * <p><strong>IMPORTANT: </strong>Calling this will make the channel to run the LBv2 code path,
+   * which is new and not as well-exercised as the current one.  You should use it only if you want
+   * to try out LBv2, or you are migrating your LoadBalancer implementation to LBv2.  See
+   * <a href="https://github.com/grpc/grpc-java/issues/2656" target="_blank">#2656</a> for more
+   * information.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
+  public abstract T loadBalancerFactory(LoadBalancer2.Factory loadBalancerFactory);
 
   /**
    * Set the decompression registry for use in the channel.  This is an advanced API call and

--- a/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/PickFirstBalancerFactory2.java
@@ -40,9 +40,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A {@link LoadBalancer} that provides no load balancing mechanism over the
+ * A {@link LoadBalancer2} that provides no load balancing mechanism over the
  * addresses from the {@link NameResolver}.  The channel's default behavior
  * (currently pick-first) is used for all addresses found.
+ *
+ * <p><strong>TECHNICAL PREVIEW: </strong>The name of this class is temporary. It will be renamed to
+ * {@code PickFirstBalancerFactory} during <a href="https://github.com/grpc/grpc-java/issues/2656"
+ * target="_blank">the transition to LBv2</a>. You should use it only if you want to experiment the
+ * LBv2 code path.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 public final class PickFirstBalancerFactory2 extends LoadBalancer2.Factory {

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -209,9 +209,7 @@ public abstract class AbstractManagedChannelImplBuilder
     return thisT();
   }
 
-  /**
-   * DO NOT CALL THIS, as its argument type will soon be renamed.
-   */
+  @Override
   public final T loadBalancerFactory(final LoadBalancer2.Factory loadBalancerFactory) {
     Preconditions.checkState(directServerAddress == null,
         "directServerAddress is set (%s), which forbids the use of LoadBalancerFactory",

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
@@ -72,6 +72,11 @@ import javax.annotation.concurrent.GuardedBy;
  * addresses from the {@link NameResolver}.  The sub-lists received from the name resolver
  * are considered to be an {@link EquivalentAddressGroup} and each of these sub-lists is
  * what is then balanced across.
+ *
+ * <p><strong>TECHNICAL PREVIEW: </strong>The name of this class is temporary. It will be renamed to
+ * {@code RoundRobinLoadBalancerFactory} during the
+ * <a href="https://github.com/grpc/grpc-java/issues/2656" target="_blank">transition to LBv2</a>.
+ * You should use it only if you want to experiment the LBv2 code path.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
 public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerFactory2.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerFactory2.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.grpclb;
+
+import io.grpc.ExperimentalApi;
+import io.grpc.LoadBalancer2;
+import io.grpc.PickFirstBalancerFactory2;
+import io.grpc.util.RoundRobinLoadBalancerFactory2;
+
+/**
+ * A factory for {@link LoadBalancer2}s that uses the GRPCLB protocol.
+ *
+ * <p><strong>TECHNICAL PREVIEW: </strong>The name of this class is temporary. It will be renamed to
+ * {@code GrpclbLoadBalancerFactory} during <a href="https://github.com/grpc/grpc-java/issues/2656">
+ * transition to LBv2</a>. You should use it only if you want to experiment the LBv2 code path.
+ *
+ * <p><b>Experimental:</b>This only works with the GRPCLB load-balancer service, which is not
+ * available yet. Right now it's only good for internal testing.
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/1782")
+public class GrpclbLoadBalancerFactory2 extends LoadBalancer2.Factory {
+
+  private static final GrpclbLoadBalancerFactory2 instance = new GrpclbLoadBalancerFactory2();
+
+  private GrpclbLoadBalancerFactory2() {
+  }
+
+  public static GrpclbLoadBalancerFactory2 getInstance() {
+    return instance;
+  }
+
+  @Override
+  public LoadBalancer2 newLoadBalancer(LoadBalancer2.Helper helper) {
+    return new GrpclbLoadBalancer2(
+        helper, PickFirstBalancerFactory2.getInstance(),
+        RoundRobinLoadBalancerFactory2.getInstance());
+  }
+}


### PR DESCRIPTION
Also add GrpclbLoadBalancerFactory2 so that GrpclbLoadBalancer2 can be used.

Resolves #2650 