### PR TITLE
core/grpclb: Ignore equivalent pickers

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -209,6 +209,16 @@ public abstract class LoadBalancer {
      * @param args the pick arguments
      */
     public abstract PickResult pickSubchannel(PickSubchannelArgs args);
+
+    /**
+     * Returns {@code true} if the two pickers should be considered equivalent.
+     *
+     * <p>As an optimization, if {@link Helper#updatePicker} receives a picker that is equivalent to
+     * the current one, the new one will be ignored.  Default implemetation uses identity equality.
+     */
+    public boolean isEquivalentTo(SubchannelPicker other) {
+      return this == other;
+    }
   }
 
   /**
@@ -424,8 +434,8 @@ public abstract class LoadBalancer {
      * called again and a new picker replaces the old one.  If {@code updatePicker()} has never been
      * called, the channel will buffer all RPCs until a picker is provided.
      *
-     * <p>If the new picker {@link Object#equals equals to} the current one, this update will be
-     * ignored.
+     * <p>If the new picker {@link SubchannelPicker#isEquivalentTo is equivalent to} the current
+     * one, this update will be ignored.
      */
     public abstract void updatePicker(SubchannelPicker picker);
 

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -423,6 +423,9 @@ public abstract class LoadBalancer {
      * <p>The channel will hold the picker and use it for all RPCs, until {@code updatePicker()} is
      * called again and a new picker replaces the old one.  If {@code updatePicker()} has never been
      * called, the channel will buffer all RPCs until a picker is provided.
+     *
+     * <p>If the new picker {@link Object#equals equals to} the current one, this update will be
+     * ignored.
      */
     public abstract void updatePicker(SubchannelPicker picker);
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -720,8 +720,10 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       runSerialized(new Runnable() {
           @Override
           public void run() {
-            subchannelPicker = picker;
-            delayedTransport.reprocess(picker);
+            if (!(picker.equals(subchannelPicker))) {
+              subchannelPicker = picker;
+              delayedTransport.reprocess(picker);
+            }
           }
         });
     }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -720,7 +720,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       runSerialized(new Runnable() {
           @Override
           public void run() {
-            if (!(picker.equals(subchannelPicker))) {
+            if (!(picker.isEquivalentTo(subchannelPicker))) {
               subchannelPicker = picker;
               delayedTransport.reprocess(picker);
             }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -478,6 +478,20 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
     public PickResult pickSubchannel(PickSubchannelArgs args) {
       return result;
     }
+
+    @Override
+    public int hashCode() {
+      return result.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof ErrorPicker)) {
+        return false;
+      }
+      ErrorPicker that = (ErrorPicker) other;
+      return result.equals(that.result);
+    }
   }
 
   @VisibleForTesting
@@ -553,6 +567,20 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
         result.updateHeaders(args.getHeaders());
         return result.result;
       }
+    }
+
+    @Override
+    public int hashCode() {
+      return list.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof RoundRobinPicker)) {
+        return false;
+      }
+      RoundRobinPicker that = (RoundRobinPicker) other;
+      return list.equals(that.list);
     }
   }
 }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -480,12 +480,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
     }
 
     @Override
-    public int hashCode() {
-      return result.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object other) {
+    public boolean isEquivalentTo(SubchannelPicker other) {
       if (!(other instanceof ErrorPicker)) {
         return false;
       }
@@ -570,12 +565,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
     }
 
     @Override
-    public int hashCode() {
-      return list.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object other) {
+    public boolean isEquivalentTo(SubchannelPicker other) {
       if (!(other instanceof RoundRobinPicker)) {
         return false;
       }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -39,6 +39,7 @@ import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.SHUTDOWN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -274,6 +275,15 @@ public class GrpclbLoadBalancerTest {
     ErrorPicker picker = new ErrorPicker(error);
     assertSame(error, picker.pickSubchannel(mockArgs).getStatus());
     verifyNoMoreInteractions(mockArgs);
+
+    // Test equality check
+    ErrorPicker picker2 = new ErrorPicker(error);
+    ErrorPicker picker3 = new ErrorPicker(Status.CANCELLED);
+    assertEquals(picker, picker2);
+    assertEquals(picker.hashCode(), picker2.hashCode());
+    assertNotEquals(picker, picker3);
+    assertNotEquals(picker2, picker3);
+    assertNotEquals(picker, GrpclbLoadBalancer.BUFFER_PICKER);
   }
 
   @Test
@@ -283,8 +293,7 @@ public class GrpclbLoadBalancerTest {
     RoundRobinEntry r2 = new RoundRobinEntry(subchannel, "LBTOKEN0001");
     RoundRobinEntry r3 = new RoundRobinEntry(subchannel, "LBTOKEN0002");
 
-    List<RoundRobinEntry> list = Arrays.asList(r1, r2, r3);
-    RoundRobinPicker picker = new RoundRobinPicker(list);
+    RoundRobinPicker picker = new RoundRobinPicker(Arrays.asList(r1, r2, r3));
 
     PickSubchannelArgs args1 = mock(PickSubchannelArgs.class);
     Metadata headers1 = new Metadata();
@@ -315,6 +324,15 @@ public class GrpclbLoadBalancerTest {
     assertSame(r1.result, picker.pickSubchannel(args4));
     verify(args4).getHeaders();
     assertFalse(headers4.containsKey(GrpclbLoadBalancer.TOKEN_KEY));
+
+    // Test equality check
+    RoundRobinPicker picker2 = new RoundRobinPicker(Arrays.asList(r2, r3, r1));
+    RoundRobinPicker picker3 = new RoundRobinPicker(Arrays.asList(r1, r2, r3));
+    assertEquals(picker, picker3);
+    assertEquals(picker.hashCode(), picker3.hashCode());
+    assertNotEquals(picker, picker2);
+    assertNotEquals(picker2, picker3);
+    assertNotEquals(picker, GrpclbLoadBalancer.BUFFER_PICKER);
 
     verify(subchannel, never()).getAttributes();
   }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -39,7 +39,6 @@ import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.SHUTDOWN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -279,11 +278,10 @@ public class GrpclbLoadBalancerTest {
     // Test equality check
     ErrorPicker picker2 = new ErrorPicker(error);
     ErrorPicker picker3 = new ErrorPicker(Status.CANCELLED);
-    assertEquals(picker, picker2);
-    assertEquals(picker.hashCode(), picker2.hashCode());
-    assertNotEquals(picker, picker3);
-    assertNotEquals(picker2, picker3);
-    assertNotEquals(picker, GrpclbLoadBalancer.BUFFER_PICKER);
+    assertTrue(picker.isEquivalentTo(picker2));
+    assertFalse(picker.isEquivalentTo(picker3));
+    assertFalse(picker2.isEquivalentTo(picker3));
+    assertFalse(picker.isEquivalentTo(GrpclbLoadBalancer.BUFFER_PICKER));
   }
 
   @Test
@@ -325,14 +323,13 @@ public class GrpclbLoadBalancerTest {
     verify(args4).getHeaders();
     assertFalse(headers4.containsKey(GrpclbLoadBalancer.TOKEN_KEY));
 
-    // Test equality check
+    // Test isEquivalentTo()
     RoundRobinPicker picker2 = new RoundRobinPicker(Arrays.asList(r2, r3, r1));
     RoundRobinPicker picker3 = new RoundRobinPicker(Arrays.asList(r1, r2, r3));
-    assertEquals(picker, picker3);
-    assertEquals(picker.hashCode(), picker3.hashCode());
-    assertNotEquals(picker, picker2);
-    assertNotEquals(picker2, picker3);
-    assertNotEquals(picker, GrpclbLoadBalancer.BUFFER_PICKER);
+    assertTrue(picker.isEquivalentTo(picker3));
+    assertFalse(picker.isEquivalentTo(picker2));
+    assertFalse(picker2.isEquivalentTo(picker3));
+    assertFalse(picker.isEquivalentTo(GrpclbLoadBalancer.BUFFER_PICKER));
 
     verify(subchannel, never()).getAttributes();
   }


### PR DESCRIPTION
Add `isEquivalentTo()` to `SubchannelPicker` to allow the Channel to ignore **equivalent** picker updates. Two benefits:
 1. Save the cycles spent on unnecessary "reprocessing" of pending streams
 2. Allows the Picker state (e.g., current round-robin index) to be kept if nothing has changed, resulting in less churn. In particular, because GRPCLB balancer may send identical address list to the client just to refresh the TTL, without this change the round-robin index is reset frequently enough to cause over-the-threshold imbalance in our integration test, resulting test failures.

Alternatively, LoadBalancer implementations could check whether the error status or round-robin list etc of the new Picker is the same as the current one and skip the call to `updatePicker()` if it's the case. However, a LoadBalancer may have more than one places where the Picker is constructed and the equivalency-check logic would be all over the place.