### PR TITLE
core/test: remove ineffective assertions.

### DIFF
--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -79,7 +79,6 @@ public class DnsNameResolverTest {
 
         @Override
         public void close(ScheduledExecutorService instance) {
-          assertSame(fakeClock, instance);
         }
       };
 
@@ -92,7 +91,6 @@ public class DnsNameResolverTest {
 
         @Override
         public void close(ExecutorService instance) {
-          assertSame(fakeExecutor, instance);
         }
       };
 


### PR DESCRIPTION
The assertions are actually wrong and fail every time.  It doesn't
cause test failures because SharedResourceHolder calls them in a
scheduled executor because of its delayed close feature.

It's better to remove them, rather than leaving them there deceiving
us.