### PR TITLE
testing,core: don't use mocks for stream tracers

### DIFF
--- a/core/src/main/java/io/grpc/StreamTracer.java
+++ b/core/src/main/java/io/grpc/StreamTracer.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import com.google.errorprone.annotations.DoNotMock;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -23,6 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
 @ThreadSafe
+@DoNotMock
 public abstract class StreamTracer {
   /**
    * Stream is closed.  This will be called exactly once.

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -17,14 +17,13 @@
 package io.grpc.internal;
 
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
@@ -36,6 +35,7 @@ import io.grpc.Status.Code;
 import io.grpc.StreamTracer;
 import io.grpc.internal.AbstractClientStream.TransportState;
 import io.grpc.internal.MessageFramerTest.ByteWritableBuffer;
+import io.grpc.internal.testing.TestClientStreamTracer;
 import java.io.ByteArrayInputStream;
 import org.junit.Before;
 import org.junit.Rule;
@@ -213,7 +213,7 @@ public class AbstractClientStreamTest {
   @Test
   public void getRequest() {
     AbstractClientStream.Sink sink = mock(AbstractClientStream.Sink.class);
-    final ClientStreamTracer tracer = spy(new ClientStreamTracer() {});
+    final TestClientStreamTracer tracer = new TestClientStreamTracer();
     ClientStreamTracer.Factory tracerFactory =
         new ClientStreamTracer.Factory() {
           @Override
@@ -237,10 +237,9 @@ public class AbstractClientStreamTest {
     // GET requests don't have BODY.
     verify(sink, never())
         .writeFrame(any(WritableBuffer.class), any(Boolean.class), any(Boolean.class));
-    verify(tracer).outboundMessage();
-    verify(tracer).outboundWireSize(1);
-    verify(tracer).outboundUncompressedSize(1);
-    verifyNoMoreInteractions(tracer);
+    assertEquals(1, tracer.getOutboundMessageCount());
+    assertEquals(1, tracer.getOutboundWireSize());
+    assertEquals(1, tracer.getOutboundUncompressedSize());
   }
 
   /**

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -25,10 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 
@@ -66,12 +63,14 @@ import io.grpc.ServerInterceptors;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.grpc.StreamTracer;
 import io.grpc.auth.MoreCallCredentials;
 import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.testing.StatsTestUtils.FakeStatsContextFactory;
 import io.grpc.internal.testing.StatsTestUtils.MetricsRecord;
+import io.grpc.internal.testing.TestClientStreamTracer;
+import io.grpc.internal.testing.TestServerStreamTracer;
+import io.grpc.internal.testing.TestStreamTracer;
 import io.grpc.protobuf.ProtoUtils;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientCalls;
@@ -139,13 +138,23 @@ public abstract class AbstractInteropTest {
   private static final LinkedBlockingQueue<ServerStreamTracerInfo> serverStreamTracers =
       new LinkedBlockingQueue<ServerStreamTracerInfo>();
 
-  private static class ServerStreamTracerInfo {
+  private static final class ServerStreamTracerInfo {
     final String fullMethodName;
-    final ServerStreamTracer tracer;
+    final InteropServerStreamTracer tracer;
 
-    ServerStreamTracerInfo(String fullMethodName, ServerStreamTracer tracer) {
+    ServerStreamTracerInfo(String fullMethodName, InteropServerStreamTracer tracer) {
       this.fullMethodName = fullMethodName;
       this.tracer = tracer;
+    }
+
+    private static final class InteropServerStreamTracer extends TestServerStreamTracer {
+      private volatile Context contextCapture;
+
+      @Override
+      public <ReqT, RespT> Context filterContext(Context context) {
+        contextCapture = context;
+        return super.filterContext(context);
+      }
     }
   }
 
@@ -153,7 +162,8 @@ public abstract class AbstractInteropTest {
       new ServerStreamTracer.Factory() {
         @Override
         public ServerStreamTracer newServerStreamTracer(String fullMethodName, Metadata headers) {
-          ServerStreamTracer tracer = spy(new ServerStreamTracer() {});
+          ServerStreamTracerInfo.InteropServerStreamTracer tracer
+              = new ServerStreamTracerInfo.InteropServerStreamTracer();
           serverStreamTracers.add(new ServerStreamTracerInfo(fullMethodName, tracer));
           return tracer;
         }
@@ -200,14 +210,14 @@ public abstract class AbstractInteropTest {
   protected TestServiceGrpc.TestServiceBlockingStub blockingStub;
   protected TestServiceGrpc.TestServiceStub asyncStub;
 
-  private final LinkedBlockingQueue<ClientStreamTracer> clientStreamTracers =
-      new LinkedBlockingQueue<ClientStreamTracer>();
+  private final LinkedBlockingQueue<TestClientStreamTracer> clientStreamTracers =
+      new LinkedBlockingQueue<TestClientStreamTracer>();
 
   private final ClientStreamTracer.Factory clientStreamTracerFactory =
       new ClientStreamTracer.Factory() {
         @Override
         public ClientStreamTracer newClientStreamTracer(CallOptions callOptions, Metadata headers) {
-          ClientStreamTracer tracer = spy(new ClientStreamTracer() {});
+          TestClientStreamTracer tracer = new TestClientStreamTracer();
           clientStreamTracers.add(tracer);
           return tracer;
         }
@@ -1654,22 +1664,26 @@ public abstract class AbstractInteropTest {
     assertMetrics(method, status, null, null);
   }
 
-  private void assertClientMetrics(String method, Status.Code status,
+  private void assertClientMetrics(String method, Status.Code code,
       Collection<? extends MessageLite> requests, Collection<? extends MessageLite> responses) {
     // Tracer-based stats
-    ClientStreamTracer tracer = clientStreamTracers.poll();
+    TestClientStreamTracer tracer = clientStreamTracers.poll();
     assertNotNull(tracer);
-    verify(tracer).outboundHeaders();
+    assertTrue(tracer.getOutboundHeaders());
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     // assertClientMetrics() is called right after application receives status,
     // but streamClosed() may be called slightly later than that.  So we need a timeout.
-    verify(tracer, timeout(5000)).streamClosed(statusCaptor.capture());
-    assertEquals(status, statusCaptor.getValue().getCode());
+    try {
+      assertTrue(tracer.await(5, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      throw new AssertionError(e);
+    }
+    assertEquals(code, tracer.getStatus().getCode());
 
     // CensusStreamTracerModule records final status in interceptor, which is guaranteed to be done
     // before application receives status.
     MetricsRecord clientRecord = clientStatsCtxFactory.pollRecord();
-    checkTags(clientRecord, false, method, status);
+    checkTags(clientRecord, false, method, code);
 
     if (requests != null && responses != null) {
       checkTracerMetrics(tracer, requests, responses);
@@ -1681,7 +1695,7 @@ public abstract class AbstractInteropTest {
     assertClientMetrics(method, status, null, null);
   }
 
-  private void assertServerMetrics(String method, Status.Code status,
+  private void assertServerMetrics(String method, Status.Code code,
       Collection<? extends MessageLite> requests, Collection<? extends MessageLite> responses) {
     AssertionError checkFailure = null;
     boolean passed = false;
@@ -1702,7 +1716,7 @@ public abstract class AbstractInteropTest {
         break;
       }
       try {
-        checkTags(serverRecord, true, method, status);
+        checkTags(serverRecord, true, method, code);
         if (requests != null && responses != null) {
           checkCensusMetrics(serverRecord, true, requests, responses);
         }
@@ -1730,12 +1744,16 @@ public abstract class AbstractInteropTest {
       }
       try {
         assertEquals(method, tracerInfo.fullMethodName);
-        verify(tracerInfo.tracer).filterContext(any(Context.class));
+        assertNotNull(tracerInfo.tracer.contextCapture);
         ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
         // On the server, streamClosed() may be called after the client receives the final status.
         // So we use a timeout.
-        verify(tracerInfo.tracer, timeout(1000)).streamClosed(statusCaptor.capture());
-        assertEquals(status, statusCaptor.getValue().getCode());
+        try {
+          assertTrue(tracerInfo.tracer.await(1, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+          throw new AssertionError(e);
+        }
+        assertEquals(code, tracerInfo.tracer.getStatus().getCode());
         if (requests != null && responses != null) {
           checkTracerMetrics(tracerInfo.tracer, responses, requests);
         }
@@ -1767,11 +1785,11 @@ public abstract class AbstractInteropTest {
   }
 
   private static void checkTracerMetrics(
-      StreamTracer tracer,
+      TestStreamTracer tracer,
       Collection<? extends MessageLite> sentMessages,
       Collection<? extends MessageLite> receivedMessages) {
-    verify(tracer, times(sentMessages.size())).outboundMessage();
-    verify(tracer, times(receivedMessages.size())).inboundMessage();
+    assertEquals(sentMessages.size(), tracer.getOutboundMessageCount());
+    assertEquals(receivedMessages.size(), tracer.getInboundMessageCount());
 
     long uncompressedSentSize = 0;
     for (MessageLite msg : sentMessages) {
@@ -1781,20 +1799,9 @@ public abstract class AbstractInteropTest {
     for (MessageLite msg : receivedMessages) {
       uncompressedReceivedSize += msg.getSerializedSize();
     }
-    ArgumentCaptor<Long> outboundSizeCaptor = ArgumentCaptor.forClass(Long.class);
-    ArgumentCaptor<Long> inboundSizeCaptor = ArgumentCaptor.forClass(Long.class);
-    verify(tracer, atLeast(0)).outboundUncompressedSize(outboundSizeCaptor.capture());
-    verify(tracer, atLeast(0)).inboundUncompressedSize(inboundSizeCaptor.capture());
-    long recordedUncompressedOutboundSize = 0;
-    for (Long size : outboundSizeCaptor.getAllValues()) {
-      recordedUncompressedOutboundSize += size;
-    }
-    long recordedUncompressedInboundSize = 0;
-    for (Long size : inboundSizeCaptor.getAllValues()) {
-      recordedUncompressedInboundSize += size;
-    }
-    assertEquals(uncompressedSentSize, recordedUncompressedOutboundSize);
-    assertEquals(uncompressedReceivedSize, recordedUncompressedInboundSize);
+
+    assertEquals(uncompressedSentSize, tracer.getOutboundUncompressedSize());
+    assertEquals(uncompressedReceivedSize, tracer.getInboundUncompressedSize());
   }
 
   private static void checkCensusMetrics(MetricsRecord record, boolean server,

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -64,6 +64,7 @@ import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.ServerTransportListener;
 import io.grpc.internal.StatsTraceContext;
+import io.grpc.internal.testing.TestServerStreamTracer;
 import io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2ServerHeadersDecoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -106,7 +107,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   private ServerStreamTracer.Factory streamTracerFactory;
 
   private final ServerTransportListener transportListener = spy(new ServerTransportListenerImpl());
-  private final ServerStreamTracer streamTracer = spy(new ServerStreamTracer() {});
+  private final TestServerStreamTracer streamTracer = new TestServerStreamTracer();
 
   private NettyServerStream stream;
   private KeepAliveManager spyKeepAliveManager;

--- a/testing/src/main/java/io/grpc/internal/testing/TestClientStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestClientStreamTracer.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal.testing;
+
+import io.grpc.ClientStreamTracer;
+import io.grpc.Status;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A {@link ClientStreamTracer} suitable for testing.
+ */
+public class TestClientStreamTracer extends ClientStreamTracer implements TestStreamTracer {
+  private final TestBaseStreamTracer delegate = new TestBaseStreamTracer();
+  protected final AtomicBoolean outboundHeadersCalled = new AtomicBoolean();
+  protected final AtomicBoolean inboundHeadersCalled = new AtomicBoolean();
+
+  @Override
+  public void await() throws InterruptedException {
+    delegate.await();
+  }
+
+  @Override
+  public boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+    return delegate.await(timeout, timeUnit);
+  }
+
+  /**
+   * Returns if {@link ClientStreamTracer#inboundHeaders} has been called.
+   */
+  public boolean getInboundHeaders() {
+    return inboundHeadersCalled.get();
+  }
+
+  /**
+   * Returns if {@link ClientStreamTracer#outboundHeaders} has been called.
+   */
+  public boolean getOutboundHeaders() {
+    return outboundHeadersCalled.get();
+  }
+
+  @Override
+  public int getInboundMessageCount() {
+    return delegate.getInboundMessageCount();
+  }
+
+  @Override
+  public Status getStatus() {
+    return delegate.getStatus();
+  }
+
+  @Override
+  public long getInboundWireSize() {
+    return delegate.getInboundWireSize();
+  }
+
+  @Override
+  public long getInboundUncompressedSize() {
+    return delegate.getInboundUncompressedSize();
+  }
+
+  @Override
+  public int getOutboundMessageCount() {
+    return delegate.getOutboundMessageCount();
+  }
+
+  @Override
+  public long getOutboundWireSize() {
+    return delegate.getOutboundWireSize();
+  }
+
+  @Override
+  public long getOutboundUncompressedSize() {
+    return delegate.getOutboundUncompressedSize();
+  }
+
+  @Override
+  public void outboundWireSize(long bytes) {
+    delegate.outboundWireSize(bytes);
+  }
+
+  @Override
+  public void inboundWireSize(long bytes) {
+    delegate.inboundWireSize(bytes);
+  }
+
+  @Override
+  public void outboundUncompressedSize(long bytes) {
+    delegate.outboundUncompressedSize(bytes);
+  }
+
+  @Override
+  public void inboundUncompressedSize(long bytes) {
+    delegate.inboundUncompressedSize(bytes);
+  }
+
+  @Override
+  public void streamClosed(Status status) {
+    delegate.streamClosed(status);
+  }
+
+  @Override
+  public void inboundMessage() {
+    delegate.inboundMessage();
+  }
+
+  @Override
+  public void outboundMessage() {
+    delegate.outboundMessage();
+  }
+
+  @Override
+  public void outboundHeaders() {
+    if (!outboundHeadersCalled.compareAndSet(false, true)
+        && delegate.failDuplicateCallbacks.get()) {
+      throw new AssertionError("outboundHeaders called more than once");
+    }
+  }
+
+  @Override
+  public void inboundHeaders() {
+    if (!inboundHeadersCalled.compareAndSet(false, true) && delegate.failDuplicateCallbacks.get()) {
+      throw new AssertionError("inboundHeaders called more than once");
+    }
+  }
+}

--- a/testing/src/main/java/io/grpc/internal/testing/TestServerStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestServerStreamTracer.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal.testing;
+
+import io.grpc.ServerCall;
+import io.grpc.ServerStreamTracer;
+import io.grpc.Status;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A {@link ServerStreamTracer} suitable for testing.
+ */
+public class TestServerStreamTracer extends ServerStreamTracer implements TestStreamTracer {
+  private final TestBaseStreamTracer delegate = new TestBaseStreamTracer();
+  protected final AtomicReference<ServerCall<?,?>> serverCall =
+      new AtomicReference<ServerCall<?,?>>();
+
+  @Override
+  public void await() throws InterruptedException {
+    delegate.await();
+  }
+
+  @Override
+  public boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+    return delegate.await(timeout, timeUnit);
+  }
+
+  /**
+   * Returns the ServerCall passed to {@link ServerStreamTracer#serverCallStarted}.
+   */
+  public ServerCall<?, ?> getServerCall() {
+    return serverCall.get();
+  }
+
+  @Override
+  public int getInboundMessageCount() {
+    return delegate.getInboundMessageCount();
+  }
+
+  @Override
+  public Status getStatus() {
+    return delegate.getStatus();
+  }
+
+  @Override
+  public long getInboundWireSize() {
+    return delegate.getInboundWireSize();
+  }
+
+  @Override
+  public long getInboundUncompressedSize() {
+    return delegate.getInboundUncompressedSize();
+  }
+
+  @Override
+  public int getOutboundMessageCount() {
+    return delegate.getOutboundMessageCount();
+  }
+
+  @Override
+  public long getOutboundWireSize() {
+    return delegate.getOutboundWireSize();
+  }
+
+  @Override
+  public long getOutboundUncompressedSize() {
+    return delegate.getOutboundUncompressedSize();
+  }
+
+  @Override
+  public void outboundWireSize(long bytes) {
+    delegate.outboundWireSize(bytes);
+  }
+
+  @Override
+  public void inboundWireSize(long bytes) {
+    delegate.inboundWireSize(bytes);
+  }
+
+  @Override
+  public void outboundUncompressedSize(long bytes) {
+    delegate.outboundUncompressedSize(bytes);
+  }
+
+  @Override
+  public void inboundUncompressedSize(long bytes) {
+    delegate.inboundUncompressedSize(bytes);
+  }
+
+  @Override
+  public void streamClosed(Status status) {
+    delegate.streamClosed(status);
+  }
+
+  @Override
+  public void inboundMessage() {
+    delegate.inboundMessage();
+  }
+
+  @Override
+  public void outboundMessage() {
+    delegate.outboundMessage();
+  }
+
+  @Override
+  public void serverCallStarted(ServerCall<?, ?> call) {
+    if (!serverCall.compareAndSet(null, call) && delegate.failDuplicateCallbacks.get()) {
+      throw new AssertionError("serverCallStarted called more than once");
+    }
+  }
+}

--- a/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal.testing;
+
+import io.grpc.Status;
+import io.grpc.StreamTracer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A {@link StreamTracer} suitable for testing.
+ */
+public interface TestStreamTracer {
+
+  /**
+   * Waits for the stream to be done.
+   */
+  void await() throws InterruptedException;
+
+  /**
+   * Waits for the stream to be done.
+   */
+  boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException;
+
+  /**
+   * Returns how many times {@link StreamTracer#inboundMessage} has been called.
+   */
+  int getInboundMessageCount();
+
+  /**
+   * Returns how many times {@link StreamTracer#outboundMessage} has been called.
+   */
+  int getOutboundMessageCount();
+
+  /**
+   * Returns the status passed to {@link StreamTracer#streamClosed}.
+   */
+  Status getStatus();
+
+  /**
+   * Returns to sum of all sizes passed to {@link StreamTracer#inboundWireSize}.
+   */
+  long getInboundWireSize();
+
+  /**
+   * Returns to sum of all sizes passed to {@link StreamTracer#inboundUncompressedSize}.
+   */
+  long getInboundUncompressedSize();
+
+  /**
+   * Returns to sum of all sizes passed to {@link StreamTracer#outboundWireSize}.
+   */
+  long getOutboundWireSize();
+
+  /**
+   * Returns to sum of al sizes passed to {@link StreamTracer#outboundUncompressedSize}.
+   */
+  long getOutboundUncompressedSize();
+
+  /**
+   * A {@link StreamTracer} suitable for testing.
+   */
+  public static class TestBaseStreamTracer extends StreamTracer implements TestStreamTracer {
+
+    protected final AtomicLong outboundWireSize = new AtomicLong();
+    protected final AtomicLong inboundWireSize = new AtomicLong();
+    protected final AtomicLong outboundUncompressedSize = new AtomicLong();
+    protected final AtomicLong inboundUncompressedSize = new AtomicLong();
+    protected final AtomicInteger inboundMessageCount = new AtomicInteger();
+    protected final AtomicInteger outboundMessageCount = new AtomicInteger();
+    protected final AtomicReference<Status> streamClosedStatus = new AtomicReference<Status>();
+    protected final CountDownLatch streamClosed = new CountDownLatch(1);
+    protected final AtomicBoolean failDuplicateCallbacks = new AtomicBoolean(true);
+
+    @Override
+    public void await() throws InterruptedException {
+      streamClosed.await();
+    }
+
+    @Override
+    public boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+      return streamClosed.await(timeout, timeUnit);
+    }
+
+    @Override
+    public int getInboundMessageCount() {
+      return inboundMessageCount.get();
+    }
+
+    @Override
+    public int getOutboundMessageCount() {
+      return outboundMessageCount.get();
+    }
+
+    @Override
+    public Status getStatus() {
+      return streamClosedStatus.get();
+    }
+
+    @Override
+    public long getInboundWireSize() {
+      return inboundWireSize.get();
+    }
+
+    @Override
+    public long getInboundUncompressedSize() {
+      return inboundUncompressedSize.get();
+    }
+
+    @Override
+    public long getOutboundWireSize() {
+      return outboundWireSize.get();
+    }
+
+    @Override
+    public long getOutboundUncompressedSize() {
+      return outboundUncompressedSize.get();
+    }
+
+    @Override
+    public void outboundWireSize(long bytes) {
+      outboundWireSize.addAndGet(bytes);
+    }
+
+    @Override
+    public void inboundWireSize(long bytes) {
+      inboundWireSize.addAndGet(bytes);
+    }
+
+    @Override
+    public void outboundUncompressedSize(long bytes) {
+      outboundUncompressedSize.addAndGet(bytes);
+    }
+
+    @Override
+    public void inboundUncompressedSize(long bytes) {
+      inboundUncompressedSize.addAndGet(bytes);
+    }
+
+    @Override
+    public void streamClosed(Status status) {
+      if (!streamClosedStatus.compareAndSet(null, status)) {
+        if (failDuplicateCallbacks.get()) {
+          throw new AssertionError("streamClosed called more than once");
+        }
+      } else {
+        streamClosed.countDown();
+      }
+    }
+
+    @Override
+    public void inboundMessage() {
+      inboundMessageCount.incrementAndGet();
+    }
+
+    @Override
+    public void outboundMessage() {
+      outboundMessageCount.incrementAndGet();
+    }
+  }
+}


### PR DESCRIPTION
This is a big, but mostly mechanical change.  The newly added Test*StreamTracer classes are designed to be extended which is why they are non final and have protected fields.  There are a few notable things in this:

1.  verifyNoMoreInteractions is gone.   The API for StreamTracers doesn't make this guarantee.  I have recovered this behavior by failing duplicate calls.  This has resulted in a few bugs in the test code being fixed.

2.  StreamTracers cannot be mocked anymore.  Tracers need to be thread safe, which mocks simply are not.  This leads to a HUGE number of reports when trying to find real races in gRPC.

3.  If these classes are useful, we can promote them out of internal.  I just put them here out of convenience.