### PR TITLE
Implement missing authority API for HandlerRegistry

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -81,6 +81,8 @@ import javax.annotation.concurrent.GuardedBy;
  * server stops servicing new requests and waits for all connections to terminate.
  */
 public final class ServerImpl extends io.grpc.Server implements WithLogId {
+  public static final Attributes.Key<String> ATTR_AUTHORITY = Attributes.Key.of("io.grpc.authority");
+
   private static final ServerStreamListener NOOP_LISTENER = new NoopListener();
 
   private final LogId logId = LogId.allocate(getClass().getName());
@@ -418,7 +420,9 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
             try {
               ServerMethodDefinition<?, ?> method = registry.lookupMethod(methodName);
               if (method == null) {
-                method = fallbackRegistry.lookupMethod(methodName);
+                String authority = stream.getAttributes()
+                                         .get(ATTR_AUTHORITY);
+                method = fallbackRegistry.lookupMethod(methodName, authority);
               }
               if (method == null) {
                 Status status = Status.UNIMPLEMENTED.withDescription(

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -45,9 +45,7 @@ import io.grpc.Attributes;
 import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.ServerTransportListener;
-import io.grpc.internal.StatsTraceContext;
+import io.grpc.internal.*;
 import io.grpc.netty.GrpcHttp2HeadersDecoder.GrpcHttp2ServerHeadersDecoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
@@ -195,8 +193,13 @@ class NettyServerHandler extends AbstractNettyHandler {
           checkNotNull(transportListener.methodDetermined(method, metadata), "statsTraceCtx");
       NettyServerStream.TransportState state = new NettyServerStream.TransportState(
           this, http2Stream, maxMessageSize, statsTraceCtx);
-      NettyServerStream stream = new NettyServerStream(ctx.channel(), state, attributes,
+      Attributes attributesWithAuthority = Attributes
+              .newBuilder()
+              .setAll(attributes).set(ServerImpl.ATTR_AUTHORITY, headers.authority().toString())
+              .build();
+      NettyServerStream stream = new NettyServerStream(ctx.channel(), state, attributesWithAuthority,
           statsTraceCtx);
+
       transportListener.streamCreated(stream, method, metadata);
       state.onStreamAllocated();
       http2Stream.setProperty(streamKey, state);

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -45,7 +45,10 @@ import io.grpc.Attributes;
 import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.internal.*;
+import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.ServerImpl;
+import io.grpc.internal.ServerTransportListener;
+import io.grpc.internal.StatsTraceContext;
 import io.grpc.netty.GrpcHttp2HeadersDecoder.GrpcHttp2ServerHeadersDecoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
@@ -194,9 +197,9 @@ class NettyServerHandler extends AbstractNettyHandler {
       NettyServerStream.TransportState state = new NettyServerStream.TransportState(
           this, http2Stream, maxMessageSize, statsTraceCtx);
       Attributes attributesWithAuthority = Attributes
-              .newBuilder()
-              .setAll(attributes).set(ServerImpl.ATTR_AUTHORITY, headers.authority().toString())
-              .build();
+          .newBuilder(attributes)
+          .set(ServerImpl.ATTR_AUTHORITY, headers.authority().toString())
+          .build();
       NettyServerStream stream = new NettyServerStream(ctx.channel(), state, attributesWithAuthority,
           statsTraceCtx);
 


### PR DESCRIPTION
`HandlerRegistry.lookupMethod(String methodName, String authority)` is never never invoked with a non-null authority string. Per the discussion on the mailing list, I implemented this method.

https://groups.google.com/forum/#!topic/grpc-io/1RPka9CKAvE