### PR TITLE
core: enable Census tags propagation by default.

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -119,7 +119,6 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private int maxInboundMessageSize = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
-  private boolean enableStatsTagPropagation;
   private boolean enableTracing;
 
   /**
@@ -301,15 +300,6 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   /**
-   * Set it to true to propagate the stats tags on the wire.  This will be deleted assuming always
-   * enabled once the instrumentation-java wire format is stabilized.
-   */
-  @Deprecated
-  public void setEnableStatsTagPropagation(boolean enabled) {
-    this.enableStatsTagPropagation = enabled;
-  }
-
-  /**
    * Set it to true to record traces and propagate tracing information on the wire.  This will be
    * deleted assuming always enabled once the instrumentation-java wire format is stabilized.
    */
@@ -338,8 +328,7 @@ public abstract class AbstractManagedChannelImplBuilder
           this.statsFactory != null ? this.statsFactory : Stats.getStatsContextFactory();
       if (statsCtxFactory != null) {
         CensusStatsModule censusStats =
-            new CensusStatsModule(
-                statsCtxFactory, GrpcUtil.STOPWATCH_SUPPLIER, enableStatsTagPropagation);
+            new CensusStatsModule(statsCtxFactory, GrpcUtil.STOPWATCH_SUPPLIER, true);
         // First interceptor runs last (see ClientInterceptors.intercept()), so that no
         // other interceptor can override the tracer factory we set in CallOptions.
         effectiveInterceptors.add(0, censusStats.getClientInterceptor());


### PR DESCRIPTION
According to Census team, the tag wire format is now stable.

/cc @dinooliva @songy23 