### PR TITLE
Backport (v1.0.x): Fix Windows build to specify Studio version

### DIFF
--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -28,7 +28,7 @@ del protobuf.zip
 pushd protobuf-%PROTOBUF_VER%\cmake
 mkdir build
 cd build
-cmake -Dprotobuf_BUILD_TESTS=OFF ..
+cmake -Dprotobuf_BUILD_TESTS=OFF -G "Visual Studio %VisualStudioVersion:~0,2%" ..
 msbuild /maxcpucount /p:Configuration=Release libprotoc.vcxproj
 call extract_includes.bat
 popd


### PR DESCRIPTION
Backport #2141 to fix Kokoro build for v1.0.x branch

The other release branches have this change already and have green builds on Kokoro.