### PR TITLE
benchmarks: fix [MissingOverride]

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AbstractConfigurationBuilder.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AbstractConfigurationBuilder.java
@@ -55,6 +55,7 @@ public abstract class AbstractConfigurationBuilder<T extends Configuration>
       return false;
     }
 
+    @Override
     public String getDefaultValue() {
       return null;
     }


### PR DESCRIPTION
```
:grpc-benchmarks:compileJavaC:\jenkins\workspace\gRPC-Java-PR-Windows\benchmarks\src\main\java\io\grpc\benchmarks\qps\AbstractConfigurationBuilder.java:58: warning:
[MissingOverride] getDefaultValue implements method in Param; expected @Override
    public String getDefaultValue() {
                  ^
    (see http://errorprone.info/bugpattern/MissingOverride)
  Did you mean '@Override public String getDefaultValue() {'?
error: warnings found and -Werror specified
1 error
1 warning
 FAILED

FAILURE: Build failed with an exception.
```