### PR TITLE
netty: InternalHandlerSettings should not be used by non-Internal classes

### DIFF
--- a/netty/src/main/java/io/grpc/netty/HandlerSettings.java
+++ b/netty/src/main/java/io/grpc/netty/HandlerSettings.java
@@ -30,18 +30,18 @@ import io.grpc.Internal;
 @Deprecated
 public final class HandlerSettings {
   public static void enable(boolean enable) {
-    InternalHandlerSettings.enable(enable);
+    NettyHandlerSettings.enable(enable);
   }
 
   public static synchronized void autoWindowOn(boolean autoFlowControl) {
-    InternalHandlerSettings.autoWindowOn(autoFlowControl);
+    NettyHandlerSettings.autoWindowOn(autoFlowControl);
   }
 
   public static synchronized int getLatestClientWindow() {
-    return InternalHandlerSettings.getLatestServerWindow();
+    return NettyHandlerSettings.getLatestServerWindow();
   }
 
   public static synchronized int getLatestServerWindow() {
-    return InternalHandlerSettings.getLatestServerWindow();
+    return NettyHandlerSettings.getLatestServerWindow();
   }
 }

--- a/netty/src/main/java/io/grpc/netty/InternalHandlerSettings.java
+++ b/netty/src/main/java/io/grpc/netty/InternalHandlerSettings.java
@@ -17,60 +17,28 @@
 package io.grpc.netty;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import io.grpc.Internal;
 
 /**
- * Allows autoFlowControl to be turned on and off from interop testing and flow control windows to
- * be accessed. For internal use only.
+ * Controlled accessor to {@link NettyHandlerSettings}.
  */
 @VisibleForTesting // Visible for tests in other packages.
 @Internal
 public final class InternalHandlerSettings {
 
-  private static volatile boolean enabled;
-
-  private static boolean autoFlowControlOn;
-  // These will be the most recently created handlers created using NettyClientTransport and
-  // NettyServerTransport
-  private static AbstractNettyHandler clientHandler;
-  private static AbstractNettyHandler serverHandler;
-
-  static void setAutoWindow(AbstractNettyHandler handler) {
-    if (!enabled) {
-      return;
-    }
-    synchronized (InternalHandlerSettings.class) {
-      handler.setAutoTuneFlowControl(autoFlowControlOn);
-      if (handler instanceof NettyClientHandler) {
-        clientHandler = handler;
-      } else if (handler instanceof NettyServerHandler) {
-        serverHandler = handler;
-      } else {
-        throw new RuntimeException("Expecting NettyClientHandler or NettyServerHandler");
-      }
-    }
-  }
-
   public static void enable(boolean enable) {
-    enabled = enable;
+    NettyHandlerSettings.enable(enable);
   }
 
   public static synchronized void autoWindowOn(boolean autoFlowControl) {
-    autoFlowControlOn = autoFlowControl;
+    NettyHandlerSettings.autoWindowOn(autoFlowControl);
   }
 
   public static synchronized int getLatestClientWindow() {
-    return getLatestWindow(clientHandler);
+    return NettyHandlerSettings.getLatestClientWindow();
   }
 
   public static synchronized int getLatestServerWindow() {
-    return getLatestWindow(serverHandler);
-  }
-
-  private static synchronized int getLatestWindow(AbstractNettyHandler handler) {
-    Preconditions.checkNotNull(handler);
-    return handler.decoder().flowController()
-        .initialWindowSize(handler.connection().connectionStream());
+    return NettyHandlerSettings.getLatestServerWindow();
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -173,7 +173,7 @@ class NettyClientTransport implements ConnectionClientTransport {
 
     handler = NettyClientHandler.newHandler(lifecycleManager, keepAliveManager, flowControlWindow,
         maxHeaderListSize, Ticker.systemTicker(), tooManyPingsRunnable);
-    InternalHandlerSettings.setAutoWindow(handler);
+    NettyHandlerSettings.setAutoWindow(handler);
 
     negotiationHandler = negotiator.newHandler(handler);
 

--- a/netty/src/main/java/io/grpc/netty/NettyHandlerSettings.java
+++ b/netty/src/main/java/io/grpc/netty/NettyHandlerSettings.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Allows autoFlowControl to be turned on and off from interop testing and flow control windows to
+ * be accessed.
+ */
+final class NettyHandlerSettings {
+
+  private static volatile boolean enabled;
+
+  private static boolean autoFlowControlOn;
+  // These will be the most recently created handlers created using NettyClientTransport and
+  // NettyServerTransport
+  private static AbstractNettyHandler clientHandler;
+  private static AbstractNettyHandler serverHandler;
+
+  static void setAutoWindow(AbstractNettyHandler handler) {
+    if (!enabled) {
+      return;
+    }
+    synchronized (InternalHandlerSettings.class) {
+      handler.setAutoTuneFlowControl(autoFlowControlOn);
+      if (handler instanceof NettyClientHandler) {
+        clientHandler = handler;
+      } else if (handler instanceof NettyServerHandler) {
+        serverHandler = handler;
+      } else {
+        throw new RuntimeException("Expecting NettyClientHandler or NettyServerHandler");
+      }
+    }
+  }
+
+  public static void enable(boolean enable) {
+    enabled = enable;
+  }
+
+  public static synchronized void autoWindowOn(boolean autoFlowControl) {
+    autoFlowControlOn = autoFlowControl;
+  }
+
+  public static synchronized int getLatestClientWindow() {
+    return getLatestWindow(clientHandler);
+  }
+
+  public static synchronized int getLatestServerWindow() {
+    return getLatestWindow(serverHandler);
+  }
+
+  private static synchronized int getLatestWindow(AbstractNettyHandler handler) {
+    Preconditions.checkNotNull(handler);
+    return handler.decoder().flowController()
+        .initialWindowSize(handler.connection().connectionStream());
+  }
+}

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -85,7 +85,7 @@ class NettyServerTransport implements ServerTransport {
 
     // Create the Netty handler for the pipeline.
     final NettyServerHandler grpcHandler = createHandler(listener);
-    InternalHandlerSettings.setAutoWindow(grpcHandler);
+    NettyHandlerSettings.setAutoWindow(grpcHandler);
 
     // Notify when the channel closes.
     channel.closeFuture().addListener(new ChannelFutureListener() {


### PR DESCRIPTION
InternalHandlerSettings is part of "netty:internal" inside google,
which is used to allow controlled exposure of internals.
"netty:internal" depends on "netty", which consists of the rest of the
netty subproject.  Therefore, "netty" should not depend on
"netty:internal".