### PR TITLE
docs: Remove annoying diff section heading

### DIFF
--- a/documentation/server-reflection-tutorial.md
+++ b/documentation/server-reflection-tutorial.md
@@ -21,7 +21,7 @@ need to make the following changes:
 ```diff
 --- a/examples/build.gradle
 +++ b/examples/build.gradle
-@@ -27,6 +27,7 @@ def grpcVersion = '1.2.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+@@ -27,6 +27,7 @@
  dependencies {
    compile "io.grpc:grpc-netty:${grpcVersion}"
    compile "io.grpc:grpc-protobuf:${grpcVersion}"


### PR DESCRIPTION
The section heading in unified diff is optional. In this case the
heading is pretty useless and causes problems.