### PR TITLE
examples: Always pass an executor to Futures.addCallback()

### DIFF
--- a/examples/src/main/java/io/grpc/examples/errorhandling/DetailErrorSample.java
+++ b/examples/src/main/java/io/grpc/examples/errorhandling/DetailErrorSample.java
@@ -31,6 +31,8 @@
 
 package io.grpc.examples.errorhandling;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
 import com.google.common.base.Verify;
 import com.google.common.base.VerifyException;
 import com.google.common.util.concurrent.FutureCallback;
@@ -157,18 +159,21 @@ public class DetailErrorSample {
 
     final CountDownLatch latch = new CountDownLatch(1);
 
-    Futures.addCallback(response, new FutureCallback<HelloReply>() {
-      @Override
-      public void onSuccess(@Nullable HelloReply result) {
-        // Won't be called, since the server in this example always fails.
-      }
+    Futures.addCallback(
+        response,
+        new FutureCallback<HelloReply>() {
+          @Override
+          public void onSuccess(@Nullable HelloReply result) {
+            // Won't be called, since the server in this example always fails.
+          }
 
-      @Override
-      public void onFailure(Throwable t) {
-        verifyErrorReply(t);
-        latch.countDown();
-      }
-    });
+          @Override
+          public void onFailure(Throwable t) {
+            verifyErrorReply(t);
+            latch.countDown();
+          }
+        },
+        directExecutor());
 
     if (!Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.SECONDS)) {
       throw new RuntimeException("timeout!");

--- a/examples/src/main/java/io/grpc/examples/errorhandling/ErrorHandlingClient.java
+++ b/examples/src/main/java/io/grpc/examples/errorhandling/ErrorHandlingClient.java
@@ -31,6 +31,8 @@
 
 package io.grpc.examples.errorhandling;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
 import com.google.common.base.Verify;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -130,21 +132,24 @@ public class ErrorHandlingClient {
 
     final CountDownLatch latch = new CountDownLatch(1);
 
-    Futures.addCallback(response, new FutureCallback<HelloReply>() {
-      @Override
-      public void onSuccess(@Nullable HelloReply result) {
-        // Won't be called, since the server in this example always fails.
-      }
+    Futures.addCallback(
+        response,
+        new FutureCallback<HelloReply>() {
+          @Override
+          public void onSuccess(@Nullable HelloReply result) {
+            // Won't be called, since the server in this example always fails.
+          }
 
-      @Override
-      public void onFailure(Throwable t) {
-        Status status = Status.fromThrowable(t);
-        Verify.verify(status.getCode() == Status.Code.INTERNAL);
-        Verify.verify(status.getDescription().contains("Crybaby"));
-        // Cause is not transmitted over the wire..
-        latch.countDown();
-      }
-    });
+          @Override
+          public void onFailure(Throwable t) {
+            Status status = Status.fromThrowable(t);
+            Verify.verify(status.getCode() == Status.Code.INTERNAL);
+            Verify.verify(status.getDescription().contains("Crybaby"));
+            // Cause is not transmitted over the wire..
+            latch.countDown();
+          }
+        },
+        directExecutor());
 
     if (!Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.SECONDS)) {
       throw new RuntimeException("timeout!");


### PR DESCRIPTION
The executor-less version is being removed, as having the executor
explicitly specified is less bug-prone.