### PR TITLE
Service Method Options (Protobuf)

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -26,7 +26,12 @@ public final class BenchmarkServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.BenchmarkService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new BenchmarkServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_UNARY_CALL = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_UNARY_CALL =
@@ -38,7 +43,12 @@ public final class BenchmarkServiceGrpc {
               io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_UNARY_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_STREAMING_CALL = 1;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_CALL =
@@ -50,6 +60,8 @@ public final class BenchmarkServiceGrpc {
               io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STREAMING_CALL).getOptions())
           .build();
 
   /**
@@ -268,10 +280,20 @@ public final class BenchmarkServiceGrpc {
     }
   }
 
-  private static final class BenchmarkServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class BenchmarkServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.benchmarks.proto.Services.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -284,7 +306,7 @@ public final class BenchmarkServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new BenchmarkServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_UNARY_CALL)
               .addMethod(METHOD_STREAMING_CALL)
               .build();

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -26,7 +26,12 @@ public final class WorkerServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.WorkerService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new WorkerServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_RUN_SERVER = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs,
       io.grpc.benchmarks.proto.Control.ServerStatus> METHOD_RUN_SERVER =
@@ -38,7 +43,12 @@ public final class WorkerServiceGrpc {
               io.grpc.benchmarks.proto.Control.ServerArgs.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Control.ServerStatus.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_RUN_SERVER).getOptions())
           .build();
+
+  private static final int METHODIDX_RUN_CLIENT = 1;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs,
       io.grpc.benchmarks.proto.Control.ClientStatus> METHOD_RUN_CLIENT =
@@ -50,7 +60,12 @@ public final class WorkerServiceGrpc {
               io.grpc.benchmarks.proto.Control.ClientArgs.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Control.ClientStatus.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_RUN_CLIENT).getOptions())
           .build();
+
+  private static final int METHODIDX_CORE_COUNT = 2;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest,
       io.grpc.benchmarks.proto.Control.CoreResponse> METHOD_CORE_COUNT =
@@ -62,7 +77,12 @@ public final class WorkerServiceGrpc {
               io.grpc.benchmarks.proto.Control.CoreRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Control.CoreResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_CORE_COUNT).getOptions())
           .build();
+
+  private static final int METHODIDX_QUIT_WORKER = 3;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void,
       io.grpc.benchmarks.proto.Control.Void> METHOD_QUIT_WORKER =
@@ -74,6 +94,8 @@ public final class WorkerServiceGrpc {
               io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_QUIT_WORKER).getOptions())
           .build();
 
   /**
@@ -392,10 +414,20 @@ public final class WorkerServiceGrpc {
     }
   }
 
-  private static final class WorkerServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class WorkerServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.benchmarks.proto.Services.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(1);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -408,7 +440,7 @@ public final class WorkerServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new WorkerServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_RUN_SERVER)
               .addMethod(METHOD_RUN_CLIENT)
               .addMethod(METHOD_CORE_COUNT)

--- a/compiler/src/java_plugin/cpp/java_generator.h
+++ b/compiler/src/java_plugin/cpp/java_generator.h
@@ -49,8 +49,12 @@ string ServiceJavaPackage(const google::protobuf::FileDescriptor* file, bool nan
 // the given service.
 string ServiceClassName(const google::protobuf::ServiceDescriptor* service);
 
+// Returns the name of the proto descriptor for a given service.
+string ServiceProtoDescriptorSupplierName(const google::protobuf::ServiceDescriptor* service);
+
 // Writes the generated service interface into the given ZeroCopyOutputStream
-void GenerateService(const google::protobuf::ServiceDescriptor* service,
+void GenerateService(int service_idx,
+                     const google::protobuf::ServiceDescriptor* service,
                      google::protobuf::io::ZeroCopyOutputStream* out,
                      ProtoFlavor flavor,
                      bool enable_deprecated);

--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -57,7 +57,7 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
           + java_grpc_generator::ServiceClassName(service) + ".java";
       std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> output(
           context->Open(filename));
-      java_grpc_generator::GenerateService(service, output.get(), flavor, enable_deprecated);
+      java_grpc_generator::GenerateService(i, service, output.get(), flavor, enable_deprecated);
     }
     return true;
   }

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -29,7 +29,12 @@ public final class TestServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.TestService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new TestServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_UNARY_CALL = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
       io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL =
@@ -41,7 +46,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.SimpleResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_UNARY_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_STREAMING_OUTPUT_CALL = 1;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
@@ -53,7 +63,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STREAMING_OUTPUT_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_STREAMING_INPUT_CALL = 2;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
@@ -65,7 +80,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STREAMING_INPUT_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_FULL_BIDI_CALL = 3;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL =
@@ -77,7 +97,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_FULL_BIDI_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_HALF_BIDI_CALL = 4;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL =
@@ -89,6 +114,8 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_HALF_BIDI_CALL).getOptions())
           .build();
 
   /**
@@ -440,10 +467,20 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static final class TestServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class TestServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -456,7 +493,7 @@ public final class TestServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new TestServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_UNARY_CALL)
               .addMethod(METHOD_STREAMING_OUTPUT_CALL)
               .addMethod(METHOD_STREAMING_INPUT_CALL)

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -29,7 +29,12 @@ public final class TestServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.TestService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new TestServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_UNARY_CALL = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
       io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL =
@@ -41,7 +46,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
               io.grpc.testing.integration.Test.SimpleResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_UNARY_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_STREAMING_OUTPUT_CALL = 1;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
@@ -53,7 +63,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STREAMING_OUTPUT_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_STREAMING_INPUT_CALL = 2;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
@@ -65,7 +80,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STREAMING_INPUT_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_FULL_BIDI_CALL = 3;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL =
@@ -77,7 +97,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_FULL_BIDI_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_HALF_BIDI_CALL = 4;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL =
@@ -89,6 +114,8 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_HALF_BIDI_CALL).getOptions())
           .build();
 
   /**

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -31,7 +31,12 @@ public final class TestServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.TestService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new TestServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_UNARY_CALL = 0;
+
   private static final int ARG_IN_METHOD_UNARY_CALL = 0;
   private static final int ARG_OUT_METHOD_UNARY_CALL = 1;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
@@ -45,7 +50,12 @@ public final class TestServiceGrpc {
               new NanoFactory<io.grpc.testing.integration.nano.Test.SimpleRequest>(ARG_IN_METHOD_UNARY_CALL)))
           .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.SimpleResponse>marshaller(
               new NanoFactory<io.grpc.testing.integration.nano.Test.SimpleResponse>(ARG_OUT_METHOD_UNARY_CALL)))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_UNARY_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_STREAMING_OUTPUT_CALL = 1;
+
   private static final int ARG_IN_METHOD_STREAMING_OUTPUT_CALL = 2;
   private static final int ARG_OUT_METHOD_STREAMING_OUTPUT_CALL = 3;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
@@ -59,7 +69,12 @@ public final class TestServiceGrpc {
               new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>(ARG_IN_METHOD_STREAMING_OUTPUT_CALL)))
           .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
               new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(ARG_OUT_METHOD_STREAMING_OUTPUT_CALL)))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STREAMING_OUTPUT_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_STREAMING_INPUT_CALL = 2;
+
   private static final int ARG_IN_METHOD_STREAMING_INPUT_CALL = 4;
   private static final int ARG_OUT_METHOD_STREAMING_INPUT_CALL = 5;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
@@ -73,7 +88,12 @@ public final class TestServiceGrpc {
               new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>(ARG_IN_METHOD_STREAMING_INPUT_CALL)))
           .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>marshaller(
               new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>(ARG_OUT_METHOD_STREAMING_INPUT_CALL)))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STREAMING_INPUT_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_FULL_BIDI_CALL = 3;
+
   private static final int ARG_IN_METHOD_FULL_BIDI_CALL = 6;
   private static final int ARG_OUT_METHOD_FULL_BIDI_CALL = 7;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
@@ -87,7 +107,12 @@ public final class TestServiceGrpc {
               new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>(ARG_IN_METHOD_FULL_BIDI_CALL)))
           .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
               new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(ARG_OUT_METHOD_FULL_BIDI_CALL)))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_FULL_BIDI_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_HALF_BIDI_CALL = 4;
+
   private static final int ARG_IN_METHOD_HALF_BIDI_CALL = 8;
   private static final int ARG_OUT_METHOD_HALF_BIDI_CALL = 9;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
@@ -101,6 +126,8 @@ public final class TestServiceGrpc {
               new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>(ARG_IN_METHOD_HALF_BIDI_CALL)))
           .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
               new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(ARG_OUT_METHOD_HALF_BIDI_CALL)))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_HALF_BIDI_CALL).getOptions())
           .build();
 
   private static final class NanoFactory<T extends com.google.protobuf.nano.MessageNano>

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -55,6 +55,7 @@ public final class MethodDescriptor<ReqT, RespT> {
 
   private final MethodType type;
   private final String fullMethodName;
+  private final Object methodOptions;
   private final Marshaller<ReqT> requestMarshaller;
   private final Marshaller<RespT> responseMarshaller;
   private final boolean idempotent;
@@ -220,13 +221,14 @@ public final class MethodDescriptor<ReqT, RespT> {
       MethodType type, String fullMethodName,
       Marshaller<RequestT> requestMarshaller,
       Marshaller<ResponseT> responseMarshaller) {
-    return new MethodDescriptor<RequestT, ResponseT>(
-        type, fullMethodName, requestMarshaller, responseMarshaller, false, false);
+    return new MethodDescriptor<RequestT, ResponseT>(type, fullMethodName, new Object(),
+        requestMarshaller, responseMarshaller, false, false);
   }
 
   private MethodDescriptor(
       MethodType type,
       String fullMethodName,
+      Object methodOptions,
       Marshaller<ReqT> requestMarshaller,
       Marshaller<RespT> responseMarshaller,
       boolean idempotent,
@@ -234,6 +236,7 @@ public final class MethodDescriptor<ReqT, RespT> {
 
     this.type = Preconditions.checkNotNull(type, "type");
     this.fullMethodName = Preconditions.checkNotNull(fullMethodName, "fullMethodName");
+    this.methodOptions = Preconditions.checkNotNull(methodOptions, "methodOptions");
     this.requestMarshaller = Preconditions.checkNotNull(requestMarshaller, "requestMarshaller");
     this.responseMarshaller = Preconditions.checkNotNull(responseMarshaller, "responseMarshaller");
     this.idempotent = idempotent;
@@ -258,6 +261,15 @@ public final class MethodDescriptor<ReqT, RespT> {
    */
   public String getFullMethodName() {
     return fullMethodName;
+  }
+
+  /**
+   * Options describing method.
+   *
+   * @since 1.4.0
+   */
+  public Object getMethodOptions() {
+    return methodOptions;
   }
 
   /**
@@ -436,6 +448,7 @@ public final class MethodDescriptor<ReqT, RespT> {
     private Marshaller<RespT> responseMarshaller;
     private MethodType type;
     private String fullMethodName;
+    private Object methodOptions = new Object();
     private boolean idempotent;
     private boolean safe;
 
@@ -487,6 +500,16 @@ public final class MethodDescriptor<ReqT, RespT> {
     }
 
     /**
+     * Sets the method options.
+     *
+     * @since 1.4.0
+     */
+    public Builder<ReqT, RespT> setMethodOptions(Object methodOptions) {
+      this.methodOptions = methodOptions;
+      return this;
+    }
+
+    /**
      * Sets whether the method is idempotent.  If true, calling this method more than once doesn't
      * have additional side effects.
      *
@@ -520,6 +543,7 @@ public final class MethodDescriptor<ReqT, RespT> {
       return new MethodDescriptor<ReqT, RespT>(
           type,
           fullMethodName,
+          methodOptions,
           requestMarshaller,
           responseMarshaller,
           idempotent,

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -26,7 +26,12 @@ public final class LoadBalancerGrpc {
 
   public static final String SERVICE_NAME = "grpc.lb.v1.LoadBalancer";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new LoadBalancerDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_BALANCE_LOAD = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest,
       io.grpc.grpclb.LoadBalanceResponse> METHOD_BALANCE_LOAD =
@@ -38,6 +43,8 @@ public final class LoadBalancerGrpc {
               io.grpc.grpclb.LoadBalanceRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.grpclb.LoadBalanceResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_BALANCE_LOAD).getOptions())
           .build();
 
   /**
@@ -196,10 +203,20 @@ public final class LoadBalancerGrpc {
     }
   }
 
-  private static final class LoadBalancerDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class LoadBalancerDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.grpclb.LoadBalancerProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -212,7 +229,7 @@ public final class LoadBalancerGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new LoadBalancerDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_BALANCE_LOAD)
               .build();
         }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -477,6 +477,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
     // stream thus no time is wasted in re-process.
     currentPicker = picker;
     helper.updatePicker(picker);
+
   }
 
   @VisibleForTesting

--- a/protobuf/src/main/java/io/grpc/protobuf/ProtoDescriptorSupplier.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/ProtoDescriptorSupplier.java
@@ -32,10 +32,16 @@
 package io.grpc.protobuf;
 
 import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.Descriptors.MethodDescriptor;
+import com.google.protobuf.Descriptors.ServiceDescriptor;
 
 /**
  * Provides access to the underlying proto file descriptor.
  */
-public interface ProtoFileDescriptorSupplier {
+public interface ProtoDescriptorSupplier {
   FileDescriptor getFileDescriptor();
+
+  ServiceDescriptor getServiceDescriptor();
+
+  MethodDescriptor getMethodDescriptor(int index);
 }

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -26,7 +26,12 @@ public final class HealthGrpc {
 
   public static final String SERVICE_NAME = "grpc.health.v1.Health";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new HealthDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_CHECK = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest,
       io.grpc.health.v1.HealthCheckResponse> METHOD_CHECK =
@@ -38,6 +43,8 @@ public final class HealthGrpc {
               io.grpc.health.v1.HealthCheckRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.health.v1.HealthCheckResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_CHECK).getOptions())
           .build();
 
   /**
@@ -206,10 +213,20 @@ public final class HealthGrpc {
     }
   }
 
-  private static final class HealthDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class HealthDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.health.v1.HealthProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -222,7 +239,7 @@ public final class HealthGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new HealthDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_CHECK)
               .build();
         }

--- a/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
@@ -26,7 +26,12 @@ public final class MonitoringGrpc {
 
   public static final String SERVICE_NAME = "grpc.instrumentation.v1alpha.Monitoring";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new MonitoringDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_GET_CANONICAL_RPC_STATS = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.Empty,
       io.grpc.instrumentation.v1alpha.CanonicalRpcStats> METHOD_GET_CANONICAL_RPC_STATS =
@@ -38,7 +43,12 @@ public final class MonitoringGrpc {
               com.google.protobuf.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.CanonicalRpcStats.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_GET_CANONICAL_RPC_STATS).getOptions())
           .build();
+
+  private static final int METHODIDX_GET_STATS = 1;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
       io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_GET_STATS =
@@ -50,7 +60,12 @@ public final class MonitoringGrpc {
               io.grpc.instrumentation.v1alpha.StatsRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.StatsResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_GET_STATS).getOptions())
           .build();
+
+  private static final int METHODIDX_WATCH_STATS = 2;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
       io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_WATCH_STATS =
@@ -62,7 +77,12 @@ public final class MonitoringGrpc {
               io.grpc.instrumentation.v1alpha.StatsRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.StatsResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_WATCH_STATS).getOptions())
           .build();
+
+  private static final int METHODIDX_GET_REQUEST_TRACES = 3;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest,
       io.grpc.instrumentation.v1alpha.TraceResponse> METHOD_GET_REQUEST_TRACES =
@@ -74,7 +94,12 @@ public final class MonitoringGrpc {
               io.grpc.instrumentation.v1alpha.TraceRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.TraceResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_GET_REQUEST_TRACES).getOptions())
           .build();
+
+  private static final int METHODIDX_GET_CUSTOM_MONITORING_DATA = 4;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
       io.grpc.instrumentation.v1alpha.CustomMonitoringData> METHOD_GET_CUSTOM_MONITORING_DATA =
@@ -86,6 +111,8 @@ public final class MonitoringGrpc {
               io.grpc.instrumentation.v1alpha.MonitoringDataGroup.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.CustomMonitoringData.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_GET_CUSTOM_MONITORING_DATA).getOptions())
           .build();
 
   /**
@@ -484,10 +511,20 @@ public final class MonitoringGrpc {
     }
   }
 
-  private static final class MonitoringDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class MonitoringDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.instrumentation.v1alpha.MonitoringProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -500,7 +537,7 @@ public final class MonitoringGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new MonitoringDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_GET_CANONICAL_RPC_STATS)
               .addMethod(METHOD_GET_STATS)
               .addMethod(METHOD_WATCH_STATS)

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -26,7 +26,12 @@ public final class ServerReflectionGrpc {
 
   public static final String SERVICE_NAME = "grpc.reflection.v1alpha.ServerReflection";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new ServerReflectionDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_SERVER_REFLECTION_INFO = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest,
       io.grpc.reflection.v1alpha.ServerReflectionResponse> METHOD_SERVER_REFLECTION_INFO =
@@ -38,6 +43,8 @@ public final class ServerReflectionGrpc {
               io.grpc.reflection.v1alpha.ServerReflectionRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.reflection.v1alpha.ServerReflectionResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_SERVER_REFLECTION_INFO).getOptions())
           .build();
 
   /**
@@ -198,10 +205,20 @@ public final class ServerReflectionGrpc {
     }
   }
 
-  private static final class ServerReflectionDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class ServerReflectionDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.v1alpha.ServerReflectionProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -214,7 +231,7 @@ public final class ServerReflectionGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new ServerReflectionDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_SERVER_REFLECTION_INFO)
               .build();
         }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -29,7 +29,12 @@ public final class AnotherDynamicServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.reflection.testing.AnotherDynamicService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new AnotherDynamicServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_METHOD = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
       io.grpc.reflection.testing.DynamicReply> METHOD_METHOD =
@@ -41,6 +46,8 @@ public final class AnotherDynamicServiceGrpc {
               io.grpc.reflection.testing.DynamicRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.reflection.testing.DynamicReply.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_METHOD).getOptions())
           .build();
 
   /**
@@ -233,10 +240,20 @@ public final class AnotherDynamicServiceGrpc {
     }
   }
 
-  private static final class AnotherDynamicServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class AnotherDynamicServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.DynamicReflectionTestProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(1);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -249,7 +266,7 @@ public final class AnotherDynamicServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new AnotherDynamicServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_METHOD)
               .build();
         }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -29,7 +29,12 @@ public final class DynamicServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.reflection.testing.DynamicService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new DynamicServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_METHOD = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
       io.grpc.reflection.testing.DynamicReply> METHOD_METHOD =
@@ -41,6 +46,8 @@ public final class DynamicServiceGrpc {
               io.grpc.reflection.testing.DynamicRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.reflection.testing.DynamicReply.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_METHOD).getOptions())
           .build();
 
   /**
@@ -233,10 +240,20 @@ public final class DynamicServiceGrpc {
     }
   }
 
-  private static final class DynamicServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class DynamicServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.DynamicReflectionTestProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -249,7 +266,7 @@ public final class DynamicServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new DynamicServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_METHOD)
               .build();
         }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -26,7 +26,12 @@ public final class ReflectableServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.reflection.testing.ReflectableService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new ReflectableServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_METHOD = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request,
       io.grpc.reflection.testing.Reply> METHOD_METHOD =
@@ -38,6 +43,8 @@ public final class ReflectableServiceGrpc {
               io.grpc.reflection.testing.Request.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.reflection.testing.Reply.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_METHOD).getOptions())
           .build();
 
   /**
@@ -206,10 +213,20 @@ public final class ReflectableServiceGrpc {
     }
   }
 
-  private static final class ReflectableServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class ReflectableServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.ReflectionTestProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -222,7 +239,7 @@ public final class ReflectableServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new ReflectableServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_METHOD)
               .build();
         }

--- a/services/src/main/java/io/grpc/protobuf/services/ProtoReflectionService.java
+++ b/services/src/main/java/io/grpc/protobuf/services/ProtoReflectionService.java
@@ -45,7 +45,7 @@ import io.grpc.InternalNotifyOnServerBuild;
 import io.grpc.Server;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.Status;
-import io.grpc.protobuf.ProtoFileDescriptorSupplier;
+import io.grpc.protobuf.ProtoDescriptorSupplier;
 import io.grpc.reflection.v1alpha.ErrorResponse;
 import io.grpc.reflection.v1alpha.ExtensionNumberResponse;
 import io.grpc.reflection.v1alpha.ExtensionRequest;
@@ -118,10 +118,10 @@ public final class ProtoReflectionService extends ServerReflectionGrpc.ServerRef
       List<ServerServiceDefinition> serverMutableServices = server.getMutableServices();
       for (ServerServiceDefinition mutableService : serverMutableServices) {
         io.grpc.ServiceDescriptor serviceDescriptor = mutableService.getServiceDescriptor();
-        if (serviceDescriptor.getSchemaDescriptor() instanceof ProtoFileDescriptorSupplier) {
+        if (serviceDescriptor.getSchemaDescriptor() instanceof ProtoDescriptorSupplier) {
           String serviceName = serviceDescriptor.getName();
           FileDescriptor fileDescriptor =
-              ((ProtoFileDescriptorSupplier) serviceDescriptor.getSchemaDescriptor())
+              ((ProtoDescriptorSupplier) serviceDescriptor.getSchemaDescriptor())
                   .getFileDescriptor();
           serverFileDescriptors.add(fileDescriptor);
           serverServiceNames.add(serviceName);
@@ -423,9 +423,9 @@ public final class ProtoReflectionService extends ServerReflectionGrpc.ServerRef
       Set<String> seenFiles = new HashSet<String>();
       for (ServerServiceDefinition service : services) {
         io.grpc.ServiceDescriptor serviceDescriptor = service.getServiceDescriptor();
-        if (serviceDescriptor.getSchemaDescriptor() instanceof ProtoFileDescriptorSupplier) {
+        if (serviceDescriptor.getSchemaDescriptor() instanceof ProtoDescriptorSupplier) {
           FileDescriptor fileDescriptor =
-              ((ProtoFileDescriptorSupplier) serviceDescriptor.getSchemaDescriptor())
+              ((ProtoDescriptorSupplier) serviceDescriptor.getSchemaDescriptor())
                   .getFileDescriptor();
           String serviceName = serviceDescriptor.getName();
           checkState(

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -26,7 +26,12 @@ public final class MetricsServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.MetricsService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new MetricsServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_GET_ALL_GAUGES = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,
       io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_ALL_GAUGES =
@@ -38,7 +43,12 @@ public final class MetricsServiceGrpc {
               io.grpc.testing.integration.Metrics.EmptyMessage.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_GET_ALL_GAUGES).getOptions())
           .build();
+
+  private static final int METHODIDX_GET_GAUGE = 1;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest,
       io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_GAUGE =
@@ -50,6 +60,8 @@ public final class MetricsServiceGrpc {
               io.grpc.testing.integration.Metrics.GaugeRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_GET_GAUGE).getOptions())
           .build();
 
   /**
@@ -277,10 +289,20 @@ public final class MetricsServiceGrpc {
     }
   }
 
-  private static final class MetricsServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class MetricsServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Metrics.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -293,7 +315,7 @@ public final class MetricsServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new MetricsServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_GET_ALL_GAUGES)
               .addMethod(METHOD_GET_GAUGE)
               .build();

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -29,7 +29,12 @@ public final class ReconnectServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.ReconnectService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new ReconnectServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_START = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> METHOD_START =
@@ -41,7 +46,12 @@ public final class ReconnectServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_START).getOptions())
           .build();
+
+  private static final int METHODIDX_STOP = 1;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       io.grpc.testing.integration.Messages.ReconnectInfo> METHOD_STOP =
@@ -53,6 +63,8 @@ public final class ReconnectServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.ReconnectInfo.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STOP).getOptions())
           .build();
 
   /**
@@ -275,10 +287,20 @@ public final class ReconnectServiceGrpc {
     }
   }
 
-  private static final class ReconnectServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class ReconnectServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(2);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -291,7 +313,7 @@ public final class ReconnectServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new ReconnectServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_START)
               .addMethod(METHOD_STOP)
               .build();

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -30,7 +30,12 @@ public final class TestServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.TestService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new TestServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_EMPTY_CALL = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> METHOD_EMPTY_CALL =
@@ -42,7 +47,12 @@ public final class TestServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_EMPTY_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_UNARY_CALL = 1;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
       io.grpc.testing.integration.Messages.SimpleResponse> METHOD_UNARY_CALL =
@@ -54,7 +64,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_UNARY_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_STREAMING_OUTPUT_CALL = 2;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
@@ -66,7 +81,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STREAMING_OUTPUT_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_STREAMING_INPUT_CALL = 3;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
       io.grpc.testing.integration.Messages.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
@@ -78,7 +98,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.StreamingInputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.StreamingInputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_STREAMING_INPUT_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_FULL_DUPLEX_CALL = 4;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL =
@@ -90,7 +115,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_FULL_DUPLEX_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_HALF_DUPLEX_CALL = 5;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL =
@@ -102,7 +132,12 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_HALF_DUPLEX_CALL).getOptions())
           .build();
+
+  private static final int METHODIDX_UNIMPLEMENTED_CALL = 6;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL =
@@ -114,6 +149,8 @@ public final class TestServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_UNIMPLEMENTED_CALL).getOptions())
           .build();
 
   /**
@@ -577,10 +614,20 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static final class TestServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class TestServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(0);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -593,7 +640,7 @@ public final class TestServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new TestServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_EMPTY_CALL)
               .addMethod(METHOD_UNARY_CALL)
               .addMethod(METHOD_STREAMING_OUTPUT_CALL)

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -30,7 +30,12 @@ public final class UnimplementedServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.UnimplementedService";
 
+  private static final io.grpc.protobuf.ProtoDescriptorSupplier SERVICE_PROTO_DESCRIPTOR =
+    new UnimplementedServiceDescriptorSupplier();
+
   // Static method descriptors that strictly reflect the proto.
+  private static final int METHODIDX_UNIMPLEMENTED_CALL = 0;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL =
@@ -42,6 +47,8 @@ public final class UnimplementedServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+          .setMethodOptions(SERVICE_PROTO_DESCRIPTOR
+              .getMethodDescriptor(METHODIDX_UNIMPLEMENTED_CALL).getOptions())
           .build();
 
   /**
@@ -238,10 +245,20 @@ public final class UnimplementedServiceGrpc {
     }
   }
 
-  private static final class UnimplementedServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static final class UnimplementedServiceDescriptorSupplier implements io.grpc.protobuf.ProtoDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().getServices().get(1);
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor(int index) {
+      return getServiceDescriptor().getMethods().get(index);
     }
   }
 
@@ -254,7 +271,7 @@ public final class UnimplementedServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new UnimplementedServiceDescriptorSupplier())
+              .setSchemaDescriptor(SERVICE_PROTO_DESCRIPTOR)
               .addMethod(METHOD_UNIMPLEMENTED_CALL)
               .build();
         }

--- a/testing-proto/src/generated/main/java/io/grpc/testing/integration/Messages.java
+++ b/testing-proto/src/generated/main/java/io/grpc/testing/integration/Messages.java
@@ -7,6 +7,7 @@ public final class Messages {
   private Messages() {}
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistryLite registry) {
+    registry.add(io.grpc.testing.integration.Messages.idempotent);
   }
 
   public static void registerAllExtensions(
@@ -9291,6 +9292,17 @@ public final class Messages {
 
   }
 
+  public static final int IDEMPOTENT_FIELD_NUMBER = 50001;
+  /**
+   * <code>extend .google.protobuf.MethodOptions { ... }</code>
+   */
+  public static final
+    com.google.protobuf.GeneratedMessage.GeneratedExtension<
+      com.google.protobuf.DescriptorProtos.MethodOptions,
+      java.lang.Boolean> idempotent = com.google.protobuf.GeneratedMessage
+          .newFileScopedGeneratedExtension(
+        java.lang.Boolean.class,
+        null);
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_grpc_testing_Payload_descriptor;
   private static final 
@@ -9361,41 +9373,43 @@ public final class Messages {
   static {
     java.lang.String[] descriptorData = {
       "\n*io/grpc/testing/integration/messages.p" +
-      "roto\022\014grpc.testing\"@\n\007Payload\022\'\n\004type\030\001 " +
-      "\001(\0162\031.grpc.testing.PayloadType\022\014\n\004body\030\002" +
-      " \001(\014\"+\n\nEchoStatus\022\014\n\004code\030\001 \001(\005\022\017\n\007mess" +
-      "age\030\002 \001(\t\"\241\002\n\rSimpleRequest\0220\n\rresponse_" +
-      "type\030\001 \001(\0162\031.grpc.testing.PayloadType\022\025\n" +
-      "\rresponse_size\030\002 \001(\005\022&\n\007payload\030\003 \001(\0132\025." +
-      "grpc.testing.Payload\022\025\n\rfill_username\030\004 " +
-      "\001(\010\022\030\n\020fill_oauth_scope\030\005 \001(\010\022;\n\024respons" +
-      "e_compression\030\006 \001(\0162\035.grpc.testing.Compr",
-      "essionType\0221\n\017response_status\030\007 \001(\0132\030.gr" +
-      "pc.testing.EchoStatus\"_\n\016SimpleResponse\022" +
-      "&\n\007payload\030\001 \001(\0132\025.grpc.testing.Payload\022" +
-      "\020\n\010username\030\002 \001(\t\022\023\n\013oauth_scope\030\003 \001(\t\"\036" +
-      "\n\rSimpleContext\022\r\n\005value\030\001 \001(\t\"C\n\031Stream" +
-      "ingInputCallRequest\022&\n\007payload\030\001 \001(\0132\025.g" +
-      "rpc.testing.Payload\"=\n\032StreamingInputCal" +
-      "lResponse\022\037\n\027aggregated_payload_size\030\001 \001" +
-      "(\005\"7\n\022ResponseParameters\022\014\n\004size\030\001 \001(\005\022\023" +
-      "\n\013interval_us\030\002 \001(\005\"\245\002\n\032StreamingOutputC",
-      "allRequest\0220\n\rresponse_type\030\001 \001(\0162\031.grpc" +
-      ".testing.PayloadType\022=\n\023response_paramet" +
-      "ers\030\002 \003(\0132 .grpc.testing.ResponseParamet" +
-      "ers\022&\n\007payload\030\003 \001(\0132\025.grpc.testing.Payl" +
-      "oad\022;\n\024response_compression\030\006 \001(\0162\035.grpc" +
-      ".testing.CompressionType\0221\n\017response_sta" +
-      "tus\030\007 \001(\0132\030.grpc.testing.EchoStatus\"E\n\033S" +
-      "treamingOutputCallResponse\022&\n\007payload\030\001 " +
-      "\001(\0132\025.grpc.testing.Payload\"3\n\017ReconnectP" +
-      "arams\022 \n\030max_reconnect_backoff_ms\030\001 \001(\005\"",
-      "3\n\rReconnectInfo\022\016\n\006passed\030\001 \001(\010\022\022\n\nback" +
-      "off_ms\030\002 \003(\005*?\n\013PayloadType\022\020\n\014COMPRESSA" +
-      "BLE\020\000\022\022\n\016UNCOMPRESSABLE\020\001\022\n\n\006RANDOM\020\002*2\n" +
-      "\017CompressionType\022\010\n\004NONE\020\000\022\010\n\004GZIP\020\001\022\013\n\007" +
-      "DEFLATE\020\002B\035\n\033io.grpc.testing.integration" +
-      "b\006proto3"
+      "roto\022\014grpc.testing\032 google/protobuf/desc" +
+      "riptor.proto\"@\n\007Payload\022\'\n\004type\030\001 \001(\0162\031." +
+      "grpc.testing.PayloadType\022\014\n\004body\030\002 \001(\014\"+" +
+      "\n\nEchoStatus\022\014\n\004code\030\001 \001(\005\022\017\n\007message\030\002 " +
+      "\001(\t\"\241\002\n\rSimpleRequest\0220\n\rresponse_type\030\001" +
+      " \001(\0162\031.grpc.testing.PayloadType\022\025\n\rrespo" +
+      "nse_size\030\002 \001(\005\022&\n\007payload\030\003 \001(\0132\025.grpc.t" +
+      "esting.Payload\022\025\n\rfill_username\030\004 \001(\010\022\030\n" +
+      "\020fill_oauth_scope\030\005 \001(\010\022;\n\024response_comp",
+      "ression\030\006 \001(\0162\035.grpc.testing.Compression" +
+      "Type\0221\n\017response_status\030\007 \001(\0132\030.grpc.tes" +
+      "ting.EchoStatus\"_\n\016SimpleResponse\022&\n\007pay" +
+      "load\030\001 \001(\0132\025.grpc.testing.Payload\022\020\n\010use" +
+      "rname\030\002 \001(\t\022\023\n\013oauth_scope\030\003 \001(\t\"\036\n\rSimp" +
+      "leContext\022\r\n\005value\030\001 \001(\t\"C\n\031StreamingInp" +
+      "utCallRequest\022&\n\007payload\030\001 \001(\0132\025.grpc.te" +
+      "sting.Payload\"=\n\032StreamingInputCallRespo" +
+      "nse\022\037\n\027aggregated_payload_size\030\001 \001(\005\"7\n\022" +
+      "ResponseParameters\022\014\n\004size\030\001 \001(\005\022\023\n\013inte",
+      "rval_us\030\002 \001(\005\"\245\002\n\032StreamingOutputCallReq" +
+      "uest\0220\n\rresponse_type\030\001 \001(\0162\031.grpc.testi" +
+      "ng.PayloadType\022=\n\023response_parameters\030\002 " +
+      "\003(\0132 .grpc.testing.ResponseParameters\022&\n" +
+      "\007payload\030\003 \001(\0132\025.grpc.testing.Payload\022;\n" +
+      "\024response_compression\030\006 \001(\0162\035.grpc.testi" +
+      "ng.CompressionType\0221\n\017response_status\030\007 " +
+      "\001(\0132\030.grpc.testing.EchoStatus\"E\n\033Streami" +
+      "ngOutputCallResponse\022&\n\007payload\030\001 \001(\0132\025." +
+      "grpc.testing.Payload\"3\n\017ReconnectParams\022",
+      " \n\030max_reconnect_backoff_ms\030\001 \001(\005\"3\n\rRec" +
+      "onnectInfo\022\016\n\006passed\030\001 \001(\010\022\022\n\nbackoff_ms" +
+      "\030\002 \003(\005*?\n\013PayloadType\022\020\n\014COMPRESSABLE\020\000\022" +
+      "\022\n\016UNCOMPRESSABLE\020\001\022\n\n\006RANDOM\020\002*2\n\017Compr" +
+      "essionType\022\010\n\004NONE\020\000\022\010\n\004GZIP\020\001\022\013\n\007DEFLAT" +
+      "E\020\002:4\n\nidempotent\022\036.google.protobuf.Meth" +
+      "odOptions\030\321\206\003 \001(\010B\035\n\033io.grpc.testing.int" +
+      "egrationb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -9408,6 +9422,7 @@ public final class Messages {
     com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
+          com.google.protobuf.DescriptorProtos.getDescriptor(),
         }, assigner);
     internal_static_grpc_testing_Payload_descriptor =
       getDescriptor().getMessageTypes().get(0);
@@ -9481,6 +9496,8 @@ public final class Messages {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_grpc_testing_ReconnectInfo_descriptor,
         new java.lang.String[] { "Passed", "BackoffMs", });
+    idempotent.internalInit(descriptor.getExtensions().get(0));
+    com.google.protobuf.DescriptorProtos.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/testing-proto/src/generated/main/java/io/grpc/testing/integration/Test.java
+++ b/testing-proto/src/generated/main/java/io/grpc/testing/integration/Test.java
@@ -26,29 +26,29 @@ public final class Test {
       "\n&io/grpc/testing/integration/test.proto" +
       "\022\014grpc.testing\032\'io/grpc/testing/integrat" +
       "ion/empty.proto\032*io/grpc/testing/integra" +
-      "tion/messages.proto2\372\004\n\013TestService\0225\n\tE" +
+      "tion/messages.proto2\200\005\n\013TestService\022;\n\tE" +
       "mptyCall\022\023.grpc.testing.Empty\032\023.grpc.tes" +
-      "ting.Empty\022F\n\tUnaryCall\022\033.grpc.testing.S" +
-      "impleRequest\032\034.grpc.testing.SimpleRespon" +
-      "se\022l\n\023StreamingOutputCall\022(.grpc.testing" +
-      ".StreamingOutputCallRequest\032).grpc.testi" +
-      "ng.StreamingOutputCallResponse0\001\022i\n\022Stre",
-      "amingInputCall\022\'.grpc.testing.StreamingI" +
-      "nputCallRequest\032(.grpc.testing.Streaming" +
-      "InputCallResponse(\001\022i\n\016FullDuplexCall\022(." +
-      "grpc.testing.StreamingOutputCallRequest\032" +
-      ").grpc.testing.StreamingOutputCallRespon" +
-      "se(\0010\001\022i\n\016HalfDuplexCall\022(.grpc.testing." +
-      "StreamingOutputCallRequest\032).grpc.testin" +
-      "g.StreamingOutputCallResponse(\0010\001\022=\n\021Uni" +
-      "mplementedCall\022\023.grpc.testing.Empty\032\023.gr" +
-      "pc.testing.Empty2U\n\024UnimplementedService",
-      "\022=\n\021UnimplementedCall\022\023.grpc.testing.Emp" +
-      "ty\032\023.grpc.testing.Empty2\177\n\020ReconnectServ" +
-      "ice\0221\n\005Start\022\023.grpc.testing.Empty\032\023.grpc" +
-      ".testing.Empty\0228\n\004Stop\022\023.grpc.testing.Em" +
-      "pty\032\033.grpc.testing.ReconnectInfoB\035\n\033io.g" +
-      "rpc.testing.integrationb\006proto3"
+      "ting.Empty\"\004\210\265\030\001\022F\n\tUnaryCall\022\033.grpc.tes" +
+      "ting.SimpleRequest\032\034.grpc.testing.Simple" +
+      "Response\022l\n\023StreamingOutputCall\022(.grpc.t" +
+      "esting.StreamingOutputCallRequest\032).grpc" +
+      ".testing.StreamingOutputCallResponse0\001\022i",
+      "\n\022StreamingInputCall\022\'.grpc.testing.Stre" +
+      "amingInputCallRequest\032(.grpc.testing.Str" +
+      "eamingInputCallResponse(\001\022i\n\016FullDuplexC" +
+      "all\022(.grpc.testing.StreamingOutputCallRe" +
+      "quest\032).grpc.testing.StreamingOutputCall" +
+      "Response(\0010\001\022i\n\016HalfDuplexCall\022(.grpc.te" +
+      "sting.StreamingOutputCallRequest\032).grpc." +
+      "testing.StreamingOutputCallResponse(\0010\001\022" +
+      "=\n\021UnimplementedCall\022\023.grpc.testing.Empt" +
+      "y\032\023.grpc.testing.Empty2U\n\024UnimplementedS",
+      "ervice\022=\n\021UnimplementedCall\022\023.grpc.testi" +
+      "ng.Empty\032\023.grpc.testing.Empty2\177\n\020Reconne" +
+      "ctService\0221\n\005Start\022\023.grpc.testing.Empty\032" +
+      "\023.grpc.testing.Empty\0228\n\004Stop\022\023.grpc.test" +
+      "ing.Empty\032\033.grpc.testing.ReconnectInfoB\035" +
+      "\n\033io.grpc.testing.integrationb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -64,6 +64,11 @@ public final class Test {
           com.google.protobuf.EmptyProtos.getDescriptor(),
           io.grpc.testing.integration.Messages.getDescriptor(),
         }, assigner);
+    com.google.protobuf.ExtensionRegistry registry =
+        com.google.protobuf.ExtensionRegistry.newInstance();
+    registry.add(io.grpc.testing.integration.Messages.idempotent);
+    com.google.protobuf.Descriptors.FileDescriptor
+        .internalUpdateFileDescriptor(descriptor, registry);
     com.google.protobuf.EmptyProtos.getDescriptor();
     io.grpc.testing.integration.Messages.getDescriptor();
   }

--- a/testing-proto/src/main/proto/io/grpc/testing/integration/messages.proto
+++ b/testing-proto/src/main/proto/io/grpc/testing/integration/messages.proto
@@ -31,9 +31,15 @@
 
 syntax = "proto3";
 
+import "google/protobuf/descriptor.proto";
+
 package grpc.testing;
 
 option java_package = "io.grpc.testing.integration";
+
+extend google.protobuf.MethodOptions {
+  bool idempotent = 50001;
+}
 
 // The type of payload that should be returned.
 enum PayloadType {

--- a/testing-proto/src/main/proto/io/grpc/testing/integration/test.proto
+++ b/testing-proto/src/main/proto/io/grpc/testing/integration/test.proto
@@ -42,7 +42,9 @@ option java_package = "io.grpc.testing.integration";
 // performance with various types of payload.
 service TestService {
   // One empty request followed by one empty response.
-  rpc EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+  rpc EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty) {
+      option (idempotent) = true;
+  };
 
   // One request followed by one response.
   rpc UnaryCall(SimpleRequest) returns (SimpleResponse);


### PR DESCRIPTION
Add support for service method options to `MethodDescriptor` and compiler.

Proto:

```protobuf
extend google.protobuf.MethodOptions {
  bool idempotent = 50001;
}

rpc EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty) {
  option (idempotent) = true;
};
```

Java runtime:

```java
((DescriptorProtos.MethodOptions) TestServiceGrpc.METHOD_EMPTY_CALL.getMethodOptions())
.getExtension(io.grpc.testing.integration.Messages.idempotent) => true
```