### PR TITLE
context: hashtrie based keyvalue store

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -97,7 +97,8 @@ public class Context {
 
   private static final Logger log = Logger.getLogger(Context.class.getName());
 
-  private static final Object[] EMPTY_ENTRIES = new Object[0];
+  private static final PersistentHashArrayMappedTrie<Key<?>, Object> EMPTY_ENTRIES =
+      new PersistentHashArrayMappedTrie<Key<?>, Object>();
 
   private static final Key<Deadline> DEADLINE_KEY = new Key<Deadline>("deadline");
 
@@ -108,7 +109,7 @@ public class Context {
    * <p>Never assume this is the default context for new threads, because {@link Storage} may define
    * a default context that is different from ROOT.
    */
-  public static final Context ROOT = new Context(null);
+  public static final Context ROOT = new Context(null, EMPTY_ENTRIES, false, false);
 
   // Lazy-loaded storage. Delaying storage initialization until after class initialization makes it
   // much easier to avoid circular loading since there can still be references to Context as long as
@@ -180,16 +181,11 @@ public class Context {
   }
 
   private final Context parent;
-  // A 64 bit bloom filter of all the Key.bloomFilterMask values in this Context and all the parents
-  // this will help us detect failed lookups faster.  In fact if there are fewer than 64 key objects
-  // this will be perfect (though we don't currently take advantage of that fact).
-  private final long keyBloomFilter;
-  // Alternating Key, Object entries
-  private final Object[] keyValueEntries;
   private final boolean cascadesCancellation;
   private ArrayList<ExecutableListener> listeners;
   private CancellationListener parentListener = new ParentListener();
   private final boolean canBeCancelled;
+  final PersistentHashArrayMappedTrie<Key<?>, Object> keyValueEntries;
 
   /**
    * Construct a context that cannot be cancelled and will not cascade cancellation from its parent.
@@ -197,8 +193,7 @@ public class Context {
   private Context(Context parent) {
     this.parent = parent;
     // Not inheriting cancellation implies not inheriting a deadline too.
-    keyValueEntries = new Object[] {DEADLINE_KEY, null};
-    keyBloomFilter = computeFilter(parent, keyValueEntries);
+    keyValueEntries = parent.keyValueEntries.put(DEADLINE_KEY, null);
     cascadesCancellation = false;
     canBeCancelled = false;
   }
@@ -207,10 +202,9 @@ public class Context {
    * Construct a context that cannot be cancelled but will cascade cancellation from its parent if
    * it is cancellable.
    */
-  private Context(Context parent, Object[] keyValueEntries) {
+  private Context(Context parent, PersistentHashArrayMappedTrie<Key<?>, Object> keyValueEntries) {
     this.parent = parent;
     this.keyValueEntries = keyValueEntries;
-    keyBloomFilter = computeFilter(parent, keyValueEntries);
     cascadesCancellation = true;
     canBeCancelled = this.parent != null && this.parent.canBeCancelled;
   }
@@ -219,20 +213,28 @@ public class Context {
    * Construct a context that can be cancelled and will cascade cancellation from its parent if
    * it is cancellable.
    */
-  private Context(Context parent, Object[] keyValueEntries, boolean isCancellable) {
+  private Context(
+      Context parent,
+      PersistentHashArrayMappedTrie<Key<?>, Object> keyValueEntries,
+      boolean isCancellable) {
     this.parent = parent;
     this.keyValueEntries = keyValueEntries;
-    keyBloomFilter = computeFilter(parent, keyValueEntries);
     cascadesCancellation = true;
     canBeCancelled = isCancellable;
   }
 
-  private static long computeFilter(Context parent, Object[] keyValueEntries) {
-    long filter = parent != null ? parent.keyBloomFilter : 0;
-    for (int i = 0; i < keyValueEntries.length; i += 2) {
-      filter |= ((Key<?>) keyValueEntries[i]).bloomFilterMask;
-    }
-    return filter;
+  /**
+   * Constructs a context that can be arbitrarily configured.
+   */
+  private Context(
+      Context parent,
+      PersistentHashArrayMappedTrie<Key<?>, Object> keyValueEntries,
+      boolean cascadesCancellation,
+      boolean isCancellable) {
+    this.parent = parent;
+    this.keyValueEntries = keyValueEntries;
+    this.cascadesCancellation = cascadesCancellation;
+    canBeCancelled = isCancellable;
   }
 
   /**
@@ -340,7 +342,7 @@ public class Context {
    *
    */
   public <V> Context withValue(Key<V> k1, V v1) {
-    return new Context(this, new Object[] {k1, v1});
+    return new Context(this, keyValueEntries.put(k1, v1));
   }
 
   /**
@@ -348,7 +350,7 @@ public class Context {
    * from its parent.
    */
   public <V1, V2> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2) {
-    return new Context(this, new Object[] {k1, v1, k2, v2});
+    return new Context(this, keyValueEntries.put(k1, v1).put(k2, v2));
   }
 
   /**
@@ -356,7 +358,7 @@ public class Context {
    * from its parent.
    */
   public <V1, V2, V3> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3) {
-    return new Context(this, new Object[] {k1, v1, k2, v2, k3, v3});
+    return new Context(this, keyValueEntries.put(k1, v1).put(k2, v2).put(k3, v3));
   }
 
   /**
@@ -365,7 +367,7 @@ public class Context {
    */
   public <V1, V2, V3, V4> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2,
       Key<V3> k3, V3 v3, Key<V4> k4, V4 v4) {
-    return new Context(this, new Object[] {k1, v1, k2, v2, k3, v3, k4, v4});
+    return new Context(this, keyValueEntries.put(k1, v1).put(k2, v2).put(k3, v3).put(k4, v4));
   }
 
   /**
@@ -667,26 +669,7 @@ public class Context {
    * Lookup the value for a key in the context inheritance chain.
    */
   private Object lookup(Key<?> key) {
-    if ((key.bloomFilterMask & keyBloomFilter) == 0) {
-      return null;
-    }
-    Object[] entries = keyValueEntries;
-    Context current = this;
-    while (true) {
-      // entries in the table are alternating key value pairs where the even numbered slots are the
-      // key objects
-      for (int i = 0; i < entries.length; i += 2) {
-        // Key objects have identity semantics, compare using ==
-        if (key == entries[i]) {
-          return entries[i + 1];
-        }
-      }
-      current = current.parent;
-      if (current == null) {
-        return null;
-      }
-      entries = current.keyValueEntries;
-    }
+    return keyValueEntries.get(key);
   }
 
   /**
@@ -706,21 +689,22 @@ public class Context {
      * If the parent deadline is before the given deadline there is no need to install the value
      * or listen for its expiration as the parent context will already be listening for it.
      */
-    private static Object[] deriveDeadline(Context parent, Deadline deadline) {
+    private static PersistentHashArrayMappedTrie<Key<?>, Object> deriveDeadline(
+        Context parent, Deadline deadline) {
       Deadline parentDeadline = DEADLINE_KEY.get(parent);
       return parentDeadline == null || deadline.isBefore(parentDeadline)
-          ? new Object[] {DEADLINE_KEY, deadline}
-          : EMPTY_ENTRIES;
+          ? parent.keyValueEntries.put(DEADLINE_KEY, deadline) :
+          parent.keyValueEntries;
     }
 
     /**
      * Create a cancellable context that does not have a deadline.
      */
     private CancellableContext(Context parent) {
-      super(parent, EMPTY_ENTRIES, true);
+      super(parent, parent.keyValueEntries, true);
       // Create a surrogate that inherits from this to attach so that you cannot retrieve a
       // cancellable context from Context.current()
-      uncancellableSurrogate = new Context(this, EMPTY_ENTRIES);
+      uncancellableSurrogate = new Context(this, keyValueEntries);
     }
 
     /**
@@ -748,7 +732,7 @@ public class Context {
           cancel(new TimeoutException("context timed out"));
         }
       }
-      uncancellableSurrogate = new Context(this, EMPTY_ENTRIES);
+      uncancellableSurrogate = new Context(this, keyValueEntries);
     }
 
 

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -693,8 +693,8 @@ public class Context {
         Context parent, Deadline deadline) {
       Deadline parentDeadline = DEADLINE_KEY.get(parent);
       return parentDeadline == null || deadline.isBefore(parentDeadline)
-          ? parent.keyValueEntries.put(DEADLINE_KEY, deadline) :
-          parent.keyValueEntries;
+          ? parent.keyValueEntries.put(DEADLINE_KEY, deadline)
+          : parent.keyValueEntries;
     }
 
     /**

--- a/context/src/main/java/io/grpc/PersistentHashArrayMappedTrie.java
+++ b/context/src/main/java/io/grpc/PersistentHashArrayMappedTrie.java
@@ -63,7 +63,7 @@ public final class PersistentHashArrayMappedTrie<K,V> {
 
   // Not actually annotated to avoid depending on guava
   // @VisibleForTesting
-  static class Leaf<K,V> implements Node<K,V> {
+  static final class Leaf<K,V> implements Node<K,V> {
     final K key;
     final V value;
 
@@ -105,7 +105,7 @@ public final class PersistentHashArrayMappedTrie<K,V> {
 
   // Not actually annotated to avoid depending on guava
   // @VisibleForTesting
-  static class CollisionLeaf<K,V> implements Node<K,V> {
+  static final class CollisionLeaf<K,V> implements Node<K,V> {
     // All keys must have same hash, but not have the same reference
     private final K[] keys;
     private final V[] values;
@@ -182,7 +182,7 @@ public final class PersistentHashArrayMappedTrie<K,V> {
 
   // Not actually annotated to avoid depending on guava
   // @VisibleForTesting
-  static class CompressedIndex<K,V> implements Node<K,V> {
+  static final class CompressedIndex<K,V> implements Node<K,V> {
     private static final int BITS = 5;
     private static final int BITS_MASK = 0x1F;
 

--- a/context/src/main/java/io/grpc/PersistentHashArrayMappedTrie.java
+++ b/context/src/main/java/io/grpc/PersistentHashArrayMappedTrie.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.util.Arrays;
+
+/**
+ * A persistent (copy-on-write) hash tree/trie. Collisions are handled
+ * linearly. Delete is not supported, but replacement is. The implementation
+ * favors simplicity and low memory allocation during insertion. Although the
+ * asymptotics are good, it is optimized for small sizes like less than 20;
+ * "unbelievably large" would be 100.
+ *
+ * <p>Inspired by popcnt-based compression seen in Ideal Hash Trees, Phil
+ * Bagwell (2000). The rest of the implementation is ignorant of/ignores the
+ * paper.
+ */
+public final class PersistentHashArrayMappedTrie<K,V> {
+  final Node<K,V> root;
+
+  public PersistentHashArrayMappedTrie() {
+    this(null);
+  }
+
+  PersistentHashArrayMappedTrie(Node<K,V> root) {
+    this.root = root;
+  }
+
+  /**
+   * Returns the value with the specified key, or {@code null} if it does not exist.
+   */
+  public V get(K key) {
+    if (root == null) {
+      return null;
+    }
+    return root.get(key, key.hashCode(), 0);
+  }
+
+  /**
+   * Returns a new trie where the key is set to the specified value.
+   */
+  public PersistentHashArrayMappedTrie<K,V> put(K key, V value) {
+    if (root == null) {
+      return new PersistentHashArrayMappedTrie<K,V>(new Leaf<K,V>(key, value));
+    } else {
+      return new PersistentHashArrayMappedTrie<K,V>(root.put(key, value, key.hashCode(), 0));
+    }
+  }
+
+  // Not actually annotated to avoid depending on guava
+  // @VisibleForTesting
+  static class Leaf<K,V> implements Node<K,V> {
+    final K key;
+    final V value;
+
+    public Leaf(K key, V value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    @Override
+    public V get(K key, int hash, int bitsConsumed) {
+      if (this.key == key) {
+        return value;
+      } else {
+        return null;
+      }
+    }
+
+    @Override
+    public Node<K,V> put(K key, V value, int hash, int bitsConsumed) {
+      int thisHash = this.key.hashCode();
+      if (thisHash != hash) {
+        // Insert
+        return CompressedIndex.combine(
+            new Leaf<K,V>(key, value), hash, this, thisHash, bitsConsumed);
+      } else if (this.key == key) {
+        // Replace
+        return new Leaf<K,V>(key, value);
+      } else {
+        // Hash collision
+        return new CollisionLeaf<K,V>(this.key, this.value, key, value);
+      }
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Leaf(key=%s value=%s)", key, value);
+    }
+  }
+
+  // Not actually annotated to avoid depending on guava
+  // @VisibleForTesting
+  static class CollisionLeaf<K,V> implements Node<K,V> {
+    // All keys must have same hash, but not have the same reference
+    private final K[] keys;
+    private final V[] values;
+
+    @SuppressWarnings("unchecked")
+    public CollisionLeaf(K key1, V value1, K key2, V value2) {
+      this((K[]) new Object[] {key1, key2}, (V[]) new Object[] {value1, value2});
+      assert key1 != key2;
+      assert key1.hashCode() == key2.hashCode();
+    }
+
+    // Not actually annotated to avoid depending on guava
+    // @VisibleForTesting
+    CollisionLeaf(K[] keys, V[] values) {
+      this.keys = keys;
+      this.values = values;
+    }
+
+    @Override
+    public V get(K key, int hash, int bitsConsumed) {
+      for (int i = 0; i < keys.length; i++) {
+        if (keys[i] == key) {
+          return values[i];
+        }
+      }
+      return null;
+    }
+
+    @Override
+    public Node<K,V> put(K key, V value, int hash, int bitsConsumed) {
+      int thisHash = keys[0].hashCode();
+      int keyIndex;
+      if (thisHash != hash) {
+        // Insert
+        return CompressedIndex.combine(
+            new Leaf<K,V>(key, value), hash, this, thisHash, bitsConsumed);
+      } else if ((keyIndex = indexOfKey(key)) != -1) {
+        // Replace
+        K[] newKeys = Arrays.copyOf(keys, keys.length);
+        V[] newValues = Arrays.copyOf(values, keys.length);
+        newKeys[keyIndex] = key;
+        newValues[keyIndex] = value;
+        return new CollisionLeaf<K,V>(newKeys, newValues);
+      } else {
+        // Yet another hash collision
+        K[] newKeys = Arrays.copyOf(keys, keys.length + 1);
+        V[] newValues = Arrays.copyOf(values, keys.length + 1);
+        newKeys[keys.length] = key;
+        newValues[keys.length] = value;
+        return new CollisionLeaf<K,V>(newKeys, newValues);
+      }
+    }
+
+    // -1 if not found
+    private int indexOfKey(K key) {
+      for (int i = 0; i < keys.length; i++) {
+        if (keys[i] == key) {
+          return i;
+        }
+      }
+      return -1;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder valuesSb = new StringBuilder();
+      valuesSb.append("CollisionLeaf(");
+      for (int i = 0; i < values.length; i++) {
+        valuesSb.append("(key=").append(keys[i]).append(" value=").append(values[i]).append(") ");
+      }
+      return valuesSb.append(")").toString();
+    }
+  }
+
+  // Not actually annotated to avoid depending on guava
+  // @VisibleForTesting
+  static class CompressedIndex<K,V> implements Node<K,V> {
+    private static final int BITS = 5;
+    private static final int BITS_MASK = 0x1F;
+
+    final int bitmap;
+    final Node<K,V>[] values;
+
+    private CompressedIndex(int bitmap, Node<K,V>[] values) {
+      this.bitmap = bitmap;
+      this.values = values;
+    }
+
+    @Override
+    public V get(K key, int hash, int bitsConsumed) {
+      int indexBit = indexBit(hash, bitsConsumed);
+      if ((bitmap & indexBit) == 0) {
+        return null;
+      }
+      int compressedIndex = compressedIndex(indexBit);
+      return values[compressedIndex].get(key, hash, bitsConsumed + BITS);
+    }
+
+    @Override
+    public Node<K,V> put(K key, V value, int hash, int bitsConsumed) {
+      int indexBit = indexBit(hash, bitsConsumed);
+      int compressedIndex = compressedIndex(indexBit);
+      if ((bitmap & indexBit) == 0) {
+        // Insert
+        int newBitmap = bitmap | indexBit;
+        @SuppressWarnings("unchecked")
+        Node<K,V>[] newValues = (Node<K,V>[]) new Node<?,?>[values.length + 1];
+        System.arraycopy(values, 0, newValues, 0, compressedIndex);
+        newValues[compressedIndex] = new Leaf<K,V>(key, value);
+        System.arraycopy(
+            values,
+            compressedIndex,
+            newValues,
+            compressedIndex + 1,
+            values.length - compressedIndex);
+        return new CompressedIndex<K,V>(newBitmap, newValues);
+      } else {
+        // Replace
+        Node<K,V>[] newValues = Arrays.copyOf(values, values.length);
+        newValues[compressedIndex] =
+            values[compressedIndex].put(key, value, hash, bitsConsumed + BITS);
+        return new CompressedIndex<K,V>(bitmap, newValues);
+      }
+    }
+
+    static <K,V> Node<K,V> combine(
+        Node<K,V> node1, int hash1, Node<K,V> node2, int hash2, int bitsConsumed) {
+      assert hash1 != hash2;
+      int indexBit1 = indexBit(hash1, bitsConsumed);
+      int indexBit2 = indexBit(hash2, bitsConsumed);
+      if (indexBit1 == indexBit2) {
+        Node<K,V> node = combine(node1, hash1, node2, hash2, bitsConsumed + BITS);
+        @SuppressWarnings("unchecked")
+        Node<K,V>[] values = (Node<K,V>[]) new Node<?,?>[] {node};
+        return new CompressedIndex<K,V>(indexBit1, values);
+      } else {
+        // Make node1 the smallest
+        if (uncompressedIndex(hash1, bitsConsumed) > uncompressedIndex(hash2, bitsConsumed)) {
+          Node<K,V> nodeCopy = node1;
+          node1 = node2;
+          node2 = nodeCopy;
+        }
+        @SuppressWarnings("unchecked")
+        Node<K,V>[] values = (Node<K,V>[]) new Node<?,?>[] {node1, node2};
+        return new CompressedIndex<K,V>(indexBit1 | indexBit2, values);
+      }
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder valuesSb = new StringBuilder();
+      valuesSb.append("CompressedIndex(")
+          .append(String.format("bitmap=%s ", Integer.toBinaryString(bitmap)));
+      for (Node<K, V> value : values) {
+        valuesSb.append(value).append(" ");
+      }
+      return valuesSb.append(")").toString();
+    }
+
+    private int compressedIndex(int indexBit) {
+      return Integer.bitCount(bitmap & (indexBit - 1));
+    }
+
+    private static int uncompressedIndex(int hash, int bitsConsumed) {
+      return (hash >>> bitsConsumed) & BITS_MASK;
+    }
+
+    private static int indexBit(int hash, int bitsConsumed) {
+      int uncompressedIndex = uncompressedIndex(hash, bitsConsumed);
+      return 1 << uncompressedIndex;
+    }
+  }
+
+  interface Node<K,V> {
+    V get(K key, int hash, int bitsConsumed);
+
+    Node<K,V> put(K key, V value, int hash, int bitsConsumed);
+  }
+}

--- a/context/src/main/java/io/grpc/PersistentHashArrayMappedTrie.java
+++ b/context/src/main/java/io/grpc/PersistentHashArrayMappedTrie.java
@@ -29,14 +29,14 @@ import java.util.Arrays;
  * Bagwell (2000). The rest of the implementation is ignorant of/ignores the
  * paper.
  */
-public final class PersistentHashArrayMappedTrie<K,V> {
-  final Node<K,V> root;
+final class PersistentHashArrayMappedTrie<K,V> {
+  private final Node<K,V> root;
 
-  public PersistentHashArrayMappedTrie() {
+  PersistentHashArrayMappedTrie() {
     this(null);
   }
 
-  PersistentHashArrayMappedTrie(Node<K,V> root) {
+  private PersistentHashArrayMappedTrie(Node<K,V> root) {
     this.root = root;
   }
 
@@ -64,8 +64,8 @@ public final class PersistentHashArrayMappedTrie<K,V> {
   // Not actually annotated to avoid depending on guava
   // @VisibleForTesting
   static final class Leaf<K,V> implements Node<K,V> {
-    final K key;
-    final V value;
+    private final K key;
+    private final V value;
 
     public Leaf(K key, V value) {
       this.key = key;
@@ -110,16 +110,16 @@ public final class PersistentHashArrayMappedTrie<K,V> {
     private final K[] keys;
     private final V[] values;
 
+    // Not actually annotated to avoid depending on guava
+    // @VisibleForTesting
     @SuppressWarnings("unchecked")
-    public CollisionLeaf(K key1, V value1, K key2, V value2) {
+    CollisionLeaf(K key1, V value1, K key2, V value2) {
       this((K[]) new Object[] {key1, key2}, (V[]) new Object[] {value1, value2});
       assert key1 != key2;
       assert key1.hashCode() == key2.hashCode();
     }
 
-    // Not actually annotated to avoid depending on guava
-    // @VisibleForTesting
-    CollisionLeaf(K[] keys, V[] values) {
+    private CollisionLeaf(K[] keys, V[] values) {
       this.keys = keys;
       this.values = values;
     }

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -759,8 +759,7 @@ public class ContextTest {
     StaticTestingClassLoader classLoader =
         new StaticTestingClassLoader(
             getClass().getClassLoader(),
-            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)|"
-                + "(io\\.grpc\\.PersistentHashArrayMappedTrie)"));
+            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)"));
     Class<?> runnable =
         classLoader.loadClass(LoadMeWithStaticTestingClassLoader.class.getName());
 

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -759,8 +759,7 @@ public class ContextTest {
     StaticTestingClassLoader classLoader =
         new StaticTestingClassLoader(
             getClass().getClassLoader(),
-            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)|"
-                + "(io\\.grpc\\.[^.]+)"));
+            Pattern.compile("(io\\.grpc\\.[^.]+)"));
     Class<?> runnable =
         classLoader.loadClass(LoadMeWithStaticTestingClassLoader.class.getName());
 

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -758,8 +758,7 @@ public class ContextTest {
   public void initContextWithCustomClassLoaderWithCustomLogger() throws Exception {
     StaticTestingClassLoader classLoader =
         new StaticTestingClassLoader(
-            getClass().getClassLoader(),
-            Pattern.compile("(io\\.grpc\\.[^.]+)"));
+            getClass().getClassLoader(), Pattern.compile("(io\\.grpc\\.[^.]+)"));
     Class<?> runnable =
         classLoader.loadClass(LoadMeWithStaticTestingClassLoader.class.getName());
 

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -759,7 +759,8 @@ public class ContextTest {
     StaticTestingClassLoader classLoader =
         new StaticTestingClassLoader(
             getClass().getClassLoader(),
-            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)"));
+            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)|"
+                + "(io\\.grpc\\.PersistentHashArrayMappedTrie)"));
     Class<?> runnable =
         classLoader.loadClass(LoadMeWithStaticTestingClassLoader.class.getName());
 

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -758,7 +758,7 @@ public class ContextTest {
   public void initContextWithCustomClassLoaderWithCustomLogger() throws Exception {
     StaticTestingClassLoader classLoader =
         new StaticTestingClassLoader(
-            getClass().getClassLoader(), Pattern.compile("(io\\.grpc\\.[^.]+)"));
+            getClass().getClassLoader(), Pattern.compile("io\\.grpc\\.[^.]+"));
     Class<?> runnable =
         classLoader.loadClass(LoadMeWithStaticTestingClassLoader.class.getName());
 

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -759,7 +759,8 @@ public class ContextTest {
     StaticTestingClassLoader classLoader =
         new StaticTestingClassLoader(
             getClass().getClassLoader(),
-            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)"));
+            Pattern.compile("(io\\.grpc\\.Context.*)|(io\\.grpc\\.ThreadLocalContextStorage.*)|"
+                + "(io\\.grpc\\.[^.]+)"));
     Class<?> runnable =
         classLoader.loadClass(LoadMeWithStaticTestingClassLoader.class.getName());
 

--- a/context/src/test/java/io/grpc/PersistentHashArrayMappedTrieTest.java
+++ b/context/src/test/java/io/grpc/PersistentHashArrayMappedTrieTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import io.grpc.PersistentHashArrayMappedTrie.CollisionLeaf;
+import io.grpc.PersistentHashArrayMappedTrie.CompressedIndex;
+import io.grpc.PersistentHashArrayMappedTrie.Leaf;
+import io.grpc.PersistentHashArrayMappedTrie.Node;
+import org.junit.Test;
+
+public class PersistentHashArrayMappedTrieTest {
+  @Test
+  public void leaf_replace() {
+    Key key = new Key(0);
+    Object value1 = new Object();
+    Object value2 = new Object();
+    Leaf<Key, Object> leaf = new Leaf<Key, Object>(key, value1);
+    Node<Key, Object> ret = leaf.put(key, value2, key.hashCode(), 0);
+    assertTrue(ret instanceof Leaf);
+    assertSame(value2, ret.get(key, key.hashCode(), 0));
+
+    assertSame(value1, leaf.get(key, key.hashCode(), 0));
+  }
+
+  @Test
+  public void leaf_collision() {
+    Key key1 = new Key(0);
+    Key key2 = new Key(0);
+    Object value1 = new Object();
+    Object value2 = new Object();
+    Leaf<Key, Object> leaf = new Leaf<Key, Object>(key1, value1);
+    Node<Key, Object> ret = leaf.put(key2, value2, key2.hashCode(), 0);
+    assertTrue(ret instanceof CollisionLeaf);
+    assertSame(value1, ret.get(key1, key1.hashCode(), 0));
+    assertSame(value2, ret.get(key2, key2.hashCode(), 0));
+
+    assertSame(value1, leaf.get(key1, key1.hashCode(), 0));
+    assertSame(null, leaf.get(key2, key2.hashCode(), 0));
+  }
+
+  @Test
+  public void leaf_insert() {
+    Key key1 = new Key(0);
+    Key key2 = new Key(1);
+    Object value1 = new Object();
+    Object value2 = new Object();
+    Leaf<Key, Object> leaf = new Leaf<Key, Object>(key1, value1);
+    Node<Key, Object> ret = leaf.put(key2, value2, key2.hashCode(), 0);
+    assertTrue(ret instanceof CompressedIndex);
+    assertSame(value1, ret.get(key1, key1.hashCode(), 0));
+    assertSame(value2, ret.get(key2, key2.hashCode(), 0));
+
+    assertSame(value1, leaf.get(key1, key1.hashCode(), 0));
+    assertSame(null, leaf.get(key2, key2.hashCode(), 0));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void collisionLeaf_assertKeysDifferent() {
+    Key key1 = new Key(0);
+    new CollisionLeaf<Key, Object>(key1, new Object(), key1, new Object());
+  }
+
+  @Test(expected = AssertionError.class)
+  public void collisionLeaf_assertHashesSame() {
+    new CollisionLeaf<Key, Object>(new Key(0), new Object(), new Key(1), new Object());
+  }
+
+  @Test
+  public void collisionLeaf_insert() {
+    Key key1 = new Key(0);
+    Key key2 = new Key(key1.hashCode());
+    Key insertKey = new Key(1);
+    Object value1 = new Object();
+    Object value2 = new Object();
+    Object insertValue = new Object();
+    CollisionLeaf<Key, Object> leaf =
+        new CollisionLeaf<Key, Object>(new Key[]{key1, key2}, new Object[]{value1, value2});
+
+    Node<Key, Object> ret = leaf.put(insertKey, insertValue, insertKey.hashCode(), 0);
+    assertTrue(ret instanceof CompressedIndex);
+    assertSame(value1, ret.get(key1, key1.hashCode(), 0));
+    assertSame(value2, ret.get(key2, key2.hashCode(), 0));
+    assertSame(insertValue, ret.get(insertKey, insertKey.hashCode(), 0));
+
+    assertSame(value1, leaf.get(key1, key1.hashCode(), 0));
+    assertSame(value2, leaf.get(key2, key2.hashCode(), 0));
+    assertSame(null, leaf.get(insertKey, insertKey.hashCode(), 0));
+  }
+
+  @Test
+  public void collisionLeaf_replace() {
+    Key replaceKey = new Key(0);
+    Object originalValue = new Object();
+    Key key = new Key(replaceKey.hashCode());
+    Object value = new Object();
+    CollisionLeaf<Key, Object> leaf =
+        new CollisionLeaf<Key, Object>(
+            new Key[]{replaceKey, key},
+            new Object[]{originalValue, value});
+    Object replaceValue = new Object();
+    Node<Key, Object> ret = leaf.put(replaceKey, replaceValue, replaceKey.hashCode(), 0);
+    assertTrue(ret instanceof CollisionLeaf);
+    assertSame(replaceValue, ret.get(replaceKey, replaceKey.hashCode(), 0));
+    assertSame(value, ret.get(key, key.hashCode(), 0));
+
+    assertSame(value, leaf.get(key, key.hashCode(), 0));
+    assertSame(originalValue, leaf.get(replaceKey, replaceKey.hashCode(), 0));
+  }
+
+  @Test
+  public void collisionLeaf_collision() {
+    Key key1 = new Key(0);
+    Key key2 = new Key(key1.hashCode());
+    Key key3 = new Key(key1.hashCode());
+    Object value1 = new Object();
+    Object value2 = new Object();
+    Object value3 = new Object();
+    CollisionLeaf<Key, Object> leaf =
+        new CollisionLeaf<Key, Object>(new Key[]{key1, key2}, new Object[]{value1, value2});
+
+    Node<Key, Object> ret = leaf.put(key3, value3, key3.hashCode(), 0);
+    assertTrue(ret instanceof CollisionLeaf);
+    assertSame(value1, ret.get(key1, key1.hashCode(), 0));
+    assertSame(value2, ret.get(key2, key2.hashCode(), 0));
+    assertSame(value3, ret.get(key3, key3.hashCode(), 0));
+
+    assertSame(value1, leaf.get(key1, key1.hashCode(), 0));
+    assertSame(value2, leaf.get(key2, key2.hashCode(), 0));
+    assertSame(null, leaf.get(key3, key3.hashCode(), 0));
+  }
+
+  @Test
+  public void compressedIndex_combine_differentIndexBit() {
+    final Key key1 = new Key(7);
+    final Key key2 = new Key(19);
+    final Object value1 = new Object();
+    final Object value2 = new Object();
+    Leaf<Key, Object> leaf1 = new Leaf<Key, Object>(key1, value1);
+    Leaf<Key, Object> leaf2 = new Leaf<Key, Object>(key2, value2);
+    class Verifier {
+      private void verify(Node<Key, Object> ret) {
+        CompressedIndex<Key, Object> collisionLeaf = (CompressedIndex<Key, Object>) ret;
+        assertEquals((1 << 7) | (1 << 19), collisionLeaf.bitmap);
+        assertEquals(2, collisionLeaf.values.length);
+        assertSame(value1, collisionLeaf.values[0].get(key1, key1.hashCode(), 0));
+        assertSame(value2, collisionLeaf.values[1].get(key2, key2.hashCode(), 0));
+
+        assertSame(value1, ret.get(key1, key1.hashCode(), 0));
+        assertSame(value2, ret.get(key2, key2.hashCode(), 0));
+      }
+    }
+
+    Verifier verifier = new Verifier();
+    verifier.verify(CompressedIndex.combine(leaf1, key1.hashCode(), leaf2, key2.hashCode(), 0));
+    verifier.verify(CompressedIndex.combine(leaf2, key2.hashCode(), leaf1, key1.hashCode(), 0));
+  }
+
+  @Test
+  public void compressedIndex_combine_sameIndexBit() {
+    final Key key1 = new Key(1 << 5 | 1); // 5 bit regions: (1, 1)
+    final Key key2 = new Key(17 << 5 | 1); // 5 bit regions: (17, 1)
+    final Object value1 = new Object();
+    final Object value2 = new Object();
+    Leaf<Key, Object> leaf1 = new Leaf<Key, Object>(key1, value1);
+    Leaf<Key, Object> leaf2 = new Leaf<Key, Object>(key2, value2);
+    class Verifier {
+      private void verify(Node<Key, Object> ret) {
+        CompressedIndex<Key, Object> collisionInternal = (CompressedIndex<Key, Object>) ret;
+        assertEquals(1 << 1, collisionInternal.bitmap);
+        assertEquals(1, collisionInternal.values.length);
+        CompressedIndex<Key, Object> collisionLeaf =
+            (CompressedIndex<Key, Object>) collisionInternal.values[0];
+        assertEquals((1 << 17) | (1 << 1), collisionLeaf.bitmap);
+        assertSame(value1, ret.get(key1, key1.hashCode(), 0));
+        assertSame(value2, ret.get(key2, key2.hashCode(), 0));
+      }
+    }
+
+    Verifier verifier = new Verifier();
+    verifier.verify(CompressedIndex.combine(leaf1, key1.hashCode(), leaf2, key2.hashCode, 0));
+    verifier.verify(CompressedIndex.combine(leaf2, key2.hashCode(), leaf1, key1.hashCode, 0));
+  }
+
+  /**
+   * A key with a settable hashcode.
+   */
+  static final class Key {
+    private final int hashCode;
+
+    Key(int hashCode) {
+      this.hashCode = hashCode;
+    }
+
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Key(hashCode=%x)", hashCode);
+    }
+  }
+}

--- a/context/src/test/java/io/grpc/PersistentHashArrayMappedTrieTest.java
+++ b/context/src/test/java/io/grpc/PersistentHashArrayMappedTrieTest.java
@@ -92,7 +92,7 @@ public class PersistentHashArrayMappedTrieTest {
     Object value2 = new Object();
     Object insertValue = new Object();
     CollisionLeaf<Key, Object> leaf =
-        new CollisionLeaf<Key, Object>(new Key[]{key1, key2}, new Object[]{value1, value2});
+        new CollisionLeaf<Key, Object>(key1, value1, key2, value2);
 
     Node<Key, Object> ret = leaf.put(insertKey, insertValue, insertKey.hashCode(), 0);
     assertTrue(ret instanceof CompressedIndex);
@@ -112,9 +112,7 @@ public class PersistentHashArrayMappedTrieTest {
     Key key = new Key(replaceKey.hashCode());
     Object value = new Object();
     CollisionLeaf<Key, Object> leaf =
-        new CollisionLeaf<Key, Object>(
-            new Key[]{replaceKey, key},
-            new Object[]{originalValue, value});
+        new CollisionLeaf<Key, Object>(replaceKey, originalValue, key, value);
     Object replaceValue = new Object();
     Node<Key, Object> ret = leaf.put(replaceKey, replaceValue, replaceKey.hashCode(), 0);
     assertTrue(ret instanceof CollisionLeaf);
@@ -134,7 +132,7 @@ public class PersistentHashArrayMappedTrieTest {
     Object value2 = new Object();
     Object value3 = new Object();
     CollisionLeaf<Key, Object> leaf =
-        new CollisionLeaf<Key, Object>(new Key[]{key1, key2}, new Object[]{value1, value2});
+        new CollisionLeaf<Key, Object>(key1, value1, key2, value2);
 
     Node<Key, Object> ret = leaf.put(key3, value3, key3.hashCode(), 0);
     assertTrue(ret instanceof CollisionLeaf);

--- a/context/src/test/java/io/grpc/PersistentHashArrayMappedTrieTest.java
+++ b/context/src/test/java/io/grpc/PersistentHashArrayMappedTrieTest.java
@@ -173,8 +173,8 @@ public class PersistentHashArrayMappedTrieTest {
 
   @Test
   public void compressedIndex_combine_sameIndexBit() {
-    final Key key1 = new Key(1 << 5 | 1); // 5 bit regions: (1, 1)
-    final Key key2 = new Key(17 << 5 | 1); // 5 bit regions: (17, 1)
+    final Key key1 = new Key(17 << 5 | 1); // 5 bit regions: (17, 1)
+    final Key key2 = new Key(31 << 5 | 1); // 5 bit regions: (31, 1)
     final Object value1 = new Object();
     final Object value2 = new Object();
     Leaf<Key, Object> leaf1 = new Leaf<Key, Object>(key1, value1);
@@ -186,7 +186,7 @@ public class PersistentHashArrayMappedTrieTest {
         assertEquals(1, collisionInternal.values.length);
         CompressedIndex<Key, Object> collisionLeaf =
             (CompressedIndex<Key, Object>) collisionInternal.values[0];
-        assertEquals((1 << 17) | (1 << 1), collisionLeaf.bitmap);
+        assertEquals((1 << 31) | (1 << 17), collisionLeaf.bitmap);
         assertSame(value1, ret.get(key1, key1.hashCode(), 0));
         assertSame(value2, ret.get(key2, key2.hashCode(), 0));
       }


### PR DESCRIPTION
This is the hashtrie data structure authored by @ejona86 

The linked list key value store is known cause problems in pathological cases where users keep updating the same key(s) over and over. This copy on write tree will have reads that cost `O(lgN)` where N is the number of keys in the map, rather than `O(M)` where M is the total number of `put` operations in the case of the linked arrays.

Also:
- added some unit tests
- ran a test putting random keys into the map and comparing the result with a java.util.HashMap to verify sanity. The test passes but I won't check it into the repo because it 
 takes a long time to run: https://gist.github.com/zpencer/12cb435235d171c1fe09aef18825fad0

Benchmarks:
linked array: https://gist.github.com/zpencer/7455cb146d39cbf5628e0608a94ad70c
hashtrie: https://gist.github.com/zpencer/4204505ccac9a32d413b3f2353a1e564