### PR TITLE
compiler: Produce unified output on diff failure

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -279,6 +279,7 @@ def configureTestTask(Task task, String dep, String extraPackage) {
   task.dependsOn "generateTest${dep}Proto"
   if (osdetector.os != 'windows') {
     task.executable "diff"
+    task.args "-u"
   } else {
     task.executable "fc"
   }


### PR DESCRIPTION
This includes the file names and context, which is soo much nicer.