### PR TITLE
core: JumpToApplication...Listener should not close context

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -585,9 +585,6 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
       callExecutor.execute(new ContextRunnable(context) {
         @Override
         public void runInContext() {
-          if (status.isOk()) {
-            context.cancel(status.getCause());
-          }
           getListener().closed(status);
         }
       });


### PR DESCRIPTION
Calling CancellableContext#close() multiple times does not cause problems, but is unnecessary here. The return value of getListener() is a ServerStreamListenerImpl, which already calls CancellableContext#cancel() inside of the `finally` block of ServerStreamListener#closed(). 