### PR TITLE
core: Simplify ChannelImpl constructor; testable Builder

### DIFF
--- a/core/src/main/java/io/grpc/internal/FixedObjectPool.java
+++ b/core/src/main/java/io/grpc/internal/FixedObjectPool.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * An object pool that always returns the same instance and does nothing when returning the object.
+ */
+final class FixedObjectPool<T> implements ObjectPool<T> {
+  private final T object;
+
+  public FixedObjectPool(T object) {
+    this.object = Preconditions.checkNotNull(object, "object");
+  }
+
+  @Override
+  public T getObject() {
+    return object;
+  }
+
+  @Override
+  public T returnObject(Object returned) {
+    return null;
+  }
+}

--- a/core/src/main/java/io/grpc/internal/OverrideAuthorityNameResolverFactory.java
+++ b/core/src/main/java/io/grpc/internal/OverrideAuthorityNameResolverFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.Attributes;
+import io.grpc.NameResolver;
+import java.net.URI;
+import javax.annotation.Nullable;
+
+/**
+ * A wrapper class that overrides the authority of a NameResolver, while preserving all other
+ * functionality.
+ */
+final class OverrideAuthorityNameResolverFactory extends NameResolver.Factory {
+  private final NameResolver.Factory delegate;
+  private final String authorityOverride;
+
+  /**
+   * Constructor for the {@link NameResolver.Factory}
+   *
+   * @param delegate The actual underlying factory that will produce the a {@link NameResolver}
+   * @param authorityOverride The authority that will be returned by {@link
+   *   NameResolver#getServiceAuthority()}
+   */
+  OverrideAuthorityNameResolverFactory(NameResolver.Factory delegate, String authorityOverride) {
+    this.delegate = delegate;
+    this.authorityOverride = authorityOverride;
+  }
+
+  @Nullable
+  @Override
+  public NameResolver newNameResolver(URI targetUri, Attributes params) {
+    final NameResolver resolver = delegate.newNameResolver(targetUri, params);
+    // Do not wrap null values. We do not want to impede error signaling.
+    if (resolver == null) {
+      return null;
+    }
+    return new NameResolver() {
+      @Override
+      public String getServiceAuthority() {
+        return authorityOverride;
+      }
+
+      @Override
+      public void start(Listener listener) {
+        resolver.start(listener);
+      }
+
+      @Override
+      public void shutdown() {
+        resolver.shutdown();
+      }
+    };
+  }
+
+  @Override
+  public String getDefaultScheme() {
+    return delegate.getDefaultScheme();
+  }
+}

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -17,16 +17,24 @@
 package io.grpc.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Attributes;
+import io.grpc.CompressorRegistry;
+import io.grpc.DecompressorRegistry;
+import io.grpc.LoadBalancer;
 import io.grpc.NameResolver;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +43,173 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link AbstractManagedChannelImplBuilder}. */
 @RunWith(JUnit4.class)
 public class AbstractManagedChannelImplBuilderTest {
+  private Builder builder = new Builder("fake");
+  private Builder directAddressBuilder = new Builder(new SocketAddress(){}, "fake");
+
+  @Test
+  public void executor_default() {
+    assertNotNull(builder.executorPool);
+  }
+
+  @Test
+  public void executor_normal() {
+    Executor executor = mock(Executor.class);
+    assertEquals(builder, builder.executor(executor));
+    assertEquals(executor, builder.executorPool.getObject());
+  }
+
+  @Test
+  public void executor_null() {
+    ObjectPool<? extends Executor> defaultValue = builder.executorPool;
+    builder.executor(mock(Executor.class));
+    assertEquals(builder, builder.executor(null));
+    assertEquals(defaultValue, builder.executorPool);
+  }
+
+  @Test
+  public void directExecutor() {
+    assertEquals(builder, builder.directExecutor());
+    assertEquals(MoreExecutors.directExecutor(), builder.executorPool.getObject());
+  }
+
+  @Test
+  public void nameResolverFactory_default() {
+    assertNotNull(builder.nameResolverFactory);
+  }
+
+  @Test
+  public void nameResolverFactory_normal() {
+    NameResolver.Factory nameResolverFactory = mock(NameResolver.Factory.class);
+    assertEquals(builder, builder.nameResolverFactory(nameResolverFactory));
+    assertEquals(nameResolverFactory, builder.nameResolverFactory);
+  }
+
+  @Test
+  public void nameResolverFactory_null() {
+    NameResolver.Factory defaultValue = builder.nameResolverFactory;
+    builder.nameResolverFactory(mock(NameResolver.Factory.class));
+    assertEquals(builder, builder.nameResolverFactory(null));
+    assertEquals(defaultValue, builder.nameResolverFactory);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void nameResolverFactory_notAllowedWithDirectAddress() {
+    directAddressBuilder.nameResolverFactory(mock(NameResolver.Factory.class));
+  }
+
+  @Test
+  public void loadBalancerFactory_default() {
+    assertNotNull(builder.loadBalancerFactory);
+  }
+
+  @Test
+  public void loadBalancerFactory_normal() {
+    LoadBalancer.Factory loadBalancerFactory = mock(LoadBalancer.Factory.class);
+    assertEquals(builder, builder.loadBalancerFactory(loadBalancerFactory));
+    assertEquals(loadBalancerFactory, builder.loadBalancerFactory);
+  }
+
+  @Test
+  public void loadBalancerFactory_null() {
+    LoadBalancer.Factory defaultValue = builder.loadBalancerFactory;
+    builder.loadBalancerFactory(mock(LoadBalancer.Factory.class));
+    assertEquals(builder, builder.loadBalancerFactory(null));
+    assertEquals(defaultValue, builder.loadBalancerFactory);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void loadBalancerFactory_notAllowedWithDirectAddress() {
+    directAddressBuilder.loadBalancerFactory(mock(LoadBalancer.Factory.class));
+  }
+
+  @Test
+  public void decompressorRegistry_default() {
+    assertNotNull(builder.decompressorRegistry);
+  }
+
+  @Test
+  public void decompressorRegistry_normal() {
+    DecompressorRegistry decompressorRegistry = DecompressorRegistry.emptyInstance();
+    assertNotEquals(decompressorRegistry, builder.decompressorRegistry);
+    assertEquals(builder, builder.decompressorRegistry(decompressorRegistry));
+    assertEquals(decompressorRegistry, builder.decompressorRegistry);
+  }
+
+  @Test
+  public void decompressorRegistry_null() {
+    DecompressorRegistry defaultValue = builder.decompressorRegistry;
+    assertEquals(builder, builder.decompressorRegistry(DecompressorRegistry.emptyInstance()));
+    assertNotEquals(defaultValue, builder.decompressorRegistry);
+    builder.decompressorRegistry(null);
+    assertEquals(defaultValue, builder.decompressorRegistry);
+  }
+
+  @Test
+  public void compressorRegistry_default() {
+    assertNotNull(builder.compressorRegistry);
+  }
+
+  @Test
+  public void compressorRegistry_normal() {
+    CompressorRegistry compressorRegistry = CompressorRegistry.newEmptyInstance();
+    assertNotEquals(compressorRegistry, builder.compressorRegistry);
+    assertEquals(builder, builder.compressorRegistry(compressorRegistry));
+    assertEquals(compressorRegistry, builder.compressorRegistry);
+  }
+
+  @Test
+  public void compressorRegistry_null() {
+    CompressorRegistry defaultValue = builder.compressorRegistry;
+    builder.compressorRegistry(CompressorRegistry.newEmptyInstance());
+    assertNotEquals(defaultValue, builder.compressorRegistry);
+    assertEquals(builder, builder.compressorRegistry(null));
+    assertEquals(defaultValue, builder.compressorRegistry);
+  }
+
+  @Test
+  public void userAgent_default() {
+    assertNull(builder.userAgent);
+  }
+
+  @Test
+  public void userAgent_normal() {
+    String userAgent = "user-agent/1";
+    assertEquals(builder, builder.userAgent(userAgent));
+    assertEquals(userAgent, builder.userAgent);
+  }
+
+  @Test
+  public void userAgent_null() {
+    assertEquals(builder, builder.userAgent(null));
+    assertNull(builder.userAgent);
+
+    builder.userAgent("user-agent/1");
+    builder.userAgent(null);
+    assertNull(builder.userAgent);
+  }
+
+  @Test
+  public void overrideAuthority_default() {
+    assertNull(builder.authorityOverride);
+  }
+
+  @Test
+  public void overrideAuthority_normal() {
+    String overrideAuthority = "best-authority";
+    assertEquals(builder, builder.overrideAuthority(overrideAuthority));
+    assertEquals(overrideAuthority, builder.authorityOverride);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void overrideAuthority_null() {
+    builder.overrideAuthority(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void overrideAuthority_invalid() {
+    builder.overrideAuthority("not_allowed");
+  }
+
   @Test
   public void makeTargetStringForDirectAddress_scopedIpv6() throws Exception {
     InetSocketAddress address = new InetSocketAddress("0:0:0:0:0:0:0:0%0", 10005);
@@ -47,23 +222,7 @@ public class AbstractManagedChannelImplBuilderTest {
 
   @Test
   public void idleTimeout() {
-    class Builder extends AbstractManagedChannelImplBuilder<Builder> {
-      Builder() {
-        super("target");
-      }
-
-      @Override
-      protected ClientTransportFactory buildTransportFactory() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public Builder usePlaintext(boolean value) {
-        return this;
-      }
-    }
-
-    Builder builder = new Builder();
+    Builder builder = new Builder("target");
 
     assertEquals(AbstractManagedChannelImplBuilder.IDLE_MODE_DEFAULT_TIMEOUT_MILLIS,
         builder.getIdleTimeoutMillis());
@@ -98,8 +257,7 @@ public class AbstractManagedChannelImplBuilderTest {
       .thenReturn(nameResolverMock);
     String override = "override:5678";
     NameResolver.Factory factory =
-        new AbstractManagedChannelImplBuilder.OverrideAuthorityNameResolverFactory(wrappedFactory,
-          override);
+        new OverrideAuthorityNameResolverFactory(wrappedFactory, override);
     NameResolver nameResolver = factory.newNameResolver(URI.create("dns:///localhost:443"),
         Attributes.EMPTY);
     assertNotNull(nameResolver);
@@ -111,9 +269,28 @@ public class AbstractManagedChannelImplBuilderTest {
     NameResolver.Factory wrappedFactory = mock(NameResolver.Factory.class);
     when(wrappedFactory.newNameResolver(any(URI.class), any(Attributes.class))).thenReturn(null);
     NameResolver.Factory factory =
-        new AbstractManagedChannelImplBuilder.OverrideAuthorityNameResolverFactory(wrappedFactory,
-            "override:5678");
+        new OverrideAuthorityNameResolverFactory(wrappedFactory, "override:5678");
     assertEquals(null,
         factory.newNameResolver(URI.create("dns:///localhost:443"), Attributes.EMPTY));
+  }
+
+  static class Builder extends AbstractManagedChannelImplBuilder<Builder> {
+    Builder(String target) {
+      super(target);
+    }
+
+    Builder(SocketAddress directServerAddress, String authority) {
+      super(directServerAddress, authority);
+    }
+
+    @Override
+    protected ClientTransportFactory buildTransportFactory() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Builder usePlaintext(boolean value) {
+      throw new UnsupportedOperationException();
+    }
   }
 }


### PR DESCRIPTION
Add some example tests for easier fields in AbstractManagedChannelImplBuilder.

Many fields are no longer Nullable, in order to move logic from construction to
mutation, which eases testing and simplifies cross-class interactions.

The nameResolverFactory comment starting 'Avoid loading the provider unless
necessary' was outdated and has not been a concern since #2071 which swapped to
a hard-coded list on Android.

Consider this a working RFC. If we like it, there are many more places we can apply
the same pattern and apply more cleanups. Specific details can maybe be done
differently, but before harping on the details, it'd be good to determine if we like the
general approach.

This is low priority :smile: