### PR TITLE
services: HealthStatusManager not to expose server stub methods

### DIFF
--- a/services/src/main/java/io/grpc/services/HealthServiceImpl.java
+++ b/services/src/main/java/io/grpc/services/HealthServiceImpl.java
@@ -46,8 +46,8 @@ import javax.annotation.Nullable;
 final class HealthServiceImpl extends HealthGrpc.HealthImplBase {
 
   /* Due to the latency of rpc calls, synchronization of the map does not help with consistency.
-   * However, need use ConcurrentHashMap to prevent the possible race condition of currently putting
-   * two keys with a colliding hashCode into the map. */
+   * However, need use ConcurrentHashMap to prevent the possible race condition of concurrently
+   * putting two keys with a colliding hashCode into the map.*/
   private final Map<String, ServingStatus> statusMap
       = new ConcurrentHashMap<String, ServingStatus>();
 

--- a/services/src/main/java/io/grpc/services/HealthServiceImpl.java
+++ b/services/src/main/java/io/grpc/services/HealthServiceImpl.java
@@ -76,8 +76,4 @@ final class HealthServiceImpl extends HealthGrpc.HealthImplBase {
   void clearStatus(String service) {
     statusMap.remove(service);
   }
-
-  void clearAll() {
-    statusMap.clear();
-  }
 }

--- a/services/src/main/java/io/grpc/services/HealthStatusManager.java
+++ b/services/src/main/java/io/grpc/services/HealthStatusManager.java
@@ -33,8 +33,8 @@ package io.grpc.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.grpc.BindableService;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
-import io.grpc.health.v1.HealthGrpc;
 
 /**
  * A {@code HealthStatusManager} object manages a health check service. A health check service is
@@ -57,7 +57,7 @@ public final class HealthStatusManager {
   /**
    * Gets the health check service created in the constructor.
    */
-  public HealthGrpc.HealthImplBase getHealthService() {
+  public BindableService getHealthService() {
     return healthService;
   }
 

--- a/services/src/test/java/io/grpc/services/HealthStatusManagerTest.java
+++ b/services/src/test/java/io/grpc/services/HealthStatusManagerTest.java
@@ -56,7 +56,8 @@ import org.mockito.InOrder;
 public class HealthStatusManagerTest {
 
   private final HealthStatusManager manager = new HealthStatusManager();
-  private final HealthGrpc.HealthImplBase health = manager.getHealthService();
+  private final HealthGrpc.HealthImplBase health =
+      (HealthGrpc.HealthImplBase) manager.getHealthService();
   private final HealthCheckResponse.ServingStatus status
       = HealthCheckResponse.ServingStatus.UNKNOWN;
 


### PR DESCRIPTION
`HealthStatusManager` should not expose server stub methods, because it is wrong to call server stub methods directly.