### PR TITLE
support GET verb in AbstractClientStream2

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/netty/OutboundHeadersBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/netty/OutboundHeadersBenchmark.java
@@ -89,7 +89,8 @@ public class OutboundHeadersBenchmark {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public Http2Headers convertClientHeaders() {
-    return Utils.convertClientHeaders(metadata, scheme, defaultPath, authority, userAgent);
+    return Utils.convertClientHeaders(metadata, scheme, defaultPath, authority, Utils.HTTP_METHOD,
+        userAgent);
   }
 
   @Benchmark
@@ -108,7 +109,8 @@ public class OutboundHeadersBenchmark {
   public ByteBuf encodeClientHeaders() throws Exception {
     scratchBuffer.clear();
     Http2Headers headers =
-        Utils.convertClientHeaders(metadata, scheme, defaultPath, authority, userAgent);
+        Utils.convertClientHeaders(metadata, scheme, defaultPath, authority, Utils.HTTP_METHOD,
+            userAgent);
     headersEncoder.encodeHeaders(1, headers, scratchBuffer);
     return scratchBuffer;
   }

--- a/core/src/main/java/io/grpc/internal/AbstractStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream2.java
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.GuardedBy;
  */
 public abstract class AbstractStream2 implements Stream {
   /** The framer to use for sending messages. */
-  protected abstract MessageFramer framer();
+  protected abstract Framer framer();
 
   /**
    * Obtain the transport state corresponding to this stream. Each stream must have its own unique

--- a/core/src/main/java/io/grpc/internal/Framer.java
+++ b/core/src/main/java/io/grpc/internal/Framer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,41 +29,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.grpc.netty;
+package io.grpc.internal;
 
-import com.google.common.base.Preconditions;
-import io.netty.handler.codec.http2.Http2Headers;
+import io.grpc.Compressor;
+import java.io.InputStream;
 
-/**
- * A command to create a new stream. This is created by {@link NettyClientStream} and passed to the
- * {@link NettyClientHandler} for processing in the Channel thread.
- */
-class CreateStreamCommand extends WriteQueue.AbstractQueuedCommand {
-  private final Http2Headers headers;
-  private final NettyClientStream.TransportState stream;
-  private final boolean get;
+/** Interface for framing gRPC messages. */
+interface Framer {
+  /**
+   * Writes out a payload message.
+   *
+   * @param message contains the message to be written out. It will be completely consumed.
+   */
+  void writePayload(InputStream message);
 
-  CreateStreamCommand(Http2Headers headers,
-                      NettyClientStream.TransportState stream) {
-    this(headers, stream, false);
-  }
+  /** Flush the buffered payload. */
+  void flush();
 
-  CreateStreamCommand(Http2Headers headers,
-                      NettyClientStream.TransportState stream, boolean get) {
-    this.stream = Preconditions.checkNotNull(stream, "stream");
-    this.headers = Preconditions.checkNotNull(headers, "headers");
-    this.get = get;
-  }
+  /** Returns whether the framer is closed. */
+  boolean isClosed();
 
-  NettyClientStream.TransportState stream() {
-    return stream;
-  }
+  /** Closes, with flush. */
+  void close();
 
-  Http2Headers headers() {
-    return headers;
-  }
+  /** Closes, without flush. */
+  void dispose();
 
-  boolean isGet() {
-    return get;
-  }
+  /** Enable or disable compression. */
+  Framer setMessageCompression(boolean enable);
+
+  /** Set the compressor used for compression. */
+  Framer setCompressor(Compressor compressor);
+
+  /** Set a size limit for each outbound message. */ 
+  void setMaxOutboundMessageSize(int maxSize);
 }

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -55,7 +55,7 @@ import javax.annotation.Nullable;
  * Encodes gRPC messages to be delivered via the transport layer which implements {@link
  * MessageFramer.Sink}.
  */
-public class MessageFramer {
+public class MessageFramer implements Framer {
 
   private static final int NO_MAX_OUTBOUND_MESSAGE_SIZE = -1;
 
@@ -104,17 +104,20 @@ public class MessageFramer {
     this.statsTraceCtx = checkNotNull(statsTraceCtx, "statsTraceCtx");
   }
 
-  MessageFramer setCompressor(Compressor compressor) {
+  @Override
+  public MessageFramer setCompressor(Compressor compressor) {
     this.compressor = checkNotNull(compressor, "Can't pass an empty compressor");
     return this;
   }
 
-  MessageFramer setMessageCompression(boolean enable) {
+  @Override
+  public MessageFramer setMessageCompression(boolean enable) {
     messageCompression = enable;
     return this;
   }
 
-  void setMaxOutboundMessageSize(int maxSize) {
+  @Override
+  public void setMaxOutboundMessageSize(int maxSize) {
     checkState(maxOutboundMessageSize == NO_MAX_OUTBOUND_MESSAGE_SIZE, "max size already set");
     maxOutboundMessageSize = maxSize;
   }
@@ -124,6 +127,7 @@ public class MessageFramer {
    *
    * @param message contains the message to be written out. It will be completely consumed.
    */
+  @Override
   public void writePayload(InputStream message) {
     verifyNotClosed();
     boolean compressed = messageCompression && compressor != Codec.Identity.NONE;
@@ -286,6 +290,7 @@ public class MessageFramer {
   /**
    * Flushes any buffered data in the framer to the sink.
    */
+  @Override
   public void flush() {
     if (buffer != null && buffer.readableBytes() > 0) {
       commitToSink(false, true);
@@ -296,6 +301,7 @@ public class MessageFramer {
    * Indicates whether or not this framer has been closed via a call to either
    * {@link #close()} or {@link #dispose()}.
    */
+  @Override
   public boolean isClosed() {
     return closed;
   }
@@ -304,6 +310,7 @@ public class MessageFramer {
    * Flushes and closes the framer and releases any buffers. After the framer is closed or
    * disposed, additional calls to this method will have no affect.
    */
+  @Override
   public void close() {
     if (!isClosed()) {
       closed = true;
@@ -320,6 +327,7 @@ public class MessageFramer {
    * Closes the framer and releases any buffers, but does not flush. After the framer is
    * closed or disposed, additional calls to this method will have no affect.
    */
+  @Override
   public void dispose() {
     closed = true;
     releaseBuffer();

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -413,7 +413,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     // Create an intermediate promise so that we can intercept the failure reported back to the
     // application.
     ChannelPromise tempPromise = ctx().newPromise();
-    encoder().writeHeaders(ctx(), streamId, headers, 0, false, tempPromise)
+    encoder().writeHeaders(ctx(), streamId, headers, 0, command.isGet(), tempPromise)
             .addListener(new ChannelFutureListener() {
               @Override
               public void operationComplete(ChannelFuture future) throws Exception {

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -65,6 +65,7 @@ class Utils {
 
   public static final AsciiString STATUS_OK = AsciiString.of("200");
   public static final AsciiString HTTP_METHOD = AsciiString.of(GrpcUtil.HTTP_METHOD);
+  public static final AsciiString HTTP_GET_METHOD = AsciiString.of("GET");
   public static final AsciiString HTTPS = AsciiString.of("https");
   public static final AsciiString HTTP = AsciiString.of("http");
   public static final AsciiString CONTENT_TYPE_HEADER = AsciiString.of(CONTENT_TYPE_KEY.name());
@@ -116,15 +117,17 @@ class Utils {
       AsciiString scheme,
       AsciiString defaultPath,
       AsciiString authority,
+      AsciiString method,
       AsciiString userAgent) {
     Preconditions.checkNotNull(defaultPath, "defaultPath");
     Preconditions.checkNotNull(authority, "authority");
+    Preconditions.checkNotNull(method, "method");
 
     return GrpcHttp2OutboundHeaders.clientRequestHeaders(
         toHttp2Headers(headers),
         authority,
         defaultPath,
-        HTTP_METHOD,
+        method,
         scheme,
         userAgent);
   }


### PR DESCRIPTION
Based on ejona86@89f0d8c. It adds a writeHeaders API to AbstractClientStream2.Sink. When sending a GET request, writeHeaders call will be delayed until we have the request payload and halfClose is called. The request payload can then be sent in the query string.