### PR TITLE
netty: add return value errorprone annotations

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -33,6 +33,7 @@ package io.grpc.netty;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.ExperimentalApi;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
@@ -133,6 +134,7 @@ public class GrpcSslContexts {
    * Set ciphers and APN appropriate for gRPC. Precisely what is set is permitted to change, so if
    * an application requires particular settings it should override the options set here.
    */
+  @CanIgnoreReturnValue
   public static SslContextBuilder configure(SslContextBuilder builder) {
     return configure(builder, defaultSslProvider());
   }
@@ -142,6 +144,7 @@ public class GrpcSslContexts {
    * an application requires particular settings it should override the options set here.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1784")
+  @CanIgnoreReturnValue
   public static SslContextBuilder configure(SslContextBuilder builder, SslProvider provider) {
     return builder.sslProvider(provider)
                   .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -39,6 +39,7 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_KEEPALIVE_TIMEOUT_NANOS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
 import io.grpc.NameResolver;
@@ -57,6 +58,7 @@ import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 
@@ -64,6 +66,7 @@ import javax.net.ssl.SSLException;
  * A builder to help simplify construction of channels using the Netty transport.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1784")
+@CanIgnoreReturnValue
 public final class NettyChannelBuilder
     extends AbstractManagedChannelImplBuilder<NettyChannelBuilder> {
   public static final int DEFAULT_FLOW_CONTROL_WINDOW = 1048576; // 1MiB
@@ -91,6 +94,7 @@ public final class NettyChannelBuilder
    * generally be preferred over this method, since that API permits delaying DNS lookups and
    * noticing changes to DNS.
    */
+  @CheckReturnValue
   public static NettyChannelBuilder forAddress(SocketAddress serverAddress) {
     return new NettyChannelBuilder(serverAddress);
   }
@@ -98,6 +102,7 @@ public final class NettyChannelBuilder
   /**
    * Creates a new builder with the given host and port.
    */
+  @CheckReturnValue
   public static NettyChannelBuilder forAddress(String host, int port) {
     return new NettyChannelBuilder(host, port);
   }
@@ -106,22 +111,27 @@ public final class NettyChannelBuilder
    * Creates a new builder with the given target string that will be resolved by
    * {@link io.grpc.NameResolver}.
    */
+  @CheckReturnValue
   public static NettyChannelBuilder forTarget(String target) {
     return new NettyChannelBuilder(target);
   }
 
+  @CheckReturnValue
   NettyChannelBuilder(String host, int port) {
     this(GrpcUtil.authorityFromHostAndPort(host, port));
   }
 
+  @CheckReturnValue
   NettyChannelBuilder(String target) {
     super(target);
   }
 
+  @CheckReturnValue
   NettyChannelBuilder(SocketAddress address) {
     super(address, getAuthorityFromAddress(address));
   }
 
+  @CheckReturnValue
   private static String getAuthorityFromAddress(SocketAddress address) {
     if (address instanceof InetSocketAddress) {
       InetSocketAddress inetAddress = (InetSocketAddress) address;
@@ -258,6 +268,7 @@ public final class NettyChannelBuilder
   }
 
   @Override
+  @CheckReturnValue
   protected ClientTransportFactory buildTransportFactory() {
     return new NettyTransportFactory(dynamicParamsFactory, channelType, channelOptions,
         negotiationType, sslContext, eventLoopGroup, flowControlWindow, maxInboundMessageSize(),
@@ -265,6 +276,7 @@ public final class NettyChannelBuilder
   }
 
   @Override
+  @CheckReturnValue
   protected Attributes getNameResolverParams() {
     int defaultPort;
     switch (negotiationType) {
@@ -287,6 +299,7 @@ public final class NettyChannelBuilder
   }
 
   @VisibleForTesting
+  @CheckReturnValue
   static ProtocolNegotiator createProtocolNegotiator(
       String authority,
       NegotiationType negotiationType,
@@ -306,6 +319,7 @@ public final class NettyChannelBuilder
     return negotiator;
   }
 
+  @CheckReturnValue
   private static ProtocolNegotiator createProtocolNegotiatorByType(
       String authority,
       NegotiationType negotiationType,
@@ -329,11 +343,13 @@ public final class NettyChannelBuilder
     }
   }
 
+  @CheckReturnValue
   interface OverrideAuthorityChecker {
     String checkAuthority(String authority);
   }
 
   @Override
+  @CheckReturnValue
   protected String checkAuthority(String authority) {
     if (authorityChecker != null) {
       return authorityChecker.checkAuthority(authority);
@@ -346,10 +362,12 @@ public final class NettyChannelBuilder
   }
 
   interface TransportCreationParamsFilterFactory {
+    @CheckReturnValue
     TransportCreationParamsFilter create(
         SocketAddress targetServerAddress, String authority, @Nullable String userAgent);
   }
 
+  @CheckReturnValue
   interface TransportCreationParamsFilter {
     SocketAddress getTargetServerAddress();
 
@@ -363,6 +381,7 @@ public final class NettyChannelBuilder
   /**
    * Creates Netty transports. Exposed for internal use, as it should be private.
    */
+  @CheckReturnValue
   private static final class NettyTransportFactory implements ClientTransportFactory {
     private final TransportCreationParamsFilterFactory transportCreationParamsFilterFactory;
     private final Class<? extends Channel> channelType;
@@ -446,6 +465,7 @@ public final class NettyChannelBuilder
       }
     }
 
+    @CheckReturnValue
     private final class DynamicNettyTransportParams implements TransportCreationParamsFilter {
 
       private final SocketAddress targetServerAddress;

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -35,6 +35,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.ExperimentalApi;
 import io.grpc.Internal;
 import io.grpc.internal.AbstractServerImplBuilder;
@@ -46,6 +47,7 @@ import io.netty.handler.ssl.SslContext;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 
@@ -53,6 +55,7 @@ import javax.net.ssl.SSLException;
  * A builder to help simplify the construction of a Netty-based GRPC server.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1784")
+@CanIgnoreReturnValue
 public final class NettyServerBuilder extends AbstractServerImplBuilder<NettyServerBuilder> {
   public static final int DEFAULT_FLOW_CONTROL_WINDOW = 1048576; // 1MiB
 
@@ -75,6 +78,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    * @param port the port on which the server is to be bound.
    * @return the server builder.
    */
+  @CheckReturnValue
   public static NettyServerBuilder forPort(int port) {
     return new NettyServerBuilder(port);
   }
@@ -85,14 +89,17 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    * @param address the socket address on which the server is to be bound.
    * @return the server builder
    */
+  @CheckReturnValue
   public static NettyServerBuilder forAddress(SocketAddress address) {
     return new NettyServerBuilder(address);
   }
 
+  @CheckReturnValue
   private NettyServerBuilder(int port) {
     this.address = new InetSocketAddress(port);
   }
 
+  @CheckReturnValue
   private NettyServerBuilder(SocketAddress address) {
     this.address = address;
   }
@@ -221,6 +228,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
   }
 
   @Override
+  @CheckReturnValue
   protected NettyServer buildTransportServer() {
     ProtocolNegotiator negotiator = protocolNegotiator;
     if (negotiator == null) {

--- a/netty/src/main/java/io/grpc/netty/WriteQueue.java
+++ b/netty/src/main/java/io/grpc/netty/WriteQueue.java
@@ -33,6 +33,7 @@ package io.grpc.netty;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
@@ -87,6 +88,7 @@ class WriteQueue {
    * @param flush true if a flush of the write should be schedule, false if a later call to
    *              enqueue will schedule the flush.
    */
+  @CanIgnoreReturnValue
   ChannelFuture enqueue(QueuedCommand command, boolean flush) {
     return enqueue(command, channel.newPromise(), flush);
   }
@@ -99,6 +101,7 @@ class WriteQueue {
    * @param flush true if a flush of the write should be schedule, false if a later call to
    *              enqueue will schedule the flush.
    */
+  @CanIgnoreReturnValue
   ChannelFuture enqueue(QueuedCommand command, ChannelPromise promise, boolean flush) {
     // Detect erroneous code that tries to reuse command objects.
     Preconditions.checkArgument(command.promise() == null, "promise must not be set on command");

--- a/netty/src/main/java/io/grpc/netty/package-info.java
+++ b/netty/src/main/java/io/grpc/netty/package-info.java
@@ -33,4 +33,5 @@
  * The main transport implementation based on <a target="_blank" href="http://netty.io">Netty</a>,
  * for both the client and the server.
  */
+@javax.annotation.CheckReturnValue
 package io.grpc.netty;

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -60,6 +60,7 @@ import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusException;
@@ -536,6 +537,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     createStream();
   }
 
+  @CanIgnoreReturnValue
   private ChannelFuture sendPing(PingCallback callback) {
     return enqueue(new SendPingCommand(callback, MoreExecutors.directExecutor()));
   }
@@ -545,11 +547,13 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     channelRead(serializedSettings);
   }
 
+  @CanIgnoreReturnValue
   private ChannelFuture createStream() throws Exception {
     ChannelFuture future = enqueue(new CreateStreamCommand(grpcHeaders, streamTransportState));
     return future;
   }
 
+  @CanIgnoreReturnValue
   private ChannelFuture cancelStream(Status status) throws Exception {
     return enqueue(new CancelClientStreamCommand(streamTransportState, status));
   }

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -145,7 +145,7 @@ public class NettyClientTransportTest {
   public void addDefaultUserAgent() throws Exception {
     startServer();
     NettyClientTransport transport = newTransport(newNegotiator());
-    transport.start(clientTransportListener);
+    callMeMaybe(transport.start(clientTransportListener));
 
     // Send a single RPC and wait for the response.
     new Rpc(transport).halfClose().waitForResponse();
@@ -169,7 +169,7 @@ public class NettyClientTransportTest {
         DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
         authority, null /* user agent */);
     transports.add(transport);
-    transport.start(clientTransportListener);
+    callMeMaybe(transport.start(clientTransportListener));
 
     // verify SO_LINGER has been set
     ChannelConfig config = transport.channel().config();
@@ -182,7 +182,7 @@ public class NettyClientTransportTest {
     startServer();
     NettyClientTransport transport = newTransport(newNegotiator(),
         DEFAULT_MAX_MESSAGE_SIZE, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, "testUserAgent");
-    transport.start(clientTransportListener);
+    callMeMaybe(transport.start(clientTransportListener));
 
     new Rpc(transport, new Metadata()).halfClose().waitForResponse();
 
@@ -199,7 +199,7 @@ public class NettyClientTransportTest {
     // Allow the response payloads of up to 1 byte.
     NettyClientTransport transport = newTransport(newNegotiator(),
         1, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, null);
-    transport.start(clientTransportListener);
+    callMeMaybe(transport.start(clientTransportListener));
 
     try {
       // Send a single RPC and wait for the response.
@@ -224,7 +224,7 @@ public class NettyClientTransportTest {
     ProtocolNegotiator negotiator = newNegotiator();
     for (int index = 0; index < 2; ++index) {
       NettyClientTransport transport = newTransport(negotiator);
-      transport.start(clientTransportListener);
+      callMeMaybe(transport.start(clientTransportListener));
     }
 
     // Send a single RPC on each transport.
@@ -245,7 +245,7 @@ public class NettyClientTransportTest {
     startServer(1, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE);
 
     NettyClientTransport transport = newTransport(newNegotiator());
-    transport.start(clientTransportListener);
+    callMeMaybe(transport.start(clientTransportListener));
 
     // Send a dummy RPC in order to ensure that the updated SETTINGS_MAX_CONCURRENT_STREAMS
     // has been received by the remote endpoint.
@@ -281,7 +281,7 @@ public class NettyClientTransportTest {
 
     NettyClientTransport transport =
         newTransport(newNegotiator(), DEFAULT_MAX_MESSAGE_SIZE, 1, null);
-    transport.start(clientTransportListener);
+    callMeMaybe(transport.start(clientTransportListener));
 
     try {
       // Send a single RPC and wait for the response.
@@ -300,7 +300,7 @@ public class NettyClientTransportTest {
     startServer(100, 1);
 
     NettyClientTransport transport = newTransport(newNegotiator());
-    transport.start(clientTransportListener);
+    callMeMaybe(transport.start(clientTransportListener));
 
     try {
       // Send a single RPC and wait for the response.
@@ -338,7 +338,7 @@ public class NettyClientTransportTest {
   public void clientStreamGetsAttributes() throws Exception {
     startServer();
     NettyClientTransport transport = newTransport(newNegotiator());
-    transport.start(clientTransportListener);
+    callMeMaybe(transport.start(clientTransportListener));
     Rpc rpc = new Rpc(transport).halfClose();
     rpc.waitForResponse();
 
@@ -390,6 +390,12 @@ public class NettyClientTransportTest {
     server.start(serverListener);
     address = TestUtils.testServerAddress(server.getPort());
     authority = GrpcUtil.authorityFromHostAndPort(address.getHostString(), address.getPort());
+  }
+
+  private void callMeMaybe(Runnable r) {
+    if (r != null) {
+      r.run();
+    }
   }
 
   private static class Rpc {

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.internal.MessageFramer;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.WritableBuffer;
@@ -221,6 +222,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
     return handler().connection();
   }
 
+  @CanIgnoreReturnValue
   protected final ChannelFuture enqueue(WriteQueue.QueuedCommand command) {
     ChannelFuture future = writeQueue.enqueue(command, newPromise(), true);
     channel.runPendingTasks();


### PR DESCRIPTION
Related to #2691.  This requires callers of the netty code to check their return values.  Exceptions are for the Channel builder  and the Server builder, since it's usually okay to not use the result of a setter.  

I eventually would like to add this to more parts of our code, but I'm starting with a small part first.