### PR TITLE
core: clean up code deprecated in 1.1

### DIFF
--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -32,8 +32,6 @@
 package io.grpc;
 
 import com.google.errorprone.annotations.DoNotMock;
-import java.net.SocketAddress;
-import javax.net.ssl.SSLSession;
 
 /**
  * Encapsulates a single call received from a remote client. Calls may not simply be unary
@@ -54,27 +52,6 @@ import javax.net.ssl.SSLSession;
  */
 @DoNotMock("Use InProcessTransport and make a fake server instead")
 public abstract class ServerCall<ReqT, RespT> {
-  /**
-   * {@link Attributes.Key} for the remote address of server call attributes
-   * {@link ServerCall#getAttributes()}
-   *
-   * @deprecated use the equivalent {@link io.grpc.Grpc#TRANSPORT_ATTR_REMOTE_ADDR} instead
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
-  @Deprecated
-  public static final Attributes.Key<SocketAddress> REMOTE_ADDR_KEY =
-      Grpc.TRANSPORT_ATTR_REMOTE_ADDR;
-
-  /**
-   * {@link Attributes.Key} for the SSL session of server call attributes
-   * {@link ServerCall#getAttributes()}
-   *
-   * @deprecated use the equivalent {@link io.grpc.Grpc#TRANSPORT_ATTR_SSL_SESSION} instead
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
-  @Deprecated
-  public static final Attributes.Key<SSLSession> SSL_SESSION_KEY =
-      Grpc.TRANSPORT_ATTR_SSL_SESSION;
 
   /**
    * Callbacks for consuming incoming RPC messages.
@@ -237,15 +214,6 @@ public abstract class ServerCall<ReqT, RespT> {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1779")
   public Attributes getAttributes() {
     return Attributes.EMPTY;
-  }
-
-  /**
-   * @deprecated use {@link #getAttributes()} instead.
-   */
-  @Deprecated
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1779")
-  public Attributes attributes() {
-    return getAttributes();
   }
 
   /**

--- a/testing/src/main/java/io/grpc/testing/DeadlineSubject.java
+++ b/testing/src/main/java/io/grpc/testing/DeadlineSubject.java
@@ -110,6 +110,8 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
      * @deprecated {@link Object#equals(Object)} is not supported on TolerantDeadlineComparison
      *     If you meant to compare deadlines, use {@link #of(Deadline)} instead.
      */
+    // Deprecation used to signal visual warning in IDE for the unaware users.
+    // This method is created as a precaution and won't be removed as part of deprecation policy.
     @Deprecated
     @Override
     public boolean equals(@Nullable Object o) {
@@ -123,6 +125,8 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
      * @throws UnsupportedOperationException always
      * @deprecated {@link Object#hashCode()} is not supported on TolerantDeadlineComparison
      */
+    // Deprecation used to signal visual warning in IDE for the unaware users.
+    // This method is created as a precaution and won't be removed as part of deprecation policy.
     @Deprecated
     @Override
     public int hashCode() {


### PR DESCRIPTION
Since we're on 1.2 train, we can clean this up now :)