### PR TITLE
testing: GrpcServerRule#directExecutor can only be called at instantiation

### DIFF
--- a/testing/src/main/java/io/grpc/testing/GrpcServerRule.java
+++ b/testing/src/main/java/io/grpc/testing/GrpcServerRule.java
@@ -16,6 +16,8 @@
 
 package io.grpc.testing;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import io.grpc.BindableService;
 import io.grpc.ExperimentalApi;
 import io.grpc.ManagedChannel;
@@ -49,9 +51,10 @@ public class GrpcServerRule extends ExternalResource {
 
   /**
    * Returns {@code this} configured to use a direct executor for the {@link ManagedChannel} and
-   * {@link Server}.
+   * {@link Server}. This can only be called at the rule instantiation.
    */
   public final GrpcServerRule directExecutor() {
+    checkState(serverName == null, "directExecutor() can only be called at the rule instantiation");
     useDirectExecutor = true;
     return this;
   }

--- a/testing/src/test/java/io/grpc/testing/GrpcServerRuleTest.java
+++ b/testing/src/test/java/io/grpc/testing/GrpcServerRuleTest.java
@@ -95,6 +95,11 @@ public class GrpcServerRuleTest {
 
       assertThat(testService.lastEmptyCallRequestThread).isNotEqualTo(Thread.currentThread());
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void callDirectExecutorNotAtRuleInstantiation() {
+      grpcServerRule.directExecutor();
+    }
   }
 
   @RunWith(JUnit4.class)


### PR DESCRIPTION
otherwise it cannot take effect