### PR TITLE
Make Kokoro show actual Gradle results

### DIFF
--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -32,6 +32,7 @@ echo vcProtobufLibs=%ESCWORKSPACE%\\grpc-java-helper\\protobuf-%PROTOBUF_VER%\\c
 echo vcProtobufInclude=%ESCWORKSPACE%\\grpc-java-helper\\protobuf-%PROTOBUF_VER%\\cmake\\build\\include>> gradle.properties
 
 cmd.exe /C "%WORKSPACE%\gradlew.bat build"
+set GRADLEEXIT=%ERRORLEVEL%
 
 @rem Rename test results .xml files to format parsable by Kokoro
 @echo off
@@ -41,4 +42,4 @@ for /r %%F in (TEST-*.xml) do (
 )
 @echo on
 
-exit %%ERRORLEVEL%%
+exit %GRADLEEXIT%


### PR DESCRIPTION
There were a couple of issues:
- `windows.bat` wasn't returning the Gradle exit code; it was returning an exit code related to the commands renaming the `*.xml` files
- `%%ERRORLEVEL%%` changed to `%ERRORLEVEL%`

After PR review, I'll remove the commit causing test failures, squash commits, and make sure the Kokoro build is green with these changes. 