### PR TITLE
interop-testing: fix NPE on empty args to test service client

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -16,6 +16,7 @@
 
 package io.grpc.testing.integration;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Files;
 import io.grpc.ManagedChannel;
 import io.grpc.internal.GrpcUtil;
@@ -82,7 +83,8 @@ public class TestServiceClient {
 
   private Tester tester = new Tester();
 
-  private void parseArgs(String[] args) {
+  @VisibleForTesting
+  void parseArgs(String[] args) {
     boolean usage = false;
     for (String arg : args) {
       if (!arg.startsWith("--")) {
@@ -161,7 +163,8 @@ public class TestServiceClient {
     }
   }
 
-  private void setUp() {
+  @VisibleForTesting
+  void setUp() {
     tester.setUp();
   }
 
@@ -318,12 +321,15 @@ public class TestServiceClient {
             throw new RuntimeException(ex);
           }
         }
-        return NettyChannelBuilder.forAddress(serverHost, serverPort)
-            .overrideAuthority(serverHostOverride)
-            .flowControlWindow(65 * 1024)
-            .negotiationType(useTls ? NegotiationType.TLS : NegotiationType.PLAINTEXT)
-            .sslContext(sslContext)
-            .build();
+        NettyChannelBuilder builder =
+            NettyChannelBuilder.forAddress(serverHost, serverPort)
+                .flowControlWindow(65 * 1024)
+                .negotiationType(useTls ? NegotiationType.TLS : NegotiationType.PLAINTEXT)
+                .sslContext(sslContext);
+        if (serverHostOverride != null) {
+          builder.overrideAuthority(serverHostOverride);
+        }
+        return builder.build();
       } else {
         OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress(serverHost, serverPort);
         if (serverHostOverride != null) {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TestServiceClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TestServiceClientTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.testing.integration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TestServiceClient}. */
+@RunWith(JUnit4.class)
+public class TestServiceClientTest {
+
+  @Test
+  public void emptyArgumentListShouldNotThrowException() {
+    TestServiceClient client = new TestServiceClient();
+    client.parseArgs(new String[0]);
+    client.setUp();
+  }
+}


### PR DESCRIPTION
Reintroduced in 924b0b2, the test service client will throw an NPE unless `--server_host_override` is explicitly set on the command line. This checks if `serverHostOverride` is set before passing it to the `NettyChannelBuilder`, and adds a (useful?) mini-test to assure that the client doesn't throw an exception on an empty argument list.