### PR TITLE
grpclb: refactor main GRPCLB logic out of GrpclbLoadBalancer.

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -165,9 +165,6 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
         default:
           // Do nohting
       }
-      // TODO(zhangkun83): if switched away from GRPCLB, clear all GRPCLB states and shutdown all
-      // Subchannels so that when switched back to GRPCLB it will have a fresh start.
-      //
       // TODO(zhangkun83): intercept the Helper to transfer Subchannels created by the delegate
       // balancers to GRPCLB if their addresses re-appear in the first response from the
       // balancer.  It returns intercepted Subchannel that let GRPCLB to control whether shutdown()

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -16,48 +16,22 @@
 
 package io.grpc.grpclb;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static io.grpc.ConnectivityState.CONNECTING;
-import static io.grpc.ConnectivityState.IDLE;
-import static io.grpc.ConnectivityState.READY;
-import static io.grpc.ConnectivityState.SHUTDOWN;
-import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.protobuf.util.Durations;
 import io.grpc.Attributes;
-import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
-import io.grpc.ManagedChannel;
-import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.grpclb.GrpclbConstants.LbPolicy;
-import io.grpc.grpclb.LoadBalanceResponse.LoadBalanceResponseTypeCase;
 import io.grpc.internal.LogId;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.WithLogId;
-import io.grpc.stub.StreamObserver;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -71,35 +45,16 @@ import javax.annotation.Nullable;
 class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
   private static final Logger logger = Logger.getLogger(GrpclbLoadBalancer.class.getName());
 
-  @VisibleForTesting
-  static final PickResult DROP_PICK_RESULT =
-      PickResult.withError(Status.UNAVAILABLE.withDescription("Dropped as requested by balancer"));
-
-  @VisibleForTesting
-  static final RoundRobinEntry BUFFER_ENTRY = new RoundRobinEntry() {
-      @Override
-      public PickResult picked(Metadata headers) {
-        return PickResult.withNoResult();
-      }
-    };
-
   private final LogId logId = LogId.allocate(getClass().getName());
 
-  private final String serviceName;
   private final Helper helper;
   private final Factory pickFirstBalancerFactory;
   private final Factory roundRobinBalancerFactory;
   private final ObjectPool<ScheduledExecutorService> timerServicePool;
   private final TimeProvider time;
 
-  private static final Attributes.Key<AtomicReference<ConnectivityStateInfo>> STATE_INFO =
-      Attributes.Key.of("io.grpc.grpclb.GrpclbLoadBalancer.stateInfo");
-
   // All mutable states in this class are mutated ONLY from Channel Executor
 
-  ///////////////////////////////////////////////////////////////////////////////
-  // General states.
-  ///////////////////////////////////////////////////////////////////////////////
   private ScheduledExecutorService timerService;
 
   // If not null, all work is delegated to it.
@@ -107,34 +62,14 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
   private LoadBalancer delegate;
   private LbPolicy lbPolicy;
 
-  ///////////////////////////////////////////////////////////////////////////////
-  // GRPCLB states, valid only if lbPolicy == GRPCLB
-  ///////////////////////////////////////////////////////////////////////////////
-
-  // null if there isn't any available LB addresses.
+  // Null if lbPolicy != GRPCLB
   @Nullable
-  private LbAddressGroup lbAddressGroup;
-  @Nullable
-  private ManagedChannel lbCommChannel;
-
-  @Nullable
-  private LbStream lbStream;
-  private Map<EquivalentAddressGroup, Subchannel> subchannels = Collections.emptyMap();
-
-  // Has the same size as the round-robin list from the balancer.
-  // A drop entry from the round-robin list becomes a DropEntry here.
-  // A backend entry from the robin-robin list becomes a null here.
-  private List<DropEntry> dropList = Collections.emptyList();
-  // Contains only non-drop, i.e., backends from the round-robin list from the balancer.
-  private List<BackendEntry> backendList = Collections.emptyList();
-  private RoundRobinPicker currentPicker =
-      new RoundRobinPicker(Collections.<DropEntry>emptyList(), Arrays.asList(BUFFER_ENTRY));
+  private GrpclbState grpclbState;
 
   GrpclbLoadBalancer(Helper helper, Factory pickFirstBalancerFactory,
       Factory roundRobinBalancerFactory, ObjectPool<ScheduledExecutorService> timerServicePool,
       TimeProvider time) {
     this.helper = checkNotNull(helper, "helper");
-    this.serviceName = checkNotNull(helper.getAuthority(), "helper returns null authority");
     this.pickFirstBalancerFactory =
         checkNotNull(pickFirstBalancerFactory, "pickFirstBalancerFactory");
     this.roundRobinBalancerFactory =
@@ -142,6 +77,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
     this.timerServicePool = checkNotNull(timerServicePool, "timerServicePool");
     this.timerService = checkNotNull(timerServicePool.getObject(), "timerService");
     this.time = checkNotNull(time, "time provider");
+    setLbPolicy(LbPolicy.GRPCLB);
   }
 
   @Override
@@ -155,14 +91,9 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
       delegate.handleSubchannelState(subchannel, newState);
       return;
     }
-    if (newState.getState() == SHUTDOWN || !(subchannels.values().contains(subchannel))) {
-      return;
+    if (grpclbState != null) {
+      grpclbState.handleSubchannelState(subchannel, newState);
     }
-    if (newState.getState() == IDLE) {
-      subchannel.requestConnection();
-    }
-    subchannel.getAttributes().get(STATE_INFO).set(newState);
-    maybeUpdatePicker();
   }
 
   @Override
@@ -194,24 +125,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
     }
 
     // Switch LB policy if requested
-    if (newLbPolicy != lbPolicy) {
-      shutdownDelegate();
-      shutdownLbComm();
-      lbAddressGroup = null;
-      switch (newLbPolicy) {
-        case PICK_FIRST:
-          delegate = checkNotNull(pickFirstBalancerFactory.newLoadBalancer(helper),
-              "pickFirstBalancerFactory.newLoadBalancer()");
-          break;
-        case ROUND_ROBIN:
-          delegate = checkNotNull(roundRobinBalancerFactory.newLoadBalancer(helper),
-              "roundRobinBalancerFactory.newLoadBalancer()");
-          break;
-        default:
-          // Do nohting
-      }
-    }
-    lbPolicy = newLbPolicy;
+    setLbPolicy(newLbPolicy);
 
     // Consume the new addresses
     switch (lbPolicy) {
@@ -222,20 +136,10 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
         break;
       case GRPCLB:
         if (newLbAddressGroups.isEmpty()) {
-          shutdownLbComm();
-          lbAddressGroup = null;
-          handleGrpclbError(Status.UNAVAILABLE.withDescription(
+          grpclbState.propagateError(Status.UNAVAILABLE.withDescription(
                   "NameResolver returned no LB address while asking for GRPCLB"));
         } else {
-          lbAddressGroup = flattenLbAddressGroups(newLbAddressGroups);
-          startLbComm();
-          // Avoid creating a new RPC just because the addresses were updated, as it can cause a
-          // stampeding herd. The current RPC may be on a connection to an address not present in
-          // newLbAddressGroups, but we're considering that "okay". If we detected the RPC is to an
-          // outdated backend, we could choose to re-create the RPC.
-          if (lbStream == null) {
-            startLbRpc();
-          }
+          grpclbState.setLbAddress(flattenLbAddressGroups(newLbAddressGroups));
         }
         break;
       default:
@@ -243,356 +147,81 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
     }
   }
 
-  private void shutdownLbComm() {
-    if (lbCommChannel != null) {
-      lbCommChannel.shutdown();
-      lbCommChannel = null;
+  private void setLbPolicy(LbPolicy newLbPolicy) {
+    if (newLbPolicy != lbPolicy) {
+      resetStates();
+      switch (newLbPolicy) {
+        case PICK_FIRST:
+          delegate = checkNotNull(pickFirstBalancerFactory.newLoadBalancer(helper),
+              "pickFirstBalancerFactory.newLoadBalancer()");
+          break;
+        case ROUND_ROBIN:
+          delegate = checkNotNull(roundRobinBalancerFactory.newLoadBalancer(helper),
+              "roundRobinBalancerFactory.newLoadBalancer()");
+          break;
+        case GRPCLB:
+          grpclbState = new GrpclbState(helper, time, timerService, logId);
+          break;
+        default:
+          // Do nohting
+      }
+      // TODO(zhangkun83): if switched away from GRPCLB, clear all GRPCLB states and shutdown all
+      // Subchannels so that when switched back to GRPCLB it will have a fresh start.
+      //
+      // TODO(zhangkun83): intercept the Helper to transfer Subchannels created by the delegate
+      // balancers to GRPCLB if their addresses re-appear in the first response from the
+      // balancer.  It returns intercepted Subchannel that let GRPCLB to control whether shutdown()
+      // is passed to the actual Subchannel.  It wraps the picker that unwrap Subchannels from
+      // the delegate, because the channel only accepts the original Subchannel.
+      //
+      // If fallback to RR happens after switching back to GRPCLB, maybe we don't want to
+      // reconnect the Subchannels for the RR delegate. We may just keep the delegate balancer
+      // unclosed to keep their Subchannels until balancer's first response arrives.
+      //  1. When fallback timer expires, feed the resolver-returned backend addresses to the RR
+      //     delegate, and use it as the current delegate.  If the RR delegate has Subchannels
+      //     from the last time it was used, they may be re-used as long as addresses match.
+      //  2. When first LB response arrives, set the current delegate to null, transfer any
+      //     re-usable Subchannels (same address) from the RR delegate, and shut down the RR
+      //     delegate.  The intercepted Helper returns interceptred Subchannels, which will not
+      //     actually shutdown the Subchannel if it's been transferred from RR delegate to GRPCLB.
     }
-    shutdownLbRpc();
+    lbPolicy = newLbPolicy;
   }
 
-  private void shutdownLbRpc() {
-    if (lbStream != null) {
-      lbStream.close(null);
-    }
-  }
-
-  private void startLbComm() {
-    if (lbCommChannel == null) {
-      lbCommChannel = helper.createOobChannel(
-          lbAddressGroup.getAddresses(), lbAddressGroup.getAuthority());
-    } else if (lbAddressGroup.getAuthority().equals(lbCommChannel.authority())) {
-      helper.updateOobChannelAddresses(lbCommChannel, lbAddressGroup.getAddresses());
-    } else {
-      // Full restart of channel
-      shutdownLbComm();
-      lbCommChannel = helper.createOobChannel(
-          lbAddressGroup.getAddresses(), lbAddressGroup.getAuthority());
-    }
-  }
-
-  private void startLbRpc() {
-    checkState(lbStream == null, "previous lbStream has not been cleared yet");
-    LoadBalancerGrpc.LoadBalancerStub stub = LoadBalancerGrpc.newStub(lbCommChannel);
-    lbStream = new LbStream(stub);
-
-    LoadBalanceRequest initRequest = LoadBalanceRequest.newBuilder()
-        .setInitialRequest(InitialLoadBalanceRequest.newBuilder()
-            .setName(serviceName).build())
-        .build();
-    try {
-      lbStream.lbRequestWriter.onNext(initRequest);
-    } catch (Exception e) {
-      lbStream.close(e);
-    }
-  }
-
-  private void shutdownDelegate() {
+  private void resetStates() {
     if (delegate != null) {
       delegate.shutdown();
       delegate = null;
+    }
+    if (grpclbState != null) {
+      grpclbState.shutdown();
+      grpclbState = null;
     }
   }
 
   @Override
   public void shutdown() {
-    shutdownDelegate();
-    shutdownLbComm();
-    for (Subchannel subchannel : subchannels.values()) {
-      subchannel.shutdown();
-    }
-    subchannels = Collections.emptyMap();
+    resetStates();
     timerService = timerServicePool.returnObject(timerService);
-  }
-
-  private void handleGrpclbError(Status status) {
-    logger.log(Level.FINE, "[{0}] Had an error: {1}; dropList={2}; backendList={3}",
-        new Object[] {logId, status, dropList, backendList});
-    if (backendList.isEmpty()) {
-      maybeUpdatePicker(
-          TRANSIENT_FAILURE, new RoundRobinPicker(dropList, Arrays.asList(new ErrorEntry(status))));
-    }
   }
 
   @Override
   public void handleNameResolutionError(Status error) {
     if (delegate != null) {
       delegate.handleNameResolutionError(error);
-    } else {
-      handleGrpclbError(error);
+    }
+    if (grpclbState != null) {
+      grpclbState.propagateError(error);
     }
   }
 
   @VisibleForTesting
   @Nullable
   GrpclbClientLoadRecorder getLoadRecorder() {
-    if (lbStream == null) {
+    if (grpclbState == null) {
       return null;
     }
-    return lbStream.loadRecorder;
-  }
-
-  private class LbStream implements StreamObserver<LoadBalanceResponse> {
-    final StreamObserver<LoadBalanceRequest> lbRequestWriter;
-    final GrpclbClientLoadRecorder loadRecorder;
-
-    final Runnable loadReportRunnable = new Runnable() {
-        @Override
-        public void run() {
-          helper.runSerialized(new Runnable() {
-              @Override
-              public void run() {
-                loadReportTask = null;
-                sendLoadReport();
-              }
-            });
-        }
-      };
-
-    // These fields are only accessed from helper.runSerialized()
-    boolean initialResponseReceived;
-    boolean closed;
-    long loadReportIntervalMillis = -1;
-    ScheduledFuture<?> loadReportTask;
-
-    LbStream(LoadBalancerGrpc.LoadBalancerStub stub) {
-      // Stats data only valid for current LbStream.  We do not carry over data from previous
-      // stream.
-      loadRecorder = new GrpclbClientLoadRecorder(time);
-      lbRequestWriter = stub.withWaitForReady().balanceLoad(this);
-    }
-
-    @Override public void onNext(final LoadBalanceResponse response) {
-      helper.runSerialized(new Runnable() {
-          @Override
-          public void run() {
-            handleResponse(response);
-          }
-        });
-    }
-
-    @Override public void onError(final Throwable error) {
-      helper.runSerialized(new Runnable() {
-          @Override
-          public void run() {
-            handleStreamClosed(Status.fromThrowable(error)
-                .augmentDescription("Stream to GRPCLB LoadBalancer had an error"));
-          }
-        });
-    }
-
-    @Override public void onCompleted() {
-      helper.runSerialized(new Runnable() {
-          @Override
-          public void run() {
-            handleStreamClosed(
-                Status.UNAVAILABLE.withDescription("Stream to GRPCLB LoadBalancer was closed"));
-          }
-        });
-    }
-
-    // Following methods must be run in helper.runSerialized()
-
-    private void sendLoadReport() {
-      if (closed) {
-        return;
-      }
-      ClientStats stats = loadRecorder.generateLoadReport();
-      // TODO(zhangkun83): flow control?
-      try {
-        lbRequestWriter.onNext(LoadBalanceRequest.newBuilder().setClientStats(stats).build());
-        scheduleNextLoadReport();
-      } catch (Exception e) {
-        close(e);
-      }
-    }
-
-    private void scheduleNextLoadReport() {
-      if (loadReportIntervalMillis > 0) {
-        loadReportTask = timerService.schedule(
-            loadReportRunnable, loadReportIntervalMillis, TimeUnit.MILLISECONDS);
-      }
-    }
-
-    private void handleResponse(LoadBalanceResponse response) {
-      if (closed) {
-        return;
-      }
-      logger.log(Level.FINE, "[{0}] Got an LB response: {1}", new Object[] {logId, response});
-
-      LoadBalanceResponseTypeCase typeCase = response.getLoadBalanceResponseTypeCase();
-      if (!initialResponseReceived) {
-        if (typeCase != LoadBalanceResponseTypeCase.INITIAL_RESPONSE) {
-          logger.log(
-              Level.WARNING,
-              "[{0}] : Did not receive response with type initial response: {1}",
-              new Object[] {logId, response});
-          return;
-        }
-        initialResponseReceived = true;
-        InitialLoadBalanceResponse initialResponse = response.getInitialResponse();
-        loadReportIntervalMillis =
-            Durations.toMillis(initialResponse.getClientStatsReportInterval());
-        scheduleNextLoadReport();
-        return;
-      }
-
-      if (typeCase != LoadBalanceResponseTypeCase.SERVER_LIST) {
-        logger.log(
-            Level.WARNING,
-            "[{0}] : Ignoring unexpected response type: {1}",
-            new Object[] {logId, response});
-        return;
-      }
-
-      // TODO(zhangkun83): handle delegate from initialResponse
-      ServerList serverList = response.getServerList();
-      HashMap<EquivalentAddressGroup, Subchannel> newSubchannelMap =
-          new HashMap<EquivalentAddressGroup, Subchannel>();
-      List<DropEntry> newDropList = new ArrayList<DropEntry>();
-      List<BackendEntry> newBackendList = new ArrayList<BackendEntry>();
-      // TODO(zhangkun83): honor expiration_interval
-      // Construct the new collections. Create new Subchannels when necessary.
-      for (Server server : serverList.getServersList()) {
-        String token = server.getLoadBalanceToken();
-        if (server.getDrop()) {
-          newDropList.add(new DropEntry(loadRecorder, token));
-        } else {
-          newDropList.add(null);
-          InetSocketAddress address;
-          try {
-            address = new InetSocketAddress(
-                InetAddress.getByAddress(server.getIpAddress().toByteArray()), server.getPort());
-          } catch (UnknownHostException e) {
-            handleGrpclbError(Status.UNAVAILABLE.withCause(e));
-            continue;
-          }
-          EquivalentAddressGroup eag = new EquivalentAddressGroup(address);
-          Subchannel subchannel = newSubchannelMap.get(eag);
-          if (subchannel == null) {
-            subchannel = subchannels.get(eag);
-            if (subchannel == null) {
-              Attributes subchannelAttrs = Attributes.newBuilder()
-                  .set(STATE_INFO,
-                      new AtomicReference<ConnectivityStateInfo>(
-                          ConnectivityStateInfo.forNonError(IDLE)))
-                  .build();
-              subchannel = helper.createSubchannel(eag, subchannelAttrs);
-              subchannel.requestConnection();
-            }
-            newSubchannelMap.put(eag, subchannel);
-          }
-          newBackendList.add(new BackendEntry(subchannel, loadRecorder, token));
-        }
-      }
-      // Close Subchannels whose addresses have been delisted
-      for (Entry<EquivalentAddressGroup, Subchannel> entry : subchannels.entrySet()) {
-        EquivalentAddressGroup eag = entry.getKey();
-        if (!newSubchannelMap.containsKey(eag)) {
-          entry.getValue().shutdown();
-        }
-      }
-
-      subchannels = Collections.unmodifiableMap(newSubchannelMap);
-      dropList = Collections.unmodifiableList(newDropList);
-      backendList = Collections.unmodifiableList(newBackendList);
-      maybeUpdatePicker();
-    }
-
-    private void handleStreamClosed(Status status) {
-      if (closed) {
-        return;
-      }
-      closed = true;
-      cleanUp();
-      handleGrpclbError(status);
-      startLbRpc();
-    }
-
-    void close(@Nullable Exception error) {
-      if (closed) {
-        return;
-      }
-      closed = true;
-      cleanUp();
-      try {
-        if (error == null) {
-          lbRequestWriter.onCompleted();
-        } else {
-          lbRequestWriter.onError(error);
-        }
-      } catch (Exception e) {
-        // Don't care
-      }
-    }
-
-    private void cleanUp() {
-      if (loadReportTask != null) {
-        loadReportTask.cancel(false);
-        loadReportTask = null;
-      }
-      if (lbStream == this) {
-        lbStream = null;
-      }
-    }
-  }
-
-  /**
-   * Make and use a picker out of the current lists and the states of subchannels if they have
-   * changed since the last picker created.
-   */
-  private void maybeUpdatePicker() {
-    List<RoundRobinEntry> pickList = new ArrayList<RoundRobinEntry>(backendList.size());
-    Status error = null;
-    boolean hasIdle = false;
-    for (BackendEntry entry : backendList) {
-      Subchannel subchannel = entry.result.getSubchannel();
-      Attributes attrs = subchannel.getAttributes();
-      ConnectivityStateInfo stateInfo = attrs.get(STATE_INFO).get();
-      if (stateInfo.getState() == READY) {
-        pickList.add(entry);
-      } else if (stateInfo.getState() == TRANSIENT_FAILURE) {
-        error = stateInfo.getStatus();
-      } else if (stateInfo.getState() == IDLE) {
-        hasIdle = true;
-      }
-    }
-    ConnectivityState state;
-    if (pickList.isEmpty()) {
-      if (error != null && !hasIdle) {
-        logger.log(Level.FINE, "[{0}] No ready Subchannel. Using error: {1}",
-            new Object[] {logId, error});
-        pickList.add(new ErrorEntry(error));
-        state = TRANSIENT_FAILURE;
-      } else {
-        logger.log(Level.FINE, "[{0}] No ready Subchannel and still connecting", logId);
-        pickList.add(BUFFER_ENTRY);
-        state = CONNECTING;
-      }
-    } else {
-      logger.log(
-          Level.FINE, "[{0}] Using drop list {1} and pick list {2}",
-          new Object[] {logId, dropList, pickList});
-      state = READY;
-    }
-    maybeUpdatePicker(state, new RoundRobinPicker(dropList, pickList));
-  }
-
-  /**
-   * Update the given picker to the helper if it's different from the current one.
-   */
-  private void maybeUpdatePicker(ConnectivityState state, RoundRobinPicker picker) {
-    // Discard the new picker if we are sure it won't make any difference, in order to save
-    // re-processing pending streams, and avoid unnecessary resetting of the pointer in
-    // RoundRobinPicker.
-    if (picker.dropList.equals(currentPicker.dropList)
-        && picker.pickList.equals(currentPicker.pickList)) {
-      return;
-    }
-    // No need to skip ErrorPicker. If the current picker is ErrorPicker, there won't be any pending
-    // stream thus no time is wasted in re-process.
-    currentPicker = picker;
-    helper.updateBalancingState(state, picker);
+    return grpclbState.getLoadRecorder();
   }
 
   @VisibleForTesting
@@ -634,167 +263,5 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
       addrs.addAll(group.getAddresses());
     }
     return new EquivalentAddressGroup(addrs);
-  }
-
-  @VisibleForTesting
-  static final class DropEntry {
-    private final GrpclbClientLoadRecorder loadRecorder;
-    private final String token;
-
-    DropEntry(GrpclbClientLoadRecorder loadRecorder, String token) {
-      this.loadRecorder = checkNotNull(loadRecorder, "loadRecorder");
-      this.token = checkNotNull(token, "token");
-    }
-
-    PickResult picked() {
-      loadRecorder.recordDroppedRequest(token);
-      return DROP_PICK_RESULT;
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("loadRecorder", loadRecorder)
-          .add("token", token)
-          .toString();
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(loadRecorder, token);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof DropEntry)) {
-        return false;
-      }
-      DropEntry that = (DropEntry) other;
-      return Objects.equal(loadRecorder, that.loadRecorder) && Objects.equal(token, that.token);
-    }
-  }
-
-  private interface RoundRobinEntry {
-    PickResult picked(Metadata headers);
-  }
-
-  @VisibleForTesting
-  static final class BackendEntry implements RoundRobinEntry {
-    @VisibleForTesting
-    final PickResult result;
-    private final GrpclbClientLoadRecorder loadRecorder;
-    private final String token;
-
-    BackendEntry(Subchannel subchannel, GrpclbClientLoadRecorder loadRecorder, String token) {
-      this.result = PickResult.withSubchannel(subchannel, loadRecorder);
-      this.loadRecorder = checkNotNull(loadRecorder, "loadRecorder");
-      this.token = checkNotNull(token, "token");
-    }
-
-    @Override
-    public PickResult picked(Metadata headers) {
-      headers.discardAll(GrpclbConstants.TOKEN_METADATA_KEY);
-      headers.put(GrpclbConstants.TOKEN_METADATA_KEY, token);
-      return result;
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("result", result)
-          .add("loadRecorder", loadRecorder)
-          .add("token", token)
-          .toString();
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(loadRecorder, result, token);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof BackendEntry)) {
-        return false;
-      }
-      BackendEntry that = (BackendEntry) other;
-      return Objects.equal(result, that.result) && Objects.equal(token, that.token)
-          && Objects.equal(loadRecorder, that.loadRecorder);
-    }
-  }
-
-  @VisibleForTesting
-  static final class ErrorEntry implements RoundRobinEntry {
-    private final PickResult result;
-
-    ErrorEntry(Status status) {
-      result = PickResult.withError(status);
-    }
-
-    @Override
-    public PickResult picked(Metadata headers) {
-      return result;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(result);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof ErrorEntry)) {
-        return false;
-      }
-      return Objects.equal(result, ((ErrorEntry) other).result);
-    }
-  }
-
-  @VisibleForTesting
-  static final class RoundRobinPicker extends SubchannelPicker {
-    @VisibleForTesting
-    final List<DropEntry> dropList;
-    private int dropIndex;
-
-    @VisibleForTesting
-    final List<? extends RoundRobinEntry> pickList;
-    private int pickIndex;
-
-    // dropList can be empty, which means no drop.
-    // pickList must not be empty.
-    RoundRobinPicker(List<DropEntry> dropList, List<? extends RoundRobinEntry> pickList) {
-      this.dropList = checkNotNull(dropList, "dropList");
-      this.pickList = checkNotNull(pickList, "pickList");
-      checkArgument(!pickList.isEmpty(), "pickList is empty");
-    }
-
-    @Override
-    public PickResult pickSubchannel(PickSubchannelArgs args) {
-      synchronized (pickList) {
-        // Two-level round-robin.
-        // First round-robin on dropList. If a drop entry is selected, request will be dropped.  If
-        // a non-drop entry is selected, then round-robin on pickList.  This makes sure requests are
-        // dropped at the same proportion as the drop entries appear on the round-robin list from
-        // the balancer, while only READY backends (that make up pickList) are selected for the
-        // non-drop cases.
-        if (!dropList.isEmpty()) {
-          DropEntry drop = dropList.get(dropIndex);
-          dropIndex++;
-          if (dropIndex == dropList.size()) {
-            dropIndex = 0;
-          }
-          if (drop != null) {
-            return drop.picked();
-          }
-        }
-
-        RoundRobinEntry pick = pickList.get(pickIndex);
-        pickIndex++;
-        if (pickIndex == pickList.size()) {
-          pickIndex = 0;
-        }
-        return pick.picked(args.getHeaders());
-      }
-    }
   }
 }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -217,11 +217,8 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
 
   @VisibleForTesting
   @Nullable
-  GrpclbClientLoadRecorder getLoadRecorder() {
-    if (grpclbState == null) {
-      return null;
-    }
-    return grpclbState.getLoadRecorder();
+  GrpclbState getGrpclbState() {
+    return grpclbState;
   }
 
   @VisibleForTesting

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -165,22 +165,6 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
         default:
           // Do nohting
       }
-      // TODO(zhangkun83): intercept the Helper to transfer Subchannels created by the delegate
-      // balancers to GRPCLB if their addresses re-appear in the first response from the
-      // balancer.  It returns intercepted Subchannel that let GRPCLB to control whether shutdown()
-      // is passed to the actual Subchannel.  It wraps the picker that unwrap Subchannels from
-      // the delegate, because the channel only accepts the original Subchannel.
-      //
-      // If fallback to RR happens after switching back to GRPCLB, maybe we don't want to
-      // reconnect the Subchannels for the RR delegate. We may just keep the delegate balancer
-      // unclosed to keep their Subchannels until balancer's first response arrives.
-      //  1. When fallback timer expires, feed the resolver-returned backend addresses to the RR
-      //     delegate, and use it as the current delegate.  If the RR delegate has Subchannels
-      //     from the last time it was used, they may be re-used as long as addresses match.
-      //  2. When first LB response arrives, set the current delegate to null, transfer any
-      //     re-usable Subchannels (same address) from the RR delegate, and shut down the RR
-      //     delegate.  The intercepted Helper returns interceptred Subchannels, which will not
-      //     actually shutdown the Subchannel if it's been transferred from RR delegate to GRPCLB.
     }
     lbPolicy = newLbPolicy;
   }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -132,6 +132,9 @@ final class GrpclbState {
     maybeUpdatePicker();
   }
 
+  /**
+   * Set the address of the balancer, and create connection if not yet connected.
+   */
   void setLbAddress(LbAddressGroup newLbAddressGroup) {
     lbAddressGroup = checkNotNull(newLbAddressGroup, "newLbAddressGroup");
     startLbComm();
@@ -155,6 +158,7 @@ final class GrpclbState {
   private void shutdownLbRpc() {
     if (lbStream != null) {
       lbStream.close(null);
+      // lbStream will be set to null in LbStream.cleanup()
     }
   }
 

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -68,6 +68,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  * GrpclbLoadBalancer switches to GRPCLB mode.  Closed and discarded when GrpclbLoadBalancer
  * switches away from GRPCLB mode.
  */
+// TODO(zhangkun83): round-robin on the backend list from the resolver if we don't get a server list
+// within a configurable timeout.
 @NotThreadSafe
 final class GrpclbState {
   private static final Logger logger = Logger.getLogger(GrpclbState.class.getName());

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -1,0 +1,641 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.grpclb;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.ConnectivityState.CONNECTING;
+import static io.grpc.ConnectivityState.IDLE;
+import static io.grpc.ConnectivityState.READY;
+import static io.grpc.ConnectivityState.SHUTDOWN;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.protobuf.util.Durations;
+import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.PickResult;
+import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.LoadBalancer.Subchannel;
+import io.grpc.LoadBalancer.SubchannelPicker;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.grpclb.LoadBalanceResponse.LoadBalanceResponseTypeCase;
+import io.grpc.internal.LogId;
+import io.grpc.stub.StreamObserver;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * The states of a GRPCLB working session of {@link GrpclbLoadBalancer}.  Created when
+ * GrpclbLoadBalancer switches to GRPCLB mode.  Closed and discarded when GrpclbLoadBalancer
+ * switches away from GRPCLB mode.
+ */
+@NotThreadSafe
+final class GrpclbState {
+  private static final Logger logger = Logger.getLogger(GrpclbState.class.getName());
+
+  @VisibleForTesting
+  static final PickResult DROP_PICK_RESULT =
+      PickResult.withError(Status.UNAVAILABLE.withDescription("Dropped as requested by balancer"));
+
+  @VisibleForTesting
+  static final RoundRobinEntry BUFFER_ENTRY = new RoundRobinEntry() {
+      @Override
+      public PickResult picked(Metadata headers) {
+        return PickResult.withNoResult();
+      }
+    };
+
+  private final LogId logId;
+  private final String serviceName;
+  private final Helper helper;
+  private final TimeProvider time;
+  private final ScheduledExecutorService timerService;
+
+  private static final Attributes.Key<AtomicReference<ConnectivityStateInfo>> STATE_INFO =
+      Attributes.Key.of("io.grpc.grpclb.GrpclbLoadBalancer.stateInfo");
+
+  @Nullable
+  private LbAddressGroup lbAddressGroup;
+
+  @Nullable
+  private ManagedChannel lbCommChannel;
+
+  @Nullable
+  private LbStream lbStream;
+  private Map<EquivalentAddressGroup, Subchannel> subchannels = Collections.emptyMap();
+
+  // Has the same size as the round-robin list from the balancer.
+  // A drop entry from the round-robin list becomes a DropEntry here.
+  // A backend entry from the robin-robin list becomes a null here.
+  private List<DropEntry> dropList = Collections.emptyList();
+  // Contains only non-drop, i.e., backends from the round-robin list from the balancer.
+  private List<BackendEntry> backendList = Collections.emptyList();
+  private RoundRobinPicker currentPicker =
+      new RoundRobinPicker(Collections.<DropEntry>emptyList(), Arrays.asList(BUFFER_ENTRY));
+
+  GrpclbState(
+      Helper helper, TimeProvider time, ScheduledExecutorService timerService, LogId logId) {
+    this.helper = checkNotNull(helper, "helper");
+    this.time = checkNotNull(time, "time provider");
+    this.timerService = checkNotNull(timerService, "timerService");
+    this.serviceName = checkNotNull(helper.getAuthority(), "helper returns null authority");
+    this.logId = checkNotNull(logId, "logId");
+  }
+
+  void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState) {
+    if (newState.getState() == SHUTDOWN || !(subchannels.values().contains(subchannel))) {
+      return;
+    }
+    if (newState.getState() == IDLE) {
+      subchannel.requestConnection();
+    }
+    subchannel.getAttributes().get(STATE_INFO).set(newState);
+    maybeUpdatePicker();
+  }
+
+  void setLbAddress(LbAddressGroup newLbAddressGroup) {
+    lbAddressGroup = checkNotNull(newLbAddressGroup, "newLbAddressGroup");
+    startLbComm();
+    // Avoid creating a new RPC just because the addresses were updated, as it can cause a
+    // stampeding herd. The current RPC may be on a connection to an address not present in
+    // newLbAddressGroups, but we're considering that "okay". If we detected the RPC is to an
+    // outdated backend, we could choose to re-create the RPC.
+    if (lbStream == null) {
+      startLbRpc();
+    }
+  }
+
+  private void shutdownLbComm() {
+    if (lbCommChannel != null) {
+      lbCommChannel.shutdown();
+      lbCommChannel = null;
+    }
+    shutdownLbRpc();
+  }
+
+  private void shutdownLbRpc() {
+    if (lbStream != null) {
+      lbStream.close(null);
+    }
+  }
+
+  private void startLbComm() {
+    if (lbCommChannel == null) {
+      lbCommChannel = helper.createOobChannel(
+          lbAddressGroup.getAddresses(), lbAddressGroup.getAuthority());
+    } else if (lbAddressGroup.getAuthority().equals(lbCommChannel.authority())) {
+      helper.updateOobChannelAddresses(lbCommChannel, lbAddressGroup.getAddresses());
+    } else {
+      // Full restart of channel
+      shutdownLbComm();
+      lbCommChannel = helper.createOobChannel(
+          lbAddressGroup.getAddresses(), lbAddressGroup.getAuthority());
+    }
+  }
+
+  private void startLbRpc() {
+    checkState(lbStream == null, "previous lbStream has not been cleared yet");
+    LoadBalancerGrpc.LoadBalancerStub stub = LoadBalancerGrpc.newStub(lbCommChannel);
+    lbStream = new LbStream(stub);
+
+    LoadBalanceRequest initRequest = LoadBalanceRequest.newBuilder()
+        .setInitialRequest(InitialLoadBalanceRequest.newBuilder()
+            .setName(serviceName).build())
+        .build();
+    try {
+      lbStream.lbRequestWriter.onNext(initRequest);
+    } catch (Exception e) {
+      lbStream.close(e);
+    }
+  }
+
+  void shutdown() {
+    shutdownLbComm();
+    for (Subchannel subchannel : subchannels.values()) {
+      subchannel.shutdown();
+    }
+    subchannels = Collections.emptyMap();
+  }
+
+  void propagateError(Status status) {
+    logger.log(Level.FINE, "[{0}] Had an error: {1}; dropList={2}; backendList={3}",
+        new Object[] {logId, status, dropList, backendList});
+    if (backendList.isEmpty()) {
+      maybeUpdatePicker(
+          TRANSIENT_FAILURE, new RoundRobinPicker(dropList, Arrays.asList(new ErrorEntry(status))));
+    }
+  }
+
+  @VisibleForTesting
+  @Nullable
+  GrpclbClientLoadRecorder getLoadRecorder() {
+    if (lbStream == null) {
+      return null;
+    }
+    return lbStream.loadRecorder;
+  }
+
+  private class LbStream implements StreamObserver<LoadBalanceResponse> {
+    final StreamObserver<LoadBalanceRequest> lbRequestWriter;
+    final GrpclbClientLoadRecorder loadRecorder;
+
+    final Runnable loadReportRunnable = new Runnable() {
+        @Override
+        public void run() {
+          helper.runSerialized(new Runnable() {
+              @Override
+              public void run() {
+                loadReportTask = null;
+                sendLoadReport();
+              }
+            });
+        }
+      };
+
+    // These fields are only accessed from helper.runSerialized()
+    boolean initialResponseReceived;
+    boolean closed;
+    long loadReportIntervalMillis = -1;
+    ScheduledFuture<?> loadReportTask;
+
+    LbStream(LoadBalancerGrpc.LoadBalancerStub stub) {
+      // Stats data only valid for current LbStream.  We do not carry over data from previous
+      // stream.
+      loadRecorder = new GrpclbClientLoadRecorder(time);
+      lbRequestWriter = stub.withWaitForReady().balanceLoad(this);
+    }
+
+    @Override public void onNext(final LoadBalanceResponse response) {
+      helper.runSerialized(new Runnable() {
+          @Override
+          public void run() {
+            handleResponse(response);
+          }
+        });
+    }
+
+    @Override public void onError(final Throwable error) {
+      helper.runSerialized(new Runnable() {
+          @Override
+          public void run() {
+            handleStreamClosed(Status.fromThrowable(error)
+                .augmentDescription("Stream to GRPCLB LoadBalancer had an error"));
+          }
+        });
+    }
+
+    @Override public void onCompleted() {
+      helper.runSerialized(new Runnable() {
+          @Override
+          public void run() {
+            handleStreamClosed(
+                Status.UNAVAILABLE.withDescription("Stream to GRPCLB LoadBalancer was closed"));
+          }
+        });
+    }
+
+    // Following methods must be run in helper.runSerialized()
+
+    private void sendLoadReport() {
+      if (closed) {
+        return;
+      }
+      ClientStats stats = loadRecorder.generateLoadReport();
+      // TODO(zhangkun83): flow control?
+      try {
+        lbRequestWriter.onNext(LoadBalanceRequest.newBuilder().setClientStats(stats).build());
+        scheduleNextLoadReport();
+      } catch (Exception e) {
+        close(e);
+      }
+    }
+
+    private void scheduleNextLoadReport() {
+      if (loadReportIntervalMillis > 0) {
+        loadReportTask = timerService.schedule(
+            loadReportRunnable, loadReportIntervalMillis, TimeUnit.MILLISECONDS);
+      }
+    }
+
+    private void handleResponse(LoadBalanceResponse response) {
+      if (closed) {
+        return;
+      }
+      logger.log(Level.FINE, "[{0}] Got an LB response: {1}", new Object[] {logId, response});
+
+      LoadBalanceResponseTypeCase typeCase = response.getLoadBalanceResponseTypeCase();
+      if (!initialResponseReceived) {
+        if (typeCase != LoadBalanceResponseTypeCase.INITIAL_RESPONSE) {
+          logger.log(
+              Level.WARNING,
+              "[{0}] : Did not receive response with type initial response: {1}",
+              new Object[] {logId, response});
+          return;
+        }
+        initialResponseReceived = true;
+        InitialLoadBalanceResponse initialResponse = response.getInitialResponse();
+        loadReportIntervalMillis =
+            Durations.toMillis(initialResponse.getClientStatsReportInterval());
+        scheduleNextLoadReport();
+        return;
+      }
+
+      if (typeCase != LoadBalanceResponseTypeCase.SERVER_LIST) {
+        logger.log(
+            Level.WARNING,
+            "[{0}] : Ignoring unexpected response type: {1}",
+            new Object[] {logId, response});
+        return;
+      }
+
+      // TODO(zhangkun83): handle delegate from initialResponse
+      ServerList serverList = response.getServerList();
+      HashMap<EquivalentAddressGroup, Subchannel> newSubchannelMap =
+          new HashMap<EquivalentAddressGroup, Subchannel>();
+      List<DropEntry> newDropList = new ArrayList<DropEntry>();
+      List<BackendEntry> newBackendList = new ArrayList<BackendEntry>();
+      // TODO(zhangkun83): honor expiration_interval
+      // Construct the new collections. Create new Subchannels when necessary.
+      for (Server server : serverList.getServersList()) {
+        String token = server.getLoadBalanceToken();
+        if (server.getDrop()) {
+          newDropList.add(new DropEntry(loadRecorder, token));
+        } else {
+          newDropList.add(null);
+          InetSocketAddress address;
+          try {
+            address = new InetSocketAddress(
+                InetAddress.getByAddress(server.getIpAddress().toByteArray()), server.getPort());
+          } catch (UnknownHostException e) {
+            propagateError(Status.UNAVAILABLE.withCause(e));
+            continue;
+          }
+          EquivalentAddressGroup eag = new EquivalentAddressGroup(address);
+          Subchannel subchannel = newSubchannelMap.get(eag);
+          if (subchannel == null) {
+            subchannel = subchannels.get(eag);
+            if (subchannel == null) {
+              Attributes subchannelAttrs = Attributes.newBuilder()
+                  .set(STATE_INFO,
+                      new AtomicReference<ConnectivityStateInfo>(
+                          ConnectivityStateInfo.forNonError(IDLE)))
+                  .build();
+              subchannel = helper.createSubchannel(eag, subchannelAttrs);
+              subchannel.requestConnection();
+            }
+            newSubchannelMap.put(eag, subchannel);
+          }
+          newBackendList.add(new BackendEntry(subchannel, loadRecorder, token));
+        }
+      }
+      // Close Subchannels whose addresses have been delisted
+      for (Entry<EquivalentAddressGroup, Subchannel> entry : subchannels.entrySet()) {
+        EquivalentAddressGroup eag = entry.getKey();
+        if (!newSubchannelMap.containsKey(eag)) {
+          entry.getValue().shutdown();
+        }
+      }
+
+      subchannels = Collections.unmodifiableMap(newSubchannelMap);
+      dropList = Collections.unmodifiableList(newDropList);
+      backendList = Collections.unmodifiableList(newBackendList);
+      maybeUpdatePicker();
+    }
+
+    private void handleStreamClosed(Status status) {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      cleanUp();
+      propagateError(status);
+      startLbRpc();
+    }
+
+    void close(@Nullable Exception error) {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      cleanUp();
+      try {
+        if (error == null) {
+          lbRequestWriter.onCompleted();
+        } else {
+          lbRequestWriter.onError(error);
+        }
+      } catch (Exception e) {
+        // Don't care
+      }
+    }
+
+    private void cleanUp() {
+      if (loadReportTask != null) {
+        loadReportTask.cancel(false);
+        loadReportTask = null;
+      }
+      if (lbStream == this) {
+        lbStream = null;
+      }
+    }
+  }
+
+  /**
+   * Make and use a picker out of the current lists and the states of subchannels if they have
+   * changed since the last picker created.
+   */
+  private void maybeUpdatePicker() {
+    List<RoundRobinEntry> pickList = new ArrayList<RoundRobinEntry>(backendList.size());
+    Status error = null;
+    boolean hasIdle = false;
+    for (BackendEntry entry : backendList) {
+      Subchannel subchannel = entry.result.getSubchannel();
+      Attributes attrs = subchannel.getAttributes();
+      ConnectivityStateInfo stateInfo = attrs.get(STATE_INFO).get();
+      if (stateInfo.getState() == READY) {
+        pickList.add(entry);
+      } else if (stateInfo.getState() == TRANSIENT_FAILURE) {
+        error = stateInfo.getStatus();
+      } else if (stateInfo.getState() == IDLE) {
+        hasIdle = true;
+      }
+    }
+    ConnectivityState state;
+    if (pickList.isEmpty()) {
+      if (error != null && !hasIdle) {
+        logger.log(Level.FINE, "[{0}] No ready Subchannel. Using error: {1}",
+            new Object[] {logId, error});
+        pickList.add(new ErrorEntry(error));
+        state = TRANSIENT_FAILURE;
+      } else {
+        logger.log(Level.FINE, "[{0}] No ready Subchannel and still connecting", logId);
+        pickList.add(BUFFER_ENTRY);
+        state = CONNECTING;
+      }
+    } else {
+      logger.log(
+          Level.FINE, "[{0}] Using drop list {1} and pick list {2}",
+          new Object[] {logId, dropList, pickList});
+      state = READY;
+    }
+    maybeUpdatePicker(state, new RoundRobinPicker(dropList, pickList));
+  }
+
+  /**
+   * Update the given picker to the helper if it's different from the current one.
+   */
+  private void maybeUpdatePicker(ConnectivityState state, RoundRobinPicker picker) {
+    // Discard the new picker if we are sure it won't make any difference, in order to save
+    // re-processing pending streams, and avoid unnecessary resetting of the pointer in
+    // RoundRobinPicker.
+    if (picker.dropList.equals(currentPicker.dropList)
+        && picker.pickList.equals(currentPicker.pickList)) {
+      return;
+    }
+    // No need to skip ErrorPicker. If the current picker is ErrorPicker, there won't be any pending
+    // stream thus no time is wasted in re-process.
+    currentPicker = picker;
+    helper.updateBalancingState(state, picker);
+  }
+
+  @VisibleForTesting
+  static final class DropEntry {
+    private final GrpclbClientLoadRecorder loadRecorder;
+    private final String token;
+
+    DropEntry(GrpclbClientLoadRecorder loadRecorder, String token) {
+      this.loadRecorder = checkNotNull(loadRecorder, "loadRecorder");
+      this.token = checkNotNull(token, "token");
+    }
+
+    PickResult picked() {
+      loadRecorder.recordDroppedRequest(token);
+      return DROP_PICK_RESULT;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("loadRecorder", loadRecorder)
+          .add("token", token)
+          .toString();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(loadRecorder, token);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof DropEntry)) {
+        return false;
+      }
+      DropEntry that = (DropEntry) other;
+      return Objects.equal(loadRecorder, that.loadRecorder) && Objects.equal(token, that.token);
+    }
+  }
+
+  private interface RoundRobinEntry {
+    PickResult picked(Metadata headers);
+  }
+
+  @VisibleForTesting
+  static final class BackendEntry implements RoundRobinEntry {
+    @VisibleForTesting
+    final PickResult result;
+    private final GrpclbClientLoadRecorder loadRecorder;
+    private final String token;
+
+    BackendEntry(Subchannel subchannel, GrpclbClientLoadRecorder loadRecorder, String token) {
+      this.result = PickResult.withSubchannel(subchannel, loadRecorder);
+      this.loadRecorder = checkNotNull(loadRecorder, "loadRecorder");
+      this.token = checkNotNull(token, "token");
+    }
+
+    @Override
+    public PickResult picked(Metadata headers) {
+      headers.discardAll(GrpclbConstants.TOKEN_METADATA_KEY);
+      headers.put(GrpclbConstants.TOKEN_METADATA_KEY, token);
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("result", result)
+          .add("loadRecorder", loadRecorder)
+          .add("token", token)
+          .toString();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(loadRecorder, result, token);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof BackendEntry)) {
+        return false;
+      }
+      BackendEntry that = (BackendEntry) other;
+      return Objects.equal(result, that.result) && Objects.equal(token, that.token)
+          && Objects.equal(loadRecorder, that.loadRecorder);
+    }
+  }
+
+  @VisibleForTesting
+  static final class ErrorEntry implements RoundRobinEntry {
+    private final PickResult result;
+
+    ErrorEntry(Status status) {
+      result = PickResult.withError(status);
+    }
+
+    @Override
+    public PickResult picked(Metadata headers) {
+      return result;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(result);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof ErrorEntry)) {
+        return false;
+      }
+      return Objects.equal(result, ((ErrorEntry) other).result);
+    }
+  }
+
+  @VisibleForTesting
+  static final class RoundRobinPicker extends SubchannelPicker {
+    @VisibleForTesting
+    final List<DropEntry> dropList;
+    private int dropIndex;
+
+    @VisibleForTesting
+    final List<? extends RoundRobinEntry> pickList;
+    private int pickIndex;
+
+    // dropList can be empty, which means no drop.
+    // pickList must not be empty.
+    RoundRobinPicker(List<DropEntry> dropList, List<? extends RoundRobinEntry> pickList) {
+      this.dropList = checkNotNull(dropList, "dropList");
+      this.pickList = checkNotNull(pickList, "pickList");
+      checkArgument(!pickList.isEmpty(), "pickList is empty");
+    }
+
+    @Override
+    public PickResult pickSubchannel(PickSubchannelArgs args) {
+      synchronized (pickList) {
+        // Two-level round-robin.
+        // First round-robin on dropList. If a drop entry is selected, request will be dropped.  If
+        // a non-drop entry is selected, then round-robin on pickList.  This makes sure requests are
+        // dropped at the same proportion as the drop entries appear on the round-robin list from
+        // the balancer, while only READY backends (that make up pickList) are selected for the
+        // non-drop cases.
+        if (!dropList.isEmpty()) {
+          DropEntry drop = dropList.get(dropIndex);
+          dropIndex++;
+          if (dropIndex == dropList.size()) {
+            dropIndex = 0;
+          }
+          if (drop != null) {
+            return drop.picked();
+          }
+        }
+
+        RoundRobinEntry pick = pickList.get(pickIndex);
+        pickIndex++;
+        if (pickIndex == pickList.size()) {
+          pickIndex = 0;
+        }
+        return pick.picked(args.getHeaders());
+      }
+    }
+  }
+}

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -96,9 +96,6 @@ final class GrpclbState {
       Attributes.Key.of("io.grpc.grpclb.GrpclbLoadBalancer.stateInfo");
 
   @Nullable
-  private LbAddressGroup lbAddressGroup;
-
-  @Nullable
   private ManagedChannel lbCommChannel;
 
   @Nullable
@@ -138,8 +135,7 @@ final class GrpclbState {
    * Set the address of the balancer, and create connection if not yet connected.
    */
   void setLbAddress(LbAddressGroup newLbAddressGroup) {
-    lbAddressGroup = checkNotNull(newLbAddressGroup, "newLbAddressGroup");
-    startLbComm();
+    startLbComm(newLbAddressGroup);
     // Avoid creating a new RPC just because the addresses were updated, as it can cause a
     // stampeding herd. The current RPC may be on a connection to an address not present in
     // newLbAddressGroups, but we're considering that "okay". If we detected the RPC is to an
@@ -164,7 +160,8 @@ final class GrpclbState {
     }
   }
 
-  private void startLbComm() {
+  private void startLbComm(LbAddressGroup lbAddressGroup) {
+    checkNotNull(lbAddressGroup, "lbAddressGroup");
     if (lbCommChannel == null) {
       lbCommChannel = helper.createOobChannel(
           lbAddressGroup.getAddresses(), lbAddressGroup.getAuthority());

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -384,12 +384,12 @@ public class GrpclbLoadBalancerTest {
     RoundRobinPicker picker = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker.dropList).containsExactly(
         null,
-        new DropEntry(balancer.getLoadRecorder(), "token0001"),
+        new DropEntry(getLoadRecorder(), "token0001"),
         null,
-        new DropEntry(balancer.getLoadRecorder(), "token0003")).inOrder();
+        new DropEntry(getLoadRecorder(), "token0003")).inOrder();
     assertThat(picker.pickList).containsExactly(
-        new BackendEntry(subchannel1, balancer.getLoadRecorder(), "token0001"),
-        new BackendEntry(subchannel2, balancer.getLoadRecorder(), "token0002")).inOrder();
+        new BackendEntry(subchannel1, getLoadRecorder(), "token0001"),
+        new BackendEntry(subchannel2, getLoadRecorder(), "token0002")).inOrder();
 
     // Report, no data
     assertNextReport(
@@ -398,7 +398,7 @@ public class GrpclbLoadBalancerTest {
 
     PickResult pick1 = picker.pickSubchannel(args);
     assertSame(subchannel1, pick1.getSubchannel());
-    assertSame(balancer.getLoadRecorder(), pick1.getStreamTracerFactory());
+    assertSame(getLoadRecorder(), pick1.getStreamTracerFactory());
 
     // Merely the pick will not be recorded as upstart.
     assertNextReport(
@@ -427,7 +427,7 @@ public class GrpclbLoadBalancerTest {
 
     PickResult pick3 = picker.pickSubchannel(args);
     assertSame(subchannel2, pick3.getSubchannel());
-    assertSame(balancer.getLoadRecorder(), pick3.getStreamTracerFactory());
+    assertSame(getLoadRecorder(), pick3.getStreamTracerFactory());
     ClientStreamTracer tracer3 =
         pick3.getStreamTracerFactory().newClientStreamTracer(CallOptions.DEFAULT, new Metadata());
 
@@ -464,7 +464,7 @@ public class GrpclbLoadBalancerTest {
 
     PickResult pick5 = picker.pickSubchannel(args);
     assertSame(subchannel1, pick1.getSubchannel());
-    assertSame(balancer.getLoadRecorder(), pick5.getStreamTracerFactory());
+    assertSame(getLoadRecorder(), pick5.getStreamTracerFactory());
     ClientStreamTracer tracer5 =
         pick5.getStreamTracerFactory().newClientStreamTracer(CallOptions.DEFAULT, new Metadata());
 
@@ -540,7 +540,7 @@ public class GrpclbLoadBalancerTest {
 
     PickResult pick1p = picker.pickSubchannel(args);
     assertSame(subchannel1, pick1p.getSubchannel());
-    assertSame(balancer.getLoadRecorder(), pick1p.getStreamTracerFactory());
+    assertSame(getLoadRecorder(), pick1p.getStreamTracerFactory());
     pick1p.getStreamTracerFactory().newClientStreamTracer(CallOptions.DEFAULT, new Metadata());
 
     // The pick from the new stream will be included in the report
@@ -879,6 +879,60 @@ public class GrpclbLoadBalancerTest {
   }
 
   @Test
+  public void resetGrpclbWhenSwitchingAwayFromGrpclb() {
+    InOrder inOrder = inOrder(helper);
+    List<EquivalentAddressGroup> grpclbResolutionList = createResolvedServerAddresses(true);
+    Attributes grpclbResolutionAttrs = Attributes.newBuilder()
+        .set(GrpclbConstants.ATTR_LB_POLICY, LbPolicy.GRPCLB).build();
+    deliverResolvedAddresses(grpclbResolutionList, grpclbResolutionAttrs);
+
+    assertSame(LbPolicy.GRPCLB, balancer.getLbPolicy());
+    assertNull(balancer.getDelegate());
+    verify(helper).createOobChannel(addrsEq(grpclbResolutionList.get(0)), eq(lbAuthority(0)));
+    assertEquals(1, fakeOobChannels.size());
+    ManagedChannel oobChannel = fakeOobChannels.poll();
+    verify(mockLbService).balanceLoad(lbResponseObserverCaptor.capture());
+    StreamObserver<LoadBalanceResponse> lbResponseObserver = lbResponseObserverCaptor.getValue();
+    assertEquals(1, lbRequestObservers.size());
+    StreamObserver<LoadBalanceRequest> lbRequestObserver = lbRequestObservers.poll();
+    verify(lbRequestObserver).onNext(
+        eq(LoadBalanceRequest.newBuilder().setInitialRequest(
+                InitialLoadBalanceRequest.newBuilder().setName(SERVICE_AUTHORITY).build())
+            .build()));
+
+    // Simulate receiving LB response
+    List<ServerEntry> backends = Arrays.asList(new ServerEntry("127.0.0.1", 2000, "token0001"));
+    inOrder.verify(helper, never())
+        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
+    lbResponseObserver.onNext(buildInitialResponse());
+    lbResponseObserver.onNext(buildLbResponse(backends));
+
+    inOrder.verify(helper).createSubchannel(
+        eq(new EquivalentAddressGroup(backends.get(0).addr)), any(Attributes.class));
+    assertEquals(1, mockSubchannels.size());
+    Subchannel subchannel = mockSubchannels.poll();
+    verify(subchannel).requestConnection();
+
+    // Switch to round-robin. GRPCLB streams and connections should be closed. 
+    List<EquivalentAddressGroup> roundRobinResolutionList =
+        createResolvedServerAddresses(false, false, false);
+    Attributes roundRobinResolutionAttrs = Attributes.newBuilder()
+        .set(GrpclbConstants.ATTR_LB_POLICY, LbPolicy.ROUND_ROBIN).build();
+    verify(lbRequestObserver, never()).onCompleted();
+    verify(subchannel, never()).shutdown();
+    assertFalse(oobChannel.isShutdown());
+    deliverResolvedAddresses(roundRobinResolutionList, roundRobinResolutionAttrs);
+
+    verify(lbRequestObserver).onCompleted();
+    verify(subchannel).shutdown();
+    assertTrue(oobChannel.isShutdown());
+    assertTrue(oobChannel.isTerminated());
+    assertSame(LbPolicy.ROUND_ROBIN, balancer.getLbPolicy());
+    assertSame(roundRobinBalancer, balancer.getDelegate());
+    assertNull(balancer.getGrpclbState());
+  }
+
+  @Test
   public void grpclbUpdatedAddresses_avoidsReconnect() {
     List<EquivalentAddressGroup> grpclbResolutionList =
         createResolvedServerAddresses(true, false);
@@ -983,15 +1037,15 @@ public class GrpclbLoadBalancerTest {
 
     assertThat(picker1.dropList).containsExactly(null, null);
     assertThat(picker1.pickList).containsExactly(
-        new BackendEntry(subchannel2, balancer.getLoadRecorder(), "token0002"));
+        new BackendEntry(subchannel2, getLoadRecorder(), "token0002"));
 
     deliverSubchannelState(subchannel1, ConnectivityStateInfo.forNonError(READY));
     inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
     RoundRobinPicker picker2 = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker2.dropList).containsExactly(null, null);
     assertThat(picker2.pickList).containsExactly(
-        new BackendEntry(subchannel1, balancer.getLoadRecorder(), "token0001"),
-        new BackendEntry(subchannel2, balancer.getLoadRecorder(), "token0002"))
+        new BackendEntry(subchannel1, getLoadRecorder(), "token0001"),
+        new BackendEntry(subchannel2, getLoadRecorder(), "token0002"))
         .inOrder();
 
     // Disconnected subchannels
@@ -1002,7 +1056,7 @@ public class GrpclbLoadBalancerTest {
     RoundRobinPicker picker3 = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker3.dropList).containsExactly(null, null);
     assertThat(picker3.pickList).containsExactly(
-        new BackendEntry(subchannel2, balancer.getLoadRecorder(), "token0002"));
+        new BackendEntry(subchannel2, getLoadRecorder(), "token0002"));
 
     deliverSubchannelState(subchannel1, ConnectivityStateInfo.forNonError(CONNECTING));
     inOrder.verifyNoMoreInteractions();
@@ -1047,10 +1101,10 @@ public class GrpclbLoadBalancerTest {
     RoundRobinPicker picker7 = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker7.dropList).containsExactly(
         null,
-        new DropEntry(balancer.getLoadRecorder(), "token0003"),
+        new DropEntry(getLoadRecorder(), "token0003"),
         null,
         null,
-        new DropEntry(balancer.getLoadRecorder(), "token0006")).inOrder();
+        new DropEntry(getLoadRecorder(), "token0006")).inOrder();
     assertThat(picker7.pickList).containsExactly(BUFFER_ENTRY);
 
     // State updates on obsolete subchannel1 will have no effect
@@ -1065,28 +1119,28 @@ public class GrpclbLoadBalancerTest {
     RoundRobinPicker picker8 = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker8.dropList).containsExactly(
         null,
-        new DropEntry(balancer.getLoadRecorder(), "token0003"),
+        new DropEntry(getLoadRecorder(), "token0003"),
         null,
         null,
-        new DropEntry(balancer.getLoadRecorder(), "token0006")).inOrder();
+        new DropEntry(getLoadRecorder(), "token0006")).inOrder();
     // subchannel2 is still IDLE, thus not in the active list
     assertThat(picker8.pickList).containsExactly(
-        new BackendEntry(subchannel3, balancer.getLoadRecorder(), "token0003"),
-        new BackendEntry(subchannel3, balancer.getLoadRecorder(), "token0005")).inOrder();
+        new BackendEntry(subchannel3, getLoadRecorder(), "token0003"),
+        new BackendEntry(subchannel3, getLoadRecorder(), "token0005")).inOrder();
     // subchannel2 becomes READY and makes it into the list
     deliverSubchannelState(subchannel2, ConnectivityStateInfo.forNonError(READY));
     inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
     RoundRobinPicker picker9 = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker9.dropList).containsExactly(
         null,
-        new DropEntry(balancer.getLoadRecorder(), "token0003"),
+        new DropEntry(getLoadRecorder(), "token0003"),
         null,
         null,
-        new DropEntry(balancer.getLoadRecorder(), "token0006")).inOrder();
+        new DropEntry(getLoadRecorder(), "token0006")).inOrder();
     assertThat(picker9.pickList).containsExactly(
-        new BackendEntry(subchannel3, balancer.getLoadRecorder(), "token0003"),
-        new BackendEntry(subchannel2, balancer.getLoadRecorder(), "token0004"),
-        new BackendEntry(subchannel3, balancer.getLoadRecorder(), "token0005")).inOrder();
+        new BackendEntry(subchannel3, getLoadRecorder(), "token0003"),
+        new BackendEntry(subchannel2, getLoadRecorder(), "token0004"),
+        new BackendEntry(subchannel3, getLoadRecorder(), "token0005")).inOrder();
     verify(subchannel3, never()).shutdown();
 
     // Update backends, with no entry
@@ -1162,6 +1216,10 @@ public class GrpclbLoadBalancerTest {
           balancer.handleResolvedAddressGroups(addrs, attrs);
         }
       });
+  }
+
+  private GrpclbClientLoadRecorder getLoadRecorder() {
+    return balancer.getGrpclbState().getLoadRecorder();
   }
 
   private static List<EquivalentAddressGroup> createResolvedServerAddresses(boolean ... isLb) {

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -22,8 +22,8 @@ import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.SHUTDOWN;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
-import static io.grpc.grpclb.GrpclbLoadBalancer.BUFFER_ENTRY;
-import static io.grpc.grpclb.GrpclbLoadBalancer.DROP_PICK_RESULT;
+import static io.grpc.grpclb.GrpclbState.BUFFER_ENTRY;
+import static io.grpc.grpclb.GrpclbState.DROP_PICK_RESULT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -63,10 +63,10 @@ import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.grpclb.GrpclbConstants.LbPolicy;
-import io.grpc.grpclb.GrpclbLoadBalancer.BackendEntry;
-import io.grpc.grpclb.GrpclbLoadBalancer.DropEntry;
-import io.grpc.grpclb.GrpclbLoadBalancer.ErrorEntry;
-import io.grpc.grpclb.GrpclbLoadBalancer.RoundRobinPicker;
+import io.grpc.grpclb.GrpclbState.BackendEntry;
+import io.grpc.grpclb.GrpclbState.DropEntry;
+import io.grpc.grpclb.GrpclbState.ErrorEntry;
+import io.grpc.grpclb.GrpclbState.RoundRobinPicker;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.FakeClock;
@@ -410,7 +410,7 @@ public class GrpclbLoadBalancerTest {
 
     PickResult pick2 = picker.pickSubchannel(args);
     assertNull(pick2.getSubchannel());
-    assertSame(GrpclbLoadBalancer.DROP_PICK_RESULT, pick2);
+    assertSame(DROP_PICK_RESULT, pick2);
 
     // Report includes upstart of pick1 and the drop of pick2
     assertNextReport(
@@ -443,7 +443,7 @@ public class GrpclbLoadBalancerTest {
 
     PickResult pick4 = picker.pickSubchannel(args);
     assertNull(pick4.getSubchannel());
-    assertSame(GrpclbLoadBalancer.DROP_PICK_RESULT, pick4);
+    assertSame(DROP_PICK_RESULT, pick4);
 
     // pick1 ended without sending anything
     tracer1.streamClosed(Status.CANCELLED);
@@ -522,7 +522,7 @@ public class GrpclbLoadBalancerTest {
     // that picker is associated with the previous stream.
     PickResult pick6 = picker.pickSubchannel(args);
     assertNull(pick6.getSubchannel());
-    assertSame(GrpclbLoadBalancer.DROP_PICK_RESULT, pick6);
+    assertSame(DROP_PICK_RESULT, pick6);
     assertNextReport(
         inOrder, lbRequestObserver, loadReportIntervalMillis,
         ClientStats.newBuilder().build());


### PR DESCRIPTION
GrpclbLoadBalancer can work in non-GRPCLB (delegate) mode according to
name resolution results.  Previously the policy selection, delegation
and GRPCLB logic are in the same file, which is not very readable.  It
will get worse as we going to implement policy fallback logic soon.
This PR refactors the GRPCLB logic out, and makes GrpclbLoadBalancer
focus on the policy selection and delegation logic.

__Notes for reviewers__: github doesn't recognize the copy of major chunks of code from `GrpclbLoadBalancer.java` to `GrpclbState.java`. You may want to fetch my branch
and view the diff with `-C`, e.g.:
```bash
$ git remote add zhangkun83 git@github.com:zhangkun83/grpc-java.git
$ git fetch zhangkun83 grpclb_fallback
$ git difftool --tool=meld -C 8634632019ee7ea35e44c6c8749343ec99ecc858 zhangkun83/grpclb_fallback
```