### PR TITLE
all,interop-testing: update google-auth-library-oauth2-http

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ subprojects {
                 guava: "com.google.guava:guava:${guavaVersion}",
                 hpack: 'com.twitter:hpack:0.10.1',
                 jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
-                oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.4.0',
+                oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.7.0',
                 google_api_protos: 'com.google.api.grpc:proto-google-common-protos:0.1.9',
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.4.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1324,6 +1324,8 @@ public abstract class AbstractInteropTest {
     // TODO(madongfly): The Auth library may have something like AccessTokenCredentials in the
     // future, change to the official implementation then.
     OAuth2Credentials credentials = new OAuth2Credentials(accessToken) {
+      private static final long serialVersionUID = 0;
+
       @Override
       public AccessToken refreshAccessToken() throws IOException {
         throw new IOException("This credential is based on a certain AccessToken, "


### PR DESCRIPTION
This avoids a guava dependency conflict that caused the interop test server to fail with the message:

> Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.platformThreadFactory()Ljava/util/concurrent/ThreadFactory;
        at io.grpc.internal.GrpcUtil.getThreadFactory(GrpcUtil.java:482)
        at io.grpc.internal.GrpcUtil$2.create(GrpcUtil.java:446)
        at io.grpc.internal.GrpcUtil$2.create(GrpcUtil.java:439)
        at io.grpc.internal.SharedResourceHolder.getInternal(SharedResourceHolder.java:104)
        at io.grpc.internal.SharedResourceHolder.get(SharedResourceHolder.java:74)
        at io.grpc.internal.SharedResourcePool.getObject(SharedResourcePool.java:35)
        at io.grpc.internal.ServerImpl.start(ServerImpl.java:149)
        at io.grpc.internal.ServerImpl.start(ServerImpl.java:70)
        at io.grpc.testing.integration.TestServiceServer.start(TestServiceServer.java:133)
        at io.grpc.testing.integration.TestServiceServer.main(TestServiceServer.java:59)
Shutting down
