### PR TITLE
doc: fix @link to cancel in java doc

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
@@ -76,8 +76,8 @@ public abstract class AbstractClientStream2 extends AbstractStream2
      * Tears down the stream, typically in the event of a timeout. This method may be called
      * multiple times and from any thread.
      *
-     * <p>This is a clone of {@link ClientStream#cancel()}; {@link AbstractClientStream2#cancel}
-     * delegates to this method.
+     * <p>This is a clone of {@link ClientStream#cancel(Status)};
+     * {@link AbstractClientStream2#cancel} delegates to this method.
      */
     void cancel(Status status);
   }


### PR DESCRIPTION
Minor fix to make linking work in IDEs.