### PR TITLE
core,netty,okhttp: plumb Attributes from NameResolver to ClientTransportFactory

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -32,6 +32,7 @@
 package io.grpc.inprocess;
 
 import com.google.common.base.Preconditions;
+import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
 import io.grpc.Internal;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
@@ -109,7 +110,7 @@ public class InProcessChannelBuilder extends
 
     @Override
     public ConnectionClientTransport newClientTransport(
-        SocketAddress addr, String authority, String userAgent) {
+        SocketAddress addr, String authority, String userAgent, Attributes attrs) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -56,9 +56,9 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
 
   @Override
   public ConnectionClientTransport newClientTransport(
-      SocketAddress serverAddress, String authority, @Nullable String userAgent) {
+      SocketAddress serverAddress, String authority, @Nullable String userAgent, Attributes attrs) {
     return new CallCredentialsApplyingTransport(
-        delegate.newClientTransport(serverAddress, authority, userAgent), authority);
+        delegate.newClientTransport(serverAddress, authority, userAgent, attrs), authority);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal;
 
+import io.grpc.Attributes;
 import java.io.Closeable;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -42,9 +43,11 @@ public interface ClientTransportFactory extends Closeable {
    *
    * @param serverAddress the address that the transport is connected to
    * @param authority the HTTP/2 authority of the server
+   * @param userAgent the user agent
+   * @param attrs the attributes for the new transport
    */
   ConnectionClientTransport newClientTransport(SocketAddress serverAddress, String authority,
-      @Nullable String userAgent);
+      @Nullable String userAgent, Attributes attrs);
 
   /**
    * Releases any resources.

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -207,7 +207,8 @@ final class InternalSubchannel implements WithLogId {
     final SocketAddress address = addrs.get(addressIndex);
 
     ConnectionClientTransport transport =
-        transportFactory.newClientTransport(address, authority, userAgent);
+        transportFactory.newClientTransport(
+            address, authority, userAgent, addressGroup.getAttributes());
     if (log.isLoggable(Level.FINE)) {
       log.log(Level.FINE, "[{0}] Created {1} for {2}",
           new Object[] {logId, transport.getLogId(), address});

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -114,16 +114,17 @@ public class CallCredentialsApplyingTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     origHeaders.put(ORIG_HEADER_KEY, ORIG_HEADER_VALUE);
-    when(mockTransportFactory.newClientTransport(address, AUTHORITY, USER_AGENT))
+    when(mockTransportFactory.newClientTransport(address, AUTHORITY, USER_AGENT, Attributes.EMPTY))
         .thenReturn(mockTransport);
     when(mockTransport.newStream(same(method), any(Metadata.class), any(CallOptions.class)))
         .thenReturn(mockStream);
     ClientTransportFactory transportFactory = new CallCredentialsApplyingTransportFactory(
         mockTransportFactory, mockExecutor);
     transport = (ForwardingConnectionClientTransport) transportFactory.newClientTransport(
-        address, AUTHORITY, USER_AGENT);
+        address, AUTHORITY, USER_AGENT, Attributes.EMPTY);
     callOptions = CallOptions.DEFAULT.withCallCredentials(mockCreds);
-    verify(mockTransportFactory).newClientTransport(address, AUTHORITY, USER_AGENT);
+    verify(mockTransportFactory).newClientTransport(
+        address, AUTHORITY, USER_AGENT, Attributes.EMPTY);
     assertSame(mockTransport, transport.delegate());
   }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -153,7 +153,7 @@ public class ManagedChannelImplIdlenessTest {
     // Verify the initial idleness
     verify(mockLoadBalancerFactory, never()).newLoadBalancer(any(Helper.class));
     verify(mockTransportFactory, never()).newClientTransport(
-        any(SocketAddress.class), anyString(), anyString());
+        any(SocketAddress.class), anyString(), anyString(), any(Attributes.class));
     verify(mockNameResolver, never()).start(any(NameResolver.Listener.class));
   }
 
@@ -350,11 +350,19 @@ public class ManagedChannelImplIdlenessTest {
     // Now make an RPC on an OOB channel
     ManagedChannel oob = helper.createOobChannel(servers.get(0), "oobauthority");
     verify(mockTransportFactory, never())
-        .newClientTransport(any(SocketAddress.class), same("oobauthority"), same(USER_AGENT));
+        .newClientTransport(
+            any(SocketAddress.class),
+            same("oobauthority"),
+            same(USER_AGENT),
+            any(Attributes.class));
     ClientCall<String, Integer> oobCall = oob.newCall(method, CallOptions.DEFAULT);
     oobCall.start(mockCallListener2, new Metadata());
     verify(mockTransportFactory)
-        .newClientTransport(any(SocketAddress.class), same("oobauthority"), same(USER_AGENT));
+        .newClientTransport(
+            any(SocketAddress.class),
+            same("oobauthority"),
+            same(USER_AGENT),
+            any(Attributes.class));
     MockClientTransportInfo oobTransportInfo = newTransports.poll();
     assertEquals(0, newTransports.size());
     // The OOB transport reports in-use state

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -104,7 +105,8 @@ final class TestUtils {
         return mockTransport;
       }
     }).when(mockTransportFactory)
-        .newClientTransport(any(SocketAddress.class), any(String.class), any(String.class));
+        .newClientTransport(
+            any(SocketAddress.class), any(String.class), any(String.class), any(Attributes.class));
 
     return captor;
   }

--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -31,6 +31,7 @@
 
 package io.grpc.netty;
 
+import io.grpc.Attributes;
 import io.grpc.Internal;
 import java.net.SocketAddress;
 
@@ -59,7 +60,7 @@ public final class InternalNettyChannelBuilder {
       extends NettyChannelBuilder.TransportCreationParamsFilterFactory {
     @Override
     TransportCreationParamsFilter create(
-        SocketAddress targetServerAddress, String authority, String userAgent);
+        SocketAddress targetServerAddress, String authority, String userAgent, Attributes attrs);
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -365,9 +365,8 @@ public final class NettyChannelBuilder
   @VisibleForTesting
   @CheckReturnValue
   static ProtocolNegotiator createProtocolNegotiator(
-      String authority,
-      NegotiationType negotiationType,
-      SslContext sslContext) {
+      String authority, NegotiationType negotiationType, SslContext sslContext, Attributes attrs) {
+    //TODO(spencerfang): set up proxy based on attributes
     ProtocolNegotiator negotiator =
         createProtocolNegotiatorByType(authority, negotiationType, sslContext);
     String proxy = System.getenv("GRPC_PROXY_EXP");
@@ -440,7 +439,7 @@ public final class NettyChannelBuilder
 
     @Nullable String getUserAgent();
 
-    ProtocolNegotiator getProtocolNegotiator();
+    ProtocolNegotiator getProtocolNegotiator(Attributes attrs);
   }
 
   /**
@@ -502,7 +501,10 @@ public final class NettyChannelBuilder
 
     @Override
     public ConnectionClientTransport newClientTransport(
-        SocketAddress serverAddress, String authority, @Nullable String userAgent) {
+        SocketAddress serverAddress,
+        String authority,
+        @Nullable String userAgent,
+        Attributes attrs) {
       checkState(!closed, "The transport factory is closed.");
 
       TransportCreationParamsFilter dparams =
@@ -517,7 +519,7 @@ public final class NettyChannelBuilder
       };
       NettyClientTransport transport = new NettyClientTransport(
           dparams.getTargetServerAddress(), channelType, channelOptions, group,
-          dparams.getProtocolNegotiator(), flowControlWindow,
+          dparams.getProtocolNegotiator(attrs), flowControlWindow,
           maxMessageSize, maxHeaderListSize, keepAliveTimeNanosState.get(), keepAliveTimeoutNanos,
           keepAliveWithoutCalls, dparams.getAuthority(), dparams.getUserAgent(),
           tooManyPingsRunnable);
@@ -566,8 +568,8 @@ public final class NettyChannelBuilder
       }
 
       @Override
-      public ProtocolNegotiator getProtocolNegotiator() {
-        return createProtocolNegotiator(authority, negotiationType, sslContext);
+      public ProtocolNegotiator getProtocolNegotiator(Attributes attrs) {
+        return createProtocolNegotiator(authority, negotiationType, sslContext, attrs);
       }
     }
   }

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import io.grpc.Attributes;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.InternalNettyChannelBuilder.OverrideAuthorityChecker;
 import io.grpc.netty.ProtocolNegotiators.TlsNegotiator;
@@ -141,7 +142,8 @@ public class NettyChannelBuilderTest {
     ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiator(
         "authority",
         NegotiationType.PLAINTEXT,
-        noSslContext);
+        noSslContext,
+        Attributes.EMPTY);
     // just check that the classes are the same, and that negotiator is not null.
     assertTrue(negotiator instanceof ProtocolNegotiators.PlaintextNegotiator);
   }
@@ -151,7 +153,8 @@ public class NettyChannelBuilderTest {
     ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiator(
         "authority",
         NegotiationType.PLAINTEXT_UPGRADE,
-        noSslContext);
+        noSslContext,
+        Attributes.EMPTY);
     // just check that the classes are the same, and that negotiator is not null.
     assertTrue(negotiator instanceof ProtocolNegotiators.PlaintextUpgradeNegotiator);
   }
@@ -161,7 +164,8 @@ public class NettyChannelBuilderTest {
     ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiator(
         "authority:1234",
         NegotiationType.TLS,
-        noSslContext);
+        noSslContext,
+        Attributes.EMPTY);
 
     assertTrue(negotiator instanceof ProtocolNegotiators.TlsNegotiator);
     ProtocolNegotiators.TlsNegotiator n = (TlsNegotiator) negotiator;
@@ -175,7 +179,8 @@ public class NettyChannelBuilderTest {
     ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiator(
         "authority:1234",
         NegotiationType.TLS,
-        GrpcSslContexts.forClient().build());
+        GrpcSslContexts.forClient().build(),
+        Attributes.EMPTY);
 
     assertTrue(negotiator instanceof ProtocolNegotiators.TlsNegotiator);
     ProtocolNegotiators.TlsNegotiator n = (TlsNegotiator) negotiator;
@@ -189,7 +194,8 @@ public class NettyChannelBuilderTest {
     ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiator(
         "bad_authority",
         NegotiationType.TLS,
-        noSslContext);
+        noSslContext,
+        Attributes.EMPTY);
 
     assertTrue(negotiator instanceof ProtocolNegotiators.TlsNegotiator);
     ProtocolNegotiators.TlsNegotiator n = (TlsNegotiator) negotiator;

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -31,6 +31,7 @@
 
 package io.grpc.netty;
 
+import io.grpc.Attributes;
 import io.grpc.ServerStreamTracer;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.InternalServer;
@@ -91,7 +92,8 @@ public class NettyTransportTest extends AbstractTransportTest {
     return clientFactory.newClientTransport(
         new InetSocketAddress("localhost", port),
         testAuthority(server),
-        null /* agent */);
+        null /* agent */,
+        Attributes.EMPTY);
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -397,7 +397,8 @@ public class OkHttpChannelBuilder extends
 
     @Override
     public ConnectionClientTransport newClientTransport(
-        SocketAddress addr, String authority, @Nullable String userAgent) {
+        SocketAddress addr, String authority, @Nullable String userAgent, Attributes attr) {
+      //TODO(spencerfang): set up proxy based on attributes
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import com.squareup.okhttp.ConnectionSpec;
+import io.grpc.Attributes;
 import io.grpc.NameResolver;
 import io.grpc.internal.GrpcUtil;
 import java.net.InetSocketAddress;
@@ -125,7 +126,7 @@ public class OkHttpChannelBuilderTest {
   public void usePlaintext_newClientTransportAllowed() {
     OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("host", 1234).usePlaintext(true);
     builder.buildTransportFactory().newClientTransport(new InetSocketAddress(5678),
-        "dummy_authority", "dummy_userAgent");
+        "dummy_authority", "dummy_userAgent", Attributes.EMPTY);
   }
 
   @Test

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -31,6 +31,7 @@
 
 package io.grpc.okhttp;
 
+import io.grpc.Attributes;
 import io.grpc.ServerStreamTracer;
 import io.grpc.internal.AccessProtectedHack;
 import io.grpc.internal.ClientTransportFactory;
@@ -91,7 +92,8 @@ public class OkHttpTransportTest extends AbstractTransportTest {
     return clientFactory.newClientTransport(
         new InetSocketAddress("::1", port),
         testAuthority(server),
-        null /* agent */);
+        null /* agent */,
+        Attributes.EMPTY);
   }
 
   @Override

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
@@ -31,6 +31,7 @@
 
 package io.grpc.internal.testing;
 
+import io.grpc.Attributes;
 import io.grpc.internal.ClientTransportFactory;
 import java.net.InetSocketAddress;
 import org.junit.Test;
@@ -55,6 +56,6 @@ public abstract class AbstractClientTransportFactoryTest {
     ClientTransportFactory transportFactory = newClientTransportFactory();
     transportFactory.close();
     transportFactory.newClientTransport(
-        new InetSocketAddress("localhost", 12345), "localhost:" + 12345, "agent");
+        new InetSocketAddress("localhost", 12345), "localhost:" + 12345, "agent", Attributes.EMPTY);
   }
 }


### PR DESCRIPTION
When DnsNameResolver resolves a name, it notifies NameResolver.Listener#onAddresses with a set of Attribute kv pairs. This diff plumbs the Attribute to ClientTransportFactory, so that we can easily add proxy related attributes in the near future. No behavior is changed here.

Tests:
Added a check to informationPropagatedToNewStreamAndCallCredentials to ensure the Attribute set is properly propagated.