### PR TITLE
all: Don't depend directly on grpc-protobuf-lite

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -32,7 +32,7 @@ for (subproject in rootProject.subprojects) {
 }
 
 dependencies {
-    compile subprojects
+    compile subprojects.minus(project(':grpc-protobuf-lite'))
 }
 
 javadoc {


### PR DESCRIPTION
grpc-protobuf-lite brings in protobuf-lite as a dependency, which has
different versions of classes in protobuf. This causes duplicate classes
on the class path, which easily breaks things. Since lite the lite
runtime/codegen is incompatible with full protobuf, it makes sense to
only depend on one of the two.

grpc-protobuf actually already has a dependency on grpc-protobuf-lite,
but excludes the protobuf-lite dependency, making the dep safe. But this
is more of an implementation detail.

We only change deps so that JavaDoc, code coverage, and similar will
still include grpc-protobuf-lite.

Fixes #2985 

Doing this now since it seems a user (in #3149) has hit this problem.
Previously it was theoretical.