### PR TITLE
fix misuse of bazel repo @com_google_protobuf

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -49,10 +49,10 @@ java_library(
         "@com_google_api_grpc_google_common_protos//jar",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava//jar",
-        "@com_google_protobuf//:protobuf_java_util",
         "@com_google_protobuf_java//:protobuf_java",
-        "@grpc_java//protobuf",
+        "@com_google_protobuf_java//:protobuf_java_util",
         "@grpc_java//core",
+        "@grpc_java//protobuf",
         "@grpc_java//stub",
     ],
 )

--- a/protobuf-lite/BUILD.bazel
+++ b/protobuf-lite/BUILD.bazel
@@ -10,6 +10,6 @@ java_library(
         "//core:internal",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava//jar",
-        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf_java//:protobuf_java",
     ],
 )

--- a/protobuf/BUILD.bazel
+++ b/protobuf/BUILD.bazel
@@ -10,7 +10,7 @@ java_library(
         "@com_google_api_grpc_google_common_protos//jar",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava//jar",
-        "@com_google_protobuf//:protobuf_java",
-        "@com_google_protobuf//:protobuf_java_util",
+        "@com_google_protobuf_java//:protobuf_java",
+        "@com_google_protobuf_java//:protobuf_java_util",
     ],
 )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -120,6 +120,9 @@ def com_google_instrumentation_api():
   )
 
 def com_google_protobuf():
+  # proto_library rules implicitly depend on @com_google_protobuf//:protoc,
+  # which is the proto-compiler.
+  # This statement defines the @com_google_protobuf repo.
   native.http_archive(
       name = "com_google_protobuf",
       sha256 = "df77b0e60afcd3d90b2654cd305e61ae8ae2e2281b4d6540c7093da4c4245d75",
@@ -128,6 +131,8 @@ def com_google_protobuf():
   )
 
 def com_google_protobuf_java():
+  # java_proto_library rules implicitly depend on @com_google_protobuf_java//:java_toolchain,
+  # which is the Java proto runtime (base classes and common utilities).
   native.http_archive(
       name = "com_google_protobuf_java",
       sha256 = "df77b0e60afcd3d90b2654cd305e61ae8ae2e2281b4d6540c7093da4c4245d75",


### PR DESCRIPTION
fix misuse of `@com_google_protobuf` mentioned in a comment of #3175 