### PR TITLE
stub: detect invalid states on server side (eg zero responses for unary)

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -39,11 +39,8 @@ import io.grpc.Status;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
-  private static final Logger log = Logger.getLogger(ServerCallImpl.class.getName());
 
   @VisibleForTesting
   static String TOO_MANY_RESPONSES = "Too many responses";
@@ -192,9 +189,10 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
     if (status.isOk() && method.getType().serverSendsOneMessage() && !messageSent) {
       internalClose(Status.INTERNAL.withDescription(MISSING_RESPONSE));
-    } else {
-      stream.close(status, trailers);
+      return;
     }
+
+    stream.close(status, trailers);
   }
 
   @Override
@@ -228,7 +226,6 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
    */
   private void internalClose(Status internalError) {
     internalClosed = true;
-    log.log(Level.FINE, internalError.getDescription(), internalError.asException());
     stream.close(internalError, new Metadata());
   }
 

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -42,9 +42,14 @@ public interface ServerStream extends Stream {
    * {@link io.grpc.Status.Code#OK} implies normal termination of the
    * stream. Any other value implies abnormal termination.
    *
+   * <p>Attempts to read from or write to the stream after closing
+   * should be ignored by implementations, and should not throw
+   * exceptions.
+   *
    * @param status details of the closure
    * @param trailers an additional block of metadata to pass to the client on stream closure.
    */
+  //TODO(spencerfang): add unit tests to verify the close behavior
   void close(Status status, Metadata trailers);
 
 

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -49,7 +49,6 @@ public interface ServerStream extends Stream {
    * @param status details of the closure
    * @param trailers an additional block of metadata to pass to the client on stream closure.
    */
-  //TODO(spencerfang): add unit tests to verify the close behavior
   void close(Status status, Metadata trailers);
 
 

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -47,10 +47,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
@@ -58,7 +55,6 @@ public class ServerCallImplTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Mock private ServerStream stream;
   @Mock private ServerCall.Listener<Long> callListener;
-  @Captor private ArgumentCaptor<Status> statusCaptor;
 
   private ServerCallImpl<Long, Long> call;
   private Context.CancellableContext context;
@@ -263,20 +259,6 @@ public class ServerCallImplTest {
     streamListener.messageRead(method.streamRequest(1234L));
 
     verify(callListener).onMessage(1234L);
-  }
-
-  @Test
-  public void streamListener_messageRead_unaryFailsOnMultiple() {
-    ServerStreamListenerImpl<Long> streamListener =
-        new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
-    streamListener.messageRead(method.streamRequest(1234L));
-    streamListener.messageRead(method.streamRequest(1234L));
-
-    // Makes sure this was only called once.
-    verify(callListener).onMessage(1234L);
-
-    verify(stream).close(statusCaptor.capture(), Mockito.isA(Metadata.class));
-    assertEquals(Status.Code.INTERNAL, statusCaptor.getValue().getCode());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -241,16 +241,16 @@ public class ServerCallImplTest {
   }
 
   @Test
-  public void sendMessage_serverSendsOne_okFailsOnMissingResponse_unary() {
-    sendMessage_serverSendsOne_okFailsOnMissingResponse(UNARY_METHOD);
+  public void serverSendsOne_okFailsOnMissingResponse_unary() {
+    serverSendsOne_okFailsOnMissingResponse(UNARY_METHOD);
   }
 
   @Test
-  public void sendMessage_serverSendsOne_okFailsOnMissingResponse_clientStreaming() {
-    sendMessage_serverSendsOne_okFailsOnMissingResponse(CLIENT_STREAMING_METHOD);
+  public void serverSendsOne_okFailsOnMissingResponse_clientStreaming() {
+    serverSendsOne_okFailsOnMissingResponse(CLIENT_STREAMING_METHOD);
   }
 
-  private void sendMessage_serverSendsOne_okFailsOnMissingResponse(
+  private void serverSendsOne_okFailsOnMissingResponse(
       MethodDescriptor<Long, Long> method) {
     ServerCallImpl<Long, Long> serverCall = new ServerCallImpl<Long, Long>(
         stream,
@@ -269,7 +269,7 @@ public class ServerCallImplTest {
   }
 
   @Test
-  public void sendMessage_serverSendsOne_canErrorWithoutResponse() {
+  public void serverSendsOne_canErrorWithoutResponse() {
     final String description = "test description";
     final Status status = Status.RESOURCE_EXHAUSTED.withDescription(description);
     final Metadata metadata = new Metadata();

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -23,7 +23,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +50,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -59,12 +63,21 @@ public class ServerCallImplTest {
   private ServerCallImpl<Long, Long> call;
   private Context.CancellableContext context;
 
-  private final MethodDescriptor<Long, Long> method = MethodDescriptor.<Long, Long>newBuilder()
-      .setType(MethodType.UNARY)
-      .setFullMethodName("/service/method")
-      .setRequestMarshaller(new LongMarshaller())
-      .setResponseMarshaller(new LongMarshaller())
-      .build();
+  private static final MethodDescriptor<Long, Long> UNARY_METHOD =
+      MethodDescriptor.<Long, Long>newBuilder()
+          .setType(MethodType.UNARY)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new LongMarshaller())
+          .setResponseMarshaller(new LongMarshaller())
+          .build();
+
+  private static final MethodDescriptor<Long, Long> CLIENT_STREAMING_METHOD =
+      MethodDescriptor.<Long, Long>newBuilder()
+          .setType(MethodType.UNARY)
+          .setFullMethodName("/service/method")
+          .setRequestMarshaller(new LongMarshaller())
+          .setResponseMarshaller(new LongMarshaller())
+          .build();
 
   private final Metadata requestHeaders = new Metadata();
 
@@ -72,7 +85,7 @@ public class ServerCallImplTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     context = Context.ROOT.withCancellation();
-    call = new ServerCallImpl<Long, Long>(stream, method, requestHeaders, context,
+    call = new ServerCallImpl<Long, Long>(stream, UNARY_METHOD, requestHeaders, context,
         DecompressorRegistry.getDefaultInstance(), CompressorRegistry.getDefaultInstance());
   }
 
@@ -152,6 +165,116 @@ public class ServerCallImplTest {
     }
 
     verify(stream).close(isA(Status.class), isA(Metadata.class));
+  }
+
+  @Test
+  public void sendMessage_serverSendsOne_closeOnSecondCall_unary() {
+    sendMessage_serverSendsOne_closeOnSecondCall(UNARY_METHOD);
+  }
+
+  @Test
+  public void sendMessage_serverSendsOne_closeOnSecondCall_clientStreaming() {
+    sendMessage_serverSendsOne_closeOnSecondCall(CLIENT_STREAMING_METHOD);
+  }
+
+  private void sendMessage_serverSendsOne_closeOnSecondCall(
+      MethodDescriptor<Long, Long> method) {
+    ServerCallImpl<Long, Long> serverCall = new ServerCallImpl<Long, Long>(
+        stream,
+        method,
+        requestHeaders,
+        context,
+        DecompressorRegistry.getDefaultInstance(),
+        CompressorRegistry.getDefaultInstance());
+    serverCall.sendHeaders(new Metadata());
+    serverCall.sendMessage(1L);
+    verify(stream, times(1)).writeMessage(any(InputStream.class));
+    verify(stream, never()).close(any(Status.class), any(Metadata.class));
+
+    // trying to send a second message causes gRPC to close the underlying stream
+    serverCall.sendMessage(1L);
+    verify(stream, times(1)).writeMessage(any(InputStream.class));
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+    ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass(Metadata.class);
+    verify(stream, times(1)).close(statusCaptor.capture(), metadataCaptor.capture());
+    assertEquals(Status.Code.INTERNAL, statusCaptor.getValue().getCode());
+    assertEquals(ServerCallImpl.TOO_MANY_RESPONSES, statusCaptor.getValue().getDescription());
+    assertTrue(metadataCaptor.getValue().keys().isEmpty());
+  }
+
+  @Test
+  public void sendMessage_serverSendsOne_closeOnSecondCall_appRunToCompletion_unary() {
+    sendMessage_serverSendsOne_closeOnSecondCall_appRunToCompletion(UNARY_METHOD);
+  }
+
+  @Test
+  public void sendMessage_serverSendsOne_closeOnSecondCall_appRunToCompletion_clientStreaming() {
+    sendMessage_serverSendsOne_closeOnSecondCall_appRunToCompletion(CLIENT_STREAMING_METHOD);
+  }
+
+  private void sendMessage_serverSendsOne_closeOnSecondCall_appRunToCompletion(
+      MethodDescriptor<Long, Long> method) {
+    ServerCallImpl<Long, Long> serverCall = new ServerCallImpl<Long, Long>(
+        stream,
+        method,
+        requestHeaders,
+        context,
+        DecompressorRegistry.getDefaultInstance(),
+        CompressorRegistry.getDefaultInstance());
+    serverCall.sendHeaders(new Metadata());
+    serverCall.sendMessage(1L);
+    serverCall.sendMessage(1L);
+    verify(stream, times(1)).writeMessage(any(InputStream.class));
+    verify(stream, times(1)).close(any(Status.class), any(Metadata.class));
+
+    // App runs to completion but everything is ignored
+    serverCall.sendMessage(1L);
+    verify(stream, times(1)).writeMessage(any(InputStream.class));
+    serverCall.close(Status.OK, new Metadata());
+    verify(stream, times(1)).close(any(Status.class), any(Metadata.class));
+    try {
+      serverCall.close(Status.OK, new Metadata());
+      fail("calling a second time should still cause an error");
+    } catch (IllegalStateException expected) {
+      // noop
+    }
+  }
+
+  @Test
+  public void sendMessage_serverSendsOne_okFailsOnMissingResponse_unary() {
+    sendMessage_serverSendsOne_okFailsOnMissingResponse(UNARY_METHOD);
+  }
+
+  @Test
+  public void sendMessage_serverSendsOne_okFailsOnMissingResponse_clientStreaming() {
+    sendMessage_serverSendsOne_okFailsOnMissingResponse(CLIENT_STREAMING_METHOD);
+  }
+
+  private void sendMessage_serverSendsOne_okFailsOnMissingResponse(
+      MethodDescriptor<Long, Long> method) {
+    ServerCallImpl<Long, Long> serverCall = new ServerCallImpl<Long, Long>(
+        stream,
+        method,
+        requestHeaders,
+        context,
+        DecompressorRegistry.getDefaultInstance(),
+        CompressorRegistry.getDefaultInstance());
+    serverCall.close(Status.OK, new Metadata());
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+    ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass(Metadata.class);
+    verify(stream, times(1)).close(statusCaptor.capture(), metadataCaptor.capture());
+    assertEquals(Status.Code.INTERNAL, statusCaptor.getValue().getCode());
+    assertEquals(ServerCallImpl.MISSING_RESPONSE, statusCaptor.getValue().getDescription());
+    assertTrue(metadataCaptor.getValue().keys().isEmpty());
+  }
+
+  @Test
+  public void sendMessage_serverSendsOne_canErrorWithoutResponse() {
+    final String description = "test description";
+    final Status status = Status.RESOURCE_EXHAUSTED.withDescription(description);
+    final Metadata metadata = new Metadata();
+    call.close(status, metadata);
+    verify(stream, times(1)).close(same(status), same(metadata));
   }
 
   @Test
@@ -256,7 +379,7 @@ public class ServerCallImplTest {
   public void streamListener_messageRead() {
     ServerStreamListenerImpl<Long> streamListener =
         new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
-    streamListener.messageRead(method.streamRequest(1234L));
+    streamListener.messageRead(UNARY_METHOD.streamRequest(1234L));
 
     verify(callListener).onMessage(1234L);
   }
@@ -265,11 +388,11 @@ public class ServerCallImplTest {
   public void streamListener_messageRead_onlyOnce() {
     ServerStreamListenerImpl<Long> streamListener =
         new ServerCallImpl.ServerStreamListenerImpl<Long>(call, callListener, context);
-    streamListener.messageRead(method.streamRequest(1234L));
+    streamListener.messageRead(UNARY_METHOD.streamRequest(1234L));
     // canceling the call should short circuit future halfClosed() calls.
     streamListener.closed(Status.CANCELLED);
 
-    streamListener.messageRead(method.streamRequest(1234L));
+    streamListener.messageRead(UNARY_METHOD.streamRequest(1234L));
 
     verify(callListener).onMessage(1234L);
   }
@@ -282,7 +405,7 @@ public class ServerCallImplTest {
         .when(callListener)
         .onMessage(any(Long.class));
 
-    InputStream inputStream = method.streamRequest(1234L);
+    InputStream inputStream = UNARY_METHOD.streamRequest(1234L);
 
     thrown.expect(RuntimeException.class);
     thrown.expectMessage("unexpected exception");

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -229,9 +229,7 @@ public class ServerCallImplTest {
 
     // App runs to completion but everything is ignored
     serverCall.sendMessage(1L);
-    verify(stream, times(1)).writeMessage(any(InputStream.class));
     serverCall.close(Status.OK, new Metadata());
-    verify(stream, times(1)).close(any(Status.class), any(Metadata.class));
     try {
       serverCall.close(Status.OK, new Metadata());
       fail("calling a second time should still cause an error");

--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
@@ -304,52 +304,6 @@ public class RouteGuideClientTest {
    * Example for testing async client-streaming.
    */
   @Test
-  public void recordRoute_wrongResponse() throws Exception {
-    client.setRandom(noRandomness);
-    Point point1 = Point.newBuilder().setLatitude(1).setLongitude(1).build();
-    final Feature requestFeature1 =
-        Feature.newBuilder().setLocation(point1).build();
-    final List<Feature> features = Arrays.asList(requestFeature1);
-
-    // implement the fake service
-    RouteGuideImplBase recordRouteImpl =
-        new RouteGuideImplBase() {
-          @Override
-          public StreamObserver<Point> recordRoute(StreamObserver<RouteSummary> responseObserver) {
-            RouteSummary response = RouteSummary.getDefaultInstance();
-            // sending more than one responses is not right for client-streaming call.
-            responseObserver.onNext(response);
-            responseObserver.onNext(response);
-            responseObserver.onCompleted();
-
-            return new StreamObserver<Point>() {
-              @Override
-              public void onNext(Point value) {
-              }
-
-              @Override
-              public void onError(Throwable t) {
-              }
-
-              @Override
-              public void onCompleted() {
-              }
-            };
-          }
-        };
-    serviceRegistry.addService(recordRouteImpl);
-
-    client.recordRoute(features, 4);
-
-    ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
-    verify(testHelper).onRpcError(errorCaptor.capture());
-    assertEquals(Status.Code.CANCELLED, Status.fromThrowable(errorCaptor.getValue()).getCode());
-  }
-
-  /**
-   * Example for testing async client-streaming.
-   */
-  @Test
   public void recordRoute_serverError() throws Exception {
     client.setRandom(noRandomness);
     Point point1 = Point.newBuilder().setLatitude(1).setLongitude(1).build();

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -261,7 +261,6 @@ public final class ServerCalls {
     private boolean sentHeaders;
     private Runnable onReadyHandler;
     private Runnable onCancelHandler;
-    private boolean sentResponse = false;
 
     ServerCallStreamObserverImpl(ServerCall<ReqT, RespT> call) {
       this.call = call;
@@ -291,7 +290,6 @@ public final class ServerCalls {
         sentHeaders = true;
       }
       call.sendMessage(response);
-      sentResponse = true;
     }
 
     @Override


### PR DESCRIPTION
The current check in ServerCallImpl is theoretically unsafe (#3059). Move that check into the stub, and expand the unit tests to cover other interesting edge cases on the server side:
- client sends one, but zero requests received at onHalfClose
- client sends one, but > 1 requests received at onHalfClose
- server sends one, but zero responses sent at onComplete
- server sends one, but > 1 responses sent via onNext

fixes #2243 
fixes #3059 