### PR TITLE
interop-testing: use Activity.RESULT_OK instead of 0

### DIFF
--- a/android-interop-testing/README.md
+++ b/android-interop-testing/README.md
@@ -45,11 +45,11 @@ $ adb shell am instrument -w -e server_host <hostname or ip address> -e server_p
 
 If the test passed successfully, it will output:
 ```
-INSTRUMENTATION_RESULT: grpc test result=Succeed!!!
-INSTRUMENTATION_CODE: 0
+INSTRUMENTATION_RESULT: grpc test result=Success!
+INSTRUMENTATION_CODE: -1
 ```
 otherwise, output something like:
 ```
 INSTRUMENTATION_RESULT: grpc test result=Failed... : <exception stacktrace if applicable>
-INSTRUMENTATION_CODE: 1
+INSTRUMENTATION_CODE: 0
 ```

--- a/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTester.java
+++ b/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/InteropTester.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
  * Implementation of the integration tests, as an AsyncTask.
  */
 final class InteropTester extends AsyncTask<Void, Void, String> {
-  static final String SUCCESS_MESSAGE = "Succeed!!!";
+  static final String SUCCESS_MESSAGE = "Success!";
   static final String LOG_TAG = "GrpcTest";
 
   private ManagedChannel channel;

--- a/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/TesterInstrumentation.java
+++ b/android-interop-testing/app/src/main/java/io/grpc/android/integrationtest/TesterInstrumentation.java
@@ -16,6 +16,7 @@
 
 package io.grpc.android.integrationtest;
 
+import android.app.Activity;
 import android.app.Instrumentation;
 import android.os.Bundle;
 import android.util.Log;
@@ -88,9 +89,9 @@ public class TesterInstrumentation extends Instrumentation {
               Bundle bundle = new Bundle();
               bundle.putString("grpc test result", result);
               if (InteropTester.SUCCESS_MESSAGE.equals(result)) {
-                finish(0, bundle);
+                finish(Activity.RESULT_OK, bundle);
               } else {
-                finish(1, bundle);
+                finish(Activity.RESULT_CANCELED, bundle);
               }
             }
           },
@@ -98,7 +99,7 @@ public class TesterInstrumentation extends Instrumentation {
     } catch (Throwable t) {
       Bundle bundle = new Bundle();
       bundle.putString("Exception encountered", t.toString());
-      finish(1, bundle);
+      finish(Activity.RESULT_CANCELED, bundle);
     }
   }
 }


### PR DESCRIPTION
Previously `TesterInstrumentation` returned a status of 0 on success. This is the same code returned when the instrumentation tests fail with an exception. This switches to returning `Activity.RESULT_OK` (-1) on success and `Activity.RESULT_CANCELED` (0) on failure, making it possible to distinguish between runtime failures and a passing test case.

Note: these are different than the JUnit instrumentation tests currently running for our Firebase open-source Android integration tests (https://github.com/grpc/grpc-java/pull/3079). This change only impacts command-line runs of the older Instrumentation interop tests, which we do not currently run in open-source. 