### PR TITLE
netty: Add server keepalive enforcement

### DIFF
--- a/netty/src/main/java/io/grpc/netty/KeepAliveEnforcer.java
+++ b/netty/src/main/java/io/grpc/netty/KeepAliveEnforcer.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.CheckReturnValue;
+
+/** Monitors the client's PING usage to make sure the rate is permitted. */
+class KeepAliveEnforcer {
+  @VisibleForTesting
+  static final int MAX_PING_STRIKES = 2;
+  @VisibleForTesting
+  static final long IMPLICIT_PERMIT_TIME_NANOS = TimeUnit.HOURS.toNanos(2);
+
+  private final boolean permitWithoutCalls;
+  private final long minTimeNanos;
+  private final Ticker ticker;
+  private final long epoch;
+
+  private long lastValidPingTime;
+  private boolean hasOutstandingCalls;
+  private int pingStrikes;
+
+  public KeepAliveEnforcer(boolean permitWithoutCalls, long minTime, TimeUnit unit) {
+    this(permitWithoutCalls, minTime, unit, SystemTicker.INSTANCE);
+  }
+
+  @VisibleForTesting
+  KeepAliveEnforcer(boolean permitWithoutCalls, long minTime, TimeUnit unit, Ticker ticker) {
+    Preconditions.checkArgument(minTime >= 0, "minTime must be non-negative");
+
+    this.permitWithoutCalls = permitWithoutCalls;
+    this.minTimeNanos = Math.min(unit.toNanos(minTime), IMPLICIT_PERMIT_TIME_NANOS);
+    this.ticker = ticker;
+    this.epoch = ticker.nanoTime();
+    lastValidPingTime = epoch;
+  }
+
+  /** Returns {@code false} when client is misbehaving and should be disconnected. */
+  @CheckReturnValue
+  public boolean pingAcceptable() {
+    long now = ticker.nanoTime();
+    boolean valid;
+    if (!hasOutstandingCalls && !permitWithoutCalls) {
+      valid = compareNanos(lastValidPingTime + IMPLICIT_PERMIT_TIME_NANOS, now) <= 0;
+    } else {
+      valid = compareNanos(lastValidPingTime + minTimeNanos, now) <= 0;
+    }
+    if (!valid) {
+      pingStrikes++;
+      return !(pingStrikes > MAX_PING_STRIKES);
+    } else {
+      lastValidPingTime = now;
+      return true;
+    }
+  }
+
+  public void resetCounters() {
+    lastValidPingTime = epoch;
+    pingStrikes = 0;
+  }
+
+  public void onTransportActive() {
+    hasOutstandingCalls = true;
+  }
+
+  public void onTransportIdle() {
+    hasOutstandingCalls = false;
+  }
+
+  /**
+   * Positive when time1 is greater; negative when time2 is greater; 0 when equal. It is important
+   * to use something like this instead of directly comparing nano times. See {@link
+   * System#nanoTime}.
+   */
+  private static long compareNanos(long time1, long time2) {
+    // Possibility of overflow/underflow is on purpose and necessary for correctness
+    return time1 - time2;
+  }
+
+  @VisibleForTesting
+  interface Ticker {
+    long nanoTime();
+  }
+
+  @VisibleForTesting
+  static class SystemTicker implements Ticker {
+    public static SystemTicker INSTANCE = new SystemTicker();
+
+    @Override
+    public long nanoTime() {
+      return System.nanoTime();
+    }
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/KeepAliveEnforcer.java
+++ b/netty/src/main/java/io/grpc/netty/KeepAliveEnforcer.java
@@ -86,15 +86,21 @@ class KeepAliveEnforcer {
     }
   }
 
+  /**
+   * Reset any counters because PINGs are allowed in response to something sent. Typically called
+   * when sending HEADERS and DATA frames.
+   */
   public void resetCounters() {
     lastValidPingTime = epoch;
     pingStrikes = 0;
   }
 
+  /** There are outstanding RPCs on the transport. */
   public void onTransportActive() {
     hasOutstandingCalls = true;
   }
 
+  /** There are no outstanding RPCs on the transport. */
   public void onTransportIdle() {
     hasOutstandingCalls = false;
   }
@@ -116,7 +122,7 @@ class KeepAliveEnforcer {
 
   @VisibleForTesting
   static class SystemTicker implements Ticker {
-    public static SystemTicker INSTANCE = new SystemTicker();
+    public static final SystemTicker INSTANCE = new SystemTicker();
 
     @Override
     public long nanoTime() {

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -561,21 +561,11 @@ class NettyServerHandler extends AbstractNettyHandler {
         ByteBuf debugData = ByteBufUtil.writeAscii(ctx.alloc(), "too_many_pings");
         goAway(ctx, connection().remote().lastStreamCreated(), Http2Error.ENHANCE_YOUR_CALM.code(),
             debugData, ctx.newPromise());
-        flush(ctx);
         Status status = Status.RESOURCE_EXHAUSTED.withDescription("Too many pings from client");
         try {
           forcefulClose(ctx, new ForcefulCloseCommand(status), ctx.newPromise());
-        } catch (Http2Exception ex) {
-          throw ex;
-        } catch (RuntimeException ex) {
-          throw ex;
         } catch (Exception ex) {
-          try {
-            exceptionCaught(ctx, ex);
-          } catch (Exception ex2) {
-            logger.log(Level.WARNING, "Exception while propagating exception", ex2);
-            logger.log(Level.WARNING, "Original failure", ex);
-          }
+          onError(ctx, ex);
         }
       }
     }

--- a/netty/src/test/java/io/grpc/netty/KeepAliveEnforcerTest.java
+++ b/netty/src/test/java/io/grpc/netty/KeepAliveEnforcerTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.netty;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link KeepAliveEnforcer}. */
+@RunWith(JUnit4.class)
+public class KeepAliveEnforcerTest {
+  private static final int LARGE_NUMBER = KeepAliveEnforcer.MAX_PING_STRIKES * 5;
+
+  private FakeTicker ticker = new FakeTicker();
+
+  @Test(expected = IllegalArgumentException.class)
+  public void negativeTime() {
+    new KeepAliveEnforcer(true, -1, TimeUnit.NANOSECONDS);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void nullTimeUnit() {
+    new KeepAliveEnforcer(true, 1, null);
+  }
+
+  @Test
+  public void permitLimitless() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(true, 0, TimeUnit.NANOSECONDS, ticker);
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    enforcer.onTransportActive();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    enforcer.onTransportIdle();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    enforcer.resetCounters();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+  }
+
+  @Test
+  public void strikeOutBecauseNoOutstandingCalls() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(false, 0, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportIdle();
+    for (int i = 0; i < KeepAliveEnforcer.MAX_PING_STRIKES; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    assertThat(enforcer.pingAcceptable()).isFalse();
+  }
+
+  @Test
+  public void startsIdle() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(false, 0, TimeUnit.NANOSECONDS, ticker);
+    for (int i = 0; i < KeepAliveEnforcer.MAX_PING_STRIKES; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    assertThat(enforcer.pingAcceptable()).isFalse();
+  }
+
+  @Test
+  public void strikeOutBecauseRateTooHighWhileActive() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(true, 1, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportActive();
+    for (int i = 0; i < KeepAliveEnforcer.MAX_PING_STRIKES; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    assertThat(enforcer.pingAcceptable()).isFalse();
+  }
+
+  @Test
+  public void strikeOutBecauseRateTooHighWhileIdle() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(true, 1, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportIdle();
+    for (int i = 0; i < KeepAliveEnforcer.MAX_PING_STRIKES; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    assertThat(enforcer.pingAcceptable()).isFalse();
+  }
+
+  @Test
+  public void permitInRateWhileActive() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(false, 1, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportActive();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+      ticker.nanoTime += 1;
+    }
+  }
+
+  @Test
+  public void permitInRateWhileIdle() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(true, 1, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportIdle();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+      ticker.nanoTime += 1;
+    }
+  }
+
+  @Test
+  public void implicitPermittedWhileIdle() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(
+        false, KeepAliveEnforcer.IMPLICIT_PERMIT_TIME_NANOS * 10, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportIdle();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+      ticker.nanoTime += KeepAliveEnforcer.IMPLICIT_PERMIT_TIME_NANOS;
+    }
+  }
+
+  @Test
+  public void implicitOverridesWhileActive() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(
+        false, KeepAliveEnforcer.IMPLICIT_PERMIT_TIME_NANOS * 10, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportActive();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+      ticker.nanoTime += KeepAliveEnforcer.IMPLICIT_PERMIT_TIME_NANOS;
+    }
+  }
+
+  @Test
+  public void implicitOverridesWhileIdle() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(
+        true, KeepAliveEnforcer.IMPLICIT_PERMIT_TIME_NANOS * 10, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportIdle();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+      ticker.nanoTime += KeepAliveEnforcer.IMPLICIT_PERMIT_TIME_NANOS;
+    }
+  }
+
+  @Test
+  public void permitsWhenTimeOverflows() {
+    ticker.nanoTime = Long.MAX_VALUE;
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(false, 1, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportActive();
+    for (int i = 0; i < KeepAliveEnforcer.MAX_PING_STRIKES; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    // Should have the maximum number of strikes now
+    ticker.nanoTime++;
+    assertThat(enforcer.pingAcceptable()).isTrue();
+  }
+
+  @Test
+  public void resetCounters_resetsStrikes() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(false, 1, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportActive();
+    for (int i = 0; i < KeepAliveEnforcer.MAX_PING_STRIKES; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    // Should have the maximum number of strikes now
+    enforcer.resetCounters();
+    for (int i = 0; i < KeepAliveEnforcer.MAX_PING_STRIKES; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    assertThat(enforcer.pingAcceptable()).isFalse();
+  }
+
+  @Test
+  public void resetCounters_resetsPingTime() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(false, 1, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportActive();
+    ticker.nanoTime += 1;
+    assertThat(enforcer.pingAcceptable()).isTrue();
+    enforcer.resetCounters();
+    // Should not cause a strike
+    assertThat(enforcer.pingAcceptable()).isTrue();
+    for (int i = 0; i < KeepAliveEnforcer.MAX_PING_STRIKES; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+  }
+
+  @Test
+  public void systemTickerIsSystemNanoTime() {
+    long before = System.nanoTime();
+    long returned = KeepAliveEnforcer.SystemTicker.INSTANCE.nanoTime();
+    long after = System.nanoTime();
+    assertThat(returned).isAtLeast(before);
+    assertThat(returned).isAtMost(after);
+  }
+
+  private static class FakeTicker implements KeepAliveEnforcer.Ticker {
+    long nanoTime;
+
+    @Override
+    public long nanoTime() {
+      return nanoTime;
+    }
+  }
+}


### PR DESCRIPTION
Everything is currently permitted, but I've tested with other
configurations and all tests pass. I'll set the restrictive default at
the same time as adding a configuration API.