### PR TITLE
netty: Handle shutdown and failures during negotiator

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -255,6 +255,10 @@ class NettyClientHandler extends AbstractNettyHandler {
     return clientWriteQueue;
   }
 
+  ClientTransportLifecycleManager getLifecycleManager() {
+    return lifecycleManager;
+  }
+
   /**
    * Returns the given processed bytes back to inbound flow control.
    */
@@ -305,8 +309,10 @@ class NettyClientHandler extends AbstractNettyHandler {
   @Override
   public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
     logger.fine("Network channel being closed by the application.");
-    lifecycleManager.notifyShutdown(
-        Status.UNAVAILABLE.withDescription("Transport closed for unknown reason"));
+    if (ctx.channel().isActive()) { // Ignore notification that the socket was closed
+      lifecycleManager.notifyShutdown(
+          Status.UNAVAILABLE.withDescription("Transport closed for unknown reason"));
+    }
     super.close(ctx, promise);
   }
 
@@ -317,21 +323,25 @@ class NettyClientHandler extends AbstractNettyHandler {
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
     try {
       logger.fine("Network channel is closed");
-      lifecycleManager.notifyShutdown(
-          Status.UNAVAILABLE.withDescription("Network closed for unknown reason"));
-      cancelPing(lifecycleManager.getShutdownThrowable());
-      // Report status to the application layer for any open streams
-      connection().forEachActiveStream(new Http2StreamVisitor() {
-        @Override
-        public boolean visit(Http2Stream stream) throws Http2Exception {
-          NettyClientStream.TransportState clientStream = clientStream(stream);
-          if (clientStream != null) {
-            clientStream.transportReportStatus(
-                lifecycleManager.getShutdownStatus(), false, new Metadata());
+      Status status = Status.UNAVAILABLE.withDescription("Network closed for unknown reason");
+      lifecycleManager.notifyShutdown(status);
+      try {
+        cancelPing(lifecycleManager.getShutdownThrowable());
+        // Report status to the application layer for any open streams
+        connection().forEachActiveStream(new Http2StreamVisitor() {
+          @Override
+          public boolean visit(Http2Stream stream) throws Http2Exception {
+            NettyClientStream.TransportState clientStream = clientStream(stream);
+            if (clientStream != null) {
+              clientStream.transportReportStatus(
+                  lifecycleManager.getShutdownStatus(), false, new Metadata());
+            }
+            return true;
           }
-          return true;
-        }
-      });
+        });
+      } finally {
+        lifecycleManager.notifyTerminated(status);
+      }
     } finally {
       // Close any open streams
       super.channelInactive(ctx);
@@ -540,8 +550,7 @@ class NettyClientHandler extends AbstractNettyHandler {
 
   private void forcefulClose(final ChannelHandlerContext ctx, final ForcefulCloseCommand msg,
       ChannelPromise promise) throws Exception {
-    lifecycleManager.notifyShutdown(msg.getStatus());
-    close(ctx, promise);
+    // close() already called by NettyClientTransport, so just need to clean up streams
     connection().forEachActiveStream(new Http2StreamVisitor() {
       @Override
       public boolean visit(Http2Stream stream) throws Http2Exception {

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -19,6 +19,7 @@ package io.grpc.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
 
 /**
@@ -113,5 +114,10 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.Qu
   @Override
   public void promise(ChannelPromise promise) {
     this.promise = promise;
+  }
+
+  @Override
+  public final void run(Channel channel) {
+    channel.write(this, promise);
   }
 }


### PR DESCRIPTION
NettyClientTransport needs to call close() on the Channel directly
instead of sending a message, since the message would typically be
delayed until negotiation completes.

The closeFuture() closes too early to be helpful, which is very
unfortunate. Using it squelches the negotiator's error handling. We now
rely on the handlers to report shutdown without any back-up. The
handlers error handling has matured, so maybe this is okay.

------

This work was initially triggered by useless error messages if using a Proxy failed. I _thought_ I had already submitted this. But then it bit me again when trying to get Conscrypt working, so I finished up the old commit.