### PR TITLE
core: allow SubchannelPicker to return a StreamTracer factory.

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -251,16 +251,20 @@ public abstract class LoadBalancer {
    */
   @Immutable
   public static final class PickResult {
-    private static final PickResult NO_RESULT = new PickResult(null, Status.OK);
+    private static final PickResult NO_RESULT = new PickResult(null, null, Status.OK);
 
     @Nullable private final Subchannel subchannel;
+    @Nullable private final ClientStreamTracer.Factory streamTracerFactory;
     // An error to be propagated to the application if subchannel == null
     // Or OK if there is no error.
     // subchannel being null and error being OK means RPC needs to wait
     private final Status status;
 
-    private PickResult(@Nullable Subchannel subchannel, Status status) {
+    private PickResult(
+        @Nullable Subchannel subchannel, @Nullable ClientStreamTracer.Factory streamTracerFactory,
+        Status status) {
       this.subchannel = subchannel;
+      this.streamTracerFactory = streamTracerFactory;
       this.status = Preconditions.checkNotNull(status, "status");
     }
 
@@ -323,9 +327,24 @@ public abstract class LoadBalancer {
      *       new state is SHUTDOWN. See {@code handleSubchannelState}'s javadoc for more
      *       details.</li>
      * </ol>
+     *
+     * @param subchannel the picked Subchannel
+     * @param streamTracerFactory if not null, will be used to trace the activities of the stream
+     *                            created as a result of this pick. Note it's possible that no
+     *                            stream is created at all in some cases.
+     */
+    public static PickResult withSubchannel(
+        Subchannel subchannel, @Nullable ClientStreamTracer.Factory streamTracerFactory) {
+      return new PickResult(
+          Preconditions.checkNotNull(subchannel, "subchannel"), streamTracerFactory, Status.OK);
+    }
+
+    /**
+     * Equivalent to {@link #withSubchannel(Subchannel, ClientStreamTracer.Factory)
+     * withSubchannel(subchannel, null)}.
      */
     public static PickResult withSubchannel(Subchannel subchannel) {
-      return new PickResult(Preconditions.checkNotNull(subchannel, "subchannel"), Status.OK);
+      return withSubchannel(subchannel, null);
     }
 
     /**
@@ -337,7 +356,7 @@ public abstract class LoadBalancer {
      */
     public static PickResult withError(Status error) {
       Preconditions.checkArgument(!error.isOk(), "error status shouldn't be OK");
-      return new PickResult(null, error);
+      return new PickResult(null, null, error);
     }
 
     /**
@@ -357,6 +376,14 @@ public abstract class LoadBalancer {
     }
 
     /**
+     * The stream tracer factory this result was created with.
+     */
+    @Nullable
+    public ClientStreamTracer.Factory getStreamTracerFactory() {
+      return streamTracerFactory;
+    }
+
+    /**
      * The status associated with this result.  Non-{@code OK} if created with {@link #withError
      * withError}, or {@code OK} otherwise.
      */
@@ -368,6 +395,7 @@ public abstract class LoadBalancer {
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("subchannel", subchannel)
+          .add("streamTracerFactory", streamTracerFactory)
           .add("status", status)
           .toString();
     }

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -340,8 +340,7 @@ public abstract class LoadBalancer {
     }
 
     /**
-     * Equivalent to {@link #withSubchannel(Subchannel, ClientStreamTracer.Factory)
-     * withSubchannel(subchannel, null)}.
+     * Equivalent to {@code withSubchannel(subchannel, null)}.
      */
     public static PickResult withSubchannel(Subchannel subchannel) {
       return withSubchannel(subchannel, null);

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -595,28 +595,27 @@ public final class GrpcUtil {
     }
     if (transport != null) {
       final ClientStreamTracer.Factory streamTracerFactory = result.getStreamTracerFactory();
-      if (streamTracerFactory != null) {
-        return new ClientTransport() {
-          @Override
-          public ClientStream newStream(
-              MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
-            return transport.newStream(
-                method, headers, callOptions.withStreamTracerFactory(streamTracerFactory));
-          }
-
-          @Override
-          public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
-            return newStream(method, headers, CallOptions.DEFAULT);
-          }
-
-          @Override
-          public void ping(PingCallback callback, Executor executor) {
-            transport.ping(callback, executor);
-          }
-        };
-      } else {
+      if (streamTracerFactory == null) {
         return transport;
       }
+      return new ClientTransport() {
+        @Override
+        public ClientStream newStream(
+            MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+          return transport.newStream(
+              method, headers, callOptions.withStreamTracerFactory(streamTracerFactory));
+        }
+
+        @Override
+        public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
+          return newStream(method, headers, CallOptions.DEFAULT);
+        }
+
+        @Override
+        public void ping(PingCallback callback, Executor executor) {
+          transport.ping(callback, executor);
+        }
+      };
     }
     if (!result.getStatus().isOk() && !isWaitForReady) {
       return new FailingClientTransport(result.getStatus());

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -40,11 +40,14 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
 import io.grpc.InternalMetadata;
 import io.grpc.InternalMetadata.TrustedAsciiMarshaller;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import java.lang.reflect.Method;
@@ -52,6 +55,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -582,7 +586,7 @@ public final class GrpcUtil {
    */
   @Nullable
   static ClientTransport getTransportFromPickResult(PickResult result, boolean isWaitForReady) {
-    ClientTransport transport;
+    final ClientTransport transport;
     Subchannel subchannel = result.getSubchannel();
     if (subchannel != null) {
       transport = ((SubchannelImpl) subchannel).obtainActiveTransport();
@@ -590,7 +594,29 @@ public final class GrpcUtil {
       transport = null;
     }
     if (transport != null) {
-      return transport;
+      final ClientStreamTracer.Factory streamTracerFactory = result.getStreamTracerFactory();
+      if (streamTracerFactory != null) {
+        return new ClientTransport() {
+          @Override
+          public ClientStream newStream(
+              MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+            return transport.newStream(
+                method, headers, callOptions.withStreamTracerFactory(streamTracerFactory));
+          }
+
+          @Override
+          public ClientStream newStream(MethodDescriptor<?, ?> method, Metadata headers) {
+            return newStream(method, headers, CallOptions.DEFAULT);
+          }
+
+          @Override
+          public void ping(PingCallback callback, Executor executor) {
+            transport.ping(callback, executor);
+          }
+        };
+      } else {
+        return transport;
+      }
     }
     if (!result.getStatus().isOk() && !isWaitForReady) {
       return new FailingClientTransport(result.getStatus());


### PR DESCRIPTION
This allows LoadBalancers to trace the activities, including the final
status of the stream that is created as a result of the pick.

@ejona86 Although earlier we talked about switching `PickResult` to builder pattern, I found this particular change works fine with the current pattern. Let me know if you prefer doing the switch now.