### PR TITLE
core: fix keepalivemanager bug on handling IDLE_AND_PING_SENT (backport 1.0.x)

### DIFF
--- a/core/src/main/java/io/grpc/internal/KeepAliveManager.java
+++ b/core/src/main/java/io/grpc/internal/KeepAliveManager.java
@@ -177,6 +177,8 @@ public class KeepAliveManager {
       state = State.PING_SCHEDULED;
       pingFuture = scheduler.schedule(sendPing, nextKeepaliveTime - ticker.read(),
           TimeUnit.NANOSECONDS);
+    } else if (state == State.IDLE_AND_PING_SENT) {
+      state = State.PING_SENT;
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
@@ -378,5 +378,40 @@ public final class KeepAliveManagerTest {
     pingCallback.onFailure(new Throwable());
     verify(transport, times(0)).shutdownNow(isA(Status.class));
   }
+
+  @Test
+  public void pingSentThenIdleThenActiveThenAck() {
+    keepAliveManager.onTransportActive();
+    ArgumentCaptor<Runnable> sendPingCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(scheduler, times(1))
+        .schedule(sendPingCaptor.capture(), isA(Long.class), isA(TimeUnit.class));
+    Runnable sendPing = sendPingCaptor.getValue();
+    ScheduledFuture<?> shutdownFuture = mock(ScheduledFuture.class);
+    // ping scheduled
+    doReturn(shutdownFuture)
+        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
+
+    // Mannually running the Runnable will send the ping.
+    ticker.time = 1000;
+    sendPing.run();
+
+    // shutdown scheduled
+    verify(scheduler, times(2))
+        .schedule(sendPingCaptor.capture(), isA(Long.class), isA(TimeUnit.class));
+    ArgumentCaptor<ClientTransport.PingCallback> pingCallbackCaptor =
+        ArgumentCaptor.forClass(ClientTransport.PingCallback.class);
+    verify(transport).ping(pingCallbackCaptor.capture(), isA(Executor.class));
+    ClientTransport.PingCallback pingCallback = pingCallbackCaptor.getValue();
+
+    keepAliveManager.onTransportIdle();
+
+    keepAliveManager.onTransportActive();
+
+    pingCallback.onSuccess(100);
+
+    // another ping scheduled
+    verify(scheduler, times(3))
+        .schedule(sendPingCaptor.capture(), isA(Long.class), isA(TimeUnit.class));
+  }
 }
 


### PR DESCRIPTION
backport of #2773 
There was a bug:
IDLE_AND_PING_SENT -> a new stream starts -> ping acked
would lead the keepalivemanager into IDLE state forever.