### PR TITLE
netty: fix transport spuriously in notInUse state

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -185,13 +185,6 @@ class NettyClientHandler extends AbstractNettyHandler {
       }
 
       @Override
-      public void onStreamRemoved(Http2Stream stream) {
-        if (connection().numActiveStreams() == 0) {
-          NettyClientHandler.this.lifecycleManager.notifyInUse(false);
-        }
-      }
-
-      @Override
       public void onStreamActive(Http2Stream stream) {
         if (connection().numActiveStreams() != 1) {
           return;
@@ -206,8 +199,13 @@ class NettyClientHandler extends AbstractNettyHandler {
 
       @Override
       public void onStreamClosed(Http2Stream stream) {
-        if (NettyClientHandler.this.keepAliveManager != null
-            && connection().numActiveStreams() == 0) {
+        if (connection().numActiveStreams() != 0) {
+          return;
+        }
+
+        NettyClientHandler.this.lifecycleManager.notifyInUse(false);
+
+        if (NettyClientHandler.this.keepAliveManager != null) {
           NettyClientHandler.this.keepAliveManager.onTransportIdle();
         }
       }

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -185,11 +185,6 @@ class NettyClientHandler extends AbstractNettyHandler {
       }
 
       @Override
-      public void onStreamAdded(Http2Stream stream) {
-        NettyClientHandler.this.lifecycleManager.notifyInUse(true);
-      }
-
-      @Override
       public void onStreamRemoved(Http2Stream stream) {
         if (connection().numActiveStreams() == 0) {
           NettyClientHandler.this.lifecycleManager.notifyInUse(false);
@@ -198,8 +193,13 @@ class NettyClientHandler extends AbstractNettyHandler {
 
       @Override
       public void onStreamActive(Http2Stream stream) {
-        if (NettyClientHandler.this.keepAliveManager != null
-            && connection().numActiveStreams() == 1) {
+        if (connection().numActiveStreams() != 1) {
+          return;
+        }
+
+        NettyClientHandler.this.lifecycleManager.notifyInUse(true);
+
+        if (NettyClientHandler.this.keepAliveManager != null) {
           NettyClientHandler.this.keepAliveManager.onTransportActive();
         }
       }


### PR DESCRIPTION
Previously, if two streams are added (but not active yet), then the transport is changed into inUse; after that, if one of them gets active and then closed and removed, then the transport will be changed into and staying at notInUse, although the other stream could later be active.