### PR TITLE
netty: Fix NPE in NettyClientTransport when keepalive is enabled

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -165,11 +165,6 @@ class NettyClientTransport implements ConnectionClientTransport {
     lifecycleManager = new ClientTransportLifecycleManager(
         Preconditions.checkNotNull(transportListener, "listener"));
 
-    if (enableKeepAlive) {
-      keepAliveManager = new KeepAliveManager(this, channel.eventLoop(), keepAliveDelayNanos,
-          keepAliveTimeoutNanos);
-    }
-
     handler = newHandler();
     HandlerSettings.setAutoWindow(handler);
 
@@ -234,6 +229,12 @@ class NettyClientTransport implements ConnectionClientTransport {
             Status.INTERNAL.withDescription("Connection closed with unknown cause"));
       }
     });
+
+    if (enableKeepAlive) {
+      keepAliveManager = new KeepAliveManager(this, channel.eventLoop(), keepAliveDelayNanos,
+          keepAliveTimeoutNanos);
+    }
+
     return null;
   }
 
@@ -274,6 +275,11 @@ class NettyClientTransport implements ConnectionClientTransport {
   @VisibleForTesting
   Channel channel() {
     return channel;
+  }
+
+  @VisibleForTesting
+  KeepAliveManager keepAliveManager() {
+    return keepAliveManager;
   }
 
   /**


### PR DESCRIPTION
* Move creation of `keepAliveManager` to the bottom of `start()`
* Enable keepAlive in `NettyClientTransportTest`
* Add test cases checking if keepalive is enabled/disabled, specifically.

Fixes #2726

cc @ejona86 @bobwenx