### PR TITLE
core,netty,okhttp: KeepAliveManager with Pinger

### DIFF
--- a/core/src/main/java/io/grpc/internal/KeepAliveManager.java
+++ b/core/src/main/java/io/grpc/internal/KeepAliveManager.java
@@ -31,8 +31,9 @@
 
 package io.grpc.internal;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Status;
 import java.util.concurrent.ScheduledExecutorService;
@@ -47,8 +48,8 @@ public class KeepAliveManager {
   private static final long MIN_KEEPALIVE_DELAY_NANOS = TimeUnit.MINUTES.toNanos(1);
 
   private final ScheduledExecutorService scheduler;
-  private final ManagedClientTransport transport;
   private final Ticker ticker;
+  private final KeepAlivePinger keepAlivePinger;
   private final boolean keepAliveDuringTransportIdle;
   private State state = State.IDLE;
   private long nextKeepaliveTime;
@@ -67,8 +68,7 @@ public class KeepAliveManager {
         }
       }
       if (shouldShutdown) {
-        transport.shutdownNow(Status.UNAVAILABLE.withDescription(
-            "Keepalive failed. The connection is likely gone"));
+        keepAlivePinger.onPingTimeout();
       }
     }
   };
@@ -92,11 +92,11 @@ public class KeepAliveManager {
       }
       if (shouldSendPing) {
         // Send the ping.
-        transport.ping(pingCallback, MoreExecutors.directExecutor());
+        keepAlivePinger.ping();
       }
     }
   };
-  private final KeepAlivePingCallback pingCallback = new KeepAlivePingCallback();
+
   private long keepAliveDelayInNanos;
   private long keepAliveTimeoutInNanos;
 
@@ -132,25 +132,24 @@ public class KeepAliveManager {
   /**
    * Creates a KeepAliverManager.
    */
-  public KeepAliveManager(ManagedClientTransport transport, ScheduledExecutorService scheduler,
-                          long keepAliveDelayInNanos, long keepAliveTimeoutInNanos,
-                          boolean keepAliveDuringTransportIdle) {
-    this(transport, scheduler, SYSTEM_TICKER,
+  public KeepAliveManager(
+      KeepAlivePinger keepAlivePinger, ScheduledExecutorService scheduler,
+      long keepAliveDelayInNanos, long keepAliveTimeoutInNanos) {
+    this(keepAlivePinger, scheduler, SYSTEM_TICKER,
         // Set a minimum cap on keepalive dealy.
-        Math.max(MIN_KEEPALIVE_DELAY_NANOS, keepAliveDelayInNanos), keepAliveTimeoutInNanos,
-        keepAliveDuringTransportIdle);
+        Math.max(MIN_KEEPALIVE_DELAY_NANOS, keepAliveDelayInNanos), keepAliveTimeoutInNanos);
   }
 
   @VisibleForTesting
-  KeepAliveManager(ManagedClientTransport transport, ScheduledExecutorService scheduler,
-                   Ticker ticker, long keepAliveDelayInNanos, long keepAliveTimeoutInNanos,
-                   boolean keepAliveDuringTransportIdle) {
-    this.transport = Preconditions.checkNotNull(transport, "transport");
-    this.scheduler = Preconditions.checkNotNull(scheduler, "scheduler");
-    this.ticker = Preconditions.checkNotNull(ticker, "ticker");
+  KeepAliveManager(
+      KeepAlivePinger keepAlivePinger, ScheduledExecutorService scheduler, Ticker ticker,
+      long keepAliveDelayInNanos, long keepAliveTimeoutInNanos) {
+    this.keepAlivePinger = checkNotNull(keepAlivePinger, "keepAlivePinger");
+    this.scheduler = checkNotNull(scheduler, "scheduler");
+    this.ticker = checkNotNull(ticker, "ticker");
     this.keepAliveDelayInNanos = keepAliveDelayInNanos;
     this.keepAliveTimeoutInNanos = keepAliveTimeoutInNanos;
-    this.keepAliveDuringTransportIdle = keepAliveDuringTransportIdle;
+    keepAliveDuringTransportIdle = keepAlivePinger.stillPingWhileIdle();;
     nextKeepaliveTime = ticker.read() + keepAliveDelayInNanos;
   }
 
@@ -234,18 +233,57 @@ public class KeepAliveManager {
     }
   }
 
-  private class KeepAlivePingCallback implements ClientTransport.PingCallback {
+  public interface KeepAlivePinger {
+    /**
+     * Sends out a keep-alive ping.
+     */
+    void ping();
+
+    /**
+     * Callback when Ping Ack was not received in KEEPALIVE_TIMEOUT. Should shutdown the transport.
+     */
+    void onPingTimeout();
+
+    /**
+     * Specifies whether the pinger should keep sending keep-alive pings when the transport has no
+     * active RPCs.
+     */
+    boolean stillPingWhileIdle();
+  }
+
+  /**
+   * Default client side {@link KeepAlivePinger}.
+   */
+  public static final class ClientKeepAlivePinger implements KeepAlivePinger {
+    private final ConnectionClientTransport transport;
+
+    public ClientKeepAlivePinger(ConnectionClientTransport transport) {
+      this.transport = transport;
+    }
 
     @Override
-    public void onSuccess(long roundTripTimeNanos) {}
+    public void ping() {
+      transport.ping(new ClientTransport.PingCallback() {
+        @Override
+        public void onSuccess(long roundTripTimeNanos) {}
+
+        @Override
+        public void onFailure(Throwable cause) {
+          transport.shutdownNow(Status.UNAVAILABLE.withDescription(
+              "Keepalive failed. The connection is likely gone"));
+        }
+      }, MoreExecutors.directExecutor());
+    }
 
     @Override
-    public void onFailure(Throwable cause) {
-      // Keepalive ping has failed. Shutdown the transport now.
-      synchronized (KeepAliveManager.this) {
-        shutdownFuture.cancel(false);
-      }
-      shutdown.run();
+    public void onPingTimeout() {
+      transport.shutdownNow(Status.UNAVAILABLE.withDescription(
+          "Keepalive failed. The connection is likely gone"));
+    }
+
+    @Override
+    public boolean stillPingWhileIdle() {
+      return false;
     }
   }
 
@@ -264,6 +302,5 @@ public class KeepAliveManager {
       return System.nanoTime();
     }
   }
-
 }
 

--- a/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
@@ -74,7 +74,7 @@ public final class KeepAliveManagerTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     keepAlivePinger = new ClientKeepAlivePinger(transport);
-    keepAliveManager = new KeepAliveManager(keepAlivePinger, scheduler, ticker, 1000, 2000);
+    keepAliveManager = new KeepAliveManager(keepAlivePinger, scheduler, ticker, 1000, 2000, false);
   }
 
   @Test
@@ -266,9 +266,8 @@ public final class KeepAliveManagerTest {
   @Test
   public void transportGoesIdle_doesntCauseIdleWhenEnabled() {
     KeepAlivePinger pinger = mock(KeepAlivePinger.class);
-    doReturn(true).when(pinger).stillPingWhileIdle();
     keepAliveManager.onTransportTermination();
-    keepAliveManager = new KeepAliveManager(pinger, scheduler, ticker, 1000, 2000);
+    keepAliveManager = new KeepAliveManager(pinger, scheduler, ticker, 1000, 2000, true);
     keepAliveManager.onTransportStarted();
 
     // Keepalive scheduling should have started immediately.

--- a/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
@@ -204,7 +204,7 @@ public final class KeepAliveManagerTest {
 
     // We do not receive the ping response. Shutdown runnable runs.
     ticker.time = 3000;
-    keepAlivePinger.onPingTimeout();
+    shutdown.run();
     verify(transport).shutdownNow(isA(Status.class));
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -234,7 +234,7 @@ class NettyClientTransport implements ConnectionClientTransport {
     if (enableKeepAlive) {
       keepAliveManager = new KeepAliveManager(
           new ClientKeepAlivePinger(this), channel.eventLoop(), keepAliveDelayNanos,
-          keepAliveTimeoutNanos);
+          keepAliveTimeoutNanos, false);
       keepAliveManager.onTransportStarted();
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -46,6 +46,7 @@ import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
 import io.grpc.internal.KeepAliveManager;
+import io.grpc.internal.KeepAliveManager.ClientKeepAlivePinger;
 import io.grpc.internal.LogId;
 import io.grpc.internal.StatsTraceContext;
 import io.netty.bootstrap.Bootstrap;
@@ -231,8 +232,9 @@ class NettyClientTransport implements ConnectionClientTransport {
     });
 
     if (enableKeepAlive) {
-      keepAliveManager = new KeepAliveManager(this, channel.eventLoop(), keepAliveDelayNanos,
-          keepAliveTimeoutNanos, false);
+      keepAliveManager = new KeepAliveManager(
+          new ClientKeepAlivePinger(this), channel.eventLoop(), keepAliveDelayNanos,
+          keepAliveTimeoutNanos);
       keepAliveManager.onTransportStarted();
     }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -371,7 +371,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     if (enableKeepAlive) {
       scheduler = SharedResourceHolder.get(TIMER_SERVICE);
       keepAliveManager = new KeepAliveManager(
-          new ClientKeepAlivePinger(this), scheduler, keepAliveDelayNanos, keepAliveTimeoutNanos);
+          new ClientKeepAlivePinger(this), scheduler, keepAliveDelayNanos, keepAliveTimeoutNanos,
+          false);
       keepAliveManager.onTransportStarted();
     }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -55,6 +55,7 @@ import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
 import io.grpc.internal.KeepAliveManager;
+import io.grpc.internal.KeepAliveManager.ClientKeepAlivePinger;
 import io.grpc.internal.LogId;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.internal.SharedResourceHolder;
@@ -369,8 +370,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
 
     if (enableKeepAlive) {
       scheduler = SharedResourceHolder.get(TIMER_SERVICE);
-      keepAliveManager = new KeepAliveManager(this, scheduler, keepAliveDelayNanos,
-          keepAliveTimeoutNanos, false);
+      keepAliveManager = new KeepAliveManager(
+          new ClientKeepAlivePinger(this), scheduler, keepAliveDelayNanos, keepAliveTimeoutNanos);
       keepAliveManager.onTransportStarted();
     }
 


### PR DESCRIPTION
Modified KeepAliveManager to use a Pinger interface, which can send ping or shutdown transport for both server and client.