### PR TITLE
context: add Context.Builder.

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -348,6 +348,14 @@ public class Context {
   }
 
   /**
+   * Create a builder which builds contexts that cascade cancellation from their parent, which is
+   * this context.
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
    * Create a new context which propagates the values of this context but does not cascade its
    * cancellation.
    */
@@ -856,6 +864,38 @@ public class Context {
     @Override
     public String toString() {
       return name;
+    }
+  }
+
+  /**
+   * Builds a context with arbitrary number of values.
+   */
+  public static final class Builder {
+    private final Context parent;
+    private final ArrayList<Object[]> values = new ArrayList<Object[]>();
+
+    private Builder(Context parent) {
+      this.parent = checkNotNull(parent, "parent");
+    }
+
+    /**
+     * Adds a value.
+     *
+     * <p>Like {@code withValues()} on the {@link Context}, the builder doesn't check duplicate
+     * keys. The outcome of duplicate keys given the same builder is unspecified.
+     *
+     * @return this builder
+     */
+    public <K,V> Builder withValue(Key<V> k, V v) {
+      values.add(new Object[]{k, v});
+      return this;
+    }
+
+    /**
+     * Builds a new context.
+     */
+    public Context build() {
+      return new Context(parent, values.toArray(new Object[values.size()][]));
     }
   }
 

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -882,11 +882,11 @@ public class Context {
      * Adds a value.
      *
      * <p>Like {@code withValues()} on the {@link Context}, the builder doesn't check duplicate
-     * keys. The outcome of duplicate keys given the same builder is unspecified.
+     * keys. The outcome of duplicate keys being added to the same builder is unspecified.
      *
      * @return this builder
      */
-    public <K,V> Builder withValue(Key<V> k, V v) {
+    public <K,V> Builder addValue(Key<V> k, V v) {
       values.add(new Object[]{k, v});
       return this;
     }

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -248,6 +248,28 @@ public class ContextTest {
   }
 
   @Test
+  public void builder() {
+    Object fav = new Object();
+    Context base = Context.current().withValues(PET, "dog", COLOR, "blue");
+    Context child = base.newBuilder()
+        .withValue(PET, "cat")
+        .withValue(FOOD, "cheese")
+        .withValue(FAVORITE, fav)
+        .withValue(LUCKY, 7)
+        .build();
+
+    child.attach();
+
+    assertEquals("cat", PET.get());
+    assertEquals("cheese", FOOD.get());
+    assertEquals("blue", COLOR.get());
+    assertEquals(fav, FAVORITE.get());
+    assertEquals(7, (int) LUCKY.get());
+
+    base.attach();
+  }
+
+  @Test
   public void cancelReturnsFalseIfAlreadyCancelled() {
     Context.CancellableContext base = Context.current().withCancellation();
     assertTrue(base.cancel(null));

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -252,10 +252,10 @@ public class ContextTest {
     Object fav = new Object();
     Context base = Context.current().withValues(PET, "dog", COLOR, "blue");
     Context child = base.newBuilder()
-        .withValue(PET, "cat")
-        .withValue(FOOD, "cheese")
-        .withValue(FAVORITE, fav)
-        .withValue(LUCKY, 7)
+        .addValue(PET, "cat")
+        .addValue(FOOD, "cheese")
+        .addValue(FAVORITE, fav)
+        .addValue(LUCKY, 7)
         .build();
 
     child.attach();


### PR DESCRIPTION
Context.withValues() are useful only if the set of keys are known
upfront.  There are cases where the keys are only known at runtime.  A
builder pattern can prevent excessive creation and chaining of Contexts
in such cases.