### PR TITLE
core: rename headersSent to outboundHeaders.

### DIFF
--- a/core/src/main/java/io/grpc/ClientStreamTracer.java
+++ b/core/src/main/java/io/grpc/ClientStreamTracer.java
@@ -42,7 +42,7 @@ public abstract class ClientStreamTracer extends StreamTracer {
   /**
    * Headers has been sent to the socket.
    */
-  public void headersSent() {
+  public void outboundHeaders() {
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -103,11 +103,11 @@ public final class StatsTraceContext {
   }
 
   /**
-   * See {@link ClientStreamTracer#headersSent}.  For client-side only.
+   * See {@link ClientStreamTracer#outboundHeaders}.  For client-side only.
    */
-  public void clientHeadersSent() {
+  public void clientOutboundHeaders() {
     for (StreamTracer tracer : tracers) {
-      ((ClientStreamTracer) tracer).headersSent();
+      ((ClientStreamTracer) tracer).outboundHeaders();
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/CensusStreamTracerModuleTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusStreamTracerModuleTest.java
@@ -191,7 +191,7 @@ public class CensusStreamTracerModuleTest {
     ClientStreamTracer tracer = callTracer.newClientStreamTracer(headers);
 
     fakeClock.forwardTime(30, MILLISECONDS);
-    tracer.headersSent();
+    tracer.outboundHeaders();
 
     fakeClock.forwardTime(100, MILLISECONDS);
     tracer.outboundWireSize(1028);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1448,7 +1448,7 @@ public abstract class AbstractInteropTest {
     // Tracer-based stats
     ClientStreamTracer tracer = clientStreamTracers.poll();
     assertNotNull(tracer);
-    verify(tracer).headersSent();
+    verify(tracer).outboundHeaders();
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     // assertClientMetrics() is called right after application receives status,
     // but streamClosed() may be called slightly later than that.  So we need a timeout.

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -422,7 +422,7 @@ class NettyClientHandler extends AbstractNettyHandler {
                   // was canceled via RST_STREAM.
                   Http2Stream http2Stream = connection().stream(streamId);
                   if (http2Stream != null) {
-                    stream.getStatsTraceContext().clientHeadersSent();
+                    stream.getStatsTraceContext().clientOutboundHeaders();
                     http2Stream.setProperty(streamKey, stream);
 
                     // Attach the client stream to the HTTP/2 stream object as user data.

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -162,7 +162,7 @@ class OkHttpClientStream extends Http2ClientStream {
     if (pendingData != null) {
       // Only happens when the stream has neither been started nor cancelled.
       frameWriter.synStream(false, false, id, 0, requestHeaders);
-      statsTraceCtx.clientHeadersSent();
+      statsTraceCtx.clientOutboundHeaders();
       requestHeaders = null;
 
       boolean flush = false;

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -661,7 +661,7 @@ public abstract class AbstractTransportTest {
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     if (metricsExpected()) {
-      clientInOrder.verify(clientStreamTracer).headersSent();
+      clientInOrder.verify(clientStreamTracer).outboundHeaders();
     }
     assertEquals(methodDescriptor.getFullMethodName(), serverStreamCreation.method);
     assertEquals(Lists.newArrayList(clientHeadersCopy.getAll(asciiKey)),
@@ -817,7 +817,7 @@ public abstract class AbstractTransportTest {
     assertEquals(status.getCode(), statusCaptor.getValue().getCode());
     assertEquals(status.getDescription(), statusCaptor.getValue().getDescription());
     if (metricsExpected()) {
-      verify(clientStreamTracer).headersSent();
+      verify(clientStreamTracer).outboundHeaders();
       verify(clientStreamTracer).streamClosed(same(statusCaptor.getValue()));
       verify(serverStreamTracer).streamClosed(same(status));
       verifyNoMoreInteractions(clientStreamTracer);
@@ -854,7 +854,7 @@ public abstract class AbstractTransportTest {
     assertEquals("Hello. Goodbye.", statusCaptor.getValue().getDescription());
     assertNull(statusCaptor.getValue().getCause());
     if (metricsExpected()) {
-      verify(clientStreamTracer).headersSent();
+      verify(clientStreamTracer).outboundHeaders();
       verify(clientStreamTracer).streamClosed(same(statusCaptor.getValue()));
       verify(serverStreamTracer).streamClosed(same(status));
       verifyNoMoreInteractions(clientStreamTracer);
@@ -898,7 +898,7 @@ public abstract class AbstractTransportTest {
     assertEquals(Lists.newArrayList(trailers.getAll(binaryKey)),
         Lists.newArrayList(metadataCaptor.getValue().getAll(binaryKey)));
     if (metricsExpected()) {
-      verify(clientStreamTracer).headersSent();
+      verify(clientStreamTracer).outboundHeaders();
       verify(clientStreamTracer).streamClosed(same(statusCaptor.getValue()));
       verify(serverStreamTracer).streamClosed(same(status));
       verifyNoMoreInteractions(clientStreamTracer);
@@ -933,7 +933,7 @@ public abstract class AbstractTransportTest {
     assertEquals(status.getDescription(), statusCaptor.getValue().getDescription());
     assertNull(statusCaptor.getValue().getCause());
     if (metricsExpected()) {
-      verify(clientStreamTracer).headersSent();
+      verify(clientStreamTracer).outboundHeaders();
       verify(clientStreamTracer).streamClosed(same(statusCaptor.getValue()));
       verify(serverStreamTracer).streamClosed(same(status));
       verifyNoMoreInteractions(clientStreamTracer);
@@ -971,7 +971,7 @@ public abstract class AbstractTransportTest {
     verify(mockServerStreamListener, never()).closed(any(Status.class));
     verify(mockClientStreamListener, never()).closed(any(Status.class), any(Metadata.class));
     if (metricsExpected()) {
-      verify(clientStreamTracer).headersSent();
+      verify(clientStreamTracer).outboundHeaders();
       verify(clientStreamTracer).streamClosed(same(status));
       verify(serverStreamTracer).streamClosed(same(statusCaptor.getValue()));
       verifyNoMoreInteractions(clientStreamTracer);
@@ -1034,7 +1034,7 @@ public abstract class AbstractTransportTest {
 
     serverStream.close(Status.OK, new Metadata());
     if (metricsExpected()) {
-      verify(clientStreamTracer).headersSent();
+      verify(clientStreamTracer).outboundHeaders();
       verify(clientStreamTracer).inboundMessage();
       verify(clientStreamTracer).inboundWireSize(anyLong());
       verify(clientStreamTracer, atLeast(1)).inboundUncompressedSize(anyLong());
@@ -1080,7 +1080,7 @@ public abstract class AbstractTransportTest {
 
     if (metricsExpected()) {
       verify(clientStreamTracerFactory).newClientStreamTracer(any(Metadata.class));
-      verify(clientStreamTracer).headersSent();
+      verify(clientStreamTracer).outboundHeaders();
       verify(clientStreamTracer).streamClosed(same(statusCaptor.getValue()));
       verify(serverStreamTracerFactory).newServerStreamTracer(anyString(), any(Metadata.class));
       verify(serverStreamTracer).streamClosed(same(status));


### PR DESCRIPTION
This is a partial backport of #2921 into v1.3.x

The addition of inboundHeaders is not backported as it turns out to be
non-trivial as OkHttp is still on AbstractClientStream on v1.3.x while
has switched to AbstractClientStream2 on master.