### PR TITLE
core: update javadocs regarding ClientCall mocks

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -97,7 +97,7 @@ import javax.annotation.Nullable;
  * @param <ReqT> type of message sent one or more times to the server.
  * @param <RespT> type of message received one or more times from the server.
  */
-@DoNotMock("Use InProcessTransport and make a fake server instead")
+@DoNotMock("Use InProcessServerBuilder and make a full featured in process server instead")
 public abstract class ClientCall<ReqT, RespT> {
   /**
    * Callbacks for receiving metadata, response messages and completion status from the server.

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -97,7 +97,7 @@ import javax.annotation.Nullable;
  * @param <ReqT> type of message sent one or more times to the server.
  * @param <RespT> type of message received one or more times from the server.
  */
-@DoNotMock("Use InProcessServerBuilder and make a full featured in process server instead")
+@DoNotMock("Use InProcessServerBuilder and make a test server instead")
 public abstract class ClientCall<ReqT, RespT> {
   /**
    * Callbacks for receiving metadata, response messages and completion status from the server.

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -29,6 +29,8 @@ import java.net.SocketAddress;
  * its name.
  *
  * <p>The channel is intended to be fully-featured, high performance, and useful in testing.
+ *
+ * <p>For usage examples, see {@link InProcessServerBuilder}.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1783")
 public final class InProcessChannelBuilder extends

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -43,7 +43,7 @@ import java.util.List;
  *   ExecutorService serverExecutor = Executors.newCachedThreadPool();
  *   Server server = InProcessServerBuilder.forName("unique-name")
  *       .executor(serverExecutor)
- *       .addService(service)
+ *       .fallbackHandlerRegistry(serviceRegistry)
  *       .build().start();
  *   ExecutorService clientExecutor = Executors.newCachedThreadPool();
  *   ManagedChannel channel = InProcessChannelBuilder.forName("unique-name")

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -28,6 +28,47 @@ import java.util.List;
  * its name.
  *
  * <p>The server is intended to be fully-featured, high performance, and useful in testing.
+ *
+ * <h3>Using JUnit TestRule</h3>
+ * The class "GrpcServerRule" (from the "grpc-java/testing") is a JUnit TestRule that
+ * creates a {@link InProcessServer} and a {@link io.grpc.ManagedChannel ManagedChannel}. This
+ * test rule contains the boiler plate code shown below. The classes "HelloWorldServerTest" and
+ * "HelloWorldClientTest" (from "grpc-java/examples") demonstrate basic usage.
+ *
+ * <h3>Usage example</h3>
+ * <h4>Server and client channel setup</h4>
+ * <pre>
+ *   MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
+ *   addServicesHelper(serviceRegistry); // your code here
+ *   ExecutorService serverExecutor = Executors.newCachedThreadPool();
+ *   Server server = InProcessServerBuilder.forName("unique-name")
+ *       .executor(serverExecutor)
+ *       .addService(service)
+ *       .build().start();
+ *   ExecutorService clientExecutor = Executors.newCachedThreadPool();
+ *   ManagedChannel channel = InProcessChannelBuilder.forName("unique-name")
+ *       .executor(clientExecutor)
+ *       .build();
+ * </pre>
+ *
+ * <h4>Client call usage</h4>
+ * <pre>
+ *   MethodDescriptor&lt;Integer, Integer&gt; methodDescriptor =
+ *       makeMethodDescriptorHelper(); // your code here
+ *   ClientCall&lt;Integer, Integer&gt; clientCall = channel.newCall(methodDescriptor,
+ *       CallOptions.DEFAULT);
+ * </pre>
+ *
+ * <h4>Stub usage</h4>
+ * All stub variants are supported:
+ * <pre>
+ *   TestServiceGrpc.TestServiceBlockingStub blockingStub =
+ *       TestServiceGrpc.newBlockingStub(channel);
+ *   TestServiceGrpc.TestServiceStub asyncStub =
+ *       TestServiceGrpc.newStub(channel);
+ *   TestServiceGrpc.TestServiceFutureStub futureStub =
+ *       TestServiceGrpc.newFutureStub(channel);
+ * </pre>
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1783")
 public final class InProcessServerBuilder

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -30,7 +30,7 @@ import java.util.List;
  * <p>The server is intended to be fully-featured, high performance, and useful in testing.
  *
  * <h3>Using JUnit TestRule</h3>
- * The class "GrpcServerRule" (from the "grpc-java/testing") is a JUnit TestRule that
+ * The class "GrpcServerRule" (from "grpc-java/testing") is a JUnit TestRule that
  * creates a {@link InProcessServer} and a {@link io.grpc.ManagedChannel ManagedChannel}. This
  * test rule contains the boilerplate code shown below. The classes "HelloWorldServerTest" and
  * "HelloWorldClientTest" (from "grpc-java/examples") demonstrate basic usage.

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -48,7 +48,7 @@ import java.util.List;
  * </pre>
  *
  * <h4>Usage in tests</h4>
- * The channel can be used like normal. A blocking stub example:
+ * The channel can be used normally. A blocking stub example:
  * <pre>
  *   TestServiceGrpc.TestServiceBlockingStub blockingStub =
  *       TestServiceGrpc.newBlockingStub(channel);

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -32,42 +32,26 @@ import java.util.List;
  * <h3>Using JUnit TestRule</h3>
  * The class "GrpcServerRule" (from the "grpc-java/testing") is a JUnit TestRule that
  * creates a {@link InProcessServer} and a {@link io.grpc.ManagedChannel ManagedChannel}. This
- * test rule contains the boiler plate code shown below. The classes "HelloWorldServerTest" and
+ * test rule contains the boilerplate code shown below. The classes "HelloWorldServerTest" and
  * "HelloWorldClientTest" (from "grpc-java/examples") demonstrate basic usage.
  *
  * <h3>Usage example</h3>
  * <h4>Server and client channel setup</h4>
  * <pre>
- *   MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
- *   addServicesHelper(serviceRegistry); // your code here
- *   ExecutorService serverExecutor = Executors.newCachedThreadPool();
  *   Server server = InProcessServerBuilder.forName("unique-name")
- *       .executor(serverExecutor)
- *       .fallbackHandlerRegistry(serviceRegistry)
+ *       .directExecutor() // directExecutor is fine for unit tests
+ *       .addService(&#47;* your code here *&#47;)
  *       .build().start();
- *   ExecutorService clientExecutor = Executors.newCachedThreadPool();
  *   ManagedChannel channel = InProcessChannelBuilder.forName("unique-name")
- *       .executor(clientExecutor)
+ *       .directExecutor()
  *       .build();
  * </pre>
  *
- * <h4>Client call usage</h4>
- * <pre>
- *   MethodDescriptor&lt;Integer, Integer&gt; methodDescriptor =
- *       makeMethodDescriptorHelper(); // your code here
- *   ClientCall&lt;Integer, Integer&gt; clientCall = channel.newCall(methodDescriptor,
- *       CallOptions.DEFAULT);
- * </pre>
- *
- * <h4>Stub usage</h4>
- * All stub variants are supported:
+ * <h4>Usage in tests</h4>
+ * The channel can be used like normal. A blocking stub example:
  * <pre>
  *   TestServiceGrpc.TestServiceBlockingStub blockingStub =
  *       TestServiceGrpc.newBlockingStub(channel);
- *   TestServiceGrpc.TestServiceStub asyncStub =
- *       TestServiceGrpc.newStub(channel);
- *   TestServiceGrpc.TestServiceFutureStub futureStub =
- *       TestServiceGrpc.newFutureStub(channel);
  * </pre>
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1783")


### PR DESCRIPTION
Change the `@DoNotMock` message to refer to `InProcessServerBuilder`, and include some usage examples that users may find useful.

fixes #3124 