### PR TITLE
Add support for specifying a custom hostname verifier when using on OkHttpChannelBuilder

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
@@ -26,6 +26,7 @@ import java.net.Socket;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -51,7 +52,8 @@ final class OkHttpTlsUpgrader {
    * @throws RuntimeException if the upgrade negotiation failed.
    */
   public static SSLSocket upgrade(SSLSocketFactory sslSocketFactory,
-      Socket socket, String host, int port, ConnectionSpec spec) throws IOException {
+      HostnameVerifier hostnameVerifier, Socket socket, String host, int port,
+      ConnectionSpec spec) throws IOException {
     Preconditions.checkNotNull(sslSocketFactory, "sslSocketFactory");
     Preconditions.checkNotNull(socket, "socket");
     Preconditions.checkNotNull(spec, "spec");
@@ -65,7 +67,10 @@ final class OkHttpTlsUpgrader {
         "Only " + TLS_PROTOCOLS + " are supported, but negotiated protocol is %s",
         negotiatedProtocol);
 
-    if (!OkHostnameVerifier.INSTANCE.verify(host, sslSocket.getSession())) {
+    if (hostnameVerifier == null) {
+      hostnameVerifier = OkHostnameVerifier.INSTANCE;
+    }
+    if (!hostnameVerifier.verify(host, sslSocket.getSession())) {
       throw new SSLPeerUnverifiedException("Cannot verify hostname: " + host);
     }
     return sslSocket;

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -183,7 +183,8 @@ public class OkHttpClientTransportTest {
   public void testToString() throws Exception {
     InetSocketAddress address = InetSocketAddress.createUnresolved("hostname", 31415);
     clientTransport = new OkHttpClientTransport(
-        address, "hostname", null /* agent */, executor, null,
+        address, "hostname", null /* agent */, executor, /* sslSocketFactory */ null,
+        /* hostnameVerifier */null,
         Utils.convertSpec(OkHttpChannelBuilder.DEFAULT_CONNECTION_SPEC), DEFAULT_MAX_MESSAGE_SIZE,
         null, null, null, tooManyPingsRunnable);
     String s = clientTransport.toString();
@@ -1328,6 +1329,7 @@ public class OkHttpClientTransportTest {
         "userAgent",
         executor,
         null,
+        null,
         ConnectionSpec.CLEARTEXT,
         DEFAULT_MAX_MESSAGE_SIZE,
         null,
@@ -1349,6 +1351,7 @@ public class OkHttpClientTransportTest {
         "authority",
         "userAgent",
         executor,
+        null,
         null,
         ConnectionSpec.CLEARTEXT,
         DEFAULT_MAX_MESSAGE_SIZE,
@@ -1379,6 +1382,7 @@ public class OkHttpClientTransportTest {
         "authority",
         "userAgent",
         executor,
+        null,
         null,
         ConnectionSpec.CLEARTEXT,
         DEFAULT_MAX_MESSAGE_SIZE,
@@ -1429,6 +1433,7 @@ public class OkHttpClientTransportTest {
         "userAgent",
         executor,
         null,
+        null,
         ConnectionSpec.CLEARTEXT,
         DEFAULT_MAX_MESSAGE_SIZE,
         (InetSocketAddress) serverSocket.getLocalSocketAddress(),
@@ -1476,6 +1481,7 @@ public class OkHttpClientTransportTest {
         "authority",
         "userAgent",
         executor,
+        null,
         null,
         ConnectionSpec.CLEARTEXT,
         DEFAULT_MAX_MESSAGE_SIZE,


### PR DESCRIPTION
We use custom x509 extensions to encode multiple dimensions of server identity, and clients verify different dimensions based on individual client requirements. This is all coded up into HostnameVerifier implementations, but we need to ability to pass this to the the OkHttpChannelBuilder. I've implemented the ability to pass this through, defaulting to the existing OkHostnameVerifier implementation when unspecified.