### PR TITLE
okhttp: ignore unknown HTTP/2 settings

### DIFF
--- a/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/framed/Http2.java
+++ b/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/framed/Http2.java
@@ -301,7 +301,8 @@ public final class Http2 implements Variant {
           case 6: // SETTINGS_MAX_HEADER_LIST_SIZE
             break; // Advisory only, so ignored.
           default:
-            throw ioException("PROTOCOL_ERROR invalid settings id: %s", id);
+            // Implementations MUST ignore any unknown or unsupported identifier.
+            continue;
         }
         settings.set(id, 0, value);
       }


### PR DESCRIPTION
This is a backport of #3036 to v1.3.x.