### PR TITLE
interop-testing: fix dealineExceeded test by increasing time interval

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -994,7 +994,7 @@ public abstract class AbstractInteropTest {
                 .build()).next();
   }
 
-  @Test(timeout = 10000)
+  @Test(timeout = 25000)
   public void deadlineExceeded() throws Exception {
     // warm up the channel and JVM
     blockingStub.emptyCall(Empty.getDefaultInstance());
@@ -1002,7 +1002,7 @@ public abstract class AbstractInteropTest {
         blockingStub.withDeadlineAfter(10, TimeUnit.MILLISECONDS);
     StreamingOutputCallRequest request = StreamingOutputCallRequest.newBuilder()
         .addResponseParameters(ResponseParameters.newBuilder()
-            .setIntervalUs(20000))
+            .setIntervalUs((int) TimeUnit.SECONDS.toMicros(20)))
         .build();
     try {
       stub.streamingOutputCall(request).next();


### PR DESCRIPTION
Increased interval from 20,000 micros (i.e. 20 millis) to 20 seconds.