### PR TITLE
grpclb: fix a bug in handling server address updates.

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -356,13 +356,16 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
           EquivalentAddressGroup eag = new EquivalentAddressGroup(address);
           // TODO(zhangkun83): save the LB token and insert it to the application RPCs' headers.
           if (!newSubchannelMap.containsKey(eag)) {
-            Attributes subchannelAttrs = Attributes.newBuilder()
-                .set(STATE_INFO,
-                    new AtomicReference<ConnectivityStateInfo>(
-                        ConnectivityStateInfo.forNonError(IDLE)))
-                .build();
-            Subchannel subchannel = helper.createSubchannel(eag, subchannelAttrs);
-            subchannel.requestConnection();
+            Subchannel subchannel = subchannels.get(eag);
+            if (subchannel == null) {
+              Attributes subchannelAttrs = Attributes.newBuilder()
+                  .set(STATE_INFO,
+                      new AtomicReference<ConnectivityStateInfo>(
+                          ConnectivityStateInfo.forNonError(IDLE)))
+                  .build();
+              subchannel = helper.createSubchannel(eag, subchannelAttrs);
+              subchannel.requestConnection();
+            }
             newSubchannelMap.put(eag, subchannel);
           }
           newRoundRobinList.add(eag);


### PR DESCRIPTION
It didn't check if the address was already there in the current
subchannel set before creating a new subchannel for it, causing a leak
of subchannels.