### PR TITLE
core: record server_elapsed_time on client

### DIFF
--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -251,7 +251,7 @@ public final class StatsTraceContext {
     }
     long roundtripNanos = stopwatch.elapsed(TimeUnit.NANOSECONDS);
     MeasurementMap.Builder builder = MeasurementMap.builder()
-        .put(latencyMetric, roundtripNanos / NANOS_PER_MILLI)
+        .put(latencyMetric, roundtripNanos / NANOS_PER_MILLI)  // in double
         .put(wireBytesSentMetric, wireBytesSent)
         .put(wireBytesReceivedMetric, wireBytesReceived)
         .put(uncompressedBytesSentMetric, uncompressedBytesSent)
@@ -260,7 +260,7 @@ public final class StatsTraceContext {
       if (clientPendingNanos >= 0) {
         builder.put(
             RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME,
-            (roundtripNanos - clientPendingNanos) / NANOS_PER_MILLI);
+            (roundtripNanos - clientPendingNanos) / NANOS_PER_MILLI);  // in double
       }
     }
     statsCtx.with(RpcConstants.RPC_STATUS, TagValue.create(status.getCode().toString()))

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -258,7 +258,8 @@ public final class StatsTraceContext {
         .put(uncompressedBytesReceivedMetric, uncompressedBytesReceived);
     if (side == Side.CLIENT) {
       if (clientPendingNanos >= 0) {
-        builder.put(RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME,
+        builder.put(
+            RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME,
             (roundtripNanos - clientPendingNanos) / NANOS_PER_MILLI);
       }
     }

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -257,7 +257,6 @@ public final class StatsTraceContext {
         .put(uncompressedBytesSentMetric, uncompressedBytesSent)
         .put(uncompressedBytesReceivedMetric, uncompressedBytesReceived);
     if (side == Side.CLIENT) {
-      long serverTime;
       if (clientPendingNanos >= 0) {
         builder.put(RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME,
             (roundtripNanos - clientPendingNanos) / NANOS_PER_MILLI);

--- a/core/src/test/java/io/grpc/internal/StatsTraceContextTest.java
+++ b/core/src/test/java/io/grpc/internal/StatsTraceContextTest.java
@@ -43,7 +43,6 @@ import io.grpc.Status;
 import io.grpc.internal.testing.StatsTestUtils.FakeStatsContextFactory;
 import io.grpc.internal.testing.StatsTestUtils;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -53,14 +52,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class StatsTraceContextTest {
-  private FakeClock fakeClock;
-  private FakeStatsContextFactory statsCtxFactory;
-
-  @Before
-  public void setUp() {
-    fakeClock = new FakeClock();
-    statsCtxFactory = new FakeStatsContextFactory();
-  }
+  private FakeClock fakeClock = new FakeClock();
+  private FakeStatsContextFactory statsCtxFactory = new FakeStatsContextFactory();
 
   @After
   public void allRecordsVerified() {

--- a/core/src/test/java/io/grpc/internal/StatsTraceContextTest.java
+++ b/core/src/test/java/io/grpc/internal/StatsTraceContextTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.google.instrumentation.stats.RpcConstants;
+import com.google.instrumentation.stats.StatsContext;
+import com.google.instrumentation.stats.TagValue;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.internal.testing.StatsTestUtils.FakeStatsContextFactory;
+import io.grpc.internal.testing.StatsTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Test for {@link StatsTraceContext}.
+ */
+@RunWith(JUnit4.class)
+public class StatsTraceContextTest {
+  private FakeClock fakeClock;
+  private FakeStatsContextFactory statsCtxFactory;
+
+  @Before
+  public void setUp() {
+    fakeClock = new FakeClock();
+    statsCtxFactory = new FakeStatsContextFactory();
+  }
+
+  @After
+  public void allRecordsVerified() {
+    assertNull(statsCtxFactory.pollRecord());
+  }
+
+  @Test
+  public void clientBasic() {
+    StatsTraceContext ctx = StatsTraceContext.newClientContextForTesting(
+        "Service1/method1", statsCtxFactory, statsCtxFactory.getDefault(),
+        fakeClock.getStopwatchSupplier());
+    fakeClock.forwardMillis(30);
+    ctx.clientHeadersSent();
+
+    fakeClock.forwardMillis(100);
+    ctx.wireBytesSent(1028);
+    ctx.uncompressedBytesSent(1128);
+
+    fakeClock.forwardMillis(16);
+    ctx.wireBytesReceived(33);
+    ctx.uncompressedBytesReceived(67);
+    ctx.wireBytesSent(99);
+    ctx.uncompressedBytesSent(865);
+
+    fakeClock.forwardMillis(24);
+    ctx.wireBytesReceived(154);
+    ctx.uncompressedBytesReceived(552);
+    ctx.callEnded(Status.OK);
+
+    StatsTestUtils.MetricsRecord record = statsCtxFactory.pollRecord();
+    assertNotNull(record);
+    assertNoServerContent(record);
+    TagValue methodTag = record.tags.get(RpcConstants.RPC_CLIENT_METHOD);
+    assertEquals("Service1/method1", methodTag.toString());
+    TagValue statusTag = record.tags.get(RpcConstants.RPC_STATUS);
+    assertEquals(Status.Code.OK.toString(), statusTag.toString());
+    assertEquals(1028 + 99, record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_REQUEST_BYTES));
+    assertEquals(1128 + 865,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
+    assertEquals(33 + 154, record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_RESPONSE_BYTES));
+    assertEquals(67 + 552,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
+    assertEquals(30 + 100 + 16 + 24,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
+    assertEquals(100 + 16 + 24,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
+  }
+
+  @Test
+  public void clientNotSent() {
+    StatsTraceContext ctx = StatsTraceContext.newClientContextForTesting(
+        "Service1/method2", statsCtxFactory, statsCtxFactory.getDefault(),
+        fakeClock.getStopwatchSupplier());
+    fakeClock.forwardMillis(3000);
+    ctx.callEnded(Status.DEADLINE_EXCEEDED.withDescription("3 seconds"));
+
+    StatsTestUtils.MetricsRecord record = statsCtxFactory.pollRecord();
+    assertNotNull(record);
+    assertNoServerContent(record);
+    TagValue methodTag = record.tags.get(RpcConstants.RPC_CLIENT_METHOD);
+    assertEquals("Service1/method2", methodTag.toString());
+    TagValue statusTag = record.tags.get(RpcConstants.RPC_STATUS);
+    assertEquals(Status.Code.DEADLINE_EXCEEDED.toString(), statusTag.toString());
+    assertEquals(0, record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_REQUEST_BYTES));
+    assertEquals(0,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
+    assertEquals(0, record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_RESPONSE_BYTES));
+    assertEquals(0,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
+    assertEquals(3000, record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
+  }
+
+  @Test
+  public void tagPropagation() {
+    StatsContext parentCtx = statsCtxFactory.getDefault().with(
+        StatsTestUtils.EXTRA_TAG, TagValue.create("extra-tag-value-897"));
+    StatsTraceContext clientCtx = StatsTraceContext.newClientContextForTesting(
+        "Service1/method3", statsCtxFactory, parentCtx, fakeClock.getStopwatchSupplier());
+    Metadata headers = new Metadata();
+    clientCtx.propagateToHeaders(headers);
+
+    StatsTraceContext serverCtx = StatsTraceContext.newServerContext(
+        "Service1/method3", statsCtxFactory, headers, fakeClock.getStopwatchSupplier());
+
+    serverCtx.callEnded(Status.OK);
+    clientCtx.callEnded(Status.OK);
+
+    StatsTestUtils.MetricsRecord serverRecord = statsCtxFactory.pollRecord();
+    assertNotNull(serverRecord);
+    assertNoClientContent(serverRecord);
+    TagValue serverMethodTag = serverRecord.tags.get(RpcConstants.RPC_SERVER_METHOD);
+    assertEquals("Service1/method3", serverMethodTag.toString());
+    TagValue serverStatusTag = serverRecord.tags.get(RpcConstants.RPC_STATUS);
+    assertEquals(Status.Code.OK.toString(), serverStatusTag.toString());
+    TagValue serverPropagatedTag = serverRecord.tags.get(StatsTestUtils.EXTRA_TAG);
+    assertEquals("extra-tag-value-897", serverPropagatedTag.toString());
+    
+    StatsTestUtils.MetricsRecord clientRecord = statsCtxFactory.pollRecord();
+    assertNotNull(clientRecord);
+    assertNoServerContent(clientRecord);
+    TagValue clientMethodTag = clientRecord.tags.get(RpcConstants.RPC_CLIENT_METHOD);
+    assertEquals("Service1/method3", clientMethodTag.toString());
+    TagValue clientStatusTag = clientRecord.tags.get(RpcConstants.RPC_STATUS);
+    assertEquals(Status.Code.OK.toString(), clientStatusTag.toString());
+    TagValue clientPropagatedTag = clientRecord.tags.get(StatsTestUtils.EXTRA_TAG);
+    assertEquals("extra-tag-value-897", clientPropagatedTag.toString());
+  }
+
+  @Test
+  public void serverBasic() {
+    StatsTraceContext ctx = StatsTraceContext.newServerContext(
+        "Service1/method4", statsCtxFactory, new Metadata(), fakeClock.getStopwatchSupplier());
+    ctx.wireBytesReceived(34);
+    ctx.uncompressedBytesReceived(67);
+
+    fakeClock.forwardMillis(100);
+    ctx.wireBytesSent(1028);
+    ctx.uncompressedBytesSent(1128);
+
+    fakeClock.forwardMillis(16);
+    ctx.wireBytesReceived(154);
+    ctx.uncompressedBytesReceived(552);
+    ctx.wireBytesSent(99);
+    ctx.uncompressedBytesSent(865);
+
+    fakeClock.forwardMillis(24);
+    ctx.callEnded(Status.CANCELLED);
+
+    StatsTestUtils.MetricsRecord record = statsCtxFactory.pollRecord();
+    assertNotNull(record);
+    assertNoClientContent(record);
+    TagValue methodTag = record.tags.get(RpcConstants.RPC_SERVER_METHOD);
+    assertEquals("Service1/method4", methodTag.toString());
+    TagValue statusTag = record.tags.get(RpcConstants.RPC_STATUS);
+    assertEquals(Status.Code.CANCELLED.toString(), statusTag.toString());
+    assertEquals(1028 + 99, record.getMetricAsLongOrFail(RpcConstants.RPC_SERVER_RESPONSE_BYTES));
+    assertEquals(1128 + 865,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
+    assertEquals(34 + 154, record.getMetricAsLongOrFail(RpcConstants.RPC_SERVER_REQUEST_BYTES));
+    assertEquals(67 + 552,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
+    assertEquals(100 + 16 + 24,
+        record.getMetricAsLongOrFail(RpcConstants.RPC_SERVER_SERVER_LATENCY));
+  }
+
+  private static void assertNoServerContent(StatsTestUtils.MetricsRecord record) {
+    assertNull(record.getMetric(RpcConstants.RPC_SERVER_ERROR_COUNT));
+    assertNull(record.getMetric(RpcConstants.RPC_SERVER_REQUEST_BYTES));
+    assertNull(record.getMetric(RpcConstants.RPC_SERVER_RESPONSE_BYTES));
+    assertNull(record.getMetric(RpcConstants.RPC_SERVER_SERVER_ELAPSED_TIME));
+    assertNull(record.getMetric(RpcConstants.RPC_SERVER_SERVER_LATENCY));
+    assertNull(record.getMetric(RpcConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
+    assertNull(record.getMetric(RpcConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
+  }
+
+  private static void assertNoClientContent(StatsTestUtils.MetricsRecord record) {
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_ERROR_COUNT));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_REQUEST_BYTES));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_RESPONSE_BYTES));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
+    assertNull(record.getMetric(RpcConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
+  }
+}

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1421,6 +1421,7 @@ public abstract class AbstractInteropTest {
           record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
       assertEquals(uncompressedResponsesSize,
           record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
+      assertNotNull(record.getMetric(RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
       // It's impossible to get the expected wire sizes because it may be compressed, so we just
       // check if they are recorded.
       assertNotNull(record.getMetric(RpcConstants.RPC_CLIENT_REQUEST_BYTES));

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -419,6 +419,7 @@ class NettyClientHandler extends AbstractNettyHandler {
                   // was canceled via RST_STREAM.
                   Http2Stream http2Stream = connection().stream(streamId);
                   if (http2Stream != null) {
+                    stream.getStatsTraceContext().clientHeadersSent();
                     http2Stream.setProperty(streamKey, stream);
 
                     // Attach the client stream to the HTTP/2 stream object as user data.

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -72,6 +72,7 @@ class OkHttpClientStream extends Http2ClientStream {
   private final OkHttpClientTransport transport;
   private final Object lock;
   private final String userAgent;
+  private final StatsTraceContext statsTraceCtx;
   private String authority;
   private Object outboundFlowState;
   private volatile int id = ABSENT_ID;
@@ -98,6 +99,7 @@ class OkHttpClientStream extends Http2ClientStream {
       String userAgent,
       StatsTraceContext statsTraceCtx) {
     super(new OkHttpWritableBufferAllocator(), maxMessageSize, statsTraceCtx);
+    this.statsTraceCtx = statsTraceCtx;
     this.method = method;
     this.headers = headers;
     this.frameWriter = frameWriter;
@@ -160,6 +162,7 @@ class OkHttpClientStream extends Http2ClientStream {
     if (pendingData != null) {
       // Only happens when the stream has neither been started nor cancelled.
       frameWriter.synStream(false, false, id, 0, requestHeaders);
+      statsTraceCtx.clientHeadersSent();
       requestHeaders = null;
 
       boolean flush = false;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -99,7 +99,7 @@ class OkHttpClientStream extends Http2ClientStream {
       String userAgent,
       StatsTraceContext statsTraceCtx) {
     super(new OkHttpWritableBufferAllocator(), maxMessageSize, statsTraceCtx);
-    this.statsTraceCtx = statsTraceCtx;
+    this.statsTraceCtx = checkNotNull(statsTraceCtx, "statsTraceCtx");
     this.method = method;
     this.headers = headers;
     this.frameWriter = frameWriter;

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -91,6 +91,9 @@ public class StatsTestUtils {
     }
   }
 
+  /**
+   * This tag will be propagated by {@link FakeStatsContextFactory} on the wire.
+   */
   public static final TagKey EXTRA_TAG = TagKey.create("/rpc/test/extratag");
 
   private static final String EXTRA_TAG_HEADER_VALUE_PREFIX = "extratag:";


### PR DESCRIPTION
It is defined as the time between the client sends out the headers, and
the RPC finishes.