### PR TITLE
core: Channel uses transport's ScheduledExecutorService

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -325,7 +325,6 @@ public abstract class AbstractManagedChannelImplBuilder
         buildTransportFactory(),
         // TODO(carl-mastrangelo): Allow clients to pass this in
         new ExponentialBackoffPolicy.Provider(),
-        SharedResourcePool.forResource(GrpcUtil.TIMER_SERVICE),
         SharedResourcePool.forResource(GrpcUtil.SHARED_CHANNEL_EXECUTOR),
         GrpcUtil.STOPWATCH_SUPPLIER,
         getEffectiveInterceptors());

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -27,6 +27,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
 import java.net.SocketAddress;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 
 final class CallCredentialsApplyingTransportFactory implements ClientTransportFactory {
@@ -44,6 +45,11 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
       SocketAddress serverAddress, String authority, @Nullable String userAgent) {
     return new CallCredentialsApplyingTransport(
         delegate.newClientTransport(serverAddress, authority, userAgent), authority);
+  }
+
+  @Override
+  public ScheduledExecutorService getScheduledExecutorService() {
+    return delegate.getScheduledExecutorService();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import java.io.Closeable;
 import java.net.SocketAddress;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 
 /** Pre-configured factory for creating {@link ConnectionClientTransport} instances. */
@@ -30,6 +31,18 @@ public interface ClientTransportFactory extends Closeable {
    */
   ConnectionClientTransport newClientTransport(SocketAddress serverAddress, String authority,
       @Nullable String userAgent);
+
+  /**
+   * Returns an executor for scheduling provided by the transport. The service should be configured
+   * to allow cancelled scheduled runnables to be GCed.
+   *
+   * <p>The executor should not be used after the factory has been closed. The caller should ensure
+   * any outstanding tasks are cancelled before the factory is closed. However, it is a
+   * <a href="https://github.com/grpc/grpc-java/issues/1981">known issue</a> that ClientCallImpl may
+   * use this executor after close, so implementations should not go out of their way to prevent
+   * usage.
+   */
+  ScheduledExecutorService getScheduledExecutorService();
 
   /**
    * Releases any resources.

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -57,7 +57,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
@@ -91,8 +90,6 @@ public class ManagedChannelImplIdlenessTest {
           .build();
 
   private final List<EquivalentAddressGroup> servers = Lists.newArrayList();
-  private final ObjectPool<ScheduledExecutorService> timerServicePool =
-      new FixedObjectPool<ScheduledExecutorService>(timer.getScheduledExecutorService());
   private final ObjectPool<Executor> executorPool =
       new FixedObjectPool<Executor>(executor.getScheduledExecutorService());
   private final ObjectPool<Executor> oobExecutorPool =
@@ -116,6 +113,8 @@ public class ManagedChannelImplIdlenessTest {
     when(mockNameResolverFactory
         .newNameResolver(any(URI.class), any(Attributes.class)))
         .thenReturn(mockNameResolver);
+    when(mockTransportFactory.getScheduledExecutorService())
+        .thenReturn(timer.getScheduledExecutorService());
 
     class Builder extends AbstractManagedChannelImplBuilder<Builder> {
       Builder(String target) {
@@ -139,7 +138,7 @@ public class ManagedChannelImplIdlenessTest {
     builder.executorPool = executorPool;
     channel = new ManagedChannelImpl(
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
-        timerServicePool, oobExecutorPool, timer.getStopwatchSupplier(),
+        oobExecutorPool, timer.getStopwatchSupplier(),
         Collections.<ClientInterceptor>emptyList());
     newTransports = TestUtils.captureTransports(mockTransportFactory);
 

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -46,6 +46,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -495,6 +496,11 @@ public final class NettyChannelBuilder
           keepAliveWithoutCalls, dparams.getAuthority(), dparams.getUserAgent(),
           tooManyPingsRunnable);
       return transport;
+    }
+
+    @Override
+    public ScheduledExecutorService getScheduledExecutorService() {
+      return group;
     }
 
     @Override


### PR DESCRIPTION
Coupled with the similar change on server-side, this removes the need for a
thread when using Netty. For InProcess and OkHttp, it would allow us to let the
user to provide the scheduler for tests or application-wide thread sharing.

The first commit is from #3184, and need not be reviewed here. This change
depends on it, but not too heavily; the dependency could be removed without
much trouble (although then at the price of merge conflicts and needing to
re-apply review fixes).