### PR TITLE
core: ServerBuilder.intercept().

### DIFF
--- a/core/src/main/java/io/grpc/InternalServerInterceptors.java
+++ b/core/src/main/java/io/grpc/InternalServerInterceptors.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+/**
+ * Accessor to internal methods of {@link ServerInterceptors}.
+ */
+@Internal
+public final class InternalServerInterceptors {
+  public static <ReqT, RespT> ServerCallHandler<ReqT, RespT> interceptCallHandler(
+      ServerInterceptor interceptor, ServerCallHandler<ReqT, RespT> callHandler) {
+    return ServerInterceptors.InterceptCallHandler.create(interceptor, callHandler);
+  }
+
+  private InternalServerInterceptors() {
+  }
+}

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -98,7 +98,7 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * @since 1.5.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3117")
-  public T addInterceptor(ServerInterceptor interceptor) {
+  public T intercept(ServerInterceptor interceptor) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -89,6 +89,20 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   public abstract T addService(BindableService bindableService);
 
   /**
+   * Adds a {@link ServerInterceptor} that is run for all services on the server.  Interceptors
+   * added through this method always run before per-service interceptors added through {@link
+   * ServerInterceptors}.  Interceptors run in the reverse order in which they are added.
+   *
+   * @param interceptor the all-service interceptor
+   * @return this
+   * @since 1.5.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3117")
+  public T addInterceptor(ServerInterceptor interceptor) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Adds a {@link ServerTransportFilter}. The order of filters being added is the order they will
    * be executed.
    *

--- a/core/src/main/java/io/grpc/ServerInterceptors.java
+++ b/core/src/main/java/io/grpc/ServerInterceptors.java
@@ -207,7 +207,7 @@ public final class ServerInterceptors {
     serviceDefBuilder.addMethod(method.withServerCallHandler(callHandler));
   }
 
-  private static class InterceptCallHandler<ReqT, RespT> implements ServerCallHandler<ReqT, RespT> {
+  static class InterceptCallHandler<ReqT, RespT> implements ServerCallHandler<ReqT, RespT> {
     public static <ReqT, RespT> InterceptCallHandler<ReqT, RespT> create(
         ServerInterceptor interceptor, ServerCallHandler<ReqT, RespT> callHandler) {
       return new InterceptCallHandler<ReqT, RespT>(interceptor, callHandler);

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -127,7 +127,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   }
 
   @Override
-  public final T addInterceptor(ServerInterceptor interceptor) {
+  public final T intercept(ServerInterceptor interceptor) {
     interceptors.add(interceptor);
     return thisT();
   }

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -33,6 +33,7 @@ import io.grpc.Internal;
 import io.grpc.InternalNotifyOnServerBuild;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptor;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServerStreamTracer;
@@ -69,6 +70,9 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
 
   private final ArrayList<ServerTransportFilter> transportFilters =
       new ArrayList<ServerTransportFilter>();
+
+  private final ArrayList<ServerInterceptor> interceptors =
+      new ArrayList<ServerInterceptor>();
 
   private final List<InternalNotifyOnServerBuild> notifyOnBuildList =
       new ArrayList<InternalNotifyOnServerBuild>();
@@ -119,6 +123,12 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   @Override
   public final T addTransportFilter(ServerTransportFilter filter) {
     transportFilters.add(checkNotNull(filter, "filter"));
+    return thisT();
+  }
+
+  @Override
+  public final T addInterceptor(ServerInterceptor interceptor) {
+    interceptors.add(interceptor);
     return thisT();
   }
 
@@ -179,7 +189,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
         firstNonNull(fallbackRegistry, EMPTY_FALLBACK_REGISTRY), transportServer,
         Context.ROOT, firstNonNull(decompressorRegistry, DecompressorRegistry.getDefaultInstance()),
         firstNonNull(compressorRegistry, CompressorRegistry.getDefaultInstance()),
-        transportFilters);
+        transportFilters, interceptors);
     for (InternalNotifyOnServerBuild notifyTarget : notifyOnBuildList) {
       notifyTarget.notifyOnBuild(server);
     }


### PR DESCRIPTION
This adds server-wide interceptors that applies to all call handlers.
Because ServerCallHandler is acquired per request, and can be dynamicly
provided by the fallback registry, the interceptors have to be installed
on a per-request basis.  This adds a few object allocations per request,
which is acceptable.