### PR TITLE
all: Keep artifacts dependencyConvergence-clean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,11 +219,20 @@ subprojects {
     // Define a separate configuration for managing the dependency on Jetty ALPN agent.
     configurations {
         alpnagent
+
+        compile {
+            // Detect Maven Enforcer's dependencyConvergence failures. We only
+            // care for artifacts used as libraries by others.
+            if (!(project.name in ["grpc-benchmarks"])) {
+                //resolutionStrategy.failOnVersionConflict()
+            }
+        }
     }
 
     dependencies {
         testCompile libraries.junit,
-                    libraries.mockito
+                    libraries.mockito,
+                    libraries.truth
 
         // Configuration for modules that use Jetty ALPN agent
         alpnagent libraries.jetty_alpn_agent

--- a/build.gradle
+++ b/build.gradle
@@ -223,7 +223,7 @@ subprojects {
         compile {
             // Detect Maven Enforcer's dependencyConvergence failures. We only
             // care for artifacts used as libraries by others.
-            if (!(project.name in ["grpc-benchmarks"])) {
+            if (!(project.name in ['grpc-benchmarks', 'grpc-interop-testing'])) {
                 resolutionStrategy.failOnVersionConflict()
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ subprojects {
             // Detect Maven Enforcer's dependencyConvergence failures. We only
             // care for artifacts used as libraries by others.
             if (!(project.name in ["grpc-benchmarks"])) {
-                //resolutionStrategy.failOnVersionConflict()
+                resolutionStrategy.failOnVersionConflict()
             }
         }
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,10 +8,14 @@ dependencies {
     compile (libraries.instrumentation_api) {
         // prefer 2.0.19 from libraries instead of 2.0.11
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // we'll always be more up-to-date
+        exclude group: 'io.grpc', module: 'grpc-context'
     }
     compile (libraries.opencensus_api) {
         // prefer 2.0.19 from libraries instead of 2.0.11
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // we'll always be more up-to-date
+        exclude group: 'io.grpc', module: 'grpc-context'
     }
 
     testCompile project(':grpc-testing')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,9 +4,15 @@ dependencies {
     compile project(':grpc-context'),
             libraries.guava,
             libraries.errorprone,
-            libraries.jsr305,
-            libraries.instrumentation_api,
-            libraries.opencensus_api
+            libraries.jsr305
+    compile (libraries.instrumentation_api) {
+        // prefer 2.0.19 from libraries instead of 2.0.11
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
+    compile (libraries.opencensus_api) {
+        // prefer 2.0.19 from libraries instead of 2.0.11
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
 
     testCompile project(':grpc-testing')
 

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -24,7 +24,8 @@ dependencies {
             libraries.junit,
             libraries.mockito,
             libraries.netty_tcnative,
-            libraries.oauth_client
+            libraries.oauth_client,
+            libraries.truth
 }
 
 configureProtoCompilation()

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -19,6 +19,8 @@ dependencies {
         // 'com.google.api:api-common' transitively depends on auto-value, which breaks our
         // annotations.
         exclude group: 'com.google.api', module: 'api-common'
+        // Prefer our more up-to-date protobuf over 3.2.0
+        exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
 
     compile (project(':grpc-protobuf-lite')) {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -3,9 +3,18 @@ description = "gRPC: Testing"
 dependencies {
     compile project(':grpc-core'),
             project(':grpc-stub'),
-            libraries.junit,
-            libraries.mockito,
-            libraries.truth
+            libraries.junit
+    compile (libraries.mockito) {
+        // prefer 1.3 from JUnit instead of 1.1
+        exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
+    // Use compileOnly to avoid dependencyConvergence problem with the Guava
+    // pulled in via Truth, for users that don't use Truth. Truth requires a
+    // more up-to-date Guava than we support elsewhere, which would trigger
+    // convergence failures in tests that only our users could resolve. Using
+    // compileOnly means only users using Truth would have the problem and
+    // they'd have to resolve it like normal anyway.
+    compileOnly libraries.truth
 
     testCompile project(':grpc-testing-proto')
 }


### PR DESCRIPTION
Maven Enforcer's dependencyConvergence is commonly used in Spring
projects, as it is inherited by all starter projects[1]. While I find
that option to be crazy and harmful (and would instead support
requireUpperBoundDeps), it does bother people.

1. https://github.com/spring-projects/spring-boot/blob/v1.5.6.RELEASE/spring-boot-starters/pom.xml#L94