### PR TITLE
all: swap to newer animalsniffer plugin

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -1,15 +1,7 @@
-plugins {
-    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
-}
-
 description = "gRpc: Auth"
 dependencies {
     compile project(':grpc-core'),
             libraries.google_auth_credentials
     testCompile libraries.oauth_client
-}
-
-// Configure the animal sniffer plugin
-animalsniffer {
-    signature = "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:+@signature"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
+    classpath "ru.vyarus:gradle-animalsniffer-plugin:1.2.0"
   }
 }
 
@@ -17,6 +18,8 @@ subprojects {
     apply plugin: "jacoco"
 
     apply plugin: "com.google.osdetector"
+    // The plugin only has an effect if a signature is specified
+    apply plugin: "ru.vyarus.animalsniffer"
 
     group = "io.grpc"
     version = "1.2.0-SNAPSHOT" // CURRENT_GRPC_VERSION

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -1,14 +1,6 @@
-plugins {
-    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
-}
-
 description = 'gRPC: Context'
 
 dependencies {
     testCompile project(':grpc-testing')
-}
-
-// Configure the animal sniffer plugin
-animalsniffer {
-    signature = "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:+@signature"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
-}
-
 description = 'gRPC: Core'
 
 dependencies {
@@ -11,11 +7,7 @@ dependencies {
             project(':grpc-context'),
             libraries.instrumentation_api
     testCompile project(':grpc-testing')
-}
-
-// Configure the animal sniffer plugin
-animalsniffer {
-    signature = "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:+@signature"
 }
 
 javadoc.exclude 'io/grpc/internal/**'

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
                 project(':grpc-testing')
+    signature "org.codehaus.mojo.signature:java17:+@signature"
 }
 
 test {

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
-}
-
 description = "gRPC: OkHttp"
 dependencies {
     compile project(':grpc-core'),
@@ -12,6 +8,7 @@ dependencies {
     testCompile project(':grpc-core').sourceSets.test.output,
                 project(':grpc-testing'),
                 project(':grpc-netty')
+    signature "org.codehaus.mojo.signature:java16:+@signature"
 }
 
 project.sourceSets {
@@ -23,11 +20,6 @@ project.sourceSets {
 }
 
 checkstyleMain.exclude '**/io/grpc/okhttp/internal/**'
-
-// Configure the animal sniffer plugin
-animalsniffer {
-    signature = "org.codehaus.mojo.signature:java16:+@signature"
-}
 
 javadoc.exclude 'io/grpc/okhttp/internal/**'
 javadoc.options.links 'http://square.github.io/okhttp/2.x/okhttp/'

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
@@ -31,6 +31,7 @@
 
 package io.grpc.okhttp;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -46,7 +47,6 @@ import io.grpc.okhttp.OkHttpProtocolNegotiator.AndroidNegotiator.TlsExtensionTyp
 import io.grpc.okhttp.internal.Platform;
 import io.grpc.okhttp.internal.Protocol;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.Provider;
 import java.security.Security;
 import javax.net.ssl.HandshakeCompletedListener;
@@ -284,7 +284,7 @@ public class OkHttpProtocolNegotiatorTest {
   public static class FakeAndroidSslSocketAlpn extends FakeAndroidSslSocket {
     @Override
     public byte[] getAlpnSelectedProtocol() {
-      return "h2".getBytes(StandardCharsets.UTF_8);
+      return "h2".getBytes(UTF_8);
     }
   }
 
@@ -302,7 +302,7 @@ public class OkHttpProtocolNegotiatorTest {
   public static class FakeAndroidSslSocketNpn extends FakeAndroidSslSocket {
     @Override
     public byte[] getNpnSelectedProtocol() {
-      return "h2".getBytes(StandardCharsets.UTF_8);
+      return "h2".getBytes(UTF_8);
     }
   }
 

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -8,10 +8,6 @@ buildscript {
     }
 }
 
-plugins {
-    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
-}
-
 apply plugin: 'com.google.protobuf'
 
 description = 'gRPC: Protobuf Lite'
@@ -22,6 +18,8 @@ dependencies {
             libraries.guava
 
     testProtobuf libraries.protobuf
+
+    signature "org.codehaus.mojo.signature:java16:+@signature"
 }
 
 compileTestJava {
@@ -56,8 +54,4 @@ protobuf {
       }
     }
   }
-}
-
-animalsniffer {
-    signature = "org.codehaus.mojo.signature:java16:+@signature"
 }

--- a/protobuf-nano/build.gradle
+++ b/protobuf-nano/build.gradle
@@ -8,20 +8,13 @@ buildscript {
     }
 }
 
-plugins {
-    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
-}
-
 description = 'gRPC: Protobuf Nano'
 
 dependencies {
     compile project(':grpc-core'),
             libraries.protobuf_nano,
             libraries.guava
-}
-
-animalsniffer {
-    signature = "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:+@signature"
 }
 
 configureProtoCompilation()

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
-}
-
 description = 'gRPC: Protobuf'
 
 dependencies {
@@ -13,8 +9,6 @@ dependencies {
     compile (project(':grpc-protobuf-lite')) {
         exclude group: 'com.google.protobuf', module: 'protobuf-lite'
     }
-}
 
-animalsniffer {
-    signature = "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:+@signature"
 }

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -8,24 +8,16 @@ buildscript {
     }
 }
 
-plugins {
-    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
-}
-
 description = "gRPC: Services"
 
 dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub')
     testCompile project(':grpc-testing')
+    signature "org.codehaus.mojo.signature:java16:+@signature"
 }
 
 configureProtoCompilation()
-
-// Configure the animal sniffer plugin
-animalsniffer {
-    signature = "org.codehaus.mojo.signature:java16:+@signature"
-}
 
 // Let intellij projects refer to generated code
 idea {

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -1,17 +1,9 @@
-plugins {
-    id "be.insaneprogramming.gradle.animalsniffer" version "1.4.0"
-}
-
 description = "gRPC: Stub"
 dependencies {
     compile project(':grpc-core')
     testCompile libraries.truth,
     project(':grpc-testing')
-}
-
-// Configure the animal sniffer plugin
-animalsniffer {
-    signature = "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:+@signature"
 }
 
 javadoc.options.links "https://google.github.io/guava/releases/${guavaVersion}/api/docs/"


### PR DESCRIPTION
The new plugin uses a newer version of animalsniffer, allows overriding
the animalsniffer version used, and has up-to-date handling. The
up-to-date handling cuts fully incremental parallel build times in half,
from 5.5s to 2.7s.

The previous plugin was supposed to be verifying tests. However, either
it wasn't verifying them or its verification was broken.