### PR TITLE
netty: move startWriteQueue right after channel is constructed

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -190,6 +190,8 @@ class NettyClientTransport implements ConnectionClientTransport {
      */
     b.handler(negotiationHandler);
     channel = b.register().channel();
+    // Start the write queue as soon as the channel is constructed
+    handler.startWriteQueue(channel);
     // Start the connection operation to the server.
     channel.connect(address).addListener(new ChannelFutureListener() {
       @Override
@@ -206,8 +208,6 @@ class NettyClientTransport implements ConnectionClientTransport {
         }
       }
     });
-    // Start the write queue as soon as the channel is constructed
-    handler.startWriteQueue(channel);
     // This write will have no effect, yet it will only complete once the negotiationHandler
     // flushes any pending writes.
     channel.write(NettyClientHandler.NOOP_MESSAGE).addListener(new ChannelFutureListener() {


### PR DESCRIPTION
As 65e4d9f has split the channel instantiation and `connect()`, we can `startWriteQueue()` even earlier.