### PR TITLE
Fix gson / opencensus bazel naming mixup

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -43,7 +43,7 @@ java_library(
         "@com_google_errorprone_error_prone_annotations//jar",
         "@com_google_guava_guava//jar",
         "@com_google_instrumentation_instrumentation_api//jar",
-        "@com_google_code_gson_gson//jar",
+        "@io_opencensus_opencensus_api//jar",
     ],
 )
 

--- a/netty/BUILD.bazel
+++ b/netty/BUILD.bazel
@@ -23,6 +23,6 @@ java_library(
         "@io_netty_netty_handler//jar",
         "@io_netty_netty_handler_proxy//jar",
         "@io_netty_netty_resolver//jar",
-        "@io_netty_netty_netty_transport//jar",
+        "@io_netty_netty_transport//jar",
     ],
 )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -187,7 +187,7 @@ def io_netty_common():
 
 def io_netty_transport():
   native.maven_jar(
-      name = "io_netty_netty_netty_transport",
+      name = "io_netty_netty_transport",
       artifact = "io.netty:netty-transport:4.1.14.Final",
       sha1 = "3ed6474f1289635fc0696ec37380e20f258950a2",
   )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -77,7 +77,7 @@ def grpc_java_repositories(
   )
   native.bind(
     name = "gson",
-    actual = "@com_google_code_gson//jar",
+    actual = "@com_google_code_gson_gson//jar",
   )
 
 def com_google_api_grpc_google_common_protos():
@@ -96,7 +96,7 @@ def com_google_code_findbugs_jsr305():
 
 def com_google_code_gson():
   native.maven_jar(
-      name = "com_google_code_gson",
+      name = "com_google_code_gson_gson",
       artifact = "com.google.code.gson:gson:jar:2.7",
       sha1 = "751f548c85fa49f330cecbb1875893f971b33c4e",
   )
@@ -243,7 +243,7 @@ def io_netty_tcnative_boringssl_static():
 
 def io_opencensus_api():
   native.maven_jar(
-      name = "com_google_code_gson_gson",
+      name = "io_opencensus_opencensus_api",
       artifact = "io.opencensus:opencensus-api:0.5.1",
       sha1 = "cbd0a716a7d85ac34b83d86b13f0a6655e45c2ba",
   )


### PR DESCRIPTION
In 72b9ee2 (see also #3328, #3338), gson kept its old name while opencensus got what should have
become gson's new name instead of a fixed opencensus name.

I think this resolves that.