### PR TITLE
core: fix keepalivemanager bug on handling IDLE_AND_PING_SENT

### DIFF
--- a/core/src/main/java/io/grpc/internal/KeepAliveManager.java
+++ b/core/src/main/java/io/grpc/internal/KeepAliveManager.java
@@ -175,6 +175,8 @@ public class KeepAliveManager {
       state = State.PING_SCHEDULED;
       pingFuture = scheduler.schedule(sendPing, nextKeepaliveTime - ticker.read(),
           TimeUnit.NANOSECONDS);
+    } else if (state == State.IDLE_AND_PING_SENT) {
+      state = State.PING_SENT;
     }
   }
 


### PR DESCRIPTION
There was a bug:
IDLE_AND_PING_SENT -> a new stream starts -> ping acked
would lead the keepalivemanager into IDLE state forever.