### PR TITLE
context: change storage API to return a restoreable context

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -881,8 +881,10 @@ public class Context {
      * Implements {@link io.grpc.Context#attach}.
      *
      * @param toAttach the context to be attached
+     * @return A {@link Context} that should be passed back into {@link #detach(Context, Context)}
+     *   as the {@code toRestore} parameter.
      */
-    public abstract void attach(Context toAttach);
+    public abstract Context attach(Context toAttach);
 
     /**
      * Implements {@link io.grpc.Context#detach}

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import com.sun.istack.internal.Nullable;
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
@@ -890,10 +891,16 @@ public class Context {
     /**
      * Implements {@link io.grpc.Context#attach}.
      *
+     * <p>Caution: {@link Context#attach()} interprets a return value of {@code null} to mean
+     * the same thing as {@link Context#ROOT}.
+     * <p>See also: {@link #current()}.
+
      * @param toAttach the context to be attached
      * @return A {@link Context} that should be passed back into {@link #detach(Context, Context)}
-     *        as the {@code toRestore} parameter.
+     *        as the {@code toRestore} parameter. {@code null} is a valid return value, but see
+     *        caution note.
      */
+    @Nullable
     public Context doAttach(Context toAttach) {
       // This is a default implementation to help migrate existing Storage implementations that
       // have an attach() method but no doAttach() method.
@@ -913,8 +920,16 @@ public class Context {
     public abstract void detach(Context toDetach, Context toRestore);
 
     /**
-     * Implements {@link io.grpc.Context#current}.  Returns the context of the current scope.
+     * Implements {@link io.grpc.Context#current}.
+     *
+     * <p>Caution: {@link Context} interprets a return value of {@code null} to mean the same
+     * thing as {@code Context{@link #ROOT}}.
+     * <p>See also {@link #doAttach(Context)}.
+     *
+     * @return The context of the current scope. {@code null} is a valid return value, but see
+     *        caution note.
      */
+    @Nullable
     public abstract Context current();
   }
 

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -385,9 +385,7 @@ public class Context {
    * }}</pre>
    */
   public Context attach() {
-    Context previous = current();
-    storage().attach(this);
-    return previous;
+    return storage().doAttach(this);
   }
 
   /**
@@ -878,13 +876,21 @@ public class Context {
    */
   public abstract static class Storage {
     /**
+     * @deprecated This is an old API that is no longer used.
+     */
+    @Deprecated
+    public void attach(Context toAttach) {
+      throw new UnsupportedOperationException("Deprecated. Do not call.");
+    }
+
+    /**
      * Implements {@link io.grpc.Context#attach}.
      *
      * @param toAttach the context to be attached
      * @return A {@link Context} that should be passed back into {@link #detach(Context, Context)}
      *        as the {@code toRestore} parameter.
      */
-    public abstract Context attach(Context toAttach);
+    public abstract Context doAttach(Context toAttach);
 
     /**
      * Implements {@link io.grpc.Context#detach}

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -882,7 +882,7 @@ public class Context {
      *
      * @param toAttach the context to be attached
      * @return A {@link Context} that should be passed back into {@link #detach(Context, Context)}
-     *   as the {@code toRestore} parameter.
+     *        as the {@code toRestore} parameter.
      */
     public abstract Context attach(Context toAttach);
 

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -16,7 +16,6 @@
 
 package io.grpc;
 
-import com.sun.istack.internal.Nullable;
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
@@ -893,6 +892,7 @@ public class Context {
      *
      * <p>Caution: {@link Context#attach()} interprets a return value of {@code null} to mean
      * the same thing as {@link Context#ROOT}.
+     *
      * <p>See also: {@link #current()}.
 
      * @param toAttach the context to be attached
@@ -900,7 +900,6 @@ public class Context {
      *        as the {@code toRestore} parameter. {@code null} is a valid return value, but see
      *        caution note.
      */
-    @Nullable
     public Context doAttach(Context toAttach) {
       // This is a default implementation to help migrate existing Storage implementations that
       // have an attach() method but no doAttach() method.
@@ -924,12 +923,12 @@ public class Context {
      *
      * <p>Caution: {@link Context} interprets a return value of {@code null} to mean the same
      * thing as {@code Context{@link #ROOT}}.
+     *
      * <p>See also {@link #doAttach(Context)}.
      *
      * @return The context of the current scope. {@code null} is a valid return value, but see
      *        caution note.
      */
-    @Nullable
     public abstract Context current();
   }
 

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -385,7 +385,11 @@ public class Context {
    * }}</pre>
    */
   public Context attach() {
-    return storage().doAttach(this);
+    Context prev = storage().doAttach(this);
+    if (prev == null) {
+      return ROOT;
+    }
+    return prev;
   }
 
   /**
@@ -890,7 +894,13 @@ public class Context {
      * @return A {@link Context} that should be passed back into {@link #detach(Context, Context)}
      *        as the {@code toRestore} parameter.
      */
-    public abstract Context doAttach(Context toAttach);
+    public Context doAttach(Context toAttach) {
+      // This is a default implementation to help migrate existing Storage implementations that
+      // have an attach() method but no doAttach() method.
+      Context current = current();
+      attach(toAttach);
+      return current;
+    }
 
     /**
      * Implements {@link io.grpc.Context#detach}

--- a/context/src/main/java/io/grpc/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/grpc/ThreadLocalContextStorage.java
@@ -28,10 +28,15 @@ final class ThreadLocalContextStorage extends Context.Storage {
   /**
    * Currently bound context.
    */
-  private static final ThreadLocal<Context> localContext = new ThreadLocal<Context>();
+  private static final ThreadLocal<Context> localContext = new ThreadLocal<Context>() {
+    @Override
+    protected Context initialValue() {
+      return Context.ROOT;
+    }
+  };
 
   @Override
-  public Context attach(Context toAttach) {
+  public Context doAttach(Context toAttach) {
     Context current = current();
     localContext.set(toAttach);
     return current;
@@ -46,7 +51,7 @@ final class ThreadLocalContextStorage extends Context.Storage {
       log.log(Level.SEVERE, "Context was not attached when detaching",
           new Throwable().fillInStackTrace());
     }
-    attach(toRestore);
+    doAttach(toRestore);
   }
 
   @Override

--- a/context/src/main/java/io/grpc/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/grpc/ThreadLocalContextStorage.java
@@ -28,12 +28,7 @@ final class ThreadLocalContextStorage extends Context.Storage {
   /**
    * Currently bound context.
    */
-  private static final ThreadLocal<Context> localContext = new ThreadLocal<Context>() {
-    @Override
-    protected Context initialValue() {
-      return Context.ROOT;
-    }
-  };
+  private static final ThreadLocal<Context> localContext = new ThreadLocal<Context>();
 
   @Override
   public Context doAttach(Context toAttach) {

--- a/context/src/main/java/io/grpc/ThreadLocalContextStorage.java
+++ b/context/src/main/java/io/grpc/ThreadLocalContextStorage.java
@@ -31,8 +31,10 @@ final class ThreadLocalContextStorage extends Context.Storage {
   private static final ThreadLocal<Context> localContext = new ThreadLocal<Context>();
 
   @Override
-  public void attach(Context toAttach) {
+  public Context attach(Context toAttach) {
+    Context current = current();
     localContext.set(toAttach);
+    return current;
   }
 
   @Override

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -35,7 +35,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -772,8 +771,7 @@ public class ContextTest {
    */
   @Test
   public void attachDetachNewThread() throws ExecutionException, InterruptedException {
-    ExecutorService exec = Executors.newSingleThreadExecutor();
-    Future<?> future = exec.submit(Context.current().wrap(new Runnable() {
+    Future<?> future = scheduler.submit(Context.current().wrap(new Runnable() {
       @Override
       public void run() {
         // noop

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -33,8 +33,11 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -761,6 +764,23 @@ public class ContextTest {
         classLoader.loadClass(LoadMeWithStaticTestingClassLoader.class.getName());
 
     ((Runnable) runnable.getDeclaredConstructor().newInstance()).run();
+  }
+
+  /**
+   * The context storage has per thread data structures.
+   * Ensure that newly created threads can attach/detach.
+   */
+  @Test
+  public void attachDetachNewThread() throws ExecutionException, InterruptedException {
+    ExecutorService exec = Executors.newSingleThreadExecutor();
+    Future<?> future = exec.submit(Context.current().wrap(new Runnable() {
+      @Override
+      public void run() {
+        // noop
+      }
+    }));
+    // just check that attach/detach completed without exceptions
+    future.get();
   }
 
   // UsedReflectively

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -766,6 +766,7 @@ public class ContextTest {
 
   /**
    * Ensure that newly created threads can attach/detach a context.
+   * The current test thread already has a context manually attached in {@link #setUp()}.
    */
   @Test
   public void newThreadAttachContext() throws Exception {
@@ -781,6 +782,7 @@ public class ContextTest {
               @Override
               public String call() {
                 Context initial = Context.current();
+                assertNotNull(initial);
                 Context toRestore = child.attach();
                 try {
                   assertNotNull(toRestore);
@@ -814,6 +816,7 @@ public class ContextTest {
             .submit(new Callable<String>() {
               @Override
               public String call() {
+                assertNotNull(Context.current());
                 return COLOR.get();
               }
             });


### PR DESCRIPTION
This API change allows storage implementations to put some state information into the return value, giving it the ability to act as a cookie. In environments where contexts can be replaced, the current `original context` can be stashed there and be restored when `detach` is called. 