### PR TITLE
all: drop thrift from grpc-all deps

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -21,7 +21,7 @@ def subprojects = [
   project(':grpc-protobuf-lite'),
   project(':grpc-protobuf-nano'),
   project(':grpc-stub'),
-  project(':grpc-thrift'),
+  // project(':grpc-thrift'), // not exported currently.
 ]
 
 for (subproject in rootProject.subprojects) {


### PR DESCRIPTION
Confirmed that is it removed from the pom file.