### PR TITLE
android-interop-testing: remove gms version metadata, add minimum sdk

### DIFF
--- a/android-interop-testing/app/src/main/AndroidManifest.xml
+++ b/android-interop-testing/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.grpc.android.integrationtest" >
 
+    <uses-sdk
+        android:minSdkVersion="9"
+        android:targetSdkVersion="22"/>
+
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
@@ -18,10 +22,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <meta-data
-            android:name="com.google.android.gms.version"
-            android:value="@integer/google_play_services_version" />
     </application>
 
     <instrumentation android:functionalTest="true"


### PR DESCRIPTION
The `com.google.android.gms.version` is no longer required, and some build tools rely on the minimum SDK being present in `AndroidManifest.xml` rather than solely in `build.gradle`.