### PR TITLE
Move okhttp to AbstractStream2

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
@@ -190,7 +190,6 @@ public abstract class AbstractClientStream2 extends AbstractStream2
 
     private Runnable deliveryStalledTask;
 
-    private boolean headersReceived;
     /**
      * Whether the stream is closed from the transport's perspective. This can differ from {@link
      * #listenerClosed} because there may still be messages buffered to deliver to the application.
@@ -233,7 +232,6 @@ public abstract class AbstractClientStream2 extends AbstractStream2
      */
     protected void inboundHeadersReceived(Metadata headers) {
       Preconditions.checkState(!statusReported, "Received headers on closed stream");
-      headersReceived = true;
       listener().headersRead(headers);
     }
 
@@ -248,12 +246,6 @@ public abstract class AbstractClientStream2 extends AbstractStream2
       try {
         if (statusReported) {
           log.log(Level.INFO, "Received data on closed stream");
-          return;
-        }
-        if (!headersReceived) {
-          transportReportStatus(
-              Status.INTERNAL.withDescription("headers not received before payload"),
-              false, new Metadata());
           return;
         }
 

--- a/core/src/main/java/io/grpc/internal/Framer.java
+++ b/core/src/main/java/io/grpc/internal/Framer.java
@@ -35,7 +35,7 @@ import io.grpc.Compressor;
 import java.io.InputStream;
 
 /** Interface for framing gRPC messages. */
-interface Framer {
+public interface Framer {
   /**
    * Writes out a payload message.
    *

--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -147,6 +147,12 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
         http2ProcessingFailed(transportError, transportErrorMetadata);
       }
     } else {
+      if (!headersReceived) {
+        http2ProcessingFailed(
+            Status.INTERNAL.withDescription("headers not received before payload"),
+            new Metadata());
+        return;
+      }
       inboundDataReceived(frame);
       if (endOfStream) {
         // This is a protocol violation as we expect to receive trailers.

--- a/core/src/test/java/io/grpc/internal/AbstractClientStream2Test.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStream2Test.java
@@ -32,7 +32,6 @@
 package io.grpc.internal;
 
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -159,17 +158,6 @@ public class AbstractClientStream2Test {
 
     thrown.expect(NullPointerException.class);
     state.inboundDataReceived(null);
-  }
-
-  @Test
-  public void inboundDataReceived_failsOnNoHeaders() {
-    AbstractClientStream2 stream = new BaseAbstractClientStream(allocator, statsTraceCtx);
-    stream.start(mockListener);
-
-    stream.transportState().inboundDataReceived(ReadableBuffers.empty());
-
-    verify(mockListener).closed(statusCaptor.capture(), any(Metadata.class));
-    assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -201,6 +201,17 @@ public class Http2ClientStreamTransportStateTest {
   }
 
   @Test
+  public void transportDataReceived_noHeaderReceived() {
+    BaseTransportState state = new BaseTransportState();
+    state.setListener(mockListener);
+    String testString = "This is a test";
+    state.transportDataReceived(ReadableBuffers.wrap(testString.getBytes(US_ASCII)), true);
+
+    verify(mockListener).closed(statusCaptor.capture(), any(Metadata.class));
+    assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
+  }
+
+  @Test
   public void transportDataReceived_debugData() {
     BaseTransportState state = new BaseTransportState();
     state.setListener(mockListener);

--- a/okhttp/src/main/java/io/grpc/okhttp/OutboundFlowController.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OutboundFlowController.java
@@ -396,7 +396,7 @@ class OutboundFlowController {
             } catch (IOException e) {
               throw new RuntimeException(e);
             }
-            stream.onStreamSentBytes(bytesToWrite);
+            stream.transportState().onSentBytes(bytesToWrite);
 
             if (enqueued) {
               // It's enqueued - remove it from the head of the pending write queue.

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -827,7 +827,7 @@ public class OkHttpClientTransportTest {
     Buffer sentFrame = captor.getValue();
     assertEquals(createMessageFrame(sentMessage), sentFrame);
     verify(frameWriter, timeout(TIME_OUT_MS)).data(eq(true), eq(5), any(Buffer.class), eq(0));
-    stream2.sendCancel(Status.CANCELLED);
+    stream2.cancel(Status.CANCELLED);
     shutdownAndVerify();
   }
 
@@ -839,9 +839,9 @@ public class OkHttpClientTransportTest {
     OkHttpClientStream stream = clientTransport.newStream(method, new Metadata());
     stream.start(listener);
     waitForStreamPending(1);
-    stream.sendCancel(Status.CANCELLED);
+    stream.cancel(Status.CANCELLED);
     // The second cancel should be an no-op.
-    stream.sendCancel(Status.UNKNOWN);
+    stream.cancel(Status.UNKNOWN);
     listener.waitUntilStreamClosed();
     assertEquals(0, clientTransport.getPendingStreamSize());
     assertEquals(Status.CANCELLED.getCode(), listener.status.getCode());
@@ -872,7 +872,7 @@ public class OkHttpClientTransportTest {
 
     // active stream should not be affected.
     assertEquals(1, activeStreamCount());
-    getStream(3).sendCancel(Status.CANCELLED);
+    getStream(3).cancel(Status.CANCELLED);
     shutdownAndVerify();
   }
 
@@ -891,7 +891,7 @@ public class OkHttpClientTransportTest {
     verify(frameWriter, timeout(TIME_OUT_MS))
         .synStream(anyBoolean(), anyBoolean(), eq(3), anyInt(), anyListHeader());
     assertEquals(1, activeStreamCount());
-    stream.sendCancel(Status.CANCELLED);
+    stream.cancel(Status.CANCELLED);
     shutdownAndVerify();
   }
 
@@ -1013,7 +1013,7 @@ public class OkHttpClientTransportTest {
 
     listener.waitUntilStreamClosed();
     assertEquals(Status.INTERNAL.getCode(), listener.status.getCode());
-    assertTrue(listener.status.getDescription().startsWith("no headers received prior to data"));
+    assertTrue(listener.status.getDescription().startsWith("headers not received before payload"));
     assertEquals(0, listener.messages.size());
     shutdownAndVerify();
   }
@@ -1034,7 +1034,7 @@ public class OkHttpClientTransportTest {
 
     listener.waitUntilStreamClosed();
     assertEquals(Status.INTERNAL.getCode(), listener.status.getCode());
-    assertTrue(listener.status.getDescription().startsWith("no headers received prior to data"));
+    assertTrue(listener.status.getDescription().startsWith("headers not received before payload"));
     assertEquals(0, listener.messages.size());
     shutdownAndVerify();
   }
@@ -1054,7 +1054,7 @@ public class OkHttpClientTransportTest {
 
     listener.waitUntilStreamClosed();
     assertEquals(Status.INTERNAL.getCode(), listener.status.getCode());
-    assertTrue(listener.status.getDescription().startsWith("no headers received prior to data"));
+    assertTrue(listener.status.getDescription().startsWith("headers not received before payload"));
     assertEquals(0, listener.messages.size());
     shutdownAndVerify();
   }


### PR DESCRIPTION
One thing worth noting is that I overrided onStreamDeallocated to get notification when transportReportStatus is called and stream is considered finished. Then I can remove the stream from transport map and also reset the stream if the framer is not yet closed.