### PR TITLE
Use CodedInputStream#newInstance(ByteBuffer) for non-segmented messages

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/AbstractReadableBuffer.java
@@ -16,6 +16,8 @@
 
 package io.grpc.internal;
 
+import java.nio.ByteBuffer;
+
 /**
  * Abstract base class for {@link ReadableBuffer} implementations.
  */
@@ -61,6 +63,16 @@ public abstract class AbstractReadableBuffer implements ReadableBuffer {
 
   @Override
   public int arrayOffset() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean hasNioBuffer() {
+    return false;
+  }
+
+  @Override
+  public ByteBuffer nioBuffer() {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/io/grpc/internal/CompositeReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/CompositeReadableBuffer.java
@@ -152,6 +152,23 @@ public class CompositeReadableBuffer extends AbstractReadableBuffer {
     return newBuffer;
   }
 
+  /**
+   * NIO ByteBuffer access is supported iff there is a single backing ReadableBuffer
+   * and it supports ByteBuffer access.
+   */
+  @Override
+  public boolean hasNioBuffer() {
+    return buffers.size() == 1 && buffers.peek().hasNioBuffer();
+  }
+
+  @Override
+  public ByteBuffer nioBuffer() {
+    if (!hasNioBuffer()) {
+      throw new UnsupportedOperationException();
+    }
+    return buffers.peek().nioBuffer();
+  }
+
   @Override
   public void close() {
     while (!buffers.isEmpty()) {

--- a/core/src/main/java/io/grpc/internal/ForwardingReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingReadableBuffer.java
@@ -106,6 +106,16 @@ public abstract class ForwardingReadableBuffer implements ReadableBuffer {
   }
 
   @Override
+  public boolean hasNioBuffer() {
+    return buf.hasNioBuffer();
+  }
+
+  @Override
+  public ByteBuffer nioBuffer() {
+    return buf.nioBuffer();
+  }
+
+  @Override
   public void close() {
     buf.close();
   }

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -355,6 +355,9 @@ public class MessageDeframer implements Closeable {
 
   private InputStream getUncompressedBody() {
     statsTraceCtx.inboundUncompressedSize(nextFrame.readableBytes());
+    if (nextFrame.hasNioBuffer()) {
+      return ReadableBuffers.openNioStream(nextFrame);
+    }
     return ReadableBuffers.openStream(nextFrame, true);
   }
 

--- a/core/src/main/java/io/grpc/internal/NioBufferBackedStream.java
+++ b/core/src/main/java/io/grpc/internal/NioBufferBackedStream.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import java.nio.ByteBuffer;
+
+public interface NioBufferBackedStream {
+  ByteBuffer nioBuffer();
+}

--- a/core/src/main/java/io/grpc/internal/ReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/ReadableBuffer.java
@@ -140,6 +140,19 @@ public interface ReadableBuffer extends Closeable {
   int arrayOffset();
 
   /**
+   * Indicates whether or not this buffer exposes a backing NIO ByteBuffer.
+   */
+  boolean hasNioBuffer();
+
+  /**
+   * Gets the backing ByteBuffer for this buffer, if available. This is an optional method, so
+   * callers should first check {@link #hasNioBuffer}.
+   *
+   * @throws UnsupportedOperationException the buffer does not support this method
+   */
+  ByteBuffer nioBuffer();
+
+  /**
    * Closes this buffer and releases any resources.
    */
   @Override

--- a/core/src/main/java/io/grpc/internal/ReadableBuffers.java
+++ b/core/src/main/java/io/grpc/internal/ReadableBuffers.java
@@ -95,8 +95,8 @@ public final class ReadableBuffers {
 
   /**
    * Creates a new {@link InputStream} backed by the given buffer. Any read taken on the stream will
-   * automatically increment the read position of this buffer. Closing the stream, however, does not
-   * affect the original buffer.
+   * automatically increment the read position of this buffer. Closing the stream will close the
+   * original buffer if {@code owner} is {@code true}.
    *
    * @param buffer the buffer backing the new {@link InputStream}.
    * @param owner if {@code true}, the returned stream will close the buffer when closed.
@@ -326,6 +326,11 @@ public final class ReadableBuffers {
       length = Math.min(buffer.readableBytes(), length);
       buffer.readBytes(dest, destOffset, length);
       return length;
+    }
+
+    @Override
+    public void close() throws IOException {
+      buffer.close();
     }
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyReadableBuffer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyReadableBuffer.java
@@ -105,4 +105,14 @@ class NettyReadableBuffer extends AbstractReadableBuffer {
       buffer.release();
     }
   }
+
+  @Override
+  public boolean hasNioBuffer() {
+    return true;
+  }
+
+  @Override
+  public ByteBuffer nioBuffer() {
+    return buffer.nioBuffer();
+  }
 }


### PR DESCRIPTION
Punch a few holes in abstractions to permit direct access to ByteBuffers for CodedInputStream. This reduces copying and garbage production and enables an optimized code path in CodedInputStream for decoding direct ByteBuffers.

Fixes #2937