### PR TITLE
all: Use fixed version number for java 6 signature

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -3,5 +3,5 @@ dependencies {
     compile project(':grpc-core'),
             libraries.google_auth_credentials
     testCompile libraries.oauth_client
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -2,5 +2,5 @@ description = 'gRPC: Context'
 
 dependencies {
     testCompile project(':grpc-testing')
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,7 +7,7 @@ dependencies {
             project(':grpc-context'),
             libraries.instrumentation_api
     testCompile project(':grpc-testing')
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
 
 javadoc.exclude 'io/grpc/internal/**'

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testCompile project(':grpc-core').sourceSets.test.output,
                 project(':grpc-testing')
     testRuntime libraries.netty_tcnative
-    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
 [compileJava, compileTestJava].each() {

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testCompile project(':grpc-core').sourceSets.test.output,
                 project(':grpc-testing'),
                 project(':grpc-netty')
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
 
 project.sourceSets {

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
     testProtobuf libraries.protobuf
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
 
 compileTestJava {

--- a/protobuf-nano/build.gradle
+++ b/protobuf-nano/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compile project(':grpc-core'),
             libraries.protobuf_nano,
             libraries.guava
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
 
 configureProtoCompilation()

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -25,7 +25,7 @@ dependencies {
         exclude group: 'com.google.protobuf', module: 'protobuf-lite'
     }
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
 
 configureProtoCompilation()

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub')
     testCompile project(':grpc-testing')
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
 
 configureProtoCompilation()

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile project(':grpc-core')
     testCompile libraries.truth,
     project(':grpc-testing')
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
 
 javadoc.options.links "https://google.github.io/guava/releases/${guavaVersion}/api/docs/"


### PR DESCRIPTION
This is important for stable builds, as if the signature changes the old source
may no longer validate.