### PR TITLE
stub: add generic method handler registry

### DIFF
--- a/core/src/main/java/io/grpc/util/MutableHandlerRegistry.java
+++ b/core/src/main/java/io/grpc/util/MutableHandlerRegistry.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Default implementation of {@link MutableHandlerRegistry}.
+ * Default implementation of {@link HandlerRegistry}.
  *
  * <p>Uses {@link ConcurrentHashMap} to avoid service registration excessively
  * blocking method lookup.

--- a/stub/src/main/java/io/grpc/stub/util/GenericMethodHandlerRegistry.java
+++ b/stub/src/main/java/io/grpc/stub/util/GenericMethodHandlerRegistry.java
@@ -41,9 +41,9 @@ import javax.annotation.Nullable;
  * @since 1.5.0
  */
 @ExperimentalApi() // TODO(zdapeng): tracking url
-public class GenericMethodHandlerRegistry extends HandlerRegistry {
+public final class GenericMethodHandlerRegistry extends HandlerRegistry {
 
-  private MutableHandlerRegistry delegate = new MutableHandlerRegistry();
+  private final MutableHandlerRegistry delegate = new MutableHandlerRegistry();
 
   /**
    * Registers a service with a generic unary method.
@@ -128,7 +128,7 @@ public class GenericMethodHandlerRegistry extends HandlerRegistry {
    *         otherwise {@code null}.
    */
   @Nullable
-  public final ServerServiceDefinition addService(ServerServiceDefinition service) {
+  public ServerServiceDefinition addService(ServerServiceDefinition service) {
     return delegate.addService(service);
   }
 
@@ -139,7 +139,7 @@ public class GenericMethodHandlerRegistry extends HandlerRegistry {
    *         otherwise {@code null}.
    */
   @Nullable
-  public final ServerServiceDefinition addService(BindableService bindableService) {
+  public ServerServiceDefinition addService(BindableService bindableService) {
     return delegate.addService(bindableService);
   }
 
@@ -148,7 +148,7 @@ public class GenericMethodHandlerRegistry extends HandlerRegistry {
    *
    * @return true if the service was found to be removed.
    */
-  public final boolean removeService(ServerServiceDefinition service) {
+  public boolean removeService(ServerServiceDefinition service) {
     return delegate.removeService(service);
   }
 
@@ -157,7 +157,7 @@ public class GenericMethodHandlerRegistry extends HandlerRegistry {
    */
   @Override
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2222")
-  public final List<ServerServiceDefinition> getServices() {
+  public List<ServerServiceDefinition> getServices() {
     return delegate.getServices();
   }
 
@@ -166,7 +166,7 @@ public class GenericMethodHandlerRegistry extends HandlerRegistry {
    */
   @Override
   @Nullable
-  public final ServerMethodDefinition<?, ?> lookupMethod(
+  public ServerMethodDefinition<?, ?> lookupMethod(
       String methodName, @Nullable String authority) {
     return delegate.lookupMethod(methodName, authority);
   }

--- a/stub/src/main/java/io/grpc/stub/util/GenericMethodHandlerRegistry.java
+++ b/stub/src/main/java/io/grpc/stub/util/GenericMethodHandlerRegistry.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.grpc.BindableService;
+import io.grpc.ExperimentalApi;
+import io.grpc.HandlerRegistry;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.stub.ServerCalls;
+import io.grpc.stub.ServerCalls.BidiStreamingMethod;
+import io.grpc.stub.ServerCalls.ClientStreamingMethod;
+import io.grpc.stub.ServerCalls.ServerStreamingMethod;
+import io.grpc.stub.ServerCalls.UnaryMethod;
+import io.grpc.util.MutableHandlerRegistry;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * An implementation of {@link HandlerRegistry} which can add generic methods or services.
+ *
+ * @since 1.5.0
+ */
+@ExperimentalApi() // TODO(zdapeng): tracking url
+public class GenericMethodHandlerRegistry extends HandlerRegistry {
+
+  private MutableHandlerRegistry delegate = new MutableHandlerRegistry();
+
+  /**
+   * Registers a service with a generic unary method.
+   *
+   * @return the previously registered service with the same service descriptor name if exists,
+   *         otherwise {@code null}.
+   */
+  @Nullable
+  public <ReqT, RespT> ServerServiceDefinition addUnaryMethod(
+      MethodDescriptor<ReqT, RespT> descriptor, UnaryMethod<ReqT, RespT> method) {
+    checkNotNull(descriptor, "descriptor");
+    checkNotNull(method, "method");
+    checkArgument(descriptor.getType() == MethodType.UNARY, "MethodType");
+    ServerServiceDefinition svcDef = ServerServiceDefinition
+        .builder(MethodDescriptor.extractFullServiceName(descriptor.getFullMethodName()))
+        .addMethod(descriptor, ServerCalls.asyncUnaryCall(method))
+        .build();
+    return addService(svcDef);
+  }
+
+  /**
+   * Registers a service with a generic server streaming method.
+   *
+   * @return the previously registered service with the same service descriptor name if exists,
+   *         otherwise {@code null}.
+   */
+  @Nullable
+  public <ReqT, RespT> ServerServiceDefinition addServerStreamingMethod(
+      MethodDescriptor<ReqT, RespT> descriptor, ServerStreamingMethod<ReqT, RespT> method) {
+    checkNotNull(descriptor, "descriptor");
+    checkNotNull(method, "method");
+    checkArgument(descriptor.getType() == MethodType.SERVER_STREAMING, "MethodType");
+    ServerServiceDefinition svcDef = ServerServiceDefinition
+        .builder(MethodDescriptor.extractFullServiceName(descriptor.getFullMethodName()))
+        .addMethod(descriptor, ServerCalls.asyncServerStreamingCall(method))
+        .build();
+    return addService(svcDef);
+  }
+
+  /**
+   * Registers a service with a generic client streaming method.
+   *
+   * @return the previously registered service with the same service descriptor name if exists,
+   *         otherwise {@code null}.
+   */
+  @Nullable
+  public <ReqT, RespT> ServerServiceDefinition addClientStreamingMethod(
+      MethodDescriptor<ReqT, RespT> descriptor, ClientStreamingMethod<ReqT, RespT> method) {
+    checkNotNull(descriptor, "descriptor");
+    checkNotNull(method, "method");
+    checkArgument(descriptor.getType() == MethodType.CLIENT_STREAMING, "MethodType");
+    ServerServiceDefinition svcDef = ServerServiceDefinition
+        .builder(MethodDescriptor.extractFullServiceName(descriptor.getFullMethodName()))
+        .addMethod(descriptor, ServerCalls.asyncClientStreamingCall(method))
+        .build();
+    return addService(svcDef);
+  }
+
+  /**
+   * Registers a service with a generic bidirectional streaming method.
+   *
+   * @return the previously registered service with the same service descriptor name if exists,
+   *         otherwise {@code null}.
+   */
+  @Nullable
+  public <ReqT, RespT> ServerServiceDefinition addBidiStreamingMethod(
+      MethodDescriptor<ReqT, RespT> descriptor, BidiStreamingMethod<ReqT, RespT> method) {
+    checkNotNull(descriptor, "descriptor");
+    checkNotNull(method, "method");
+    checkArgument(descriptor.getType() == MethodType.BIDI_STREAMING, "MethodType");
+    ServerServiceDefinition svcDef = ServerServiceDefinition
+        .builder(MethodDescriptor.extractFullServiceName(descriptor.getFullMethodName()))
+        .addMethod(descriptor, ServerCalls.asyncBidiStreamingCall(method))
+        .build();
+    return addService(svcDef);
+  }
+
+  /**
+   * Registers a service.
+   *
+   * @return the previously registered service with the same service descriptor name if exists,
+   *         otherwise {@code null}.
+   */
+  @Nullable
+  public final ServerServiceDefinition addService(ServerServiceDefinition service) {
+    return delegate.addService(service);
+  }
+
+  /**
+   * Registers a service.
+   *
+   * @return the previously registered service with the same service descriptor name if exists,
+   *         otherwise {@code null}.
+   */
+  @Nullable
+  public final ServerServiceDefinition addService(BindableService bindableService) {
+    return delegate.addService(bindableService);
+  }
+
+  /**
+   * Removes a registered service
+   *
+   * @return true if the service was found to be removed.
+   */
+  public final boolean removeService(ServerServiceDefinition service) {
+    return delegate.removeService(service);
+  }
+
+  /**
+   *  Note: This does not necessarily return a consistent view of the map.
+   */
+  @Override
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2222")
+  public final List<ServerServiceDefinition> getServices() {
+    return delegate.getServices();
+  }
+
+  /**
+   * Note: This does not actually honor the authority provided.  It will, eventually in the future.
+   */
+  @Override
+  @Nullable
+  public final ServerMethodDefinition<?, ?> lookupMethod(
+      String methodName, @Nullable String authority) {
+    return delegate.lookupMethod(methodName, authority);
+  }
+}

--- a/stub/src/test/java/io/grpc/stub/util/GenericMethodHandlerRegistryTest.java
+++ b/stub/src/test/java/io/grpc/stub/util/GenericMethodHandlerRegistryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.stub.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.stub.ServerCalls.BidiStreamingMethod;
+import io.grpc.stub.ServerCalls.ClientStreamingMethod;
+import io.grpc.stub.ServerCalls.ServerStreamingMethod;
+import io.grpc.stub.ServerCalls.UnaryMethod;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.TestMethodDescriptors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GenericMethodHandlerRegistryTest {
+  @Test
+  public void addUnaryMethod() {
+    GenericMethodHandlerRegistry registry = new GenericMethodHandlerRegistry();
+    ServerServiceDefinition svcDef = registry.addUnaryMethod(
+        MethodDescriptor.<Void, Void>newBuilder()
+            .setType(MethodType.UNARY)
+            .setFullMethodName(MethodDescriptor.generateFullMethodName("foo", "bar"))
+            .setRequestMarshaller(TestMethodDescriptors.<Void>noopMarshaller())
+            .setResponseMarshaller(TestMethodDescriptors.<Void>noopMarshaller())
+            .build(),
+        new UnaryMethod<Void, Void>() {
+          @Override public void invoke(Void request, StreamObserver<Void> responseObserver) {}
+        });
+
+    assertNull(svcDef);
+    assertNotNull(registry.lookupMethod("foo/bar"));
+  }
+
+  @Test
+  public void addServerStreamingMethod() {
+    GenericMethodHandlerRegistry registry = new GenericMethodHandlerRegistry();
+    ServerServiceDefinition svcDef = registry.addServerStreamingMethod(
+        MethodDescriptor.<Void, Void>newBuilder()
+            .setType(MethodType.SERVER_STREAMING)
+            .setFullMethodName(MethodDescriptor.generateFullMethodName("foo", "bar"))
+            .setRequestMarshaller(TestMethodDescriptors.<Void>noopMarshaller())
+            .setResponseMarshaller(TestMethodDescriptors.<Void>noopMarshaller())
+            .build(),
+        new ServerStreamingMethod<Void, Void>() {
+          @Override public void invoke(Void request, StreamObserver<Void> responseObserver) {}
+        });
+
+    assertNull(svcDef);
+    assertNotNull(registry.lookupMethod("foo/bar"));
+  }
+
+  @Test
+  public void addClientStreamingMethod() {
+    GenericMethodHandlerRegistry registry = new GenericMethodHandlerRegistry();
+    ServerServiceDefinition svcDef = registry.addClientStreamingMethod(
+        MethodDescriptor.<Void, Void>newBuilder().setType(MethodType.CLIENT_STREAMING)
+            .setFullMethodName(MethodDescriptor.generateFullMethodName("foo", "bar"))
+            .setRequestMarshaller(TestMethodDescriptors.<Void>noopMarshaller())
+            .setResponseMarshaller(TestMethodDescriptors.<Void>noopMarshaller()).build(),
+        new ClientStreamingMethod<Void, Void>() {
+          @Override
+          public StreamObserver<Void> invoke(StreamObserver<Void> responseObserver) {
+            return null;
+          }
+        });
+
+    assertNull(svcDef);
+    assertNotNull(registry.lookupMethod("foo/bar"));
+  }
+
+  @Test
+  public void addBidiStreamingMethod() {
+    GenericMethodHandlerRegistry registry = new GenericMethodHandlerRegistry();
+    ServerServiceDefinition svcDef = registry.addBidiStreamingMethod(
+        MethodDescriptor.<Void, Void>newBuilder().setType(MethodType.BIDI_STREAMING)
+            .setFullMethodName(MethodDescriptor.generateFullMethodName("foo", "bar"))
+            .setRequestMarshaller(TestMethodDescriptors.<Void>noopMarshaller())
+            .setResponseMarshaller(TestMethodDescriptors.<Void>noopMarshaller()).build(),
+        new BidiStreamingMethod<Void, Void>() {
+          @Override
+          public StreamObserver<Void> invoke(StreamObserver<Void> responseObserver) {
+            return null;
+          }
+        });
+
+    assertNull(svcDef);
+    assertNotNull(registry.lookupMethod("foo/bar"));
+  }
+}

--- a/testing/src/main/java/io/grpc/testing/GrpcServerRule.java
+++ b/testing/src/main/java/io/grpc/testing/GrpcServerRule.java
@@ -27,7 +27,6 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.util.GenericMethodHandlerRegistry;
-import io.grpc.util.MutableHandlerRegistry;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.junit.rules.ExternalResource;
@@ -35,8 +34,8 @@ import org.junit.rules.TestRule;
 
 /**
  * {@code GrpcServerRule} is a JUnit {@link TestRule} that starts an in-process gRPC service with
- * a {@link MutableHandlerRegistry} for adding services. It is particularly useful for mocking out
- * external gRPC-based services and asserting that the expected requests were made.
+ * a {@link GenericMethodHandlerRegistry} for adding services. It is particularly useful for mocking
+ * out external gRPC-based services and asserting that the expected requests were made.
  *
  * <p>An {@link AbstractStub} can be created against this service by using the
  * {@link ManagedChannel} provided by {@link GrpcServerRule#getChannel()}.

--- a/testing/src/main/java/io/grpc/testing/GrpcServerRule.java
+++ b/testing/src/main/java/io/grpc/testing/GrpcServerRule.java
@@ -26,6 +26,7 @@ import io.grpc.ServerServiceDefinition;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.AbstractStub;
+import io.grpc.stub.util.GenericMethodHandlerRegistry;
 import io.grpc.util.MutableHandlerRegistry;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -46,7 +47,7 @@ public class GrpcServerRule extends ExternalResource {
   private ManagedChannel channel;
   private Server server;
   private String serverName;
-  private MutableHandlerRegistry serviceRegistry;
+  private GenericMethodHandlerRegistry serviceRegistry;
   private boolean useDirectExecutor;
 
   /**
@@ -84,7 +85,7 @@ public class GrpcServerRule extends ExternalResource {
    * Returns the service registry for this service. The registry is used to add service instances
    * (e.g. {@link BindableService} or {@link ServerServiceDefinition} to the server.
    */
-  public final MutableHandlerRegistry getServiceRegistry() {
+  public final GenericMethodHandlerRegistry getServiceRegistry() {
     return serviceRegistry;
   }
 
@@ -121,7 +122,7 @@ public class GrpcServerRule extends ExternalResource {
   protected void before() throws Throwable {
     serverName = UUID.randomUUID().toString();
 
-    serviceRegistry = new MutableHandlerRegistry();
+    serviceRegistry = new GenericMethodHandlerRegistry();
 
     InProcessServerBuilder serverBuilder = InProcessServerBuilder.forName(serverName)
         .fallbackHandlerRegistry(serviceRegistry);


### PR DESCRIPTION
This is the first of a sequence of PRs to make unit test easier.

Although we have `InProcess` transports and `GrpcServerRule`, unit testing is sometimes still very hard, especially when testing a user-defined generic interceptor without depending on an existing service or method, without proto codegen. 

To test this kind of interceptor, the user has to provide a `ClientCall` object. 
`ClientCall` is marked `@DoNotMock`, because a `ClientCall` object is not something that a user can provide, it is always produced by the grpc core library (and wrapped with interceptors). 

Without an existing service or method, it's hard to get a stub or method descriptor and so it's hard to use  `GrpcServerRule`. So it is hard to get a genuine `ClientCall` to test the interceptor. Users are now using `NoopClientCall` basically as an alternative of mocked client call, which is as bad as a mock. I've seen people writing wrong features in their interceptor and all tests passed with `NoopClientCall`, which would fail if using a genuine `ClientCall` instead.

So it would be helpful if the test framework can

- register generic methods to `GrpcServerRule`; (this PR)
- provide generic InProcess methods descriptors (`TestMethodDescriptors.noopMethod` or mocked method descriptor does not work). (next PR)
- make `NoopClientCall` for internal developer/advanced use only, not for application developers.