### PR TITLE
core/netty/okhttp: KeepAliveManager with Pinger

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -46,6 +46,7 @@ import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
 import io.grpc.internal.KeepAliveManager;
+import io.grpc.internal.KeepAliveManager.ClientKeepAlivePinger;
 import io.grpc.internal.LogId;
 import io.grpc.internal.StatsTraceContext;
 import io.netty.bootstrap.Bootstrap;
@@ -231,7 +232,8 @@ class NettyClientTransport implements ConnectionClientTransport {
     });
 
     if (enableKeepAlive) {
-      keepAliveManager = new KeepAliveManager(this, channel.eventLoop(), keepAliveDelayNanos,
+      keepAliveManager = new KeepAliveManager(
+          new ClientKeepAlivePinger(this), channel.eventLoop(), keepAliveDelayNanos,
           keepAliveTimeoutNanos);
     }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -55,6 +55,7 @@ import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
 import io.grpc.internal.KeepAliveManager;
+import io.grpc.internal.KeepAliveManager.ClientKeepAlivePinger;
 import io.grpc.internal.LogId;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.internal.SharedResourceHolder;
@@ -369,8 +370,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
 
     if (enableKeepAlive) {
       scheduler = SharedResourceHolder.get(TIMER_SERVICE);
-      keepAliveManager = new KeepAliveManager(this, scheduler, keepAliveDelayNanos,
-          keepAliveTimeoutNanos);
+      keepAliveManager = new KeepAliveManager(
+          new ClientKeepAlivePinger(this), scheduler, keepAliveDelayNanos, keepAliveTimeoutNanos);
     }
 
     frameWriter = new AsyncFrameWriter(this, serializingExecutor);


### PR DESCRIPTION
* Preparing to support server side keepalive, modified KeepAliveManager to use a Pinger interface, which can send ping or shutdown transport regardless of server or client.

* On server side, keepalive is happening even the transport is idle, so the IDLE and IDLE_AND_PING_SENT states do not make sense for server. Therefore removed `IDLE`, `IDLE_AND_PING_SENT`, and `DISCONNECTED` states, and used boolean variables `isIdle`, `isShutdown`, and `noPingWhenIdle` to do more fine-grained control.

* Not to use Ping `onSuccess()` callback to cancle shutdownFuture any more, instead, regard `onDataReceived()` as ping Ack.