### PR TITLE
netty: fix server keepalive not initialized bug

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -334,6 +334,7 @@ class NettyServerHandler extends AbstractNettyHandler {
     if (keepAliveTimeInNanos != SERVER_KEEPALIVE_TIME_NANOS_DISABLED) {
       keepAliveManager = new KeepAliveManager(new KeepAlivePinger(ctx), ctx.executor(),
           keepAliveTimeInNanos, keepAliveTimeoutInNanos, true /* keepAliveDuringTransportIdle */);
+      keepAliveManager.onTransportStarted();
     }
     super.handlerAdded(ctx);
   }
@@ -441,9 +442,6 @@ class NettyServerHandler extends AbstractNettyHandler {
   @Override
   public void handleProtocolNegotiationCompleted(Attributes attrs) {
     attributes = transportListener.transportReady(attrs);
-    if (keepAliveManager != null) {
-      keepAliveManager.onTransportStarted();
-    }
   }
 
   @VisibleForTesting
@@ -706,7 +704,7 @@ class NettyServerHandler extends AbstractNettyHandler {
           logger.log(Level.FINE, String.format("Window: %d",
               decoder().flowController().initialWindowSize(connection().connectionStream())));
         }
-      } else {
+      } else if (data.getLong(data.readerIndex()) != KEEPALIVE_PING_BUF.getLong(0)) {
         logger.warning("Received unexpected ping ack. No ping outstanding");
       }
     }

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -704,7 +704,7 @@ class NettyServerHandler extends AbstractNettyHandler {
           logger.log(Level.FINE, String.format("Window: %d",
               decoder().flowController().initialWindowSize(connection().connectionStream())));
         }
-      } else if (data.getLong(data.readerIndex()) != KEEPALIVE_PING_BUF.getLong(0)) {
+      } else if (!KEEPALIVE_PING_BUF.equals(data)) {
         logger.warning("Received unexpected ping ack. No ping outstanding");
       }
     }

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -399,14 +399,6 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   }
 
   @Test
-  public void keepAliveManagerStarted() throws Exception {
-    manualSetUp();
-    verify(spyKeepAliveManager).onTransportStarted();
-    verify(spyKeepAliveManager, never()).onDataReceived();
-    verify(spyKeepAliveManager, never()).onTransportTermination();
-  }
-
-  @Test
   public void keepAliveManagerOnDataReceived_headersRead() throws Exception {
     manualSetUp();
     ByteBuf headersFrame = headersFrame(STREAM_ID, new DefaultHttp2Headers());


### PR DESCRIPTION
fixes #2982 

The problem is `grpcHandler.handleProtocolNegotiationCompleted` can happen before `ctx.pipeline().replace(this, null, grpcHandler)` in which `handlerAdded()` is called

Moved `keepAliveManager.onTransportStarted()` inside `handlerAdded()` to fix it.

Tested with manual interoptest and it's working now.

Removed the test case `keepAliveManagerStarted() ` that is not functioning. The test case `keepAliveManager_pingSent()` already covered it.