### PR TITLE
netty: Use tcnative in tests instead of Jetty ALPN

### DIFF
--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -7,11 +7,8 @@ dependencies {
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
                 project(':grpc-testing')
+    testRuntime libraries.netty_tcnative
     signature "org.codehaus.mojo.signature:java17:+@signature"
-}
-
-test {
-    jvmArgs "-javaagent:" + configurations.alpnagent.asPath
 }
 
 javadoc.options.links 'http://netty.io/4.1/api/'


### PR DESCRIPTION
I'm quite confused how we went this long using Jetty ALPN for the Netty
tests. Anyway, we strongly prefer tcnative, so we should be using it in
the tests.

CC @lukaszx0 