### PR TITLE
core: pass status to ManagedClientTransport.shutdown()

### DIFF
--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -30,8 +30,8 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
   }
 
   @Override
-  public void shutdown() {
-    delegate().shutdown();
+  public void shutdown(Status status) {
+    delegate().shutdown(status);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -84,6 +84,10 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   static final Status SHUTDOWN_NOW_STATUS =
       Status.UNAVAILABLE.withDescription("Channel shutdownNow invoked");
 
+  @VisibleForTesting
+  static final Status SHUTDOWN_STATUS =
+      Status.UNAVAILABLE.withDescription("Channel shutdown invoked");
+
   private final String target;
   private final NameResolver.Factory nameResolverFactory;
   private final Attributes nameResolverParams;
@@ -470,7 +474,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       }
     });
 
-    delayedTransport.shutdown();
+    delayedTransport.shutdown(SHUTDOWN_STATUS);
     channelExecutor.executeLater(new Runnable() {
         @Override
         public void run() {
@@ -659,7 +663,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
               // shutdown even if "terminating" is already true.  The subchannel will not be used in
               // this case, because delayed transport has terminated when "terminating" becomes
               // true, and no more requests will be sent to balancer beyond this point.
-              internalSubchannel.shutdown();
+              internalSubchannel.shutdown(SHUTDOWN_STATUS);
             }
             if (!terminated) {
               // If channel has not terminated, it will track the subchannel and block termination
@@ -904,7 +908,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
                   new Runnable() {
                     @Override
                     public void run() {
-                      subchannel.shutdown();
+                      subchannel.shutdown(SHUTDOWN_STATUS);
                     }
                   }), SUBCHANNEL_SHUTDOWN_DELAY_SECONDS, TimeUnit.SECONDS);
           return;
@@ -912,7 +916,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       }
       // When terminating == true, no more real streams will be created. It's safe and also
       // desirable to shutdown timely.
-      subchannel.shutdown();
+      subchannel.shutdown(SHUTDOWN_STATUS);
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -88,6 +88,10 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   static final Status SHUTDOWN_STATUS =
       Status.UNAVAILABLE.withDescription("Channel shutdown invoked");
 
+  @VisibleForTesting
+  static final Status SUBCHANNEL_SHUTDOWN_STATUS =
+      Status.UNAVAILABLE.withDescription("Subchannel shutdown invoked");
+
   private final String target;
   private final NameResolver.Factory nameResolverFactory;
   private final Attributes nameResolverParams;
@@ -908,7 +912,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
                   new Runnable() {
                     @Override
                     public void run() {
-                      subchannel.shutdown(SHUTDOWN_STATUS);
+                      subchannel.shutdown(SUBCHANNEL_SHUTDOWN_STATUS);
                     }
                   }), SUBCHANNEL_SHUTDOWN_DELAY_SECONDS, TimeUnit.SECONDS);
           return;

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -56,7 +56,7 @@ public interface ManagedClientTransport extends ClientTransport, WithLogId {
    * {@link Listener#transportShutdown} callback called), or be transferred off this transport (in
    * which case they may succeed).  This method may only be called once.
    */
-  void shutdown();
+  void shutdown(Status reason);
 
   /**
    * Initiates a forceful shutdown in which preexisting and new calls are closed. Existing calls

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -109,7 +109,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
     subchannelImpl = new AbstractSubchannel() {
         @Override
         public void shutdown() {
-          subchannel.shutdown();
+          subchannel.shutdown(Status.UNAVAILABLE.withDescription("OobChannel is shutdown"));
         }
 
         @Override
@@ -179,7 +179,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   @Override
   public ManagedChannel shutdown() {
     shutdown = true;
-    delayedTransport.shutdown();
+    delayedTransport.shutdown(Status.UNAVAILABLE.withDescription("OobChannel.shutdown() called"));
     return this;
   }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -747,7 +747,7 @@ public class ManagedChannelImplTest {
     sub1.shutdown();
     verify(transportInfo1.transport, never()).shutdown(any(Status.class));
     timer.forwardTime(1, TimeUnit.SECONDS);
-    verify(transportInfo1.transport).shutdown(same(ManagedChannelImpl.SHUTDOWN_STATUS));
+    verify(transportInfo1.transport).shutdown(same(ManagedChannelImpl.SUBCHANNEL_SHUTDOWN_STATUS));
 
     // ... but not after Channel is terminating
     verify(mockLoadBalancer, never()).shutdown();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -399,7 +399,11 @@ public class ManagedChannelImplTest {
     }
     // LoadBalancer should shutdown the subchannel
     subchannel.shutdown();
-    verify(mockTransport).shutdown();
+    if (shutdownNow) {
+      verify(mockTransport).shutdown(same(ManagedChannelImpl.SHUTDOWN_NOW_STATUS));
+    } else {
+      verify(mockTransport).shutdown(same(ManagedChannelImpl.SHUTDOWN_STATUS));
+    }
 
     // Killing the remaining real transport will terminate the channel
     transportListener.transportShutdown(Status.UNAVAILABLE);
@@ -415,10 +419,6 @@ public class ManagedChannelImplTest {
     verify(mockTransportFactory).close();
     verify(mockTransport, atLeast(0)).getLogId();
     verifyNoMoreInteractions(mockTransport);
-  }
-
-  @Test
-  public void shutdownNowWithMultipleOobChannels() {
   }
 
   @Test
@@ -745,18 +745,18 @@ public class ManagedChannelImplTest {
     sub1.shutdown();
     timer.forwardTime(ManagedChannelImpl.SUBCHANNEL_SHUTDOWN_DELAY_SECONDS - 1, TimeUnit.SECONDS);
     sub1.shutdown();
-    verify(transportInfo1.transport, never()).shutdown();
+    verify(transportInfo1.transport, never()).shutdown(any(Status.class));
     timer.forwardTime(1, TimeUnit.SECONDS);
-    verify(transportInfo1.transport).shutdown();
+    verify(transportInfo1.transport).shutdown(same(ManagedChannelImpl.SHUTDOWN_STATUS));
 
     // ... but not after Channel is terminating
     verify(mockLoadBalancer, never()).shutdown();
     channel.shutdown();
     verify(mockLoadBalancer).shutdown();
-    verify(transportInfo2.transport, never()).shutdown();
+    verify(transportInfo2.transport, never()).shutdown(any(Status.class));
 
     sub2.shutdown();
-    verify(transportInfo2.transport).shutdown();
+    verify(transportInfo2.transport).shutdown(same(ManagedChannelImpl.SHUTDOWN_STATUS));
   }
 
   @Test

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -540,8 +540,7 @@ class NettyClientHandler extends AbstractNettyHandler {
 
   private void forcefulClose(final ChannelHandlerContext ctx, final ForcefulCloseCommand msg,
       ChannelPromise promise) throws Exception {
-    lifecycleManager.notifyShutdown(
-        Status.UNAVAILABLE.withDescription("Channel requested transport to shut down"));
+    lifecycleManager.notifyShutdown(msg.getStatus());
     close(ctx, promise);
     connection().forEachActiveStream(new Http2StreamVisitor() {
       @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -248,16 +248,14 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public void shutdown() {
+  public void shutdown(Status reason) {
     // start() could have failed
     if (channel == null) {
       return;
     }
     // Notifying of termination is automatically done when the channel closes.
     if (channel.isOpen()) {
-      Status status
-          = Status.UNAVAILABLE.withDescription("Channel requested transport to shut down");
-      handler.getWriteQueue().enqueue(new GracefulCloseCommand(status), true);
+      handler.getWriteQueue().enqueue(new GracefulCloseCommand(reason), true);
     }
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -118,7 +118,7 @@ public class NettyClientTransportTest {
   public void teardown() throws Exception {
     Context.ROOT.attach();
     for (NettyClientTransport transport : transports) {
-      transport.shutdown();
+      transport.shutdown(Status.UNAVAILABLE);
     }
 
     if (server != null) {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -587,13 +587,13 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public void shutdown() {
+  public void shutdown(Status reason) {
     synchronized (lock) {
       if (goAwayStatus != null) {
         return;
       }
 
-      goAwayStatus = Status.UNAVAILABLE.withDescription("Transport stopped");
+      goAwayStatus = reason;
       listener.transportShutdown(goAwayStatus);
       stopIfNecessary();
     }
@@ -601,7 +601,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
 
   @Override
   public void shutdownNow(Status reason) {
-    shutdown();
+    shutdown(reason);
     synchronized (lock) {
       Iterator<Map.Entry<Integer, OkHttpClientStream>> it = streams.entrySet().iterator();
       while (it.hasNext()) {


### PR DESCRIPTION
This aligns with shutdownNow(), which is already accepting a status.
The status will be propagated to application when RPCs failed because
of transport shutdown, which will become useful information for debug.