### PR TITLE
interop-testing: larger timeout for HTTP/2 client

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/Http2Client.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/Http2Client.java
@@ -138,8 +138,8 @@ public final class Http2Client {
 
   private void setUp() {
     channel = createChannel();
-    blockingStub = TestServiceGrpc.newBlockingStub(channel).withWaitForReady();
-    asyncStub = TestServiceGrpc.newStub(channel).withWaitForReady();
+    blockingStub = TestServiceGrpc.newBlockingStub(channel);
+    asyncStub = TestServiceGrpc.newStub(channel);
   }
 
   private void shutdown() {
@@ -199,7 +199,7 @@ public final class Http2Client {
   }
 
   private class Tester {
-    private final int timeoutSeconds = 5;
+    private final int timeoutSeconds = 180;
 
     private final int responseSize = 314159;
     private final int payloadSize = 271828;
@@ -230,13 +230,13 @@ public final class Http2Client {
       if (!responseObserver.awaitCompletion(timeoutSeconds, TimeUnit.SECONDS)) {
         throw new AssertionError("Operation timed out");
       }
-      if (responseObserver.getResponses().size() != 1) {
-        throw new AssertionError("Expected one response");
-      }
       if (responseObserver.getError() == null) {
         throw new AssertionError("Expected call to fail");
       }
       assertRstStreamReceived(Status.fromThrowable(responseObserver.getError()));
+      if (responseObserver.getResponses().size() != 1) {
+        throw new AssertionError("Expected one response");
+      }
     }
 
     private void rstDuringData() throws Exception {
@@ -246,13 +246,13 @@ public final class Http2Client {
       if (!responseObserver.awaitCompletion(timeoutSeconds, TimeUnit.SECONDS)) {
         throw new AssertionError("Operation timed out");
       }
-      if (responseObserver.getResponses().size() != 0) {
-        throw new AssertionError("Expected zero responses");
-      }
       if (responseObserver.getError() == null) {
         throw new AssertionError("Expected call to fail");
       }
       assertRstStreamReceived(Status.fromThrowable(responseObserver.getError()));
+      if (responseObserver.getResponses().size() != 0) {
+        throw new AssertionError("Expected zero responses");
+      }
     }
 
     private void goAway() throws Exception {


### PR DESCRIPTION
The Java HTTP/2 test client has been flaky (https://github.com/grpc/grpc/issues/10390, plus assorted others), and the failing tests (`MAX_STREAMS`, `RST_AFTER_DATA`, `RST_DURING_DATA`) all set what now looks like a rather spare deadline of five seconds in the Java client. Looking at the successful runs for these tests in the other languages, the tests can occasionally take a very long time, up to two minutes. See for example [go's MAX_STREAMS test case clocking in at 1:53](https://grpc-testing.appspot.com/job/gRPC_interop_pull_requests/15990/testReport/(root)/tests/cloud_to_cloud_go_http2_server_max_streams/). None of the other tests in the Java client set a deadline at all, and they are all reliably passing.

This PR increases the timeout value to 180 seconds.

It also removes the wait-for-ready on the stubs, which is no longer necessary after the addition in https://github.com/grpc/grpc/pull/10100 of a blocking health-check to the interop test setup process. Wait-for-ready is unrelated to the flakes (`MAX_STREAMS` was failing on the worker RPCs, which don't have wait-for-ready set and occur after a blocking unary call already succeeded) but this change (plus some reordered assertions) will allow distinguishing between future test failures due to connection failures and failures due to hanging RPCs, something which currently is not very clear from the log messages.