### PR TITLE
all: Bump Jetty ALPN agent version, for new JREs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ subprojects {
                 math: 'org.apache.commons:commons-math3:3.6',
 
                 // Jetty ALPN dependencies
-                jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.3'
+                jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.6'
         ]
     }
 


### PR DESCRIPTION
Jetty ALPN was broken with jdk1.8.0_121