### PR TITLE
Stabilize auth flow using CallCredentials

### DIFF
--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -69,6 +69,9 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
   }
 
   @Override
+  public void thisUsesUnstableApi() {}
+
+  @Override
   public void applyRequestMetadata(MethodDescriptor<?, ?> method, Attributes attrs,
       Executor appExecutor, final MetadataApplier applier) {
     String authority = checkNotNull(attrs.get(ATTR_AUTHORITY), "authority");

--- a/auth/src/main/java/io/grpc/auth/MoreCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/MoreCallCredentials.java
@@ -27,8 +27,10 @@ public final class MoreCallCredentials {
   /**
    * Converts a Google Auth Library {@link Credentials} to {@link CallCredentials}.
    *
-   * <p>Although this is a stable API, note that the returned instance's API is not stable. See
-   * {@link CallCredentials}.
+   * <p>Although this is a stable API, note that the returned instance's API is not stable. You are
+   * free to use the class name {@code CallCredentials} and pass the instance to other code, but the
+   * instance can't be called directly from code expecting stable behavior. See {@link
+   * CallCredentials}.
    */
   public static CallCredentials from(Credentials creds) {
     return new GoogleAuthLibraryCallCredentials(creds);

--- a/auth/src/main/java/io/grpc/auth/MoreCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/MoreCallCredentials.java
@@ -18,7 +18,6 @@ package io.grpc.auth;
 
 import com.google.auth.Credentials;
 import io.grpc.CallCredentials;
-import io.grpc.ExperimentalApi;
 
 /**
  * A utility class that converts other types of credentials to {@link CallCredentials}.

--- a/auth/src/main/java/io/grpc/auth/MoreCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/MoreCallCredentials.java
@@ -23,10 +23,12 @@ import io.grpc.ExperimentalApi;
 /**
  * A utility class that converts other types of credentials to {@link CallCredentials}.
  */
-@ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
 public final class MoreCallCredentials {
   /**
    * Converts a Google Auth Library {@link Credentials} to {@link CallCredentials}.
+   *
+   * <p>Although this is a stable API, note that the returned instance's API is not stable. See
+   * {@link CallCredentials}.
    */
   public static CallCredentials from(Credentials creds) {
     return new GoogleAuthLibraryCallCredentials(creds);

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -28,14 +28,20 @@ import java.util.concurrent.Executor;
  * FooGrpc.FooStub stub = FooGrpc.newStub(channel);
  * response = stub.withCallCredentials(creds).bar(request);
  * </pre>
+ *
+ * <p>The contents and nature of this interface (and whether it remains an interface) is
+ * experimental, in that it can change. However, we are guaranteeing stability for the
+ * <em>name</em>. That is, we are guaranteeing stability for code to be returned a reference and
+ * pass that reference to gRPC for usage. However, code may not call or implement the {@code
+ * CallCredentials} itself if it wishes to only use stable APIs.
  */
-@ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
 public interface CallCredentials {
   /**
    * The security level of the transport. It is guaranteed to be present in the {@code attrs} passed
    * to {@link #applyRequestMetadata}. It is by default {@link SecurityLevel#NONE} but can be
    * overridden by the transport.
    */
+  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
   public static final Key<SecurityLevel> ATTR_SECURITY_LEVEL =
       Key.of("io.grpc.CallCredentials.securityLevel");
 
@@ -45,6 +51,7 @@ public interface CallCredentials {
    * by default from the channel, but can be overridden by the transport and {@link
    * io.grpc.CallOptions} with increasing precedence.
    */
+  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
   public static final Key<String> ATTR_AUTHORITY = Key.of("io.grpc.CallCredentials.authority");
 
   /**
@@ -65,6 +72,7 @@ public interface CallCredentials {
    * @param applier The outlet of the produced headers. It can be called either before or after this
    *        method returns.
    */
+  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
   void applyRequestMetadata(
       MethodDescriptor<?, ?> method, Attributes attrs,
       Executor appExecutor, MetadataApplier applier);
@@ -74,6 +82,7 @@ public interface CallCredentials {
    *
    * <p>Exactly one of its methods must be called to make the RPC proceed.
    */
+  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
   public interface MetadataApplier {
     /**
      * Called when headers are successfully generated. They will be merged into the original

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -78,6 +78,13 @@ public interface CallCredentials {
       Executor appExecutor, MetadataApplier applier);
 
   /**
+   * Should be a noop but never called; tries to make it clearer to implementors that they may break
+   * in the future.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
+  void thisUsesUnstableApi();
+
+  /**
    * The outlet of the produced headers. Not thread-safe.
    *
    * <p>Exactly one of its methods must be called to make the RPC proceed.

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -41,7 +41,7 @@ public interface CallCredentials {
    * to {@link #applyRequestMetadata}. It is by default {@link SecurityLevel#NONE} but can be
    * overridden by the transport.
    */
-  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   public static final Key<SecurityLevel> ATTR_SECURITY_LEVEL =
       Key.of("io.grpc.CallCredentials.securityLevel");
 
@@ -51,7 +51,7 @@ public interface CallCredentials {
    * by default from the channel, but can be overridden by the transport and {@link
    * io.grpc.CallOptions} with increasing precedence.
    */
-  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   public static final Key<String> ATTR_AUTHORITY = Key.of("io.grpc.CallCredentials.authority");
 
   /**
@@ -72,7 +72,7 @@ public interface CallCredentials {
    * @param applier The outlet of the produced headers. It can be called either before or after this
    *        method returns.
    */
-  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   void applyRequestMetadata(
       MethodDescriptor<?, ?> method, Attributes attrs,
       Executor appExecutor, MetadataApplier applier);
@@ -82,7 +82,7 @@ public interface CallCredentials {
    *
    * <p>Exactly one of its methods must be called to make the RPC proceed.
    */
-  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   public interface MetadataApplier {
     /**
      * Called when headers are successfully generated. They will be merged into the original

--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -91,7 +91,6 @@ public final class CallOptions {
   /**
    * Returns a new {@code CallOptions} with the given call credentials.
    */
-  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
   public CallOptions withCallCredentials(@Nullable CallCredentials credentials) {
     CallOptions newOptions = new CallOptions(this);
     newOptions.credentials = credentials;
@@ -187,7 +186,6 @@ public final class CallOptions {
   /**
    * Returns the call credentials.
    */
-  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
   @Nullable
   public CallCredentials getCredentials() {
     return credentials;

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -173,7 +173,6 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
    *
    * @since 1.0.0
    */
-  @ExperimentalApi("https//github.com/grpc/grpc-java/issues/1914")
   public final S withCallCredentials(CallCredentials credentials) {
     return build(channel, callOptions.withCallCredentials(credentials));
   }


### PR DESCRIPTION
As discussed in #1914, we need CallCredentials and MoreCallCredentials
to be stable, but there's less of a strong need for the contents of
CallCredentials to be stable. We're willing to commit to the name,
without needing to commit to the plumbing.

CC @garrettjonesgoogle