### PR TITLE
Avoid request threads on AppEngine Java 8

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -482,12 +482,10 @@ public final class GrpcUtil {
    * @return a {@link ThreadFactory}.
    */
   public static ThreadFactory getThreadFactory(String nameFormat, boolean daemon) {
-    ThreadFactory threadFactory = MoreExecutors.platformThreadFactory();
     if (IS_RESTRICTED_APPENGINE) {
-      return threadFactory;
+      return MoreExecutors.platformThreadFactory();
     } else {
       return new ThreadFactoryBuilder()
-          .setThreadFactory(threadFactory)
           .setDaemon(daemon)
           .setNameFormat(nameFormat)
           .build();


### PR DESCRIPTION
While the code had correctly determined full threads were available, the
call to MoreExecutors returned a request thread factory, which has
limitations.

Note that Async stub users may not be able to call GAE APIs in
callbacks. This is because the threads aren't request threads. They can
override the individual call's executor with
com.google.appengine.api.ThreadManager.currentRequestThreadFactory() in
an interceptor via callOptions.withExecutor().

Fixes #3296

-----

@neozwu, can you test this?

As a user, I think I'd expect the Async API callbacks to be done or request threads. But this isn't very feasible to configure automatically because the executor would need to "save" the environment when a new call is created and re-associate callbacks with it. It'd be easy to override blindly, but then users couldn't override the executor.