### PR TITLE
Finish support for GET methods in OkHttp transport

### DIFF
--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -444,9 +444,13 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         any(Boolean.class));
     ArgumentCaptor<CreateStreamCommand> cmdCap = ArgumentCaptor.forClass(CreateStreamCommand.class);
     verify(writeQueue).enqueue(cmdCap.capture(), eq(true));
-    assertThat(ImmutableListMultimap.copyOf(cmdCap.getValue().headers()))
-        .containsEntry(AsciiString.of(":path"), AsciiString.of(
-            "//testService/test?" + BaseEncoding.base64().encode(msg)));
+    ImmutableListMultimap<CharSequence, CharSequence> headers =
+        ImmutableListMultimap.copyOf(cmdCap.getValue().headers());
+    assertThat(headers).containsEntry(AsciiString.of(":method"), Utils.HTTP_GET_METHOD);
+    assertThat(headers)
+        .containsEntry(
+            AsciiString.of(":path"),
+            AsciiString.of("//testService/test?" + BaseEncoding.base64().encode(msg)));
   }
 
   @Override

--- a/okhttp/src/main/java/io/grpc/okhttp/Headers.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Headers.java
@@ -36,6 +36,7 @@ class Headers {
 
   public static final Header SCHEME_HEADER = new Header(Header.TARGET_SCHEME, "https");
   public static final Header METHOD_HEADER = new Header(Header.TARGET_METHOD, GrpcUtil.HTTP_METHOD);
+  public static final Header METHOD_GET_HEADER = new Header(Header.TARGET_METHOD, "GET");
   public static final Header CONTENT_TYPE_HEADER =
       new Header(CONTENT_TYPE_KEY.name(), GrpcUtil.CONTENT_TYPE_GRPC);
   public static final Header TE_HEADER = new Header("te", GrpcUtil.TE_TRAILERS);
@@ -45,8 +46,8 @@ class Headers {
    * creating a stream. Since this serializes the headers, this method should be called in the
    * application thread context.
    */
-  public static List<Header> createRequestHeaders(Metadata headers, String defaultPath,
-      String authority, String userAgent) {
+  public static List<Header> createRequestHeaders(
+      Metadata headers, String defaultPath, String authority, String userAgent, boolean useGet) {
     Preconditions.checkNotNull(headers, "headers");
     Preconditions.checkNotNull(defaultPath, "defaultPath");
     Preconditions.checkNotNull(authority, "authority");
@@ -56,7 +57,11 @@ class Headers {
 
     // Set GRPC-specific headers.
     okhttpHeaders.add(SCHEME_HEADER);
-    okhttpHeaders.add(METHOD_HEADER);
+    if (useGet) {
+      okhttpHeaders.add(METHOD_GET_HEADER);
+    } else {
+      okhttpHeaders.add(METHOD_HEADER);
+    }
 
     okhttpHeaders.add(new Header(Header.TARGET_AUTHORITY, authority));
     String path = defaultPath;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -101,6 +101,10 @@ class OkHttpClientStream extends AbstractClientStream {
     return id;
   }
 
+  /**
+   * Returns whether the stream uses GET. This is not known until after {@link Sink#writeHeaders} is
+   * invoked.
+   */
   boolean useGet() {
     return useGet;
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -58,6 +58,8 @@ class OkHttpClientStream extends AbstractClientStream {
   private final TransportState state;
   private final Sink sink = new Sink();
 
+  private boolean useGet = false;
+
   OkHttpClientStream(
       MethodDescriptor<?, ?> method,
       Metadata headers,
@@ -99,6 +101,10 @@ class OkHttpClientStream extends AbstractClientStream {
     return id;
   }
 
+  boolean useGet() {
+    return useGet;
+  }
+
   @Override
   public void setAuthority(String authority) {
     this.authority = checkNotNull(authority, "authority");
@@ -114,6 +120,7 @@ class OkHttpClientStream extends AbstractClientStream {
     public void writeHeaders(Metadata metadata, byte[] payload) {
       String defaultPath = "/" + method.getFullMethodName();
       if (payload != null) {
+        useGet = true;
         defaultPath += "?" + BaseEncoding.base64().encode(payload);
       }
       metadata.discardAll(GrpcUtil.USER_AGENT_KEY);
@@ -200,7 +207,7 @@ class OkHttpClientStream extends AbstractClientStream {
 
       if (pendingData != null) {
         // Only happens when the stream has neither been started nor cancelled.
-        frameWriter.synStream(false, false, id, 0, requestHeaders);
+        frameWriter.synStream(useGet, false, id, 0, requestHeaders);
         statsTraceCtx.clientOutboundHeaders();
         requestHeaders = null;
 
@@ -346,8 +353,7 @@ class OkHttpClientStream extends AbstractClientStream {
 
     @GuardedBy("lock")
     private void streamReady(Metadata metadata, String path) {
-      requestHeaders =
-          Headers.createRequestHeaders(metadata, path, authority, userAgent);
+      requestHeaders = Headers.createRequestHeaders(metadata, path, authority, userAgent, useGet);
       transport.streamReadyToStart(OkHttpClientStream.this);
     }
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -315,8 +315,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     setInUse();
     stream.transportState().start(nextStreamId);
     // For unary and server streaming, there will be a data frame soon, no need to flush the header.
-    if (stream.getType() != MethodType.UNARY
-        && stream.getType() != MethodType.SERVER_STREAMING) {
+    if ((stream.getType() != MethodType.UNARY && stream.getType() != MethodType.SERVER_STREAMING)
+        || stream.useGet()) {
       frameWriter.flush();
     }
     if (nextStreamId >= Integer.MAX_VALUE - 2) {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -191,7 +191,9 @@ public class OkHttpClientStreamTest {
     verify(transport).streamReadyToStart(eq(stream));
     stream.transportState().start(3);
 
-    verify(frameWriter).synStream(eq(false), eq(false), eq(3), eq(0), headersCaptor.capture());
+    verify(frameWriter)
+        .synStream(eq(true), eq(false), eq(3), eq(0), headersCaptor.capture());
+    assertThat(headersCaptor.getValue()).contains(Headers.METHOD_GET_HEADER);
     assertThat(headersCaptor.getValue()).contains(
         new Header(Header.TARGET_PATH, "/" + getMethod.getFullMethodName() + "?"
             + BaseEncoding.base64().encode(msg)));


### PR DESCRIPTION
It turns out that https://github.com/grpc/grpc-java/pull/2945 did not fully implement GET support for the OkHttp transport. This PR modifies the outgoing headers for a GET request to specify `method: GET` and sets `endStream=true`, and also tells the frame writer to immediately flush the headers instead of waiting for additional data on the stream (which will never come).

Edit: This also adds a test for `method: GET` to the corresponding Netty test case. Netty was already doing things correctly, but did not have test coverage for this.