### PR TITLE
core: replace EquivalentAddressGroup with ResolvedServerInfo

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer2.java
+++ b/core/src/main/java/io/grpc/LoadBalancer2.java
@@ -330,7 +330,7 @@ public abstract class LoadBalancer2 {
      * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
      * Subchannels within {@link #shutdown}.
      */
-    public abstract Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs);
+    public abstract Subchannel createSubchannel(ResolvedServerInfo addrs, Attributes attrs);
 
     /**
      * Out-of-band channel for LoadBalancer’s own RPC needs, e.g., talking to an external
@@ -339,8 +339,7 @@ public abstract class LoadBalancer2 {
      * <p>The LoadBalancer is responsible for closing unused OOB channels, and closing all OOB
      * channels within {@link #shutdown}.
      */
-    public abstract ManagedChannel createOobChannel(
-        EquivalentAddressGroup eag, String authority);
+    public abstract ManagedChannel createOobChannel(ResolvedServerInfo eag, String authority);
 
     /**
      * Set a new picker to the channel.
@@ -400,7 +399,7 @@ public abstract class LoadBalancer2 {
     /**
      * Returns the addresses that this Subchannel is bound to.
      */
-    public abstract EquivalentAddressGroup getAddresses();
+    public abstract ResolvedServerInfo getAddresses();
 
     /**
      * The same attributes passed to {@link Helper#createSubchannel Helper.createSubchannel()}.

--- a/core/src/main/java/io/grpc/ResolvedServerInfo.java
+++ b/core/src/main/java/io/grpc/ResolvedServerInfo.java
@@ -31,10 +31,14 @@
 
 package io.grpc;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Objects;
 import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.List;
+
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -43,34 +47,48 @@ import javax.annotation.concurrent.Immutable;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
 @Immutable
 public final class ResolvedServerInfo {
-  private final SocketAddress address;
+  private final List<? extends SocketAddress> addrs;
   private final Attributes attributes;
 
   /**
-   * Constructs a new resolved server without attributes.
+   * Constructs a new resolved server for a single address, without attributes.
    *
-   * @param address the address of the server
+   * @param addresses the addresses of the server
    */
-  public ResolvedServerInfo(SocketAddress address) {
-    this(address, Attributes.EMPTY);
+  public ResolvedServerInfo(List<? extends SocketAddress> addrs) {
+    this(addrs, Attributes.EMPTY);
   }
 
   /**
-   * Constructs a new resolved server with attributes.
+   * Constructs a new resolved server for a single address, without attributes.
+   *
+   * @param address the address of the server
+   */
+  public ResolvedServerInfo(SocketAddress addrs) {
+    this(Collections.singletonList(addrs), Attributes.EMPTY);
+  }
+
+  /**
+   * Constructs a new resolved server for a single address, with attributes.
    *
    * @param address the address of the server
    * @param attributes attributes associated with this address.
    */
-  public ResolvedServerInfo(SocketAddress address, Attributes attributes) {
-    this.address = checkNotNull(address);
-    this.attributes = checkNotNull(attributes);
+  public ResolvedServerInfo(List<? extends SocketAddress> addrs, Attributes attributes) {
+    checkArgument(addrs.isEmpty(), "addresses can't be empty");
+    this.addrs = Collections.unmodifiableList(addrs);
+    this.attributes = checkNotNull(attributes, "attributes");
   }
 
   /**
    * Returns the address.
    */
   public SocketAddress getAddress() {
-    return address;
+    return addrs.get(0);
+  }
+
+  public List<? extends SocketAddress> getAddresses() {
+    return addrs;
   }
 
   /**
@@ -82,7 +100,7 @@ public final class ResolvedServerInfo {
 
   @Override
   public String toString() {
-    return "[address=" + address + ", attrs=" + attributes + "]";
+    return "[addrs=" + addrs + ", attrs=" + attributes + "]";
   }
 
   /**
@@ -106,7 +124,7 @@ public final class ResolvedServerInfo {
       return false;
     }
     ResolvedServerInfo that = (ResolvedServerInfo) o;
-    return Objects.equal(address, that.address) && Objects.equal(attributes, that.attributes);
+    return Objects.equal(addrs, that.addrs) && Objects.equal(attributes, that.attributes);
   }
 
   /**
@@ -120,6 +138,6 @@ public final class ResolvedServerInfo {
    */
   @Override
   public int hashCode() {
-    return Objects.hashCode(address, attributes);
+    return Objects.hashCode(addrs, attributes);
   }
 }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -43,7 +43,7 @@ import com.google.common.base.Supplier;
 import com.google.errorprone.annotations.ForOverride;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
-import io.grpc.EquivalentAddressGroup;
+import io.grpc.ResolvedServerInfo;
 import io.grpc.Status;
 import java.net.SocketAddress;
 import java.util.ArrayList;
@@ -68,7 +68,7 @@ final class InternalSubchannel implements WithLogId {
   private static final Logger log = Logger.getLogger(InternalSubchannel.class.getName());
 
   private final LogId logId = LogId.allocate(getClass().getName());
-  private final EquivalentAddressGroup addressGroup;
+  private final ResolvedServerInfo addressGroup;
   private final String authority;
   private final String userAgent;
   private final BackoffPolicy.Provider backoffPolicyProvider;
@@ -148,7 +148,7 @@ final class InternalSubchannel implements WithLogId {
   @GuardedBy("lock")
   private ConnectivityStateInfo state = ConnectivityStateInfo.forNonError(IDLE);
 
-  InternalSubchannel(EquivalentAddressGroup addressGroup, String authority, String userAgent,
+  InternalSubchannel(ResolvedServerInfo addressGroup, String authority, String userAgent,
       BackoffPolicy.Provider backoffPolicyProvider,
       ClientTransportFactory transportFactory, ScheduledExecutorService scheduledExecutor,
       Supplier<Stopwatch> stopwatchSupplier, ChannelExecutor channelExecutor, Callback callback) {
@@ -199,7 +199,7 @@ final class InternalSubchannel implements WithLogId {
     if (nextAddressIndex == 0) {
       connectingTimer.reset().start();
     }
-    List<SocketAddress> addrs = addressGroup.getAddresses();
+    List<? extends SocketAddress> addrs = addressGroup.getAddresses();
     final SocketAddress address = addrs.get(nextAddressIndex++);
     if (nextAddressIndex >= addrs.size()) {
       nextAddressIndex = 0;
@@ -351,7 +351,7 @@ final class InternalSubchannel implements WithLogId {
     }
   }
 
-  EquivalentAddressGroup getAddressGroup() {
+  ResolvedServerInfo getAddressGroup() {
     return addressGroup;
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl2.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl2.java
@@ -58,9 +58,11 @@ import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.NameResolver;
+import io.grpc.ResolvedServerInfo;
 import io.grpc.ResolvedServerInfoGroup;
 import io.grpc.Status;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashSet;
@@ -597,7 +599,8 @@ public final class ManagedChannelImpl2 extends ManagedChannel implements WithLog
     }
 
     @Override
-    public SubchannelImpl createSubchannel(EquivalentAddressGroup addressGroup, Attributes attrs) {
+    public SubchannelImpl createSubchannel(ResolvedServerInfo addressGroup,
+        Attributes attrs) {
       checkNotNull(addressGroup, "addressGroup");
       checkNotNull(attrs, "attrs");
       ScheduledExecutorService scheduledExecutorCopy = scheduledExecutor;
@@ -659,7 +662,7 @@ public final class ManagedChannelImpl2 extends ManagedChannel implements WithLog
     }
 
     @Override
-    public ManagedChannel createOobChannel(EquivalentAddressGroup addressGroup, String authority) {
+    public ManagedChannel createOobChannel(ResolvedServerInfo addressGroup, String authority) {
       ScheduledExecutorService scheduledExecutorCopy = scheduledExecutor;
       checkState(scheduledExecutorCopy != null,
           "scheduledExecutor is already cleared. Looks like you are calling this method after "
@@ -859,7 +862,7 @@ public final class ManagedChannelImpl2 extends ManagedChannel implements WithLog
     }
 
     @Override
-    public EquivalentAddressGroup getAddresses() {
+    public ResolvedServerInfo getAddresses() {
       return subchannel.getAddressGroup();
     }
 

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory2.java
@@ -95,8 +95,7 @@ public class RoundRobinLoadBalancerFactory2 extends LoadBalancer2.Factory {
   @VisibleForTesting
   static class RoundRobinLoadBalancer extends LoadBalancer2 {
     private final Helper helper;
-    private final Map<EquivalentAddressGroup, Subchannel> subchannels =
-        new HashMap<EquivalentAddressGroup, Subchannel>();
+    private final Map<EquivalentAddressGroup, Subchannel> subchannels = new HashMap<EquivalentAddressGroup, Subchannel>();
 
     @VisibleForTesting
     static final Attributes.Key<AtomicReference<ConnectivityStateInfo>> STATE_INFO =


### PR DESCRIPTION
Now that we have a new LoadBalancer2 API in place, I'd like to propose removing `EquivalentAddressGroup` and replacing it with `ResolvedServerInfo`.

I think that having two, very similar objects adds unnecessary confusion and more importantly a lot of boilerplate that users need to deal with when custom LBs. With the new API and how things are designed (managing subchannels/connections _manually_ in LB) we don't need `EquivalentAddressGroup` anymore and can just add another dimension to the resolved server group of objects by allowing `ResolvedServerInfo` to store more than one address.

In my opinion, this would greatly simplify and unify `NameResolver`/`LoadBalancer` logic and code.

@zhangkun83 @ejona86 @carl-mastrangelo What do you think? 