### PR TITLE
benchmarks: Fix broken building of ServerServiceDefinition

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/HandlerRegistryBenchmark.java
@@ -37,7 +37,6 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerServiceDefinition;
-import io.grpc.ServiceDescriptor;
 import io.grpc.testing.TestMethodDescriptors;
 import io.grpc.util.MutableHandlerRegistry;
 import java.util.ArrayList;
@@ -83,8 +82,7 @@ public class HandlerRegistryBenchmark {
     fullMethodNames = new ArrayList<String>(serviceCount * methodCountPerService);
     for (int serviceIndex = 0; serviceIndex < serviceCount; ++serviceIndex) {
       String serviceName = randomString();
-      ServerServiceDefinition.Builder serviceBuilder = ServerServiceDefinition.builder(
-          new ServiceDescriptor(serviceName));
+      ServerServiceDefinition.Builder serviceBuilder = ServerServiceDefinition.builder(serviceName);
       for (int methodIndex = 0; methodIndex < methodCountPerService; ++methodIndex) {
         String methodName = randomString();
 


### PR DESCRIPTION
This appears to have been broken by 3df1446 (which was reverted and
later rolled forward again in 66ab956).

Without this fix, the ServerServiceDefinition.Builder realizes that a
method is registered that isn't in the ServiceDescriptor. Swapping to a
different constructor causes the builder to generate the
ServiceDescriptor for us.

```
java.lang.IllegalStateException: No entry in descriptor matching bound method E6Cq77iKGNKVCGyVOqq8DqEazX9AcBdPNoMj86c3I5zo4Tv77U/vLe7QS7mhUfaooN7eYdBW7gd9oyV.kc9I0zJumfuUbhyb7SR1u
        at io.grpc.ServerServiceDefinition$Builder.build(ServerServiceDefinition.java:164)
        at io.grpc.benchmarks.netty.HandlerRegistryBenchmark.setup(HandlerRegistryBenchmark.java:107)
```