### PR TITLE
compiler: update path to protoc plugin in README.md

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -34,17 +34,17 @@ You will see a `PASS` if the test succeeds.
 
 To compile a proto file and generate Java interfaces out of the service definitions:
 ```
-$ protoc --plugin=protoc-gen-grpc-java=build/binaries/java_pluginExecutable/protoc-gen-grpc-java \
+$ protoc --plugin=protoc-gen-grpc-java=build/exe/java_plugin/protoc-gen-grpc-java \
   --grpc-java_out="$OUTPUT_FILE" --proto_path="$DIR_OF_PROTO_FILE" "$PROTO_FILE"
 ```
 To generate Java interfaces with protobuf lite:
 ```
-$ protoc --plugin=protoc-gen-grpc-java=build/binaries/java_pluginExecutable/protoc-gen-grpc-java \
+$ protoc --plugin=protoc-gen-grpc-java=build/exe/java_plugin/protoc-gen-grpc-java \
   --grpc-java_out=lite:"$OUTPUT_FILE" --proto_path="$DIR_OF_PROTO_FILE" "$PROTO_FILE"
 ```
 To generate Java interfaces with protobuf nano:
 ```
-$ protoc --plugin=protoc-gen-grpc-java=build/binaries/java_pluginExecutable/protoc-gen-grpc-java \
+$ protoc --plugin=protoc-gen-grpc-java=build/exe/java_plugin/protoc-gen-grpc-java \
   --grpc-java_out=nano:"$OUTPUT_FILE" --proto_path="$DIR_OF_PROTO_FILE" "$PROTO_FILE"
 ```
 


### PR DESCRIPTION
Now matches the actual value used for `javaPluginPath` in
https://github.com/grpc/grpc-java/blob/master/build.gradle#L65.