### PR TITLE
netty: Update to Netty 4.1.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ subprojects {
         protocPluginBaseName = 'protoc-gen-grpc-java'
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
-        nettyVersion = '4.1.14.Final'
+        nettyVersion = '4.1.15.Final'
         guavaVersion = '19.0'
         protobufVersion = '3.3.1'
         protocVersion = '3.3.0' // TODO(carl-mastrangelo): set this from protobufVersion when versions align again
@@ -200,7 +200,7 @@ subprojects {
                 netty: "io.netty:netty-codec-http2:[${nettyVersion}]",
                 netty_epoll: "io.netty:netty-transport-native-epoll:${nettyVersion}" + epoll_suffix,
                 netty_proxy_handler: "io.netty:netty-handler-proxy:${nettyVersion}",
-                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.5.Final',
+                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.6.Final',
 
                 // Test dependencies.
                 junit: 'junit:junit:4.11',

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -25,7 +25,6 @@ import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
-import io.netty.handler.ssl.ApplicationProtocolNegotiator;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
@@ -38,6 +37,7 @@ import java.util.List;
 /**
  * Utility for configuring SslContext for gRPC.
  */
+@SuppressWarnings("deprecation")
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1784")
 public class GrpcSslContexts {
   private GrpcSslContexts() {}
@@ -174,7 +174,9 @@ public class GrpcSslContexts {
     }
   }
 
-  static void ensureAlpnAndH2Enabled(ApplicationProtocolNegotiator alpnNegotiator) {
+  @SuppressWarnings("deprecation")
+  static void ensureAlpnAndH2Enabled(
+      io.netty.handler.ssl.ApplicationProtocolNegotiator alpnNegotiator) {
     checkArgument(alpnNegotiator != null, "ALPN must be configured");
     checkArgument(alpnNegotiator.protocols() != null && !alpnNegotiator.protocols().isEmpty(),
         "ALPN must be enabled and list HTTP/2 as a supported protocol.");


### PR DESCRIPTION
We'll need to figure out what we want to do about the deprecated API.
We'll probably just drop the verification check, but need to look into
it a bit.

----

I'll wait for the release announcement before actually merging.