### PR TITLE
Propagate trailers in runtime status exception

### DIFF
--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -423,9 +423,11 @@ public final class Status {
     Throwable cause = checkNotNull(t, "t");
     while (cause != null) {
       if (cause instanceof StatusException) {
-        return ((StatusException) cause).getTrailers();
+        Metadata trailers = ((StatusException) cause).getTrailers();
+        return (trailers == null) ? new Metadata() : trailers;
       } else if (cause instanceof StatusRuntimeException) {
-        return ((StatusRuntimeException) cause).getTrailers();
+        Metadata trailers = ((StatusRuntimeException) cause).getTrailers();
+        return (trailers == null) ? new Metadata() : trailers;
       }
       cause = cause.getCause();
     }

--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -416,7 +416,7 @@ public final class Status {
   /**
    * Extract an error trailers from the causal chain of a {@link Throwable}.
    *
-   * @return the trailers or {@code null} if not found.
+   * @return the trailers or an empty {@link Metadata} if not found.
    */
   @ExperimentalApi
   public static Metadata trailersFromThrowable(Throwable t) {
@@ -429,7 +429,7 @@ public final class Status {
       }
       cause = cause.getCause();
     }
-    return null;
+    return new Metadata();
   }
 
   static String formatThrowableMessage(Status status) {

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -146,10 +146,10 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
       stream.writeMessage(resp);
       stream.flush();
     } catch (RuntimeException e) {
-      close(Status.fromThrowable(e), new Metadata());
+      close(Status.fromThrowable(e), Status.trailersFromThrowable(e));
       throw e;
     } catch (Throwable t) {
-      close(Status.fromThrowable(t), new Metadata());
+      close(Status.fromThrowable(t), Status.trailersFromThrowable(t));
       throw new RuntimeException(t);
     }
   }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -567,10 +567,10 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
           try {
             getListener().messageRead(message);
           } catch (RuntimeException e) {
-            internalClose(Status.fromThrowable(e), new Metadata());
+            internalClose(Status.fromThrowable(e), Status.trailersFromThrowable(e));
             throw e;
           } catch (Error e) {
-            internalClose(Status.fromThrowable(e), new Metadata());
+            internalClose(Status.fromThrowable(e), Status.trailersFromThrowable(e));
             throw e;
           }
         }
@@ -585,10 +585,10 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
           try {
             getListener().halfClosed();
           } catch (RuntimeException e) {
-            internalClose(Status.fromThrowable(e), new Metadata());
+            internalClose(Status.fromThrowable(e), Status.trailersFromThrowable(e));
             throw e;
           } catch (Error e) {
-            internalClose(Status.fromThrowable(e), new Metadata());
+            internalClose(Status.fromThrowable(e), Status.trailersFromThrowable(e));
             throw e;
           }
         }
@@ -619,10 +619,10 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
           try {
             getListener().onReady();
           } catch (RuntimeException e) {
-            internalClose(Status.fromThrowable(e), new Metadata());
+            internalClose(Status.fromThrowable(e), Status.trailersFromThrowable(e));
             throw e;
           } catch (Error e) {
-            internalClose(Status.fromThrowable(e), new Metadata());
+            internalClose(Status.fromThrowable(e), Status.trailersFromThrowable(e));
             throw e;
           }
         }

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -287,11 +287,7 @@ public final class ServerCalls {
 
     @Override
     public void onError(Throwable t) {
-      Metadata metadata = Status.trailersFromThrowable(t);
-      if (metadata == null) {
-        metadata = new Metadata();
-      }
-      call.close(Status.fromThrowable(t), metadata);
+      call.close(Status.fromThrowable(t), Status.trailersFromThrowable(t));
     }
 
     @Override


### PR DESCRIPTION
This propagates trailers to the client when server code throws a StatusRuntimeException.

Previously trailers were only propagated by invoking `responseListener.onError()`.  
This previous behavior was surprising behavior because the Status is passed back to the client when throwing exceptions, but the trailers were lost.

This will allow application code to communicate trailers without handing the responseListener through the stack.