### PR TITLE
core: remove incorrect reporting of CLIENT_SERVER_ELAPSED_TIME.

### DIFF
--- a/core/src/test/java/io/grpc/internal/CensusStreamTracerModuleTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusStreamTracerModuleTest.java
@@ -234,8 +234,6 @@ public class CensusStreamTracerModuleTest {
         record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
     assertEquals(30 + 100 + 16 + 24,
         record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
-    assertEquals(100 + 16 + 24,
-        record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
   }
 
   @Test

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1616,7 +1616,6 @@ public abstract class AbstractInteropTest {
       assertEquals(uncompressedResponsesSize,
           record.getMetricAsLongOrFail(RpcConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
       assertNotNull(record.getMetric(RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
-      assertNotNull(record.getMetric(RpcConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
       // It's impossible to get the expected wire sizes because it may be compressed, so we just
       // check if they are recorded.
       assertNotNull(record.getMetric(RpcConstants.RPC_CLIENT_REQUEST_BYTES));


### PR DESCRIPTION
Per spec this metric should be calculated on the server and sent back to
the client, for which the mechanism is not currently defined. As it's
not a required metric, we remove the incorrect implementation for now.

Internal ref: b/37208451