### PR TITLE
core: add missing @ThreadSafe annotation

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -32,10 +32,12 @@
 package io.grpc;
 
 import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A {@link Channel} that provides lifecycle management.
  */
+@ThreadSafe
 public abstract class ManagedChannel extends Channel {
   /**
    * Initiates an orderly shutdown in which preexisting calls continue but new calls are immediately


### PR DESCRIPTION
Both `ManagedChannelImpl` and `Channel` have it

cc @zhangkun83 