### PR TITLE
examples: migrate unittest examples to GrpcServerRule

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -68,3 +68,7 @@ with a mock/fake service implementation.
 
 For testing a gRPC server, create the server as an InProcessServer,
 and test it against a real client stub with an InProcessChannel.
+
+The gRPC-java library also provides a JUnit rule,
+[GrpcServerRule](../testing/src/main/java/io/grpc/testing/GrpcServerRule.java), to do the starting
+up and shutting down boilerplate for you.

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   compile "io.grpc:grpc-protobuf:${grpcVersion}"
   compile "io.grpc:grpc-stub:${grpcVersion}"
 
+  testCompile "io.grpc:grpc-testing:${grpcVersion}"
   testCompile "junit:junit:4.11"
   testCompile "org.mockito:mockito-core:1.9.5"
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -29,6 +29,12 @@
       <version>${grpc.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-testing</artifactId>
+      <version>${grpc.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>

--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
@@ -37,12 +37,13 @@ public class HelloWorldClient {
     this(ManagedChannelBuilder.forAddress(host, port)
         // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
         // needing certificates.
-        .usePlaintext(true));
+        .usePlaintext(true)
+        .build());
   }
 
   /** Construct client for accessing RouteGuide server using the existing channel. */
-  HelloWorldClient(ManagedChannelBuilder<?> channelBuilder) {
-    channel = channelBuilder.build();
+  HelloWorldClient(ManagedChannel channel) {
+    this.channel = channel;
     blockingStub = GreeterGrpc.newBlockingStub(channel);
   }
 

--- a/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldServerTest.java
+++ b/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldServerTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 
 import io.grpc.examples.helloworld.HelloWorldServer.GreeterImpl;
 import io.grpc.testing.GrpcServerRule;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,19 +42,15 @@ public class HelloWorldServerTest {
   @Rule
   public final GrpcServerRule grpcServerRule = new GrpcServerRule().directExecutor();
 
-  @Before
-  public void setUp() throws Exception {
-    // Add the service to the in-process server.
-    grpcServerRule.getServiceRegistry().addService(new GreeterImpl());
-  }
-
   /**
    * To test the server, make calls with a real stub using the in-process channel, and verify
    * behaviors or state changes from the client side.
    */
   @Test
   public void greeterImpl_replyMessage() throws Exception {
+    // Add the service to the in-process server.
     grpcServerRule.getServiceRegistry().addService(new GreeterImpl());
+
     GreeterGrpc.GreeterBlockingStub blockingStub =
         GreeterGrpc.newBlockingStub(grpcServerRule.getChannel());
     String testName = "test name";


### PR DESCRIPTION
migrated simple tests using `GrpcServerRule`.
Kept the low level in-process channel setup and tear down code for the RouteGuide example to show how users can use in-process directly to set more custom channel builder options when needed.

resolves #2490