### PR TITLE
Canonicalize URL prefixes to https://grpc.io (backport to 1.4.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Readme](SECURITY.md).
 <table>
   <tr>
     <td><b>Homepage:</b></td>
-    <td><a href="http://www.grpc.io/">www.grpc.io</a></td>
+    <td><a href="https://grpc.io/">grpc.io</a></td>
   </tr>
   <tr>
     <td><b>Mailing List:</b></td>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -385,4 +385,4 @@ git commit -m "Javadoc for $MAJOR.$MINOR.$PATCH"
 ```
 
 Push gh-pages to the main repository and verify the current version is [live
-on grpc.io](http://www.grpc.io/grpc-java/javadoc/).
+on grpc.io](https://grpc.io/grpc-java/javadoc/).

--- a/build.gradle
+++ b/build.gradle
@@ -316,7 +316,7 @@ subprojects {
                     id "grpc.io"
                     name "gRPC Contributors"
                     email "grpc-io@googlegroups.com"
-                    url "http://grpc.io/"
+                    url "https://grpc.io/"
                     // https://issues.gradle.org/browse/GRADLE-2719
                     organization = "Google, Inc."
                     organizationUrl "https://www.google.com"

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ to check out a git release tag, since there will already be a build of grpc
 available. Otherwise you must follow [COMPILING](../COMPILING.md).
 
 You may want to read through the
-[Quick Start Guide](http://www.grpc.io/docs/quickstart/java.html)
+[Quick Start Guide](https://grpc.io/docs/quickstart/java.html)
 before trying out the examples.
 
 To build the examples, run in this directory:
@@ -35,7 +35,7 @@ $ ./build/install/examples/bin/hello-world-client
 That's it!
 
 Please refer to gRPC Java's [README](../README.md) and
-[tutorial](http://www.grpc.io/docs/tutorials/basic/java.html) for more
+[tutorial](https://grpc.io/docs/tutorials/basic/java.html) for more
 information.
 
 ## Maven

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -7,7 +7,7 @@ PREREQUISITES
 
 - [Android Tutorial](https://developer.android.com/training/basics/firstapp/index.html) if you're new to Android development
 
-- [gRPC Java Android Quick Start Guide](http://www.grpc.io/docs/quickstart/android.html)
+- [gRPC Java Android Quick Start Guide](https://grpc.io/docs/quickstart/android.html)
 
 - We only have Android gRPC client in this example. Please follow examples in other languages to build and run a gRPC server.
 
@@ -28,5 +28,5 @@ $ ./gradlew installDebug
 ```
 
 Please refer to the
-[tutorial](http://www.grpc.io/docs/tutorials/basic/android.html) on
+[tutorial](https://grpc.io/docs/tutorials/basic/android.html) on
 how to use gRPC in Android programs.

--- a/stub/src/main/java/io/grpc/stub/package-info.java
+++ b/stub/src/main/java/io/grpc/stub/package-info.java
@@ -37,7 +37,7 @@
  *
  * <p>In the most common case of gRPC over Protocol Buffers, stub classes are automatically
  * generated from service definition .proto files by the Protobuf compiler. See <a
- * href="http://www.grpc.io/docs/generatedcode/java.html">gRPC java Generated Code Guide</a>.
+ * href="https://grpc.io/docs/generatedcode/java.html">gRPC java Generated Code Guide</a>.
  *
  * <p>The server side stub classes are abstract classes with RPC methods for the server application
  * to implement/override. These classes internally use {@link io.grpc.stub.ServerCalls} to interact


### PR DESCRIPTION
Backport #3212 to 1.4.x

