### PR TITLE
core: set server stream decompressor in transport thread

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -44,7 +44,6 @@ import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
-import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.InternalDecompressorRegistry;
 import io.grpc.Metadata;
@@ -79,17 +78,6 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
     this.messageAcceptEncoding = inboundHeaders.get(MESSAGE_ACCEPT_ENCODING_KEY);
     this.decompressorRegistry = decompressorRegistry;
     this.compressorRegistry = compressorRegistry;
-
-    if (inboundHeaders.containsKey(MESSAGE_ENCODING_KEY)) {
-      String encoding = inboundHeaders.get(MESSAGE_ENCODING_KEY);
-      Decompressor decompressor = decompressorRegistry.lookupDecompressor(encoding);
-      if (decompressor == null) {
-        throw Status.UNIMPLEMENTED
-            .withDescription(String.format("Can't find decompressor for %s", encoding))
-            .asRuntimeException();
-      }
-      stream.setDecompressor(decompressor);
-    }
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -35,6 +35,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.grpc.Contexts.statusFromCancelled;
 import static io.grpc.Status.DEADLINE_EXCEEDED;
+import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -43,6 +44,7 @@ import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
+import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.HandlerRegistry;
 import io.grpc.Metadata;
@@ -377,6 +379,18 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
     @Override
     public void streamCreated(
         final ServerStream stream, final String methodName, final Metadata headers) {
+      if (headers.containsKey(MESSAGE_ENCODING_KEY)) {
+        String encoding = headers.get(MESSAGE_ENCODING_KEY);
+        Decompressor decompressor = decompressorRegistry.lookupDecompressor(encoding);
+        if (decompressor == null) {
+          stream.close(
+              Status.UNIMPLEMENTED.withDescription(
+                  String.format("Can't find decompressor for %s", encoding)),
+              new Metadata());
+          return;
+        }
+        stream.setDecompressor(decompressor);
+      }
 
       final StatsTraceContext statsTraceCtx = Preconditions.checkNotNull(
           stream.statsTraceContext(), "statsTraceCtx not present from stream");

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -375,6 +376,28 @@ public class ServerImplTest {
     verify(streamTracerFactory).newServerStreamTracer(eq("Waiter/nonexist"), same(requestHeaders));
     verify(streamTracer, never()).serverCallStarted(any(ServerCall.class));
     assertEquals(Status.Code.UNIMPLEMENTED, statusCaptor.getValue().getCode());
+  }
+
+  @Test
+  public void decompressorNotFound() throws Exception {
+    String decompressorName = "NON_EXISTENT_DECOMPRESSOR";
+    createAndStartServer(NO_FILTERS);
+    ServerTransportListener transportListener
+        = transportServer.registerNewServerTransport(new SimpleServerTransport());
+    Metadata requestHeaders = new Metadata();
+    requestHeaders.put(MESSAGE_ENCODING_KEY, decompressorName);
+    StatsTraceContext statsTraceCtx =
+        StatsTraceContext.newServerContext(
+            streamTracerFactories, "Waiter/nonexist", requestHeaders);
+    when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
+
+    transportListener.streamCreated(stream, "Waiter/nonexist", requestHeaders);
+
+    verify(stream).close(statusCaptor.capture(), any(Metadata.class));
+    Status status = statusCaptor.getValue();
+    assertEquals(Status.Code.UNIMPLEMENTED, status.getCode());
+    assertEquals("Can't find decompressor for " + decompressorName, status.getDescription());
+    verifyNoMoreInteractions(stream);
   }
 
   @Test


### PR DESCRIPTION
Currently, inbound headers are processed in the transport thread, but the resulting new stream's decompressor is not set until the `ServerCallImpl` constructor is invoked from a `wrappedExecutor` thread. The `ServerCallImpl` constructor will parse the headers and, if necessary, call `MessageDeframer#setDecompressor` to set the decompressor. This is not thread-safe, as incoming data frames may simultaneously be consumed by the deframer in the transport thread.

This PR moves the call to `setDecompressor` into the transport thread. This is a similar issue to https://github.com/grpc/grpc-java/issues/2865 on the client side. My in-progress move of client deframing to the client thread made the compression test (https://github.com/grpc/grpc-java/issues/2157) extra flaky, but due to this race condition on the server side.

If https://github.com/grpc/grpc-java/issues/2865 is the only cause for https://github.com/grpc/grpc-java/issues/2157, then moving client deframing to the app thread should also clear up the flaky compression test.