### PR TITLE
grpclb: set LB tokens to headers.

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -31,6 +31,7 @@
 
 package io.grpc;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -346,6 +347,20 @@ public abstract class LoadBalancer {
     @Override
     public String toString() {
       return "[subchannel=" + subchannel + " status=" + status + "]";
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(subchannel, status);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof PickResult)) {
+        return false;
+      }
+      PickResult that = (PickResult) other;
+      return Objects.equal(subchannel, that.subchannel) && Objects.equal(status, that.status);
     }
   }
 

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -204,7 +204,7 @@ public abstract class LoadBalancer {
     public abstract CallOptions getCallOptions();
 
     /**
-     * Call metadata.
+     * Headers of the call. {@code pickSubchannel()} may mutate it before before returning.
      */
     public abstract Metadata getHeaders();
 

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -31,6 +31,7 @@
 
 package io.grpc;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.List;
@@ -346,7 +347,10 @@ public abstract class LoadBalancer {
 
     @Override
     public String toString() {
-      return "[subchannel=" + subchannel + " status=" + status + "]";
+      return MoreObjects.toStringHelper(this)
+          .add("subchannel", subchannel)
+          .add("status", status)
+          .toString();
     }
 
     @Override

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -14,6 +14,7 @@ dependencies {
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.protobuf
+    testCompile libraries.truth
 }
 
 configureProtoCompilation()

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -40,6 +40,7 @@ import static io.grpc.ConnectivityState.SHUTDOWN;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import io.grpc.Attributes;
 import io.grpc.ConnectivityStateInfo;
@@ -487,7 +488,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
   static final class RoundRobinEntry {
     final PickResult result;
     @Nullable
-    final String token;
+    private final String token;
 
     /**
      * A non-drop result.
@@ -514,7 +515,10 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
 
     @Override
     public String toString() {
-      return "[result=" + result + ", token=" + token + "]";
+      return MoreObjects.toStringHelper(this)
+          .add("result", result)
+          .add("token", token)
+          .toString();
     }
 
     @Override
@@ -535,7 +539,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
   @VisibleForTesting
   static final class RoundRobinPicker extends SubchannelPicker {
     final List<RoundRobinEntry> list;
-    int index;
+    private int index;
 
     RoundRobinPicker(List<RoundRobinEntry> resultList) {
       checkArgument(!resultList.isEmpty(), "resultList is empty");

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -40,11 +40,13 @@ import static io.grpc.ConnectivityState.SHUTDOWN;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
 import io.grpc.Attributes;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
 import io.grpc.ResolvedServerInfoGroup;
 import io.grpc.Status;
 import io.grpc.grpclb.GrpclbConstants.LbPolicy;
@@ -90,10 +92,15 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
   private final Factory roundRobinBalancerFactory;
 
   private static final Attributes.Key<AtomicReference<ConnectivityStateInfo>> STATE_INFO =
-        Attributes.Key.of("io.grpc.grpclb.GrpclbLoadBalancer.stateInfo");
+      Attributes.Key.of("io.grpc.grpclb.GrpclbLoadBalancer.stateInfo");
+
   @VisibleForTesting
-  static final PickResult THROTTLED_RESULT =
-      PickResult.withError(Status.UNAVAILABLE.withDescription("Throttled by LB"));
+  static final Metadata.Key<String> TOKEN_KEY =
+      Metadata.Key.of("lb-token", Metadata.ASCII_STRING_MARSHALLER);
+
+  @VisibleForTesting
+  static final RoundRobinEntry DROP_ENTRY =
+      new RoundRobinEntry(Status.UNAVAILABLE.withDescription("Drop requested by balancer"));
 
   // All mutable states in this class are mutated ONLY from Channel Executor
 
@@ -124,8 +131,8 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
   @Nullable
   private StreamObserver<LoadBalanceRequest> lbRequestWriter;
   private Map<EquivalentAddressGroup, Subchannel> subchannels = Collections.emptyMap();
-  // A null element indicate a simulated error for throttling purpose
-  private List<EquivalentAddressGroup> roundRobinList = Collections.emptyList();
+
+  private List<RoundRobinEntry> roundRobinList = Collections.emptyList();
 
   GrpclbLoadBalancer(Helper helper, Factory pickFirstBalancerFactory,
       Factory roundRobinBalancerFactory) {
@@ -337,12 +344,12 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
       ServerList serverList = response.getServerList();
       HashMap<EquivalentAddressGroup, Subchannel> newSubchannelMap =
           new HashMap<EquivalentAddressGroup, Subchannel>();
-      List<EquivalentAddressGroup> newRoundRobinList = new ArrayList<EquivalentAddressGroup>();
+      List<RoundRobinEntry> newRoundRobinList = new ArrayList<RoundRobinEntry>();
       // TODO(zhangkun83): honor expiration_interval
       // Construct the new collections. Create new Subchannels when necessary.
       for (Server server : serverList.getServersList()) {
         if (server.getDropRequest()) {
-          newRoundRobinList.add(null);
+          newRoundRobinList.add(DROP_ENTRY);
         } else {
           InetSocketAddress address;
           try {
@@ -353,9 +360,10 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
             continue;
           }
           EquivalentAddressGroup eag = new EquivalentAddressGroup(address);
-          // TODO(zhangkun83): save the LB token and insert it to the application RPCs' headers.
-          if (!newSubchannelMap.containsKey(eag)) {
-            Subchannel subchannel = subchannels.get(eag);
+          String token = server.getLoadBalanceToken();
+          Subchannel subchannel = newSubchannelMap.get(eag);
+          if (subchannel == null) {
+            subchannel = subchannels.get(eag);
             if (subchannel == null) {
               Attributes subchannelAttrs = Attributes.newBuilder()
                   .set(STATE_INFO,
@@ -367,7 +375,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
             }
             newSubchannelMap.put(eag, subchannel);
           }
-          newRoundRobinList.add(eag);
+          newRoundRobinList.add(new RoundRobinEntry(subchannel, token));
         }
       }
       // Close Subchannels whose addresses have been delisted
@@ -419,21 +427,21 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
    * Make a picker out of the current roundRobinList and the states of subchannels.
    */
   private SubchannelPicker makePicker() {
-    List<PickResult> resultList = new ArrayList<PickResult>();
+    List<RoundRobinEntry> resultList = new ArrayList<RoundRobinEntry>();
     Status error = null;
-    for (EquivalentAddressGroup eag : roundRobinList) {
-      if (eag == null) {
-        resultList.add(THROTTLED_RESULT);
-      } else {
-        Subchannel subchannel = subchannels.get(eag);
-        checkNotNull(subchannel, "Subchannel for %s not found", eag);
+    for (RoundRobinEntry entry : roundRobinList) {
+      Subchannel subchannel = entry.result.getSubchannel();
+      if (subchannel != null) {
         Attributes attrs = subchannel.getAttributes();
         ConnectivityStateInfo stateInfo = attrs.get(STATE_INFO).get();
         if (stateInfo.getState() == READY) {
-          resultList.add(PickResult.withSubchannel(subchannel));
+          resultList.add(entry);
         } else if (stateInfo.getState() == TRANSIENT_FAILURE) {
           error = stateInfo.getStatus();
         }
+      } else {
+        // This is a drop entry.
+        resultList.add(entry);
       }
     }
     if (resultList.isEmpty()) {
@@ -476,11 +484,60 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
   }
 
   @VisibleForTesting
+  static final class RoundRobinEntry {
+    final PickResult result;
+    @Nullable
+    final String token;
+
+    /**
+     * A non-drop result.
+     */
+    RoundRobinEntry(Subchannel subchannel, String token) {
+      this.result = PickResult.withSubchannel(subchannel);
+      this.token = token;
+    }
+
+    /**
+     * A drop result.
+     */
+    RoundRobinEntry(Status dropStatus) {
+      this.result = PickResult.withError(dropStatus);
+      this.token = null;
+    }
+
+    void updateHeaders(Metadata headers) {
+      if (token != null) {
+        headers.discardAll(TOKEN_KEY);
+        headers.put(TOKEN_KEY, token);
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "[result=" + result + ", token=" + token + "]";
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(result, token);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof RoundRobinEntry)) {
+        return false;
+      }
+      RoundRobinEntry that = (RoundRobinEntry) other;
+      return Objects.equal(result, that.result) && Objects.equal(token, that.token);
+    }
+  }
+
+  @VisibleForTesting
   static final class RoundRobinPicker extends SubchannelPicker {
-    final List<PickResult> list;
+    final List<RoundRobinEntry> list;
     int index;
 
-    RoundRobinPicker(List<PickResult> resultList) {
+    RoundRobinPicker(List<RoundRobinEntry> resultList) {
       checkArgument(!resultList.isEmpty(), "resultList is empty");
       list = resultList;
     }
@@ -488,12 +545,13 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
     @Override
     public PickResult pickSubchannel(PickSubchannelArgs args) {
       synchronized (list) {
-        PickResult result = list.get(index);
+        RoundRobinEntry result = list.get(index);
         index++;
         if (index == list.size()) {
           index = 0;
         }
-        return result;
+        result.updateHeaders(args.getHeaders());
+        return result.result;
       }
     }
   }

--- a/grpclb/src/main/java/io/grpc/grpclb/LbAddressGroup.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/LbAddressGroup.java
@@ -38,7 +38,7 @@ import io.grpc.EquivalentAddressGroup;
 /**
  * Represents a balancer address entry.
  */
-class LbAddressGroup {
+final class LbAddressGroup {
   private final EquivalentAddressGroup addresses;
   private final String authority;
 


### PR DESCRIPTION
The balancer service attaches a token string for each `Server` entry it
sends to the client.  The client has to set the token to the `"lb-token"`
header when assigning that Server entry to an RPC.

For convenience of testing, also implemented `hashCode()` and `equals()` for
`PickResult`.

cc @ejona86 for the changes in `PickResult`.