### PR TITLE
netty: support `status()` on Headers

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2HeadersUtils.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2HeadersUtils.java
@@ -125,6 +125,11 @@ class GrpcHttp2HeadersUtils {
     }
 
     @Override
+    public CharSequence status() {
+      return get(Http2Headers.PseudoHeaderName.STATUS.value());
+    }
+
+    @Override
     public List<CharSequence> getAll(CharSequence csName) {
       AsciiString name = requireAsciiString(csName);
       List<CharSequence> returnValues = new ArrayList<CharSequence>(4);

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2OutboundHeaders.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2OutboundHeaders.java
@@ -70,8 +70,8 @@ final class GrpcHttp2OutboundHeaders extends AbstractHttp2Headers {
   @SuppressWarnings("ReferenceEquality") // STATUS.value() never changes.
   public CharSequence status() {
     // preHeaders is never null.  It has status as the first element or not at all.
-    if (preHeaders.length >= 2 && preHeaders[0] == Http2Headers.PseudoHeaderName.STATUS.value()) {
-      return preHeaders[1];
+    if (preHeaders.length >= 1 && preHeaders[0] == Http2Headers.PseudoHeaderName.STATUS.value()) {
+      return Utils.STATUS_OK;
     }
     return null;
   }

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2OutboundHeaders.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2OutboundHeaders.java
@@ -70,8 +70,8 @@ final class GrpcHttp2OutboundHeaders extends AbstractHttp2Headers {
   @SuppressWarnings("ReferenceEquality") // STATUS.value() never changes.
   public CharSequence status() {
     // preHeaders is never null.  It has status as the first element or not at all.
-    if (preHeaders.length >= 1 && preHeaders[0] == Http2Headers.PseudoHeaderName.STATUS.value()) {
-      return Utils.STATUS_OK;
+    if (preHeaders.length >= 2 && preHeaders[0] == Http2Headers.PseudoHeaderName.STATUS.value()) {
+      return preHeaders[1];
     }
     return null;
   }

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2OutboundHeaders.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2OutboundHeaders.java
@@ -67,6 +67,16 @@ final class GrpcHttp2OutboundHeaders extends AbstractHttp2Headers {
   }
 
   @Override
+  @SuppressWarnings("ReferenceEquality") // STATUS.value() never changes.
+  public CharSequence status() {
+    // preHeaders is never null.  It has status as the first element or not at all.
+    if (preHeaders.length >= 1 && preHeaders[0] == Http2Headers.PseudoHeaderName.STATUS.value()) {
+      return Http2Headers.PseudoHeaderName.STATUS.value();
+    }
+    return null;
+  }
+
+  @Override
   public Iterator<Entry<CharSequence, CharSequence>> iterator() {
     return new Itr();
   }

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2OutboundHeaders.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2OutboundHeaders.java
@@ -70,8 +70,8 @@ final class GrpcHttp2OutboundHeaders extends AbstractHttp2Headers {
   @SuppressWarnings("ReferenceEquality") // STATUS.value() never changes.
   public CharSequence status() {
     // preHeaders is never null.  It has status as the first element or not at all.
-    if (preHeaders.length >= 1 && preHeaders[0] == Http2Headers.PseudoHeaderName.STATUS.value()) {
-      return Http2Headers.PseudoHeaderName.STATUS.value();
+    if (preHeaders.length >= 2 && preHeaders[0] == Http2Headers.PseudoHeaderName.STATUS.value()) {
+      return preHeaders[1];
     }
     return null;
   }


### PR DESCRIPTION
Recent Netty change https://github.com/netty/netty/commit/a91df58ca17d5b30c57c46dde5b1d60bb659b029
caused the `status()` method to be invoked, which AbstractHttp2Headers does not implement.
This change is necesary to upgrade to Netty 4.1.14