### PR TITLE
core: clarify security methods on channel and server

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -152,6 +152,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    *
    * @param skipNegotiation @{code true} if there is a priori knowledge that the endpoint supports
    *                        plaintext, {@code false} if plaintext use must be negotiated.
+   * @throws UnsupportedOperationException if plaintext mode is not supported.
    * @return this
    * @since 1.0.0
    */

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -152,6 +152,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    *
    * @param skipNegotiation @{code true} if there is a priori knowledge that the endpoint supports
    *                        plaintext, {@code false} if plaintext use must be negotiated.
+   *
    * @throws UnsupportedOperationException if plaintext mode is not supported.
    * @return this
    * @since 1.0.0

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -143,9 +143,9 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    *
    * @param certChain file containing the full certificate chain
    * @param privateKey file containing the private key
-   * @throws UnsupportedOperationException if the server does not support TLS.
    *
    * @return this
+   * @throws UnsupportedOperationException if the server does not support TLS.
    * @since 1.0.0
    */
   public abstract T useTransportSecurity(File certChain, File privateKey);

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -143,6 +143,7 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    *
    * @param certChain file containing the full certificate chain
    * @param privateKey file containing the private key
+   * @throws UnsupportedOperationException if the server does not support TLS.
    *
    * @return this
    * @since 1.0.0


### PR DESCRIPTION
This change is here to allow custom server / channel implementations to throw if TLS or plaintext is not supported.  This is the case when using custom, security specific builders.

As a side effect InProcessServerBuilder throwing UOE is now allowed from the javadoc.