### PR TITLE
core: delete deprecated pickSubchannel()

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -171,26 +171,9 @@ public abstract class LoadBalancer {
     /**
      * Make a balancing decision for a new RPC.
      *
-     * @param affinity the affinity attributes provided via {@link CallOptions#withAffinity}
-     * @param headers the headers container of the RPC. It can be mutated within this method.
-     * @deprecated this signature is going to be removed in the next minor release. Implementations
-     *     should instead override the {@link #pickSubchannel(LoadBalancer.PickSubchannelArgs)}.
-     */
-    @Deprecated
-    public PickResult pickSubchannel(Attributes affinity, Metadata headers) {
-      throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Make a balancing decision for a new RPC.
-     *
      * @param args the pick arguments
      */
-    // TODO(lukaszx0) make it abstract once deprecated overload will be removed.
-    @SuppressWarnings("deprecation")
-    public PickResult pickSubchannel(PickSubchannelArgs args) {
-      return pickSubchannel(args.getCallOptions().getAffinity(), args.getHeaders());
-    }
+    public abstract PickResult pickSubchannel(PickSubchannelArgs args);
   }
 
   /**


### PR DESCRIPTION
The deprecation happens in 1.2.0. Now we can delete it for the next release.