### PR TITLE
core: Server uses transport's ScheduledExecutorService

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -22,10 +22,7 @@ import io.grpc.Internal;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
-import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.SharedResourceHolder;
 import java.net.SocketAddress;
-import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Builder for a channel that issues in-process requests. Clients identify the in-process server by
@@ -88,8 +85,6 @@ public final class InProcessChannelBuilder extends
   @Internal
   static final class InProcessClientTransportFactory implements ClientTransportFactory {
     private final String name;
-    private final ScheduledExecutorService timerService =
-        SharedResourceHolder.get(GrpcUtil.TIMER_SERVICE);
 
     private boolean closed;
 
@@ -103,16 +98,13 @@ public final class InProcessChannelBuilder extends
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
-      return new InProcessTransport(name, authority, timerService);
+      return new InProcessTransport(name, authority);
     }
 
     @Override
     public void close() {
-      if (closed) {
-        return;
-      }
       closed = true;
-      SharedResourceHolder.release(GrpcUtil.TIMER_SERVICE, timerService);
+      // Do nothing.
     }
   }
 }

--- a/core/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -16,12 +16,17 @@
 
 package io.grpc.inprocess;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.internal.InternalServer;
+import io.grpc.internal.ObjectPool;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerTransportListener;
+import io.grpc.internal.SharedResourceHolder.Resource;
+import io.grpc.internal.SharedResourcePool;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
@@ -36,14 +41,28 @@ final class InProcessServer implements InternalServer {
   private final String name;
   private ServerListener listener;
   private boolean shutdown;
+  /** Expected to be a SharedResourcePool except in testing. */
+  private final ObjectPool<ScheduledExecutorService> schedulerPool;
+  /**
+   * Only used to make sure the scheduler has at least one reference. Since child transports can
+   * outlive this server, they must get their own reference.
+   */
+  private ScheduledExecutorService scheduler;
 
-  InProcessServer(String name) {
+  InProcessServer(String name, Resource<ScheduledExecutorService> schedulerResource) {
+    this(name, SharedResourcePool.forResource(schedulerResource));
+  }
+
+  @VisibleForTesting
+  InProcessServer(String name, ObjectPool<ScheduledExecutorService> schedulerPool) {
     this.name = name;
+    this.schedulerPool = schedulerPool;
   }
 
   @Override
   public void start(ServerListener serverListener) throws IOException {
     this.listener = serverListener;
+    this.scheduler = schedulerPool.getObject();
     // Must be last, as channels can start connecting after this point.
     if (registry.putIfAbsent(name, this) != null) {
       throw new IOException("name already registered: " + name);
@@ -60,6 +79,7 @@ final class InProcessServer implements InternalServer {
     if (!registry.remove(name, this)) {
       throw new AssertionError();
     }
+    scheduler = schedulerPool.returnObject(scheduler);
     synchronized (this) {
       shutdown = true;
       listener.serverShutdown();
@@ -71,5 +91,9 @@ final class InProcessServer implements InternalServer {
       return null;
     }
     return listener.transportCreated(transport);
+  }
+
+  ObjectPool<ScheduledExecutorService> getScheduledExecutorServicePool() {
+    return schedulerPool;
   }
 }

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import io.grpc.ExperimentalApi;
 import io.grpc.ServerStreamTracer;
 import io.grpc.internal.AbstractServerImplBuilder;
+import io.grpc.internal.GrpcUtil;
 import java.io.File;
 import java.util.List;
 
@@ -54,7 +55,7 @@ public final class InProcessServerBuilder
     // TODO(zhangkun83): InProcessTransport by-passes framer and deframer, thus message sizses are
     // not counted.  Therefore, we disable stats for now.
     // (https://github.com/grpc/grpc-java/issues/2284)
-    return new InProcessServer(name);
+    return new InProcessServer(name, GrpcUtil.TIMER_SERVICE);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckReturnValue;
@@ -58,6 +59,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   private final LogId logId = LogId.allocate(getClass().getName());
   private final String name;
   private final String authority;
+  private final ScheduledExecutorService scheduler;
   private ServerTransportListener serverTransportListener;
   private Attributes serverStreamAttributes;
   private ManagedClientTransport.Listener clientTransportListener;
@@ -70,13 +72,10 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   @GuardedBy("this")
   private Set<InProcessStream> streams = new HashSet<InProcessStream>();
 
-  public InProcessTransport(String name) {
-    this(name, null);
-  }
-
-  public InProcessTransport(String name, String authority) {
+  public InProcessTransport(String name, String authority, ScheduledExecutorService scheduler) {
     this.name = name;
     this.authority = authority;
+    this.scheduler = scheduler;
   }
 
   @CheckReturnValue
@@ -198,6 +197,11 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   @Override
   public Attributes getAttributes() {
     return Attributes.EMPTY;
+  }
+
+  @Override
+  public ScheduledExecutorService getScheduledExecutorService() {
+    return scheduler;
   }
 
   private synchronized void notifyShutdown(Status s) {

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -185,7 +185,6 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   public Server build() {
     ServerImpl server = new ServerImpl(
         this,
-        SharedResourcePool.forResource(GrpcUtil.TIMER_SERVICE),
         buildTransportServer(Collections.unmodifiableList(getTracerFactories())),
         Context.ROOT);
     for (InternalNotifyOnServerBuild notifyTarget : notifyOnBuildList) {

--- a/core/src/main/java/io/grpc/internal/ServerTransport.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransport.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import io.grpc.Status;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** An inbound connection. */
 public interface ServerTransport extends WithLogId {
@@ -32,4 +33,13 @@ public interface ServerTransport extends WithLogId {
    * should be closed with the provided {@code reason}.
    */
   void shutdownNow(Status reason);
+
+  /**
+   * Returns an executor for scheduling provided by the transport. The service should be configured
+   * to allow cancelled scheduled runnables to be GCed.
+   *
+   * <p>The executor may not be used after the transport terminates. The caller should ensure any
+   * outstanding tasks are cancelled when the transport terminates.
+   */
+  ScheduledExecutorService getScheduledExecutorService();
 }

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -17,13 +17,11 @@
 package io.grpc.inprocess;
 
 import io.grpc.ServerStreamTracer;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.testing.AbstractTransportTest;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -33,17 +31,9 @@ public class InProcessTransportTest extends AbstractTransportTest {
   private static final String TRANSPORT_NAME = "perfect-for-testing";
   private static final String AUTHORITY = "a-testing-authority";
 
-  private static final ScheduledExecutorService scheduler =
-      Executors.newSingleThreadScheduledExecutor();
-
-  @AfterClass
-  public static void shutdown() {
-    scheduler.shutdown();
-  }
-
   @Override
   protected InternalServer newServer(List<ServerStreamTracer.Factory> streamTracerFactories) {
-    return new InProcessServer(TRANSPORT_NAME);
+    return new InProcessServer(TRANSPORT_NAME, GrpcUtil.TIMER_SERVICE);
   }
 
   @Override
@@ -59,7 +49,7 @@ public class InProcessTransportTest extends AbstractTransportTest {
 
   @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
-    return new InProcessTransport(TRANSPORT_NAME, testAuthority(server), scheduler);
+    return new InProcessTransport(TRANSPORT_NAME, testAuthority(server));
   }
 
   @Override

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -21,6 +21,9 @@ import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.testing.AbstractTransportTest;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -29,6 +32,14 @@ import org.junit.runners.JUnit4;
 public class InProcessTransportTest extends AbstractTransportTest {
   private static final String TRANSPORT_NAME = "perfect-for-testing";
   private static final String AUTHORITY = "a-testing-authority";
+
+  private static final ScheduledExecutorService scheduler =
+      Executors.newSingleThreadScheduledExecutor();
+
+  @AfterClass
+  public static void shutdown() {
+    scheduler.shutdown();
+  }
 
   @Override
   protected InternalServer newServer(List<ServerStreamTracer.Factory> streamTracerFactories) {
@@ -48,7 +59,7 @@ public class InProcessTransportTest extends AbstractTransportTest {
 
   @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
-    return new InProcessTransport(TRANSPORT_NAME, testAuthority(server));
+    return new InProcessTransport(TRANSPORT_NAME, testAuthority(server), scheduler);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -97,6 +98,11 @@ class NettyServerTransport implements ServerTransport {
 
     ChannelHandler negotiationHandler = protocolNegotiator.newHandler(grpcHandler);
     channel.pipeline().addLast(negotiationHandler);
+  }
+
+  @Override
+  public ScheduledExecutorService getScheduledExecutorService() {
+    return channel.eventLoop();
   }
 
   @Override


### PR DESCRIPTION
For Netty, this reduces the number of threads necessary for servers (although
until channel is converted, actual number of threads isn't impacted) and
naturally reduces contention and timeout latency.

For InProcess, this gets us closer to allowing applications to provide all
executors, which is especially useful during tests.

CC @zhangkun83 