### PR TITLE
core: stop using static flags for Census control.

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -45,7 +45,6 @@ import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -281,7 +280,7 @@ public abstract class AbstractManagedChannelImplBuilder
    * Set it to true to propagate the stats tags on the wire.  This will be deleted assuming always
    * enabled once the instrumentation-java wire format is stabilized.
    */
-  @Internal
+  @Deprecated
   public void setEnableStatsTagPropagation(boolean enabled) {
     this.enableStatsTagPropagation = enabled;
   }
@@ -290,7 +289,7 @@ public abstract class AbstractManagedChannelImplBuilder
    * Set it to true to record traces and propagate tracing information on the wire.  This will be
    * deleted assuming always enabled once the instrumentation-java wire format is stabilized.
    */
-  @Internal
+  @Deprecated
   public void setEnableTracing(boolean enabled) {
     this.enableTracing = enabled;
   }

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -173,20 +173,17 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   public ServerImpl build() {
     ArrayList<ServerStreamTracer.Factory> tracerFactories =
         new ArrayList<ServerStreamTracer.Factory>();
-    if (GrpcUtil.enableCensusStats) {
-      StatsContextFactory statsFactory =
-          this.statsFactory != null ? this.statsFactory : Stats.getStatsContextFactory();
-      if (statsFactory != null) {
-        CensusStatsModule censusStats =
-            new CensusStatsModule(statsFactory, GrpcUtil.STOPWATCH_SUPPLIER);
-        tracerFactories.add(censusStats.getServerTracerFactory());
-      }
+    StatsContextFactory statsFactory =
+        this.statsFactory != null ? this.statsFactory : Stats.getStatsContextFactory();
+    if (statsFactory != null) {
+      CensusStatsModule censusStats =
+          new CensusStatsModule(
+              statsFactory, GrpcUtil.STOPWATCH_SUPPLIER, true /** only matters on client-side **/);
+      tracerFactories.add(censusStats.getServerTracerFactory());
     }
-    if (GrpcUtil.enableCensusTracing) {
-      CensusTracingModule censusTracing =
-          new CensusTracingModule(Tracing.getTracer(), Tracing.getBinaryPropagationHandler());
-      tracerFactories.add(censusTracing.getServerTracerFactory());
-    }
+    CensusTracingModule censusTracing =
+        new CensusTracingModule(Tracing.getTracer(), Tracing.getBinaryPropagationHandler());
+    tracerFactories.add(censusTracing.getServerTracerFactory());
     tracerFactories.addAll(streamTracerFactories);
 
     io.grpc.internal.InternalServer transportServer =

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -203,20 +203,6 @@ public final class GrpcUtil {
   public static final long SERVER_KEEPALIVE_TIME_NANOS_DISABLED = Long.MAX_VALUE;
 
   /**
-   * Whether the channel builder and server builder will try to load and use Census stats library.
-   * Delete this and assume always on once Census stats has been fully tested and its wire-format is
-   * stabilized.
-   */
-  public static boolean enableCensusStats;
-
-  /**
-   * Whether the channel builder and server builder will try to load and use Census tracing library.
-   * Delete this and assume always on once Census stats has been fully tested and its wire-format is
-   * stabilized.
-   */
-  public static boolean enableCensusTracing;
-
-  /**
    * Maps HTTP error response status codes to transport codes, as defined in <a
    * href="https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md">
    * http-grpc-status-mapping.md</a>. Never returns a status for which {@code status.isOk()} is

--- a/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
@@ -32,7 +32,6 @@
 package io.grpc.testing.integration;
 
 import io.grpc.ManagedChannel;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.HandlerSettings;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -47,7 +46,6 @@ public class AutoWindowSizingOnTest extends AbstractInteropTest {
 
   @BeforeClass
   public static void turnOnAutoWindow() {
-    GrpcUtil.enableCensusStats = true;
     HandlerSettings.enable(true);
     HandlerSettings.autoWindowOn(true);
     startStaticServer(

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -32,7 +32,6 @@
 package io.grpc.testing.integration;
 
 import io.grpc.ManagedChannel;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -53,7 +52,6 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
   /** Start server. */
   @BeforeClass
   public static void startServer() {
-    GrpcUtil.enableCensusStats = true;
     startStaticServer(
         NettyServerBuilder
             .forAddress(new LocalAddress("in-process-1"))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -32,7 +32,6 @@
 package io.grpc.testing.integration;
 
 import io.grpc.ManagedChannel;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
@@ -56,7 +55,6 @@ public class Http2NettyTest extends AbstractInteropTest {
   /** Starts the server with HTTPS. */
   @BeforeClass
   public static void startServer() {
-    GrpcUtil.enableCensusStats = true;
     try {
       startStaticServer(NettyServerBuilder.forPort(0)
           .flowControlWindow(65 * 1024)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -70,7 +70,6 @@ public class Http2OkHttpTest extends AbstractInteropTest {
   /** Starts the server with HTTPS. */
   @BeforeClass
   public static void startServer() throws Exception {
-    GrpcUtil.enableCensusStats = true;
     try {
       SslProvider sslProvider = SslContext.defaultServerProvider();
       if (sslProvider == SslProvider.OPENSSL && !OpenSsl.isAlpnSupported()) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -95,7 +95,6 @@ public class TransportCompressionTest extends AbstractInteropTest {
   /** Start server. */
   @BeforeClass
   public static void startServer() {
-    GrpcUtil.enableCensusStats = true;
     compressors.register(FZIPPER);
     compressors.register(Codec.Identity.NONE);
     startStaticServer(


### PR DESCRIPTION
Static mutable flags are evil.  Turned them to options on channel
builder.  Also restore the local stats recording by default, because
these flags were added with the concern of wire-compatibility, but not
local feature.