### PR TITLE
POC: channel state API plumbing

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -462,7 +463,33 @@ public abstract class LoadBalancer {
      * called again and a new picker replaces the old one.  If {@code updatePicker()} has never been
      * called, the channel will buffer all RPCs until a picker is provided.
      */
+    // TODO(zdapeng): add '@deprecated Please migrate ALL usages to {@link #updateBalancingState}'
+    // TODO(zdapeng): and add '@Deprecated'
     public abstract void updatePicker(SubchannelPicker picker);
+
+    /**
+     * Set a new state with a new picker to the channel.
+     *
+     * <p>When a new picker is provided via {@code updateBalancingState()}, the channel will apply
+     * the picker on all buffered RPCs, by calling {@link SubchannelPicker#pickSubchannel(
+     * LoadBalancer.PickSubchannelArgs)}.
+     *
+     * <p>The channel will hold the picker and use it for all RPCs, until {@code
+     * updateBalancingState()} is called again and a new picker replaces the old one.  If {@code
+     * updateBalancingState()} has never been called, the channel will buffer all RPCs until a
+     * picker is provided.
+     *
+     * <p>implSpec: This method must be overridden
+     */
+    public void updateBalancingState(
+        @Nonnull ConnectivityState newState, @Nonnull SubchannelPicker newPicker) {
+      deprecatedUpdatePicker(newPicker);
+    }
+
+    @SuppressWarnings("deprecation") // internal fallback method
+    private void deprecatedUpdatePicker(SubchannelPicker picker) {
+      updatePicker(picker);
+    }
 
     /**
      * Schedule a task to be run in the Channel Executor, which serializes the task with the

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -482,7 +482,10 @@ public abstract class LoadBalancer {
      * updateBalancingState()} has never been called, the channel will buffer all RPCs until a
      * picker is provided.
      *
-     * <p>implSpec: This method must be overridden
+     * <p>The passed state will be the channel's new state. The SHUTDOWN state should not be passed
+     * and its behavior is undefined.
+     *
+     * <p>This method must be overridden
      */
     public void updateBalancingState(
         @Nonnull ConnectivityState newState, @Nonnull SubchannelPicker newPicker) {

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -462,6 +462,9 @@ public abstract class LoadBalancer {
      * <p>The channel will hold the picker and use it for all RPCs, until {@code updatePicker()} is
      * called again and a new picker replaces the old one.  If {@code updatePicker()} has never been
      * called, the channel will buffer all RPCs until a picker is provided.
+     *
+     * <p>Using this method implies that this load balancer doesn't support channel state, and the
+     * application will get exception when trying to get the channel state.
      */
     // TODO(zdapeng): add '@deprecated Please migrate ALL usages to {@link #updateBalancingState}'
     // TODO(zdapeng): and add '@Deprecated'
@@ -483,12 +486,7 @@ public abstract class LoadBalancer {
      */
     public void updateBalancingState(
         @Nonnull ConnectivityState newState, @Nonnull SubchannelPicker newPicker) {
-      deprecatedUpdatePicker(newPicker);
-    }
-
-    @SuppressWarnings("deprecation") // internal fallback method
-    private void deprecatedUpdatePicker(SubchannelPicker picker) {
-      updatePicker(picker);
+      updatePicker(newPicker);
     }
 
     /**

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -484,8 +484,6 @@ public abstract class LoadBalancer {
      *
      * <p>The passed state will be the channel's new state. The SHUTDOWN state should not be passed
      * and its behavior is undefined.
-     *
-     * <p>This method must be overridden
      */
     public void updateBalancingState(
         @Nonnull ConnectivityState newState, @Nonnull SubchannelPicker newPicker) {

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -97,7 +97,6 @@ public abstract class ManagedChannel extends Channel {
    *
    * @param source the assumed current state, typically just returned by {@link #getState}
    * @param callback the one-off callback
-   * @throws UnsupportedOperationException if not supported by implementation
    * @since 1.1.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/28")

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -97,6 +97,7 @@ public abstract class ManagedChannel extends Channel {
    *
    * @param source the assumed current state, typically just returned by {@link #getState}
    * @param callback the one-off callback
+   * @throws UnsupportedOperationException if not supported by implementation
    * @since 1.1.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/28")

--- a/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
+++ b/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
@@ -68,11 +68,7 @@ final class ConnectivityStateManager {
   }
 
   private void gotoNullableState(@Nullable ConnectivityState newState) {
-    if (state != newState) {
-      checkState(
-          state != ConnectivityState.SHUTDOWN,
-          "Cannot transition out of SHUTDOWN to " + newState);
-
+    if (state != newState && state != ConnectivityState.SHUTDOWN) {
       state = newState;
       if (listeners.isEmpty()) {
         return;

--- a/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
+++ b/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
@@ -63,11 +63,11 @@ final class ConnectivityStateManager {
    */
   void gotoState(@Nonnull ConnectivityState newState) {
     checkNotNull(newState, "newState");
+    checkState(state != null, "ConnectivityStateManager is already disabled");
     gotoNullableState(newState);
   }
 
   private void gotoNullableState(@Nullable ConnectivityState newState) {
-    checkState(state != null, "ConnectivityStateManager is already disabled");
     if (state != newState) {
       checkState(
           state != ConnectivityState.SHUTDOWN,
@@ -103,9 +103,7 @@ final class ConnectivityStateManager {
    * supported.
    */
   void disable() {
-    if (state != null) {
-      gotoNullableState(null);
-    }
+    gotoNullableState(null);
   }
 
   private static final class Listener {

--- a/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
+++ b/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
@@ -41,8 +41,6 @@ final class ConnectivityStateManager {
   /**
    * Adds a listener for state change event.
    *
-   * <p>Must be synchronized with {@link #gotoState}.
-   *
    * <p>The {@code executor} must be one that can run RPC call listeners.
    */
   void notifyWhenStateChanged(Runnable callback, Executor executor, ConnectivityState source) {
@@ -58,9 +56,6 @@ final class ConnectivityStateManager {
     }
   }
 
-  /**
-   * Must be synchronized with {@link #notifyWhenStateChanged}.
-   */
   void gotoState(@Nonnull ConnectivityState newState) {
     checkNotNull(newState, "newState");
     checkState(state != null, "ConnectivityStateManager is disabled");
@@ -88,10 +83,11 @@ final class ConnectivityStateManager {
    * Gets the current connectivity state of the channel. This method is threadsafe.
    */
   public ConnectivityState getState() {
-    if (state == null) {
+    ConnectivityState stateCopy = state;
+    if (stateCopy == null) {
       throw new UnsupportedOperationException("Channel state API is not implemented");
     }
-    return state;
+    return stateCopy;
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -581,26 +581,26 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   public ConnectivityState getState(boolean requestConnection) {
     ConnectivityState savedChannelState = channelStateManager.getState();
     if (requestConnection && savedChannelState == IDLE) {
-      channelExecutor.executeLater(new LogExceptionRunnable(
+      channelExecutor.executeLater(
           new Runnable() {
             @Override
             public void run() {
               exitIdleMode();
             }
-          })).drain();
+          }).drain();
     }
     return savedChannelState;
   }
 
   @Override
   public void notifyWhenStateChanged(final ConnectivityState source, final Runnable callback) {
-    channelExecutor.executeLater(new LogExceptionRunnable(
+    channelExecutor.executeLater(
         new Runnable() {
           @Override
           public void run() {
             channelStateManager.notifyWhenStateChanged(callback, executor, source);
           }
-        })).drain();
+        }).drain();
   }
 
   private class LbHelperImpl extends LoadBalancer.Helper {
@@ -679,7 +679,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       checkNotNull(newState, "newState");
       checkNotNull(newPicker, "newPicker");
 
-      runSerialized(new LogExceptionRunnable(
+      runSerialized(
           new Runnable() {
             @Override
             public void run() {
@@ -687,7 +687,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
               delayedTransport.reprocess(newPicker);
               channelStateManager.gotoState(newState);
             }
-          }));
+          });
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -95,8 +95,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   private final ObjectPool<? extends Executor> oobExecutorPool;
   private final LogId logId = LogId.allocate(getClass().getName());
 
-  @VisibleForTesting
-  final ChannelExecutor channelExecutor = new ChannelExecutor();
+  private final ChannelExecutor channelExecutor = new ChannelExecutor();
 
   private final DecompressorRegistry decompressorRegistry;
   private final CompressorRegistry compressorRegistry;
@@ -686,7 +685,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       checkNotNull(newState, "newState");
       checkNotNull(newPicker, "newPicker");
       if (newState == SHUTDOWN) {
-        // It's unclear if it is appropriate to report SHUTDOWN state from lb. Ignore it for now.
+        // It's not appropriate to report SHUTDOWN state from lb. Ignore it for now.
         return;
       }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -593,14 +593,11 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
 
   @Override
   public void notifyWhenStateChanged(final ConnectivityState source, final Runnable callback) {
-    if (channelStateManager.getState() == null) {
-      throw new UnsupportedOperationException();
-    }
     channelExecutor.executeLater(new LogExceptionRunnable(
         new Runnable() {
           @Override
           public void run() {
-            channelStateManager.addListener(callback, executor, source);
+            channelStateManager.notifyWhenStateChanged(callback, executor, source);
           }
         })).drain();
   }
@@ -687,7 +684,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
             public void run() {
               subchannelPicker = newPicker;
               delayedTransport.reprocess(newPicker);
-              channelStateManager.updateState(newState);
+              channelStateManager.gotoState(newState);
             }
           }));
     }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -94,7 +94,8 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   private final ObjectPool<? extends Executor> oobExecutorPool;
   private final LogId logId = LogId.allocate(getClass().getName());
 
-  private final ChannelExecutor channelExecutor = new ChannelExecutor();
+  @VisibleForTesting
+  final ChannelExecutor channelExecutor = new ChannelExecutor();
 
   private final DecompressorRegistry decompressorRegistry;
   private final CompressorRegistry compressorRegistry;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -684,10 +684,6 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
         final ConnectivityState newState, final SubchannelPicker newPicker) {
       checkNotNull(newState, "newState");
       checkNotNull(newPicker, "newPicker");
-      if (newState == SHUTDOWN) {
-        // It's not appropriate to report SHUTDOWN state from lb. Ignore it for now.
-        return;
-      }
 
       runSerialized(
           new Runnable() {
@@ -695,7 +691,11 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
             public void run() {
               subchannelPicker = newPicker;
               delayedTransport.reprocess(newPicker);
-              channelStateManager.gotoState(newState);
+              // It's not appropriate to report SHUTDOWN state from lb.
+              // Ignore the case of newState == SHUTDOWN for now.
+              if (newState != SHUTDOWN) {
+                channelStateManager.gotoState(newState);
+              }
             }
           });
     }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1205,10 +1205,10 @@ public class ManagedChannelImplTest {
 
     Runnable onStateChanged = mock(Runnable.class);
     channel.notifyWhenStateChanged(ConnectivityState.IDLE, onStateChanged);
-    helper.updatePicker(mockPicker);
-    channel.channelExecutor.drain();
     executor.runDueTasks();
-    channel.channelExecutor.drain();
+    verify(onStateChanged, never()).run();
+
+    helper.updatePicker(mockPicker);
     executor.runDueTasks();
 
     verify(onStateChanged).run();
@@ -1230,14 +1230,12 @@ public class ManagedChannelImplTest {
     assertEquals(ConnectivityState.IDLE, channel.getState(false));
 
     channel.notifyWhenStateChanged(ConnectivityState.IDLE, onStateChanged);
-    channel.channelExecutor.drain();
     executor.runDueTasks();
     assertFalse(stateChanged.get());
 
     // state change from IDLE to CONNECTING
     helper.updateBalancingState(ConnectivityState.CONNECTING, mockPicker);
     // onStateChanged callback should run
-    channel.channelExecutor.drain();
     executor.runDueTasks();
     assertTrue(stateChanged.get());
 
@@ -1245,7 +1243,6 @@ public class ManagedChannelImplTest {
     stateChanged.set(false);
     channel.notifyWhenStateChanged(ConnectivityState.IDLE, onStateChanged);
     // onStateChanged callback should run immediately
-    channel.channelExecutor.drain();
     executor.runDueTasks();
     assertTrue(stateChanged.get());
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1260,6 +1260,7 @@ public class ManagedChannelImplTest {
     createChannel(new FakeNameResolverFactory(false), NO_INTERCEPTOR);
     assertEquals(ConnectivityState.IDLE, channel.getState(false));
     channel.notifyWhenStateChanged(ConnectivityState.IDLE, onStateChanged);
+    executor.runDueTasks();
     assertFalse(stateChanged.get());
 
     channel.shutdown();


### PR DESCRIPTION
This is only implementing how subchannel state changes are hooked up to channel state APIs. Debates in state semantics and transition rules for loadbalanced channel such as #2873 are not addressed. Any changes in state semantics and transition rules in the future can be easily adapted.