### PR TITLE
core: record individual messages to Census tracing

### DIFF
--- a/core/src/main/java/io/grpc/StreamTracer.java
+++ b/core/src/main/java/io/grpc/StreamTracer.java
@@ -62,32 +62,45 @@ public abstract class StreamTracer {
   }
 
   /**
+   * An outbound message has been completely serialized, revealing its wire size.
+   */
+  public void outboundMessageSerialized(long wireSize) {
+  }
+
+  /**
+   * An inbound message has been completely read from the wire, revealing its wire size.
+   */
+  public void inboundMessageReceived(long wireSize) {
+  }
+
+  /**
    * The wire size of some outbound data is revealed. This can only used to record the accumulative
-   * outbound wire size. There is no guarantee wrt timing or granularity of this method.
+   * outbound wire size.  gRPC makes the best effort to call it as soon the information is
+   * available, although there is not guarantee wrt timing or granularity.
    */
   public void outboundWireSize(long bytes) {
   }
 
   /**
    * The uncompressed size of some outbound data is revealed. This can only used to record the
-   * accumulative outbound uncompressed size. There is no guarantee wrt timing or granularity of
-   * this method.
+   * accumulative outbound uncompressed size. gRPC makes the best effort to call it as soon as the
+   * information is available, although there is not guarantee wrt timing or granularity.
    */
   public void outboundUncompressedSize(long bytes) {
   }
 
   /**
    * The wire size of some inbound data is revealed. This can only be used to record the
-   * accumulative received wire size. There is no guarantee wrt timing or granularity of this
-   * method.
+   * accumulative received wire size. gRPC makes the best effort to call it as soon as the
+   * information is available, although there is not guarantee wrt timing or granularity.
    */
   public void inboundWireSize(long bytes) {
   }
 
   /**
    * The uncompressed size of some inbound data is revealed. This can only used to record the
-   * accumulative received uncompressed size. There is no guarantee wrt timing or granularity of
-   * this method.
+   * accumulative received uncompressed size. gRPC makes the best effort to call it as soon as the
+   * information is available, although there is not guarantee wrt timing or granularity.
    */
   public void inboundUncompressedSize(long bytes) {
   }

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -362,6 +362,7 @@ public class MessageDeframer implements Closeable {
     InputStream stream = compressedFlag ? getCompressedBody() : getUncompressedBody();
     nextFrame = null;
     listener.messageRead(stream);
+    statsTraceCtx.inboundMessageReceived(requiredLength);
 
     // Done with this frame, begin processing the next header.
     state = State.HEADER;

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -229,4 +229,26 @@ public final class StatsTraceContext {
       tracer.inboundWireSize(bytes);
     }
   }
+
+  /**
+   * See {@link StreamTracer#outboundMessageSerialized}
+   *
+   * <p>Called from {@link io.grpc.internal.MessageFramer}.
+   */
+  public void outboundMessageSerialized(long wireSize) {
+    for (StreamTracer tracer : tracers) {
+      tracer.outboundMessageSerialized(wireSize);
+    }
+  }
+
+  /**
+   * See {@link StreamTracer#inboundMessage}.
+   *
+   * <p>Called from {@link io.grpc.internal.MessageDeframer}.
+   */
+  public void inboundMessageReceived(long wireSize) {
+    for (StreamTracer tracer : tracers) {
+      tracer.inboundMessageReceived(wireSize);
+    }
+  }
 }

--- a/core/src/test/java/io/grpc/internal/MessageFramerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageFramerTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -54,6 +55,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -97,7 +99,7 @@ public class MessageFramerTest {
     verify(sink).deliverFrame(toWriteBuffer(new byte[] {0, 0, 0, 0, 2, 3, 14}), false, true);
     assertEquals(1, allocator.allocCount);
     verifyNoMoreInteractions(sink);
-    checkStats(1, 2, 2);
+    checkStats(new Message(2, 2));
   }
 
   @Test
@@ -109,7 +111,7 @@ public class MessageFramerTest {
     verify(sink).deliverFrame(toWriteBuffer(new byte[] {3, 14}), false, true);
     assertEquals(2, allocator.allocCount);
     verifyNoMoreInteractions(sink);
-    checkStats(1, 2, 2);
+    checkStats(new Message(2, 2));
   }
 
   @Test
@@ -123,7 +125,7 @@ public class MessageFramerTest {
         toWriteBuffer(new byte[] {0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 1, 14}), false, true);
     verifyNoMoreInteractions(sink);
     assertEquals(1, allocator.allocCount);
-    checkStats(2, 2, 2);
+    checkStats(new Message(1, 1), new Message(1, 1));
   }
 
   @Test
@@ -135,7 +137,7 @@ public class MessageFramerTest {
         toWriteBuffer(new byte[] {0, 0, 0, 0, 7, 3, 14, 1, 5, 9, 2, 6}), true, true);
     verifyNoMoreInteractions(sink);
     assertEquals(1, allocator.allocCount);
-    checkStats(1, 7, 7);
+    checkStats(new Message(7, 7));
   }
 
   @Test
@@ -144,7 +146,7 @@ public class MessageFramerTest {
     verify(sink).deliverFrame(null, true, true);
     verifyNoMoreInteractions(sink);
     assertEquals(0, allocator.allocCount);
-    checkStats(0, 0, 0);
+    checkStats();
   }
 
   @Test
@@ -160,7 +162,7 @@ public class MessageFramerTest {
     verify(sink).deliverFrame(toWriteBuffer(new byte[] {5}), false, true);
     verifyNoMoreInteractions(sink);
     assertEquals(2, allocator.allocCount);
-    checkStats(1, 8, 8);
+    checkStats(new Message(8, 8));
   }
 
   @Test
@@ -177,7 +179,7 @@ public class MessageFramerTest {
     verify(sink).deliverFrame(toWriteBufferWithMinSize(new byte[] {1, 3}, 12), false, true);
     verifyNoMoreInteractions(sink);
     assertEquals(2, allocator.allocCount);
-    checkStats(2, 4, 4);
+    checkStats(new Message(3, 3), new Message(1, 1));
   }
 
   @Test
@@ -186,7 +188,7 @@ public class MessageFramerTest {
     framer.flush();
     verify(sink).deliverFrame(toWriteBuffer(new byte[] {0, 0, 0, 0, 0}), false, true);
     assertEquals(1, allocator.allocCount);
-    checkStats(1, 0, 0);
+    checkStats(new Message(0, 0));
   }
 
   @Test
@@ -197,7 +199,7 @@ public class MessageFramerTest {
     verify(sink).deliverFrame(toWriteBuffer(new byte[] {0, 0, 0, 0, 0}), false, true);
     // One alloc for the header
     assertEquals(1, allocator.allocCount);
-    checkStats(1, 0, 0);
+    checkStats(new Message(0, 0));
   }
 
   @Test
@@ -208,7 +210,7 @@ public class MessageFramerTest {
     verify(sink).deliverFrame(toWriteBuffer(new byte[] {0, 0, 0, 0, 2, 3, 14}), false, true);
     verifyNoMoreInteractions(sink);
     assertEquals(1, allocator.allocCount);
-    checkStats(1, 2, 2);
+    checkStats(new Message(2, 2));
   }
 
   @Test
@@ -228,7 +230,7 @@ public class MessageFramerTest {
     assertEquals(toWriteBuffer(data), buffer);
     verifyNoMoreInteractions(sink);
     assertEquals(1, allocator.allocCount);
-    checkStats(1, 1000, 1000);
+    checkStats(new Message(1000, 1000));
   }
 
   @Test
@@ -255,7 +257,7 @@ public class MessageFramerTest {
 
     verifyNoMoreInteractions(sink);
     assertEquals(3, allocator.allocCount);
-    checkStats(1, 1000, 1000);
+    checkStats(new Message(1000, 1000));
   }
 
   @Test
@@ -280,7 +282,7 @@ public class MessageFramerTest {
     assertTrue(length < 1000);
 
     assertEquals(frameCaptor.getAllValues().get(1).size(), length);
-    checkStats(1, length, 1000);
+    checkStats(new Message(length, 1000));
   }
 
   @Test
@@ -305,7 +307,7 @@ public class MessageFramerTest {
     assertEquals(1000, length);
 
     assertEquals(buffer.data.length - 5 , length);
-    checkStats(1, 1000, 1000);
+    checkStats(new Message(1000, 1000));
   }
 
   @Test
@@ -331,7 +333,7 @@ public class MessageFramerTest {
     assertEquals(1000, length);
 
     assertEquals(buffer.data.length - 5 , length);
-    checkStats(1, 1000, 1000);
+    checkStats(new Message(1000, 1000));
   }
 
   @Test
@@ -360,7 +362,7 @@ public class MessageFramerTest {
     writeKnownLength(framer, new byte[]{});
     framer.flush();
     verify(sink).deliverFrame(toWriteBuffer(new byte[] {0, 0, 0, 0, 0}), false, true);
-    checkStats(1, 0, 0);
+    checkStats(new Message(0, 0));
   }
 
   private static WritableBuffer toWriteBuffer(byte[] data) {
@@ -382,11 +384,12 @@ public class MessageFramerTest {
     // TODO(carl-mastrangelo): add framer.flush() here.
   }
 
-  private void checkStats(int messagesSent, long wireBytesSent, long uncompressedBytesSent) {
+  private void checkStats(Message ... messages) {
     long actualWireSize = 0;
     long actualUncompressedSize = 0;
 
-    verify(tracer, times(messagesSent)).outboundMessage();
+    verify(tracer, times(messages.length)).outboundMessage();
+
     verify(tracer, atLeast(0)).outboundWireSize(wireSizeCaptor.capture());
     for (Long portion : wireSizeCaptor.getAllValues()) {
       actualWireSize += portion;
@@ -397,9 +400,28 @@ public class MessageFramerTest {
       actualUncompressedSize += portion;
     }
 
+    long expectedWireSize = 0;
+    long expectedUncompressedSize = 0;
+    InOrder inOrder = inOrder(tracer);
+    for (Message message : messages) {
+      inOrder.verify(tracer).outboundMessageSerialized(message.wireSize);
+      expectedWireSize += message.wireSize;
+      expectedUncompressedSize += message.uncompressedSize;
+    }
+    assertEquals(expectedWireSize, actualWireSize);
+    assertEquals(expectedUncompressedSize, actualUncompressedSize);
+
     verifyNoMoreInteractions(tracer);
-    assertEquals(wireBytesSent, actualWireSize);
-    assertEquals(uncompressedBytesSent, actualUncompressedSize);
+  }
+
+  private static class Message {
+    final long wireSize;
+    final long uncompressedSize;
+
+    Message(long wireSize, long uncompressedSize) {
+      this.wireSize = wireSize;
+      this.uncompressedSize = uncompressedSize;
+    }
   }
 
   static class ByteWritableBuffer implements WritableBuffer {

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -692,6 +692,7 @@ public abstract class AbstractTransportTest {
     verify(mockServerStreamListener, timeout(TIMEOUT_MS)).messageRead(inputStreamCaptor.capture());
     if (metricsExpected()) {
       clientInOrder.verify(clientStreamTracer).outboundWireSize(anyLong());
+      clientInOrder.verify(clientStreamTracer).outboundMessageSerialized(anyLong());
       clientInOrder.verify(clientStreamTracer).outboundUncompressedSize(anyLong());
       serverInOrder.verify(serverStreamTracer).inboundMessage();
     }
@@ -703,7 +704,8 @@ public abstract class AbstractTransportTest {
 
     if (metricsExpected()) {
       serverInOrder.verify(serverStreamTracer).inboundWireSize(anyLong());
-      serverInOrder.verify(serverStreamTracer, atLeast(1)).inboundUncompressedSize(anyLong());
+      serverInOrder.verify(serverStreamTracer).inboundMessageReceived(anyLong());
+      verify(serverStreamTracer, atLeast(1)).inboundUncompressedSize(anyLong());
     }
 
     Metadata serverHeaders = new Metadata();
@@ -732,6 +734,7 @@ public abstract class AbstractTransportTest {
     verify(mockClientStreamListener, timeout(TIMEOUT_MS)).messageRead(inputStreamCaptor.capture());
     if (metricsExpected()) {
       serverInOrder.verify(serverStreamTracer).outboundWireSize(anyLong());
+      serverInOrder.verify(serverStreamTracer).outboundMessageSerialized(anyLong());
       serverInOrder.verify(serverStreamTracer, atLeast(1)).outboundUncompressedSize(anyLong());
       clientInOrder.verify(clientStreamTracer).inboundHeaders();
       clientInOrder.verify(clientStreamTracer).inboundMessage();
@@ -739,7 +742,8 @@ public abstract class AbstractTransportTest {
     assertEquals("Hi. Who are you?", methodDescriptor.parseResponse(inputStreamCaptor.getValue()));
     if (metricsExpected()) {
       clientInOrder.verify(clientStreamTracer).inboundWireSize(anyLong());
-      clientInOrder.verify(clientStreamTracer, atLeast(1)).inboundUncompressedSize(anyLong());
+      clientInOrder.verify(clientStreamTracer).inboundMessageReceived(anyLong());
+      verify(clientStreamTracer, atLeast(1)).inboundUncompressedSize(anyLong());
     }
     inputStreamCaptor.getValue().close();
 
@@ -1041,10 +1045,12 @@ public abstract class AbstractTransportTest {
       verify(clientStreamTracer).inboundHeaders();
       verify(clientStreamTracer).inboundMessage();
       verify(clientStreamTracer).inboundWireSize(anyLong());
+      verify(clientStreamTracer).inboundMessageReceived(anyLong());
       verify(clientStreamTracer, atLeast(1)).inboundUncompressedSize(anyLong());
       verify(clientStreamTracer).streamClosed(same(status));
       verify(serverStreamTracer).outboundMessage();
       verify(serverStreamTracer).outboundWireSize(anyLong());
+      verify(serverStreamTracer).outboundMessageSerialized(anyLong());
       verify(serverStreamTracer, atLeast(1)).outboundUncompressedSize(anyLong());
       // There is a race between client cancelling and server closing.  The final status seen by the
       // server is non-deterministic.


### PR DESCRIPTION
- Outbound messages are recorded when they are fully serialized.
- Inbound messages are recorded when they are fully read from wire.
- Wire (compressed) sizes are recorded.
- Uses per-stream per-direction incremental serial number as the message ID.