### PR TITLE
core: don't intern Metadata keys

### DIFF
--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -644,8 +644,7 @@ public final class Metadata {
 
     private Key(String name) {
       this.originalName = checkNotNull(name, "name");
-      // Intern the result for faster string identity checking.
-      this.name = validateName(this.originalName.toLowerCase(Locale.ROOT)).intern();
+      this.name = validateName(this.originalName.toLowerCase(Locale.ROOT));
       this.nameBytes = this.name.getBytes(US_ASCII);
     }
 


### PR DESCRIPTION
Interning strings isn't needed much any more since keys are now
compared by byte value.  Also, intern is slow (about 150ns per)
which affects code that creates keys often.  Lastly, older
versions of Java don't garbage collect interned strings, which
lowers the applications stability.