### PR TITLE
all: fix typo of overridden

### DIFF
--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -178,7 +178,7 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
   static JwtHelper createJwtHelperOrNull(ClassLoader loader) {
     Class<?> rawServiceAccountClass;
     try {
-      // Specify loader so it can be overriden in tests
+      // Specify loader so it can be overridden in tests
       rawServiceAccountClass
           = Class.forName("com.google.auth.oauth2.ServiceAccountCredentials", false, loader);
     } catch (ClassNotFoundException ex) {

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -126,7 +126,7 @@ public abstract class AbstractManagedChannelImplBuilder
    * larger than this limit is received it will not be processed and the RPC will fail with
    * RESOURCE_EXHAUSTED.
    */
-  // Can be overriden by subclasses.
+  // Can be overridden by subclasses.
   @Override
   public T maxInboundMessageSize(int max) {
     checkArgument(max >= 0, "negative max");

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -234,7 +234,7 @@ class NettyClientStream extends AbstractClientStream {
     }
 
     /**
-     * Intended to be overriden by NettyClientTransport, which has more information about failures.
+     * Intended to be overridden by NettyClientTransport, which has more information about failures.
      * May only be called from event loop.
      */
     protected abstract Status statusFromFailedFuture(ChannelFuture f);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -554,7 +554,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   }
 
   /**
-   * Gets the overriden authority hostname.  If the authority is overriden to be an invalid
+   * Gets the overridden authority hostname.  If the authority is overridden to be an invalid
    * authority, uri.getHost() will (rightly) return null, since the authority is no longer
    * an actual service.  This method overrides the behavior for practical reasons.  For example,
    * if an authority is in the form "invalid_authority" (note the "_"), rather than return null,

--- a/testing/src/main/java/io/grpc/internal/NoopClientCall.java
+++ b/testing/src/main/java/io/grpc/internal/NoopClientCall.java
@@ -22,14 +22,14 @@ import io.grpc.Metadata;
 /**
  * {@link NoopClientCall} is a class that is designed for use in tests.  It is designed to be used
  * in places where a scriptable call is necessary.  By default, all methods are noops, and designed
- * to be overriden.
+ * to be overridden.
  */
 public class NoopClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
 
   /**
    * {@link NoopClientCall.NoopClientCallListener} is a class that is designed for use in tests.
    * It is designed to be used in places where a scriptable call listener is necessary.  By
-   * default, all methods are noops, and designed to be overriden.
+   * default, all methods are noops, and designed to be overridden.
    */
   public static class NoopClientCallListener<T> extends ClientCall.Listener<T> {
   }

--- a/testing/src/main/java/io/grpc/internal/NoopServerCall.java
+++ b/testing/src/main/java/io/grpc/internal/NoopServerCall.java
@@ -24,14 +24,14 @@ import io.grpc.Status;
 /**
  * {@link NoopServerCall} is a class that is designed for use in tests.  It is designed to be used
  * in places where a scriptable call is necessary.  By default, all methods are noops, and designed
- * to be overriden.
+ * to be overridden.
  */
 public class NoopServerCall<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
   /**
    * {@link NoopServerCall.NoopServerCallListener} is a class that is designed for use in tests.
    * It is designed to be used in places where a scriptable call listener is necessary.  By
-   * default, all methods are noops, and designed to be overriden.
+   * default, all methods are noops, and designed to be overridden.
    */
   public static class NoopServerCallListener<T> extends ServerCall.Listener<T> {
   }

--- a/testing/src/main/java/io/grpc/testing/NoopClientCall.java
+++ b/testing/src/main/java/io/grpc/testing/NoopClientCall.java
@@ -23,7 +23,7 @@ import io.grpc.Metadata;
 /**
  * {@link NoopClientCall} is a class that is designed for use in tests.  It is designed to be used
  * in places where a scriptable call is necessary.  By default, all methods are noops, and designed
- * to be overriden.
+ * to be overridden.
  *
  * @deprecated moved to {@link io.grpc.internal.NoopClientCall} and for internal use only. Please
  *             use {@link GrpcServerRule} to test on InProcess channels instead
@@ -35,7 +35,7 @@ public class NoopClientCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
   /**
    * {@link NoopClientCall.NoopClientCallListener} is a class that is designed for use in tests.
    * It is designed to be used in places where a scriptable call listener is necessary.  By
-   * default, all methods are noops, and designed to be overriden.
+   * default, all methods are noops, and designed to be overridden.
    */
   @Deprecated
   public static class NoopClientCallListener<T> extends ClientCall.Listener<T> {

--- a/testing/src/main/java/io/grpc/testing/NoopServerCall.java
+++ b/testing/src/main/java/io/grpc/testing/NoopServerCall.java
@@ -25,7 +25,7 @@ import io.grpc.Status;
 /**
  * {@link NoopServerCall} is a class that is designed for use in tests.  It is designed to be used
  * in places where a scriptable call is necessary.  By default, all methods are noops, and designed
- * to be overriden.
+ * to be overridden.
  *
  * @deprecated moved to {@link io.grpc.internal.NoopServerCall} and for internal use only. Please
  *             use {@link GrpcServerRule} to test on InProcess channels instead
@@ -37,7 +37,7 @@ public class NoopServerCall<ReqT, RespT> extends ServerCall<ReqT, RespT> {
   /**
    * {@link NoopServerCall.NoopServerCallListener} is a class that is designed for use in tests.
    * It is designed to be used in places where a scriptable call listener is necessary.  By
-   * default, all methods are noops, and designed to be overriden.
+   * default, all methods are noops, and designed to be overridden.
    */
   @Deprecated
   public static class NoopServerCallListener<T> extends ServerCall.Listener<T> {


### PR DESCRIPTION
s/overriden/overridden/g