### PR TITLE
okhttp: Make Headers package-private

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/Headers.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Headers.java
@@ -32,7 +32,7 @@ import okio.ByteString;
 /**
  * Constants for request/response headers.
  */
-public class Headers {
+class Headers {
 
   public static final Header SCHEME_HEADER = new Header(Header.TARGET_SCHEME, "https");
   public static final Header METHOD_HEADER = new Header(Header.TARGET_METHOD, GrpcUtil.HTTP_METHOD);


### PR DESCRIPTION
There was no way to use it without touching internal APIs, and it should
never have been public to begin with as it serves no purpose to a user.

CC @ericgribkoff 