### PR TITLE
core: advance past empty buffer in CompositeReadableBuffer

### DIFF
--- a/core/src/main/java/io/grpc/internal/CompositeReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/CompositeReadableBuffer.java
@@ -166,6 +166,10 @@ public class CompositeReadableBuffer extends AbstractReadableBuffer {
   private void execute(ReadOperation op, int length) {
     checkReadable(length);
 
+    if (!buffers.isEmpty()) {
+      advanceBufferIfNecessary();
+    }
+
     for (; length > 0 && !buffers.isEmpty(); advanceBufferIfNecessary()) {
       ReadableBuffer buffer = buffers.peek();
       int lengthToCopy = Math.min(length, buffer.readableBytes());

--- a/core/src/test/java/io/grpc/internal/CompositeReadableBufferTest.java
+++ b/core/src/test/java/io/grpc/internal/CompositeReadableBufferTest.java
@@ -69,6 +69,16 @@ public class CompositeReadableBufferTest {
   }
 
   @Test
+  public void readUnsignedByteShouldSkipZeroLengthBuffer() {
+    composite = new CompositeReadableBuffer();
+    composite.addBuffer(ReadableBuffers.wrap(new byte[0]));
+    byte[] in = {1};
+    composite.addBuffer(ReadableBuffers.wrap(in));
+    assertEquals(1, composite.readUnsignedByte());
+    assertEquals(0, composite.readableBytes());
+  }
+
+  @Test
   public void skipBytesShouldSucceed() {
     int remaining = EXPECTED_VALUE.length();
     composite.skipBytes(1);


### PR DESCRIPTION
If the initial buffer in a CompositeReadableBuffer has 0 readable bytes, invoking readUnsignedByte() on the composite triggers the following exception:

```
java.lang.IndexOutOfBoundsException
	at io.grpc.internal.AbstractReadableBuffer.checkReadable(AbstractReadableBuffer.java:72)
	at io.grpc.internal.ReadableBuffers$ByteArrayWrapper.readUnsignedByte(ReadableBuffers.java:158)
	at io.grpc.internal.CompositeReadableBuffer$1.readInternal(CompositeReadableBuffer.java:71)
	at io.grpc.internal.CompositeReadableBuffer$ReadOperation.read(CompositeReadableBuffer.java:220)
	at io.grpc.internal.CompositeReadableBuffer.execute(CompositeReadableBuffer.java:178)
	at io.grpc.internal.CompositeReadableBuffer.readUnsignedByte(CompositeReadableBuffer.java:74)
	at io.grpc.internal.CompositeReadableBufferTest.readUnsignedByteShouldSkipZeroLengthBuffer(CompositeReadableBufferTest.java:77)
```

This change avoids the exception by invoking `advanceBufferIfNecessary()` before the for loop in `execute`, which will close the empty buffer and skip forward.

It seems that empty buffers should probably not be put into a CompositeReadableBuffer, but I didn't see anything to that effect in the Javadoc, and it's currently allowed by the code. An alternative fix would be to disallow empty buffers being added to the composite.