### PR TITLE
core: Fix unused variables

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -187,8 +187,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
         firstNonNull(fallbackRegistry, EMPTY_FALLBACK_REGISTRY), transportServer,
         Context.ROOT, firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
         firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()),
-        transportFilters,
-        GrpcUtil.STOPWATCH_SUPPLIER);
+        transportFilters);
     for (InternalNotifyOnServerBuild notifyTarget : notifyOnBuildList) {
       notifyTarget.notifyOnBuild(server);
     }

--- a/core/src/main/java/io/grpc/internal/CensusStreamTracerModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStreamTracerModule.java
@@ -132,7 +132,7 @@ final class CensusStreamTracerModule {
    * Returns the server tracer factory.
    */
   ServerStreamTracer.Factory getServerTracerFactory() {
-    return new ServerTracerFactory();
+    return serverTracerFactory;
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -659,7 +659,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
           "scheduledExecutor is already cleared. Looks like you are calling this method after "
           + "you've already shut down");
       final OobChannel oobChannel = new OobChannel(
-          authority, oobExecutorPool, scheduledExecutorCopy, stopwatchSupplier, channelExecutor);
+          authority, oobExecutorPool, scheduledExecutorCopy, channelExecutor);
       final InternalSubchannel internalSubchannel = new InternalSubchannel(
           addressGroup, authority, userAgent, backoffPolicyProvider, transportFactory,
           scheduledExecutorCopy, stopwatchSupplier, channelExecutor,

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -178,7 +178,7 @@ public class MessageFramer implements Framer {
     return written;
   }
 
-  private int writeCompressed(InputStream message, int messageLength) throws IOException {
+  private int writeCompressed(InputStream message, int unusedMessageLength) throws IOException {
     BufferChainOutputStream bufferChain = new BufferChainOutputStream();
 
     OutputStream compressingStream = compressor.compress(bufferChain);

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -33,8 +33,6 @@ package io.grpc.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Stopwatch;
-import com.google.common.base.Supplier;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
@@ -73,7 +71,6 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   private final ObjectPool<? extends Executor> executorPool;
   private final Executor executor;
   private final ScheduledExecutorService deadlineCancellationExecutor;
-  private final Supplier<Stopwatch> stopwatchSupplier;
   private final CountDownLatch terminatedLatch = new CountDownLatch(1);
   private volatile boolean shutdown;
 
@@ -89,14 +86,12 @@ final class OobChannel extends ManagedChannel implements WithLogId {
 
   OobChannel(
       String authority, ObjectPool<? extends Executor> executorPool,
-      ScheduledExecutorService deadlineCancellationExecutor, Supplier<Stopwatch> stopwatchSupplier,
-      ChannelExecutor channelExecutor) {
+      ScheduledExecutorService deadlineCancellationExecutor, ChannelExecutor channelExecutor) {
     this.authority = checkNotNull(authority, "authority");
     this.executorPool = checkNotNull(executorPool, "executorPool");
     this.executor = checkNotNull(executorPool.getObject(), "executor");
     this.deadlineCancellationExecutor = checkNotNull(
         deadlineCancellationExecutor, "deadlineCancellationExecutor");
-    this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");
     this.delayedTransport = new DelayedClientTransport(executor, channelExecutor);
     this.delayedTransport.start(new ManagedClientTransport.Listener() {
         @Override

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -42,12 +42,12 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link InProcessTransport}. */
 @RunWith(JUnit4.class)
 public class InProcessTransportTest extends AbstractTransportTest {
-  private static final String transportName = "perfect-for-testing";
-  private static final String authority = "a-testing-authority";
+  private static final String TRANSPORT_NAME = "perfect-for-testing";
+  private static final String AUTHORITY = "a-testing-authority";
 
   @Override
   protected InternalServer newServer(List<ServerStreamTracer.Factory> streamTracerFactories) {
-    return new InProcessServer(transportName);
+    return new InProcessServer(TRANSPORT_NAME);
   }
 
   @Override
@@ -58,12 +58,12 @@ public class InProcessTransportTest extends AbstractTransportTest {
 
   @Override
   protected String testAuthority(InternalServer server) {
-    return authority;
+    return AUTHORITY;
   }
 
   @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
-    return new InProcessTransport(transportName, testAuthority(server));
+    return new InProcessTransport(TRANSPORT_NAME, testAuthority(server));
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/CensusStreamTracerModuleTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusStreamTracerModuleTest.java
@@ -266,7 +266,7 @@ public class CensusStreamTracerModuleTest {
     ClientCallTracer callTracer = census.newClientCallTracer(clientCtx, methodName);
     Metadata headers = new Metadata();
     // This propagates clientCtx to headers
-    ClientStreamTracer clientTracer = callTracer.newClientStreamTracer(headers);
+    callTracer.newClientStreamTracer(headers);
 
     ServerStreamTracer serverTracer =
         census.getServerTracerFactory().newServerStreamTracer(methodName, headers);

--- a/core/src/test/java/io/grpc/internal/MessageFramerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageFramerTest.java
@@ -43,7 +43,6 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 import io.grpc.Codec;
 import io.grpc.StreamTracer;
-import io.grpc.internal.testing.StatsTestUtils.FakeStatsContextFactory;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
@@ -77,14 +76,12 @@ public class MessageFramerTest {
   private ArgumentCaptor<Long> uncompressedSizeCaptor;
   private BytesWritableBufferAllocator allocator =
       new BytesWritableBufferAllocator(1000, 1000);
-  private FakeStatsContextFactory statsCtxFactory;
   private StatsTraceContext statsTraceCtx;
 
   /** Set up for test. */
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    statsCtxFactory = new FakeStatsContextFactory();
     // MessageDeframerTest tests with a client-side StatsTraceContext, so here we test with a
     // server-side StatsTraceContext.
     statsTraceCtx = new StatsTraceContext(new StreamTracer[]{tracer});

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1033,8 +1033,7 @@ public class ServerImplTest {
   private void createServer(List<ServerTransportFilter> filters) {
     assertNull(server);
     server = new ServerImpl(executorPool, timerPool, registry, fallbackRegistry,
-        transportServer, SERVER_CONTEXT, decompressorRegistry, compressorRegistry, filters,
-        GrpcUtil.STOPWATCH_SUPPLIER);
+        transportServer, SERVER_CONTEXT, decompressorRegistry, compressorRegistry, filters);
   }
 
   private void verifyExecutorsAcquired() {


### PR DESCRIPTION
I did not fix the unused statsTraceCtx in
AbstractClientStream2.GetFramer. Instead, I opened
https://github.com/grpc/grpc-java/issues/2896