### PR TITLE
Add config and build files to run Windows tests on Kokoro

### DIFF
--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -1,0 +1,42 @@
+@rem ##########################################################################
+@rem
+@rem Script to set up Kokoro worker and run Windows tests
+@rem
+@rem ##########################################################################
+
+@rem Enter repo root
+cd /d %~dp0\..\..
+
+set WORKSPACE=T:\src\github\grpc-java
+set ESCWORKSPACE=%WORKSPACE:\=\\%
+
+mkdir grpc-java-helper
+
+@rem Install 7za
+@rem TODO(mattkwong): After Windows tests are no longer running on Jenkins, 7za
+@rem doesn't need to be installed and make_dependencies.bat can use unzip instead
+wget http://www.7-zip.org/a/7za920.zip
+unzip 7za920.zip
+mv 7za.exe grpc-java-helper
+
+cd grpc-java-helper
+
+call "%VS120COMNTOOLS%\vsvars32.bat"
+call "%WORKSPACE%\buildscripts\make_dependencies.bat"
+
+cd "%WORKSPACE%"
+
+echo targetArch=x86_32> gradle.properties
+echo failOnWarnings=true>> gradle.properties
+echo vcProtobufLibs=%ESCWORKSPACE%\\grpc-java-helper\\protobuf-%PROTOBUF_VER%\\cmake\\build\\Release>> gradle.properties
+echo vcProtobufInclude=%ESCWORKSPACE%\\grpc-java-helper\\protobuf-%PROTOBUF_VER%\\cmake\\build\\include>> gradle.properties
+
+cmd.exe /C "%WORKSPACE%\gradlew.bat build"
+
+@rem Rename test results .xml files to format parsable by Kokoro
+for /r %%F in (TEST-*.xml) do (
+  mkdir "%%~dpnF"
+  move "%%F" "%%~dpnF\sponge_log.xml"
+)
+
+exit %%ERRORLEVEL%%

--- a/buildscripts/kokoro/windows.cfg
+++ b/buildscripts/kokoro/windows.cfg
@@ -1,0 +1,11 @@
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-java/buildscripts/kokoro/windows.bat"
+timeout_mins: 45
+action {
+  define_artifacts {
+    regex: "github/grpc-java/all/build/docs/javadoc/**",
+    regex: "**/build/test-results/**/*.xml"
+  }
+}


### PR DESCRIPTION
This adds the necessary files to run the current Jenkins Windows tests on Kokoro. 