### PR TITLE
okhttp: ignore unknown HTTP/2 settings

### DIFF
--- a/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/framed/Http2.java
+++ b/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/framed/Http2.java
@@ -301,7 +301,8 @@ public final class Http2 implements Variant {
           case 6: // SETTINGS_MAX_HEADER_LIST_SIZE
             break; // Advisory only, so ignored.
           default:
-            throw ioException("PROTOCOL_ERROR invalid settings id: %s", id);
+            // Implementations MUST ignore any unknown or unsupported identifier.
+            continue;
         }
         settings.set(id, 0, value);
       }


### PR DESCRIPTION
Intended to address https://github.com/grpc/grpc-java/issues/3032.

This was addressed in OkHttp3 by https://github.com/square/okhttp/pull/2299, but I'm fairly certain their fix still contains a bug - they parse the settings id as a Java short, so anything in the experimental range (such as gRPC C++ servers are using) is a negative number, and the linked pull request's use of `break` instead of `continue` results in an index out of bounds exception in `Settings#set`. I'll follow up on that with the OkHttp repo separately. 

@ejona86 I'm not sure of the status of the code in okhttp/third_party - since this is "shaded" from OkHttp2, can we patch it, or do we need to move the modifications somehow out of the third_party/ subdirectory? As-is, I'm also not sure where to put tests for this, but just wanted to get the process started.