### PR TITLE
context: remove unused fields

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -840,8 +840,6 @@ public class Context {
    * Key for indexing values stored in a context.
    */
   public static final class Key<T> {
-    private static final AtomicInteger keyCounter = new AtomicInteger();
-    private final long bloomFilterMask;
     private final String name;
     private final T defaultValue;
 
@@ -852,7 +850,6 @@ public class Context {
     Key(String name, T defaultValue) {
       this.name = checkNotNull(name, "name");
       this.defaultValue = defaultValue;
-      this.bloomFilterMask = 1 << (keyCounter.getAndIncrement() & 63);
     }
 
     /**

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;


### PR DESCRIPTION
These are unused fields that slipped past the previous diff.