### PR TITLE
interop-testing: add alpnagent to support okhttp in test client

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -29,9 +29,16 @@ test {
 task test_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.TestServiceClient"
     applicationName = "test-client"
-    defaultJvmOpts = ["-javaagent:" + configurations.alpnagent.asPath]
+    defaultJvmOpts = ["-javaagent:JAVAAGENT_APP_HOME" + configurations.alpnagent.singleFile.name]
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + configurations.runtime
+    dependencies {
+        runtime configurations.alpnagent
+    }
+    doLast {
+        unixScript.text = unixScript.text.replace('JAVAAGENT_APP_HOME', '\$APP_HOME/lib/')
+        windowsScript.text = windowsScript.text.replace('JAVAAGENT_APP_HOME', '%APP_HOME%\\lib\\')
+    }
 }
 
 task test_server(type: CreateStartScripts) {

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -29,6 +29,7 @@ test {
 task test_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.TestServiceClient"
     applicationName = "test-client"
+    defaultJvmOpts = ["-javaagent:" + configurations.alpnagent.asPath]
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + configurations.runtime
 }


### PR DESCRIPTION
In response to https://github.com/grpc/grpc/issues/11258 / https://github.com/grpc/grpc-java/issues/3032, we should run our full suite of interop tests using OkHttp. As best I can tell, OkHttp cannot use ALPN unless it has the ALPN agent, which was [removed](https://github.com/grpc/grpc-java/commit/9466eb5014bd4ed2fd0af2567c605ae79a27e86b#diff-dbbdfba18c8958c51b031ef112a6fa7c) a while ago from the build rule, back when we were still using the boot classpath. This adds it back in, so that the `--use_okhttp=true` option in the test client is able to use TLS.