### PR TITLE
core: add ServerCall.getAuthority()

### DIFF
--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -32,6 +32,7 @@
 package io.grpc;
 
 import com.google.errorprone.annotations.DoNotMock;
+import javax.annotation.Nullable;
 
 /**
  * Encapsulates a single call received from a remote client. Calls may not simply be unary
@@ -213,6 +214,17 @@ public abstract class ServerCall<ReqT, RespT> {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1779")
   public Attributes getAttributes() {
     return Attributes.EMPTY;
+  }
+
+  /**
+   * Gets the authority this call is addressed to.
+   *
+   * @return the authority string. {@code null} if not available.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2924")
+  @Nullable
+  public String getAuthority() {
+    return null;
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -195,6 +195,11 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
   }
 
   @Override
+  public String getAuthority() {
+    return stream.getAuthority();
+  }
+
+  @Override
   public MethodDescriptor<ReqT, RespT> getMethodDescriptor() {
     return method;
   }

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -34,6 +34,7 @@ package io.grpc.internal;
 import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import javax.annotation.Nullable;
 
 /**
  * Extension of {@link Stream} to support server-side termination semantics.
@@ -78,8 +79,9 @@ public interface ServerStream extends Stream {
 
   /**
    * Gets the authority this stream is addressed to.
-   * @return the authority string.
+   * @return the authority string. {@code null} if not available.
    */
+  @Nullable
   String getAuthority();
 
   /**

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -181,6 +181,20 @@ public class ServerCallImplTest {
   }
 
   @Test
+  public void getAuthority() {
+    when(stream.getAuthority()).thenReturn("fooapi.googleapis.com");
+    assertEquals("fooapi.googleapis.com", call.getAuthority());
+    verify(stream).getAuthority();
+  }
+
+  @Test
+  public void getNullAuthority() {
+    when(stream.getAuthority()).thenReturn(null);
+    assertNull(call.getAuthority());
+    verify(stream).getAuthority();
+  }
+
+  @Test
   public void setMessageCompression() {
     call.setMessageCompression(true);
 


### PR DESCRIPTION
Resolves #727 

Also mark `ServerStream.getAuthority()` as nullable because `AbstractServerStream.getAuthority()` already returns null.