### PR TITLE
interop-testing: Support conscrypt at runtime with OkHttp

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -46,6 +46,8 @@ public class TestServiceClient {
    * The main application allowing this client to be launched from the command line.
    */
   public static void main(String[] args) throws Exception {
+    // Let OkHttp use Conscrypt if it is available.
+    Util.installConscryptIfAvailable();
     final TestServiceClient client = new TestServiceClient();
     client.parseArgs(args);
     client.setUp();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/Util.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/Util.java
@@ -19,6 +19,10 @@ package io.grpc.testing.integration;
 import com.google.protobuf.MessageLite;
 import io.grpc.Metadata;
 import io.grpc.protobuf.ProtoUtils;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.Provider;
+import java.security.Security;
 import java.util.List;
 import org.junit.Assert;
 
@@ -61,5 +65,42 @@ public class Util {
         assertEquals(expected.get(i), actual.get(i));
       }
     }
+  }
+
+  private static boolean conscryptInstallAttempted;
+
+  /**
+   * Add Conscrypt to the list of security providers, if it is available. If it appears to be
+   * available but fails to load, this method will throw an exception. Since the list of security
+   * providers is static, this method does nothing if the provider is not available or succeeded
+   * previously.
+   */
+  public static void installConscryptIfAvailable() {
+    if (conscryptInstallAttempted) {
+      return;
+    }
+    Class<?> conscrypt;
+    try {
+      conscrypt = Class.forName("org.conscrypt.Conscrypt");
+    } catch (ClassNotFoundException ex) {
+      conscryptInstallAttempted = true;
+      return;
+    }
+    Method newProvider;
+    try {
+      newProvider = conscrypt.getMethod("newProvider");
+    } catch (NoSuchMethodException ex) {
+      throw new RuntimeException("Could not find newProvider method on Conscrypt", ex);
+    }
+    Provider provider;
+    try {
+      provider = (Provider) newProvider.invoke(null);
+    } catch (IllegalAccessException ex) {
+      throw new RuntimeException("Could not invoke Conscrypt.newProvider", ex);
+    } catch (InvocationTargetException ex) {
+      throw new RuntimeException("Could not invoke Conscrypt.newProvider", ex);
+    }
+    Security.addProvider(provider);
+    conscryptInstallAttempted = true;
   }
 }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -51,6 +51,12 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class Http2OkHttpTest extends AbstractInteropTest {
+  @BeforeClass
+  public static void loadConscrypt() throws Exception {
+    // Load conscrypt if it is available. Either Conscrypt or Jetty ALPN needs to be available for
+    // OkHttp to negotiate.
+    Util.installConscryptIfAvailable();
+  }
 
   /** Starts the server with HTTPS. */
   @BeforeClass


### PR DESCRIPTION
Conscrypt can thus be an alternative to Jetty ALPN for running these
OkHttp integration tests.