### PR TITLE
netty: add timeouts to address test flakiness

### DIFF
--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -128,9 +128,6 @@ public abstract class AbstractTransportTest {
    */
   protected abstract boolean metricsExpected();
 
-
-  protected void sync(ManagedClientTransport client) {}
-
   /**
    * When non-null, will be shut down during tearDown(). However, it _must_ have been started with
    * {@code serverListener}, otherwise tearDown() can't wait for shutdown which can put following

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -646,7 +646,7 @@ public abstract class AbstractTransportTest {
     StreamCreation serverStreamCreation
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     if (metricsExpected()) {
-      clientInOrder.verify(clientStreamTracer).outboundHeaders();
+      verify(clientStreamTracer, timeout(TIMEOUT_MS)).outboundHeaders();
     }
     assertEquals(methodDescriptor.getFullMethodName(), serverStreamCreation.method);
     assertEquals(Lists.newArrayList(clientHeadersCopy.getAll(asciiKey)),

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -128,6 +128,9 @@ public abstract class AbstractTransportTest {
    */
   protected abstract boolean metricsExpected();
 
+
+  protected void sync(ManagedClientTransport client) {}
+
   /**
    * When non-null, will be shut down during tearDown(). However, it _must_ have been started with
    * {@code serverListener}, otherwise tearDown() can't wait for shutdown which can put following
@@ -1033,7 +1036,7 @@ public abstract class AbstractTransportTest {
       verify(serverStreamTracer, atLeast(1)).outboundUncompressedSize(anyLong());
       // There is a race between client cancelling and server closing.  The final status seen by the
       // server is non-deterministic.
-      verify(serverStreamTracer).streamClosed(any(Status.class));
+      verify(serverStreamTracer, timeout(TIMEOUT_MS)).streamClosed(any(Status.class));
       verifyNoMoreInteractions(clientStreamTracer);
       verifyNoMoreInteractions(serverStreamTracer);
     }


### PR DESCRIPTION
For `basicStream`, we can not use a timeout with the `inOrder` mock. The test looks like it's only testing for one interaction in that part of the test, rather than multiple interactions in a specific order. This looks fine to me. Please let me know what you think.

`clientCancelFromWithinMessageRead` is another test that needs a timeout argument.