### PR TITLE
Move client deframing to the call executor

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream2.java
@@ -177,7 +177,11 @@ public abstract class AbstractStream2 implements Stream {
      * closes.
      */
     protected final void scheduleDeframerClose(boolean stopDelivery) {
-      deframer.sink().scheduleClose(stopDelivery);
+      if (stopDelivery) {
+        deframer.sink().scheduleImmediateClose();
+      } else {
+        deframer.sink().scheduleCloseWhenComplete();
+      }
     }
 
     /**

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -393,6 +393,20 @@ class DelayedStream implements ClientStream {
     }
 
     @Override
+    public void scheduleDeframerSource(final MessageDeframer.Source source) {
+      if (passThrough) {
+        realListener.scheduleDeframerSource(source);
+      } else {
+        delayOrExecute(new Runnable() {
+          @Override
+          public void run() {
+            realListener.scheduleDeframerSource(source);
+          }
+        });
+      }
+    }
+
+    @Override
     public void onReady() {
       if (passThrough) {
         realListener.onReady();

--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -86,7 +86,8 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
    * Called to process a failure in HTTP/2 processing. It should notify the transport to cancel the
    * stream and call {@code transportReportStatus()}.
    */
-  protected abstract void http2ProcessingFailed(Status status, Metadata trailers);
+  protected abstract void http2ProcessingFailed(Status status, boolean stopDelivery,
+      Metadata trailers);
 
   /**
    * Called by subclasses whenever {@code Headers} are received from the transport.
@@ -144,12 +145,13 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
           + ReadableBuffers.readAsString(frame, errorCharset));
       frame.close();
       if (transportError.getDescription().length() > 1000 || endOfStream) {
-        http2ProcessingFailed(transportError, transportErrorMetadata);
+        http2ProcessingFailed(transportError, false, transportErrorMetadata);
       }
     } else {
       if (!headersReceived) {
         http2ProcessingFailed(
             Status.INTERNAL.withDescription("headers not received before payload"),
+            false,
             new Metadata());
         return;
       }
@@ -179,7 +181,7 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
     }
     if (transportError != null) {
       transportError = transportError.augmentDescription("trailers: " + trailers);
-      http2ProcessingFailed(transportError, transportErrorMetadata);
+      http2ProcessingFailed(transportError, false, transportErrorMetadata);
     } else {
       Status status = statusFromTrailers(trailers);
       stripTransportDetails(trailers);

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -321,9 +321,12 @@ public class MessageDeframer {
       boolean needToCloseData = true;
       try {
         Preconditions.checkState(!isScheduledToClose(), "close already scheduled");
+        int dataSize = data.readableBytes();
         unprocessed.addBuffer(data);
         needToCloseData = false;
         sinkListener.scheduleDeframerSource(source);
+        // TODO(ericgribkoff) Clean up interfaces (move this to Sink.Listener)
+        source.sourceListener.bytesRead(dataSize);
       } finally {
         if (needToCloseData) {
           data.close();
@@ -478,7 +481,8 @@ public class MessageDeframer {
         return true;
       } finally {
         if (totalBytesRead > 0) {
-          sourceListener.bytesRead(totalBytesRead);
+          // TODO(ericgribkoff) Performance improves by notifying directly from transport thread.
+          //sourceListener.bytesRead(totalBytesRead);
           if (state == State.BODY) {
             statsTraceCtx.inboundWireSize(totalBytesRead);
           }

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -321,12 +321,9 @@ public class MessageDeframer {
       boolean needToCloseData = true;
       try {
         Preconditions.checkState(!isScheduledToClose(), "close already scheduled");
-        int dataSize = data.readableBytes();
         unprocessed.addBuffer(data);
         needToCloseData = false;
         sinkListener.scheduleDeframerSource(source);
-        // TODO(ericgribkoff) Clean up interfaces (move this to Sink.Listener)
-        source.sourceListener.bytesRead(dataSize);
       } finally {
         if (needToCloseData) {
           data.close();
@@ -481,8 +478,7 @@ public class MessageDeframer {
         return true;
       } finally {
         if (totalBytesRead > 0) {
-          // TODO(ericgribkoff) Performance improves by notifying directly from transport thread.
-          //sourceListener.bytesRead(totalBytesRead);
+          sourceListener.bytesRead(totalBytesRead);
           if (state == State.BODY) {
             statsTraceCtx.inboundWireSize(totalBytesRead);
           }

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -44,7 +44,6 @@ import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
-import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.InternalDecompressorRegistry;
 import io.grpc.Metadata;
@@ -79,17 +78,6 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
     this.messageAcceptEncoding = inboundHeaders.get(MESSAGE_ACCEPT_ENCODING_KEY);
     this.decompressorRegistry = decompressorRegistry;
     this.compressorRegistry = compressorRegistry;
-
-    if (inboundHeaders.containsKey(MESSAGE_ENCODING_KEY)) {
-      String encoding = inboundHeaders.get(MESSAGE_ENCODING_KEY);
-      Decompressor decompressor = decompressorRegistry.lookupDecompressor(encoding);
-      if (decompressor == null) {
-        throw Status.UNIMPLEMENTED
-            .withDescription(String.format("Can't find decompressor for %s", encoding))
-            .asRuntimeException();
-      }
-      stream.setDecompressor(decompressor);
-    }
   }
 
   @Override
@@ -255,6 +243,14 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
             throw new RuntimeException(t);
           }
         }
+      }
+    }
+
+    @Override
+    public void scheduleDeframerSource(final MessageDeframer.Source source) {
+      InputStream message;
+      while ((message = source.next()) != null) {
+        messageRead(message);
       }
     }
 

--- a/core/src/main/java/io/grpc/internal/StreamListener.java
+++ b/core/src/main/java/io/grpc/internal/StreamListener.java
@@ -48,7 +48,15 @@ public interface StreamListener {
    *
    * @param message the bytes of the message.
    */
+  // TODO(ericgribkoff) Remove this method.
   void messageRead(InputStream message);
+
+  /**
+   * Called to schedule deframing in the application thread.
+   *
+   * @param source the message deframer source
+   */
+  void scheduleDeframerSource(MessageDeframer.Source source);
 
   /**
    * This indicates that the transport is now capable of sending additional messages

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -33,11 +33,11 @@ package io.grpc.internal;
 
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -49,7 +49,6 @@ import com.google.common.primitives.Bytes;
 import io.grpc.Codec;
 import io.grpc.StatusRuntimeException;
 import io.grpc.StreamTracer;
-import io.grpc.internal.MessageDeframer.Listener;
 import io.grpc.internal.MessageDeframer.SizeEnforcingInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -63,9 +62,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 /**
  * Tests for {@link MessageDeframer}.
@@ -74,165 +70,187 @@ import org.mockito.stubbing.Answer;
 public class MessageDeframerTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
-  private Listener listener = mock(Listener.class);
+  private MessageDeframer.Sink.Listener sinkListener = mock(MessageDeframer.Sink.Listener.class);
+  private MessageDeframer.Source.Listener sourceListener =
+      mock(MessageDeframer.Source.Listener.class);
   private StreamTracer tracer = mock(StreamTracer.class);
   private StatsTraceContext statsTraceCtx = new StatsTraceContext(new StreamTracer[]{tracer});
   private ArgumentCaptor<Long> wireSizeCaptor = ArgumentCaptor.forClass(Long.class);
   private ArgumentCaptor<Long> uncompressedSizeCaptor = ArgumentCaptor.forClass(Long.class);
 
-  private MessageDeframer deframer = new MessageDeframer(listener, Codec.Identity.NONE,
-      DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, "test");
+  private MessageDeframer deframer = new MessageDeframer(sinkListener, sourceListener,
+      Codec.Identity.NONE, DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, "test");
 
-  private ArgumentCaptor<InputStream> messages = ArgumentCaptor.forClass(InputStream.class);
+  private ArgumentCaptor<MessageDeframer.Source> sourceCaptor =
+          ArgumentCaptor.forClass(MessageDeframer.Source.class);
 
   @Test
   public void simplePayload() {
-    deframer.request(1);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 2, 3, 14}), false);
-    verify(listener).messageRead(messages.capture());
-    assertEquals(Bytes.asList(new byte[]{3, 14}), bytes(messages));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
+    deframer.sink().request(1);
+    deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 2, 3, 14}));
+    verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
+    assertEquals(Bytes.asList(new byte[]{3, 14}), bytes(sourceCaptor.getValue().next()));
+    assertNull(sourceCaptor.getValue().next());
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(1, 2, 2);
   }
 
   @Test
   public void smallCombinedPayloads() {
-    deframer.request(2);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 2, 14, 15}), false);
-    verify(listener, times(2)).messageRead(messages.capture());
-    List<InputStream> streams = messages.getAllValues();
-    assertEquals(2, streams.size());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(streams.get(0)));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    assertEquals(Bytes.asList(new byte[] {14, 15}), bytes(streams.get(1)));
-    verifyNoMoreInteractions(listener);
+    deframer.sink().request(2);
+    deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 2, 14, 15}));
+    verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
+    assertEquals(Bytes.asList(new byte[] {3}), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    assertEquals(Bytes.asList(new byte[] {14, 15}), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    assertNull(sourceCaptor.getValue().next());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(2, 3, 3);
   }
 
   @Test
   public void endOfStreamWithPayloadShouldNotifyEndOfStream() {
-    deframer.request(1);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}), true);
-    verify(listener).messageRead(messages.capture());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(messages));
-    verify(listener).endOfStream();
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
+    deframer.sink().request(1);
+    deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}));
+    deframer.sink().scheduleClose(false);
+    verify(sinkListener, times(3)).scheduleDeframerSource(sourceCaptor.capture());
+    assertEquals(Bytes.asList(new byte[] {3}), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    assertNull(sourceCaptor.getValue().next());
+    verify(sourceListener).deframerClosed(false);
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(1, 1, 1);
   }
 
   @Test
   public void endOfStreamShouldNotifyEndOfStream() {
-    deframer.deframe(buffer(new byte[0]), true);
-    verify(listener).endOfStream();
-    verifyNoMoreInteractions(listener);
+    deframer.sink().deframe(buffer(new byte[0]));
+    deframer.sink().scheduleClose(false);
+    verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
+    assertNull(sourceCaptor.getValue().next());
+    verify(sourceListener).deframerClosed(false);
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
+    checkStats(0, 0, 0);
+  }
+
+  @Test
+  public void endOfStreamWithPartialMessageInNextFrame() {
+    deframer.sink().deframe(buffer(new byte[1]));
+    deframer.sink().request(1);
+    deframer.sink().scheduleClose(false);
+    verify(sinkListener, times(3)).scheduleDeframerSource(sourceCaptor.capture());
+    assertNull(sourceCaptor.getValue().next());
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    verify(sourceListener).deframerClosed(true);
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(0, 0, 0);
   }
 
   @Test
   public void payloadSplitBetweenBuffers() {
-    deframer.request(1);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 7, 3, 14, 1, 5, 9}), false);
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    deframer.deframe(buffer(new byte[] {2, 6}), false);
-    verify(listener).messageRead(messages.capture());
-    assertEquals(Bytes.asList(new byte[] {3, 14, 1, 5, 9, 2, 6}), bytes(messages));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    assertTrue(deframer.isStalled());
-    verifyNoMoreInteractions(listener);
+    deframer.sink().request(1);
+    deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 7, 3, 14, 1, 5, 9}));
+    verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
+    assertNull(sourceCaptor.getValue().next());
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
+    deframer.sink().deframe(buffer(new byte[] {2, 6}));
+    verify(sinkListener, times(3)).scheduleDeframerSource(sourceCaptor.capture());
+    assertEquals(
+        Bytes.asList(new byte[] {3, 14, 1, 5, 9, 2, 6}), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(1, 7, 7);
   }
 
   @Test
   public void frameHeaderSplitBetweenBuffers() {
-    deframer.request(1);
-
-    deframer.deframe(buffer(new byte[] {0, 0}), false);
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    deframer.deframe(buffer(new byte[] {0, 0, 1, 3}), false);
-    verify(listener).messageRead(messages.capture());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(messages));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    assertTrue(deframer.isStalled());
-    verifyNoMoreInteractions(listener);
+    deframer.sink().request(1);
+    deframer.sink().deframe(buffer(new byte[] {0, 0}));
+    verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
+    assertNull(sourceCaptor.getValue().next());
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
+    deframer.sink().deframe(buffer(new byte[] {0, 0, 1, 3}));
+    verify(sinkListener, times(3)).scheduleDeframerSource(sourceCaptor.capture());
+    assertEquals(Bytes.asList(new byte[] {3}), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(1, 1, 1);
   }
 
   @Test
   public void emptyPayload() {
-    deframer.request(1);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 0}), false);
-    verify(listener).messageRead(messages.capture());
-    assertEquals(Bytes.asList(), bytes(messages));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
+    deframer.sink().request(1);
+    deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 0}));
+    verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
+    assertEquals(Bytes.asList(), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(1, 0, 0);
   }
 
   @Test
   public void largerFrameSize() {
-    deframer.request(1);
-    deframer.deframe(ReadableBuffers.wrap(
-        Bytes.concat(new byte[] {0, 0, 0, 3, (byte) 232}, new byte[1000])), false);
-    verify(listener).messageRead(messages.capture());
-    assertEquals(Bytes.asList(new byte[1000]), bytes(messages));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
+    deframer.sink().request(1);
+    deframer.sink().deframe(ReadableBuffers.wrap(
+        Bytes.concat(new byte[] {0, 0, 0, 3, (byte) 232}, new byte[1000])));
+    verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
+    assertEquals(Bytes.asList(new byte[1000]), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(1, 1000, 1000);
   }
 
   @Test
   public void endOfStreamCallbackShouldWaitForMessageDelivery() {
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}), true);
-    verifyNoMoreInteractions(listener);
+    deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}));
+    deframer.sink().scheduleClose(false);
+    verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
+    assertNull(sourceCaptor.getValue().next());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
 
-    deframer.request(1);
-    verify(listener).messageRead(messages.capture());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(messages));
-    verify(listener).endOfStream();
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
+    deframer.sink().request(1);
+    verify(sinkListener, times(3)).scheduleDeframerSource(sourceCaptor.capture());
+    assertEquals(Bytes.asList(new byte[] {3}), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    assertNull(sourceCaptor.getValue().next());
+    verify(sourceListener).deframerClosed(false);
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(1, 1, 1);
   }
 
   @Test
   public void compressed() {
-    deframer = new MessageDeframer(listener, new Codec.Gzip(), DEFAULT_MAX_MESSAGE_SIZE,
-        statsTraceCtx, "test");
-    deframer.request(1);
+    deframer = new MessageDeframer(sinkListener, sourceListener, new Codec.Gzip(),
+        DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, "test");
+    deframer.sink().request(1);
 
     byte[] payload = compress(new byte[1000]);
     assertTrue(payload.length < 100);
     byte[] header = new byte[] {1, 0, 0, 0, (byte) payload.length};
-    deframer.deframe(buffer(Bytes.concat(header, payload)), false);
-    verify(listener).messageRead(messages.capture());
-    assertEquals(Bytes.asList(new byte[1000]), bytes(messages));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
+    deframer.sink().deframe(buffer(Bytes.concat(header, payload)));
+    verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
+    assertEquals(Bytes.asList(new byte[1000]), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
+    verifyNoMoreInteractions(sinkListener);
+    verifyNoMoreInteractions(sourceListener);
     checkStats(1, payload.length, 1000);
-  }
-
-  @Test
-  public void deliverIsReentrantSafe() {
-    doAnswer(new Answer<Void>() {
-      @Override
-      public Void answer(InvocationOnMock invocation) throws Throwable {
-        deframer.request(1);
-        return null;
-      }
-    }).when(listener).messageRead(Matchers.<InputStream>any());
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}), true);
-    verifyNoMoreInteractions(listener);
-
-    deframer.request(1);
-    verify(listener).messageRead(messages.capture());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(messages));
-    verify(listener).endOfStream();
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -116,7 +116,7 @@ public class MessageDeframerTest {
   public void endOfStreamWithPayloadShouldNotifyEndOfStream() {
     deframer.sink().request(1);
     deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}));
-    deframer.sink().scheduleClose(false);
+    deframer.sink().scheduleCloseWhenComplete();
     verify(sinkListener, times(3)).scheduleDeframerSource(sourceCaptor.capture());
     assertEquals(Bytes.asList(new byte[] {3}), bytes(sourceCaptor.getValue().next()));
     verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
@@ -130,7 +130,7 @@ public class MessageDeframerTest {
   @Test
   public void endOfStreamShouldNotifyEndOfStream() {
     deframer.sink().deframe(buffer(new byte[0]));
-    deframer.sink().scheduleClose(false);
+    deframer.sink().scheduleCloseWhenComplete();
     verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
     assertNull(sourceCaptor.getValue().next());
     verify(sourceListener).deframerClosed(false);
@@ -143,7 +143,7 @@ public class MessageDeframerTest {
   public void endOfStreamWithPartialMessageInNextFrame() {
     deframer.sink().deframe(buffer(new byte[1]));
     deframer.sink().request(1);
-    deframer.sink().scheduleClose(false);
+    deframer.sink().scheduleCloseWhenComplete();
     verify(sinkListener, times(3)).scheduleDeframerSource(sourceCaptor.capture());
     assertNull(sourceCaptor.getValue().next());
     verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
@@ -218,7 +218,7 @@ public class MessageDeframerTest {
   @Test
   public void endOfStreamCallbackShouldWaitForMessageDelivery() {
     deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}));
-    deframer.sink().scheduleClose(false);
+    deframer.sink().scheduleCloseWhenComplete();
     verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
     assertNull(sourceCaptor.getValue().next());
     verifyNoMoreInteractions(sinkListener);

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -130,6 +130,7 @@ public class MessageDeframerTest {
   @Test
   public void endOfStreamShouldNotifyEndOfStream() {
     deframer.sink().deframe(buffer(new byte[0]));
+    verify(sourceListener, atLeastOnce()).bytesRead(0);
     deframer.sink().scheduleCloseWhenComplete();
     verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
     assertNull(sourceCaptor.getValue().next());
@@ -218,6 +219,7 @@ public class MessageDeframerTest {
   @Test
   public void endOfStreamCallbackShouldWaitForMessageDelivery() {
     deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
     deframer.sink().scheduleCloseWhenComplete();
     verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
     assertNull(sourceCaptor.getValue().next());
@@ -227,7 +229,6 @@ public class MessageDeframerTest {
     deframer.sink().request(1);
     verify(sinkListener, times(3)).scheduleDeframerSource(sourceCaptor.capture());
     assertEquals(Bytes.asList(new byte[] {3}), bytes(sourceCaptor.getValue().next()));
-    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
     assertNull(sourceCaptor.getValue().next());
     verify(sourceListener).deframerClosed(false);
     verifyNoMoreInteractions(sinkListener);

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -130,7 +130,6 @@ public class MessageDeframerTest {
   @Test
   public void endOfStreamShouldNotifyEndOfStream() {
     deframer.sink().deframe(buffer(new byte[0]));
-    verify(sourceListener, atLeastOnce()).bytesRead(0);
     deframer.sink().scheduleCloseWhenComplete();
     verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
     assertNull(sourceCaptor.getValue().next());
@@ -219,7 +218,6 @@ public class MessageDeframerTest {
   @Test
   public void endOfStreamCallbackShouldWaitForMessageDelivery() {
     deframer.sink().deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}));
-    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
     deframer.sink().scheduleCloseWhenComplete();
     verify(sinkListener, times(2)).scheduleDeframerSource(sourceCaptor.capture());
     assertNull(sourceCaptor.getValue().next());
@@ -229,6 +227,7 @@ public class MessageDeframerTest {
     deframer.sink().request(1);
     verify(sinkListener, times(3)).scheduleDeframerSource(sourceCaptor.capture());
     assertEquals(Bytes.asList(new byte[] {3}), bytes(sourceCaptor.getValue().next()));
+    verify(sourceListener, atLeastOnce()).bytesRead(anyInt());
     assertNull(sourceCaptor.getValue().next());
     verify(sourceListener).deframerClosed(false);
     verifyNoMoreInteractions(sinkListener);

--- a/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
+++ b/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
@@ -43,6 +43,9 @@ class NoopClientStreamListener implements ClientStreamListener {
   public void messageRead(InputStream message) {}
 
   @Override
+  public void scheduleDeframerSource(MessageDeframer.Source source) {}
+
+  @Override
   public void onReady() {}
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -52,6 +52,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.AsciiString;
@@ -201,17 +202,22 @@ class NettyClientStream extends AbstractClientStream2 {
     }
   }
 
-  /** This should only called from the transport thread. */
+  /**
+   * {@link io.grpc.internal.MessageDeframer.Source.Listener} methods will be called from the
+   * deframing thread. Other methods should only be called from the transport thread.
+   */
   public abstract static class TransportState extends Http2ClientStreamTransportState
       implements StreamIdHolder {
     private final NettyClientHandler handler;
+    private final EventLoop eventLoop;
     private int id;
     private Http2Stream http2Stream;
 
-    public TransportState(NettyClientHandler handler, int maxMessageSize,
+    public TransportState(NettyClientHandler handler, EventLoop eventLoop, int maxMessageSize,
         StatsTraceContext statsTraceCtx) {
       super(maxMessageSize, statsTraceCtx);
       this.handler = checkNotNull(handler, "handler");
+      this.eventLoop = checkNotNull(eventLoop, "eventLoop");
     }
 
     @Override
@@ -253,20 +259,53 @@ class NettyClientStream extends AbstractClientStream2 {
     protected abstract Status statusFromFailedFuture(ChannelFuture f);
 
     @Override
-    protected void http2ProcessingFailed(Status status, Metadata trailers) {
-      transportReportStatus(status, false, trailers);
+    protected void http2ProcessingFailed(Status status, boolean stopDelivery, Metadata trailers) {
+      transportReportStatus(status, stopDelivery, trailers);
       handler.getWriteQueue().enqueue(new CancelClientStreamCommand(this, status), true);
     }
 
     @Override
-    public void bytesRead(int processedBytes) {
-      handler.returnProcessedBytes(http2Stream, processedBytes);
-      handler.getWriteQueue().scheduleFlush();
+    public final void deframerClosed(boolean hasPartialMessageIgnored) {
+      if (eventLoop.inEventLoop()) {
+        deframerClosedNotThreadSafe();
+      } else {
+        eventLoop.execute(new Runnable() {
+          @Override
+          public void run() {
+            deframerClosedNotThreadSafe();
+          }
+        });
+      }
     }
 
     @Override
-    protected void deframeFailed(Throwable cause) {
-      http2ProcessingFailed(Status.fromThrowable(cause), new Metadata());
+    public void bytesRead(final int processedBytes) {
+      if (eventLoop.inEventLoop()) {
+        handler.returnProcessedBytes(http2Stream, processedBytes);
+        handler.getWriteQueue().scheduleFlush();
+      } else {
+        eventLoop.execute(new Runnable() {
+          @Override
+          public void run() {
+            handler.returnProcessedBytes(http2Stream, processedBytes);
+            handler.getWriteQueue().scheduleFlush();
+          }
+        });
+      }
+    }
+
+    @Override
+    public void deframeFailed(final Throwable cause) {
+      if (eventLoop.inEventLoop()) {
+        http2ProcessingFailed(Status.fromThrowable(cause), true, new Metadata());
+      } else {
+        eventLoop.execute(new Runnable() {
+          @Override
+          public void run() {
+            http2ProcessingFailed(Status.fromThrowable(cause), true, new Metadata());
+          }
+        });
+      }
     }
 
     void transportHeadersReceived(Http2Headers headers, boolean endOfStream) {

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -160,7 +160,8 @@ class NettyClientTransport implements ConnectionClientTransport {
     }
     StatsTraceContext statsTraceCtx = StatsTraceContext.newClientContext(callOptions, headers);
     return new NettyClientStream(
-        new NettyClientStream.TransportState(handler, maxMessageSize, statsTraceCtx) {
+        new NettyClientStream.TransportState(handler, channel.eventLoop(),
+            maxMessageSize, statsTraceCtx) {
           @Override
           protected Status statusFromFailedFuture(ChannelFuture f) {
             return NettyClientTransport.this.statusFromFailedFuture(f);

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -150,7 +150,7 @@ class NettyServerStream extends AbstractServerStream {
     }
   }
 
-  /** This should only called from the transport thread. */
+  /** This should only be called from the transport thread. */
   public static class TransportState extends AbstractServerStream.TransportState
       implements StreamIdHolder {
     private final Http2Stream http2Stream;
@@ -170,7 +170,7 @@ class NettyServerStream extends AbstractServerStream {
     }
 
     @Override
-    protected void deframeFailed(Throwable cause) {
+    public void deframeFailed(Throwable cause) {
       log.log(Level.WARNING, "Exception processing message", cause);
       Status status = Status.fromThrowable(cause);
       transportReportStatus(status);

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -69,6 +70,7 @@ import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ClientTransport.PingCallback;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.KeepAliveManager;
+import io.grpc.internal.MessageDeframer;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.netty.GrpcHttp2HeadersDecoder.GrpcHttp2ClientHeadersDecoder;
 import io.netty.buffer.ByteBuf;
@@ -77,6 +79,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Connection;
@@ -100,6 +103,8 @@ import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 /**
  * Tests for {@link NettyClientHandler}.
@@ -141,8 +146,24 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
       mockKeepAliveManager = mock(KeepAliveManager.class);
     }
 
+    doAnswer(
+          new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+              MessageDeframer.Source mp = (MessageDeframer.Source) invocation.getArguments()[0];
+              InputStream message;
+              while ((message = mp.next()) != null) {
+                streamListener.messageRead(message);
+              }
+              return null;
+            }
+          })
+      .when(streamListener)
+      .scheduleDeframerSource(any(MessageDeframer.Source.class));
+
     initChannel(new GrpcHttp2ClientHeadersDecoder(GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE));
-    streamTransportState = new TransportStateImpl(handler(), DEFAULT_MAX_MESSAGE_SIZE);
+    streamTransportState = new TransportStateImpl(handler(), channel.eventLoop(),
+        DEFAULT_MAX_MESSAGE_SIZE);
     streamTransportState.setListener(streamListener);
 
     grpcHeaders = new DefaultHttp2Headers()
@@ -447,12 +468,14 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     enqueue(new CreateStreamCommand(grpcHeaders, streamTransportState));
     assertEquals(3, streamTransportState.id());
 
-    streamTransportState = new TransportStateImpl(handler(), DEFAULT_MAX_MESSAGE_SIZE);
+    streamTransportState = new TransportStateImpl(handler(), channel.eventLoop(),
+        DEFAULT_MAX_MESSAGE_SIZE);
     streamTransportState.setListener(streamListener);
     enqueue(new CreateStreamCommand(grpcHeaders, streamTransportState));
     assertEquals(5, streamTransportState.id());
 
-    streamTransportState = new TransportStateImpl(handler(), DEFAULT_MAX_MESSAGE_SIZE);
+    streamTransportState = new TransportStateImpl(handler(), channel.eventLoop(),
+        DEFAULT_MAX_MESSAGE_SIZE);
     streamTransportState.setListener(streamListener);
     enqueue(new CreateStreamCommand(grpcHeaders, streamTransportState));
     assertEquals(7, streamTransportState.id());
@@ -654,8 +677,8 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
   }
 
   private static class TransportStateImpl extends NettyClientStream.TransportState {
-    public TransportStateImpl(NettyClientHandler handler, int maxMessageSize) {
-      super(handler, maxMessageSize, StatsTraceContext.NOOP);
+    public TransportStateImpl(NettyClientHandler handler, EventLoop eventLoop, int maxMessageSize) {
+      super(handler, eventLoop, maxMessageSize, StatsTraceContext.NOOP);
     }
 
     @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -66,6 +66,7 @@ import io.grpc.internal.ClientTransport;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ManagedClientTransport;
+import io.grpc.internal.MessageDeframer;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
@@ -572,6 +573,14 @@ public class NettyClientTransportTest {
     }
 
     @Override
+    public void scheduleDeframerSource(MessageDeframer.Source source) {
+      InputStream message;
+      while ((message = source.next()) != null) {
+        messageRead(message);
+      }
+    }
+
+    @Override
     public void onReady() {
     }
   }
@@ -594,6 +603,14 @@ public class NettyClientTransportTest {
       // Just echo back the message.
       stream.writeMessage(message);
       stream.flush();
+    }
+
+    @Override
+    public void scheduleDeframerSource(MessageDeframer.Source source) {
+      InputStream message;
+      while ((message = source.next()) != null) {
+        messageRead(message);
+      }
     }
 
     @Override

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -81,7 +81,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
 
   private ByteBuf content;
 
-  private EmbeddedChannel channel;
+  protected EmbeddedChannel channel;
 
   private ChannelHandlerContext ctx;
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -242,25 +242,35 @@ class OkHttpClientStream extends AbstractClientStream2 {
 
     @GuardedBy("lock")
     @Override
-    protected void http2ProcessingFailed(Status status, Metadata trailers) {
+    protected void http2ProcessingFailed(Status status, boolean stopDelivery, Metadata trailers) {
+      transportReportStatus(status, stopDelivery, trailers);
       cancel(status, trailers);
     }
 
-    @GuardedBy("lock")
     @Override
-    protected void deframeFailed(Throwable cause) {
-      http2ProcessingFailed(Status.fromThrowable(cause), new Metadata());
+    public void deframeFailed(Throwable cause) {
+      synchronized (lock) {
+        http2ProcessingFailed(Status.fromThrowable(cause), true, new Metadata());
+      }
     }
 
-    @GuardedBy("lock")
+    @Override
+    public void deframerClosed(boolean hasPartialMessageIgnored) {
+      synchronized (lock) {
+        deframerClosedNotThreadSafe();
+      }
+    }
+
     @Override
     public void bytesRead(int processedBytes) {
-      processedWindow -= processedBytes;
-      if (processedWindow <= WINDOW_UPDATE_THRESHOLD) {
-        int delta = Utils.DEFAULT_WINDOW_SIZE - processedWindow;
-        window += delta;
-        processedWindow += delta;
-        frameWriter.windowUpdate(id(), delta);
+      synchronized (lock) {
+        processedWindow -= processedBytes;
+        if (processedWindow <= WINDOW_UPDATE_THRESHOLD) {
+          int delta = Utils.DEFAULT_WINDOW_SIZE - processedWindow;
+          window += delta;
+          processedWindow += delta;
+          frameWriter.windowUpdate(id(), delta);
+        }
       }
     }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -47,6 +47,7 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.MessageDeframer;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.okhttp.internal.framed.ErrorCode;
 import io.grpc.okhttp.internal.framed.Header;
@@ -221,6 +222,12 @@ public class OkHttpClientStreamTest {
 
     @Override
     public void messageRead(InputStream message) {}
+
+    @Override
+    public void scheduleDeframerSource(MessageDeframer.Source source) {
+      while (source.next() != null) {
+      }
+    }
 
     @Override
     public void headersRead(Metadata headers) {}

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -582,15 +582,16 @@ public class OkHttpClientTransportTest {
     long messageFrameLength = buffer.size();
     frameHandler().data(false, 3, buffer, (int) messageFrameLength);
     ArgumentCaptor<Integer> idCaptor = ArgumentCaptor.forClass(Integer.class);
-    verify(frameWriter, timeout(TIME_OUT_MS)).windowUpdate(
+    verify(frameWriter, timeout(TIME_OUT_MS).times(2)).windowUpdate(
         idCaptor.capture(), eq(messageFrameLength));
+    // TODO(ericgribkoff) "Eagerly" reporting bytes queued in the deframer changes the behavior
     // Should only send window update for the connection.
-    assertEquals(1, idCaptor.getAllValues().size());
-    assertEquals(0, (int)idCaptor.getValue());
+    assertEquals(2, idCaptor.getAllValues().size());
+    assertEquals(3, (int)idCaptor.getAllValues().get(0));
+    assertEquals(0, (int)idCaptor.getAllValues().get(1));
 
     stream.request(1);
     // We return the bytes for the stream window as we read the message.
-    verify(frameWriter, timeout(TIME_OUT_MS)).windowUpdate(eq(3), eq(messageFrameLength));
 
     getStream(3).cancel(Status.CANCELLED);
     verify(frameWriter, timeout(TIME_OUT_MS)).rstStream(eq(3), eq(ErrorCode.CANCEL));

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -74,6 +74,7 @@ import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ManagedClientTransport;
+import io.grpc.internal.MessageDeframer;
 import io.grpc.okhttp.OkHttpClientTransport.ClientFrameHandler;
 import io.grpc.okhttp.internal.ConnectionSpec;
 import io.grpc.okhttp.internal.framed.ErrorCode;
@@ -1722,6 +1723,14 @@ public class OkHttpClientTransportTest {
       String msg = getContent(message);
       if (msg != null) {
         messages.add(msg);
+      }
+    }
+
+    @Override
+    public void scheduleDeframerSource(MessageDeframer.Source source) {
+      InputStream message;
+      while ((message = source.next()) != null) {
+        messageRead(message);
       }
     }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -582,16 +582,15 @@ public class OkHttpClientTransportTest {
     long messageFrameLength = buffer.size();
     frameHandler().data(false, 3, buffer, (int) messageFrameLength);
     ArgumentCaptor<Integer> idCaptor = ArgumentCaptor.forClass(Integer.class);
-    verify(frameWriter, timeout(TIME_OUT_MS).times(2)).windowUpdate(
+    verify(frameWriter, timeout(TIME_OUT_MS)).windowUpdate(
         idCaptor.capture(), eq(messageFrameLength));
-    // TODO(ericgribkoff) "Eagerly" reporting bytes queued in the deframer changes the behavior
     // Should only send window update for the connection.
-    assertEquals(2, idCaptor.getAllValues().size());
-    assertEquals(3, (int)idCaptor.getAllValues().get(0));
-    assertEquals(0, (int)idCaptor.getAllValues().get(1));
+    assertEquals(1, idCaptor.getAllValues().size());
+    assertEquals(0, (int)idCaptor.getValue());
 
     stream.request(1);
     // We return the bytes for the stream window as we read the message.
+    verify(frameWriter, timeout(TIME_OUT_MS)).windowUpdate(eq(3), eq(messageFrameLength));
 
     getStream(3).cancel(Status.CANCELLED);
     verify(frameWriter, timeout(TIME_OUT_MS)).rstStream(eq(3), eq(ErrorCode.CANCEL));


### PR DESCRIPTION
This PR moves client-side deframing out of the transport thread and onto the call executor. This lays the groundwork for full-stream compression by allowing the full-stream decompression, once implemented, to occur in an application-provided thread rather than slowing down the transport.

To accomplish this, the operation of the `MessageDeframer` class is split into two parts. `MessageDeframer.Sink` is invoked from the transport thread, and queues incoming raw data frames in preparation for deframing them as gRPC messages in a separate thread. `MessageDeframer.Source` is invoked in the client call executor thread, and handles the actual deframing and our existing per-message decompression.

The `Sink` and `Source` of the `MessageDeframer` are safe to run concurrently in separate threads. The `CompositeReadableBuffer` holding raw incoming data frames is now backed by a `ConcurrentLinkedList`. Since we have exactly one thread (`MessageDeframer.Sink` in the transport thread) adding to the buffer and one thread (`MessageDeframer.Source` in the serializing call executor) reading from the buffer, `ConcurrentLinkedList` is a bit more than necessary for thread-safety, but initial benchmarks indicate that the primary runtime cost is the context switching between the transport and application threads rather than the lockless synchronization in Java's `ConcurrentLinkedList`. If it becomes the bottleneck, we can move to a data structure optimized for this one-producer, one-consumer scenario.

This PR combines the two existing deframer-to-transport notifications, `deliveryStalled()` and `endOfStream()`, into a single method: `deframerClosed()`. Previously, `deliveryStalled()` was ignored when deframing for a server, and only had an impact on the client side when `transportReportStatus()` had already been called. On the other hand, `endOfStream()` was only ever called by the deframer on the server side, as the `endOfStream` argument to `MessageDeframer#deframe(ReadableBuffer, boolean endOfStream)` was only set to true in `AbstractServerStream2`. Combining these two client- and server-specific notifications into one method, `deframerClosed()` is only invoked after the transport thread has notified the deframer that it should close. This can be in response to a normal event, such as receiving trailing metadata: in this case, the deframer will continue to send queued messages to the application and close once done. Or it can be due to an immediate close request, such as in response to a cancellation from the application code: this will cause the deframer to close and discard any remaining messages.