### PR TITLE
all: Fix basic compatibility with Mockito 2.7.19

### DIFF
--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -190,7 +190,7 @@ public class ClientCallImplTest {
     streamListener.headersRead(new Metadata());
 
     RuntimeException failure = new RuntimeException("bad");
-    doThrow(failure).when(callListener).onMessage(any(Void.class));
+    doThrow(failure).when(callListener).onMessage(Matchers.<Void>any());
 
     /*
      * In unary calls, the server closes the call right after responding, so the onClose call is

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -473,7 +473,7 @@ public abstract class AbstractTransportTest {
       // Transport doesn't support ping, so this neither passes nor fails.
       assumeTrue(false);
     }
-    verify(mockPingCallback, timeout(TIMEOUT_MS)).onSuccess(Matchers.anyInt());
+    verify(mockPingCallback, timeout(TIMEOUT_MS)).onSuccess(Matchers.anyLong());
     verify(mockClientTransportListener, never()).transportInUse(anyBoolean());
   }
 
@@ -494,7 +494,7 @@ public abstract class AbstractTransportTest {
       // Transport doesn't support ping, so this neither passes nor fails.
       assumeTrue(false);
     }
-    verify(mockPingCallback, timeout(TIMEOUT_MS)).onSuccess(Matchers.anyInt());
+    verify(mockPingCallback, timeout(TIMEOUT_MS)).onSuccess(Matchers.anyLong());
     stream.cancel(Status.CANCELLED);
   }
 


### PR DESCRIPTION
We aren't upgrading yet, because we don't want to begin using the new
Mockito APIs. But all the tests now pass with the newer version. There
are a lot of warnings that can't be fixed until we bump the mockito
version.