### PR TITLE
Canonicalize URL prefixes to https://grpc.io (backport to v1.0.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Readme](SECURITY.md).
 <table>
   <tr>
     <td><b>Homepage:</b></td>
-    <td><a href="http://www.grpc.io/">www.grpc.io</a></td>
+    <td><a href="https://grpc.io/">grpc.io</a></td>
   </tr>
   <tr>
     <td><b>Mailing List:</b></td>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -350,4 +350,4 @@ git commit -m "Javadoc for $MAJOR.$MINOR.$PATCH"
 ```
 
 Push gh-pages to the main repository and verify the current version is [live
-on grpc.io](http://www.grpc.io/grpc-java/javadoc/).
+on grpc.io](https://grpc.io/grpc-java/javadoc/).

--- a/build.gradle
+++ b/build.gradle
@@ -286,7 +286,7 @@ subprojects {
                     id "grpc.io"
                     name "gRPC Contributors"
                     email "grpc-io@googlegroups.com"
-                    url "http://grpc.io/"
+                    url "https://grpc.io/"
                     // https://issues.gradle.org/browse/GRADLE-2719
                     organization = "Google, Inc."
                     organizationUrl "https://www.google.com"

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ $ ./build/install/examples/bin/hello-world-client
 That's it!
 
 Please refer to gRPC Java's [README](../README.md) and
-[tutorial](http://www.grpc.io/docs/tutorials/basic/java.html) for more
+[tutorial](https://grpc.io/docs/tutorials/basic/java.html) for more
 information.
 
 ## Maven


### PR DESCRIPTION
cf. #3212 