### PR TITLE
context: declare that context should not be mocked

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -87,8 +87,10 @@ import java.util.logging.Logger;
  * they store.</li>
  *    <li>Context is not intended for passing optional parameters to an API and developers should
  * take care to avoid excessive dependence on context when designing an API.</li>
+ *    <li>Do not mock this class.  Use {@link #ROOT} for a non-null instance.
  * </ul>
  */
+/* @DoNotMock("Use ROOT for a non-null Context") // commented out to avoid dependencies  */
 public class Context {
 
   private static final Logger log = Logger.getLogger(Context.class.getName());


### PR DESCRIPTION
Normally I would make this final, but CancellableContext extends it, and it's public API now.  We can't really add `@DoNotMock` since it is a dependency, even as compileOnly, since the retention is runtime.  It seems a menacing comment is the best we can do.