### PR TITLE
doc: fix link to class in java doc

### DIFF
--- a/core/src/test/java/io/grpc/internal/ManagedChannelImpl2Test.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImpl2Test.java
@@ -225,7 +225,7 @@ public class ManagedChannelImpl2Test {
   }
 
   /**
-   * The counterpart of {@link ManagedChannelImpl2IdlenessTest#enterIdleModeAfterForceExit}.
+   * The counterpart of {@link ManagedChannelImplIdlenessTest#enterIdleModeAfterForceExit}.
    */
   @Test
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Links to correct class now.