### PR TITLE
core: use RESOURCE_EXHAUSTED for max message size failures

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -172,7 +172,7 @@ public abstract class AbstractClientStream extends AbstractStream
 
   @Override
   protected final void deframeFailed(Throwable cause) {
-    cancel(Status.INTERNAL.withDescription("Exception deframing message").withCause(cause));
+    cancel(Status.fromThrowable(cause));
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -344,8 +344,10 @@ public class MessageDeframer implements Closeable {
     // Update the required length to include the length of the frame.
     requiredLength = nextFrame.readInt();
     if (requiredLength < 0 || requiredLength > maxInboundMessageSize) {
-      throw Status.INTERNAL.withDescription(String.format("%s: Frame size %d exceeds maximum: %d. ",
-              debugString, requiredLength, maxInboundMessageSize)).asRuntimeException();
+      throw Status.RESOURCE_EXHAUSTED.withDescription(
+          String.format("%s: Frame size %d exceeds maximum: %d. ",
+              debugString, requiredLength, maxInboundMessageSize))
+          .asRuntimeException();
     }
 
     statsTraceCtx.inboundMessage();
@@ -469,7 +471,7 @@ public class MessageDeframer implements Closeable {
 
     private void verifySize() {
       if (count > maxMessageSize) {
-        throw Status.INTERNAL.withDescription(String.format(
+        throw Status.RESOURCE_EXHAUSTED.withDescription(String.format(
                 "%s: Compressed frame exceeds maximum frame size: %d. Bytes read: %d. ",
                 debugString, maxMessageSize, count)).asRuntimeException();
       }

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -169,7 +169,7 @@ public class MessageFramer implements Framer {
     BufferChainOutputStream bufferChain = new BufferChainOutputStream();
     int written = writeToOutputStream(message, bufferChain);
     if (maxOutboundMessageSize >= 0 && written > maxOutboundMessageSize) {
-      throw Status.INTERNAL
+      throw Status.RESOURCE_EXHAUSTED
           .withDescription(
               String.format("message too large %d > %d", written , maxOutboundMessageSize))
           .asRuntimeException();
@@ -189,7 +189,7 @@ public class MessageFramer implements Framer {
       compressingStream.close();
     }
     if (maxOutboundMessageSize >= 0 && written > maxOutboundMessageSize) {
-      throw Status.CANCELLED
+      throw Status.RESOURCE_EXHAUSTED
           .withDescription(
               String.format("message too large %d > %d", written , maxOutboundMessageSize))
           .asRuntimeException();
@@ -212,7 +212,7 @@ public class MessageFramer implements Framer {
   private int writeKnownLengthUncompressed(InputStream message, int messageLength)
       throws IOException {
     if (maxOutboundMessageSize >= 0 && messageLength > maxOutboundMessageSize) {
-      throw Status.CANCELLED
+      throw Status.RESOURCE_EXHAUSTED
           .withDescription(
               String.format("message too large %d > %d", messageLength , maxOutboundMessageSize))
           .asRuntimeException();

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -155,7 +155,7 @@ public class AbstractClientStreamTest {
     stream.deframeFailed(new RuntimeException("something bad"));
 
     verify(mockListener).closed(statusCaptor.capture(), isA(Metadata.class));
-    assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
+    assertEquals(Code.UNKNOWN, statusCaptor.getValue().getCode());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -269,7 +269,7 @@ public class MessageDeframerTest {
 
     try {
       thrown.expect(StatusRuntimeException.class);
-      thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
+      thrown.expectMessage("RESOURCE_EXHAUSTED: test: Compressed frame exceeds");
 
       while (stream.read() != -1) {}
     } finally {
@@ -316,7 +316,7 @@ public class MessageDeframerTest {
 
     try {
       thrown.expect(StatusRuntimeException.class);
-      thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
+      thrown.expectMessage("RESOURCE_EXHAUSTED: test: Compressed frame exceeds");
 
       stream.read(buf, 0, buf.length);
     } finally {
@@ -361,7 +361,7 @@ public class MessageDeframerTest {
 
     try {
       thrown.expect(StatusRuntimeException.class);
-      thrown.expectMessage("INTERNAL: test: Compressed frame exceeds");
+      thrown.expectMessage("RESOURCE_EXHAUSTED: test: Compressed frame exceeds");
 
       stream.skip(4);
     } finally {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -906,7 +906,7 @@ public abstract class AbstractInteropTest {
       fail();
     } catch (StatusRuntimeException ex) {
       Status s = ex.getStatus();
-      assertThat(s.getCode()).named(s.toString()).isEqualTo(Status.Code.INTERNAL);
+      assertThat(s.getCode()).named(s.toString()).isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
       assertThat(Throwables.getStackTraceAsString(ex)).contains("exceeds maximum");
     }
   }

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -32,7 +32,6 @@
 package io.grpc.netty;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static io.grpc.Status.Code.INTERNAL;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.grpc.internal.GrpcUtil.DEFAULT_SERVER_KEEPALIVE_TIMEOUT_NANOS;
 import static io.grpc.internal.GrpcUtil.DEFAULT_SERVER_KEEPALIVE_TIME_NANOS;
@@ -58,6 +57,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.StatusException;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
@@ -213,7 +213,7 @@ public class NettyClientTransportTest {
       fail("Expected the stream to fail.");
     } catch (ExecutionException e) {
       Status status = Status.fromThrowable(e);
-      assertEquals(INTERNAL, status.getCode());
+      assertEquals(Code.RESOURCE_EXHAUSTED, status.getCode());
       assertTrue("Missing exceeds maximum from: " + status.getDescription(),
           status.getDescription().contains("exceeds maximum"));
     }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -33,7 +33,6 @@ package io.grpc.okhttp;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.truth.Truth.assertThat;
-import static io.grpc.Status.Code.INTERNAL;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.grpc.okhttp.Headers.CONTENT_TYPE_HEADER;
 import static io.grpc.okhttp.Headers.METHOD_HEADER;
@@ -218,7 +217,7 @@ public class OkHttpClientTransportTest {
     frameHandler().data(false, 3, buffer, (int) buffer.size());
 
     listener.waitUntilStreamClosed();
-    assertEquals(INTERNAL, listener.status.getCode());
+    assertEquals(Code.RESOURCE_EXHAUSTED, listener.status.getCode());
     shutdownAndVerify();
   }
 


### PR DESCRIPTION
Parallel of https://github.com/grpc/grpc/pull/10612

The change in ACS brings it in line with ACS2