### PR TITLE
Implemented ClientCallStreamObserver.cancel()

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
@@ -25,20 +25,20 @@ import javax.annotation.Nullable;
  * client calls.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1788")
-public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> {
-    /**
-     * Prevent any further processing for this {@code ClientCallStreamObserver}. No further messages will be received.
-     * The server is informed of cancellations, but may not stop processing the call. Cancelling an already
-     * {@code cancel()}ed {@code ClientCallStreamObserver} has no effect.
-     *
-     * <p>No other methods on this class can be called after this method has been called.
-     *
-     * <p>It is recommended that at least one of the arguments to be non-{@code null}, to provide
-     * useful debug information. Both argument being null may log warnings and result in suboptimal
-     * performance. Also note that the provided information will not be sent to the server.
-     *
-     * @param message if not {@code null}, will appear as the description of the CANCELLED status
-     * @param cause if not {@code null}, will appear as the cause of the CANCELLED status
-     */
-    public abstract void cancel(@Nullable String message, @Nullable Throwable cause);
+public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> {  /**
+  * Prevent any further processing for this {@code ClientCallStreamObserver}. No further messages
+  * will be received. The server is informed of cancellations, but may not stop processing the
+  * call. Cancelling an already
+  * {@code cancel()}ed {@code ClientCallStreamObserver} has no effect.
+  *
+  * <p>No other methods on this class can be called after this method has been called.
+  *
+  * <p>It is recommended that at least one of the arguments to be non-{@code null}, to provide
+  * useful debug information. Both argument being null may log warnings and result in suboptimal
+  * performance. Also note that the provided information will not be sent to the server.
+  *
+  * @param message if not {@code null}, will appear as the description of the CANCELLED status
+  * @param cause if not {@code null}, will appear as the cause of the CANCELLED status
+  */
+  public abstract void cancel(@Nullable String message, @Nullable Throwable cause);
 }

--- a/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
@@ -31,6 +31,8 @@ public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> 
      * The server is informed of cancellations, but may not stop processing the call. Cancelling an already
      * {@code cancel()}ed {@code ClientCallStreamObserver} has no effect.
      *
+     * <p>No other methods on this class can be called after this method has been called.
+     *
      * <p>It is recommended that at least one of the arguments to be non-{@code null}, to provide
      * useful debug information. Both argument being null may log warnings and result in suboptimal
      * performance. Also note that the provided information will not be sent to the server.

--- a/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
@@ -26,20 +26,20 @@ import javax.annotation.Nullable;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1788")
 public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> {
- /**
-  * Prevent any further processing for this {@code ClientCallStreamObserver}. No further messages
-  * will be received. The server is informed of cancellations, but may not stop processing the
-  * call. Cancelling an already
-  * {@code cancel()}ed {@code ClientCallStreamObserver} has no effect.
-  *
-  * <p>No other methods on this class can be called after this method has been called.
-  *
-  * <p>It is recommended that at least one of the arguments to be non-{@code null}, to provide
-  * useful debug information. Both argument being null may log warnings and result in suboptimal
-  * performance. Also note that the provided information will not be sent to the server.
-  *
-  * @param message if not {@code null}, will appear as the description of the CANCELLED status
-  * @param cause if not {@code null}, will appear as the cause of the CANCELLED status
-  */
+  /**
+   * Prevent any further processing for this {@code ClientCallStreamObserver}. No further messages
+   * will be received. The server is informed of cancellations, but may not stop processing the
+   * call. Cancelling an already
+   * {@code cancel()}ed {@code ClientCallStreamObserver} has no effect.
+   *
+   * <p>No other methods on this class can be called after this method has been called.
+   *
+   * <p>It is recommended that at least one of the arguments to be non-{@code null}, to provide
+   * useful debug information. Both argument being null may log warnings and result in suboptimal
+   * performance. Also note that the provided information will not be sent to the server.
+   *
+   * @param message if not {@code null}, will appear as the description of the CANCELLED status
+   * @param cause if not {@code null}, will appear as the cause of the CANCELLED status
+   */
   public abstract void cancel(@Nullable String message, @Nullable Throwable cause);
 }

--- a/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
@@ -25,7 +25,8 @@ import javax.annotation.Nullable;
  * client calls.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1788")
-public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> {  /**
+public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> {
+ /**
   * Prevent any further processing for this {@code ClientCallStreamObserver}. No further messages
   * will be received. The server is informed of cancellations, but may not stop processing the
   * call. Cancelling an already

--- a/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
@@ -24,4 +24,10 @@ import io.grpc.ExperimentalApi;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1788")
 public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> {
+    /**
+     * Prevent any further processing for this {@code ClientCallStreamObserver}. No further messages will be received.
+     * The server is informed of cancellations, but may not stop processing the call. Cancelling an already
+     * {@code cancel()}ed {@code ClientCallStreamObserver} has no effect.
+     */
+    public abstract void cancel();
 }

--- a/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
@@ -18,6 +18,8 @@ package io.grpc.stub;
 
 import io.grpc.ExperimentalApi;
 
+import javax.annotation.Nullable;
+
 /**
  * A refinement of {@link CallStreamObserver} that allows for lower-level interaction with
  * client calls.
@@ -28,6 +30,13 @@ public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> 
      * Prevent any further processing for this {@code ClientCallStreamObserver}. No further messages will be received.
      * The server is informed of cancellations, but may not stop processing the call. Cancelling an already
      * {@code cancel()}ed {@code ClientCallStreamObserver} has no effect.
+     *
+     * <p>It is recommended that at least one of the arguments to be non-{@code null}, to provide
+     * useful debug information. Both argument being null may log warnings and result in suboptimal
+     * performance. Also note that the provided information will not be sent to the server.
+     *
+     * @param message if not {@code null}, will appear as the description of the CANCELLED status
+     * @param cause if not {@code null}, will appear as the cause of the CANCELLED status
      */
-    public abstract void cancel();
+    public abstract void cancel(@Nullable String message, @Nullable Throwable cause);
 }

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -329,8 +329,8 @@ public final class ClientCalls {
     }
 
     @Override
-    public void cancel() {
-      call.cancel("Call cancelled by request.", new StatusException(Status.CANCELLED));
+    public void cancel(@Nullable String message, @Nullable Throwable cause) {
+      call.cancel(message, cause);
     }
   }
 

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -327,6 +327,11 @@ public final class ClientCalls {
     public void setMessageCompression(boolean enable) {
       call.setMessageCompression(enable);
     }
+
+    @Override
+    public void cancel() {
+      call.cancel("Call cancelled by request.", new StatusException(Status.CANCELLED));
+    }
   }
 
   private static class StreamObserverToCallListenerAdapter<ReqT, RespT>


### PR DESCRIPTION
Allow a client to gracefully cancel a one-to-many streaming service by signaling the server to stop sending messages.

Addresses #3095