### PR TITLE
doc: there's no type param anymore

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -44,8 +44,6 @@ import javax.annotation.concurrent.GuardedBy;
 
 /**
  * Abstract base class for {@link Stream} implementations.
- *
- * @param <IdT> type of the unique identifier of this stream.
  */
 public abstract class AbstractStream implements Stream {
   /**


### PR DESCRIPTION
Small clean up of a doc that is irrelevant