### PR TITLE
core: Fix User-Agent Javadoc in ManagedChannelBuilder

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -118,8 +118,8 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   /**
    * Provides a custom {@code User-Agent} for the application.
    *
-   * <p>It's an optional parameter. If provided, the given agent will be prepended by the
-   * grpc {@code User-Agent}.
+   * <p>It's an optional parameter. The library will provide a user agent independent of this
+   * option. If provided, the given agent will prepend the library's user agent information.
    */
   public abstract T userAgent(String userAgent);
 


### PR DESCRIPTION
The behavior of how the application's User-Agent is used changed in
2247ad2. But the Javadoc was not updated.