### PR TITLE
netty: client transport needs to flush fence operation

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -41,7 +41,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -224,7 +224,7 @@ class NettyClientTransport implements ConnectionClientTransport {
     channel.connect(address);
     // This write will have no effect, yet it will only complete once the negotiationHandler
     // flushes any pending writes.
-    channel.write(NettyClientHandler.NOOP_MESSAGE).addListener(new ChannelFutureListener() {
+    channel.writeAndFlush(NettyClientHandler.NOOP_MESSAGE).addListener(new ChannelFutureListener() {
       @Override
       public void operationComplete(ChannelFuture future) throws Exception {
         if (!future.isSuccess()) {
@@ -234,9 +234,6 @@ class NettyClientTransport implements ConnectionClientTransport {
         }
       }
     });
-    // Flush the channel to ensure the NOOP_MESSAGE eventually gets processed, but we will not
-    // offer any timing or ordering guarantees on when the listener fires.
-    channel.flush();
     // Handle transport shutdown when the channel is closed.
     channel.closeFuture().addListener(new ChannelFutureListener() {
       @Override


### PR DESCRIPTION
tldr: the NOOP_MESSAGE fence operation is racey; we are not flushing
the channel and the application thread is not waiting for the
operation to complete.

Details:

On windows, the serverNotListening test sometimes still fails with this
problem:

https://gist.github.com/zpencer/077da915c70e9bd75624932cfa21aa9d


The test fails on this assertion:
```
verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportTerminated();
```

The call being verified should have been called when the NOOP_MESSAGE
fails. Because the call to `NettyClientTransport.start` returns a null
for the success case, the caller immediately starts the verification
with a 1s timeout. We should return a Runnable that tells the caller
to block until the fence operation is done. We also need to flush the
channel to ensure it completes at all.