### PR TITLE
all: fix errorprones

### DIFF
--- a/core/src/test/java/io/grpc/ServiceDescriptorTest.java
+++ b/core/src/test/java/io/grpc/ServiceDescriptorTest.java
@@ -36,6 +36,7 @@ import io.grpc.testing.TestMethodDescriptors;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -77,23 +78,22 @@ public class ServiceDescriptorTest {
 
   @Test
   public void failsOnNonMatchingNames() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("service names");
-
-    new ServiceDescriptor("name", Collections.<MethodDescriptor<?, ?>>singletonList(
+    List<MethodDescriptor<?, ?>> descriptors = Collections.<MethodDescriptor<?, ?>>singletonList(
         MethodDescriptor.create(
             MethodType.UNARY,
             MethodDescriptor.generateFullMethodName("wrongservice", "method"),
             TestMethodDescriptors.voidMarshaller(),
-            TestMethodDescriptors.voidMarshaller())));
+            TestMethodDescriptors.voidMarshaller()));
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("service names");
+
+    new ServiceDescriptor("name", descriptors);
   }
 
   @Test
   public void failsOnNonDuplicateNames() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("duplicate");
-
-    new ServiceDescriptor("name", Arrays.<MethodDescriptor<?, ?>>asList(
+    List<MethodDescriptor<?, ?>> descriptors = Arrays.<MethodDescriptor<?, ?>>asList(
         MethodDescriptor.create(
             MethodType.UNARY,
             MethodDescriptor.generateFullMethodName("name", "method"),
@@ -103,6 +103,11 @@ public class ServiceDescriptorTest {
             MethodType.UNARY,
             MethodDescriptor.generateFullMethodName("name", "method"),
             TestMethodDescriptors.voidMarshaller(),
-            TestMethodDescriptors.voidMarshaller())));
+            TestMethodDescriptors.voidMarshaller()));
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("duplicate");
+
+    new ServiceDescriptor("name", descriptors);
   }
 }

--- a/core/src/test/java/io/grpc/internal/AbstractClientStream2Test.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStream2Test.java
@@ -42,6 +42,7 @@ import io.grpc.Codec;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
+import io.grpc.internal.AbstractClientStream2.TransportState;
 import io.grpc.internal.MessageFramerTest.ByteWritableBuffer;
 import org.junit.Before;
 import org.junit.Rule;
@@ -149,9 +150,11 @@ public class AbstractClientStream2Test {
     ClientStreamListener listener = new NoopClientStreamListener();
     AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
     stream.start(listener);
-    thrown.expect(NullPointerException.class);
 
-    stream.transportState().inboundDataReceived(null);
+    TransportState state = stream.transportState();
+
+    thrown.expect(NullPointerException.class);
+    state.inboundDataReceived(null);
   }
 
   @Test
@@ -181,8 +184,10 @@ public class AbstractClientStream2Test {
     stream.start(mockListener);
     stream.transportState().transportReportStatus(Status.CANCELLED, false, new Metadata());
 
+    TransportState state = stream.transportState();
+
     thrown.expect(IllegalStateException.class);
-    stream.transportState().inboundHeadersReceived(new Metadata());
+    state.inboundHeadersReceived(new Metadata());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.verify;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.internal.AbstractServerStream.TransportState;
 import io.grpc.internal.MessageFramerTest.ByteWritableBuffer;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -105,19 +106,22 @@ public class AbstractServerStreamTest {
 
   @Test
   public void setListener_setOnlyOnce() {
-    stream.transportState().setListener(new ServerStreamListenerBase());
+    TransportState state = stream.transportState();
+    state.setListener(new ServerStreamListenerBase());
     thrown.expect(IllegalStateException.class);
 
-    stream.transportState().setListener(new ServerStreamListenerBase());
+    state.setListener(new ServerStreamListenerBase());
   }
 
   @Test
   public void listenerReady_onlyOnce() {
     stream.transportState().setListener(new ServerStreamListenerBase());
     stream.transportState().onStreamAllocated();
-    thrown.expect(IllegalStateException.class);
 
-    stream.transportState().onStreamAllocated();
+    TransportState state = stream.transportState();
+
+    thrown.expect(IllegalStateException.class);
+    state.onStreamAllocated();
   }
 
 
@@ -132,9 +136,10 @@ public class AbstractServerStreamTest {
 
   @Test
   public void setListener_failsOnNull() {
-    thrown.expect(NullPointerException.class);
+    TransportState state = stream.transportState();
 
-    stream.transportState().setListener(null);
+    thrown.expect(NullPointerException.class);
+    state.setListener(null);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -271,13 +271,14 @@ public class MessageDeframerTest {
     SizeEnforcingInputStream stream =
         new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
 
-    thrown.expect(StatusRuntimeException.class);
-    thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
+    try {
+      thrown.expect(StatusRuntimeException.class);
+      thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
 
-    while (stream.read() != -1) {}
-
-    // Never run, makes compiler nag go away
-    stream.close();
+      while (stream.read() != -1) {}
+    } finally {
+      stream.close();
+    }
   }
 
   @Test
@@ -317,13 +318,14 @@ public class MessageDeframerTest {
         new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
     byte[] buf = new byte[10];
 
-    thrown.expect(StatusRuntimeException.class);
-    thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
+    try {
+      thrown.expect(StatusRuntimeException.class);
+      thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
 
-    stream.read(buf, 0, buf.length);
-
-    // Never called
-    stream.close();
+      stream.read(buf, 0, buf.length);
+    } finally {
+      stream.close();
+    }
   }
 
   @Test
@@ -361,13 +363,14 @@ public class MessageDeframerTest {
     SizeEnforcingInputStream stream =
         new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
 
-    thrown.expect(StatusRuntimeException.class);
-    thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
+    try {
+      thrown.expect(StatusRuntimeException.class);
+      thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
 
-    stream.skip(4);
-
-    // never run
-    stream.close();
+      stream.skip(4);
+    } finally {
+      stream.close();
+    }
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -322,9 +322,11 @@ public class ServerCallImplTest {
         .when(callListener)
         .onMessage(any(Long.class));
 
+    InputStream inputStream = method.streamRequest(1234L);
+
     thrown.expect(RuntimeException.class);
     thrown.expectMessage("unexpected exception");
-    streamListener.messageRead(method.streamRequest(1234L));
+    streamListener.messageRead(inputStream);
   }
 
   private void checkStats(Status.Code statusCode) {

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -74,9 +74,7 @@ public class NettyChannelBuilderTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid authority:");
 
-    Object unused = builder.overrideAuthority("[invalidauthority")
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .buildTransportFactory();
+    builder.overrideAuthority("[invalidauthority");
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -69,10 +69,10 @@ public class NettyChannelBuilderTest {
 
   @Test
   public void failOverrideInvalidAuthority() {
+    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
+
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid authority:");
-
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
 
     Object unused = builder.overrideAuthority("[invalidauthority")
         .negotiationType(NegotiationType.PLAINTEXT)
@@ -96,12 +96,12 @@ public class NettyChannelBuilderTest {
 
   @Test
   public void failIfSslContextIsNotClient() {
+    SslContext sslContext = mock(SslContext.class);
+    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
+
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Server SSL context can not be used for client channel");
 
-    SslContext sslContext = mock(SslContext.class);
-
-    NettyChannelBuilder builder = new NettyChannelBuilder(new SocketAddress(){});
     builder.sslContext(sslContext);
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyServerBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerBuilderTest.java
@@ -58,13 +58,13 @@ public class NettyServerBuilderTest {
 
   @Test
   public void failIfSslContextIsNotServer() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Client SSL context can not be used for server");
-
     SslContext sslContext = mock(SslContext.class);
     when(sslContext.isClient()).thenReturn(true);
 
-    NettyServerBuilder builder = NettyServerBuilder.forPort(8080);;
+    NettyServerBuilder builder = NettyServerBuilder.forPort(8080);
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Client SSL context can not be used for server");
     builder.sslContext(sslContext);
   }
 }

--- a/netty/src/test/java/io/grpc/netty/NettyStreamTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyStreamTestBase.java
@@ -83,12 +83,16 @@ public abstract class NettyStreamTestBase<T extends Stream> {
   @Mock
   private ChannelPipeline pipeline;
 
+  // ChannelFuture has too many methods to implement; we stubbed all necessary methods of Future.
+  @SuppressWarnings("DoNotMock")
   @Mock
   protected ChannelFuture future;
 
   @Mock
   protected EventLoop eventLoop;
 
+  // ChannelPromise has too many methods to implement; we stubbed all necessary methods of Future.
+  @SuppressWarnings("DoNotMock")
   @Mock
   protected ChannelPromise promise;
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -69,13 +69,11 @@ public class OkHttpChannelBuilderTest {
 
   @Test
   public void failOverrideInvalidAuthority() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid authority:");
     OkHttpChannelBuilder builder = new OkHttpChannelBuilder("good", 1234);
 
-    builder.overrideAuthority("[invalidauthority")
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .buildTransportFactory();
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid authority:");
+    builder.overrideAuthority("[invalidauthority");
   }
 
   @Test


### PR DESCRIPTION
fix JavaStyle and ErrorProne warnings found in internal weekly import:

- Calls to ExpectedException#expect should always be followed by exactly one statement.
- Do not mock 'java.util.concurrent.Future'