### PR TITLE
core: Providers should consider Robolectric as Android

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/core/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -126,7 +126,8 @@ public abstract class ManagedChannelProvider {
   protected static boolean isAndroid() {
     try {
       // Specify a class loader instead of null because we may be running under Robolectric
-      Class.forName("android.app.Application", /*initialize=*/ false, ManagedChannelProvider.class);
+      Class.forName("android.app.Application", /*initialize=*/ false,
+          ManagedChannelProvider.class.getClassLoader());
       return true;
     } catch (Exception e) {
       // If Application isn't loaded, it might as well not be Android.

--- a/core/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/core/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -125,7 +125,8 @@ public abstract class ManagedChannelProvider {
    */
   protected static boolean isAndroid() {
     try {
-      Class.forName("android.app.Application", /*initialize=*/ false, null);
+      // Specify a class loader instead of null because we may be running under Robolectric
+      Class.forName("android.app.Application", /*initialize=*/ false, ManagedChannelProvider.class);
       return true;
     } catch (Exception e) {
       // If Application isn't loaded, it might as well not be Android.

--- a/core/src/main/java/io/grpc/NameResolverProvider.java
+++ b/core/src/main/java/io/grpc/NameResolverProvider.java
@@ -125,7 +125,8 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
   private static boolean isAndroid() {
     try {
       // Specify a class loader instead of null because we may be running under Robolectric
-      Class.forName("android.app.Application", /*initialize=*/ false, NameResolverProvider.class);
+      Class.forName("android.app.Application", /*initialize=*/ false,
+          NameResolverProvider.class.getClassLoader());
       return true;
     } catch (Exception e) {
       // If Application isn't loaded, it might as well not be Android.

--- a/core/src/main/java/io/grpc/NameResolverProvider.java
+++ b/core/src/main/java/io/grpc/NameResolverProvider.java
@@ -124,7 +124,8 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
 
   private static boolean isAndroid() {
     try {
-      Class.forName("android.app.Application", /*initialize=*/ false, null);
+      // Specify a class loader instead of null because we may be running under Robolectric
+      Class.forName("android.app.Application", /*initialize=*/ false, NameResolverProvider.class);
       return true;
     } catch (Exception e) {
       // If Application isn't loaded, it might as well not be Android.


### PR DESCRIPTION
null class loader means to use the bootstrap class loader, which would
normally make sense. However, Robolectric tests run on OpenJDK and
provide the Android environment as part of the application, so "Android"
won't be present in the bootstrap class loader.