### PR TITLE
android-interop-testing: instrumented interop tests

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -11,6 +11,7 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         debug {
@@ -55,14 +56,19 @@ protobuf {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:support-annotations:23.1.1'
     compile 'com.google.android.gms:play-services-base:7.3.0'
-    // You need to build grpc-java to obtain these libraries below.
+    // You need to build grpc-java to obtain the grpc libraries below.
     compile 'io.grpc:grpc-protobuf-nano:1.5.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     compile 'io.grpc:grpc-okhttp:1.5.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     compile 'io.grpc:grpc-stub:1.5.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     compile 'io.grpc:grpc-testing:1.5.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     compile 'javax.annotation:javax.annotation-api:1.2'
+    compile 'junit:junit:4.12'
+
+    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile 'com.android.support.test:runner:0.5'
 }
 
 gradle.projectsEvaluated {

--- a/android-interop-testing/app/proguard-rules.pro
+++ b/android-interop-testing/app/proguard-rules.pro
@@ -13,6 +13,7 @@
 -dontwarn com.google.common.**
 -dontwarn javax.naming.**
 -dontwarn okio.**
+-dontwarn org.junit.**
 -dontwarn org.mockito.**
 -dontwarn sun.reflect.**
 # Ignores: can't find referenced class javax.lang.model.element.Modifier

--- a/android-interop-testing/app/src/androidTest/java/io/grpc/android/integrationtest/InteropTesterTest.java
+++ b/android-interop-testing/app/src/androidTest/java/io/grpc/android/integrationtest/InteropTesterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.android.integrationtest;
+
+import static junit.framework.Assert.assertTrue;
+
+import android.support.test.runner.AndroidJUnit4;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class InteropTesterTest {
+  private final int TIMEOUT_SECONDS = 120;
+
+  @Test
+  public void interopTests() throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicBoolean passed = new AtomicBoolean(false);
+    new InteropTester(
+            "all",
+            TesterOkHttpChannelBuilder.build(
+                "grpc-test.sandbox.googleapis.com", 443, null, true, null, null),
+            new InteropTester.TestListener() {
+              @Override
+              public void onPreTest() {}
+
+              @Override
+              public void onPostTest(String result) {
+                if (result.equals(InteropTester.SUCCESS_MESSAGE)) {
+                  passed.set(true);
+                }
+                latch.countDown();
+              }
+            },
+            false)
+        .execute();
+    assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    assertTrue(passed.get());
+  }
+}

--- a/android-interop-testing/app/src/androidTest/java/io/grpc/android/integrationtest/InteropTesterTest.java
+++ b/android-interop-testing/app/src/androidTest/java/io/grpc/android/integrationtest/InteropTesterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, gRPC Authors All rights reserved.
+ * Copyright 2017, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,11 @@
 
 package io.grpc.android.integrationtest;
 
-import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertEquals;
 
 import android.support.test.runner.AndroidJUnit4;
-import java.util.concurrent.CountDownLatch;
+import com.google.common.util.concurrent.SettableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,8 +30,7 @@ public class InteropTesterTest {
 
   @Test
   public void interopTests() throws Exception {
-    final CountDownLatch latch = new CountDownLatch(1);
-    final AtomicBoolean passed = new AtomicBoolean(false);
+    final SettableFuture<String> resultFuture = SettableFuture.create();
     new InteropTester(
             "all",
             TesterOkHttpChannelBuilder.build(
@@ -43,15 +41,12 @@ public class InteropTesterTest {
 
               @Override
               public void onPostTest(String result) {
-                if (result.equals(InteropTester.SUCCESS_MESSAGE)) {
-                  passed.set(true);
-                }
-                latch.countDown();
+                resultFuture.set(result);
               }
             },
             false)
         .execute();
-    assertTrue(latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
-    assertTrue(passed.get());
+    String result = resultFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    assertEquals(result, InteropTester.SUCCESS_MESSAGE);
   }
 }


### PR DESCRIPTION
This adds an instrumented test which runs the Android interops against our deployed test server. This will be used in Firebase test lab to get tests running on Android emulators and/or devices.