### PR TITLE
core: refactor SubchannelImpl

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/AbstractSubchannel.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * The base interface of the Subchannels returned by {@link
  * io.grpc.LoadBalancer.Helper#createSubchannel}.
  */
-abstract class SubchannelImpl extends LoadBalancer.Subchannel {
+abstract class AbstractSubchannel extends LoadBalancer.Subchannel {
   /**
    * Same as {@link InternalSubchannel#obtainActiveTransport}.
    */

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -575,7 +575,7 @@ public final class GrpcUtil {
     final ClientTransport transport;
     Subchannel subchannel = result.getSubchannel();
     if (subchannel != null) {
-      transport = ((SubchannelImpl) subchannel).obtainActiveTransport();
+      transport = ((AbstractSubchannel) subchannel).obtainActiveTransport();
     } else {
       transport = null;
     }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -795,7 +795,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   }
 
   private final class SubchannelImpl extends AbstractSubchannel {
-    // Set right after SubchannelImplImpl is created.
+    // Set right after SubchannelImpl is created.
     InternalSubchannel subchannel;
     final Object shutdownLock = new Object();
     final Attributes attrs;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -577,7 +577,8 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     }
 
     @Override
-    public SubchannelImpl createSubchannel(EquivalentAddressGroup addressGroup, Attributes attrs) {
+    public AbstractSubchannel createSubchannel(
+        EquivalentAddressGroup addressGroup, Attributes attrs) {
       checkNotNull(addressGroup, "addressGroup");
       checkNotNull(attrs, "attrs");
       ScheduledExecutorService scheduledExecutorCopy = scheduledExecutor;
@@ -793,7 +794,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     }
   }
 
-  private final class SubchannelImplImpl extends SubchannelImpl {
+  private final class SubchannelImplImpl extends AbstractSubchannel {
     // Set right after SubchannelImplImpl is created.
     InternalSubchannel subchannel;
     final Object shutdownLock = new Object();

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -585,7 +585,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       checkState(scheduledExecutorCopy != null,
           "scheduledExecutor is already cleared. Looks like you are calling this method after "
           + "you've already shut down");
-      final SubchannelImplImpl subchannel = new SubchannelImplImpl(attrs);
+      final SubchannelImpl subchannel = new SubchannelImpl(attrs);
       final InternalSubchannel internalSubchannel = new InternalSubchannel(
             addressGroup, authority(), userAgent, backoffPolicyProvider, transportFactory,
             scheduledExecutorCopy, stopwatchSupplier, channelExecutor,
@@ -642,9 +642,9 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     @Override
     public void updateSubchannelAddresses(
         LoadBalancer.Subchannel subchannel, EquivalentAddressGroup addrs) {
-      checkArgument(subchannel instanceof SubchannelImplImpl,
+      checkArgument(subchannel instanceof SubchannelImpl,
           "subchannel must have been returned from createSubchannel");
-      ((SubchannelImplImpl) subchannel).subchannel.updateAddresses(addrs);
+      ((SubchannelImpl) subchannel).subchannel.updateAddresses(addrs);
     }
 
     @Override
@@ -794,7 +794,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     }
   }
 
-  private final class SubchannelImplImpl extends AbstractSubchannel {
+  private final class SubchannelImpl extends AbstractSubchannel {
     // Set right after SubchannelImplImpl is created.
     InternalSubchannel subchannel;
     final Object shutdownLock = new Object();
@@ -805,7 +805,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     @GuardedBy("shutdownLock")
     ScheduledFuture<?> delayedShutdownTask;
 
-    SubchannelImplImpl(Attributes attrs) {
+    SubchannelImpl(Attributes attrs) {
       this.attrs = checkNotNull(attrs, "attrs");
     }
 

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -48,7 +48,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   private static final Logger log = Logger.getLogger(OobChannel.class.getName());
 
   private InternalSubchannel subchannel;
-  private SubchannelImpl subchannelImpl;
+  private AbstractSubchannel subchannelImpl;
   private SubchannelPicker subchannelPicker;
 
   private final LogId logId = LogId.allocate(getClass().getName());
@@ -106,7 +106,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   void setSubchannel(final InternalSubchannel subchannel) {
     log.log(Level.FINE, "[{0}] Created with [{1}]", new Object[] {this, subchannel});
     this.subchannel = subchannel;
-    subchannelImpl = new SubchannelImpl() {
+    subchannelImpl = new AbstractSubchannel() {
         @Override
         public void shutdown() {
           subchannel.shutdown();

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -67,7 +67,7 @@ import org.mockito.stubbing.Answer;
 public class DelayedClientTransportTest {
   @Mock private ManagedClientTransport.Listener transportListener;
   @Mock private SubchannelPicker mockPicker;
-  @Mock private SubchannelImpl mockSubchannel;
+  @Mock private AbstractSubchannel mockSubchannel;
   @Mock private ClientTransport mockRealTransport;
   @Mock private ClientTransport mockRealTransport2;
   @Mock private ClientStream mockRealStream;
@@ -282,9 +282,9 @@ public class DelayedClientTransportTest {
     CallOptions waitForReadyCallOptions = CallOptions.DEFAULT.withOption(SHARD_ID, 2)
         .withWaitForReady();
 
-    SubchannelImpl subchannel1 = mock(SubchannelImpl.class);
-    SubchannelImpl subchannel2 = mock(SubchannelImpl.class);
-    SubchannelImpl subchannel3 = mock(SubchannelImpl.class);
+    AbstractSubchannel subchannel1 = mock(AbstractSubchannel.class);
+    AbstractSubchannel subchannel2 = mock(AbstractSubchannel.class);
+    AbstractSubchannel subchannel3 = mock(AbstractSubchannel.class);
     when(mockRealTransport.newStream(any(MethodDescriptor.class), any(Metadata.class),
         any(CallOptions.class))).thenReturn(mockRealStream);
     when(mockRealTransport2.newStream(any(MethodDescriptor.class), any(Metadata.class),
@@ -445,7 +445,7 @@ public class DelayedClientTransportTest {
   @Test
   public void reprocess_NoPendingStream() {
     SubchannelPicker picker = mock(SubchannelPicker.class);
-    SubchannelImpl subchannel = mock(SubchannelImpl.class);
+    AbstractSubchannel subchannel = mock(AbstractSubchannel.class);
     when(subchannel.obtainActiveTransport()).thenReturn(mockRealTransport);
     when(picker.pickSubchannel(any(PickSubchannelArgs.class))).thenReturn(
         PickResult.withSubchannel(subchannel));


### PR DESCRIPTION
The old `SubchannelImpl` is actually not implementing anything, and the old `SubchannelImplImpl` has a weird name.