### PR TITLE
javadoc: fix broken links in javadoc

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -42,6 +42,7 @@ import com.google.instrumentation.stats.StatsContextFactory;
 import com.google.instrumentation.trace.Tracing;
 import io.grpc.Attributes;
 import io.grpc.ClientInterceptor;
+import io.grpc.ClientStreamTracer;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;

--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -57,7 +57,7 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
         /**
          * RFC 7231 says status codes are 3 digits long.
          *
-         * @see: <a href="https://tools.ietf.org/html/rfc7231#section-6">RFC 7231</a>
+         * @see <a href="https://tools.ietf.org/html/rfc7231#section-6">RFC 7231</a>
          */
         @Override
         public Integer parseAsciiString(byte[] serialized) {

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -60,8 +60,6 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Transports for a single {@link SocketAddress}.
- *
- * <p>This is the next version of {@link TransportSet} in development.
  */
 @ThreadSafe
 final class InternalSubchannel implements WithLogId {

--- a/core/src/main/java/io/grpc/internal/MoreThrowables.java
+++ b/core/src/main/java/io/grpc/internal/MoreThrowables.java
@@ -33,7 +33,7 @@ package io.grpc.internal;
 
 import com.google.common.base.Preconditions;
 
-/** Utility functions when interacting with {@link Throwables}. */
+/** Utility functions when interacting with {@link Throwable}s. */
 // TODO(ejona): Delete this once we've upgraded to Guava 20 or later.
 final class MoreThrowables {
   /**

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -112,10 +112,10 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
   /**
    * Construct a server.
    *
+   * @param executorPool provides an executor to call methods on behalf of remote clients
    * @param registry the primary method registry
    * @param fallbackRegistry the secondary method registry, used only if the primary registry
    *        doesn't have the method
-   * @param executor to call methods on behalf of remote clients
    */
   ServerImpl(ObjectPool<? extends Executor> executorPool,
       ObjectPool<ScheduledExecutorService> timeoutServicePool,

--- a/core/src/main/java/io/grpc/internal/WithLogId.java
+++ b/core/src/main/java/io/grpc/internal/WithLogId.java
@@ -37,8 +37,7 @@ package io.grpc.internal;
 public interface WithLogId {
   /**
    * Returns an ID that is primarily used in debug logs. It usually contains the class name and a
-   * numeric ID that is unique among the instances. {@link GrpcUtil#getLogId} is a canonical
-   * implementation.
+   * numeric ID that is unique among the instances.
    *
    * <p>The subclasses of this interface usually want to include the log ID in their {@link
    * #toString} results.

--- a/netty/src/main/java/io/grpc/netty/StreamIdHolder.java
+++ b/netty/src/main/java/io/grpc/netty/StreamIdHolder.java
@@ -34,7 +34,7 @@ package io.grpc.netty;
 /** Container for stream ids. */
 interface StreamIdHolder {
   /**
-   * Returns the id or {@link io.grpc.internal.AbstractStream#ABSENT_ID}.
+   * Returns the id.
    */
   int id();
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -175,7 +175,7 @@ class OkHttpClientStream extends AbstractClientStream2 {
     @GuardedBy("lock")
     private List<Header> requestHeaders;
     /**
-     * Null iff {@link #requestHeaders} is null.  Non-null iff neither {@link #sendCancel} nor
+     * Null iff {@link #requestHeaders} is null.  Non-null iff neither {@link #cancel} nor
      * {@link #start(int)} have been called.
      */
     @GuardedBy("lock")


### PR DESCRIPTION
Did a code analysis on javadoc. There are some broken links in javadoc, although none of them are in public and non-internal API. 