### PR TITLE
[WIP] core: Allow LoadBalancer2 to use a different authority per SubChannel

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer2.java
+++ b/core/src/main/java/io/grpc/LoadBalancer2.java
@@ -329,7 +329,17 @@ public abstract class LoadBalancer2 {
      * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
      * Subchannels within {@link #shutdown}.
      */
-    public abstract Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs);
+    public abstract Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs,
+        String authority);
+
+    /**
+     * Creates a Subchannel with the default authority of the load balancer.
+     *
+     * @see LoadBalancer2.Helper#createSubchannel(EquivalentAddressGroup, Attributes, String).
+     */
+    public Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
+      return createSubchannel(addrs, attrs, getAuthority());
+    }
 
     /**
      * Out-of-band channel for LoadBalancer’s own RPC needs, e.g., talking to an external

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl2.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl2.java
@@ -600,16 +600,18 @@ public final class ManagedChannelImpl2 extends ManagedChannel implements WithLog
     }
 
     @Override
-    public SubchannelImpl createSubchannel(EquivalentAddressGroup addressGroup, Attributes attrs) {
+    public SubchannelImpl createSubchannel(EquivalentAddressGroup addressGroup, Attributes attrs,
+        String authority) {
       checkNotNull(addressGroup, "addressGroup");
       checkNotNull(attrs, "attrs");
+      checkNotNull(authority, "authority");
       ScheduledExecutorService scheduledExecutorCopy = scheduledExecutor;
       checkState(scheduledExecutorCopy != null,
           "scheduledExecutor is already cleared. Looks like you are calling this method after "
           + "you've already shut down");
       final SubchannelImplImpl subchannel = new SubchannelImplImpl(attrs);
       final InternalSubchannel internalSubchannel = new InternalSubchannel(
-            addressGroup, authority(), userAgent, backoffPolicyProvider, transportFactory,
+            addressGroup, authority, userAgent, backoffPolicyProvider, transportFactory,
             scheduledExecutorCopy, stopwatchSupplier, channelExecutor,
             new InternalSubchannel.Callback() {
               // All callbacks are run in channelExecutor


### PR DESCRIPTION
Add a variant of `createSubChannel()` to `LbHelperImpl`. The new method has an additional argument for authority.

*Background:* Square has the following configuration of NameResolver and LoadBalancer.

- NameResolver resolves an RPC service name (e.g., `ExampleService`) to DNS names (e.g., `example.datacenter1.squareup.com`, `example.datacenter2.squareup.com`).
- LoadBalancer creates a `SubChannel` per DNS name.

Each `Subchannel` gets its authority from `ManagedChannel#authority()`, which returns the service authority that the NameResolver uses (= `ExampleService`).

On the other hand, our certificate is not configured to support `ExampleService` as an SNI. Thus, we got the following error:

```
Updating sub channel state: TRANSIENT_FAILURE(Status{code=UNAVAILABLE,description=null, cause=javax.net.ssl.SSLHandshakeException: General OpenSslEngine problem
   ...
  at java.lang.Thread.run(Thread.java:745)
  Caused by: java.security.cert.CertificateException: No subject alternative DNS name matching ExampleService found.
```

We can of course update our certificates, but it would be nice if we can just use a different authority per `Subchannel`.