### PR TITLE
testing: remove negative asserts about stats.

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -253,10 +253,6 @@ public abstract class AbstractInteropTest {
     if (channel != null) {
       channel.shutdown();
     }
-    if (!metricsExpected()) {
-      assertEquals(0, clientStreamTracers.size());
-      assertEquals(0, serverStreamTracers.size());
-    }
   }
 
   protected abstract ManagedChannel createChannel();


### PR DESCRIPTION
They were added in #2863. In TestServiceClient metricsExpected() returns
false because server-side stats is not available, but client-side stats
are there, thus these asserts would fail.

Resolves grpc/grpc/issues/10552