### PR TITLE
core: Add support for the AppEngine development sandbox

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -70,11 +70,15 @@ public final class GrpcUtil {
 
   public static final Charset US_ASCII = Charset.forName("US-ASCII");
 
+  private static boolean isAppengineEnvironment() {
+    String appengineEnvironment = System.getProperty("com.google.appengine.runtime.environment");
+    return "Production".equals(appengineEnvironment) || "Development".equals(appengineEnvironment);
+  }
+
   // Certain production AppEngine runtimes have constraints on threading and socket handling
   // that need to be accommodated.
   public static final boolean IS_RESTRICTED_APPENGINE =
-      "Production".equals(System.getProperty("com.google.appengine.runtime.environment"))
-          && "1.7".equals(System.getProperty("java.specification.version"));
+      isAppengineEnvironment() && "1.7".equals(System.getProperty("java.specification.version"));
 
   /**
    * {@link io.grpc.Metadata.Key} for the timeout header.

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -70,15 +70,11 @@ public final class GrpcUtil {
 
   public static final Charset US_ASCII = Charset.forName("US-ASCII");
 
-  private static boolean isAppengineEnvironment() {
-    String appengineEnvironment = System.getProperty("com.google.appengine.runtime.environment");
-    return "Production".equals(appengineEnvironment) || "Development".equals(appengineEnvironment);
-  }
-
-  // Certain production AppEngine runtimes have constraints on threading and socket handling
+  // AppEngine runtimes have constraints on threading and socket handling
   // that need to be accommodated.
   public static final boolean IS_RESTRICTED_APPENGINE =
-      isAppengineEnvironment() && "1.7".equals(System.getProperty("java.specification.version"));
+      System.getProperty("com.google.appengine.runtime.environment") != null
+          && "1.7".equals(System.getProperty("java.specification.version"));
 
   /**
    * {@link io.grpc.Metadata.Key} for the timeout header.


### PR DESCRIPTION
The App Engine development appserver imposes similar ClassLoader restrictions to the production environment. This patch allows for development of grpc using code in the development appserver. First grpc patch - please let me know if I missed any of the contributing guidelines!