### PR TITLE
examples: add bazel build example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target
 
 # Bazel
 bazel-bin
+bazel-examples
 bazel-genfiles
 bazel-grpc-java
 bazel-out

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,0 +1,98 @@
+load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+
+proto_library(
+    name = "helloworld_proto",
+    srcs = ["src/main/proto/helloworld.proto"],
+)
+
+java_proto_library(
+    name = "helloworld_java_proto",
+    deps = [":helloworld_proto"],
+)
+
+java_grpc_library(
+    name = "helloworld_java_grpc",
+    srcs = [":helloworld_proto"],
+    deps = [":helloworld_java_proto"],
+)
+
+proto_library(
+    name = "route_guide_proto",
+    srcs = ["src/main/proto/route_guide.proto"],
+)
+
+java_proto_library(
+    name = "route_guide_java_proto",
+    deps = [":route_guide_proto"],
+)
+
+java_grpc_library(
+    name = "route_guide_java_grpc",
+    srcs = [":route_guide_proto"],
+    deps = [":route_guide_java_proto"],
+)
+
+java_library(
+    name = "examples",
+    testonly = 1,
+    srcs = glob(
+        ["src/main/java/**/*.java"],
+    ),
+    resources = glob(
+        ["src/main/resources/**"],
+    ),
+    deps = [
+        ":helloworld_java_grpc",
+        ":helloworld_java_proto",
+        ":route_guide_java_grpc",
+        ":route_guide_java_proto",
+        "@com_google_api_grpc_google_common_protos//jar",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava//jar",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@com_google_protobuf_java//:protobuf_java",
+        "@grpc_java//protobuf",
+        "@grpc_java//core",
+        "@grpc_java//stub",
+    ],
+)
+
+java_binary(
+    name = "hello-world-client",
+    testonly = 1,
+    main_class = "io.grpc.examples.helloworld.HelloWorldClient",
+    runtime_deps = [
+        ":examples",
+        "@grpc_java//netty",
+    ],
+)
+
+java_binary(
+    name = "hello-world-server",
+    testonly = 1,
+    main_class = "io.grpc.examples.helloworld.HelloWorldServer",
+    runtime_deps = [
+        ":examples",
+        "@grpc_java//netty",
+    ],
+)
+
+java_binary(
+    name = "route-guide-client",
+    testonly = 1,
+    main_class = "io.grpc.examples.routeguide.RouteGuideClient",
+    runtime_deps = [
+        ":examples",
+        "@grpc_java//netty",
+    ],
+)
+
+java_binary(
+    name = "route-guide-server",
+    testonly = 1,
+    main_class = "io.grpc.examples.routeguide.RouteGuideServer",
+    runtime_deps = [
+        ":examples",
+        "@grpc_java//netty",
+    ],
+)

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,17 @@ $ # In another terminal run the client
 $ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworld.HelloWorldClient
 ```
 
+## Bazel
+
+If you prefer to use Bazel:
+```
+(With Bazel v0.4.5 or above.)
+$ # Run the server:
+$ bazel run //:hello-world-server
+$ # In another terminal run the client
+$ bazel run //:hello-world-client
+```
+
 Unit test examples
 ==============================================
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,10 +54,11 @@ $ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworld.HelloWorldClient
 If you prefer to use Bazel:
 ```
 (With Bazel v0.4.5 or above.)
+$ bazel build :hello-world-server :hello-world-client
 $ # Run the server:
-$ bazel run //:hello-world-server
+$ bazel-bin/hello-world-server
 $ # In another terminal run the client
-$ bazel run //:hello-world-client
+$ bazel-bin/hello-world-client
 ```
 
 Unit test examples

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -1,0 +1,17 @@
+workspace(name = "examples")
+
+# For released versions, use the tagged git-repository:
+# git_repository(
+#     name = "grpc_java",
+#     remote = "https://github.com/grpc/grpc-java.git",
+#     tag = "<TAG>",
+# )
+local_repository(
+    name = "grpc_java",
+    path = "..",
+)
+
+load("@grpc_java//:repositories.bzl", "grpc_java_repositories")
+
+grpc_java_repositories()
+


### PR DESCRIPTION
## Maven

If you prefer to use Maven:
```
$ mvn verify
$ # Run the server
$ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworld.HelloWorldServer
$ # In another terminal run the client
$ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworld.HelloWorldClient
```

## Bazel

If you prefer to use Bazel:
```
(With Bazel v0.4.5 or above.)
$ bazel build :hello-world-server :hello-world-client
$ # Run the server:
$ bazel-bin/hello-world-server
$ # In another terminal run the client
$ bazel-bin/hello-world-client
```