### PR TITLE
core: OverrideAuthorityNameResolverFactory should forward refresh() (#3062)

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -93,6 +93,9 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private final List<ClientInterceptor> interceptors = new ArrayList<ClientInterceptor>();
 
+  // Access via getter, which may perform authority override as needed
+  private NameResolver.Factory nameResolverFactory = DEFAULT_NAME_RESOLVER_FACTORY;
+
   final String target;
 
   @Nullable
@@ -104,7 +107,6 @@ public abstract class AbstractManagedChannelImplBuilder
   @Nullable
   String authorityOverride;
 
-  NameResolver.Factory nameResolverFactory = DEFAULT_NAME_RESOLVER_FACTORY;
 
   LoadBalancer.Factory loadBalancerFactory = DEFAULT_LOAD_BALANCER_FACTORY;
 
@@ -365,6 +367,17 @@ public abstract class AbstractManagedChannelImplBuilder
    */
   protected Attributes getNameResolverParams() {
     return Attributes.EMPTY;
+  }
+
+  /**
+   * Returns a {@link NameResolver.Factory} for the channel.
+   */
+  public NameResolver.Factory getNameResolverFactory() {
+    if (authorityOverride == null) {
+      return nameResolverFactory;
+    } else {
+      return new OverrideAuthorityNameResolverFactory(nameResolverFactory, authorityOverride);
+    }
   }
 
   private static class DirectAddressNameResolverFactory extends NameResolver.Factory {

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -104,6 +104,7 @@ public abstract class AbstractManagedChannelImplBuilder
   @Nullable
   String userAgent;
 
+  @VisibleForTesting
   @Nullable
   String authorityOverride;
 

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -372,7 +372,7 @@ public abstract class AbstractManagedChannelImplBuilder
   /**
    * Returns a {@link NameResolver.Factory} for the channel.
    */
-  public NameResolver.Factory getNameResolverFactory() {
+  NameResolver.Factory getNameResolverFactory() {
     if (authorityOverride == null) {
       return nameResolverFactory;
     } else {

--- a/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.NameResolver;
+
+/**
+* A forwarding class to ensure non overridden methods are forwarded to the delegate.
+ */
+public class ForwardingNameResolver extends NameResolver {
+  private final NameResolver delegate;
+
+  public ForwardingNameResolver(NameResolver delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public String getServiceAuthority() {
+    return delegate.getServiceAuthority();
+  }
+
+  @Override
+  public void start(Listener listener) {
+    delegate.start(listener);
+  }
+
+  @Override
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  public void refresh() {
+    delegate.refresh();
+  }
+}

--- a/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
@@ -16,15 +16,18 @@
 
 package io.grpc.internal;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import io.grpc.NameResolver;
 
 /**
 * A forwarding class to ensure non overridden methods are forwarded to the delegate.
  */
-public class ForwardingNameResolver extends NameResolver {
+abstract class ForwardingNameResolver extends NameResolver {
   private final NameResolver delegate;
 
-  public ForwardingNameResolver(NameResolver delegate) {
+  ForwardingNameResolver(NameResolver delegate) {
+    checkNotNull(delegate, "delegate can not be null");
     this.delegate = delegate;
   }
 

--- a/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
@@ -1,32 +1,17 @@
 /*
- * Copyright 2017, Google Inc. All rights reserved.
+ * Copyright 2017, gRPC Authors All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- *    * Redistributions in binary form must reproduce the above
- * copyright notice, this list of conditions and the following disclaimer
- * in the documentation and/or other materials provided with the
- * distribution.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    * Neither the name of Google Inc. nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package io.grpc.internal;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -373,12 +373,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       Supplier<Stopwatch> stopwatchSupplier,
       List<ClientInterceptor> interceptors) {
     this.target = checkNotNull(builder.target, "target");
-    NameResolver.Factory tmpNameResolverFactory = builder.nameResolverFactory;
-    if (builder.authorityOverride != null) {
-      tmpNameResolverFactory = new OverrideAuthorityNameResolverFactory(
-          tmpNameResolverFactory, builder.authorityOverride);
-    }
-    this.nameResolverFactory = tmpNameResolverFactory;
+    this.nameResolverFactory = builder.getNameResolverFactory();
     this.nameResolverParams = checkNotNull(builder.getNameResolverParams(), "nameResolverParams");
     this.nameResolver = getNameResolver(target, nameResolverFactory, nameResolverParams);
     this.loadBalancerFactory =

--- a/core/src/main/java/io/grpc/internal/OverrideAuthorityNameResolverFactory.java
+++ b/core/src/main/java/io/grpc/internal/OverrideAuthorityNameResolverFactory.java
@@ -49,20 +49,10 @@ final class OverrideAuthorityNameResolverFactory extends NameResolver.Factory {
     if (resolver == null) {
       return null;
     }
-    return new NameResolver() {
+    return new ForwardingNameResolver(resolver) {
       @Override
       public String getServiceAuthority() {
         return authorityOverride;
-      }
-
-      @Override
-      public void start(Listener listener) {
-        resolver.start(listener);
-      }
-
-      @Override
-      public void shutdown() {
-        resolver.shutdown();
       }
     };
   }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -295,5 +296,25 @@ public class AbstractManagedChannelImplBuilderTest {
 
     overrideResolver.refresh();
     verify(mockResolver).refresh();
+  }
+
+  static class Builder extends AbstractManagedChannelImplBuilder<Builder> {
+    Builder(String target) {
+      super(target);
+    }
+
+    Builder(SocketAddress directServerAddress, String authority) {
+      super(directServerAddress, authority);
+    }
+
+    @Override
+    protected ClientTransportFactory buildTransportFactory() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Builder usePlaintext(boolean value) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -21,9 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -286,15 +284,16 @@ public class AbstractManagedChannelImplBuilderTest {
         new OverrideAuthorityNameResolverFactory(wrappedFactory, "override:5678");
     NameResolver overrideResolver =
         factory.newNameResolver(URI.create("dns:///localhost:443"), Attributes.EMPTY);
-
+    assertNotNull(overrideResolver);
     NameResolver.Listener listener = mock(NameResolver.Listener.class);
+
     overrideResolver.start(listener);
-    verify(mockResolver).start(eq(listener));
+    verify(mockResolver).start(listener);
 
     overrideResolver.shutdown();
-    verify(mockResolver, times(1)).shutdown();
+    verify(mockResolver).shutdown();
 
     overrideResolver.refresh();
-    verify(mockResolver, times(1)).refresh();
+    verify(mockResolver).refresh();
   }
 }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -214,7 +214,7 @@ public class AbstractManagedChannelImplBuilderTest {
     Builder builder = new Builder("target");
     assertNull(builder.authorityOverride);
     assertFalse(builder.getNameResolverFactory() instanceof OverrideAuthorityNameResolverFactory);
-    builder.overrideAuthority("different_authority");
+    builder.overrideAuthority("google.com");
     assertTrue(builder.getNameResolverFactory() instanceof OverrideAuthorityNameResolverFactory);
   }
 

--- a/core/src/test/java/io/grpc/internal/OverrideAuthorityNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/OverrideAuthorityNameResolverTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.Attributes;
+import io.grpc.NameResolver;
+import java.net.URI;
+import org.junit.Test;
+
+public class OverrideAuthorityNameResolverTest {
+  @Test
+  public void overridesAuthority() {
+    NameResolver nameResolverMock = mock(NameResolver.class);
+    NameResolver.Factory wrappedFactory = mock(NameResolver.Factory.class);
+    when(wrappedFactory.newNameResolver(any(URI.class), any(Attributes.class)))
+        .thenReturn(nameResolverMock);
+    String override = "override:5678";
+    NameResolver.Factory factory =
+        new OverrideAuthorityNameResolverFactory(wrappedFactory, override);
+    NameResolver nameResolver = factory.newNameResolver(URI.create("dns:///localhost:443"),
+        Attributes.EMPTY);
+    assertNotNull(nameResolver);
+    assertEquals(override, nameResolver.getServiceAuthority());
+  }
+
+  @Test
+  public void wontWrapNull() {
+    NameResolver.Factory wrappedFactory = mock(NameResolver.Factory.class);
+    when(wrappedFactory.newNameResolver(any(URI.class), any(Attributes.class))).thenReturn(null);
+    NameResolver.Factory factory =
+        new OverrideAuthorityNameResolverFactory(wrappedFactory, "override:5678");
+    assertEquals(null,
+        factory.newNameResolver(URI.create("dns:///localhost:443"), Attributes.EMPTY));
+  }
+
+  @Test
+  public void forwardsNonOverridenCalls() {
+    NameResolver.Factory wrappedFactory = mock(NameResolver.Factory.class);
+    NameResolver mockResolver = mock(NameResolver.class);
+    when(wrappedFactory.newNameResolver(any(URI.class), any(Attributes.class)))
+        .thenReturn(mockResolver);
+    NameResolver.Factory factory =
+        new OverrideAuthorityNameResolverFactory(wrappedFactory, "override:5678");
+    NameResolver overrideResolver =
+        factory.newNameResolver(URI.create("dns:///localhost:443"), Attributes.EMPTY);
+    assertNotNull(overrideResolver);
+    NameResolver.Listener listener = mock(NameResolver.Listener.class);
+
+    overrideResolver.start(listener);
+    verify(mockResolver).start(listener);
+
+    overrideResolver.shutdown();
+    verify(mockResolver).shutdown();
+
+    overrideResolver.refresh();
+    verify(mockResolver).refresh();
+  }
+}


### PR DESCRIPTION
The current implementation has a bug where certain methods are not forwarded to the delegate.

This is essentially the same as e4f1f398a0f92cc09054c351ea6c5e6816459c77 which was merged to the v1.4.x branch. This PR uses the new license header.

Fixes #3061