### PR TITLE
testing: change names of noopMarshaller to void marshaller

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
@@ -91,8 +91,8 @@ public class HandlerRegistryBenchmark {
         MethodDescriptor<Void, Void> methodDescriptor = MethodDescriptor.<Void, Void>newBuilder()
             .setType(MethodDescriptor.MethodType.UNKNOWN)
             .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, methodName))
-            .setRequestMarshaller(TestMethodDescriptors.noopMarshaller())
-            .setResponseMarshaller(TestMethodDescriptors.noopMarshaller())
+            .setRequestMarshaller(TestMethodDescriptors.voidMarshaller())
+            .setResponseMarshaller(TestMethodDescriptors.voidMarshaller())
             .build();
         serviceBuilder.addMethod(methodDescriptor,
             new ServerCallHandler<Void, Void>() {

--- a/core/src/test/java/io/grpc/ClientInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/ClientInterceptorsTest.java
@@ -73,7 +73,7 @@ public class ClientInterceptorsTest {
 
   private BaseClientCall call = new BaseClientCall();
 
-  private final MethodDescriptor<Void, Void> method = TestMethodDescriptors.noopMethod();
+  private final MethodDescriptor<Void, Void> method = TestMethodDescriptors.voidMethod();
 
   /**
    * Sets up mocks.

--- a/core/src/test/java/io/grpc/ServiceDescriptorTest.java
+++ b/core/src/test/java/io/grpc/ServiceDescriptorTest.java
@@ -76,8 +76,8 @@ public class ServiceDescriptorTest {
         MethodDescriptor.create(
             MethodType.UNARY,
             MethodDescriptor.generateFullMethodName("wrongservice", "method"),
-            TestMethodDescriptors.noopMarshaller(),
-            TestMethodDescriptors.noopMarshaller())));
+            TestMethodDescriptors.voidMarshaller(),
+            TestMethodDescriptors.voidMarshaller())));
   }
 
   @Test
@@ -89,12 +89,12 @@ public class ServiceDescriptorTest {
         MethodDescriptor.create(
             MethodType.UNARY,
             MethodDescriptor.generateFullMethodName("name", "method"),
-            TestMethodDescriptors.noopMarshaller(),
-            TestMethodDescriptors.noopMarshaller()),
+            TestMethodDescriptors.voidMarshaller(),
+            TestMethodDescriptors.voidMarshaller()),
         MethodDescriptor.create(
             MethodType.UNARY,
             MethodDescriptor.generateFullMethodName("name", "method"),
-            TestMethodDescriptors.noopMarshaller(),
-            TestMethodDescriptors.noopMarshaller())));
+            TestMethodDescriptors.voidMarshaller(),
+            TestMethodDescriptors.voidMarshaller())));
   }
 }

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -112,8 +112,8 @@ public class ClientCallImplTest {
   private final MethodDescriptor<Void, Void> method = MethodDescriptor.<Void, Void>newBuilder()
       .setType(MethodType.UNARY)
       .setFullMethodName("service/method")
-      .setRequestMarshaller(TestMethodDescriptors.noopMarshaller())
-      .setResponseMarshaller(TestMethodDescriptors.noopMarshaller())
+      .setRequestMarshaller(TestMethodDescriptors.voidMarshaller())
+      .setResponseMarshaller(TestMethodDescriptors.voidMarshaller())
       .build();
 
   private final FakeStatsContextFactory statsCtxFactory = new FakeStatsContextFactory();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -131,7 +131,7 @@ public class OkHttpClientTransportTest {
   @Mock
   private FrameWriter frameWriter;
 
-  private MethodDescriptor<Void, Void> method = TestMethodDescriptors.noopMethod();
+  private MethodDescriptor<Void, Void> method = TestMethodDescriptors.voidMethod();
 
   @Mock
   private ManagedClientTransport.Listener transportListener;

--- a/testing/src/main/java/io/grpc/testing/TestMethodDescriptors.java
+++ b/testing/src/main/java/io/grpc/testing/TestMethodDescriptors.java
@@ -40,6 +40,8 @@ import java.io.InputStream;
 /**
  * A collection of method descriptor constructors useful for tests.  These are useful if you need
  * a descriptor, but don't really care how it works.
+ *
+ * @since 1.1.0
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2600")
 public final class TestMethodDescriptors {
@@ -48,36 +50,63 @@ public final class TestMethodDescriptors {
   /**
    * Creates a new method descriptor that always creates zero length messages, and always parses to
    * null objects.
+   *
+   * @since 1.1.0
    */
-  public static MethodDescriptor<Void, Void> noopMethod() {
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2600")
+  public static MethodDescriptor<Void, Void> voidMethod() {
+    return TestMethodDescriptors.<Void, Void>noopMethod();
+  }
+
+  /**
+   * Creates a new method descriptor that always creates zero length messages, and always parses to
+   * null objects.
+   *
+   * @since 1.1.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2600")
+  public static <ReqT, RespT> MethodDescriptor<ReqT, RespT> noopMethod() {
     return noopMethod("service_foo", "method_bar");
   }
 
-  private static MethodDescriptor<Void, Void> noopMethod(
+  private static <ReqT, RespT> MethodDescriptor<ReqT, RespT> noopMethod(
       String serviceName, String methodName) {
-    return MethodDescriptor.<Void, Void>newBuilder()
+    return MethodDescriptor.<ReqT, RespT>newBuilder()
         .setType(MethodType.UNARY)
         .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, methodName))
-        .setRequestMarshaller(noopMarshaller())
-        .setResponseMarshaller(noopMarshaller())
+        .setRequestMarshaller(TestMethodDescriptors.<ReqT>noopMarshaller())
+        .setResponseMarshaller(TestMethodDescriptors.<RespT>noopMarshaller())
         .build();
   }
 
   /**
    * Creates a new marshaller that does nothing.
+   *
+   * @since 1.1.0
    */
-  public static MethodDescriptor.Marshaller<Void> noopMarshaller() {
-    return new NoopMarshaller();
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2600")
+  public static MethodDescriptor.Marshaller<Void> voidMarshaller() {
+    return TestMethodDescriptors.<Void>noopMarshaller();
   }
 
-  private static final class NoopMarshaller implements MethodDescriptor.Marshaller<Void> {
+  /**
+   * Creates a new marshaller that does nothing.
+   *
+   * @since 1.1.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2600")
+  public static <T> MethodDescriptor.Marshaller<T> noopMarshaller() {
+    return new NoopMarshaller<T>();
+  }
+
+  private static final class NoopMarshaller<T> implements MethodDescriptor.Marshaller<T> {
     @Override
-    public InputStream stream(Void value) {
+    public InputStream stream(T value) {
       return new ByteArrayInputStream(new byte[]{});
     }
 
     @Override
-    public Void parse(InputStream stream) {
+    public T parse(InputStream stream) {
       return null;
     }
   }


### PR DESCRIPTION
This is needed because in interceptor tests, often the types cannot
be changed.  The void methods stay for users who are writing tests
where they actually don't care about types.  The noop methods
require types to be specified.  This is for users who don't care
about the implementation.  These represent different levels of
commitment.

This eases the transistion of code Mocking MethodDescriptor, which
breaks in this release.