### PR TITLE
core,netty,okhttp: add grpc-payload-bin in GET requests

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -344,6 +344,8 @@ public abstract class AbstractClientStream extends AbstractStream
     }
   }
 
+  public static final String GRPC_PAYLOAD_BIN_KEY = "grpc-payload-bin";
+
   private class GetFramer implements Framer {
     private Metadata headers;
     private boolean closed;

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -113,9 +113,13 @@ class NettyClientStream extends AbstractClientStream {
       AsciiString httpMethod;
       if (get) {
         // Forge the query string
-        // TODO(ericgribkoff) Add the key back to the query string
         defaultPath =
-            new AsciiString(defaultPath + "?" + BaseEncoding.base64().encode(requestPayload));
+            new AsciiString(
+                defaultPath
+                    + "?"
+                    + GRPC_PAYLOAD_BIN_KEY
+                    + "="
+                    + BaseEncoding.base64().encode(requestPayload));
         httpMethod = Utils.HTTP_GET_METHOD;
       } else {
         httpMethod = Utils.HTTP_METHOD;

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -17,6 +17,7 @@
 package io.grpc.netty;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.AbstractClientStream.GRPC_PAYLOAD_BIN_KEY;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.grpc.netty.NettyTestUtil.messageFrame;
 import static io.grpc.netty.Utils.CONTENT_TYPE_GRPC;
@@ -407,8 +408,13 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     ArgumentCaptor<CreateStreamCommand> cmdCap = ArgumentCaptor.forClass(CreateStreamCommand.class);
     verify(writeQueue).enqueue(cmdCap.capture(), eq(true));
     assertThat(ImmutableListMultimap.copyOf(cmdCap.getValue().headers()))
-        .containsEntry(AsciiString.of(":path"), AsciiString.of(
-            "//testService/test?" + BaseEncoding.base64().encode(msg)));
+        .containsEntry(
+            AsciiString.of(":path"),
+            AsciiString.of(
+                "//testService/test?"
+                    + GRPC_PAYLOAD_BIN_KEY
+                    + "="
+                    + BaseEncoding.base64().encode(msg)));
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -114,7 +114,7 @@ class OkHttpClientStream extends AbstractClientStream {
     public void writeHeaders(Metadata metadata, byte[] payload) {
       String defaultPath = "/" + method.getFullMethodName();
       if (payload != null) {
-        defaultPath += "?" + BaseEncoding.base64().encode(payload);
+        defaultPath += "?" + GRPC_PAYLOAD_BIN_KEY + "=" + BaseEncoding.base64().encode(payload);
       }
       metadata.discardAll(GrpcUtil.USER_AGENT_KEY);
       synchronized (state.lock) {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -17,6 +17,7 @@
 package io.grpc.okhttp;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.AbstractClientStream.GRPC_PAYLOAD_BIN_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -193,9 +194,16 @@ public class OkHttpClientStreamTest {
     stream.transportState().start(3);
 
     verify(frameWriter).synStream(eq(false), eq(false), eq(3), eq(0), headersCaptor.capture());
-    assertThat(headersCaptor.getValue()).contains(
-        new Header(Header.TARGET_PATH, "/" + getMethod.getFullMethodName() + "?"
-            + BaseEncoding.base64().encode(msg)));
+    assertThat(headersCaptor.getValue())
+        .contains(
+            new Header(
+                Header.TARGET_PATH,
+                "/"
+                    + getMethod.getFullMethodName()
+                    + "?"
+                    + GRPC_PAYLOAD_BIN_KEY
+                    + "="
+                    + BaseEncoding.base64().encode(msg)));
   }
 
   // TODO(carl-mastrangelo): extract this out into a testing/ directory and remove other definitions
@@ -214,4 +222,3 @@ public class OkHttpClientStreamTest {
     public void closed(Status status, Metadata trailers) {}
   }
 }
-


### PR DESCRIPTION
Once https://github.com/grpc/grpc/pull/12092 is checked in, this updates the Java client to use query strings of the form `?grpc-payload-bin=<base64 encoded gRPC message>`. This is a revert of https://github.com/grpc/grpc-java/commit/e36d229 plus deletion of a `TODO` message. 

Edit: And adding the key to OKHttp as well.