### PR TITLE
Introduce MethodDescriptorSupplier

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -270,8 +270,10 @@ public final class BenchmarkServiceGrpc {
     }
   }
 
-  private static class BenchmarkServiceFileDescriptorSupplier
+  private static abstract class BenchmarkServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    BenchmarkServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.benchmarks.proto.Services.getDescriptor();
@@ -283,12 +285,17 @@ public final class BenchmarkServiceGrpc {
     }
   }
 
+  private static final class BenchmarkServiceFileDescriptorSupplier
+      extends BenchmarkServiceBaseDescriptorSupplier {
+    BenchmarkServiceFileDescriptorSupplier() {}
+  }
+
   private static final class BenchmarkServiceMethodDescriptorSupplier
-      extends BenchmarkServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends BenchmarkServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private BenchmarkServiceMethodDescriptorSupplier(String methodName) {
+    BenchmarkServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -270,7 +270,8 @@ public final class BenchmarkServiceGrpc {
     }
   }
 
-  private static class BenchmarkServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class BenchmarkServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.benchmarks.proto.Services.getDescriptor();
@@ -282,10 +283,12 @@ public final class BenchmarkServiceGrpc {
     }
   }
 
-  private static final class BenchmarkServiceMethodDescriptorSupplier extends BenchmarkServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class BenchmarkServiceMethodDescriptorSupplier
+      extends BenchmarkServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public BenchmarkServiceMethodDescriptorSupplier(String methodName) {
+    private BenchmarkServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -38,6 +38,7 @@ public final class BenchmarkServiceGrpc {
               io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("UnaryCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
@@ -50,6 +51,7 @@ public final class BenchmarkServiceGrpc {
               io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("StreamingCall"))
           .build();
 
   /**
@@ -268,10 +270,28 @@ public final class BenchmarkServiceGrpc {
     }
   }
 
-  private static final class BenchmarkServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class BenchmarkServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.benchmarks.proto.Services.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("BenchmarkService");
+    }
+  }
+
+  private static final class BenchmarkServiceMethodDescriptorSupplier extends BenchmarkServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public BenchmarkServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -284,7 +304,7 @@ public final class BenchmarkServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new BenchmarkServiceDescriptorSupplier())
+              .setSchemaDescriptor(new BenchmarkServiceFileDescriptorSupplier())
               .addMethod(METHOD_UNARY_CALL)
               .addMethod(METHOD_STREAMING_CALL)
               .build();

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -396,8 +396,10 @@ public final class WorkerServiceGrpc {
     }
   }
 
-  private static class WorkerServiceFileDescriptorSupplier
+  private static abstract class WorkerServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    WorkerServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.benchmarks.proto.Services.getDescriptor();
@@ -409,12 +411,17 @@ public final class WorkerServiceGrpc {
     }
   }
 
+  private static final class WorkerServiceFileDescriptorSupplier
+      extends WorkerServiceBaseDescriptorSupplier {
+    WorkerServiceFileDescriptorSupplier() {}
+  }
+
   private static final class WorkerServiceMethodDescriptorSupplier
-      extends WorkerServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends WorkerServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private WorkerServiceMethodDescriptorSupplier(String methodName) {
+    WorkerServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -38,6 +38,7 @@ public final class WorkerServiceGrpc {
               io.grpc.benchmarks.proto.Control.ServerArgs.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Control.ServerStatus.getDefaultInstance()))
+          .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("RunServer"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs,
@@ -50,6 +51,7 @@ public final class WorkerServiceGrpc {
               io.grpc.benchmarks.proto.Control.ClientArgs.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Control.ClientStatus.getDefaultInstance()))
+          .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("RunClient"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest,
@@ -62,6 +64,7 @@ public final class WorkerServiceGrpc {
               io.grpc.benchmarks.proto.Control.CoreRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Control.CoreResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("CoreCount"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void,
@@ -74,6 +77,7 @@ public final class WorkerServiceGrpc {
               io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
+          .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("QuitWorker"))
           .build();
 
   /**
@@ -392,10 +396,28 @@ public final class WorkerServiceGrpc {
     }
   }
 
-  private static final class WorkerServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class WorkerServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.benchmarks.proto.Services.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("WorkerService");
+    }
+  }
+
+  private static final class WorkerServiceMethodDescriptorSupplier extends WorkerServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public WorkerServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -408,7 +430,7 @@ public final class WorkerServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new WorkerServiceDescriptorSupplier())
+              .setSchemaDescriptor(new WorkerServiceFileDescriptorSupplier())
               .addMethod(METHOD_RUN_SERVER)
               .addMethod(METHOD_RUN_CLIENT)
               .addMethod(METHOD_CORE_COUNT)

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -396,7 +396,8 @@ public final class WorkerServiceGrpc {
     }
   }
 
-  private static class WorkerServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class WorkerServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.benchmarks.proto.Services.getDescriptor();
@@ -408,10 +409,12 @@ public final class WorkerServiceGrpc {
     }
   }
 
-  private static final class WorkerServiceMethodDescriptorSupplier extends WorkerServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class WorkerServiceMethodDescriptorSupplier
+      extends WorkerServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public WorkerServiceMethodDescriptorSupplier(String methodName) {
+    private WorkerServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -903,59 +903,46 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
 
 
   if (flavor == ProtoFlavor::NORMAL) {
+    (*vars)["proto_base_descriptor_supplier"] = service->name() + "BaseDescriptorSupplier";
     (*vars)["proto_file_descriptor_supplier"] = service->name() + "FileDescriptorSupplier";
     (*vars)["proto_method_descriptor_supplier"] = service->name() + "MethodDescriptorSupplier";
     (*vars)["proto_class_name"] = google::protobuf::compiler::java::ClassName(service->file());
     p->Print(
         *vars,
-        "private static class $proto_file_descriptor_supplier$\n"
-        "    implements $ProtoFileDescriptorSupplier$, $ProtoServiceDescriptorSupplier$ {\n");
-    p->Indent();
-    p->Print(*vars, "@$Override$\n");
-    p->Print(
-        *vars,
-        "public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {\n");
-    p->Indent();
-    p->Print(*vars, "return $proto_class_name$.getDescriptor();\n");
-    p->Outdent();
-    p->Print(*vars, "}\n\n");
-
-    p->Print(*vars, "@$Override$\n");
-    p->Print(
-        *vars,
-        "public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {\n");
-    p->Indent();
-    p->Print(*vars, "return getFileDescriptor().findServiceByName(\"$service_name$\");\n");
-    p->Outdent();
-    p->Print(*vars, "}\n");
-
-    p->Outdent();
-    p->Print(*vars, "}\n\n");
-
-    p->Print(
-        *vars,
+        "private static abstract class $proto_base_descriptor_supplier$\n"
+        "    implements $ProtoFileDescriptorSupplier$, $ProtoServiceDescriptorSupplier$ {\n"
+        "  $proto_base_descriptor_supplier$() {}\n"
+        "\n"
+        "  @$Override$\n"
+        "  public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {\n"
+        "    return $proto_class_name$.getDescriptor();\n"
+        "  }\n"
+        "\n"
+        "  @$Override$\n"
+        "  public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {\n"
+        "    return getFileDescriptor().findServiceByName(\"$service_name$\");\n"
+        "  }\n"
+        "}\n"
+        "\n"
+        "private static final class $proto_file_descriptor_supplier$\n"
+        "    extends $proto_base_descriptor_supplier$ {\n"
+        "  $proto_file_descriptor_supplier$() {}\n"
+        "}\n"
+        "\n"
         "private static final class $proto_method_descriptor_supplier$\n"
-        "    extends $proto_file_descriptor_supplier$\n"
-        "      implements $ProtoMethodDescriptorSupplier$ {\n");
-    p->Indent();
-    p->Print(*vars, "private final String methodName;\n\n");
-    p->Print(*vars, "private $proto_method_descriptor_supplier$(String methodName) {\n");
-    p->Indent();
-    p->Print(*vars, "this.methodName = methodName;\n");
-    p->Outdent();
-    p->Print(*vars, "}\n\n");
-
-    p->Print(*vars, "@$Override$\n");
-    p->Print(
-        *vars,
-        "public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {\n");
-    p->Indent();
-    p->Print(*vars, "return getServiceDescriptor().findMethodByName(methodName);\n");
-    p->Outdent();
-    p->Print(*vars, "}\n");
-
-    p->Outdent();
-    p->Print(*vars, "}\n\n");
+        "    extends $proto_base_descriptor_supplier$\n"
+        "    implements $ProtoMethodDescriptorSupplier$ {\n"
+        "  private final String methodName;\n"
+        "\n"
+        "  $proto_method_descriptor_supplier$(String methodName) {\n"
+        "    this.methodName = methodName;\n"
+        "  }\n"
+        "\n"
+        "  @$Override$\n"
+        "  public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {\n"
+        "    return getServiceDescriptor().findMethodByName(methodName);\n"
+        "  }\n"
+        "}\n\n");
   }
 
   p->Print(

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -367,7 +367,17 @@ static void PrintMethodFields(
           "        .setRequestMarshaller($ProtoUtils$.marshaller(\n"
           "            $input_type$.getDefaultInstance()))\n"
           "        .setResponseMarshaller($ProtoUtils$.marshaller(\n"
-          "            $output_type$.getDefaultInstance()))\n"
+          "            $output_type$.getDefaultInstance()))\n");
+
+      (*vars)["proto_method_descriptor_supplier"] = service->name() + "MethodDescriptorSupplier";
+      if (flavor == ProtoFlavor::NORMAL) {
+        p->Print(
+            *vars,
+          "        .setSchemaDescriptor(new $proto_method_descriptor_supplier$(\"$method_name$\"))\n");
+      }
+
+      p->Print(
+          *vars,
           "        .build();\n");
     }
   }
@@ -893,11 +903,12 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
 
 
   if (flavor == ProtoFlavor::NORMAL) {
-    (*vars)["proto_descriptor_supplier"] = service->name() + "DescriptorSupplier";
+    (*vars)["proto_file_descriptor_supplier"] = service->name() + "FileDescriptorSupplier";
+    (*vars)["proto_method_descriptor_supplier"] = service->name() + "MethodDescriptorSupplier";
     (*vars)["proto_class_name"] = google::protobuf::compiler::java::ClassName(service->file());
     p->Print(
         *vars,
-        "private static final class $proto_descriptor_supplier$ implements $ProtoFileDescriptorSupplier$ {\n");
+        "private static class $proto_file_descriptor_supplier$ implements $ProtoFileDescriptorSupplier$, $ProtoServiceDescriptorSupplier$ {\n");
     p->Indent();
     p->Print(*vars, "@$Override$\n");
     p->Print(
@@ -906,7 +917,40 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
     p->Indent();
     p->Print(*vars, "return $proto_class_name$.getDescriptor();\n");
     p->Outdent();
+    p->Print(*vars, "}\n\n");
+
+    p->Print(*vars, "@$Override$\n");
+    p->Print(
+        *vars,
+        "public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {\n");
+    p->Indent();
+    p->Print(*vars, "return getFileDescriptor().findServiceByName(\"$service_name$\");\n");
+    p->Outdent();
     p->Print(*vars, "}\n");
+
+    p->Outdent();
+    p->Print(*vars, "}\n\n");
+
+    p->Print(
+        *vars,
+        "private static final class $proto_method_descriptor_supplier$ extends $proto_file_descriptor_supplier$ implements $ProtoMethodDescriptorSupplier$ {\n");
+    p->Indent();
+    p->Print(*vars, "private final String methodName;\n\n");
+    p->Print(*vars, "public $proto_method_descriptor_supplier$(String methodName) {\n");
+    p->Indent();
+    p->Print(*vars, "this.methodName = methodName;\n");
+    p->Outdent();
+    p->Print(*vars, "}\n\n");
+
+    p->Print(*vars, "@$Override$\n");
+    p->Print(
+        *vars,
+        "public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {\n");
+    p->Indent();
+    p->Print(*vars, "return getServiceDescriptor().findMethodByName(methodName);\n");
+    p->Outdent();
+    p->Print(*vars, "}\n");
+
     p->Outdent();
     p->Print(*vars, "}\n\n");
   }
@@ -940,7 +984,7 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
   if (flavor == ProtoFlavor::NORMAL) {
     p->Print(
         *vars,
-        "\n.setSchemaDescriptor(new $proto_descriptor_supplier$())");
+        "\n.setSchemaDescriptor(new $proto_file_descriptor_supplier$())");
   }
   for (int i = 0; i < service->method_count(); ++i) {
     const MethodDescriptor* method = service->method(i);
@@ -1187,6 +1231,10 @@ void GenerateService(const ServiceDescriptor* service,
       "io.grpc.ServiceDescriptor";
   vars["ProtoFileDescriptorSupplier"] =
       "io.grpc.protobuf.ProtoFileDescriptorSupplier";
+  vars["ProtoServiceDescriptorSupplier"] =
+      "io.grpc.protobuf.ProtoServiceDescriptorSupplier";
+  vars["ProtoMethodDescriptorSupplier"] =
+      "io.grpc.protobuf.ProtoMethodDescriptorSupplier";
   vars["AbstractStub"] = "io.grpc.stub.AbstractStub";
   vars["MethodDescriptor"] = "io.grpc.MethodDescriptor";
   vars["NanoUtils"] = "io.grpc.protobuf.nano.NanoUtils";

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -908,7 +908,8 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
     (*vars)["proto_class_name"] = google::protobuf::compiler::java::ClassName(service->file());
     p->Print(
         *vars,
-        "private static class $proto_file_descriptor_supplier$ implements $ProtoFileDescriptorSupplier$, $ProtoServiceDescriptorSupplier$ {\n");
+        "private static class $proto_file_descriptor_supplier$\n"
+        "    implements $ProtoFileDescriptorSupplier$, $ProtoServiceDescriptorSupplier$ {\n");
     p->Indent();
     p->Print(*vars, "@$Override$\n");
     p->Print(
@@ -933,10 +934,12 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
 
     p->Print(
         *vars,
-        "private static final class $proto_method_descriptor_supplier$ extends $proto_file_descriptor_supplier$ implements $ProtoMethodDescriptorSupplier$ {\n");
+        "private static final class $proto_method_descriptor_supplier$\n"
+        "    extends $proto_file_descriptor_supplier$\n"
+        "      implements $ProtoMethodDescriptorSupplier$ {\n");
     p->Indent();
     p->Print(*vars, "private final String methodName;\n\n");
-    p->Print(*vars, "public $proto_method_descriptor_supplier$(String methodName) {\n");
+    p->Print(*vars, "private $proto_method_descriptor_supplier$(String methodName) {\n");
     p->Indent();
     p->Print(*vars, "this.methodName = methodName;\n");
     p->Outdent();

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -445,8 +445,10 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static class TestServiceFileDescriptorSupplier
+  private static abstract class TestServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    TestServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
@@ -458,12 +460,17 @@ public final class TestServiceGrpc {
     }
   }
 
+  private static final class TestServiceFileDescriptorSupplier
+      extends TestServiceBaseDescriptorSupplier {
+    TestServiceFileDescriptorSupplier() {}
+  }
+
   private static final class TestServiceMethodDescriptorSupplier
-      extends TestServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends TestServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private TestServiceMethodDescriptorSupplier(String methodName) {
+    TestServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -41,6 +41,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.SimpleResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("UnaryCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
@@ -53,6 +54,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingOutputCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
@@ -65,6 +67,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingInputCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
@@ -77,6 +80,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("FullBidiCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
@@ -89,6 +93,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("HalfBidiCall"))
           .build();
 
   /**
@@ -440,10 +445,28 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static final class TestServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class TestServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("TestService");
+    }
+  }
+
+  private static final class TestServiceMethodDescriptorSupplier extends TestServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public TestServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -456,7 +479,7 @@ public final class TestServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new TestServiceDescriptorSupplier())
+              .setSchemaDescriptor(new TestServiceFileDescriptorSupplier())
               .addMethod(METHOD_UNARY_CALL)
               .addMethod(METHOD_STREAMING_OUTPUT_CALL)
               .addMethod(METHOD_STREAMING_INPUT_CALL)

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -445,7 +445,8 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static class TestServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class TestServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
@@ -457,10 +458,12 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static final class TestServiceMethodDescriptorSupplier extends TestServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class TestServiceMethodDescriptorSupplier
+      extends TestServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public TestServiceMethodDescriptorSupplier(String methodName) {
+    private TestServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -42,6 +42,7 @@ public final class MethodDescriptor<ReqT, RespT> {
   private final String fullMethodName;
   private final Marshaller<ReqT> requestMarshaller;
   private final Marshaller<RespT> responseMarshaller;
+  private final Object schemaDescriptor;
   private final boolean idempotent;
   private final boolean safe;
 
@@ -208,7 +209,7 @@ public final class MethodDescriptor<ReqT, RespT> {
       Marshaller<RequestT> requestMarshaller,
       Marshaller<ResponseT> responseMarshaller) {
     return new MethodDescriptor<RequestT, ResponseT>(
-        type, fullMethodName, requestMarshaller, responseMarshaller, false, false);
+        type, fullMethodName, requestMarshaller, responseMarshaller, null, false, false);
   }
 
   private MethodDescriptor(
@@ -216,6 +217,7 @@ public final class MethodDescriptor<ReqT, RespT> {
       String fullMethodName,
       Marshaller<ReqT> requestMarshaller,
       Marshaller<RespT> responseMarshaller,
+      Object schemaDescriptor,
       boolean idempotent,
       boolean safe) {
 
@@ -223,6 +225,7 @@ public final class MethodDescriptor<ReqT, RespT> {
     this.fullMethodName = Preconditions.checkNotNull(fullMethodName, "fullMethodName");
     this.requestMarshaller = Preconditions.checkNotNull(requestMarshaller, "requestMarshaller");
     this.responseMarshaller = Preconditions.checkNotNull(responseMarshaller, "responseMarshaller");
+    this.schemaDescriptor = schemaDescriptor;
     this.idempotent = idempotent;
     this.safe = safe;
     Preconditions.checkArgument(!safe || type == MethodType.UNARY,
@@ -309,6 +312,20 @@ public final class MethodDescriptor<ReqT, RespT> {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2592")
   public Marshaller<RespT> getResponseMarshaller() {
     return responseMarshaller;
+  }
+
+  /**
+   * Returns the schema descriptor for this method. A schema descriptor is an object that is not
+   * used by gRPC core but includes information related to the service method. The type of the
+   * object is specific to the consumer, so both the code setting the schema descriptor and the code
+   * calling {@link #getSchemaDescriptor()} must coordinate.  For example, protobuf generated code
+   * sets this value, in order to be consumed by the server reflection service.  See also:
+   * {@code io.grpc.protobuf.ProtoMethodDescriptorSupplier}.
+   *
+   * @since 1.5.0
+   */
+  public Object getSchemaDescriptor() {
+    return schemaDescriptor;
   }
 
   /**
@@ -425,6 +442,7 @@ public final class MethodDescriptor<ReqT, RespT> {
     private String fullMethodName;
     private boolean idempotent;
     private boolean safe;
+    private Object schemaDescriptor;
 
     private Builder() {}
 
@@ -474,6 +492,20 @@ public final class MethodDescriptor<ReqT, RespT> {
     }
 
     /**
+     * Sets the schema descriptor for this builder.  A schema descriptor is an object that is not
+     * used by gRPC core but includes information related to the methods. The type of the object
+     * is specific to the consumer, so both the code calling this and the code calling
+     * {@link MethodDescriptor#getSchemaDescriptor()} must coordinate.
+     *
+     * @param schemaDescriptor an object that describes the service structure.  Should be immutable.
+     * @since 1.5.0
+     */
+    public Builder<ReqT, RespT> setSchemaDescriptor(@Nullable Object schemaDescriptor) {
+      this.schemaDescriptor = schemaDescriptor;
+      return this;
+    }
+
+    /**
      * Sets whether the method is idempotent.  If true, calling this method more than once doesn't
      * have additional side effects.
      *
@@ -509,6 +541,7 @@ public final class MethodDescriptor<ReqT, RespT> {
           fullMethodName,
           requestMarshaller,
           responseMarshaller,
+          schemaDescriptor,
           idempotent,
           safe);
     }

--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -42,7 +42,7 @@ public final class MethodDescriptor<ReqT, RespT> {
   private final String fullMethodName;
   private final Marshaller<ReqT> requestMarshaller;
   private final Marshaller<RespT> responseMarshaller;
-  private final Object schemaDescriptor;
+  private final @Nullable Object schemaDescriptor;
   private final boolean idempotent;
   private final boolean safe;
 
@@ -324,7 +324,7 @@ public final class MethodDescriptor<ReqT, RespT> {
    *
    * @since 1.5.0
    */
-  public Object getSchemaDescriptor() {
+  public @Nullable Object getSchemaDescriptor() {
     return schemaDescriptor;
   }
 

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -197,8 +197,10 @@ public final class LoadBalancerGrpc {
     }
   }
 
-  private static class LoadBalancerFileDescriptorSupplier
+  private static abstract class LoadBalancerBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    LoadBalancerBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.grpclb.LoadBalancerProto.getDescriptor();
@@ -210,12 +212,17 @@ public final class LoadBalancerGrpc {
     }
   }
 
+  private static final class LoadBalancerFileDescriptorSupplier
+      extends LoadBalancerBaseDescriptorSupplier {
+    LoadBalancerFileDescriptorSupplier() {}
+  }
+
   private static final class LoadBalancerMethodDescriptorSupplier
-      extends LoadBalancerFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends LoadBalancerBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private LoadBalancerMethodDescriptorSupplier(String methodName) {
+    LoadBalancerMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -197,7 +197,8 @@ public final class LoadBalancerGrpc {
     }
   }
 
-  private static class LoadBalancerFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class LoadBalancerFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.grpclb.LoadBalancerProto.getDescriptor();
@@ -209,10 +210,12 @@ public final class LoadBalancerGrpc {
     }
   }
 
-  private static final class LoadBalancerMethodDescriptorSupplier extends LoadBalancerFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class LoadBalancerMethodDescriptorSupplier
+      extends LoadBalancerFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public LoadBalancerMethodDescriptorSupplier(String methodName) {
+    private LoadBalancerMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -38,6 +38,7 @@ public final class LoadBalancerGrpc {
               io.grpc.grpclb.LoadBalanceRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.grpclb.LoadBalanceResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new LoadBalancerMethodDescriptorSupplier("BalanceLoad"))
           .build();
 
   /**
@@ -196,10 +197,28 @@ public final class LoadBalancerGrpc {
     }
   }
 
-  private static final class LoadBalancerDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class LoadBalancerFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.grpclb.LoadBalancerProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("LoadBalancer");
+    }
+  }
+
+  private static final class LoadBalancerMethodDescriptorSupplier extends LoadBalancerFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public LoadBalancerMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -212,7 +231,7 @@ public final class LoadBalancerGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new LoadBalancerDescriptorSupplier())
+              .setSchemaDescriptor(new LoadBalancerFileDescriptorSupplier())
               .addMethod(METHOD_BALANCE_LOAD)
               .build();
         }

--- a/protobuf/src/main/java/io/grpc/protobuf/ProtoMethodDescriptorSupplier.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/ProtoMethodDescriptorSupplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.protobuf;
+
+import com.google.protobuf.Descriptors.MethodDescriptor;
+
+/**
+ * Provides access to the underlying proto service method descriptor.
+ */
+public interface ProtoMethodDescriptorSupplier {
+  /**
+   * Returns method descriptor to the proto service method.
+   */
+  MethodDescriptor getMethodDescriptor();
+}

--- a/protobuf/src/main/java/io/grpc/protobuf/ProtoMethodDescriptorSupplier.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/ProtoMethodDescriptorSupplier.java
@@ -17,13 +17,15 @@
 package io.grpc.protobuf;
 
 import com.google.protobuf.Descriptors.MethodDescriptor;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Provides access to the underlying proto service method descriptor.
  */
-public interface ProtoMethodDescriptorSupplier {
+public interface ProtoMethodDescriptorSupplier extends ProtoServiceDescriptorSupplier {
   /**
    * Returns method descriptor to the proto service method.
    */
+  @CheckReturnValue
   MethodDescriptor getMethodDescriptor();
 }

--- a/protobuf/src/main/java/io/grpc/protobuf/ProtoServiceDescriptorSupplier.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/ProtoServiceDescriptorSupplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.protobuf;
+
+import com.google.protobuf.Descriptors.ServiceDescriptor;
+
+/**
+ * Provides access to the underlying proto service descriptor.
+ */
+public interface ProtoServiceDescriptorSupplier extends ProtoFileDescriptorSupplier {
+  /**
+   * Returns service descriptor to the proto service.
+   */
+  ServiceDescriptor getServiceDescriptor();
+}

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -207,8 +207,10 @@ public final class HealthGrpc {
     }
   }
 
-  private static class HealthFileDescriptorSupplier
+  private static abstract class HealthBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    HealthBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.health.v1.HealthProto.getDescriptor();
@@ -220,12 +222,17 @@ public final class HealthGrpc {
     }
   }
 
+  private static final class HealthFileDescriptorSupplier
+      extends HealthBaseDescriptorSupplier {
+    HealthFileDescriptorSupplier() {}
+  }
+
   private static final class HealthMethodDescriptorSupplier
-      extends HealthFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends HealthBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private HealthMethodDescriptorSupplier(String methodName) {
+    HealthMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -38,6 +38,7 @@ public final class HealthGrpc {
               io.grpc.health.v1.HealthCheckRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.health.v1.HealthCheckResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new HealthMethodDescriptorSupplier("Check"))
           .build();
 
   /**
@@ -206,10 +207,28 @@ public final class HealthGrpc {
     }
   }
 
-  private static final class HealthDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class HealthFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.health.v1.HealthProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("Health");
+    }
+  }
+
+  private static final class HealthMethodDescriptorSupplier extends HealthFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public HealthMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -222,7 +241,7 @@ public final class HealthGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new HealthDescriptorSupplier())
+              .setSchemaDescriptor(new HealthFileDescriptorSupplier())
               .addMethod(METHOD_CHECK)
               .build();
         }

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -207,7 +207,8 @@ public final class HealthGrpc {
     }
   }
 
-  private static class HealthFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class HealthFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.health.v1.HealthProto.getDescriptor();
@@ -219,10 +220,12 @@ public final class HealthGrpc {
     }
   }
 
-  private static final class HealthMethodDescriptorSupplier extends HealthFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class HealthMethodDescriptorSupplier
+      extends HealthFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public HealthMethodDescriptorSupplier(String methodName) {
+    private HealthMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
@@ -489,8 +489,10 @@ public final class MonitoringGrpc {
     }
   }
 
-  private static class MonitoringFileDescriptorSupplier
+  private static abstract class MonitoringBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    MonitoringBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.instrumentation.v1alpha.MonitoringProto.getDescriptor();
@@ -502,12 +504,17 @@ public final class MonitoringGrpc {
     }
   }
 
+  private static final class MonitoringFileDescriptorSupplier
+      extends MonitoringBaseDescriptorSupplier {
+    MonitoringFileDescriptorSupplier() {}
+  }
+
   private static final class MonitoringMethodDescriptorSupplier
-      extends MonitoringFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends MonitoringBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private MonitoringMethodDescriptorSupplier(String methodName) {
+    MonitoringMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
@@ -38,6 +38,7 @@ public final class MonitoringGrpc {
               com.google.protobuf.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.CanonicalRpcStats.getDefaultInstance()))
+          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetCanonicalRpcStats"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
@@ -50,6 +51,7 @@ public final class MonitoringGrpc {
               io.grpc.instrumentation.v1alpha.StatsRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.StatsResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetStats"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
@@ -62,6 +64,7 @@ public final class MonitoringGrpc {
               io.grpc.instrumentation.v1alpha.StatsRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.StatsResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("WatchStats"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest,
@@ -74,6 +77,7 @@ public final class MonitoringGrpc {
               io.grpc.instrumentation.v1alpha.TraceRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.TraceResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetRequestTraces"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
@@ -86,6 +90,7 @@ public final class MonitoringGrpc {
               io.grpc.instrumentation.v1alpha.MonitoringDataGroup.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.instrumentation.v1alpha.CustomMonitoringData.getDefaultInstance()))
+          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetCustomMonitoringData"))
           .build();
 
   /**
@@ -484,10 +489,28 @@ public final class MonitoringGrpc {
     }
   }
 
-  private static final class MonitoringDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class MonitoringFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.instrumentation.v1alpha.MonitoringProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("Monitoring");
+    }
+  }
+
+  private static final class MonitoringMethodDescriptorSupplier extends MonitoringFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public MonitoringMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -500,7 +523,7 @@ public final class MonitoringGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new MonitoringDescriptorSupplier())
+              .setSchemaDescriptor(new MonitoringFileDescriptorSupplier())
               .addMethod(METHOD_GET_CANONICAL_RPC_STATS)
               .addMethod(METHOD_GET_STATS)
               .addMethod(METHOD_WATCH_STATS)

--- a/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
@@ -489,7 +489,8 @@ public final class MonitoringGrpc {
     }
   }
 
-  private static class MonitoringFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class MonitoringFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.instrumentation.v1alpha.MonitoringProto.getDescriptor();
@@ -501,10 +502,12 @@ public final class MonitoringGrpc {
     }
   }
 
-  private static final class MonitoringMethodDescriptorSupplier extends MonitoringFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class MonitoringMethodDescriptorSupplier
+      extends MonitoringFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public MonitoringMethodDescriptorSupplier(String methodName) {
+    private MonitoringMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -199,8 +199,10 @@ public final class ServerReflectionGrpc {
     }
   }
 
-  private static class ServerReflectionFileDescriptorSupplier
+  private static abstract class ServerReflectionBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    ServerReflectionBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.v1alpha.ServerReflectionProto.getDescriptor();
@@ -212,12 +214,17 @@ public final class ServerReflectionGrpc {
     }
   }
 
+  private static final class ServerReflectionFileDescriptorSupplier
+      extends ServerReflectionBaseDescriptorSupplier {
+    ServerReflectionFileDescriptorSupplier() {}
+  }
+
   private static final class ServerReflectionMethodDescriptorSupplier
-      extends ServerReflectionFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends ServerReflectionBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private ServerReflectionMethodDescriptorSupplier(String methodName) {
+    ServerReflectionMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -199,7 +199,8 @@ public final class ServerReflectionGrpc {
     }
   }
 
-  private static class ServerReflectionFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class ServerReflectionFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.v1alpha.ServerReflectionProto.getDescriptor();
@@ -211,10 +212,12 @@ public final class ServerReflectionGrpc {
     }
   }
 
-  private static final class ServerReflectionMethodDescriptorSupplier extends ServerReflectionFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class ServerReflectionMethodDescriptorSupplier
+      extends ServerReflectionFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public ServerReflectionMethodDescriptorSupplier(String methodName) {
+    private ServerReflectionMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -38,6 +38,7 @@ public final class ServerReflectionGrpc {
               io.grpc.reflection.v1alpha.ServerReflectionRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.reflection.v1alpha.ServerReflectionResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new ServerReflectionMethodDescriptorSupplier("ServerReflectionInfo"))
           .build();
 
   /**
@@ -198,10 +199,28 @@ public final class ServerReflectionGrpc {
     }
   }
 
-  private static final class ServerReflectionDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class ServerReflectionFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.v1alpha.ServerReflectionProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("ServerReflection");
+    }
+  }
+
+  private static final class ServerReflectionMethodDescriptorSupplier extends ServerReflectionFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public ServerReflectionMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -214,7 +233,7 @@ public final class ServerReflectionGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new ServerReflectionDescriptorSupplier())
+              .setSchemaDescriptor(new ServerReflectionFileDescriptorSupplier())
               .addMethod(METHOD_SERVER_REFLECTION_INFO)
               .build();
         }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -234,8 +234,10 @@ public final class AnotherDynamicServiceGrpc {
     }
   }
 
-  private static class AnotherDynamicServiceFileDescriptorSupplier
+  private static abstract class AnotherDynamicServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    AnotherDynamicServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.DynamicReflectionTestProto.getDescriptor();
@@ -247,12 +249,17 @@ public final class AnotherDynamicServiceGrpc {
     }
   }
 
+  private static final class AnotherDynamicServiceFileDescriptorSupplier
+      extends AnotherDynamicServiceBaseDescriptorSupplier {
+    AnotherDynamicServiceFileDescriptorSupplier() {}
+  }
+
   private static final class AnotherDynamicServiceMethodDescriptorSupplier
-      extends AnotherDynamicServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends AnotherDynamicServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private AnotherDynamicServiceMethodDescriptorSupplier(String methodName) {
+    AnotherDynamicServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -41,6 +41,7 @@ public final class AnotherDynamicServiceGrpc {
               io.grpc.reflection.testing.DynamicRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.reflection.testing.DynamicReply.getDefaultInstance()))
+          .setSchemaDescriptor(new AnotherDynamicServiceMethodDescriptorSupplier("Method"))
           .build();
 
   /**
@@ -233,10 +234,28 @@ public final class AnotherDynamicServiceGrpc {
     }
   }
 
-  private static final class AnotherDynamicServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class AnotherDynamicServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.DynamicReflectionTestProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("AnotherDynamicService");
+    }
+  }
+
+  private static final class AnotherDynamicServiceMethodDescriptorSupplier extends AnotherDynamicServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public AnotherDynamicServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -249,7 +268,7 @@ public final class AnotherDynamicServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new AnotherDynamicServiceDescriptorSupplier())
+              .setSchemaDescriptor(new AnotherDynamicServiceFileDescriptorSupplier())
               .addMethod(METHOD_METHOD)
               .build();
         }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -234,7 +234,8 @@ public final class AnotherDynamicServiceGrpc {
     }
   }
 
-  private static class AnotherDynamicServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class AnotherDynamicServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.DynamicReflectionTestProto.getDescriptor();
@@ -246,10 +247,12 @@ public final class AnotherDynamicServiceGrpc {
     }
   }
 
-  private static final class AnotherDynamicServiceMethodDescriptorSupplier extends AnotherDynamicServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class AnotherDynamicServiceMethodDescriptorSupplier
+      extends AnotherDynamicServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public AnotherDynamicServiceMethodDescriptorSupplier(String methodName) {
+    private AnotherDynamicServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -234,8 +234,10 @@ public final class DynamicServiceGrpc {
     }
   }
 
-  private static class DynamicServiceFileDescriptorSupplier
+  private static abstract class DynamicServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    DynamicServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.DynamicReflectionTestProto.getDescriptor();
@@ -247,12 +249,17 @@ public final class DynamicServiceGrpc {
     }
   }
 
+  private static final class DynamicServiceFileDescriptorSupplier
+      extends DynamicServiceBaseDescriptorSupplier {
+    DynamicServiceFileDescriptorSupplier() {}
+  }
+
   private static final class DynamicServiceMethodDescriptorSupplier
-      extends DynamicServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends DynamicServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private DynamicServiceMethodDescriptorSupplier(String methodName) {
+    DynamicServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -234,7 +234,8 @@ public final class DynamicServiceGrpc {
     }
   }
 
-  private static class DynamicServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class DynamicServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.DynamicReflectionTestProto.getDescriptor();
@@ -246,10 +247,12 @@ public final class DynamicServiceGrpc {
     }
   }
 
-  private static final class DynamicServiceMethodDescriptorSupplier extends DynamicServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class DynamicServiceMethodDescriptorSupplier
+      extends DynamicServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public DynamicServiceMethodDescriptorSupplier(String methodName) {
+    private DynamicServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -41,6 +41,7 @@ public final class DynamicServiceGrpc {
               io.grpc.reflection.testing.DynamicRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.reflection.testing.DynamicReply.getDefaultInstance()))
+          .setSchemaDescriptor(new DynamicServiceMethodDescriptorSupplier("Method"))
           .build();
 
   /**
@@ -233,10 +234,28 @@ public final class DynamicServiceGrpc {
     }
   }
 
-  private static final class DynamicServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class DynamicServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.DynamicReflectionTestProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("DynamicService");
+    }
+  }
+
+  private static final class DynamicServiceMethodDescriptorSupplier extends DynamicServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public DynamicServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -249,7 +268,7 @@ public final class DynamicServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new DynamicServiceDescriptorSupplier())
+              .setSchemaDescriptor(new DynamicServiceFileDescriptorSupplier())
               .addMethod(METHOD_METHOD)
               .build();
         }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -207,8 +207,10 @@ public final class ReflectableServiceGrpc {
     }
   }
 
-  private static class ReflectableServiceFileDescriptorSupplier
+  private static abstract class ReflectableServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    ReflectableServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.ReflectionTestProto.getDescriptor();
@@ -220,12 +222,17 @@ public final class ReflectableServiceGrpc {
     }
   }
 
+  private static final class ReflectableServiceFileDescriptorSupplier
+      extends ReflectableServiceBaseDescriptorSupplier {
+    ReflectableServiceFileDescriptorSupplier() {}
+  }
+
   private static final class ReflectableServiceMethodDescriptorSupplier
-      extends ReflectableServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends ReflectableServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private ReflectableServiceMethodDescriptorSupplier(String methodName) {
+    ReflectableServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -207,7 +207,8 @@ public final class ReflectableServiceGrpc {
     }
   }
 
-  private static class ReflectableServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class ReflectableServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.ReflectionTestProto.getDescriptor();
@@ -219,10 +220,12 @@ public final class ReflectableServiceGrpc {
     }
   }
 
-  private static final class ReflectableServiceMethodDescriptorSupplier extends ReflectableServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class ReflectableServiceMethodDescriptorSupplier
+      extends ReflectableServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public ReflectableServiceMethodDescriptorSupplier(String methodName) {
+    private ReflectableServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -38,6 +38,7 @@ public final class ReflectableServiceGrpc {
               io.grpc.reflection.testing.Request.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.reflection.testing.Reply.getDefaultInstance()))
+          .setSchemaDescriptor(new ReflectableServiceMethodDescriptorSupplier("Method"))
           .build();
 
   /**
@@ -206,10 +207,28 @@ public final class ReflectableServiceGrpc {
     }
   }
 
-  private static final class ReflectableServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class ReflectableServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.reflection.testing.ReflectionTestProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("ReflectableService");
+    }
+  }
+
+  private static final class ReflectableServiceMethodDescriptorSupplier extends ReflectableServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public ReflectableServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -222,7 +241,7 @@ public final class ReflectableServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new ReflectableServiceDescriptorSupplier())
+              .setSchemaDescriptor(new ReflectableServiceFileDescriptorSupplier())
               .addMethod(METHOD_METHOD)
               .build();
         }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -279,8 +279,10 @@ public final class MetricsServiceGrpc {
     }
   }
 
-  private static class MetricsServiceFileDescriptorSupplier
+  private static abstract class MetricsServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    MetricsServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Metrics.getDescriptor();
@@ -292,12 +294,17 @@ public final class MetricsServiceGrpc {
     }
   }
 
+  private static final class MetricsServiceFileDescriptorSupplier
+      extends MetricsServiceBaseDescriptorSupplier {
+    MetricsServiceFileDescriptorSupplier() {}
+  }
+
   private static final class MetricsServiceMethodDescriptorSupplier
-      extends MetricsServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends MetricsServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private MetricsServiceMethodDescriptorSupplier(String methodName) {
+    MetricsServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -279,7 +279,8 @@ public final class MetricsServiceGrpc {
     }
   }
 
-  private static class MetricsServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class MetricsServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Metrics.getDescriptor();
@@ -291,10 +292,12 @@ public final class MetricsServiceGrpc {
     }
   }
 
-  private static final class MetricsServiceMethodDescriptorSupplier extends MetricsServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class MetricsServiceMethodDescriptorSupplier
+      extends MetricsServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public MetricsServiceMethodDescriptorSupplier(String methodName) {
+    private MetricsServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -38,6 +38,7 @@ public final class MetricsServiceGrpc {
               io.grpc.testing.integration.Metrics.EmptyMessage.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new MetricsServiceMethodDescriptorSupplier("GetAllGauges"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest,
@@ -50,6 +51,7 @@ public final class MetricsServiceGrpc {
               io.grpc.testing.integration.Metrics.GaugeRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new MetricsServiceMethodDescriptorSupplier("GetGauge"))
           .build();
 
   /**
@@ -277,10 +279,28 @@ public final class MetricsServiceGrpc {
     }
   }
 
-  private static final class MetricsServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class MetricsServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Metrics.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("MetricsService");
+    }
+  }
+
+  private static final class MetricsServiceMethodDescriptorSupplier extends MetricsServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public MetricsServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -293,7 +313,7 @@ public final class MetricsServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new MetricsServiceDescriptorSupplier())
+              .setSchemaDescriptor(new MetricsServiceFileDescriptorSupplier())
               .addMethod(METHOD_GET_ALL_GAUGES)
               .addMethod(METHOD_GET_GAUGE)
               .build();

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -277,8 +277,10 @@ public final class ReconnectServiceGrpc {
     }
   }
 
-  private static class ReconnectServiceFileDescriptorSupplier
+  private static abstract class ReconnectServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    ReconnectServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
@@ -290,12 +292,17 @@ public final class ReconnectServiceGrpc {
     }
   }
 
+  private static final class ReconnectServiceFileDescriptorSupplier
+      extends ReconnectServiceBaseDescriptorSupplier {
+    ReconnectServiceFileDescriptorSupplier() {}
+  }
+
   private static final class ReconnectServiceMethodDescriptorSupplier
-      extends ReconnectServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends ReconnectServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private ReconnectServiceMethodDescriptorSupplier(String methodName) {
+    ReconnectServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -41,6 +41,7 @@ public final class ReconnectServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+          .setSchemaDescriptor(new ReconnectServiceMethodDescriptorSupplier("Start"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
@@ -53,6 +54,7 @@ public final class ReconnectServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.ReconnectInfo.getDefaultInstance()))
+          .setSchemaDescriptor(new ReconnectServiceMethodDescriptorSupplier("Stop"))
           .build();
 
   /**
@@ -275,10 +277,28 @@ public final class ReconnectServiceGrpc {
     }
   }
 
-  private static final class ReconnectServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class ReconnectServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("ReconnectService");
+    }
+  }
+
+  private static final class ReconnectServiceMethodDescriptorSupplier extends ReconnectServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public ReconnectServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -291,7 +311,7 @@ public final class ReconnectServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new ReconnectServiceDescriptorSupplier())
+              .setSchemaDescriptor(new ReconnectServiceFileDescriptorSupplier())
               .addMethod(METHOD_START)
               .addMethod(METHOD_STOP)
               .build();

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -277,7 +277,8 @@ public final class ReconnectServiceGrpc {
     }
   }
 
-  private static class ReconnectServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class ReconnectServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
@@ -289,10 +290,12 @@ public final class ReconnectServiceGrpc {
     }
   }
 
-  private static final class ReconnectServiceMethodDescriptorSupplier extends ReconnectServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class ReconnectServiceMethodDescriptorSupplier
+      extends ReconnectServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public ReconnectServiceMethodDescriptorSupplier(String methodName) {
+    private ReconnectServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -659,8 +659,10 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static class TestServiceFileDescriptorSupplier
+  private static abstract class TestServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    TestServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
@@ -672,12 +674,17 @@ public final class TestServiceGrpc {
     }
   }
 
+  private static final class TestServiceFileDescriptorSupplier
+      extends TestServiceBaseDescriptorSupplier {
+    TestServiceFileDescriptorSupplier() {}
+  }
+
   private static final class TestServiceMethodDescriptorSupplier
-      extends TestServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends TestServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private TestServiceMethodDescriptorSupplier(String methodName) {
+    TestServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -659,7 +659,8 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static class TestServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class TestServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
@@ -671,10 +672,12 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static final class TestServiceMethodDescriptorSupplier extends TestServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class TestServiceMethodDescriptorSupplier
+      extends TestServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public TestServiceMethodDescriptorSupplier(String methodName) {
+    private TestServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -42,6 +42,7 @@ public final class TestServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("EmptyCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
@@ -54,6 +55,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("UnaryCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
@@ -66,6 +68,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("CacheableUnaryCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
@@ -78,6 +81,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingOutputCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
@@ -90,6 +94,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.StreamingInputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.StreamingInputCallResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingInputCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
@@ -102,6 +107,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("FullDuplexCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
@@ -114,6 +120,7 @@ public final class TestServiceGrpc {
               io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("HalfDuplexCall"))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
@@ -126,6 +133,7 @@ public final class TestServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("UnimplementedCall"))
           .build();
 
   /**
@@ -651,10 +659,28 @@ public final class TestServiceGrpc {
     }
   }
 
-  private static final class TestServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class TestServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("TestService");
+    }
+  }
+
+  private static final class TestServiceMethodDescriptorSupplier extends TestServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public TestServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -667,7 +693,7 @@ public final class TestServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new TestServiceDescriptorSupplier())
+              .setSchemaDescriptor(new TestServiceFileDescriptorSupplier())
               .addMethod(METHOD_EMPTY_CALL)
               .addMethod(METHOD_UNARY_CALL)
               .addMethod(METHOD_CACHEABLE_UNARY_CALL)

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -239,8 +239,10 @@ public final class UnimplementedServiceGrpc {
     }
   }
 
-  private static class UnimplementedServiceFileDescriptorSupplier
+  private static abstract class UnimplementedServiceBaseDescriptorSupplier
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    UnimplementedServiceBaseDescriptorSupplier() {}
+
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
@@ -252,12 +254,17 @@ public final class UnimplementedServiceGrpc {
     }
   }
 
+  private static final class UnimplementedServiceFileDescriptorSupplier
+      extends UnimplementedServiceBaseDescriptorSupplier {
+    UnimplementedServiceFileDescriptorSupplier() {}
+  }
+
   private static final class UnimplementedServiceMethodDescriptorSupplier
-      extends UnimplementedServiceFileDescriptorSupplier
-        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+      extends UnimplementedServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    private UnimplementedServiceMethodDescriptorSupplier(String methodName) {
+    UnimplementedServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -42,6 +42,7 @@ public final class UnimplementedServiceGrpc {
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
               com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+          .setSchemaDescriptor(new UnimplementedServiceMethodDescriptorSupplier("UnimplementedCall"))
           .build();
 
   /**
@@ -238,10 +239,28 @@ public final class UnimplementedServiceGrpc {
     }
   }
 
-  private static final class UnimplementedServiceDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier {
+  private static class UnimplementedServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("UnimplementedService");
+    }
+  }
+
+  private static final class UnimplementedServiceMethodDescriptorSupplier extends UnimplementedServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    public UnimplementedServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
     }
   }
 
@@ -254,7 +273,7 @@ public final class UnimplementedServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new UnimplementedServiceDescriptorSupplier())
+              .setSchemaDescriptor(new UnimplementedServiceFileDescriptorSupplier())
               .addMethod(METHOD_UNIMPLEMENTED_CALL)
               .build();
         }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -239,7 +239,8 @@ public final class UnimplementedServiceGrpc {
     }
   }
 
-  private static class UnimplementedServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private static class UnimplementedServiceFileDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
       return io.grpc.testing.integration.Test.getDescriptor();
@@ -251,10 +252,12 @@ public final class UnimplementedServiceGrpc {
     }
   }
 
-  private static final class UnimplementedServiceMethodDescriptorSupplier extends UnimplementedServiceFileDescriptorSupplier implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+  private static final class UnimplementedServiceMethodDescriptorSupplier
+      extends UnimplementedServiceFileDescriptorSupplier
+        implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
     private final String methodName;
 
-    public UnimplementedServiceMethodDescriptorSupplier(String methodName) {
+    private UnimplementedServiceMethodDescriptorSupplier(String methodName) {
       this.methodName = methodName;
     }
 


### PR DESCRIPTION
Second iteration on providing an easier way to access service methods which I took stab at in #2904.

It introduces new `MethodDescriptorSupplier` and `MethodDescriptor#setSchemaDescriptor`.

cc @ejona86