### PR TITLE
Update auth lib to 0.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ subprojects {
                 guava: "com.google.guava:guava:${guavaVersion}",
                 hpack: 'com.twitter:hpack:0.10.1',
                 jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
-                oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.4.0',
+                oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.7.0',
                 google_api_protos: 'com.google.api.grpc:proto-google-common-protos:0.1.9',
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.4.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',


### PR DESCRIPTION
0.4.0 is still using an older version of guava (jdk5-0.13) which causes runtime exception in tests.