### PR TITLE
v1.4.x: update netty-tcnative version in SECURITY.md; and bump to 4.0.3

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ In Maven, you can use the [os-maven-plugin](https://github.com/trustin/os-maven-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork26</version>
+      <version>2.0.3.Final</version>
     </dependency>
   </dependencies>
 </project>
@@ -80,7 +80,7 @@ buildscript {
 }
 
 dependencies {
-    compile 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork26'
+    compile 'io.netty:netty-tcnative-boringssl-static:2.0.3.Final'
 }
 ```
 
@@ -115,7 +115,7 @@ In Maven, you can use the [os-maven-plugin](https://github.com/trustin/os-maven-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>1.1.33.Fork26</version>
+      <version>2.0.3.Final</version>
       <classifier>${tcnative.classifier}</classifier>
     </dependency>
   </dependencies>
@@ -183,7 +183,7 @@ if (osdetector.os == "linux" && osdetector.release.isLike("fedora")) {
 }
 
 dependencies {
-    compile 'io.netty:netty-tcnative:1.1.33.Fork26:' + tcnative_classifier
+    compile 'io.netty:netty-tcnative:2.0.3.Final:' + tcnative_classifier
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ subprojects {
                 netty: "io.netty:netty-codec-http2:[${nettyVersion}]",
                 netty_epoll: "io.netty:netty-transport-native-epoll:${nettyVersion}" + epoll_suffix,
                 netty_proxy_handler: "io.netty:netty-handler-proxy:${nettyVersion}",
-                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.1.Final',
+                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.3.Final',
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',


### PR DESCRIPTION
This cherry-picks #3087 to the v1.4.x branch, since updating SECURITY.md was missed before the release.

If we were strict about the versions, we would recommend 2.0.1, since that's what we were using at the time of the release, but it doesn't seem to matter much in this case and 2.0.3 is expected to be a faster and support shading.