### PR TITLE
context: move KeyValueEntries into an abstract class

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -691,7 +691,7 @@ public class Context {
       super(parent, parent.keyValueEntries, true);
       // Create a surrogate that inherits from this to attach so that you cannot retrieve a
       // cancellable context from Context.current()
-      uncancellableSurrogate = new Context(this, parent.keyValueEntries);
+      uncancellableSurrogate = new Context(this, keyValueEntries);
     }
 
     /**

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -105,7 +105,8 @@ public class Context {
    * <p>Never assume this is the default context for new threads, because {@link Storage} may define
    * a default context that is different from ROOT.
    */
-  public static final Context ROOT = new Context(null, LinkedArrayKeyValueEntries.EMPTY, false, false);
+  public static final Context ROOT =
+      new Context(null, LinkedArrayKeyValueEntries.EMPTY, false, false);
 
   // Lazy-loaded storage. Delaying storage initialization until after class initialization makes it
   // much easier to avoid circular loading since there can still be references to Context as long as
@@ -217,6 +218,9 @@ public class Context {
     canBeCancelled = isCancellable;
   }
 
+  /**
+   * Constructs a context that can be arbitrarily configured.
+   */
   private Context(
       Context parent,
       KeyValueEntries keyValueEntries,

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -97,8 +96,6 @@ public class Context {
 
   private static final Logger log = Logger.getLogger(Context.class.getName());
 
-  private static final Object[] EMPTY_ENTRIES = new Object[0];
-
   private static final Key<Deadline> DEADLINE_KEY = new Key<Deadline>("deadline");
 
   /**
@@ -108,7 +105,7 @@ public class Context {
    * <p>Never assume this is the default context for new threads, because {@link Storage} may define
    * a default context that is different from ROOT.
    */
-  public static final Context ROOT = new Context(null);
+  public static final Context ROOT = new Context(null, LinkedArrayKeyValueEntries.EMPTY, false, false);
 
   // Lazy-loaded storage. Delaying storage initialization until after class initialization makes it
   // much easier to avoid circular loading since there can still be references to Context as long as
@@ -180,16 +177,12 @@ public class Context {
   }
 
   private final Context parent;
-  // A 64 bit bloom filter of all the Key.bloomFilterMask values in this Context and all the parents
-  // this will help us detect failed lookups faster.  In fact if there are fewer than 64 key objects
-  // this will be perfect (though we don't currently take advantage of that fact).
-  private final long keyBloomFilter;
-  // Alternating Key, Object entries
-  private final Object[] keyValueEntries;
   private final boolean cascadesCancellation;
   private ArrayList<ExecutableListener> listeners;
   private CancellationListener parentListener = new ParentListener();
   private final boolean canBeCancelled;
+
+  final KeyValueEntries keyValueEntries;
 
   /**
    * Construct a context that cannot be cancelled and will not cascade cancellation from its parent.
@@ -197,8 +190,7 @@ public class Context {
   private Context(Context parent) {
     this.parent = parent;
     // Not inheriting cancellation implies not inheriting a deadline too.
-    keyValueEntries = new Object[] {DEADLINE_KEY, null};
-    keyBloomFilter = computeFilter(parent, keyValueEntries);
+    keyValueEntries = parent.keyValueEntries.put(DEADLINE_KEY, null);
     cascadesCancellation = false;
     canBeCancelled = false;
   }
@@ -207,10 +199,9 @@ public class Context {
    * Construct a context that cannot be cancelled but will cascade cancellation from its parent if
    * it is cancellable.
    */
-  private Context(Context parent, Object[] keyValueEntries) {
+  private Context(Context parent, KeyValueEntries keyValueEntries) {
     this.parent = parent;
     this.keyValueEntries = keyValueEntries;
-    keyBloomFilter = computeFilter(parent, keyValueEntries);
     cascadesCancellation = true;
     canBeCancelled = this.parent != null && this.parent.canBeCancelled;
   }
@@ -219,20 +210,22 @@ public class Context {
    * Construct a context that can be cancelled and will cascade cancellation from its parent if
    * it is cancellable.
    */
-  private Context(Context parent, Object[] keyValueEntries, boolean isCancellable) {
+  private Context(Context parent, KeyValueEntries keyValueEntries, boolean isCancellable) {
     this.parent = parent;
     this.keyValueEntries = keyValueEntries;
-    keyBloomFilter = computeFilter(parent, keyValueEntries);
     cascadesCancellation = true;
     canBeCancelled = isCancellable;
   }
 
-  private static long computeFilter(Context parent, Object[] keyValueEntries) {
-    long filter = parent != null ? parent.keyBloomFilter : 0;
-    for (int i = 0; i < keyValueEntries.length; i += 2) {
-      filter |= ((Key<?>) keyValueEntries[i]).bloomFilterMask;
-    }
-    return filter;
+  private Context(
+      Context parent,
+      KeyValueEntries keyValueEntries,
+      boolean cascadesCancellation,
+      boolean canBeCancelled) {
+    this.parent = parent;
+    this.keyValueEntries = keyValueEntries;
+    this.cascadesCancellation = cascadesCancellation;
+    this.canBeCancelled = canBeCancelled;
   }
 
   /**
@@ -340,7 +333,7 @@ public class Context {
    *
    */
   public <V> Context withValue(Key<V> k1, V v1) {
-    return new Context(this, new Object[] {k1, v1});
+    return new Context(this, keyValueEntries.put(k1, v1));
   }
 
   /**
@@ -348,7 +341,7 @@ public class Context {
    * from its parent.
    */
   public <V1, V2> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2) {
-    return new Context(this, new Object[] {k1, v1, k2, v2});
+    return new Context(this, keyValueEntries.put(k1, v1, k2, v2));
   }
 
   /**
@@ -356,7 +349,7 @@ public class Context {
    * from its parent.
    */
   public <V1, V2, V3> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3) {
-    return new Context(this, new Object[] {k1, v1, k2, v2, k3, v3});
+    return new Context(this, keyValueEntries.put(k1, v1, k2, v2, k3, v3));
   }
 
   /**
@@ -365,7 +358,7 @@ public class Context {
    */
   public <V1, V2, V3, V4> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2,
       Key<V3> k3, V3 v3, Key<V4> k4, V4 v4) {
-    return new Context(this, new Object[] {k1, v1, k2, v2, k3, v3, k4, v4});
+    return new Context(this, keyValueEntries.put(k1, v1, k2, v2, k3, v3, k4, v4));
   }
 
   /**
@@ -664,32 +657,6 @@ public class Context {
   }
 
   /**
-   * Lookup the value for a key in the context inheritance chain.
-   */
-  private Object lookup(Key<?> key) {
-    if ((key.bloomFilterMask & keyBloomFilter) == 0) {
-      return null;
-    }
-    Object[] entries = keyValueEntries;
-    Context current = this;
-    while (true) {
-      // entries in the table are alternating key value pairs where the even numbered slots are the
-      // key objects
-      for (int i = 0; i < entries.length; i += 2) {
-        // Key objects have identity semantics, compare using ==
-        if (key == entries[i]) {
-          return entries[i + 1];
-        }
-      }
-      current = current.parent;
-      if (current == null) {
-        return null;
-      }
-      entries = current.keyValueEntries;
-    }
-  }
-
-  /**
    * A context which inherits cancellation from its parent but which can also be independently
    * cancelled and which will propagate cancellation to its descendants. To avoid leaking memory,
    * every CancellableContext must have a defined lifetime, after which it is guaranteed to be
@@ -706,21 +673,21 @@ public class Context {
      * If the parent deadline is before the given deadline there is no need to install the value
      * or listen for its expiration as the parent context will already be listening for it.
      */
-    private static Object[] deriveDeadline(Context parent, Deadline deadline) {
+    private static KeyValueEntries deriveDeadline(Context parent, Deadline deadline) {
       Deadline parentDeadline = DEADLINE_KEY.get(parent);
       return parentDeadline == null || deadline.isBefore(parentDeadline)
-          ? new Object[] {DEADLINE_KEY, deadline}
-          : EMPTY_ENTRIES;
+          ? parent.keyValueEntries.put(DEADLINE_KEY, deadline)
+          : parent.keyValueEntries;
     }
 
     /**
      * Create a cancellable context that does not have a deadline.
      */
     private CancellableContext(Context parent) {
-      super(parent, EMPTY_ENTRIES, true);
+      super(parent, parent.keyValueEntries, true);
       // Create a surrogate that inherits from this to attach so that you cannot retrieve a
       // cancellable context from Context.current()
-      uncancellableSurrogate = new Context(this, EMPTY_ENTRIES);
+      uncancellableSurrogate = new Context(this, parent.keyValueEntries);
     }
 
     /**
@@ -748,7 +715,7 @@ public class Context {
           cancel(new TimeoutException("context timed out"));
         }
       }
-      uncancellableSurrogate = new Context(this, EMPTY_ENTRIES);
+      uncancellableSurrogate = new Context(this, keyValueEntries);
     }
 
 
@@ -856,8 +823,6 @@ public class Context {
    * Key for indexing values stored in a context.
    */
   public static final class Key<T> {
-    private static final AtomicInteger keyCounter = new AtomicInteger();
-    private final long bloomFilterMask;
     private final String name;
     private final T defaultValue;
 
@@ -868,7 +833,6 @@ public class Context {
     Key(String name, T defaultValue) {
       this.name = checkNotNull(name, "name");
       this.defaultValue = defaultValue;
-      this.bloomFilterMask = 1 << (keyCounter.getAndIncrement() & 63);
     }
 
     /**
@@ -884,13 +848,46 @@ public class Context {
      */
     @SuppressWarnings("unchecked")
     public T get(Context context) {
-      T value = (T) context.lookup(this);
+      T value = (T) context.keyValueEntries.lookup(this);
       return value == null ? defaultValue : value;
     }
 
     @Override
     public String toString() {
       return name;
+    }
+  }
+
+  /**
+   * An internal interface for key-value storage implementations.
+   */
+  abstract static class KeyValueEntries {
+    /**
+     * Returns the Object associated with this key, or {@code null} if it does not exist.
+     */
+    abstract Object lookup(Key<?> key);
+
+    /** Returns a new {@link KeyValueEntries} instance with the key-value pair. */
+    abstract <V> KeyValueEntries put(Key<V> key, V value);
+
+    /** Returns a new {@link KeyValueEntries} instance with the key-value pairs. */
+    public <V1, V2> KeyValueEntries put(Key<V1> key1, V1 value1, Key<V2> key2, V2 value2) {
+      return put(key1, value1).put(key2, value2);
+    }
+
+    /** Returns a new {@link KeyValueEntries} instance with the key-value pairs. */
+    <V1, V2, V3> KeyValueEntries put(
+        Key<V1> key1, V1 value1, Key<V2> key2, V2 value2, Key<V3> key3, V3 value3) {
+      return put(key1, value1, key2, value2).put(key3, value3);
+    }
+
+    /** Returns a new {@link KeyValueEntries} instance with the key-value pairs. */
+    <V1, V2, V3, V4> KeyValueEntries put(
+        Key<V1> key1, V1 value1,
+        Key<V2> key2, V2 value2,
+        Key<V3> key3, V3 value3,
+        Key<V4> key4, V4 value4) {
+      return put(key1, value1, key2, value2, key3, value3).put(key4, value4);
     }
   }
 

--- a/context/src/main/java/io/grpc/LinkedArrayKeyValueEntries.java
+++ b/context/src/main/java/io/grpc/LinkedArrayKeyValueEntries.java
@@ -1,0 +1,98 @@
+package io.grpc;
+
+/**
+ * A {@link Context.KeyValueEntries} that is implemented as a linked list of arrays. Key-values
+ * are stored in alternating slots of an array. Modifications are performed by appending to the
+ * end of the linked list. Reads are performed by following the parent pointers until the desired
+ * key is found, or if it is determined to be absent.
+ *
+ * A bloom filter is used to fast-fail reading keys that are absent.
+ */
+final class LinkedArrayKeyValueEntries extends Context.KeyValueEntries {
+  private static final Object[] EMPTY_ENTRIES = new Object[0];
+
+  private final LinkedArrayKeyValueEntries parent;
+  // A 64 bit bloom filter of all the Key.bloomFilterMask values in this Context and all the parents
+  // this will help us detect failed lookups faster.  In fact if there are fewer than 64 key objects
+  // this will be perfect (though we don't currently take advantage of that fact).
+  private final long keyBloomFilter;
+  // Alternating Key, Object entries
+  private final Object[] keyValueEntries;
+
+  public static final LinkedArrayKeyValueEntries EMPTY =
+      new LinkedArrayKeyValueEntries(null, EMPTY_ENTRIES);
+
+  private LinkedArrayKeyValueEntries(LinkedArrayKeyValueEntries parent, Object[] overwrites) {
+    this.parent = parent;
+    keyBloomFilter = computeFilter(parent, overwrites);
+    keyValueEntries = overwrites;
+  }
+
+  /**
+   * Lookup the value for a key in the context inheritance chain.
+   */
+  @Override
+  public Object lookup(Context.Key<?> key) {
+    if ((computeBloomFilterMask(key) & keyBloomFilter) == 0) {
+      return null;
+    }
+    Object[] entries = keyValueEntries;
+    LinkedArrayKeyValueEntries current = this;
+    while (true) {
+      // entries in the table are alternating key value pairs where the even numbered slots are the
+      // key objects
+      for (int i = 0; i < entries.length; i += 2) {
+        // Key objects have identity semantics, compare using ==
+        if (key == entries[i]) {
+          return entries[i + 1];
+        }
+      }
+      current = current.parent;
+      if (current == null) {
+        return null;
+      }
+      entries = current.keyValueEntries;
+    }
+  }
+
+  private static long computeFilter(LinkedArrayKeyValueEntries parent, Object[] keyValueEntries) {
+    long filter = parent != null ? parent.keyBloomFilter : 0;
+    for (int i = 0; i < keyValueEntries.length; i += 2) {
+      filter |= computeBloomFilterMask((Context.Key<?>) keyValueEntries[i]);
+    }
+    return filter;
+  }
+
+  private static long computeBloomFilterMask(Context.Key<?> entry) {
+    return entry.hashCode() % 64;
+  }
+
+  @Override
+  public <V> Context.KeyValueEntries put(Context.Key<V> key, V value) {
+    return new LinkedArrayKeyValueEntries(this, new Object[] {key, value});
+  }
+
+  @Override
+  public <V1, V2> Context.KeyValueEntries put(
+      Context.Key<V1> key1, V1 value1, Context.Key<V2> key2, V2 value2) {
+    return new LinkedArrayKeyValueEntries(this, new Object[] {key1, value1, key2, value2});
+  }
+
+  @Override
+  public <V1, V2, V3> Context.KeyValueEntries put(
+      Context.Key<V1> key1, V1 value1,
+      Context.Key<V2> key2, V2 value2,
+      Context.Key<V3> key3, V3 value3) {
+    return new LinkedArrayKeyValueEntries(this, new Object[] {key1, value1, key2, value2, key3, value3});
+  }
+
+  @Override
+  public <V1, V2, V3, V4> Context.KeyValueEntries put(
+      Context.Key<V1> key1, V1 value1,
+      Context.Key<V2> key2, V2 value2,
+      Context.Key<V3> key3, V3 value3,
+      Context.Key<V4> key4, V4 value4) {
+    return new LinkedArrayKeyValueEntries(
+        this, new Object[] {key1, value1, key2, value2, key3, value3, key4, value4});
+  }
+}

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -759,7 +759,8 @@ public class ContextTest {
     StaticTestingClassLoader classLoader =
         new StaticTestingClassLoader(
             getClass().getClassLoader(),
-            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)"));
+            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)"
+                + "|(io\\.grpc\\.\\w+KeyValueEntries)"));
     Class<?> runnable =
         classLoader.loadClass(LoadMeWithStaticTestingClassLoader.class.getName());
 


### PR DESCRIPTION
This will make it a lot easier to plug in the alternate data
structures from #3248 and also has a nice side effect of making
Context easier to understand.

The bloom filter mask of the `Context.Key` is now `hashCode() %
64` because from the `LinkedArrayKeyValueEntries` class we no
longer have insight into how many `Context.Key`s were created.