### PR TITLE
compiler: Fix some warnings when building with Bazel

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -87,7 +87,7 @@ static inline string MessageFullJavaName(bool nano, const Descriptor* desc) {
       // No java package specified.
       return "nano." + name;
     }
-    for (int i = 0; i < name.size(); ++i) {
+    for (size_t i = 0; i < name.size(); ++i) {
       if ((name[i] == '.') && (i < (name.size() - 1)) && isupper(name[i + 1])) {
         return name.substr(0, i + 1) + "nano." + name.substr(i + 1);
       }
@@ -251,7 +251,7 @@ static void GrpcWriteDocCommentBody(Printer* printer,
       printer->Print(" * <pre>\n");
     }
 
-    for (int i = 0; i < lines.size(); i++) {
+    for (size_t i = 0; i < lines.size(); i++) {
       // Most lines should start with a space.  Watch out for lines that start
       // with a /, since putting that right after the leading asterisk will
       // close the comment.
@@ -781,7 +781,7 @@ static void PrintMethodHandlerClass(const ServiceDescriptor* service,
   }
   stable_sort(sorted_methods.begin(), sorted_methods.end(),
               CompareMethodClientStreaming);
-  for (int i = 0; i < sorted_methods.size(); i++) {
+  for (size_t i = 0; i < sorted_methods.size(); i++) {
     const MethodDescriptor* method = sorted_methods[i];
     (*vars)["method_id"] = to_string(i);
     (*vars)["method_id_name"] = MethodIdFieldName(method);

--- a/compiler/src/java_plugin/cpp/java_generator.h
+++ b/compiler/src/java_plugin/cpp/java_generator.h
@@ -10,15 +10,12 @@
 
 class LogHelper {
   std::ostream* os;
-  bool abort;
 
  public:
-  LogHelper(std::ostream* os, bool abort) : os(os), abort(abort) {}
+  LogHelper(std::ostream* os) : os(os) {}
   ~LogHelper() {
     *os << std::endl;
-    if (abort) {
-      ::abort();
-    }
+    ::abort();
   }
   std::ostream& get_os() {
     return *os;
@@ -27,7 +24,7 @@ class LogHelper {
 
 // Abort the program after logging the mesage if the given condition is not
 // true. Otherwise, do nothing.
-#define GRPC_CODEGEN_CHECK(x) !(x) && LogHelper(&std::cerr, true).get_os() \
+#define GRPC_CODEGEN_CHECK(x) !(x) && LogHelper(&std::cerr).get_os() \
                              << "CHECK FAILED: " << __FILE__ << ":" \
                              << __LINE__ << ": "
 

--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -38,7 +38,7 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
         java_grpc_generator::ProtoFlavor::NORMAL;
 
     bool enable_deprecated = false;
-    for (int i = 0; i < options.size(); i++) {
+    for (size_t i = 0; i < options.size(); i++) {
       if (options[i].first == "nano") {
         flavor = java_grpc_generator::ProtoFlavor::NANO;
       } else if (options[i].first == "lite") {


### PR DESCRIPTION
This fixes sign-compare and maybe-unintialized. An unused-value warning
remains.

I changed LogHelper to always call abort so the compiler would know the
method does not return, which fixed the maxbe-uninitialized warning.