### PR TITLE
grpclb: force GRPCLB policy when NameResolver returns at least one balancer

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -184,14 +184,11 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
       }
     }
 
-    if (newBackendServers.isEmpty()) {
-      // handleResolvedAddressGroups()'s javadoc has guaranteed updatedServers is never empty.
-      checkState(!newLbAddressGroups.isEmpty(),
-          "No backend address nor LB address.  updatedServers=%s", updatedServers);
+    if (!newLbAddressGroups.isEmpty()) {
       if (newLbPolicy != LbPolicy.GRPCLB) {
         newLbPolicy = LbPolicy.GRPCLB;
-        logger.log(Level.FINE, "[{0}] Switching to GRPCLB because all addresses are balancers",
-            logId);
+        logger.log(
+            Level.FINE, "[{0}] Switching to GRPCLB because there is at least one balancer", logId);
       }
     }
     if (newLbPolicy == null) {

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -754,7 +754,7 @@ public class GrpclbLoadBalancerTest {
 
     // Switch to PICK_FIRST
     List<EquivalentAddressGroup> pickFirstResolutionList =
-        createResolvedServerAddresses(true, false);
+        createResolvedServerAddresses(false, false);
     Attributes pickFirstResolutionAttrs = Attributes.newBuilder()
         .set(GrpclbConstants.ATTR_LB_POLICY, LbPolicy.PICK_FIRST).build();
     verify(pickFirstBalancerFactory, never()).newLoadBalancer(any(Helper.class));
@@ -768,7 +768,7 @@ public class GrpclbLoadBalancerTest {
     verify(pickFirstBalancerFactory).newLoadBalancer(same(helper));
     // Only non-LB addresses are passed to the delegate
     verify(pickFirstBalancer).handleResolvedAddressGroups(
-        eq(Arrays.asList(pickFirstResolutionList.get(1))), same(pickFirstResolutionAttrs));
+        eq(pickFirstResolutionList), same(pickFirstResolutionAttrs));
     assertSame(LbPolicy.PICK_FIRST, balancer.getLbPolicy());
     assertSame(pickFirstBalancer, balancer.getDelegate());
     // GRPCLB connection is closed
@@ -777,7 +777,7 @@ public class GrpclbLoadBalancerTest {
 
     // Switch to ROUND_ROBIN
     List<EquivalentAddressGroup> roundRobinResolutionList =
-        createResolvedServerAddresses(true, false, false);
+        createResolvedServerAddresses(false, false, false);
     Attributes roundRobinResolutionAttrs = Attributes.newBuilder()
         .set(GrpclbConstants.ATTR_LB_POLICY, LbPolicy.ROUND_ROBIN).build();
     verify(roundRobinBalancerFactory, never()).newLoadBalancer(any(Helper.class));
@@ -786,13 +786,13 @@ public class GrpclbLoadBalancerTest {
     verify(roundRobinBalancerFactory).newLoadBalancer(same(helper));
     // Only non-LB addresses are passed to the delegate
     verify(roundRobinBalancer).handleResolvedAddressGroups(
-        eq(roundRobinResolutionList.subList(1, 3)), same(roundRobinResolutionAttrs));
+        eq(roundRobinResolutionList), same(roundRobinResolutionAttrs));
     assertSame(LbPolicy.ROUND_ROBIN, balancer.getLbPolicy());
     assertSame(roundRobinBalancer, balancer.getDelegate());
 
-    // Special case: if all addresses are loadbalancers, use GRPCLB no matter what the NameResolver
-    // says.
-    grpclbResolutionList = createResolvedServerAddresses(true, true, true);
+    // Special case: if at least one address is loadbalancer, use GRPCLB no matter what the
+    // NameResolver says.
+    grpclbResolutionList = createResolvedServerAddresses(true, false, true, false);
     grpclbResolutionAttrs = Attributes.newBuilder()
         .set(GrpclbConstants.ATTR_LB_POLICY, LbPolicy.PICK_FIRST).build();
     deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
@@ -801,7 +801,6 @@ public class GrpclbLoadBalancerTest {
     assertNull(balancer.getDelegate());
     EquivalentAddressGroup combinedEag = new EquivalentAddressGroup(Arrays.asList(
         grpclbResolutionList.get(0).getAddresses().get(0),
-        grpclbResolutionList.get(1).getAddresses().get(0),
         grpclbResolutionList.get(2).getAddresses().get(0)));
     verify(helper).createOobChannel(eq(combinedEag), eq(lbAuthority(0)));
     assertEquals(1, fakeOobChannels.size());
@@ -809,7 +808,7 @@ public class GrpclbLoadBalancerTest {
     verify(mockLbService, times(2)).balanceLoad(lbResponseObserverCaptor.capture());
 
     // Special case: PICK_FIRST is the default
-    pickFirstResolutionList = createResolvedServerAddresses(true, false, false);
+    pickFirstResolutionList = createResolvedServerAddresses(false, false, false);
     pickFirstResolutionAttrs = Attributes.EMPTY;
     verify(pickFirstBalancerFactory).newLoadBalancer(any(Helper.class));
     assertFalse(oobChannel.isShutdown());
@@ -818,7 +817,7 @@ public class GrpclbLoadBalancerTest {
     verify(pickFirstBalancerFactory, times(2)).newLoadBalancer(same(helper));
     // Only non-LB addresses are passed to the delegate
     verify(pickFirstBalancer).handleResolvedAddressGroups(
-        eq(pickFirstResolutionList.subList(1, 3)), same(pickFirstResolutionAttrs));
+        eq(pickFirstResolutionList), same(pickFirstResolutionAttrs));
     assertSame(LbPolicy.PICK_FIRST, balancer.getLbPolicy());
     assertSame(pickFirstBalancer, balancer.getDelegate());
     // GRPCLB connection is closed


### PR DESCRIPTION
Previously only when all addresses returned by NameResolver are
balancers would GRPCLB be forced.  This change is a follow-up of
https://github.com/grpc/grpc/pull/10258