### PR TITLE
examples: Enable maven enforcer requireUpperBoundDeps

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -74,6 +74,24 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Everyone using maven should really use the rule, in order to prevent
accidentally using an older version of a common library, like protobuf.