### PR TITLE
Fix shared subchannel state in RoundRobin LB

### DIFF
--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory.java
@@ -109,19 +109,19 @@ public class RoundRobinLoadBalancerFactory extends LoadBalancer.Factory {
       Set<EquivalentAddressGroup> addedAddrs = setsDifference(latestAddrs, currentAddrs);
       Set<EquivalentAddressGroup> removedAddrs = setsDifference(currentAddrs, latestAddrs);
 
-      // NB(lukaszx0): we don't merge `attributes` with `subchannelAttr` because subchannel doesn't
-      // need them. They're describing the resolved server list but we're not taking any action
-      // based on this information.
-      Attributes subchannelAttrs = Attributes.newBuilder()
-          // NB(lukaszx0): because attributes are immutable we can't set new value for the key
-          // after creation but since we can mutate the values we leverge that and set
-          // AtomicReference which will allow mutating state info for given channel.
-          .set(STATE_INFO, new AtomicReference<ConnectivityStateInfo>(
-              ConnectivityStateInfo.forNonError(IDLE)))
-          .build();
-
       // Create new subchannels for new addresses.
       for (EquivalentAddressGroup addressGroup : addedAddrs) {
+        // NB(lukaszx0): we don't merge `attributes` with `subchannelAttr` because subchannel
+        // doesn't need them. They're describing the resolved server list but we're not taking
+        // any action based on this information.
+        Attributes subchannelAttrs = Attributes.newBuilder()
+            // NB(lukaszx0): because attributes are immutable we can't set new value for the key
+            // after creation but since we can mutate the values we leverge that and set
+            // AtomicReference which will allow mutating state info for given channel.
+            .set(STATE_INFO, new AtomicReference<ConnectivityStateInfo>(
+                ConnectivityStateInfo.forNonError(IDLE)))
+            .build();
+
         Subchannel subchannel = checkNotNull(helper.createSubchannel(addressGroup, subchannelAttrs),
             "subchannel");
         subchannels.put(addressGroup, subchannel);

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -116,7 +116,7 @@ public class RoundRobinLoadBalancerTest {
           public Subchannel answer(InvocationOnMock invocation) throws Throwable {
             Object[] args = invocation.getArguments();
             Subchannel subchannel = subchannels.get(args[0]);
-            when(subchannel.getAttributes()).thenReturn((Attributes)args[1]);
+            when(subchannel.getAttributes()).thenReturn((Attributes) args[1]);
             return subchannel;
           }
         });


### PR DESCRIPTION
handleResolvedAddresses constructs subchannels for each address in
an EquivalentAddressGroup, sharing a reference to an immutable
Atrributes. However, as noted, this Attributes instance contains
a mutable AtomicReference, eventually causing subchannel state
changes to be improperly reflected in *all* subchannels of an
EquivalentAddressGroup.

This change gives each subchannel its own Attributes instance, mitigating
this issue.