### PR TITLE
testing-proto: add string message to testing proto

### DIFF
--- a/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleRequest.java
+++ b/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleRequest.java
@@ -19,6 +19,7 @@ public  final class SimpleRequest extends
     super(builder);
   }
   private SimpleRequest() {
+    requestMessage_ = "";
   }
 
   @java.lang.Override
@@ -31,6 +32,7 @@ public  final class SimpleRequest extends
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    int mutable_bitField0_ = 0;
     try {
       boolean done = false;
       while (!done) {
@@ -43,6 +45,12 @@ public  final class SimpleRequest extends
             if (!input.skipField(tag)) {
               done = true;
             }
+            break;
+          }
+          case 10: {
+            java.lang.String s = input.readStringRequireUtf8();
+
+            requestMessage_ = s;
             break;
           }
         }
@@ -68,6 +76,48 @@ public  final class SimpleRequest extends
             io.grpc.testing.protobuf.SimpleRequest.class, io.grpc.testing.protobuf.SimpleRequest.Builder.class);
   }
 
+  public static final int REQUESTMESSAGE_FIELD_NUMBER = 1;
+  private volatile java.lang.Object requestMessage_;
+  /**
+   * <pre>
+   * An optional string message for test.
+   * </pre>
+   *
+   * <code>string requestMessage = 1;</code>
+   */
+  public java.lang.String getRequestMessage() {
+    java.lang.Object ref = requestMessage_;
+    if (ref instanceof java.lang.String) {
+      return (java.lang.String) ref;
+    } else {
+      com.google.protobuf.ByteString bs = 
+          (com.google.protobuf.ByteString) ref;
+      java.lang.String s = bs.toStringUtf8();
+      requestMessage_ = s;
+      return s;
+    }
+  }
+  /**
+   * <pre>
+   * An optional string message for test.
+   * </pre>
+   *
+   * <code>string requestMessage = 1;</code>
+   */
+  public com.google.protobuf.ByteString
+      getRequestMessageBytes() {
+    java.lang.Object ref = requestMessage_;
+    if (ref instanceof java.lang.String) {
+      com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString.copyFromUtf8(
+              (java.lang.String) ref);
+      requestMessage_ = b;
+      return b;
+    } else {
+      return (com.google.protobuf.ByteString) ref;
+    }
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -80,6 +130,9 @@ public  final class SimpleRequest extends
 
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
+    if (!getRequestMessageBytes().isEmpty()) {
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, requestMessage_);
+    }
   }
 
   public int getSerializedSize() {
@@ -87,6 +140,9 @@ public  final class SimpleRequest extends
     if (size != -1) return size;
 
     size = 0;
+    if (!getRequestMessageBytes().isEmpty()) {
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, requestMessage_);
+    }
     memoizedSize = size;
     return size;
   }
@@ -103,6 +159,8 @@ public  final class SimpleRequest extends
     io.grpc.testing.protobuf.SimpleRequest other = (io.grpc.testing.protobuf.SimpleRequest) obj;
 
     boolean result = true;
+    result = result && getRequestMessage()
+        .equals(other.getRequestMessage());
     return result;
   }
 
@@ -113,6 +171,8 @@ public  final class SimpleRequest extends
     }
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
+    hash = (37 * hash) + REQUESTMESSAGE_FIELD_NUMBER;
+    hash = (53 * hash) + getRequestMessage().hashCode();
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -246,6 +306,8 @@ public  final class SimpleRequest extends
     }
     public Builder clear() {
       super.clear();
+      requestMessage_ = "";
+
       return this;
     }
 
@@ -268,6 +330,7 @@ public  final class SimpleRequest extends
 
     public io.grpc.testing.protobuf.SimpleRequest buildPartial() {
       io.grpc.testing.protobuf.SimpleRequest result = new io.grpc.testing.protobuf.SimpleRequest(this);
+      result.requestMessage_ = requestMessage_;
       onBuilt();
       return result;
     }
@@ -309,6 +372,10 @@ public  final class SimpleRequest extends
 
     public Builder mergeFrom(io.grpc.testing.protobuf.SimpleRequest other) {
       if (other == io.grpc.testing.protobuf.SimpleRequest.getDefaultInstance()) return this;
+      if (!other.getRequestMessage().isEmpty()) {
+        requestMessage_ = other.requestMessage_;
+        onChanged();
+      }
       onChanged();
       return this;
     }
@@ -332,6 +399,95 @@ public  final class SimpleRequest extends
           mergeFrom(parsedMessage);
         }
       }
+      return this;
+    }
+
+    private java.lang.Object requestMessage_ = "";
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string requestMessage = 1;</code>
+     */
+    public java.lang.String getRequestMessage() {
+      java.lang.Object ref = requestMessage_;
+      if (!(ref instanceof java.lang.String)) {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        requestMessage_ = s;
+        return s;
+      } else {
+        return (java.lang.String) ref;
+      }
+    }
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string requestMessage = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRequestMessageBytes() {
+      java.lang.Object ref = requestMessage_;
+      if (ref instanceof String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        requestMessage_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string requestMessage = 1;</code>
+     */
+    public Builder setRequestMessage(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  
+      requestMessage_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string requestMessage = 1;</code>
+     */
+    public Builder clearRequestMessage() {
+      
+      requestMessage_ = getDefaultInstance().getRequestMessage();
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string requestMessage = 1;</code>
+     */
+    public Builder setRequestMessageBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+      
+      requestMessage_ = value;
+      onChanged();
       return this;
     }
     public final Builder setUnknownFields(

--- a/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleRequestOrBuilder.java
+++ b/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleRequestOrBuilder.java
@@ -6,4 +6,22 @@ package io.grpc.testing.protobuf;
 public interface SimpleRequestOrBuilder extends
     // @@protoc_insertion_point(interface_extends:grpc.testing.SimpleRequest)
     com.google.protobuf.MessageOrBuilder {
+
+  /**
+   * <pre>
+   * An optional string message for test.
+   * </pre>
+   *
+   * <code>string requestMessage = 1;</code>
+   */
+  java.lang.String getRequestMessage();
+  /**
+   * <pre>
+   * An optional string message for test.
+   * </pre>
+   *
+   * <code>string requestMessage = 1;</code>
+   */
+  com.google.protobuf.ByteString
+      getRequestMessageBytes();
 }

--- a/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleResponse.java
+++ b/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleResponse.java
@@ -19,6 +19,7 @@ public  final class SimpleResponse extends
     super(builder);
   }
   private SimpleResponse() {
+    responseMessage_ = "";
   }
 
   @java.lang.Override
@@ -31,6 +32,7 @@ public  final class SimpleResponse extends
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     this();
+    int mutable_bitField0_ = 0;
     try {
       boolean done = false;
       while (!done) {
@@ -43,6 +45,12 @@ public  final class SimpleResponse extends
             if (!input.skipField(tag)) {
               done = true;
             }
+            break;
+          }
+          case 10: {
+            java.lang.String s = input.readStringRequireUtf8();
+
+            responseMessage_ = s;
             break;
           }
         }
@@ -68,6 +76,48 @@ public  final class SimpleResponse extends
             io.grpc.testing.protobuf.SimpleResponse.class, io.grpc.testing.protobuf.SimpleResponse.Builder.class);
   }
 
+  public static final int RESPONSEMESSAGE_FIELD_NUMBER = 1;
+  private volatile java.lang.Object responseMessage_;
+  /**
+   * <pre>
+   * An optional string message for test.
+   * </pre>
+   *
+   * <code>string responseMessage = 1;</code>
+   */
+  public java.lang.String getResponseMessage() {
+    java.lang.Object ref = responseMessage_;
+    if (ref instanceof java.lang.String) {
+      return (java.lang.String) ref;
+    } else {
+      com.google.protobuf.ByteString bs = 
+          (com.google.protobuf.ByteString) ref;
+      java.lang.String s = bs.toStringUtf8();
+      responseMessage_ = s;
+      return s;
+    }
+  }
+  /**
+   * <pre>
+   * An optional string message for test.
+   * </pre>
+   *
+   * <code>string responseMessage = 1;</code>
+   */
+  public com.google.protobuf.ByteString
+      getResponseMessageBytes() {
+    java.lang.Object ref = responseMessage_;
+    if (ref instanceof java.lang.String) {
+      com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString.copyFromUtf8(
+              (java.lang.String) ref);
+      responseMessage_ = b;
+      return b;
+    } else {
+      return (com.google.protobuf.ByteString) ref;
+    }
+  }
+
   private byte memoizedIsInitialized = -1;
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -80,6 +130,9 @@ public  final class SimpleResponse extends
 
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
+    if (!getResponseMessageBytes().isEmpty()) {
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, responseMessage_);
+    }
   }
 
   public int getSerializedSize() {
@@ -87,6 +140,9 @@ public  final class SimpleResponse extends
     if (size != -1) return size;
 
     size = 0;
+    if (!getResponseMessageBytes().isEmpty()) {
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, responseMessage_);
+    }
     memoizedSize = size;
     return size;
   }
@@ -103,6 +159,8 @@ public  final class SimpleResponse extends
     io.grpc.testing.protobuf.SimpleResponse other = (io.grpc.testing.protobuf.SimpleResponse) obj;
 
     boolean result = true;
+    result = result && getResponseMessage()
+        .equals(other.getResponseMessage());
     return result;
   }
 
@@ -113,6 +171,8 @@ public  final class SimpleResponse extends
     }
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
+    hash = (37 * hash) + RESPONSEMESSAGE_FIELD_NUMBER;
+    hash = (53 * hash) + getResponseMessage().hashCode();
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -246,6 +306,8 @@ public  final class SimpleResponse extends
     }
     public Builder clear() {
       super.clear();
+      responseMessage_ = "";
+
       return this;
     }
 
@@ -268,6 +330,7 @@ public  final class SimpleResponse extends
 
     public io.grpc.testing.protobuf.SimpleResponse buildPartial() {
       io.grpc.testing.protobuf.SimpleResponse result = new io.grpc.testing.protobuf.SimpleResponse(this);
+      result.responseMessage_ = responseMessage_;
       onBuilt();
       return result;
     }
@@ -309,6 +372,10 @@ public  final class SimpleResponse extends
 
     public Builder mergeFrom(io.grpc.testing.protobuf.SimpleResponse other) {
       if (other == io.grpc.testing.protobuf.SimpleResponse.getDefaultInstance()) return this;
+      if (!other.getResponseMessage().isEmpty()) {
+        responseMessage_ = other.responseMessage_;
+        onChanged();
+      }
       onChanged();
       return this;
     }
@@ -332,6 +399,95 @@ public  final class SimpleResponse extends
           mergeFrom(parsedMessage);
         }
       }
+      return this;
+    }
+
+    private java.lang.Object responseMessage_ = "";
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string responseMessage = 1;</code>
+     */
+    public java.lang.String getResponseMessage() {
+      java.lang.Object ref = responseMessage_;
+      if (!(ref instanceof java.lang.String)) {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        responseMessage_ = s;
+        return s;
+      } else {
+        return (java.lang.String) ref;
+      }
+    }
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string responseMessage = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getResponseMessageBytes() {
+      java.lang.Object ref = responseMessage_;
+      if (ref instanceof String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        responseMessage_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string responseMessage = 1;</code>
+     */
+    public Builder setResponseMessage(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  
+      responseMessage_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string responseMessage = 1;</code>
+     */
+    public Builder clearResponseMessage() {
+      
+      responseMessage_ = getDefaultInstance().getResponseMessage();
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * An optional string message for test.
+     * </pre>
+     *
+     * <code>string responseMessage = 1;</code>
+     */
+    public Builder setResponseMessageBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+      
+      responseMessage_ = value;
+      onChanged();
       return this;
     }
     public final Builder setUnknownFields(

--- a/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleResponseOrBuilder.java
+++ b/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleResponseOrBuilder.java
@@ -6,4 +6,22 @@ package io.grpc.testing.protobuf;
 public interface SimpleResponseOrBuilder extends
     // @@protoc_insertion_point(interface_extends:grpc.testing.SimpleResponse)
     com.google.protobuf.MessageOrBuilder {
+
+  /**
+   * <pre>
+   * An optional string message for test.
+   * </pre>
+   *
+   * <code>string responseMessage = 1;</code>
+   */
+  java.lang.String getResponseMessage();
+  /**
+   * <pre>
+   * An optional string message for test.
+   * </pre>
+   *
+   * <code>string responseMessage = 1;</code>
+   */
+  com.google.protobuf.ByteString
+      getResponseMessageBytes();
 }

--- a/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleServiceProto.java
+++ b/testing-proto/src/generated/main/java/io/grpc/testing/protobuf/SimpleServiceProto.java
@@ -34,18 +34,19 @@ public final class SimpleServiceProto {
   static {
     java.lang.String[] descriptorData = {
       "\n,io/grpc/testing/protobuf/simpleservice" +
-      ".proto\022\014grpc.testing\"\017\n\rSimpleRequest\"\020\n" +
-      "\016SimpleResponse2\327\002\n\rSimpleService\022G\n\010Una" +
-      "ryRpc\022\033.grpc.testing.SimpleRequest\032\034.grp" +
-      "c.testing.SimpleResponse\"\000\022S\n\022ClientStre" +
-      "amingRpc\022\033.grpc.testing.SimpleRequest\032\034." +
-      "grpc.testing.SimpleResponse\"\000(\001\022S\n\022Serve" +
-      "rStreamingRpc\022\033.grpc.testing.SimpleReque" +
-      "st\032\034.grpc.testing.SimpleResponse\"\0000\001\022S\n\020" +
-      "BidiStreamingRpc\022\033.grpc.testing.SimpleRe",
-      "quest\032\034.grpc.testing.SimpleResponse\"\000(\0010" +
-      "\001B0\n\030io.grpc.testing.protobufB\022SimpleSer" +
-      "viceProtoP\001b\006proto3"
+      ".proto\022\014grpc.testing\"\'\n\rSimpleRequest\022\026\n" +
+      "\016requestMessage\030\001 \001(\t\")\n\016SimpleResponse\022" +
+      "\027\n\017responseMessage\030\001 \001(\t2\327\002\n\rSimpleServi" +
+      "ce\022G\n\010UnaryRpc\022\033.grpc.testing.SimpleRequ" +
+      "est\032\034.grpc.testing.SimpleResponse\"\000\022S\n\022C" +
+      "lientStreamingRpc\022\033.grpc.testing.SimpleR" +
+      "equest\032\034.grpc.testing.SimpleResponse\"\000(\001" +
+      "\022S\n\022ServerStreamingRpc\022\033.grpc.testing.Si" +
+      "mpleRequest\032\034.grpc.testing.SimpleRespons",
+      "e\"\0000\001\022S\n\020BidiStreamingRpc\022\033.grpc.testing" +
+      ".SimpleRequest\032\034.grpc.testing.SimpleResp" +
+      "onse\"\000(\0010\001B0\n\030io.grpc.testing.protobufB\022" +
+      "SimpleServiceProtoP\001b\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -64,13 +65,13 @@ public final class SimpleServiceProto {
     internal_static_grpc_testing_SimpleRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_grpc_testing_SimpleRequest_descriptor,
-        new java.lang.String[] { });
+        new java.lang.String[] { "RequestMessage", });
     internal_static_grpc_testing_SimpleResponse_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_grpc_testing_SimpleResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_grpc_testing_SimpleResponse_descriptor,
-        new java.lang.String[] { });
+        new java.lang.String[] { "ResponseMessage", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/testing-proto/src/main/proto/io/grpc/testing/protobuf/simpleservice.proto
+++ b/testing-proto/src/main/proto/io/grpc/testing/protobuf/simpleservice.proto
@@ -40,8 +40,12 @@ service SimpleService {
 
 // A simple request message type for test.
 message SimpleRequest {
+  // An optional string message for test.
+  string requestMessage = 1;
 }
 
 // A simple response message type for test.
 message SimpleResponse {
+  // An optional string message for test.
+  string responseMessage = 1;
 }


### PR DESCRIPTION
In migrating internal tests to use testing protos, I found it was not convenient to test in some scenarios without having a field in the message. All `SimpleResponse` messages are `equals` to each other. Users might not want to assume reference identity/inequality between server and client for equal/unequal messages even for InProcess. Even with reference identity, it would still be inconvenient if their were hundreds of messages.

To have a  non-proto based String to String service instead is another solution, but the usefulness of this proto based service would still be too limited.