### PR TITLE
benchmark: add missing server side workloads

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -17,15 +17,18 @@
 package io.grpc.benchmarks.qps;
 
 import com.google.common.util.concurrent.UncaughtExceptionHandlers;
+import com.google.protobuf.ByteString;
 import io.grpc.Server;
+import io.grpc.Status;
 import io.grpc.benchmarks.Utils;
 import io.grpc.benchmarks.proto.BenchmarkServiceGrpc;
-import io.grpc.benchmarks.proto.Messages.SimpleRequest;
-import io.grpc.benchmarks.proto.Messages.SimpleResponse;
+import io.grpc.benchmarks.proto.Messages;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import io.grpc.stub.StreamObservers;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -36,10 +39,12 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.File;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -202,36 +207,160 @@ public class AsyncServer {
   }
 
   public static class BenchmarkServiceImpl extends BenchmarkServiceGrpc.BenchmarkServiceImplBase {
+    // Always use the same canned response for bidi. This is allowed by the spec.
+    private static final int BIDI_RESPONSE_BYTES = 100;
+    private static final Messages.SimpleResponse BIDI_RESPONSE = Messages.SimpleResponse
+        .newBuilder()
+        .setPayload(Messages.Payload.newBuilder()
+            .setBody(ByteString.copyFrom(new byte[BIDI_RESPONSE_BYTES])).build())
+        .build();
+    private final AtomicBoolean shutdown = new AtomicBoolean();
+
+    public BenchmarkServiceImpl() {
+    }
+
+    public void shutdown() {
+      this.shutdown.set(true);
+    }
 
     @Override
-    public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
-      SimpleResponse response = Utils.makeResponse(request);
-      responseObserver.onNext(response);
+    public void unaryCall(Messages.SimpleRequest request,
+        StreamObserver<Messages.SimpleResponse> responseObserver) {
+      responseObserver.onNext(Utils.makeResponse(request));
       responseObserver.onCompleted();
     }
 
     @Override
-    public StreamObserver<SimpleRequest> streamingCall(
-        final StreamObserver<SimpleResponse> responseObserver) {
-      return new StreamObserver<SimpleRequest>() {
+    public StreamObserver<Messages.SimpleRequest> streamingCall(
+        final StreamObserver<Messages.SimpleResponse> observer) {
+      final ServerCallStreamObserver<Messages.SimpleResponse> responseObserver =
+          (ServerCallStreamObserver<Messages.SimpleResponse>) observer;
+      // TODO(spencerfang): flow control to stop reading when !responseObserver.isReady
+      return new StreamObserver<Messages.SimpleRequest>() {
         @Override
-        public void onNext(SimpleRequest request) {
-          SimpleResponse response = Utils.makeResponse(request);
-          responseObserver.onNext(response);
+        public void onNext(Messages.SimpleRequest value) {
+          if (shutdown.get()) {
+            responseObserver.onCompleted();
+            return;
+          }
+          responseObserver.onNext(Utils.makeResponse(value));
         }
 
         @Override
         public void onError(Throwable t) {
-          System.out.println("Encountered an error in streamingCall");
-          t.printStackTrace();
+          // other side closed with non OK
         }
 
         @Override
         public void onCompleted() {
-          responseObserver.onCompleted();
+          // other side closed with OK
         }
       };
     }
 
+    @Override
+    public StreamObserver<Messages.SimpleRequest> streamingFromClient(
+        final StreamObserver<Messages.SimpleResponse> responseObserver) {
+      return new StreamObserver<Messages.SimpleRequest>() {
+        Messages.SimpleRequest lastSeen = null;
+
+        @Override
+        public void onNext(Messages.SimpleRequest value) {
+          if (shutdown.get()) {
+            responseObserver.onCompleted();
+            return;
+          }
+          lastSeen = value;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+          // other side closed with non OK
+        }
+
+        @Override
+        public void onCompleted() {
+          if (lastSeen != null) {
+            responseObserver.onNext(Utils.makeResponse(lastSeen));
+          } else {
+            responseObserver.onError(
+                Status.FAILED_PRECONDITION
+                    .withDescription("never received any requests").asException());
+          }
+        }
+      };
+    }
+
+    @Override
+    public void streamingFromServer(
+        final Messages.SimpleRequest request,
+        final StreamObserver<Messages.SimpleResponse> observer) {
+      // send forever, until the client cancels or we shut down
+      final Messages.SimpleResponse response = Utils.makeResponse(request);
+      final ServerCallStreamObserver<Messages.SimpleResponse> responseObserver =
+          (ServerCallStreamObserver<Messages.SimpleResponse>) observer;
+      StreamObservers.copyWithFlowControl(
+          new Iterator<Messages.SimpleResponse>() {
+            @Override
+            public boolean hasNext() {
+              return !shutdown.get() && !responseObserver.isCancelled();
+            }
+
+            @Override
+            public Messages.SimpleResponse next() {
+              return response;
+            }
+
+            @Override
+            public void remove() {
+              throw new UnsupportedOperationException();
+            }
+          },
+          responseObserver);
+    }
+
+    @Override
+    public StreamObserver<Messages.SimpleRequest> streamingBothWays(
+        final StreamObserver<Messages.SimpleResponse> observer) {
+      // receive data forever and send data forever until client cancels or we shut down.
+      final ServerCallStreamObserver<Messages.SimpleResponse> responseObserver =
+          (ServerCallStreamObserver<Messages.SimpleResponse>) observer;
+      StreamObservers.copyWithFlowControl(
+          new Iterator<Messages.SimpleResponse>() {
+            @Override
+            public boolean hasNext() {
+              return !shutdown.get() && !responseObserver.isCancelled();
+            }
+
+            @Override
+            public Messages.SimpleResponse next() {
+              return BIDI_RESPONSE;
+            }
+
+            @Override
+            public void remove() {
+              throw new UnsupportedOperationException();
+            }
+          },
+          responseObserver
+      );
+
+      return new StreamObserver<Messages.SimpleRequest>() {
+        @Override
+        public void onNext(final Messages.SimpleRequest request) {
+          // noop
+        }
+
+        @Override
+        public void onError(Throwable t) {
+          // other side closed with non OK
+        }
+
+        @Override
+        public void onCompleted() {
+          // other side closed with OK
+        }
+      };
+    }
   }
 }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -223,7 +223,7 @@ public class AsyncServer {
     }
 
     public void shutdown() {
-      this.shutdown.set(true);
+      shutdown.set(true);
     }
 
     @Override

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -209,6 +209,7 @@ public class AsyncServer {
   }
 
   public static class BenchmarkServiceImpl extends BenchmarkServiceGrpc.BenchmarkServiceImplBase {
+    private static final long SHUTDOWN_POLL_NANOS = TimeUnit.MILLISECONDS.toNanos(100);
     // Always use the same canned response for bidi. This is allowed by the spec.
     private static final int BIDI_RESPONSE_BYTES = 100;
     private static final Messages.SimpleResponse BIDI_RESPONSE = Messages.SimpleResponse
@@ -216,6 +217,8 @@ public class AsyncServer {
         .setPayload(Messages.Payload.newBuilder()
             .setBody(ByteString.copyFrom(new byte[BIDI_RESPONSE_BYTES])).build())
         .build();
+
+    private final ThreadLocal<Long> shutdownPollNanos = new ThreadLocal<Long>();
     private final AtomicBoolean shutdown = new AtomicBoolean();
 
     public BenchmarkServiceImpl() {
@@ -223,6 +226,25 @@ public class AsyncServer {
 
     public void shutdown() {
       this.shutdown.set(true);
+    }
+
+    /**
+     * Helper method to avoid polling the shutdown volatile in a tight loop. The server shutdown
+     * operation only happens once at the end of the test scenario, so there's no need to
+     * constantly check it.
+     */
+    private boolean shouldShutdown() {
+      Long latestPoll = shutdownPollNanos.get();
+      long now = System.nanoTime();
+      if (latestPoll == null) {
+        shutdownPollNanos.set(now);
+        return false;
+      } else if (now - latestPoll < SHUTDOWN_POLL_NANOS) {
+        return false;
+      } else {
+        shutdownPollNanos.set(now);
+        return shutdown.get();
+      }
     }
 
     @Override
@@ -241,7 +263,7 @@ public class AsyncServer {
       return new StreamObserver<Messages.SimpleRequest>() {
         @Override
         public void onNext(Messages.SimpleRequest value) {
-          if (shutdown.get()) {
+          if (shouldShutdown()) {
             responseObserver.onCompleted();
             return;
           }
@@ -270,7 +292,7 @@ public class AsyncServer {
 
         @Override
         public void onNext(Messages.SimpleRequest value) {
-          if (shutdown.get()) {
+          if (shouldShutdown()) {
             responseObserver.onCompleted();
             return;
           }
@@ -311,7 +333,7 @@ public class AsyncServer {
           new Iterator<Messages.SimpleResponse>() {
             @Override
             public boolean hasNext() {
-              return !shutdown.get() && !responseObserver.isCancelled();
+              return !shouldShutdown() && !responseObserver.isCancelled();
             }
 
             @Override
@@ -339,7 +361,7 @@ public class AsyncServer {
           new Iterator<Messages.SimpleResponse>() {
             @Override
             public boolean hasNext() {
-              return !shutdown.get() && !responseObserver.isCancelled();
+              return !shouldShutdown() && !responseObserver.isCancelled();
             }
 
             @Override


### PR DESCRIPTION
Add missing workloads for missing streaming workloads. Client workloads coming on another PR.

Also, refactor away some redundant code.