### PR TITLE
core: Mark NameResolverProvider experimental and clarify docs

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -159,10 +159,14 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T usePlaintext(boolean skipNegotiation);
 
   /**
-   * Provides a custom {@link NameResolver.Factory} for the channel.
+   * Provides a custom {@link NameResolver.Factory} for the channel. If this method is not called,
+   * the builder will try the providers listed by {@link NameResolverProvider#providers()} for the
+   * given target.
    *
-   * <p>If this method is not called, the builder will try the providers listed by {@link
-   * NameResolverProvider#providers()} for the given target.
+   * <p>This method should rarely be used, as name resolvers should provide a {@code
+   * NameResolverProvider} and users rely on service loading to find implementations in the class
+   * path. That allows application's configuration to easily choose the name resolver via the
+   * 'target' string passed to {@link ManagedChannelBuilder#forTarget(String)}.
    *
    * @return this
    * @since 1.0.0

--- a/core/src/main/java/io/grpc/NameResolverProvider.java
+++ b/core/src/main/java/io/grpc/NameResolverProvider.java
@@ -33,7 +33,7 @@ import java.util.ServiceLoader;
  * exceptions may reasonably occur for implementation-specific reasons, implementations should
  * generally handle the exception gracefully and return {@code false} from {@link #isAvailable()}.
  */
-@Internal
+@ExperimentalApi
 public abstract class NameResolverProvider extends NameResolver.Factory {
   /**
    * The port number used in case the target or the underlying naming system doesn't provide a


### PR DESCRIPTION
We don't want people to be desensitized to the Internal annotation.
NameResolverProvider should have probably been ExperimentalApi from the
start, but it was copied from ManagedChannelProvider.

Theoretically, ManagedChannelProvider could be marked ExperimentalApi as
well, but there are no known use cases for doing so since making an
alternative ManagedChannel implementation is quite difficuilt and we
aren't aware of anybody interested in doing so. That isn't the case for
NameResolverProvider; NameResolverProvider is core to 'targets' being
useful.

CC @zhangkun83 