### PR TITLE
compiler: remove streaming calls from javadoc for newFutureStub

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -68,7 +68,7 @@ public final class BenchmarkServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static BenchmarkServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -92,7 +92,7 @@ public final class WorkerServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static WorkerServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -1078,8 +1078,8 @@ static void PrintService(const ServiceDescriptor* service,
   p->Print("}\n\n");
 
   // TODO(nmittler): Replace with WriteDocComment once included by protobuf distro.
-  GrpcWriteDocComment(p, " Creates a new ListenableFuture-style stub that supports unary and "
-                         "streaming output calls on the service");
+  GrpcWriteDocComment(p, " Creates a new ListenableFuture-style stub that supports unary calls "
+                         "on the service");
   p->Print(
       *vars,
       "public static $service_name$FutureStub newFutureStub(\n"

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -107,7 +107,7 @@ public final class TestServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static TestServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -107,7 +107,7 @@ public final class TestServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static TestServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -170,7 +170,7 @@ public final class TestServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static TestServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -56,7 +56,7 @@ public final class LoadBalancerGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static LoadBalancerFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -56,7 +56,7 @@ public final class HealthGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static HealthFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
@@ -104,7 +104,7 @@ public final class MonitoringGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static MonitoringFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -56,7 +56,7 @@ public final class ServerReflectionGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static ServerReflectionFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -59,7 +59,7 @@ public final class AnotherDynamicServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static AnotherDynamicServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -59,7 +59,7 @@ public final class DynamicServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static DynamicServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -56,7 +56,7 @@ public final class ReflectableServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static ReflectableServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -68,7 +68,7 @@ public final class MetricsServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static MetricsServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -71,7 +71,7 @@ public final class ReconnectServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static ReconnectServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -144,7 +144,7 @@ public final class TestServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static TestServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -60,7 +60,7 @@ public final class UnimplementedServiceGrpc {
   }
 
   /**
-   * Creates a new ListenableFuture-style stub that supports unary and streaming output calls on the service
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
    */
   public static UnimplementedServiceFutureStub newFutureStub(
       io.grpc.Channel channel) {


### PR DESCRIPTION
FutureStubs only support unary calls