### PR TITLE
core: Tweak getAttributes() JavaDoc

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -253,9 +253,14 @@ public abstract class ClientCall<ReqT, RespT> {
   }
 
   /**
-   * Returns a set of attributes, which may vary depending on the particular
-   * implementation and the state of the call, channel, or transport at the moment it is being
-   * called. By default it returns EMPTY attributes.
+   * Returns additional properties of the call. May only be called after {@link Listener#onHeaders}
+   * or {@link Listener#onClose}. If called prematurely, the implementation may throw {@code
+   * IllegalStateException} or return abitrary {@code Attributes}.
+   *
+   * <p>{@link Grpc} defines commonly used attributes, but they are not guaranteed to be present.
+   *
+   * @return non-{@code null} attributes
+   * @throws IllegalStateException (optional) if called before permitted
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2607")
   public Attributes getAttributes() {

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -229,10 +229,9 @@ public abstract class ServerCall<ReqT, RespT> {
    * Returns properties of a single call.
    *
    * <p>Attributes originate from the transport and can be altered by {@link ServerTransportFilter}.
-   * {@link Grpc} defines commonly used attributes, while the availability of them in a particular
-   * {@code ServerCall} is not guaranteed.
+   * {@link Grpc} defines commonly used attributes, but they are not guaranteed to be present.
    *
-   * @return Attributes container
+   * @return non-{@code null} Attributes container
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1779")
   public Attributes getAttributes() {


### PR DESCRIPTION
It now provides more guarantees and should be more obvious when it is
safe to use.