### PR TITLE
android-interop-testing: use google() repository

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -17,6 +17,7 @@ allprojects {
     repositories {
         mavenLocal()
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
Gradle 4.0.1 adds a [`google()` repository](https://docs.gradle.org/4.0-rc-1/release-notes.html#convenience-method-for-adding-google-repository) that now has some of the android dependencies. Adding this allows the `appcompat-v7` and `support-annotations` dependencies to be automatically downloaded during the build if not already installed via the Android SDK Manager. This partially addresses https://github.com/grpc/grpc/issues/11771.

Edit: https://github.com/grpc/grpc/issues/11771 was filed before the switch to Gradle 4.0.1, but this is still the correct repository for the mentioned dependencies: https://developer.android.com/studio/build/dependencies.html#google-maven "See which libraries are in the Maven repo"