### PR TITLE
Implement missing authority API for HandlerRegistry

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -119,7 +119,7 @@ public class InProcessChannelBuilder extends
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
-      return new InProcessTransport(name);
+      return new InProcessTransport(name, authority);
     }
 
     @Override

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -84,6 +84,10 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
   @GuardedBy("this")
   private Set<InProcessStream> streams = new HashSet<InProcessStream>();
 
+  public InProcessTransport(String name) {
+    this(name, null);
+  }
+
   public InProcessTransport(String name, String authority) {
     this.name = name;
     this.authority = authority;
@@ -238,7 +242,7 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
     private final StatsTraceContext serverStatsTraceContext;
     private final Metadata headers;
     private final MethodDescriptor<?, ?> method;
-    private String authority;
+    private volatile String authority;
 
     private InProcessStream(MethodDescriptor<?, ?> method, Metadata headers,
         StatsTraceContext serverStatsTraceContext, String authority) {

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -82,9 +82,12 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
   private Status shutdownStatus;
   @GuardedBy("this")
   private Set<InProcessStream> streams = new HashSet<InProcessStream>();
+  @GuardedBy("this")
+  private String authority;
 
-  public InProcessTransport(String name) {
+  public InProcessTransport(String name, String authority) {
     this.name = name;
+    this.authority = authority;
   }
 
   @CheckReturnValue
@@ -420,6 +423,11 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
       }
 
       @Override
+      public String getAuthority() {
+        return authority;
+      }
+
+      @Override
       public StatsTraceContext statsTraceContext() {
         return serverStatsTraceContext;
       }
@@ -550,8 +558,7 @@ class InProcessTransport implements ServerTransport, ConnectionClientTransport {
 
       @Override
       public void setAuthority(String string) {
-        // TODO(ejona): Do something with this? Could be useful for testing, but can we "validate"
-        // it?
+        authority = string;
       }
 
       @Override

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -168,6 +168,11 @@ public abstract class AbstractServerStream extends AbstractStream2
   }
 
   @Override
+  public String getAuthority() {
+    return "";
+  }
+
+  @Override
   public final void setListener(ServerStreamListener serverStreamListener) {
     transportState().setListener(serverStreamListener);
   }

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -169,7 +169,7 @@ public abstract class AbstractServerStream extends AbstractStream2
 
   @Override
   public String getAuthority() {
-    return "";
+    return null;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -418,7 +418,7 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
             try {
               ServerMethodDefinition<?, ?> method = registry.lookupMethod(methodName);
               if (method == null) {
-                method = fallbackRegistry.lookupMethod(methodName);
+                method = fallbackRegistry.lookupMethod(methodName, stream.getAuthority());
               }
               if (method == null) {
                 Status status = Status.UNIMPLEMENTED.withDescription(

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -76,6 +76,11 @@ public interface ServerStream extends Stream {
    */
   Attributes getAttributes();
 
+  /**
+   * Gets the authority this stream is addressed to.
+   * @return the authority string.
+   */
+  String getAuthority();
 
   /**
    * Sets the server stream listener.

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -41,6 +41,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InProcessTransportTest extends AbstractTransportTest {
   private static final String transportName = "perfect-for-testing";
+  private static final String authority = "a-testing-authority";
 
   @Override
   protected InternalServer newServer() {
@@ -54,6 +55,6 @@ public class InProcessTransportTest extends AbstractTransportTest {
 
   @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
-    return new InProcessTransport(transportName);
+    return new InProcessTransport(transportName, authority);
   }
 }

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -54,7 +54,12 @@ public class InProcessTransportTest extends AbstractTransportTest {
   }
 
   @Override
+  protected String testAuthority(InternalServer server) {
+    return authority;
+  }
+
+  @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
-    return new InProcessTransport(transportName, authority);
+    return new InProcessTransport(transportName, testAuthority(server));
   }
 }

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -423,6 +423,7 @@ public class ServerImplTest {
     assertEquals(1, executor.runDueTasks());
     ServerCall<String, Integer> call = callReference.get();
     assertNotNull(call);
+    verify(stream).getAuthority();
 
     String order = "Lots of pizza, please";
     streamListener.messageRead(STRING_MARSHALLER.stream(order));
@@ -604,6 +605,7 @@ public class ServerImplTest {
     verifyNoMoreInteractions(stream);
 
     assertEquals(1, executor.runDueTasks());
+    verify(stream).getAuthority();
     verify(stream).close(same(status), notNull(Metadata.class));
     verify(stream, atLeast(1)).statsTraceContext();
     verifyNoMoreInteractions(stream);

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -211,8 +211,8 @@ class NettyServerHandler extends AbstractNettyHandler {
 
   private String getOrUpdateAuthority(AsciiString authority) {
     if (authority == null) {
-      return "";
-    } else if (lastKnownAuthority == null || !lastKnownAuthority.equals(authority)) {
+      return null;
+    } else if (!authority.equals(lastKnownAuthority)) {
       lastKnownAuthority = authority;
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -77,7 +77,9 @@ import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.handler.codec.http2.Http2StreamVisitor;
 import io.netty.handler.logging.LogLevel;
+import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -96,6 +98,7 @@ class NettyServerHandler extends AbstractNettyHandler {
   private Throwable connectionError;
   private boolean teWarningLogged;
   private WriteQueue serverWriteQueue;
+  private AsciiString lastKnownAuthority;
 
   static NettyServerHandler newHandler(ServerTransportListener transportListener,
                                        int maxStreams,
@@ -190,8 +193,9 @@ class NettyServerHandler extends AbstractNettyHandler {
           checkNotNull(transportListener.methodDetermined(method, metadata), "statsTraceCtx");
       NettyServerStream.TransportState state = new NettyServerStream.TransportState(
           this, http2Stream, maxMessageSize, statsTraceCtx);
+      String authority = getOrUpdateAuthority((AsciiString)headers.authority());
       NettyServerStream stream = new NettyServerStream(ctx.channel(), state, attributes,
-          statsTraceCtx);
+          authority, statsTraceCtx);
       transportListener.streamCreated(stream, method, metadata);
       state.onStreamAllocated();
       http2Stream.setProperty(streamKey, state);
@@ -203,6 +207,18 @@ class NettyServerHandler extends AbstractNettyHandler {
       // Throw an exception that will get handled by onStreamError.
       throw newStreamException(streamId, e);
     }
+  }
+
+  private String getOrUpdateAuthority(AsciiString authority) {
+    if (authority == null) {
+      return "";
+    } else if (lastKnownAuthority == null || !lastKnownAuthority.equals(authority)) {
+      lastKnownAuthority = authority;
+    }
+
+    // AsciiString.toString() is internally cached, so subsequent calls will not
+    // result in recomputing the String representation of lastKnownAuthority.
+    return lastKnownAuthority.toString();
   }
 
   private void onDataRead(int streamId, ByteBuf data, int padding, boolean endOfStream)

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -60,14 +60,16 @@ class NettyServerStream extends AbstractServerStream {
   private final Channel channel;
   private final WriteQueue writeQueue;
   private final Attributes attributes;
+  private final String authority;
 
   public NettyServerStream(Channel channel, TransportState state, Attributes transportAttrs,
-      StatsTraceContext statsTraceCtx) {
+      String authority, StatsTraceContext statsTraceCtx) {
     super(new NettyWritableBufferAllocator(channel.alloc()), statsTraceCtx);
     this.state = checkNotNull(state, "transportState");
     this.channel = checkNotNull(channel, "channel");
     this.writeQueue = state.handler.getWriteQueue();
     this.attributes = checkNotNull(transportAttrs);
+    this.authority = checkNotNull(authority);
   }
 
   @Override
@@ -83,6 +85,11 @@ class NettyServerStream extends AbstractServerStream {
   @Override
   public Attributes getAttributes() {
     return attributes;
+  }
+
+  @Override
+  public String getAuthority() {
+    return authority;
   }
 
   private class Sink implements AbstractServerStream.Sink {

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -69,7 +69,7 @@ class NettyServerStream extends AbstractServerStream {
     this.channel = checkNotNull(channel, "channel");
     this.writeQueue = state.handler.getWriteQueue();
     this.attributes = checkNotNull(transportAttrs);
-    this.authority = checkNotNull(authority);
+    this.authority = authority;
   }
 
   @Override

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -293,7 +293,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     NettyServerStream.TransportState state = new NettyServerStream.TransportState(
         handler, http2Stream, DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx);
     NettyServerStream stream = new NettyServerStream(channel, state, Attributes.EMPTY,
-        statsTraceCtx);
+        "test-authority", statsTraceCtx);
     stream.transportState().setListener(serverListener);
     state.onStreamAllocated();
     verify(serverListener, atLeastOnce()).onReady();

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -78,11 +78,16 @@ public class NettyTransportTest extends AbstractTransportTest {
   }
 
   @Override
+  protected String testAuthority(InternalServer server) {
+    return "localhost:" + server.getPort();
+  }
+
+  @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
     int port = server.getPort();
     return clientFactory.newClientTransport(
         new InetSocketAddress("localhost", port),
-        "localhost:" + port,
+        testAuthority(server),
         null /* agent */);
   }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -76,11 +76,16 @@ public class OkHttpTransportTest extends AbstractTransportTest {
   }
 
   @Override
+  protected String testAuthority(InternalServer server) {
+    return "127.0.0.1:" + server.getPort();
+  }
+
+  @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
     int port = server.getPort();
     return clientFactory.newClientTransport(
         new InetSocketAddress("127.0.0.1", port),
-        "127.0.0.1:" + port,
+        testAuthority(server),
         null /* agent */);
   }
 


### PR DESCRIPTION
`HandlerRegistry.lookupMethod(String methodName, String authority)` is never never invoked with a non-null authority string. Per the discussion on the mailing list, I implemented this method.

https://groups.google.com/forum/#!topic/grpc-io/1RPka9CKAvE