### PR TITLE
interop-testing: Remove useless tcnative configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,6 @@ subprojects {
     // Define a separate configuration for managing the dependency on Jetty ALPN agent.
     configurations {
         alpnagent
-        tcnative
     }
 
     dependencies {
@@ -204,9 +203,6 @@ subprojects {
 
         // Configuration for modules that use Jetty ALPN agent
         alpnagent libraries.jetty_alpn_agent
-
-        // Configuration for modules that use Netty tcnative (for OpenSSL).
-        tcnative libraries.netty_tcnative
 
         // The ErrorProne plugin defaults to the latest, which would break our
         // build if error prone releases a new version with a new check

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -23,19 +23,6 @@ test {
     jvmArgs "-javaagent:" + configurations.alpnagent.asPath
 }
 
-// The application plugin uses the distribution plugin and configures the jars to be
-// placed into the "lib" folder. Since we don't include netty_tcnative as a dependency,
-// we have to manually copy it into the lib folder so that it's available to the scripts.
-distributions {
-    main {
-        contents {
-            from(configurations.tcnative) {
-                into "lib"
-            }
-        }
-    }
-}
-
 // For the generated scripts, use Netty tcnative (i.e. OpenSSL).
 // Note that OkHttp currently only supports ALPN, so OpenSSL version >= 1.0.2 is required.
 
@@ -43,28 +30,28 @@ task test_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.TestServiceClient"
     applicationName = "test-client"
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + configurations.runtime + configurations.tcnative
+    classpath = jar.outputs.files + configurations.runtime
 }
 
 task test_server(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.TestServiceServer"
     applicationName = "test-server"
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + configurations.runtime + configurations.tcnative
+    classpath = jar.outputs.files + configurations.runtime
 }
 
 task reconnect_test_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.ReconnectTestClient"
     applicationName = "reconnect-test-client"
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + configurations.runtime + configurations.tcnative
+    classpath = jar.outputs.files + configurations.runtime
 }
 
 task stresstest_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.StressTestClient"
     applicationName = "stresstest-client"
     outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + configurations.runtime + configurations.tcnative
+    classpath = jar.outputs.files + configurations.runtime
     defaultJvmOpts = ["-verbose:gc", "-XX:+PrintFlagsFinal"]
 }
 


### PR DESCRIPTION
It doesn't do anything, since tcnative has been specified as a normal
dependency for a while.