### PR TITLE
core,benchmarks: use Atomics for StatsTraceContext

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/internal/StatsTraceContextBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/internal/StatsTraceContextBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmark for {@link StatsTraceContext}.
+ */
+@State(Scope.Benchmark)
+public class StatsTraceContextBenchmark {
+
+  private final String methodName = MethodDescriptor.generateFullMethodName("service", "method");
+
+  private final Supplier<Stopwatch> stopWatches = new Supplier<Stopwatch>() {
+
+    @Override
+    public Stopwatch get() {
+      return Stopwatch.createUnstarted();
+    }
+  };
+
+  private final Metadata emptyMetadata = new Metadata();
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public StatsTraceContext newClientContext() {
+    return StatsTraceContext.newClientContext(
+        methodName, NoopStatsContextFactory.INSTANCE, stopWatches);
+  }
+
+  /**
+   * Javadoc comment.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public StatsTraceContext newServerContext_empty() {
+    return StatsTraceContext.newServerContext(
+        methodName, NoopStatsContextFactory.INSTANCE, emptyMetadata, stopWatches);
+  }
+}


### PR DESCRIPTION
This removes a needless warning, and isn't much slower.  Also this
includes a benchmark for StatsTraceContext to measure the overhead
for creation.  It adds about 40ns per RPC.  Optimization will come
after structural changes are made to break the dependency on
Census.