### PR TITLE
Server side cancellations should promptly inform server

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -232,7 +232,8 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
               ServerStreamListenerImpl.this.call.cancelled = true;
             }
           },
-          MoreExecutors.directExecutor());
+          MoreExecutors.directExecutor()
+      );
     }
 
     @SuppressWarnings("Finally") // The code avoids suppressing the exception thrown from try

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -232,8 +232,7 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
               ServerStreamListenerImpl.this.call.cancelled = true;
             }
           },
-          MoreExecutors.directExecutor()
-      );
+          MoreExecutors.directExecutor());
     }
 
     @SuppressWarnings("Finally") // The code avoids suppressing the exception thrown from try

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -594,7 +594,10 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
       callExecutor.execute(new ContextRunnable(context) {
         @Override
         public void runInContext() {
-            getListener().closed(status);
+          if (status.isOk()) {
+            context.cancel(status.getCause());
+          }
+          getListener().closed(status);
         }
       });
     }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -584,7 +584,8 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
 
     @Override
     public void closed(final Status status) {
-      // Immediately inform any users of the context that their work should be aborted.
+      // For cancellations, promptly inform any users of the context that their work should be
+      // aborted. Otherwise, we can wait until pending work is done.
       if (!status.isOk()) {
         context.cancel(status.getCause());
       }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -123,17 +123,6 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
       InternalServer transportServer, Context rootContext,
       DecompressorRegistry decompressorRegistry, CompressorRegistry compressorRegistry,
       List<ServerTransportFilter> transportFilters) {
-    this(executorPool, timeoutServicePool, registry, fallbackRegistry, transportServer,
-        rootContext, decompressorRegistry, compressorRegistry, transportFilters, null);
-  }
-
-  @VisibleForTesting
-  ServerImpl(ObjectPool<? extends Executor> executorPool,
-      ObjectPool<ScheduledExecutorService> timeoutServicePool,
-      InternalHandlerRegistry registry, HandlerRegistry fallbackRegistry,
-      InternalServer transportServer, Context rootContext,
-      DecompressorRegistry decompressorRegistry, CompressorRegistry compressorRegistry,
-      List<ServerTransportFilter> transportFilters, Executor cancelExecutor) {
     this.executorPool = Preconditions.checkNotNull(executorPool, "executorPool");
     this.timeoutServicePool = Preconditions.checkNotNull(timeoutServicePool, "timeoutServicePool");
     this.registry = Preconditions.checkNotNull(registry, "registry");

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -627,6 +627,7 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
     }
   }
 
+  @VisibleForTesting
   static class ContextCloser implements Runnable {
     private final Context.CancellableContext context;
     private final Throwable cause;

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -828,8 +828,10 @@ public class ServerImplTest {
 
     // isCancelled is expected to be true immediately after calling closed(), without needing
     // to wait for the executor to run any tasks.
+    assertFalse(callReference.get().isCancelled());
     assertFalse(context.get().isCancelled());
     streamListener.closed(Status.CANCELLED);
+    assertTrue(callReference.get().isCancelled());
     assertTrue(context.get().isCancelled());
 
     assertEquals(1, executor.runDueTasks());

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -773,7 +773,7 @@ public class ServerImplTest {
     verify(stream, times(0)).close(isA(Status.class), isNotNull(Metadata.class));
   }
 
-  public ServerStreamListener testClientClose_setup(
+  private ServerStreamListener testClientClose_setup(
       final AtomicReference<ServerCall<String, Integer>> callReference,
       final AtomicReference<Context> context,
       final AtomicBoolean contextCancelled
@@ -851,7 +851,7 @@ public class ServerImplTest {
   }
 
   @Test
-  public void testClientClose_OKTriggersDelayedCancellation() throws Exception {
+  public void testClientClose_OkTriggersDelayedCancellation() throws Exception {
     final AtomicBoolean contextCancelled = new AtomicBoolean(false);
     final AtomicReference<Context> context = new AtomicReference<Context>();
     final AtomicReference<ServerCall<String, Integer>> callReference

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1107,8 +1107,7 @@ public class ServerImplTest {
   private void createServer(List<ServerTransportFilter> filters) {
     assertNull(server);
     server = new ServerImpl(executorPool, timerPool, registry, fallbackRegistry,
-        transportServer, SERVER_CONTEXT, decompressorRegistry, compressorRegistry, filters,
-        executor.getScheduledExecutorService());
+        transportServer, SERVER_CONTEXT, decompressorRegistry, compressorRegistry, filters);
   }
 
   private void verifyExecutorsAcquired() {

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -836,9 +836,9 @@ public class ServerImplTest {
 
   @Test
   public void testClientClose_cancelTriggersImmediateCancellation() throws Exception {
-    final AtomicBoolean contextCancelled = new AtomicBoolean(false);
-    final AtomicReference<Context> context = new AtomicReference<Context>();
-    final AtomicReference<ServerCall<String, Integer>> callReference
+    AtomicBoolean contextCancelled = new AtomicBoolean(false);
+    AtomicReference<Context> context = new AtomicReference<Context>();
+    AtomicReference<ServerCall<String, Integer>> callReference
         = new AtomicReference<ServerCall<String, Integer>>();
 
     ServerStreamListener streamListener = testClientClose_setup(callReference,
@@ -860,9 +860,9 @@ public class ServerImplTest {
 
   @Test
   public void testClientClose_OkTriggersDelayedCancellation() throws Exception {
-    final AtomicBoolean contextCancelled = new AtomicBoolean(false);
-    final AtomicReference<Context> context = new AtomicReference<Context>();
-    final AtomicReference<ServerCall<String, Integer>> callReference
+    AtomicBoolean contextCancelled = new AtomicBoolean(false);
+    AtomicReference<Context> context = new AtomicReference<Context>();
+    AtomicReference<ServerCall<String, Integer>> callReference
         = new AtomicReference<ServerCall<String, Integer>>();
 
     ServerStreamListener streamListener = testClientClose_setup(callReference,


### PR DESCRIPTION
When we cancel a stream, we must 1) set both ServerCall.isCancelled() and CancellableContext.isCancelled() to be true, as well 2) notify any listeners that the stream is now cancelled. Today, this happens in JumpToApplicationThreadServerStreamListener therefore both 1 and 2 happen in a serialized executor and may become queued. This diff moves 1 to be executed immediately on the cancelling thread's context (we are still required to run 2 in the executor for correctness reasons). The result is that anyone polling for isCancelled() in either of the two places will immediately see the update rather than waiting.

Fixes #2112 
