### PR TITLE
core: Fix Bazel building for :util

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -54,6 +54,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         ":core",
+        ":internal",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava//jar",
     ],


### PR DESCRIPTION
It is now using io.grpc.internal.SerializingExecutor.