### PR TITLE
netty: fix NettyHandlerSettings synchronized on wrong object.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyHandlerSettings.java
+++ b/netty/src/main/java/io/grpc/netty/NettyHandlerSettings.java
@@ -36,7 +36,7 @@ final class NettyHandlerSettings {
     if (!enabled) {
       return;
     }
-    synchronized (InternalHandlerSettings.class) {
+    synchronized (NettyHandlerSettings.class) {
       handler.setAutoTuneFlowControl(autoFlowControlOn);
       if (handler instanceof NettyClientHandler) {
         clientHandler = handler;


### PR DESCRIPTION
Bug introduced in commit 8c017337eb03b7e77ae97fa15b0f761d98466d2b