### PR TITLE
core: Remove internal comment referencing compression frames

### DIFF
--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -353,8 +353,7 @@ public class MessageDeframer implements Closeable {
   }
 
   /**
-   * Processes the body of the GRPC compression frame. A single compression frame may contain
-   * several GRPC messages within it.
+   * Processes the GRPC message body, which depending on frame header flags may be compressed.
    */
   private void processBody() {
     InputStream stream = compressedFlag ? getCompressedBody() : getUncompressedBody();


### PR DESCRIPTION
Compression frames existed in a very early iteration of the gRPC
protocol. It was killed long ago.