### PR TITLE
compiler: Fix compilation error

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <vector>
 #include <google/protobuf/compiler/java/java_names.h>


### PR DESCRIPTION
The code uses std::back_insert_iterator which is part of the iterator header. The header is not included though.

We (bazel) noticed the build failing on Windows when using the Visual Studio C++ compiler.