### PR TITLE
Okhttp: keepAlivedManager#onTransportShutdown moved from shutdown to stopIfNecessary and refactored

### DIFF
--- a/core/src/main/java/io/grpc/internal/KeepAliveManager.java
+++ b/core/src/main/java/io/grpc/internal/KeepAliveManager.java
@@ -220,9 +220,9 @@ public class KeepAliveManager {
   }
 
   /**
-   * Transport is shutting down. We no longer need to do keepalives.
+   * Transport is being terminated. We no longer need to do keepalives.
    */
-  public synchronized void onTransportShutdown() {
+  public synchronized void onTransportTermination() {
     if (state != State.DISCONNECTED) {
       state = State.DISCONNECTED;
       if (shutdownFuture != null) {

--- a/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
@@ -265,7 +265,7 @@ public final class KeepAliveManagerTest {
 
   @Test
   public void transportGoesIdle_doesntCauseIdleWhenEnabled() {
-    keepAliveManager.onTransportShutdown();
+    keepAliveManager.onTransportTermination();
     keepAliveManager = new KeepAliveManager(transport, scheduler, ticker, 1000, 2000, true);
     keepAliveManager.onTransportStarted();
 
@@ -368,7 +368,7 @@ public final class KeepAliveManagerTest {
     verify(scheduler, times(1)).schedule(isA(Runnable.class), isA(Long.class),
         isA(TimeUnit.class));
     // Transport is shutting down.
-    keepAliveManager.onTransportShutdown();
+    keepAliveManager.onTransportTermination();
     // Ping future should have been cancelled.
     verify(pingFuture).cancel(isA(Boolean.class));
   }
@@ -394,7 +394,7 @@ public final class KeepAliveManagerTest {
         isA(TimeUnit.class));
 
     // Transport is shutting down.
-    keepAliveManager.onTransportShutdown();
+    keepAliveManager.onTransportTermination();
     // Shutdown task has been cancelled.
     verify(shutdownFuture).cancel(isA(Boolean.class));
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -334,7 +334,7 @@ class NettyClientHandler extends AbstractNettyHandler {
       // Close any open streams
       super.channelInactive(ctx);
       if (keepAliveManager != null) {
-        keepAliveManager.onTransportShutdown();
+        keepAliveManager.onTransportTermination();
       }
     }
   }

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -366,7 +366,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     handler().channelInactive(ctx());
     assertTrue(future.isDone());
     assertFalse(future.isSuccess());
-    verify(mockKeepAliveManager, times(1)).onTransportShutdown(); // channelInactive
+    verify(mockKeepAliveManager, times(1)).onTransportTermination(); // channelInactive
     verifyNoMoreInteractions(mockKeepAliveManager);
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -751,8 +751,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     stopped = true;
 
     if (keepAliveManager != null) {
-      keepAliveManager.onTransportShutdown();
-      // KeepAliveManager should stop using the scheduler after onTransportShutdown gets called.
+      keepAliveManager.onTransportTermination();
+      // KeepAliveManager should stop using the scheduler after onTransportTermination gets called.
       scheduler = SharedResourceHolder.release(TIMER_SERVICE, scheduler);
     }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -605,11 +605,6 @@ class OkHttpClientTransport implements ConnectionClientTransport {
       goAwayStatus = Status.UNAVAILABLE.withDescription("Transport stopped");
       listener.transportShutdown(goAwayStatus);
       stopIfNecessary();
-      if (keepAliveManager != null) {
-        keepAliveManager.onTransportShutdown();
-        // KeepAliveManager should stop using the scheduler after onTransportShutdown gets called.
-        scheduler = SharedResourceHolder.release(TIMER_SERVICE, scheduler);
-      }
     }
   }
 
@@ -746,7 +741,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
    * When the transport is in goAway state, we should stop it once all active streams finish.
    */
   @GuardedBy("lock")
-  void stopIfNecessary() {
+  private void stopIfNecessary() {
     if (!(goAwayStatus != null && streams.isEmpty() && pendingStreams.isEmpty())) {
       return;
     }
@@ -754,6 +749,12 @@ class OkHttpClientTransport implements ConnectionClientTransport {
       return;
     }
     stopped = true;
+
+    if (keepAliveManager != null) {
+      keepAliveManager.onTransportShutdown();
+      // KeepAliveManager should stop using the scheduler after onTransportShutdown gets called.
+      scheduler = SharedResourceHolder.release(TIMER_SERVICE, scheduler);
+    }
 
     if (ping != null) {
       ping.failed(getPingFailure());


### PR DESCRIPTION
`keepAlivedManager#onTransportshutdown` should not be called in `transport.shutdown()` because it is possible that there are still open RPC streams, and maybe inactive, so keepalive is still needed.