### PR TITLE
core: integrate instrumentation-java (Census) tracing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,6 @@ subprojects {
     repositories {
         mavenCentral()
         mavenLocal()
-        maven {
-          url "https://oss.sonatype.org/content/repositories/snapshots/"
-        }
     }
 
     [compileJava, compileTestJava].each() {
@@ -169,7 +166,7 @@ subprojects {
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.4.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
                 okio: 'com.squareup.okio:okio:1.6.0',
-                instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.2-SNAPSHOT',
+                instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.2',
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 // swap to ${protobufVersion} after versions align again
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",

--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ subprojects {
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.4.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
                 okio: 'com.squareup.okio:okio:1.6.0',
-                instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.1-SNAPSHOT',
+                instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.2-SNAPSHOT',
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 // swap to ${protobufVersion} after versions align again
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",

--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ subprojects {
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.4.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
                 okio: 'com.squareup.okio:okio:1.6.0',
-                instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.3.0',
+                instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.0',
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 // swap to ${protobufVersion} after versions align again
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ subprojects {
     repositories {
         mavenCentral()
         mavenLocal()
+        maven {
+          url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 
     [compileJava, compileTestJava].each() {
@@ -166,7 +169,7 @@ subprojects {
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.4.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
                 okio: 'com.squareup.okio:okio:1.6.0',
-                instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.0',
+                instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.1-SNAPSHOT',
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 // swap to ${protobufVersion} after versions align again
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -39,6 +39,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.instrumentation.stats.Stats;
 import com.google.instrumentation.stats.StatsContextFactory;
+import com.google.instrumentation.trace.Tracing;
 import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
@@ -294,7 +295,9 @@ public abstract class AbstractManagedChannelImplBuilder
       if (statsCtxFactory != null) {
         interceptors = new ArrayList<ClientInterceptor>(this.interceptors);
         CensusStreamTracerModule census =
-            new CensusStreamTracerModule(statsCtxFactory, GrpcUtil.STOPWATCH_SUPPLIER);
+            new CensusStreamTracerModule(
+                statsCtxFactory, Tracing.getTracer(), Tracing.getBinaryPropagationHandler(),
+                GrpcUtil.STOPWATCH_SUPPLIER);
         // First interceptor runs last (see ClientInterceptors.intercept()), so that no
         // other interceptor can override the tracer factory we set in CallOptions.
         interceptors.add(0, census.getClientInterceptor());

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -290,7 +290,7 @@ public abstract class AbstractManagedChannelImplBuilder
 
     List<ClientInterceptor> effectiveInterceptors =
         new ArrayList<ClientInterceptor>(this.interceptors);
-    if (recordsStats()) {
+    if (GrpcUtil.enableCensusStats && recordsStats()) {
       StatsContextFactory statsCtxFactory =
           this.statsFactory != null ? this.statsFactory : Stats.getStatsContextFactory();
       if (statsCtxFactory != null) {
@@ -301,9 +301,11 @@ public abstract class AbstractManagedChannelImplBuilder
         effectiveInterceptors.add(0, censusStats.getClientInterceptor());
       }
     }
-    CensusTracingModule censusTracing =
-        new CensusTracingModule(Tracing.getTracer(), Tracing.getBinaryPropagationHandler());
-    effectiveInterceptors.add(0, censusTracing.getClientInterceptor());
+    if (GrpcUtil.enableCensusTracing) {
+      CensusTracingModule censusTracing =
+          new CensusTracingModule(Tracing.getTracer(), Tracing.getBinaryPropagationHandler());
+      effectiveInterceptors.add(0, censusTracing.getClientInterceptor());
+    }
 
     return new ManagedChannelImpl(
         target,

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -176,13 +176,15 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
     StatsContextFactory statsFactory =
         this.statsFactory != null ? this.statsFactory : Stats.getStatsContextFactory();
     if (statsFactory != null) {
-      CensusStreamTracerModule census =
-          new CensusStreamTracerModule(
-              statsFactory, Tracing.getTracer(), Tracing.getBinaryPropagationHandler(),
-              GrpcUtil.STOPWATCH_SUPPLIER);
-      tracerFactories.add(census.getServerTracerFactory());
+      CensusStatsModule censusStats =
+          new CensusStatsModule(statsFactory, GrpcUtil.STOPWATCH_SUPPLIER);
+      tracerFactories.add(censusStats.getServerTracerFactory());
     }
+    CensusTracingModule censusTracing =
+        new CensusTracingModule(Tracing.getTracer(), Tracing.getBinaryPropagationHandler());
+    tracerFactories.add(censusTracing.getServerTracerFactory());
     tracerFactories.addAll(streamTracerFactories);
+
     io.grpc.internal.InternalServer transportServer =
         buildTransportServer(Collections.unmodifiableList(tracerFactories));
     ServerImpl server = new ServerImpl(getExecutorPool(),

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -173,16 +173,20 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   public ServerImpl build() {
     ArrayList<ServerStreamTracer.Factory> tracerFactories =
         new ArrayList<ServerStreamTracer.Factory>();
-    StatsContextFactory statsFactory =
-        this.statsFactory != null ? this.statsFactory : Stats.getStatsContextFactory();
-    if (statsFactory != null) {
-      CensusStatsModule censusStats =
-          new CensusStatsModule(statsFactory, GrpcUtil.STOPWATCH_SUPPLIER);
-      tracerFactories.add(censusStats.getServerTracerFactory());
+    if (GrpcUtil.enableCensusStats) {
+      StatsContextFactory statsFactory =
+          this.statsFactory != null ? this.statsFactory : Stats.getStatsContextFactory();
+      if (statsFactory != null) {
+        CensusStatsModule censusStats =
+            new CensusStatsModule(statsFactory, GrpcUtil.STOPWATCH_SUPPLIER);
+        tracerFactories.add(censusStats.getServerTracerFactory());
+      }
     }
-    CensusTracingModule censusTracing =
-        new CensusTracingModule(Tracing.getTracer(), Tracing.getBinaryPropagationHandler());
-    tracerFactories.add(censusTracing.getServerTracerFactory());
+    if (GrpcUtil.enableCensusTracing) {
+      CensusTracingModule censusTracing =
+          new CensusTracingModule(Tracing.getTracer(), Tracing.getBinaryPropagationHandler());
+      tracerFactories.add(censusTracing.getServerTracerFactory());
+    }
     tracerFactories.addAll(streamTracerFactories);
 
     io.grpc.internal.InternalServer transportServer =

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -38,6 +38,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.instrumentation.stats.Stats;
 import com.google.instrumentation.stats.StatsContextFactory;
+import com.google.instrumentation.trace.Tracing;
 import io.grpc.BindableService;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
@@ -176,7 +177,9 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
         this.statsFactory != null ? this.statsFactory : Stats.getStatsContextFactory();
     if (statsFactory != null) {
       CensusStreamTracerModule census =
-          new CensusStreamTracerModule(statsFactory, GrpcUtil.STOPWATCH_SUPPLIER);
+          new CensusStreamTracerModule(
+              statsFactory, Tracing.getTracer(), Tracing.getBinaryPropagationHandler(),
+              GrpcUtil.STOPWATCH_SUPPLIER);
       tracerFactories.add(census.getServerTracerFactory());
     }
     tracerFactories.addAll(streamTracerFactories);

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -338,6 +338,7 @@ final class CensusStatsModule {
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
         MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      // New RPCs on client-side inherit the stats context from the current Context.
       StatsContext parentCtx = STATS_CONTEXT_KEY.get();
       if (parentCtx == null) {
         parentCtx = statsCtxFactory.getDefault();

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -34,7 +34,6 @@ package io.grpc.internal;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.instrumentation.trace.ContextUtils.CONTEXT_SPAN_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
@@ -75,8 +74,9 @@ import javax.annotation.Nullable;
  * the ClientStream, and in some cases may even not create a ClientStream at all.  Therefore, it's
  * the factory that reports the summary to Census.
  *
- * <p>On the server-side, a tracer is created for each call, because ServerStream starts earlier
- * than the ServerCall.  Therefore, it's the tracer that reports the summary to Census.
+ * <p>On the server-side, there is only one ServerStream per each ServerCall, and ServerStream
+ * starts earlier than the ServerCall.  Therefore, only one tracer is created per stream/call and
+ * it's the tracer that reports the summary to Census.
  */
 final class CensusStatsModule {
   private static final Logger logger = Logger.getLogger(CensusStatsModule.class.getName());

--- a/core/src/main/java/io/grpc/internal/CensusStreamTracerModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStreamTracerModule.java
@@ -96,8 +96,10 @@ final class CensusStreamTracerModule {
   private final Tracer censusTracer;
   private final BinaryPropagationHandler censusTracingPropagationHandler;
   private final Supplier<Stopwatch> stopwatchSupplier;
-  private final Metadata.Key<StatsContext> statsHeader;
-  private final Metadata.Key<SpanContext> tracingHeader;
+  @VisibleForTesting
+  final Metadata.Key<StatsContext> statsHeader;
+  @VisibleForTesting
+  final Metadata.Key<SpanContext> tracingHeader;
   private final CensusClientInterceptor clientInterceptor = new CensusClientInterceptor();
   private final ServerTracerFactory serverTracerFactory = new ServerTracerFactory();
 
@@ -235,7 +237,9 @@ final class CensusStreamTracerModule {
       checkState(streamTracer.compareAndSet(null, tracer),
           "Are you creating multiple streams per call? This class doesn't yet support this case.");
       headers.discardAll(statsHeader);
-      headers.put(statsHeader, parentCtx);
+      if (parentCtx != statsCtxFactory.getDefault()) {
+        headers.put(statsHeader, parentCtx);
+      }
       headers.discardAll(tracingHeader);
       headers.put(tracingHeader, span.getContext());
       return tracer;

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -212,6 +212,7 @@ final class CensusTracingModule {
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
         MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      // New RPCs on client-side inherit the tracing context from the current Context.
       Span parentSpan = CONTEXT_SPAN_KEY.get();
       final ClientCallTracer tracerFactory =
           newClientCallTracer(parentSpan, method.getFullMethodName());

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -197,9 +197,13 @@ final class CensusTracingModule {
   }
 
   private final class ServerTracerFactory extends ServerStreamTracer.Factory {
+    @SuppressWarnings("ReferenceEquality")
     @Override
     public ServerStreamTracer newServerStreamTracer(String fullMethodName, Metadata headers) {
       SpanContext remoteSpan = headers.get(tracingHeader);
+      if (remoteSpan == SpanContext.INVALID) {
+        remoteSpan = null;
+      }
       return new ServerTracer(fullMethodName, remoteSpan);
     }
   }

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.instrumentation.trace.ContextUtils.CONTEXT_SPAN_KEY;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.instrumentation.trace.BinaryPropagationHandler;
+import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.SpanContext;
+import com.google.instrumentation.trace.Tracer;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientStreamTracer;
+import io.grpc.Context;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerStreamTracer;
+import io.grpc.Status;
+import io.grpc.StreamTracer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * Provides factories for {@link StreamTracer} that records traces to Census.
+ *
+ * <p>On the client-side, a factory is created for each call, because ClientCall starts earlier than
+ * the ClientStream, and in some cases may even not create a ClientStream at all.  Therefore, it's
+ * the factory that reports the summary to Census.
+ *
+ * <p>On the server-side, a tracer is created for each call, because ServerStream starts earlier
+ * than the ServerCall.  Therefore, it's the tracer that reports the summary to Census.
+ */
+final class CensusTracingModule {
+  private static final Logger logger = Logger.getLogger(CensusTracingModule.class.getName());
+  // TODO(zhangkun83): record NetworkEvent to Span for each message
+  private static final ClientStreamTracer noopClientTracer = new ClientStreamTracer() {};
+
+  private final Tracer censusTracer;
+  private final BinaryPropagationHandler censusTracingPropagationHandler;
+  @VisibleForTesting
+  final Metadata.Key<SpanContext> tracingHeader;
+  private final TracingClientInterceptor clientInterceptor = new TracingClientInterceptor();
+  private final ServerTracerFactory serverTracerFactory = new ServerTracerFactory();
+
+  CensusTracingModule(
+      Tracer censusTracer, final BinaryPropagationHandler censusTracingPropagationHandler) {
+    this.censusTracer = checkNotNull(censusTracer, "censusTracer");
+    this.censusTracingPropagationHandler =
+        checkNotNull(censusTracingPropagationHandler, "censusTracingPropagationHandler");
+    this.tracingHeader =
+        Metadata.Key.of("grpc-trace-bin", new Metadata.BinaryMarshaller<SpanContext>() {
+            @Override
+            public byte[] toBytes(SpanContext context) {
+              return censusTracingPropagationHandler.toBinaryValue(context);
+            }
+
+            @Override
+            public SpanContext parseBytes(byte[] serialized) {
+              try {
+                return censusTracingPropagationHandler.fromBinaryValue(serialized);
+              } catch (Exception e) {
+                logger.log(Level.FINE, "Failed to parse tracing header", e);
+                return SpanContext.INVALID;
+              }
+            }
+          });
+  }
+
+  /**
+   * Creates a {@link ClientCallTracer} for a new call.
+   */
+  @VisibleForTesting
+  ClientCallTracer newClientCallTracer(@Nullable Span parentSpan, String fullMethodName) {
+    return new ClientCallTracer(parentSpan, fullMethodName);
+  }
+
+  /**
+   * Returns the server tracer factory.
+   */
+  ServerStreamTracer.Factory getServerTracerFactory() {
+    return serverTracerFactory;
+  }
+
+  /**
+   * Returns the client interceptor that facilitates Census-based stats reporting.
+   */
+  ClientInterceptor getClientInterceptor() {
+    return clientInterceptor;
+  }
+
+  private static String makeSpanName(String prefix, String fullMethodName) {
+    return prefix + "." + fullMethodName.replace('/', '.');
+  }
+
+  @VisibleForTesting
+  final class ClientCallTracer extends ClientStreamTracer.Factory {
+
+    private final String fullMethodName;
+    private final AtomicBoolean callEnded = new AtomicBoolean(false);
+    private final Span span;
+
+    ClientCallTracer(@Nullable Span parentSpan, String fullMethodName) {
+      this.span =
+          censusTracer.spanBuilder(parentSpan, makeSpanName("Sent", fullMethodName)).startSpan();
+      this.fullMethodName = checkNotNull(fullMethodName, "fullMethodName");
+    }
+
+    @Override
+    public ClientStreamTracer newClientStreamTracer(Metadata headers) {
+      headers.discardAll(tracingHeader);
+      headers.put(tracingHeader, span.getContext());
+      return noopClientTracer;
+    }
+
+    /**
+     * Record a finished call and mark the current time as the end time.
+     *
+     * <p>Can be called from any thread without synchronization.  Calling it the second time or more
+     * is a no-op.
+     */
+    void callEnded(Status status) {
+      if (!callEnded.compareAndSet(false, true)) {
+        return;
+      }
+      span.end();
+    }
+  }
+
+  private final class ServerTracer extends ServerStreamTracer {
+    private final String fullMethodName;
+    private final Span span;
+    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
+
+    ServerTracer(String fullMethodName, @Nullable SpanContext remoteSpan) {
+      this.fullMethodName = checkNotNull(fullMethodName, "fullMethodName");
+      this.span =
+          censusTracer.spanBuilderWithRemoteParent(
+              remoteSpan, makeSpanName("Recv", fullMethodName))
+          .startSpan();
+    }
+
+    /**
+     * Record a finished stream and mark the current time as the end time.
+     *
+     * <p>Can be called from any thread without synchronization.  Calling it the second time or more
+     * is a no-op.
+     */
+    @Override
+    public void streamClosed(Status status) {
+      if (!streamClosed.compareAndSet(false, true)) {
+        return;
+      }
+      span.end();
+    }
+
+    @Override
+    public <ReqT, RespT> Context filterContext(Context context) {
+      return context.withValue(CONTEXT_SPAN_KEY, span);
+    }
+  }
+
+  private final class ServerTracerFactory extends ServerStreamTracer.Factory {
+    @Override
+    public ServerStreamTracer newServerStreamTracer(String fullMethodName, Metadata headers) {
+      SpanContext remoteSpan = headers.get(tracingHeader);
+      return new ServerTracer(fullMethodName, remoteSpan);
+    }
+  }
+
+  private class TracingClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      Span parentSpan = CONTEXT_SPAN_KEY.get();
+      final ClientCallTracer tracerFactory =
+          newClientCallTracer(parentSpan, method.getFullMethodName());
+      ClientCall<ReqT, RespT> call =
+          next.newCall(method, callOptions.withStreamTracerFactory(tracerFactory));
+      return new SimpleForwardingClientCall<ReqT, RespT>(call) {
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+          delegate().start(
+              new SimpleForwardingClientCallListener<RespT>(responseListener) {
+                @Override
+                public void onClose(Status status, Metadata trailers) {
+                  tracerFactory.callEnded(status);
+                  super.onClose(status, trailers);
+                }
+              },
+              headers);
+        }
+      };
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -203,6 +203,20 @@ public final class GrpcUtil {
   public static final long SERVER_KEEPALIVE_TIME_NANOS_DISABLED = Long.MAX_VALUE;
 
   /**
+   * Whether the channel builder and server builder will try to load and use Census stats library.
+   * Delete this and assume always on once Census stats has been fully tested and its wire-format is
+   * stabilized.
+   */
+  public static boolean enableCensusStats;
+
+  /**
+   * Whether the channel builder and server builder will try to load and use Census tracing library.
+   * Delete this and assume always on once Census stats has been fully tested and its wire-format is
+   * stabilized.
+   */
+  public static boolean enableCensusTracing;
+
+  /**
    * Maps HTTP error response status codes to transport codes, as defined in <a
    * href="https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md">
    * http-grpc-status-mapping.md</a>. Never returns a status for which {@code status.isOk()} is

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -557,6 +557,13 @@ public class CensusModulesTest {
     headers.put(censusTracing.tracingHeader, fakeClientSpanContext);
     assertSame(SpanContext.INVALID, headers.get(censusTracing.tracingHeader));
     assertNotSame(fakeServerParentSpanContext, SpanContext.INVALID);
+
+    // A null Span is used as the parent in this case
+    censusTracing.getServerTracerFactory().newServerStreamTracer(
+        method.getFullMethodName(), headers);
+    verify(mockSpanFactory).startSpanWithRemoteParent(
+        isNull(SpanContext.class), eq("Recv.package1.service2.method3"),
+        any(StartSpanOptions.class));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/CensusStreamTracerModuleTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusStreamTracerModuleTest.java
@@ -44,6 +44,8 @@ import static org.mockito.Mockito.when;
 import com.google.instrumentation.stats.RpcConstants;
 import com.google.instrumentation.stats.StatsContext;
 import com.google.instrumentation.stats.TagValue;
+import com.google.instrumentation.trace.SpanFactory;
+import com.google.instrumentation.trace.Tracer;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -81,9 +83,9 @@ public class CensusStreamTracerModuleTest {
 
   private final FakeClock fakeClock = new FakeClock();
   private final FakeStatsContextFactory statsCtxFactory = new FakeStatsContextFactory();
-  private final CensusStreamTracerModule census =
-      new CensusStreamTracerModule(statsCtxFactory, fakeClock.getStopwatchSupplier());
 
+  @Mock
+  private SpanFactory mockSpanFactory;
   @Mock
   private Channel mockChannel;
   @Mock
@@ -95,12 +97,18 @@ public class CensusStreamTracerModuleTest {
   @Captor
   private ArgumentCaptor<ClientCall.Listener<Void>> clientCallListenerCaptor;
 
+  private Tracer tracer;
+  private CensusStreamTracerModule census;
+
   @Before
   @SuppressWarnings("unchecked")
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(mockChannel.newCall(any(MethodDescriptor.class), any(CallOptions.class)))
         .thenReturn(mockClientCall);
+    tracer = new Tracer(mockSpanFactory) {};
+    census =
+        new CensusStreamTracerModule(statsCtxFactory, tracer, fakeClock.getStopwatchSupplier());
   }
 
   @After

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -470,7 +470,7 @@ public abstract class AbstractInteropTest {
       // CensusStreamTracerModule record final status in the interceptor, thus is guaranteed to be
       // recorded.  The tracer stats rely on the stream being created, which is not always the case
       // in this test.  Therefore we don't check the tracer stats.
-      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord();
+      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord(5, TimeUnit.SECONDS);
       checkTags(
           clientRecord, false, "grpc.testing.TestService/StreamingInputCall",
           Status.CANCELLED.getCode());
@@ -776,7 +776,7 @@ public abstract class AbstractInteropTest {
   }
 
   @Test(timeout = 10000)
-  public void deadlineExceeded() {
+  public void deadlineExceeded() throws Exception {
     // warm up the channel and JVM
     blockingStub.emptyCall(Empty.getDefaultInstance());
     TestServiceGrpc.TestServiceBlockingStub stub =
@@ -795,7 +795,7 @@ public abstract class AbstractInteropTest {
       assertMetrics("grpc.testing.TestService/EmptyCall", Status.Code.OK);
       // Stream may not have been created before deadline is exceeded, thus we don't test the tracer
       // stats.
-      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord();
+      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord(5, TimeUnit.SECONDS);
       checkTags(
           clientRecord, false, "grpc.testing.TestService/StreamingOutputCall",
           Status.Code.DEADLINE_EXCEEDED);
@@ -828,7 +828,7 @@ public abstract class AbstractInteropTest {
       assertMetrics("grpc.testing.TestService/EmptyCall", Status.Code.OK);
       // Stream may not have been created when deadline is exceeded, thus we don't check tracer
       // stats.
-      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord();
+      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord(5, TimeUnit.SECONDS);
       checkTags(
           clientRecord, false, "grpc.testing.TestService/StreamingOutputCall",
           Status.Code.DEADLINE_EXCEEDED);
@@ -852,7 +852,7 @@ public abstract class AbstractInteropTest {
     // recorded.  The tracer stats rely on the stream being created, which is not the case if
     // deadline is exceeded before the call is created. Therefore we don't check the tracer stats.
     if (metricsExpected()) {
-      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord();
+      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord(5, TimeUnit.SECONDS);
       checkTags(
           clientRecord, false, "grpc.testing.TestService/EmptyCall",
           Status.DEADLINE_EXCEEDED.getCode());
@@ -871,7 +871,7 @@ public abstract class AbstractInteropTest {
     if (metricsExpected()) {
       assertMetrics("grpc.testing.TestService/EmptyCall", Status.Code.OK);
 
-      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord();
+      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord(5, TimeUnit.SECONDS);
       checkTags(
           clientRecord, false, "grpc.testing.TestService/EmptyCall",
           Status.DEADLINE_EXCEEDED.getCode());
@@ -1195,7 +1195,7 @@ public abstract class AbstractInteropTest {
       // CensusStreamTracerModule record final status in the interceptor, thus is guaranteed to be
       // recorded.  The tracer stats rely on the stream being created, which is not always the case
       // in this test, thus we will not check that.
-      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord();
+      MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord(5, TimeUnit.SECONDS);
       checkTags(
           clientRecord, false, "grpc.testing.TestService/FullDuplexCall",
           Status.DEADLINE_EXCEEDED.getCode());
@@ -1483,7 +1483,7 @@ public abstract class AbstractInteropTest {
       try {
         // On the server, the stats is finalized in ServerStreamListener.closed(), which can be run
         // after the client receives the final status.  So we use a timeout.
-        serverRecord = serverStatsCtxFactory.pollRecord(1, TimeUnit.SECONDS);
+        serverRecord = serverStatsCtxFactory.pollRecord(5, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
@@ -32,6 +32,7 @@
 package io.grpc.testing.integration;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.HandlerSettings;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -46,6 +47,7 @@ public class AutoWindowSizingOnTest extends AbstractInteropTest {
 
   @BeforeClass
   public static void turnOnAutoWindow() {
+    GrpcUtil.enableCensusStats = true;
     HandlerSettings.enable(true);
     HandlerSettings.autoWindowOn(true);
     startStaticServer(

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -32,6 +32,7 @@
 package io.grpc.testing.integration;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -52,6 +53,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
   /** Start server. */
   @BeforeClass
   public static void startServer() {
+    GrpcUtil.enableCensusStats = true;
     startStaticServer(
         NettyServerBuilder
             .forAddress(new LocalAddress("in-process-1"))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -32,6 +32,7 @@
 package io.grpc.testing.integration;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -55,6 +56,7 @@ public class Http2NettyTest extends AbstractInteropTest {
   /** Starts the server with HTTPS. */
   @BeforeClass
   public static void startServer() {
+    GrpcUtil.enableCensusStats = true;
     try {
       startStaticServer(NettyServerBuilder.forPort(0)
           .flowControlWindow(65 * 1024)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -70,6 +70,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
   /** Starts the server with HTTPS. */
   @BeforeClass
   public static void startServer() throws Exception {
+    GrpcUtil.enableCensusStats = true;
     try {
       SslProvider sslProvider = SslContext.defaultServerProvider();
       if (sslProvider == SslProvider.OPENSSL && !OpenSsl.isAlpnSupported()) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -95,6 +95,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
   /** Start server. */
   @BeforeClass
   public static void startServer() {
+    GrpcUtil.enableCensusStats = true;
     compressors.register(FZIPPER);
     compressors.register(Codec.Identity.NONE);
     startStaticServer(

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -136,7 +136,7 @@ public class StatsTestUtils {
     }
 
     @Override
-    public StatsContext deserialize(InputStream buffer) {
+    public StatsContext deserialize(InputStream buffer) throws IOException {
       String serializedString;
       try {
         serializedString = new String(IoUtils.toByteArray(buffer), UTF_8);
@@ -149,7 +149,7 @@ public class StatsTestUtils {
       } else if (serializedString.startsWith(NO_EXTRA_TAG_HEADER_VALUE_PREFIX)) {
         return getDefault();
       } else {
-        return null;
+        throw new IOException("Malformed value");
       }
     }
 


### PR DESCRIPTION
Main implementation is in `CensusTracingModule`.

Also a few fix-ups in the stats implementation `CensusStatsModule`:
- Change header key name from `grpc-census-bin` to `grpc-tags-bin`
- Server does not fail on header parse errors. Uses the default instead.

DO NOT SUBMIT: currently using snapshot version of Census. Must switch to a release version before submitting.