### PR TITLE
core: use nanos more consistently

### DIFF
--- a/core/src/main/java/io/grpc/internal/BackoffPolicy.java
+++ b/core/src/main/java/io/grpc/internal/BackoffPolicy.java
@@ -42,6 +42,6 @@ interface BackoffPolicy {
   /**
    * @return The number of milliseconds to wait.
    */
-  long nextBackoffMillis();
+  long nextBackoffNanos();
 }
 

--- a/core/src/main/java/io/grpc/internal/ExponentialBackoffPolicy.java
+++ b/core/src/main/java/io/grpc/internal/ExponentialBackoffPolicy.java
@@ -52,19 +52,19 @@ final class ExponentialBackoffPolicy implements BackoffPolicy {
   }
 
   private Random random = new Random();
-  private long initialBackoffMillis = TimeUnit.SECONDS.toMillis(1);
-  private long maxBackoffMillis = TimeUnit.MINUTES.toMillis(2);
+  private long initialBackoffNanos = TimeUnit.SECONDS.toNanos(1);
+  private long maxBackoffNanos = TimeUnit.MINUTES.toNanos(2);
   private double multiplier = 1.6;
   private double jitter = .2;
 
-  private long nextBackoffMillis = initialBackoffMillis;
+  private long nextBackoffNanos = initialBackoffNanos;
 
   @Override
-  public long nextBackoffMillis() {
-    long currentBackoffMillis = nextBackoffMillis;
-    nextBackoffMillis = Math.min((long) (currentBackoffMillis * multiplier), maxBackoffMillis);
-    return currentBackoffMillis
-        + uniformRandom(-jitter * currentBackoffMillis, jitter * currentBackoffMillis);
+  public long nextBackoffNanos() {
+    long currentBackoffNanos = nextBackoffNanos;
+    nextBackoffNanos = Math.min((long) (currentBackoffNanos * multiplier), maxBackoffNanos);
+    return currentBackoffNanos
+        + uniformRandom(-jitter * currentBackoffNanos, jitter * currentBackoffNanos);
   }
 
   private long uniformRandom(double low, double high) {
@@ -85,14 +85,14 @@ final class ExponentialBackoffPolicy implements BackoffPolicy {
   }
 
   @VisibleForTesting
-  ExponentialBackoffPolicy setInitialBackoffMillis(long initialBackoffMillis) {
-    this.initialBackoffMillis = initialBackoffMillis;
+  ExponentialBackoffPolicy setInitialBackoffNanos(long initialBackoffNanos) {
+    this.initialBackoffNanos = initialBackoffNanos;
     return this;
   }
 
   @VisibleForTesting
-  ExponentialBackoffPolicy setMaxBackoffMillis(long maxBackoffMillis) {
-    this.maxBackoffMillis = maxBackoffMillis;
+  ExponentialBackoffPolicy setMaxBackoffNanos(long maxBackoffNanos) {
+    this.maxBackoffNanos = maxBackoffNanos;
     return this;
   }
 

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -252,16 +252,16 @@ final class InternalSubchannel implements WithLogId {
     if (reconnectPolicy == null) {
       reconnectPolicy = backoffPolicyProvider.get();
     }
-    long delayMillis =
-        reconnectPolicy.nextBackoffMillis() - connectingTimer.elapsed(TimeUnit.MILLISECONDS);
+    long delayNanos =
+        reconnectPolicy.nextBackoffNanos() - connectingTimer.elapsed(TimeUnit.NANOSECONDS);
     if (log.isLoggable(Level.FINE)) {
-      log.log(Level.FINE, "[{0}] Scheduling backoff for {1} ms", new Object[]{logId, delayMillis});
+      log.log(Level.FINE, "[{0}] Scheduling backoff for {1} ns", new Object[]{logId, delayNanos});
     }
     Preconditions.checkState(reconnectTask == null, "previous reconnectTask is not done");
     reconnectTask = scheduledExecutor.schedule(
         new LogExceptionRunnable(new EndOfCurrentBackoff()),
-        delayMillis,
-        TimeUnit.MILLISECONDS);
+        delayNanos,
+        TimeUnit.NANOSECONDS);
   }
 
   @GuardedBy("lock")

--- a/core/src/test/java/io/grpc/ContextsTest.java
+++ b/core/src/test/java/io/grpc/ContextsTest.java
@@ -230,9 +230,9 @@ public class ContextsTest {
   public void statusFromCancelled_TimeoutExceptionShouldMapToDeadlineExceeded() {
     FakeClock fakeClock = new FakeClock();
     Context.CancellableContext cancellableContext = Context.current()
-        .withDeadlineAfter(100, TimeUnit.MILLISECONDS, fakeClock.getScheduledExecutorService());
+        .withDeadlineAfter(100, TimeUnit.NANOSECONDS, fakeClock.getScheduledExecutorService());
     fakeClock.forwardTime(System.nanoTime(), TimeUnit.NANOSECONDS);
-    fakeClock.forwardMillis(100);
+    fakeClock.forwardNanos(100);
 
     assertTrue(cancellableContext.isCancelled());
     assertThat(cancellableContext.cancellationCause(), instanceOf(TimeoutException.class));

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -180,11 +180,11 @@ public class DnsNameResolverTest {
 
     // First retry scheduled
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardMillis(TimeUnit.MINUTES.toMillis(1) - 1);
+    fakeClock.forwardNanos(TimeUnit.MINUTES.toNanos(1) - 1);
     assertEquals(1, fakeClock.numPendingTasks());
 
     // First retry
-    fakeClock.forwardMillis(1);
+    fakeClock.forwardNanos(1);
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockListener, times(2)).onError(statusCaptor.capture());
     assertEquals(name, resolver.invocations.poll());
@@ -194,11 +194,11 @@ public class DnsNameResolverTest {
 
     // Second retry scheduled
     assertEquals(1, fakeClock.numPendingTasks());
-    fakeClock.forwardMillis(TimeUnit.MINUTES.toMillis(1) - 1);
+    fakeClock.forwardNanos(TimeUnit.MINUTES.toNanos(1) - 1);
     assertEquals(1, fakeClock.numPendingTasks());
 
     // Second retry
-    fakeClock.forwardMillis(1);
+    fakeClock.forwardNanos(1);
     assertEquals(0, fakeClock.numPendingTasks());
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockListener).onUpdate(resultCaptor.capture(), any(Attributes.class));

--- a/core/src/test/java/io/grpc/internal/ExponentialBackoffPolicyTest.java
+++ b/core/src/test/java/io/grpc/internal/ExponentialBackoffPolicyTest.java
@@ -54,16 +54,16 @@ public class ExponentialBackoffPolicyTest {
 
   @Test
   public void maxDelayReached() {
-    long maxBackoffMillis = 120 * 1000;
-    policy.setMaxBackoffMillis(maxBackoffMillis)
+    long maxBackoffNanos = 120 * 1000;
+    policy.setMaxBackoffNanos(maxBackoffNanos)
         .setJitter(0)
         .setRandom(notRandom);
     for (int i = 0; i < 50; i++) {
-      if (maxBackoffMillis == policy.nextBackoffMillis()) {
+      if (maxBackoffNanos == policy.nextBackoffNanos()) {
         return; // Success
       }
     }
-    assertEquals("max delay not reached", maxBackoffMillis, policy.nextBackoffMillis());
+    assertEquals("max delay not reached", maxBackoffNanos, policy.nextBackoffNanos());
   }
 
   @Test public void canProvide() {

--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>To simulate the locking scenario of using real executors, it never runs tasks within {@code
  * schedule()} or {@code execute()}. Instead, you should call {@link #runDueTasks} in your test
- * method to run all due tasks. {@link #forwardTime} and {@link #forwardMillis} call {@link
+ * method to run all due tasks. {@link #forwardTime} and {@link #forwardNanos} call {@link
  * #runDueTasks} automatically.
  */
 public final class FakeClock {
@@ -266,8 +266,8 @@ public final class FakeClock {
    *
    * @return the number of tasks run by this call
    */
-  public int forwardMillis(long millis) {
-    return forwardTime(millis, TimeUnit.MILLISECONDS);
+  public int forwardNanos(long nanos) {
+    return forwardTime(nanos, TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -262,7 +262,7 @@ public final class FakeClock {
   }
 
   /**
-   * Forward the time by the given milliseconds and run all due tasks.
+   * Forward the time by the given nanoseconds and run all due tasks.
    *
    * @return the number of tasks run by this call
    */

--- a/core/src/test/java/io/grpc/internal/FakeClockTest.java
+++ b/core/src/test/java/io/grpc/internal/FakeClockTest.java
@@ -59,12 +59,12 @@ public class FakeClockTest {
   public void testScheduledExecutorService_isDone() {
     FakeClock fakeClock = new FakeClock();
     ScheduledFuture<?> future = fakeClock.getScheduledExecutorService()
-        .schedule(newRunnable(), 100L, TimeUnit.MILLISECONDS);
+        .schedule(newRunnable(), 100L, TimeUnit.NANOSECONDS);
 
-    fakeClock.forwardMillis(99L);
+    fakeClock.forwardNanos(99L);
     assertFalse(future.isDone());
 
-    fakeClock.forwardMillis(2L);
+    fakeClock.forwardNanos(2L);
     assertTrue(future.isDone());
   }
 
@@ -72,12 +72,12 @@ public class FakeClockTest {
   public void testScheduledExecutorService_cancel() {
     FakeClock fakeClock = new FakeClock();
     ScheduledFuture<?> future = fakeClock.getScheduledExecutorService()
-        .schedule(newRunnable(), 100L, TimeUnit.MILLISECONDS);
+        .schedule(newRunnable(), 100L, TimeUnit.NANOSECONDS);
 
-    fakeClock.forwardMillis(99L);
+    fakeClock.forwardNanos(99L);
     future.cancel(false);
 
-    fakeClock.forwardMillis(2);
+    fakeClock.forwardNanos(2);
     assertTrue(future.isCancelled());
   }
 
@@ -85,10 +85,10 @@ public class FakeClockTest {
   public void testScheduledExecutorService_getDelay() {
     FakeClock fakeClock = new FakeClock();
     ScheduledFuture<?> future = fakeClock.getScheduledExecutorService()
-        .schedule(newRunnable(), 100L, TimeUnit.MILLISECONDS);
+        .schedule(newRunnable(), 100L, TimeUnit.NANOSECONDS);
 
-    fakeClock.forwardMillis(90L);
-    assertEquals(10L, future.getDelay(TimeUnit.MILLISECONDS));
+    fakeClock.forwardNanos(90L);
+    assertEquals(10L, future.getDelay(TimeUnit.NANOSECONDS));
   }
 
   @Test
@@ -103,9 +103,9 @@ public class FakeClockTest {
           }
         },
         100L,
-        TimeUnit.MILLISECONDS);
+        TimeUnit.NANOSECONDS);
 
-    fakeClock.forwardMillis(100L);
+    fakeClock.forwardNanos(100L);
     assertTrue(result[0]);
   }
 
@@ -113,27 +113,27 @@ public class FakeClockTest {
   public void testStopWatch() {
     FakeClock fakeClock = new FakeClock();
     Stopwatch stopwatch = fakeClock.getStopwatchSupplier().get();
-    long expectedElapsedMillis = 0L;
+    long expectedElapsedNanos = 0L;
 
     stopwatch.start();
 
-    fakeClock.forwardMillis(100L);
-    expectedElapsedMillis += 100L;
-    assertEquals(expectedElapsedMillis, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+    fakeClock.forwardNanos(100L);
+    expectedElapsedNanos += 100L;
+    assertEquals(expectedElapsedNanos, stopwatch.elapsed(TimeUnit.NANOSECONDS));
 
     fakeClock.forwardTime(10L, TimeUnit.MINUTES);
-    expectedElapsedMillis += TimeUnit.MINUTES.toMillis(10L);
-    assertEquals(expectedElapsedMillis, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+    expectedElapsedNanos += TimeUnit.MINUTES.toNanos(10L);
+    assertEquals(expectedElapsedNanos, stopwatch.elapsed(TimeUnit.NANOSECONDS));
 
     stopwatch.stop();
 
-    fakeClock.forwardMillis(1000L);
-    assertEquals(expectedElapsedMillis, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+    fakeClock.forwardNanos(1000L);
+    assertEquals(expectedElapsedNanos, stopwatch.elapsed(TimeUnit.NANOSECONDS));
 
     stopwatch.reset();
 
-    expectedElapsedMillis = 0L;
-    assertEquals(expectedElapsedMillis, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+    expectedElapsedNanos = 0L;
+    assertEquals(expectedElapsedNanos, stopwatch.elapsed(TimeUnit.NANOSECONDS));
   }
 
   @Test
@@ -142,14 +142,14 @@ public class FakeClockTest {
     FakeClock fakeClock = new FakeClock();
     ScheduledExecutorService scheduledExecutorService = fakeClock.getScheduledExecutorService();
 
-    scheduledExecutorService.schedule(newRunnable(), 200L, TimeUnit.MILLISECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 200L, TimeUnit.NANOSECONDS);
     scheduledExecutorService.execute(newRunnable());
-    scheduledExecutorService.schedule(newRunnable(), 0L, TimeUnit.MILLISECONDS);
-    scheduledExecutorService.schedule(newRunnable(), 80L, TimeUnit.MILLISECONDS);
-    scheduledExecutorService.schedule(newRunnable(), 90L, TimeUnit.MILLISECONDS);
-    scheduledExecutorService.schedule(newRunnable(), 100L, TimeUnit.MILLISECONDS);
-    scheduledExecutorService.schedule(newRunnable(), 110L, TimeUnit.MILLISECONDS);
-    scheduledExecutorService.schedule(newRunnable(), 120L, TimeUnit.MILLISECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 0L, TimeUnit.NANOSECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 80L, TimeUnit.NANOSECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 90L, TimeUnit.NANOSECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 100L, TimeUnit.NANOSECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 110L, TimeUnit.NANOSECONDS);
+    scheduledExecutorService.schedule(newRunnable(), 120L, TimeUnit.NANOSECONDS);
 
 
     assertEquals(8, fakeClock.numPendingTasks());
@@ -160,12 +160,12 @@ public class FakeClockTest {
     assertEquals(6, fakeClock.numPendingTasks());
     assertEquals(0, fakeClock.getDueTasks().size());
 
-    fakeClock.forwardMillis(90L);
+    fakeClock.forwardNanos(90L);
 
     assertEquals(4, fakeClock.numPendingTasks());
     assertEquals(0, fakeClock.getDueTasks().size());
 
-    fakeClock.forwardMillis(20L);
+    fakeClock.forwardNanos(20L);
 
     assertEquals(2, fakeClock.numPendingTasks());
     assertEquals(0, fakeClock.getDueTasks().size());

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -336,7 +336,7 @@ public class ManagedChannelImplIdlenessTest {
     public BackoffPolicy get() {
       return new BackoffPolicy() {
         @Override
-        public long nextBackoffMillis() {
+        public long nextBackoffNanos() {
           return 1;
         }
       };

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1114,7 +1114,7 @@ public class ManagedChannelImplTest {
     public BackoffPolicy get() {
       return new BackoffPolicy() {
         @Override
-        public long nextBackoffMillis() {
+        public long nextBackoffNanos() {
           return 1;
         }
       };

--- a/core/src/test/java/io/grpc/internal/StatsTraceContextTest.java
+++ b/core/src/test/java/io/grpc/internal/StatsTraceContextTest.java
@@ -31,18 +31,20 @@
 
 package io.grpc.internal;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import com.google.instrumentation.stats.RpcConstants;
 import com.google.instrumentation.stats.StatsContext;
+import com.google.instrumentation.stats.StatsContextFactory;
 import com.google.instrumentation.stats.TagValue;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.internal.testing.StatsTestUtils.FakeStatsContextFactory;
 import io.grpc.internal.testing.StatsTestUtils;
+import io.grpc.internal.testing.StatsTestUtils.FakeStatsContextFactory;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -67,20 +69,20 @@ public class StatsTraceContextTest {
     StatsTraceContext ctx = StatsTraceContext.newClientContextForTesting(
         methodName, statsCtxFactory, statsCtxFactory.getDefault(),
         fakeClock.getStopwatchSupplier());
-    fakeClock.forwardMillis(30);
+    fakeClock.forwardTime(30, MILLISECONDS);
     ctx.clientHeadersSent();
 
-    fakeClock.forwardMillis(100);
+    fakeClock.forwardTime(100, MILLISECONDS);
     ctx.wireBytesSent(1028);
     ctx.uncompressedBytesSent(1128);
 
-    fakeClock.forwardMillis(16);
+    fakeClock.forwardTime(16, MILLISECONDS);
     ctx.wireBytesReceived(33);
     ctx.uncompressedBytesReceived(67);
     ctx.wireBytesSent(99);
     ctx.uncompressedBytesSent(865);
 
-    fakeClock.forwardMillis(24);
+    fakeClock.forwardTime(24, MILLISECONDS);
     ctx.wireBytesReceived(154);
     ctx.uncompressedBytesReceived(552);
     ctx.callEnded(Status.OK);
@@ -111,7 +113,7 @@ public class StatsTraceContextTest {
     StatsTraceContext ctx = StatsTraceContext.newClientContextForTesting(
         methodName, statsCtxFactory, statsCtxFactory.getDefault(),
         fakeClock.getStopwatchSupplier());
-    fakeClock.forwardMillis(3000);
+    fakeClock.forwardTime(3000, MILLISECONDS);
     ctx.callEnded(Status.DEADLINE_EXCEEDED.withDescription("3 seconds"));
 
     StatsTestUtils.MetricsRecord record = statsCtxFactory.pollRecord();
@@ -168,7 +170,7 @@ public class StatsTraceContextTest {
     assertNull(serverRecord.getMetric(RpcConstants.RPC_SERVER_ERROR_COUNT));
     TagValue serverPropagatedTag = serverRecord.tags.get(StatsTestUtils.EXTRA_TAG);
     assertEquals("extra-tag-value-897", serverPropagatedTag.toString());
-    
+
     StatsTestUtils.MetricsRecord clientRecord = statsCtxFactory.pollRecord();
     assertNotNull(clientRecord);
     assertNoServerContent(clientRecord);
@@ -189,17 +191,17 @@ public class StatsTraceContextTest {
     ctx.wireBytesReceived(34);
     ctx.uncompressedBytesReceived(67);
 
-    fakeClock.forwardMillis(100);
+    fakeClock.forwardTime(100, MILLISECONDS);
     ctx.wireBytesSent(1028);
     ctx.uncompressedBytesSent(1128);
 
-    fakeClock.forwardMillis(16);
+    fakeClock.forwardTime(16, MILLISECONDS);
     ctx.wireBytesReceived(154);
     ctx.uncompressedBytesReceived(552);
     ctx.wireBytesSent(99);
     ctx.uncompressedBytesSent(865);
 
-    fakeClock.forwardMillis(24);
+    fakeClock.forwardTime(24, MILLISECONDS);
     ctx.callEnded(Status.CANCELLED);
 
     StatsTestUtils.MetricsRecord record = statsCtxFactory.pollRecord();


### PR DESCRIPTION
Rather than use a mix of millis and nanos, let's just use nanos throughout.  We can convert to millis on API boundaries (like with Census).  Many Java APIs already speak Nanos, so we should too.