### PR TITLE
build,protobuf: update google_api_protos dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ subprojects {
                 hpack: 'com.twitter:hpack:0.10.1',
                 jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
                 oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.4.0',
-                google_api_protos: 'com.google.api.grpc:grpc-google-common-protos:0.1.6',
+                google_api_protos: 'com.google.api.grpc:proto-google-common-protos:0.1.9',
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.4.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
                 okio: 'com.squareup.okio:okio:1.6.0',

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -16,7 +16,6 @@ dependencies {
             libraries.protobuf_util
 
     compile (libraries.google_api_protos) {
-        exclude group: 'io.grpc'
         // 'com.google.api' transitively depends on 'com.google.auto.value:auto-value:1.1', which
         // breaks our annotations.
         exclude group: 'com.google.api'

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -16,9 +16,9 @@ dependencies {
             libraries.protobuf_util
 
     compile (libraries.google_api_protos) {
-        // 'com.google.api' transitively depends on 'com.google.auto.value:auto-value:1.1', which
-        // breaks our annotations.
-        exclude group: 'com.google.api'
+        // 'com.google.api:api-common' transitively depends on auto-value, which breaks our
+        // annotations.
+        exclude group: 'com.google.api', module: 'api-common'
     }
 
     compile (project(':grpc-protobuf-lite')) {


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-java/issues/2961.

Thanks to @zhangkun83 who identified a similar issue with instrumentation-java, I've sent https://github.com/googleapis/api-common-java/pull/27 to make their dependency on auto-value compileOnly, which will enable remove the remaining `exclude group` from the dependency on `libraries.google_api_protos`. AFAIK the presence of this rule doesn't impact https://github.com/grpc/grpc-java/issues/2961.