### PR TITLE
core: fix ConnectivityStateManager is already disabled bug

### DIFF
--- a/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
+++ b/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
@@ -63,13 +63,7 @@ final class ConnectivityStateManager {
    */
   void gotoState(@Nonnull ConnectivityState newState) {
     checkNotNull(newState, "newState");
-    if (newState != ConnectivityState.SHUTDOWN) {
-      checkState(state != null, "ConnectivityStateManager is already disabled");
-    } else if (state == null ) {
-      // When ConnectivityStateManager is already disabled, then channel shutdown is called.
-      // Keep state being null.
-      return;
-    }
+    checkState(!isDisabled(), "ConnectivityStateManager is already disabled");
     gotoNullableState(newState);
   }
 
@@ -106,6 +100,13 @@ final class ConnectivityStateManager {
    */
   void disable() {
     gotoNullableState(null);
+  }
+
+  /**
+   * This method is threadsafe.
+   */
+  boolean isDisabled() {
+    return state == null;
   }
 
   private static final class Listener {

--- a/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
+++ b/core/src/main/java/io/grpc/internal/ConnectivityStateManager.java
@@ -63,7 +63,13 @@ final class ConnectivityStateManager {
    */
   void gotoState(@Nonnull ConnectivityState newState) {
     checkNotNull(newState, "newState");
-    checkState(state != null, "ConnectivityStateManager is already disabled");
+    if (newState != ConnectivityState.SHUTDOWN) {
+      checkState(state != null, "ConnectivityStateManager is already disabled");
+    } else if (state == null ) {
+      // When ConnectivityStateManager is already disabled, then channel shutdown is called.
+      // Keep state being null.
+      return;
+    }
     gotoNullableState(newState);
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -462,7 +462,9 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     channelExecutor.executeLater(new Runnable() {
       @Override
       public void run() {
-        channelStateManager.gotoState(SHUTDOWN);
+        if (!channelStateManager.isDisabled()) {
+          channelStateManager.gotoState(SHUTDOWN);
+        }
       }
     });
 

--- a/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.ConnectivityState;
@@ -232,6 +233,7 @@ public class ConnectivityStateManagerTest {
   @Test
   public void disable() {
     state.disable();
+    assertTrue(state.isDisabled());
 
     thrown.expect(UnsupportedOperationException.class);
     thrown.expectMessage("Channel state API is not implemented");
@@ -242,21 +244,11 @@ public class ConnectivityStateManagerTest {
   public void disableThenDisable() {
     state.disable();
     state.disable();
+    assertTrue(state.isDisabled());
 
     thrown.expect(UnsupportedOperationException.class);
     thrown.expectMessage("Channel state API is not implemented");
     state.getState();
-  }
-
-  @Test
-  public void diableThenShutdown() {
-    state.disable();
-    state.gotoState(ConnectivityState.SHUTDOWN);
-
-    thrown.expect(UnsupportedOperationException.class);
-    thrown.expectMessage("Channel state API is not implemented");
-    state.getState();
-
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/ConnectivityStateManagerTest.java
@@ -22,7 +22,9 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.ConnectivityState;
 import java.util.LinkedList;
 import java.util.concurrent.Executor;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -31,6 +33,9 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class ConnectivityStateManagerTest {
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
   private final FakeClock executor = new FakeClock();
   private final ConnectivityStateManager state = new ConnectivityStateManager();
   private final LinkedList<ConnectivityState> sink = new LinkedList<ConnectivityState>();
@@ -222,5 +227,53 @@ public class ConnectivityStateManagerTest {
     state.gotoState(ConnectivityState.READY);
     assertEquals(1, sink.size());
     assertEquals(ConnectivityState.READY, sink.poll());
+  }
+
+  @Test
+  public void disable() {
+    state.disable();
+
+    thrown.expect(UnsupportedOperationException.class);
+    thrown.expectMessage("Channel state API is not implemented");
+    state.getState();
+  }
+
+  @Test
+  public void disableThenDisable() {
+    state.disable();
+    state.disable();
+
+    thrown.expect(UnsupportedOperationException.class);
+    thrown.expectMessage("Channel state API is not implemented");
+    state.getState();
+  }
+
+  @Test
+  public void diableThenShutdown() {
+    state.disable();
+    state.gotoState(ConnectivityState.SHUTDOWN);
+
+    thrown.expect(UnsupportedOperationException.class);
+    thrown.expectMessage("Channel state API is not implemented");
+    state.getState();
+
+  }
+
+  @Test
+  public void disableThenGotoReady() {
+    state.disable();
+
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("ConnectivityStateManager is already disabled");
+    state.gotoState(ConnectivityState.READY);
+  }
+
+  @Test
+  public void shutdownThenReady() {
+    state.gotoState(ConnectivityState.SHUTDOWN);
+    assertEquals(ConnectivityState.SHUTDOWN, state.getState());
+
+    state.gotoState(ConnectivityState.READY);
+    assertEquals(ConnectivityState.SHUTDOWN, state.getState());
   }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1193,18 +1193,6 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void getState_loadBalancerDoesNotSupportChannelStateThenChannelShutdown() {
-    createChannel(new FakeNameResolverFactory(false), NO_INTERCEPTOR);
-    assertEquals(ConnectivityState.IDLE, channel.getState(false));
-    helper.updatePicker(mockPicker);
-
-    channel.shutdown();
-
-    thrown.expect(UnsupportedOperationException.class);
-    channel.getState(false);
-  }
-
-  @Test
   public void notifyWhenStateChanged_loadBalancerDoesNotSupportChannelState() {
     createChannel(new FakeNameResolverFactory(false), NO_INTERCEPTOR);
     assertEquals(ConnectivityState.IDLE, channel.getState(false));

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1193,6 +1193,18 @@ public class ManagedChannelImplTest {
   }
 
   @Test
+  public void getState_loadBalancerDoesNotSupportChannelStateThenChannelShutdown() {
+    createChannel(new FakeNameResolverFactory(false), NO_INTERCEPTOR);
+    assertEquals(ConnectivityState.IDLE, channel.getState(false));
+    helper.updatePicker(mockPicker);
+
+    channel.shutdown();
+
+    thrown.expect(UnsupportedOperationException.class);
+    channel.getState(false);
+  }
+
+  @Test
   public void notifyWhenStateChanged_loadBalancerDoesNotSupportChannelState() {
     createChannel(new FakeNameResolverFactory(false), NO_INTERCEPTOR);
     assertEquals(ConnectivityState.IDLE, channel.getState(false));


### PR DESCRIPTION
Fix bug found by internal user
```
W/ChannelExecutor: Runnable threw exception in ChannelExecutor
     java.lang.IllegalStateException: ConnectivityStateManager is already disabled
 at com.google.common.base.Preconditions.checkState(Preconditions.java:459)
 at io.grpc.internal.ConnectivityStateManager.gotoState(ConnectivityStateManager.java:66)
 at io.grpc.internal.ManagedChannelImpl$5.run(ManagedChannelImpl.java:476)
 at io.grpc.internal.ChannelExecutor.drain(ChannelExecutor.java:72)
 at io.grpc.internal.DelayedClientTransport.shutdown(DelayedClientTransport.java:216)
 at io.grpc.internal.ManagedChannelImpl.shutdown(ManagedChannelImpl.java:480)
 at io.grpc.internal.ManagedChannelImpl.shutdown(ManagedChannelImpl.java:69)
```