### PR TITLE
build.gradle: intellij fix for gradle 4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
         }
       }
     }
-    // TODO(zpencer): workaround until intellij 2017.2 is released
+    // TODO(zpencer): remove when intellij 2017.2 is released
     // https://github.com/gradle/gradle/issues/2315
     idea.module.inheritOutputDirs = true
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ subprojects {
         }
       }
     }
+    // TODO(zpencer): workaround until intellij 2017.2 is released
+    // https://github.com/gradle/gradle/issues/2315
+    idea.module.inheritOutputDirs = true
 
     group = "io.grpc"
     version = "1.6.0-SNAPSHOT" // CURRENT_GRPC_VERSION


### PR DESCRIPTION
Without this config change, unit tests will not be runnable in
intellij using gradle 4.0

https://github.com/gradle/gradle/issues/2315