### PR TITLE
all: Downgrade to Guava 19

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -57,9 +57,6 @@ protobuf {
 dependencies {
     compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'com.google.android.gms:play-services-base:7.3.0'
-    compile 'com.google.code.findbugs:jsr305:3.0.0'
-    compile 'com.google.guava:guava:18.0'
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
     // You need to build grpc-java to obtain these libraries below.
     compile 'io.grpc:grpc-protobuf-nano:1.2.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     compile 'io.grpc:grpc-okhttp:1.2.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects {
         protocPluginBaseName = 'protoc-gen-grpc-java'
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
-        guavaVersion = '20.0'
+        guavaVersion = '19.0'
         protobufVersion = '3.2.0'
         protobufNanoVersion = '3.0.0-alpha-5'
 

--- a/core/src/main/java/io/grpc/internal/MoreThrowables.java
+++ b/core/src/main/java/io/grpc/internal/MoreThrowables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,38 +31,26 @@
 
 package io.grpc.internal;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.base.Preconditions;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-/**
- * A simple wrapper for a {@link Runnable} that logs any exception thrown by it, before
- * re-throwing it.
- */
-public final class LogExceptionRunnable implements Runnable {
-
-  private static final Logger log = Logger.getLogger(LogExceptionRunnable.class.getName());
-
-  private final Runnable task;
-
-  public LogExceptionRunnable(Runnable task) {
-    this.task = checkNotNull(task, "task");
-  }
-
-  @Override
-  public void run() {
-    try {
-      task.run();
-    } catch (Throwable t) {
-      log.log(Level.SEVERE, "Exception while executing runnable " + task, t);
-      MoreThrowables.throwIfUnchecked(t);
-      throw new AssertionError(t);
+/** Utility functions when interacting with {@link Throwables}. */
+final class MoreThrowables {
+  /**
+   * Throws {code t} if it is an instance of {@link RuntimeException} or {@link Error}.
+   *
+   * <p>This is intended to mimic Guava's method by the same name, but which is unavailable to us
+   * due to compatibility with older Guava versions.
+   */
+  public static void throwIfUnchecked(Throwable t) {
+    Preconditions.checkNotNull(t);
+    if (t instanceof RuntimeException) {
+      throw (RuntimeException) t;
+    }
+    if (t instanceof Error) {
+      throw (Error) t;
     }
   }
 
-  @Override
-  public String toString() {
-    return "LogExceptionRunnable(" + task + ")";
-  }
+  // Prevent instantiation
+  private MoreThrowables() {}
 }

--- a/core/src/main/java/io/grpc/internal/MoreThrowables.java
+++ b/core/src/main/java/io/grpc/internal/MoreThrowables.java
@@ -34,6 +34,7 @@ package io.grpc.internal;
 import com.google.common.base.Preconditions;
 
 /** Utility functions when interacting with {@link Throwables}. */
+// TODO(ejona): Delete this once we've upgraded to Guava 20 or later.
 final class MoreThrowables {
   /**
    * Throws {code t} if it is an instance of {@link RuntimeException} or {@link Error}.

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -39,7 +39,6 @@ import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import io.grpc.Attributes;
 import io.grpc.Codec;
 import io.grpc.Compressor;
@@ -247,7 +246,7 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
         } finally {
           if (t != null) {
             // TODO(carl-mastrangelo): Maybe log e here.
-            Throwables.throwIfUnchecked(t);
+            MoreThrowables.throwIfUnchecked(t);
             throw new RuntimeException(t);
           }
         }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -52,9 +52,6 @@ protobuf {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:22.1.1'
-    compile 'com.google.code.findbugs:jsr305:3.0.0'
-    compile 'com.google.guava:guava:20.0'
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
 
     // You need to build grpc-java to obtain these libraries below.
     compile 'io.grpc:grpc-okhttp:1.2.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -50,9 +50,6 @@ protobuf {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:23.+'
-    compile 'com.google.code.findbugs:jsr305:3.0.0'
-    compile 'com.google.guava:guava:20.0'
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
 
     // You need to build grpc-java to obtain these libraries below.
     compile 'io.grpc:grpc-okhttp:1.2.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1254,7 +1254,7 @@ public abstract class AbstractInteropTest {
 
     HostAndPort remoteAddress = HostAndPort.fromString(serverCallCapture.get().getAttributes()
             .get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR).toString());
-    assertEquals(expectedRemoteAddress, remoteAddress.getHost());
+    assertEquals(expectedRemoteAddress, remoteAddress.getHostText());
   }
 
   /** Helper for asserting TLS info in SSLSession {@link io.grpc.ServerCall#getAttributes()} */

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -51,7 +51,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.net.HostAndPort;
 import com.google.instrumentation.stats.RpcConstants;
 import com.google.instrumentation.stats.StatsContextFactory;
 import com.google.instrumentation.stats.TagValue;
@@ -1252,9 +1251,12 @@ public abstract class AbstractInteropTest {
 
     stub.unaryCall(SimpleRequest.getDefaultInstance());
 
-    HostAndPort remoteAddress = HostAndPort.fromString(serverCallCapture.get().getAttributes()
-            .get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR).toString());
-    assertEquals(expectedRemoteAddress, remoteAddress.getHostText());
+    String inetSocketString = serverCallCapture.get().getAttributes()
+        .get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR).toString();
+    // The substring is simply host:port, even if host is IPv6 as it fails to use []. Can't use
+    // standard parsing because the string isn't following any standard.
+    String host = inetSocketString.substring(0, inetSocketString.lastIndexOf(':'));
+    assertEquals(expectedRemoteAddress, host);
   }
 
   /** Helper for asserting TLS info in SSLSession {@link io.grpc.ServerCall#getAttributes()} */


### PR DESCRIPTION
Guava 20 introduced some overloading optimizations for Preconditions
that require using Guava 20+ at runtime. Unfortunately, Guava 20 removes
some things that is causing incompatibilities with other libraries, like
Cassandra. While the incompatibility did trigger some of those libraries
to improve compatibility for newer Guavas, we'd like to give the
community more time to work through it. See #2688

At this commit, we appear to be compatible with Guava 18+. It's not
clear if we want to actually "support" 18, but it did compile. Guava 17
doesn't have at least MoreObjects, directExecutor, and firstNotNull.
Guava 21 compiles without warnings, so it should be compatible with
Guava 22 when it is released.

One test method will fail with the upcoming Guava 22, but this won't
impact applications. I made MoreThrowables to avoid using any
known-deprecated Guava methods in our JARs, to reduce pain for those
stuck with old versions of gRPC in the future (July 2018).

In the stand-alone Android apps I removed unnecessary explicit deps
instead of syncing the version used.