### PR TITLE
netty/test: be less agreesive on checking cause

### DIFF
--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -309,8 +309,7 @@ public class NettyClientTransportTest {
       fail("The stream should have been failed due to server received header exceeds header list"
           + " size limit!");
     } catch (Exception e) {
-      Throwable rootCause = getRootCause(e);
-      Status status = ((StatusException) rootCause).getStatus();
+      Status status = Status.fromThrowable(e);
       assertEquals(status.toString(), Status.Code.INTERNAL, status.getCode());
     }
   }


### PR DESCRIPTION
For #2762

If it doesn't fix the flaky test, status.toString() will print out the
whole stack trace so that we will know what's in there.