### PR TITLE
core: Mark InternalNotifyOnServerBuilder @Internal

### DIFF
--- a/core/src/main/java/io/grpc/InternalNotifyOnServerBuild.java
+++ b/core/src/main/java/io/grpc/InternalNotifyOnServerBuild.java
@@ -21,7 +21,7 @@ package io.grpc;
  * {@link ServerBuilder} is that this method will be called on all registered services implementing
  * the interface after build() has been called and before the {@link Server} instance is returned.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/2222")
+@Internal
 public interface InternalNotifyOnServerBuild {
   /** Notifies the service that the server has been built. */
   void notifyOnBuild(Server server);


### PR DESCRIPTION
It is misnamed if it is @ExperimentalApi. Even being @Internal is
strange, since nothing in io.grpc actually uses it and so it could
actually be in io.grpc.internal.

I'm not trying to fix the API, but just make it slightly more
consistent.