### PR TITLE
Context: add test for the scenario that Context's logger itself is using Context

### DIFF
--- a/context/build.gradle
+++ b/context/build.gradle
@@ -2,5 +2,6 @@ description = 'gRPC: Context'
 
 dependencies {
     testCompile project(':grpc-testing')
+    testCompile project(':grpc-core').sourceSets.test.output
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -45,6 +45,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,30 +57,6 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class ContextTest {
-
-  // The following logger setup is to test the scenario when the logger itself is using Context,
-  // the Context/Storage initialization shouldn't fail.
-  private static final Logger logger = Logger.getLogger(Context.class.getName());
-
-  static {
-    logger.setLevel(Level.ALL);
-    logger.addHandler(new Handler() {
-      @Override
-      public void publish(LogRecord record) {
-        Context ctx = Context.current();
-        Context previous = ctx.attach();
-        ctx.detach(previous);
-      }
-
-      @Override
-      public void flush() {
-      }
-
-      @Override
-      public void close() throws SecurityException {
-      }
-    });
-  }
 
   private static final Context.Key<String> PET = Context.key("pet");
   private static final Context.Key<String> FOOD = Context.keyWithDefault("food", "lasagna");
@@ -768,5 +745,53 @@ public class ContextTest {
     context = parent.withDeadline(deadline, scheduler);
     assertTrue(context.isCancelled());
     assertThat(context.cancellationCause(), instanceOf(TimeoutException.class));
+  }
+
+  /**
+   * Tests initializing the {@link Context} class with a custom logger which uses Context's storage
+   * when logging.
+   */
+  @Test
+  public void initContextWithCustomClassLoaderWithCustomLogger() throws Exception {
+    StaticTestingClassLoader classLoader =
+        new StaticTestingClassLoader(
+            getClass().getClassLoader(),
+            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)"));
+    Class<?> runnable =
+        classLoader.loadClass(LoadMeWithStaticTestingClassLoader.class.getName());
+
+    ((Runnable) runnable.getDeclaredConstructor().newInstance()).run();
+  }
+
+  // UsedReflectively
+  public static final class LoadMeWithStaticTestingClassLoader implements Runnable {
+    @Override
+    public void run() {
+      Logger logger = Logger.getLogger(Context.class.getName());
+      logger.setLevel(Level.ALL);
+      Handler handler = new Handler() {
+        @Override
+        public void publish(LogRecord record) {
+          Context ctx = Context.current();
+          Context previous = ctx.attach();
+          ctx.detach(previous);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+        }
+      };
+      logger.addHandler(handler);
+
+      try {
+        assertNotNull(Context.ROOT);
+      } finally {
+        logger.removeHandler(handler);
+      }
+    }
   }
 }

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -57,6 +57,30 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ContextTest {
 
+  // The following logger setup is to test the scenario when the logger itself is using Context,
+  // the Context/Storage initialization shouldn't fail.
+  private static final Logger logger = Logger.getLogger(Context.class.getName());
+
+  static {
+    logger.setLevel(Level.ALL);
+    logger.addHandler(new Handler() {
+      @Override
+      public void publish(LogRecord record) {
+        Context ctx = Context.current();
+        Context previous = ctx.attach();
+        ctx.detach(previous);
+      }
+
+      @Override
+      public void flush() {
+      }
+
+      @Override
+      public void close() throws SecurityException {
+      }
+    });
+  }
+
   private static final Context.Key<String> PET = Context.key("pet");
   private static final Context.Key<String> FOOD = Context.keyWithDefault("food", "lasagna");
   private static final Context.Key<String> COLOR = Context.key("color");


### PR DESCRIPTION
This will break if 2f6e2c87ab1aeda591fcb7764a8ad6bb20855a2a & a3a5420922ecf1ddc2c4ab77c273be3df47b74f5 are reverted:

```
io.grpc.ContextTest > initContextWithCustomClassLoaderWithCustomLogger FAILED
    java.lang.ExceptionInInitializerError
        at io.grpc.ContextTest$LoadMeWithStaticTestingClassLoader.run(ContextTest.java:789)
        at io.grpc.ContextTest.initContextWithCustomClassLoaderWithCustomLogger(ContextTest.java:760)

        Caused by:
        java.lang.RuntimeException: Storage override had failed to initialize
            at io.grpc.Context.storage(Context.java:134)
            at io.grpc.Context.current(Context.java:163)
            at io.grpc.ContextTest$LoadMeWithStaticTestingClassLoader$1.publish(ContextTest.java:773)
            at java.util.logging.Logger.log(Logger.java:738)
            at java.util.logging.Logger.doLog(Logger.java:765)
            at java.util.logging.Logger.log(Logger.java:875)
            at io.grpc.Context.<clinit>(Context.java:122)
            ... 2 more
```