### PR TITLE
core: deprecate MethodDescriptor.create

### DIFF
--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -200,7 +200,9 @@ public final class MethodDescriptor<ReqT, RespT> {
    * @param requestMarshaller the marshaller used to encode and decode requests
    * @param responseMarshaller the marshaller used to encode and decode responses
    * @since 1.0.0
+   * @deprecated use {@link #newBuilder()}.
    */
+  @Deprecated
   public static <RequestT, ResponseT> MethodDescriptor<RequestT, ResponseT> create(
       MethodType type, String fullMethodName,
       Marshaller<RequestT> requestMarshaller,

--- a/core/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/core/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -32,6 +32,7 @@ import org.junit.runners.JUnit4;
 public class MethodDescriptorTest {
   @Test
   public void createMethodDescriptor() {
+    @SuppressWarnings("deprecation") // MethodDescriptor.create
     MethodDescriptor<String, String> descriptor = MethodDescriptor.<String, String>create(
         MethodType.CLIENT_STREAMING, "/package.service/method", new StringMarshaller(),
         new StringMarshaller());

--- a/core/src/test/java/io/grpc/ServiceDescriptorTest.java
+++ b/core/src/test/java/io/grpc/ServiceDescriptorTest.java
@@ -63,6 +63,7 @@ public class ServiceDescriptorTest {
 
   @Test
   public void failsOnNonMatchingNames() {
+    @SuppressWarnings("deprecation") // MethodDescriptor.create
     List<MethodDescriptor<?, ?>> descriptors = Collections.<MethodDescriptor<?, ?>>singletonList(
         MethodDescriptor.create(
             MethodType.UNARY,
@@ -78,6 +79,7 @@ public class ServiceDescriptorTest {
 
   @Test
   public void failsOnNonDuplicateNames() {
+    @SuppressWarnings("deprecation") // MethodDescriptor.create
     List<MethodDescriptor<?, ?>> descriptors = Arrays.<MethodDescriptor<?, ?>>asList(
         MethodDescriptor.create(
             MethodType.UNARY,

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -131,9 +131,13 @@ public class CensusModulesTest {
         }
       };
 
-  private final MethodDescriptor<String, String> method = MethodDescriptor.create(
-      MethodDescriptor.MethodType.UNKNOWN, "package1.service2/method3",
-      MARSHALLER, MARSHALLER);
+  private final MethodDescriptor<String, String> method =
+      MethodDescriptor.<String, String>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNKNOWN)
+          .setRequestMarshaller(MARSHALLER)
+          .setResponseMarshaller(MARSHALLER)
+          .setFullMethodName("package1.service2/method3")
+          .build();
   private final FakeClock fakeClock = new FakeClock();
   private final FakeStatsContextFactory statsCtxFactory = new FakeStatsContextFactory();
   private final Random random = new Random(0);


### PR DESCRIPTION
Depends on #2886, related to #2625.

cc @carl-mastrangelo 