### PR TITLE
core: Override SubchannelImpl.toString()

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -940,5 +940,10 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     public Attributes getAttributes() {
       return attrs;
     }
+
+    @Override
+    public String toString() {
+      return subchannel.getLogId().toString();
+    }
   }
 }


### PR DESCRIPTION
LoadBalancer may log subchannels. This makes the logs more informative.