### PR TITLE
Add cacheable_unary interop test

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream2.java
@@ -329,8 +329,6 @@ public abstract class AbstractClientStream2 extends AbstractStream2
     }
   }
 
-  public static final String GRPC_PAYLOAD_BIN_KEY = "grpc-payload-bin";
-
   private class GetFramer implements Framer {
     private Metadata headers;
     private boolean closed;

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -38,6 +38,7 @@ import com.google.common.base.Preconditions;
  */
 public enum TestCases {
   EMPTY_UNARY("empty (zero bytes) request and response"),
+  CACHEABLE_UNARY("cacheable unary rpc sent using GET"),
   LARGE_UNARY("single request and (large) response"),
   CLIENT_STREAMING("request streaming with single response"),
   SERVER_STREAMING("single request with response streaming"),

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -209,6 +209,11 @@ public class TestServiceClient {
         tester.emptyUnary();
         break;
 
+      case CACHEABLE_UNARY: {
+        tester.cacheableUnary();
+        break;
+      }
+
       case LARGE_UNARY:
         tester.largeUnary();
         break;

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
@@ -54,11 +54,27 @@ public class TestCasesTest {
   @Test
   public void testCaseNamesShouldMapToEnums() {
     // names of testcases as defined in the interop spec
-    String[] testCases = {"empty_unary", "large_unary", "client_streaming", "server_streaming",
-      "ping_pong", "empty_stream", "compute_engine_creds", "service_account_creds",
-      "jwt_token_creds", "oauth2_auth_token", "per_rpc_creds", "custom_metadata",
-      "status_code_and_message", "unimplemented_method", "unimplemented_service",
-      "cancel_after_begin", "cancel_after_first_response", "timeout_on_sleeping_server"};
+    String[] testCases = {
+      "empty_unary",
+      "cacheable_unary",
+      "large_unary",
+      "client_streaming",
+      "server_streaming",
+      "ping_pong",
+      "empty_stream",
+      "compute_engine_creds",
+      "service_account_creds",
+      "jwt_token_creds",
+      "oauth2_auth_token",
+      "per_rpc_creds",
+      "custom_metadata",
+      "status_code_and_message",
+      "unimplemented_method",
+      "unimplemented_service",
+      "cancel_after_begin",
+      "cancel_after_first_response",
+      "timeout_on_sleeping_server"
+    };
 
     assertEquals(testCases.length, TestCases.values().length);
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -128,8 +128,8 @@ class NettyClientStream extends AbstractClientStream2 {
       AsciiString httpMethod;
       if (get) {
         // Forge the query string
-        defaultPath = new AsciiString(defaultPath + "?" + GRPC_PAYLOAD_BIN_KEY + "="
-            + BaseEncoding.base64().encode(requestPayload));
+        defaultPath =
+            new AsciiString(defaultPath + "?" + BaseEncoding.base64().encode(requestPayload));
         httpMethod = Utils.HTTP_GET_METHOD;
       } else {
         httpMethod = Utils.HTTP_METHOD;

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -128,6 +128,7 @@ class NettyClientStream extends AbstractClientStream2 {
       AsciiString httpMethod;
       if (get) {
         // Forge the query string
+        // TODO(ericgribkoff) Add the key back to the query string
         defaultPath =
             new AsciiString(defaultPath + "?" + BaseEncoding.base64().encode(requestPayload));
         httpMethod = Utils.HTTP_GET_METHOD;

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -422,7 +422,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     verify(writeQueue).enqueue(cmdCap.capture(), eq(true));
     assertThat(ImmutableListMultimap.copyOf(cmdCap.getValue().headers()))
         .containsEntry(AsciiString.of(":path"), AsciiString.of(
-            "//testService/test?grpc-payload-bin=" + BaseEncoding.base64().encode(msg)));
+            "//testService/test?" + BaseEncoding.base64().encode(msg)));
   }
 
   @Override

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -56,6 +56,18 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
+      io.grpc.testing.integration.Messages.SimpleResponse> METHOD_CACHEABLE_UNARY_CALL =
+      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.SimpleRequest, io.grpc.testing.integration.Messages.SimpleResponse>newBuilder()
+          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(generateFullMethodName(
+              "grpc.testing.TestService", "CacheableUnaryCall"))
+          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+              io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()))
+          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+              io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()))
+          .build();
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
       io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse>newBuilder()
@@ -169,6 +181,18 @@ public final class TestServiceGrpc {
 
     /**
      * <pre>
+     * One request followed by one response. Response has cache control
+     * headers set such that a caching HTTP proxy (such as GFE) can
+     * satisfy subsequent requests.
+     * </pre>
+     */
+    public void cacheableUnaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_CACHEABLE_UNARY_CALL, responseObserver);
+    }
+
+    /**
+     * <pre>
      * One request followed by a sequence of responses (streamed download).
      * The server returns the payload with client desired type and sizes.
      * </pre>
@@ -241,6 +265,13 @@ public final class TestServiceGrpc {
                 io.grpc.testing.integration.Messages.SimpleRequest,
                 io.grpc.testing.integration.Messages.SimpleResponse>(
                   this, METHODID_UNARY_CALL)))
+          .addMethod(
+            METHOD_CACHEABLE_UNARY_CALL,
+            asyncUnaryCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Messages.SimpleRequest,
+                io.grpc.testing.integration.Messages.SimpleResponse>(
+                  this, METHODID_CACHEABLE_UNARY_CALL)))
           .addMethod(
             METHOD_STREAMING_OUTPUT_CALL,
             asyncServerStreamingCall(
@@ -322,6 +353,19 @@ public final class TestServiceGrpc {
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * One request followed by one response. Response has cache control
+     * headers set such that a caching HTTP proxy (such as GFE) can
+     * satisfy subsequent requests.
+     * </pre>
+     */
+    public void cacheableUnaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(METHOD_CACHEABLE_UNARY_CALL, getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -432,6 +476,18 @@ public final class TestServiceGrpc {
 
     /**
      * <pre>
+     * One request followed by one response. Response has cache control
+     * headers set such that a caching HTTP proxy (such as GFE) can
+     * satisfy subsequent requests.
+     * </pre>
+     */
+    public io.grpc.testing.integration.Messages.SimpleResponse cacheableUnaryCall(io.grpc.testing.integration.Messages.SimpleRequest request) {
+      return blockingUnaryCall(
+          getChannel(), METHOD_CACHEABLE_UNARY_CALL, getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * One request followed by a sequence of responses (streamed download).
      * The server returns the payload with client desired type and sizes.
      * </pre>
@@ -500,6 +556,19 @@ public final class TestServiceGrpc {
 
     /**
      * <pre>
+     * One request followed by one response. Response has cache control
+     * headers set such that a caching HTTP proxy (such as GFE) can
+     * satisfy subsequent requests.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> cacheableUnaryCall(
+        io.grpc.testing.integration.Messages.SimpleRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(METHOD_CACHEABLE_UNARY_CALL, getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * The test server will not implement this method. It will be used
      * to test the behavior when clients call unimplemented methods.
      * </pre>
@@ -513,11 +582,12 @@ public final class TestServiceGrpc {
 
   private static final int METHODID_EMPTY_CALL = 0;
   private static final int METHODID_UNARY_CALL = 1;
-  private static final int METHODID_STREAMING_OUTPUT_CALL = 2;
-  private static final int METHODID_UNIMPLEMENTED_CALL = 3;
-  private static final int METHODID_STREAMING_INPUT_CALL = 4;
-  private static final int METHODID_FULL_DUPLEX_CALL = 5;
-  private static final int METHODID_HALF_DUPLEX_CALL = 6;
+  private static final int METHODID_CACHEABLE_UNARY_CALL = 2;
+  private static final int METHODID_STREAMING_OUTPUT_CALL = 3;
+  private static final int METHODID_UNIMPLEMENTED_CALL = 4;
+  private static final int METHODID_STREAMING_INPUT_CALL = 5;
+  private static final int METHODID_FULL_DUPLEX_CALL = 6;
+  private static final int METHODID_HALF_DUPLEX_CALL = 7;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -542,6 +612,10 @@ public final class TestServiceGrpc {
           break;
         case METHODID_UNARY_CALL:
           serviceImpl.unaryCall((io.grpc.testing.integration.Messages.SimpleRequest) request,
+              (io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse>) responseObserver);
+          break;
+        case METHODID_CACHEABLE_UNARY_CALL:
+          serviceImpl.cacheableUnaryCall((io.grpc.testing.integration.Messages.SimpleRequest) request,
               (io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse>) responseObserver);
           break;
         case METHODID_STREAMING_OUTPUT_CALL:
@@ -596,6 +670,7 @@ public final class TestServiceGrpc {
               .setSchemaDescriptor(new TestServiceDescriptorSupplier())
               .addMethod(METHOD_EMPTY_CALL)
               .addMethod(METHOD_UNARY_CALL)
+              .addMethod(METHOD_CACHEABLE_UNARY_CALL)
               .addMethod(METHOD_STREAMING_OUTPUT_CALL)
               .addMethod(METHOD_STREAMING_INPUT_CALL)
               .addMethod(METHOD_FULL_DUPLEX_CALL)

--- a/testing-proto/src/generated/main/java/io/grpc/testing/integration/Test.java
+++ b/testing-proto/src/generated/main/java/io/grpc/testing/integration/Test.java
@@ -26,29 +26,31 @@ public final class Test {
       "\n&io/grpc/testing/integration/test.proto" +
       "\022\014grpc.testing\032\'io/grpc/testing/integrat" +
       "ion/empty.proto\032*io/grpc/testing/integra" +
-      "tion/messages.proto2\372\004\n\013TestService\0225\n\tE" +
+      "tion/messages.proto2\313\005\n\013TestService\0225\n\tE" +
       "mptyCall\022\023.grpc.testing.Empty\032\023.grpc.tes" +
       "ting.Empty\022F\n\tUnaryCall\022\033.grpc.testing.S" +
       "impleRequest\032\034.grpc.testing.SimpleRespon" +
-      "se\022l\n\023StreamingOutputCall\022(.grpc.testing" +
+      "se\022O\n\022CacheableUnaryCall\022\033.grpc.testing." +
+      "SimpleRequest\032\034.grpc.testing.SimpleRespo" +
+      "nse\022l\n\023StreamingOutputCall\022(.grpc.testin",
+      "g.StreamingOutputCallRequest\032).grpc.test" +
+      "ing.StreamingOutputCallResponse0\001\022i\n\022Str" +
+      "eamingInputCall\022\'.grpc.testing.Streaming" +
+      "InputCallRequest\032(.grpc.testing.Streamin" +
+      "gInputCallResponse(\001\022i\n\016FullDuplexCall\022(" +
+      ".grpc.testing.StreamingOutputCallRequest" +
+      "\032).grpc.testing.StreamingOutputCallRespo" +
+      "nse(\0010\001\022i\n\016HalfDuplexCall\022(.grpc.testing" +
       ".StreamingOutputCallRequest\032).grpc.testi" +
-      "ng.StreamingOutputCallResponse0\001\022i\n\022Stre",
-      "amingInputCall\022\'.grpc.testing.StreamingI" +
-      "nputCallRequest\032(.grpc.testing.Streaming" +
-      "InputCallResponse(\001\022i\n\016FullDuplexCall\022(." +
-      "grpc.testing.StreamingOutputCallRequest\032" +
-      ").grpc.testing.StreamingOutputCallRespon" +
-      "se(\0010\001\022i\n\016HalfDuplexCall\022(.grpc.testing." +
-      "StreamingOutputCallRequest\032).grpc.testin" +
-      "g.StreamingOutputCallResponse(\0010\001\022=\n\021Uni" +
-      "mplementedCall\022\023.grpc.testing.Empty\032\023.gr" +
-      "pc.testing.Empty2U\n\024UnimplementedService",
-      "\022=\n\021UnimplementedCall\022\023.grpc.testing.Emp" +
-      "ty\032\023.grpc.testing.Empty2\177\n\020ReconnectServ" +
-      "ice\0221\n\005Start\022\023.grpc.testing.Empty\032\023.grpc" +
-      ".testing.Empty\0228\n\004Stop\022\023.grpc.testing.Em" +
-      "pty\032\033.grpc.testing.ReconnectInfoB\035\n\033io.g" +
-      "rpc.testing.integrationb\006proto3"
+      "ng.StreamingOutputCallResponse(\0010\001\022=\n\021Un",
+      "implementedCall\022\023.grpc.testing.Empty\032\023.g" +
+      "rpc.testing.Empty2U\n\024UnimplementedServic" +
+      "e\022=\n\021UnimplementedCall\022\023.grpc.testing.Em" +
+      "pty\032\023.grpc.testing.Empty2\177\n\020ReconnectSer" +
+      "vice\0221\n\005Start\022\023.grpc.testing.Empty\032\023.grp" +
+      "c.testing.Empty\0228\n\004Stop\022\023.grpc.testing.E" +
+      "mpty\032\033.grpc.testing.ReconnectInfoB\035\n\033io." +
+      "grpc.testing.integrationb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/testing-proto/src/main/proto/io/grpc/testing/integration/test.proto
+++ b/testing-proto/src/main/proto/io/grpc/testing/integration/test.proto
@@ -47,6 +47,11 @@ service TestService {
   // One request followed by one response.
   rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
 
+  // One request followed by one response. Response has cache control
+  // headers set such that a caching HTTP proxy (such as GFE) can
+  // satisfy subsequent requests.
+  rpc CacheableUnaryCall(SimpleRequest) returns (SimpleResponse);
+
   // One request followed by a sequence of responses (streamed download).
   // The server returns the payload with client desired type and sizes.
   rpc StreamingOutputCall(StreamingOutputCallRequest)


### PR DESCRIPTION
This PR has two commits:

1. Remove the `grpc-payload-bin=` prefix from outgoing GET requests. This brings the implementation inline with C++ and our test server behind GFE.
2. Add the cacheable_unary interop test, which verifies that GET requests sent to a server behind a caching proxy are correctly sent and responses cached.