### PR TITLE
Part 2 - Client-side full-stream decompression

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -110,6 +110,12 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
+  public T enableFullStreamDecompression() {
+    delegate().enableFullStreamDecompression();
+    return thisT();
+  }
+
+  @Override
   public T decompressorRegistry(DecompressorRegistry registry) {
     delegate().decompressorRegistry(registry);
     return thisT();

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -193,8 +193,21 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory);
 
   /**
-   * Set the decompression registry for use in the channel.  This is an advanced API call and
-   * shouldn't be used unless you are using custom message encoding.   The default supported
+   * Enables full-stream decompression of inbound streams. This will cause the channel's outbound
+   * headers to advertise support for GZIP compressed streams, and gRPC servers which support the
+   * feature may respond with a GZIP compressed stream.
+   *
+   * <p>EXPERIMENTAL: This method is here to enable an experimental feature, and may be changed or
+   * removed once the feature is stable.
+   *
+   * @since 1.7.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3399")
+  public abstract T enableFullStreamDecompression();
+
+  /**
+   * Set the decompression registry for use in the channel. This is an advanced API call and
+   * shouldn't be used unless you are using custom message encoding. The default supported
    * decompressors are in {@link DecompressorRegistry#getDefaultInstance}.
    *
    * @return this

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -593,6 +593,9 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       public void setCompressor(Compressor compressor) {}
 
       @Override
+      public void setFullStreamDecompression(boolean fullStreamDecompression) {}
+
+      @Override
       public void setDecompressorRegistry(DecompressorRegistry decompressorRegistry) {}
 
       @Override

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -118,6 +118,8 @@ public abstract class AbstractManagedChannelImplBuilder
 
   LoadBalancer.Factory loadBalancerFactory = DEFAULT_LOAD_BALANCER_FACTORY;
 
+  boolean fullStreamDecompression;
+
   DecompressorRegistry decompressorRegistry = DEFAULT_DECOMPRESSOR_REGISTRY;
 
   CompressorRegistry compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
@@ -224,6 +226,12 @@ public abstract class AbstractManagedChannelImplBuilder
     } else {
       this.loadBalancerFactory = DEFAULT_LOAD_BALANCER_FACTORY;
     }
+    return thisT();
+  }
+
+  @Override
+  public final T enableFullStreamDecompression() {
+    this.fullStreamDecompression = true;
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/internal/ApplicationThreadDeframer.java
+++ b/core/src/main/java/io/grpc/internal/ApplicationThreadDeframer.java
@@ -45,15 +45,12 @@ public class ApplicationThreadDeframer implements Deframer, MessageDeframer.List
 
   ApplicationThreadDeframer(
       MessageDeframer.Listener listener,
-      Decompressor decompressor,
-      int maxMessageSize,
-      StatsTraceContext statsTraceCtx,
-      String debugString,
-      TransportExecutor transportExecutor) {
-    this.deframer =
-        new MessageDeframer(this, decompressor, maxMessageSize, statsTraceCtx, debugString);
+      TransportExecutor transportExecutor,
+      MessageDeframer deframer) {
     this.storedListener = checkNotNull(listener, "listener");
     this.transportExecutor = checkNotNull(transportExecutor, "transportExecutor");
+    deframer.setListener(this);
+    this.deframer = deframer;
   }
 
   @Override
@@ -64,6 +61,11 @@ public class ApplicationThreadDeframer implements Deframer, MessageDeframer.List
   @Override
   public void setDecompressor(Decompressor decompressor) {
     deframer.setDecompressor(decompressor);
+  }
+
+  @Override
+  public void setFullStreamDecompressor(GzipInflatingBuffer fullStreamDecompressor) {
+    deframer.setFullStreamDecompressor(fullStreamDecompressor);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ClientStream.java
@@ -53,6 +53,12 @@ public interface ClientStream extends Stream {
   void setAuthority(String authority);
 
   /**
+   * Enables full-stream decompression, allowing the client stream to use {@link
+   * GzipInflatingBuffer} to decode inbound GZIP compressed streams.
+   */
+  void setFullStreamDecompression(boolean fullStreamDecompression);
+
+  /**
    * Sets the registry to find a decompressor for the framer. May only be called before {@link
    * #start}. If the transport does not support compression, this may do nothing.
    *

--- a/core/src/main/java/io/grpc/internal/Deframer.java
+++ b/core/src/main/java/io/grpc/internal/Deframer.java
@@ -33,6 +33,14 @@ public interface Deframer {
   void setDecompressor(Decompressor decompressor);
 
   /**
+   * Sets the decompressor used for full-stream decompression. Full-stream decompression disables
+   * any per-message decompressor set by {@link #setDecompressor}.
+   *
+   * @param fullStreamDecompressor the decompressing wrapper
+   */
+  void setFullStreamDecompressor(GzipInflatingBuffer fullStreamDecompressor);
+
+  /**
    * Requests up to the given number of messages from the call. No additional messages will be
    * delivered.
    *

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -303,6 +303,17 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
+  public void setFullStreamDecompression(final boolean fullStreamDecompression) {
+    delayOrExecute(
+        new Runnable() {
+          @Override
+          public void run() {
+            realStream.setFullStreamDecompression(fullStreamDecompression);
+          }
+        });
+  }
+
+  @Override
   public void setDecompressorRegistry(final DecompressorRegistry decompressorRegistry) {
     checkNotNull(decompressorRegistry, "decompressorRegistry");
     delayOrExecute(new Runnable() {

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -84,6 +84,18 @@ public final class GrpcUtil {
   public static final Metadata.Key<byte[]> MESSAGE_ACCEPT_ENCODING_KEY =
       InternalMetadata.keyOf(GrpcUtil.MESSAGE_ACCEPT_ENCODING, new AcceptEncodingMarshaller());
 
+  /**
+   * {@link io.grpc.Metadata.Key} for the stream's content encoding header.
+   */
+  public static final Metadata.Key<String> CONTENT_ENCODING_KEY =
+      Metadata.Key.of(GrpcUtil.CONTENT_ENCODING, Metadata.ASCII_STRING_MARSHALLER);
+
+  /**
+   * {@link io.grpc.Metadata.Key} for the stream's accepted content encoding header.
+   */
+  public static final Metadata.Key<byte[]> CONTENT_ACCEPT_ENCODING_KEY =
+      InternalMetadata.keyOf(GrpcUtil.CONTENT_ACCEPT_ENCODING, new AcceptEncodingMarshaller());
+
   private static final class AcceptEncodingMarshaller implements TrustedAsciiMarshaller<byte[]> {
     @Override
     public byte[] toAsciiString(byte[] value) {
@@ -153,6 +165,16 @@ public final class GrpcUtil {
    * The accepted message encodings (i.e. compression) that can be used in the stream.
    */
   public static final String MESSAGE_ACCEPT_ENCODING = "grpc-accept-encoding";
+
+  /**
+   * The content-encoding used to compress the full gRPC stream.
+   */
+  public static final String CONTENT_ENCODING = "content-encoding";
+
+  /**
+   * The accepted content-encodings that can be used to compress the full gRPC stream.
+   */
+  public static final String CONTENT_ACCEPT_ENCODING = "accept-encoding";
 
   /**
    * The default maximum uncompressed size (in bytes) for inbound messages. Defaults to 4 MiB.

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -111,6 +111,8 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
 
   private final ChannelExecutor channelExecutor = new ChannelExecutor();
 
+  private boolean fullStreamDecompression;
+
   private final DecompressorRegistry decompressorRegistry;
   private final CompressorRegistry compressorRegistry;
 
@@ -411,6 +413,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
           "invalid idleTimeoutMillis %s", builder.idleTimeoutMillis);
       this.idleTimeoutMillis = builder.idleTimeoutMillis;
     }
+    this.fullStreamDecompression = builder.fullStreamDecompression;
     this.decompressorRegistry = checkNotNull(builder.decompressorRegistry, "decompressorRegistry");
     this.compressorRegistry = checkNotNull(builder.compressorRegistry, "compressorRegistry");
     this.userAgent = builder.userAgent;
@@ -562,13 +565,14 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
         executor = ManagedChannelImpl.this.executor;
       }
       return new ClientCallImpl<ReqT, RespT>(
-          method,
-          executor,
-          callOptions,
-          transportProvider,
-          terminated ? null : transportFactory.getScheduledExecutorService())
-              .setDecompressorRegistry(decompressorRegistry)
-              .setCompressorRegistry(compressorRegistry);
+              method,
+              executor,
+              callOptions,
+              transportProvider,
+              terminated ? null : transportFactory.getScheduledExecutorService())
+          .setFullStreamDecompression(fullStreamDecompression)
+          .setDecompressorRegistry(decompressorRegistry)
+          .setCompressorRegistry(compressorRegistry);
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/NoopClientStream.java
+++ b/core/src/main/java/io/grpc/internal/NoopClientStream.java
@@ -68,6 +68,9 @@ public class NoopClientStream implements ClientStream {
   public void setCompressor(Compressor compressor) {}
 
   @Override
+  public void setFullStreamDecompression(boolean fullStreamDecompression) {}
+
+  @Override
   public void setDecompressorRegistry(DecompressorRegistry decompressorRegistry) {}
 
   @Override

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -154,6 +154,17 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
+  public void fullStreamDecompression_default() {
+    assertFalse(builder.fullStreamDecompression);
+  }
+
+  @Test
+  public void fullStreamDecompression_enabled() {
+    assertEquals(builder, builder.enableFullStreamDecompression());
+    assertTrue(builder.fullStreamDecompression);
+  }
+
+  @Test
   public void decompressorRegistry_default() {
     assertNotNull(builder.decompressorRegistry);
   }

--- a/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.primitives.Bytes;
+import io.grpc.internal.StreamListener.MessageProducer;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.LinkedList;
+import java.util.Queue;
+import javax.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ApplicationThreadDeframer}. */
+@RunWith(JUnit4.class)
+public class ApplicationThreadDeframerTest {
+  private MessageDeframer mockDeframer = mock(MessageDeframer.class);
+  private DeframerListener listener = new DeframerListener();
+  private TransportExecutor transportExecutor = new TransportExecutor();
+  private ApplicationThreadDeframer applicationThreadDeframer =
+      new ApplicationThreadDeframer(listener, transportExecutor, mockDeframer);
+
+  @Before
+  public void setUp() {
+    // ApplicationThreadDeframer constructor injects itself as the wrapped deframer's listener.
+    verify(mockDeframer).setListener(applicationThreadDeframer);
+  }
+
+  @Test
+  public void requestInvokesMessagesAvailableOnListener() {
+    applicationThreadDeframer.request(1);
+    verifyZeroInteractions(mockDeframer);
+    listener.runStoredProducer();
+    verify(mockDeframer).request(1);
+  }
+
+  @Test
+  public void deframeInvokesMessagesAvailableOnListener() {
+    ReadableBuffer frame = ReadableBuffers.wrap(new byte[1]);
+    applicationThreadDeframer.deframe(frame);
+    verifyZeroInteractions(mockDeframer);
+    listener.runStoredProducer();
+    verify(mockDeframer).deframe(frame);
+  }
+
+  @Test
+  public void closeWhenCompleteInvokesMessagesAvailableOnListener() {
+    applicationThreadDeframer.closeWhenComplete();
+    verifyZeroInteractions(mockDeframer);
+    listener.runStoredProducer();
+    verify(mockDeframer).closeWhenComplete();
+  }
+
+  @Test
+  public void closeInvokesMessagesAvailableOnListener() {
+    applicationThreadDeframer.close();
+    verify(mockDeframer).stopDelivery();
+    verifyNoMoreInteractions(mockDeframer);
+    listener.runStoredProducer();
+    verify(mockDeframer).close();
+  }
+
+  @Test
+  public void bytesReadInvokesTransportExecutor() {
+    applicationThreadDeframer.bytesRead(1);
+    assertEquals(0, listener.bytesRead);
+    transportExecutor.runStoredRunnable();
+    assertEquals(1, listener.bytesRead);
+  }
+
+  @Test
+  public void deframerClosedInvokesTransportExecutor() {
+    applicationThreadDeframer.deframerClosed(true);
+    assertFalse(listener.deframerClosedWithPartialMessage);
+    transportExecutor.runStoredRunnable();
+    assertTrue(listener.deframerClosedWithPartialMessage);
+  }
+
+  @Test
+  public void deframeFailedInvokesTransportExecutor() {
+    Throwable cause = new Throwable("error");
+    applicationThreadDeframer.deframeFailed(cause);
+    assertNull(listener.deframeFailedCause);
+    transportExecutor.runStoredRunnable();
+    assertEquals(cause, listener.deframeFailedCause);
+  }
+
+  @Test
+  public void messagesAvailableDrainsToMessageReadQueue_returnedByInitializingMessageProducer()
+      throws Exception {
+    byte[][] messageBytes = {{1, 2, 3}, {4}, {5, 6}};
+    Queue<InputStream> messages = new LinkedList<InputStream>();
+    for (int i = 0; i < messageBytes.length; i++) {
+      messages.add(new ByteArrayInputStream(messageBytes[i]));
+    }
+    MultiMessageProducer messageProducer = new MultiMessageProducer(messages);
+    applicationThreadDeframer.messagesAvailable(messageProducer);
+    applicationThreadDeframer.request(1 /* value is ignored */);
+    for (int i = 0; i < messageBytes.length; i++) {
+      InputStream message = listener.storedProducer.next();
+      assertNotNull(message);
+      assertEquals(Bytes.asList(messageBytes[i]), Bytes.asList(ByteStreams.toByteArray(message)));
+    }
+    assertNull(listener.storedProducer.next());
+  }
+
+  private static class DeframerListener implements MessageDeframer.Listener {
+    private MessageProducer storedProducer;
+    private int bytesRead;
+    private boolean deframerClosedWithPartialMessage;
+    private Throwable deframeFailedCause;
+
+    private void runStoredProducer() {
+      assertNotNull(storedProducer);
+      storedProducer.next();
+    }
+
+    @Override
+    public void bytesRead(int numBytes) {
+      assertEquals(0, bytesRead);
+      bytesRead = numBytes;
+    }
+
+    @Override
+    public void messagesAvailable(MessageProducer producer) {
+      assertNull(storedProducer);
+      storedProducer = producer;
+    }
+
+    @Override
+    public void deframerClosed(boolean hasPartialMessage) {
+      assertFalse(deframerClosedWithPartialMessage);
+      deframerClosedWithPartialMessage = hasPartialMessage;
+    }
+
+    @Override
+    public void deframeFailed(Throwable cause) {
+      assertNull(deframeFailedCause);
+      deframeFailedCause = cause;
+    }
+  }
+
+  private static class TransportExecutor implements ApplicationThreadDeframer.TransportExecutor {
+    private Runnable storedRunnable;
+
+    private void runStoredRunnable() {
+      assertNotNull(storedRunnable);
+      storedRunnable.run();
+    }
+
+    @Override
+    public void runOnTransportThread(Runnable r) {
+      assertNull(storedRunnable);
+      storedRunnable = r;
+    }
+  }
+
+  private static class MultiMessageProducer implements StreamListener.MessageProducer {
+    private final Queue<InputStream> messages;
+
+    private MultiMessageProducer(Queue<InputStream> messages) {
+      this.messages = messages;
+    }
+
+    @Nullable
+    @Override
+    public InputStream next() {
+      return messages.poll();
+    }
+  }
+}

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -20,7 +20,9 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -41,13 +43,21 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
@@ -56,166 +66,235 @@ import org.mockito.stubbing.Answer;
 /**
  * Tests for {@link MessageDeframer}.
  */
-@RunWith(JUnit4.class)
+@RunWith(Enclosed.class)
 public class MessageDeframerTest {
-  @Rule public final ExpectedException thrown = ExpectedException.none();
 
-  private Listener listener = mock(Listener.class);
-  private TestBaseStreamTracer tracer = new TestBaseStreamTracer();
-  private StatsTraceContext statsTraceCtx = new StatsTraceContext(new StreamTracer[]{tracer});
+  @RunWith(Parameterized.class)
+  public static class WithAndWithoutFullStreamCompressionTests {
 
-  private MessageDeframer deframer = new MessageDeframer(listener, Codec.Identity.NONE,
-      DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, "test");
+    /**
+     * Auto called by test.
+     */
+    @Parameters(name = "{index}: useGzipInflatingBuffer={0}")
+    public static Collection<Object[]> data() {
+      return Arrays.asList(new Object[][]{
+              {false}, {true}
+      });
+    }
 
-  private ArgumentCaptor<StreamListener.MessageProducer> producer =
-      ArgumentCaptor.forClass(StreamListener.MessageProducer.class);
+    @Parameter // Automatically set by test runner, must be public
+    public boolean useGzipInflatingBuffer;
 
-  @Test
-  public void simplePayload() {
-    deframer.request(1);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 2, 3, 14}));
-    verify(listener).messagesAvailable(producer.capture());
-    assertEquals(Bytes.asList(new byte[] {3, 14}), bytes(producer.getValue().next()));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    checkStats(2, 2);
-  }
+    private Listener listener = mock(Listener.class);
+    private TestBaseStreamTracer tracer = new TestBaseStreamTracer();
+    private StatsTraceContext statsTraceCtx = new StatsTraceContext(new StreamTracer[]{tracer});
 
-  @Test
-  public void smallCombinedPayloads() {
-    deframer.request(2);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 2, 14, 15}));
-    verify(listener, times(2)).messagesAvailable(producer.capture());
-    List<StreamListener.MessageProducer> streams = producer.getAllValues();
-    assertEquals(2, streams.size());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(streams.get(0).next()));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    assertEquals(Bytes.asList(new byte[] {14, 15}), bytes(streams.get(1).next()));
-    verifyNoMoreInteractions(listener);
-    checkStats(1, 1, 2, 2);
-  }
+    private MessageDeframer deframer = new MessageDeframer(listener, Codec.Identity.NONE,
+            DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, "test");
 
-  @Test
-  public void endOfStreamWithPayloadShouldNotifyEndOfStream() {
-    deframer.request(1);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}));
-    deframer.closeWhenComplete();
-    verify(listener).messagesAvailable(producer.capture());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(producer.getValue().next()));
-    verify(listener).deframerClosed(false);
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    checkStats(1, 1);
-  }
+    private ArgumentCaptor<StreamListener.MessageProducer> producer =
+            ArgumentCaptor.forClass(StreamListener.MessageProducer.class);
 
-  @Test
-  public void endOfStreamShouldNotifyEndOfStream() {
-    deframer.deframe(buffer(new byte[0]));
-    deframer.closeWhenComplete();
-    verify(listener).deframerClosed(false);
-    verifyNoMoreInteractions(listener);
-    checkStats();
-  }
+    @Before
+    public void setUp() {
+      if (useGzipInflatingBuffer) {
+        deframer.setFullStreamDecompressor(new GzipInflatingBuffer() {
+          @Override
+          public void addGzippedBytes(ReadableBuffer buffer) {
+            try {
+              ByteArrayOutputStream gzippedOutputStream = new ByteArrayOutputStream();
+              OutputStream gzipCompressingStream = new GZIPOutputStream(
+                      gzippedOutputStream);
+              buffer.readBytes(gzipCompressingStream, buffer.readableBytes());
+              gzipCompressingStream.close();
+              super.addGzippedBytes(ReadableBuffers.wrap(gzippedOutputStream.toByteArray()));
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+          }
+        });
+      }
+    }
 
-  @Test
-  public void endOfStreamWithPartialMessageShouldNotifyDeframerClosedWithPartialMessage() {
-    deframer.request(1);
-    deframer.deframe(buffer(new byte[1]));
-    deframer.closeWhenComplete();
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verify(listener).deframerClosed(true);
-    verifyNoMoreInteractions(listener);
-    checkStats();
-  }
+    @Test
+    public void simplePayload() {
+      deframer.request(1);
+      deframer.deframe(buffer(new byte[]{0, 0, 0, 0, 2, 3, 14}));
+      verify(listener).messagesAvailable(producer.capture());
+      assertEquals(Bytes.asList(new byte[]{3, 14}), bytes(producer.getValue().next()));
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer, 2, 2);
+    }
 
-  @Test
-  public void payloadSplitBetweenBuffers() {
-    deframer.request(1);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 7, 3, 14, 1, 5, 9}));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    deframer.deframe(buffer(new byte[] {2, 6}));
-    verify(listener).messagesAvailable(producer.capture());
-    assertEquals(
-        Bytes.asList(new byte[] {3, 14, 1, 5, 9, 2, 6}), bytes(producer.getValue().next()));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    checkStats(7, 7);
-  }
+    @Test
+    public void smallCombinedPayloads() {
+      deframer.request(2);
+      deframer.deframe(buffer(new byte[]{0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 2, 14, 15}));
+      verify(listener, times(2)).messagesAvailable(producer.capture());
+      List<StreamListener.MessageProducer> streams = producer.getAllValues();
+      assertEquals(2, streams.size());
+      assertEquals(Bytes.asList(new byte[]{3}), bytes(streams.get(0).next()));
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      assertEquals(Bytes.asList(new byte[]{14, 15}), bytes(streams.get(1).next()));
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer, 1, 1, 2, 2);
+    }
 
-  @Test
-  public void frameHeaderSplitBetweenBuffers() {
-    deframer.request(1);
+    @Test
+    public void endOfStreamWithPayloadShouldNotifyEndOfStream() {
+      deframer.request(1);
+      deframer.deframe(buffer(new byte[]{0, 0, 0, 0, 1, 3}));
+      deframer.closeWhenComplete();
+      verify(listener).messagesAvailable(producer.capture());
+      assertEquals(Bytes.asList(new byte[]{3}), bytes(producer.getValue().next()));
+      verify(listener).deframerClosed(false);
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer, 1, 1);
+    }
 
-    deframer.deframe(buffer(new byte[] {0, 0}));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    deframer.deframe(buffer(new byte[] {0, 0, 1, 3}));
-    verify(listener).messagesAvailable(producer.capture());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(producer.getValue().next()));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    checkStats(1, 1);
-  }
+    @Test
+    public void endOfStreamShouldNotifyEndOfStream() {
+      deframer.deframe(buffer(new byte[0]));
+      deframer.closeWhenComplete();
+      deframer.request(1);
+      if (useGzipInflatingBuffer) {
+        deframer.request(1); // process the 20-byte empty GZIP stream, to get stalled=true
+        verify(listener, atLeast(1)).bytesRead(anyInt());
+      }
+      verify(listener).deframerClosed(false);
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer);
+    }
 
-  @Test
-  public void emptyPayload() {
-    deframer.request(1);
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 0}));
-    verify(listener).messagesAvailable(producer.capture());
-    assertEquals(Bytes.asList(), bytes(producer.getValue().next()));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    checkStats(0, 0);
-  }
+    @Test
+    public void endOfStreamWithPartialMessageShouldNotifyDeframerClosedWithPartialMessage() {
+      deframer.request(1);
+      deframer.deframe(buffer(new byte[1]));
+      deframer.closeWhenComplete();
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verify(listener).deframerClosed(true);
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer);
+    }
 
-  @Test
-  public void largerFrameSize() {
-    deframer.request(1);
-    deframer.deframe(ReadableBuffers.wrap(
-        Bytes.concat(new byte[] {0, 0, 0, 3, (byte) 232}, new byte[1000])));
-    verify(listener).messagesAvailable(producer.capture());
-    assertEquals(Bytes.asList(new byte[1000]), bytes(producer.getValue().next()));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    checkStats(1000, 1000);
-  }
+    @Test
+    public void endOfStreamWithInvalidGzipBlockShouldNotifyDeframerClosedWithPartialMessage() {
+      assumeTrue("test only valid for full-stream compression", useGzipInflatingBuffer);
 
-  @Test
-  public void endOfStreamCallbackShouldWaitForMessageDelivery() {
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}));
-    deframer.closeWhenComplete();
-    verifyNoMoreInteractions(listener);
+      // Create new deframer to allow writing bytes directly to the GzipInflatingBuffer
+      MessageDeframer deframer = new MessageDeframer(listener, Codec.Identity.NONE,
+              DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, "test");
+      deframer.setFullStreamDecompressor(new GzipInflatingBuffer());
+      deframer.request(1);
+      deframer.deframe(buffer(new byte[1]));
+      deframer.closeWhenComplete();
+      verify(listener).deframerClosed(true);
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer);
+    }
 
-    deframer.request(1);
-    verify(listener).messagesAvailable(producer.capture());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(producer.getValue().next()));
-    verify(listener).deframerClosed(false);
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    checkStats(1, 1);
-  }
+    @Test
+    public void payloadSplitBetweenBuffers() {
+      deframer.request(1);
+      deframer.deframe(buffer(new byte[]{0, 0, 0, 0, 7, 3, 14, 1, 5, 9}));
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
+      deframer.deframe(buffer(new byte[]{2, 6}));
+      verify(listener).messagesAvailable(producer.capture());
+      assertEquals(
+              Bytes.asList(new byte[]{3, 14, 1, 5, 9, 2, 6}), bytes(producer.getValue().next()));
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
 
-  @Test
-  public void compressed() {
-    deframer = new MessageDeframer(listener, new Codec.Gzip(), DEFAULT_MAX_MESSAGE_SIZE,
-        statsTraceCtx, "test");
-    deframer.request(1);
+      if (useGzipInflatingBuffer) {
+        checkStats(
+            tracer,
+            7 /* msg size */ + 2 /* second buffer adds two bytes of overhead in deflate block */,
+            7);
+      } else {
+        checkStats(tracer, 7, 7);
+      }
+    }
 
-    byte[] payload = compress(new byte[1000]);
-    assertTrue(payload.length < 100);
-    byte[] header = new byte[] {1, 0, 0, 0, (byte) payload.length};
-    deframer.deframe(buffer(Bytes.concat(header, payload)));
-    verify(listener).messagesAvailable(producer.capture());
-    assertEquals(Bytes.asList(new byte[1000]), bytes(producer.getValue().next()));
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-    checkStats(payload.length, 1000);
-  }
+    @Test
+    public void frameHeaderSplitBetweenBuffers() {
+      deframer.request(1);
 
-  @Test
-  public void deliverIsReentrantSafe() {
-    doAnswer(
+      deframer.deframe(buffer(new byte[]{0, 0}));
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
+      deframer.deframe(buffer(new byte[]{0, 0, 1, 3}));
+      verify(listener).messagesAvailable(producer.capture());
+      assertEquals(Bytes.asList(new byte[]{3}), bytes(producer.getValue().next()));
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer, 1, 1);
+    }
+
+    @Test
+    public void emptyPayload() {
+      deframer.request(1);
+      deframer.deframe(buffer(new byte[]{0, 0, 0, 0, 0}));
+      verify(listener).messagesAvailable(producer.capture());
+      assertEquals(Bytes.asList(), bytes(producer.getValue().next()));
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer, 0, 0);
+    }
+
+    @Test
+    public void largerFrameSize() {
+      deframer.request(1);
+      deframer.deframe(ReadableBuffers.wrap(
+              Bytes.concat(new byte[]{0, 0, 0, 3, (byte) 232}, new byte[1000])));
+      verify(listener).messagesAvailable(producer.capture());
+      assertEquals(Bytes.asList(new byte[1000]), bytes(producer.getValue().next()));
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
+      if (useGzipInflatingBuffer) {
+        checkStats(tracer, 8 /* compressed size */, 1000);
+      } else {
+        checkStats(tracer, 1000, 1000);
+      }
+    }
+
+    @Test
+    public void endOfStreamCallbackShouldWaitForMessageDelivery() {
+      deframer.deframe(buffer(new byte[]{0, 0, 0, 0, 1, 3}));
+      deframer.closeWhenComplete();
+      verifyNoMoreInteractions(listener);
+
+      deframer.request(1);
+      verify(listener).messagesAvailable(producer.capture());
+      assertEquals(Bytes.asList(new byte[]{3}), bytes(producer.getValue().next()));
+      verify(listener).deframerClosed(false);
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer, 1, 1);
+    }
+
+    @Test
+    public void compressed() {
+      deframer = new MessageDeframer(listener, new Codec.Gzip(), DEFAULT_MAX_MESSAGE_SIZE,
+              statsTraceCtx, "test");
+      deframer.request(1);
+
+      byte[] payload = compress(new byte[1000]);
+      assertTrue(payload.length < 100);
+      byte[] header = new byte[]{1, 0, 0, 0, (byte) payload.length};
+      deframer.deframe(buffer(Bytes.concat(header, payload)));
+      verify(listener).messagesAvailable(producer.capture());
+      assertEquals(Bytes.asList(new byte[1000]), bytes(producer.getValue().next()));
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
+      checkStats(tracer, payload.length, 1000);
+    }
+
+    @Test
+    public void deliverIsReentrantSafe() {
+      doAnswer(
           new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -223,169 +302,182 @@ public class MessageDeframerTest {
               return null;
             }
           })
-        .when(listener)
-        .messagesAvailable(Matchers.<StreamListener.MessageProducer>any());
-    deframer.deframe(buffer(new byte[] {0, 0, 0, 0, 1, 3}));
-    deframer.closeWhenComplete();
-    verifyNoMoreInteractions(listener);
+          .when(listener)
+          .messagesAvailable(Matchers.<StreamListener.MessageProducer>any());
+      deframer.deframe(buffer(new byte[]{0, 0, 0, 0, 1, 3}));
+      deframer.closeWhenComplete();
+      verifyNoMoreInteractions(listener);
 
-    deframer.request(1);
-    verify(listener).messagesAvailable(producer.capture());
-    assertEquals(Bytes.asList(new byte[] {3}), bytes(producer.getValue().next()));
-    verify(listener).deframerClosed(false);
-    verify(listener, atLeastOnce()).bytesRead(anyInt());
-    verifyNoMoreInteractions(listener);
-  }
-
-  @Test
-  public void sizeEnforcingInputStream_readByteBelowLimit() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx, "test");
-
-    while (stream.read() != -1) {}
-
-    stream.close();
-    checkSizeEnforcingInputStreamStats(3);
-  }
-
-  @Test
-  public void sizeEnforcingInputStream_readByteAtLimit() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
-
-    while (stream.read() != -1) {}
-
-    stream.close();
-    checkSizeEnforcingInputStreamStats(3);
-  }
-
-  @Test
-  public void sizeEnforcingInputStream_readByteAboveLimit() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
-
-    try {
-      thrown.expect(StatusRuntimeException.class);
-      thrown.expectMessage("RESOURCE_EXHAUSTED: test: Compressed frame exceeds");
-
-      while (stream.read() != -1) {}
-    } finally {
-      stream.close();
+      deframer.request(1);
+      verify(listener).messagesAvailable(producer.capture());
+      assertEquals(Bytes.asList(new byte[]{3}), bytes(producer.getValue().next()));
+      verify(listener).deframerClosed(false);
+      verify(listener, atLeastOnce()).bytesRead(anyInt());
+      verifyNoMoreInteractions(listener);
     }
   }
 
-  @Test
-  public void sizeEnforcingInputStream_readBelowLimit() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx, "test");
-    byte[] buf = new byte[10];
+  @RunWith(JUnit4.class)
+  public static class SizeEnforcingInputStreamTests {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
 
-    int read = stream.read(buf, 0, buf.length);
+    private TestBaseStreamTracer tracer = new TestBaseStreamTracer();
+    private StatsTraceContext statsTraceCtx = new StatsTraceContext(new StreamTracer[]{tracer});
 
-    assertEquals(3, read);
-    stream.close();
-    checkSizeEnforcingInputStreamStats(3);
-  }
+    @Test
+    public void sizeEnforcingInputStream_readByteBelowLimit() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx, "test");
 
-  @Test
-  public void sizeEnforcingInputStream_readAtLimit() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
-    byte[] buf = new byte[10];
+      while (stream.read() != -1) {
+      }
 
-    int read = stream.read(buf, 0, buf.length);
-
-    assertEquals(3, read);
-    stream.close();
-    checkSizeEnforcingInputStreamStats(3);
-  }
-
-  @Test
-  public void sizeEnforcingInputStream_readAboveLimit() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
-    byte[] buf = new byte[10];
-
-    try {
-      thrown.expect(StatusRuntimeException.class);
-      thrown.expectMessage("RESOURCE_EXHAUSTED: test: Compressed frame exceeds");
-
-      stream.read(buf, 0, buf.length);
-    } finally {
       stream.close();
+      checkSizeEnforcingInputStreamStats(tracer, 3);
     }
-  }
 
-  @Test
-  public void sizeEnforcingInputStream_skipBelowLimit() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx, "test");
+    @Test
+    public void sizeEnforcingInputStream_readByteAtLimit() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
 
-    long skipped = stream.skip(4);
+      while (stream.read() != -1) {
+      }
 
-    assertEquals(3, skipped);
-
-    stream.close();
-    checkSizeEnforcingInputStreamStats(3);
-  }
-
-  @Test
-  public void sizeEnforcingInputStream_skipAtLimit() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
-
-    long skipped = stream.skip(4);
-
-    assertEquals(3, skipped);
-    stream.close();
-    checkSizeEnforcingInputStreamStats(3);
-  }
-
-  @Test
-  public void sizeEnforcingInputStream_skipAboveLimit() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
-
-    try {
-      thrown.expect(StatusRuntimeException.class);
-      thrown.expectMessage("RESOURCE_EXHAUSTED: test: Compressed frame exceeds");
-
-      stream.skip(4);
-    } finally {
       stream.close();
+      checkSizeEnforcingInputStreamStats(tracer, 3);
     }
-  }
 
-  @Test
-  public void sizeEnforcingInputStream_markReset() throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
-    SizeEnforcingInputStream stream =
-        new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
-    // stream currently looks like: |foo
-    stream.skip(1); // f|oo
-    stream.mark(10); // any large number will work.
-    stream.skip(2); // foo|
-    stream.reset(); // f|oo
-    long skipped = stream.skip(2); // foo|
+    @Test
+    public void sizeEnforcingInputStream_readByteAboveLimit() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
 
-    assertEquals(2, skipped);
-    stream.close();
-    checkSizeEnforcingInputStreamStats(3);
+      try {
+        thrown.expect(StatusRuntimeException.class);
+        thrown.expectMessage("RESOURCE_EXHAUSTED: test: Compressed frame exceeds");
+
+        while (stream.read() != -1) {
+        }
+      } finally {
+        stream.close();
+      }
+    }
+
+    @Test
+    public void sizeEnforcingInputStream_readBelowLimit() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx, "test");
+      byte[] buf = new byte[10];
+
+      int read = stream.read(buf, 0, buf.length);
+
+      assertEquals(3, read);
+      stream.close();
+      checkSizeEnforcingInputStreamStats(tracer, 3);
+    }
+
+    @Test
+    public void sizeEnforcingInputStream_readAtLimit() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
+      byte[] buf = new byte[10];
+
+      int read = stream.read(buf, 0, buf.length);
+
+      assertEquals(3, read);
+      stream.close();
+      checkSizeEnforcingInputStreamStats(tracer, 3);
+    }
+
+    @Test
+    public void sizeEnforcingInputStream_readAboveLimit() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
+      byte[] buf = new byte[10];
+
+      try {
+        thrown.expect(StatusRuntimeException.class);
+        thrown.expectMessage("RESOURCE_EXHAUSTED: test: Compressed frame exceeds");
+
+        stream.read(buf, 0, buf.length);
+      } finally {
+        stream.close();
+      }
+    }
+
+    @Test
+    public void sizeEnforcingInputStream_skipBelowLimit() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 4, statsTraceCtx, "test");
+
+      long skipped = stream.skip(4);
+
+      assertEquals(3, skipped);
+
+      stream.close();
+      checkSizeEnforcingInputStreamStats(tracer, 3);
+    }
+
+    @Test
+    public void sizeEnforcingInputStream_skipAtLimit() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
+
+      long skipped = stream.skip(4);
+
+      assertEquals(3, skipped);
+      stream.close();
+      checkSizeEnforcingInputStreamStats(tracer, 3);
+    }
+
+    @Test
+    public void sizeEnforcingInputStream_skipAboveLimit() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 2, statsTraceCtx, "test");
+
+      try {
+        thrown.expect(StatusRuntimeException.class);
+        thrown.expectMessage("RESOURCE_EXHAUSTED: test: Compressed frame exceeds");
+
+        stream.skip(4);
+      } finally {
+        stream.close();
+      }
+    }
+
+    @Test
+    public void sizeEnforcingInputStream_markReset() throws IOException {
+      ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes(Charsets.UTF_8));
+      SizeEnforcingInputStream stream =
+              new MessageDeframer.SizeEnforcingInputStream(in, 3, statsTraceCtx, "test");
+      // stream currently looks like: |foo
+      stream.skip(1); // f|oo
+      stream.mark(10); // any large number will work.
+      stream.skip(2); // foo|
+      stream.reset(); // f|oo
+      long skipped = stream.skip(2); // foo|
+
+      assertEquals(2, skipped);
+      stream.close();
+      checkSizeEnforcingInputStreamStats(tracer, 3);
+    }
   }
 
   /**
    * @param sizes in the format {wire0, uncompressed0, wire1, uncompressed1, ...}
    */
-  private void checkStats(long... sizes) {
+  private static void checkStats(TestBaseStreamTracer tracer, long... sizes) {
     assertEquals(0, sizes.length % 2);
     int count = sizes.length / 2;
     long expectedWireSize = 0;
@@ -405,7 +497,8 @@ public class MessageDeframerTest {
     assertEquals(expectedUncompressedSize, tracer.getInboundUncompressedSize());
   }
 
-  private void checkSizeEnforcingInputStreamStats(long uncompressedSize) {
+  private static void checkSizeEnforcingInputStreamStats(
+      TestBaseStreamTracer tracer, long uncompressedSize) {
     assertNull(tracer.nextInboundEvent());
     assertNull(tracer.nextOutboundEvent());
     assertEquals(0, tracer.getInboundWireSize());

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -80,6 +80,7 @@ public class TestServiceClient {
   private String defaultServiceAccount;
   private String serviceAccountKeyFile;
   private String oauthScope;
+  private boolean fullStreamDecompression;
 
   private Tester tester = new Tester();
 
@@ -130,6 +131,8 @@ public class TestServiceClient {
         serviceAccountKeyFile = value;
       } else if ("oauth_scope".equals(key)) {
         oauthScope = value;
+      } else if ("full_stream_decompression".equals(key)) {
+        fullStreamDecompression = Boolean.parseBoolean(value);
       } else {
         System.err.println("Unknown argument: " + key);
         usage = true;
@@ -158,6 +161,8 @@ public class TestServiceClient {
           + "\n  --service_account_key_file  Path to service account json key file."
             + c.serviceAccountKeyFile
           + "\n  --oauth_scope               Scope for OAuth tokens. Default " + c.oauthScope
+          + "\n  --full_stream_decompression Enable full-stream decompression. Default "
+            + c.fullStreamDecompression
       );
       System.exit(1);
     }
@@ -329,6 +334,9 @@ public class TestServiceClient {
         if (serverHostOverride != null) {
           builder.overrideAuthority(serverHostOverride);
         }
+        if (fullStreamDecompression) {
+          builder.enableFullStreamDecompression();
+        }
         return builder.build();
       } else {
         OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress(serverHost, serverPort);
@@ -349,6 +357,9 @@ public class TestServiceClient {
           }
         } else {
           builder.usePlaintext(true);
+        }
+        if (fullStreamDecompression) {
+          builder.enableFullStreamDecompression();
         }
         return builder.build();
       }

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -55,6 +56,7 @@ import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.StreamTracer;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.KeepAliveManager;
@@ -271,9 +273,6 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
     assertNull("no messages expected", streamListenerMessageQueue.poll());
   }
 
-  // TODO(ericgribkoff) Figure out how this test should be restructured to accommodate application-
-  // thread deframing.
-  /*
   @Test
   public void streamErrorShouldNotCloseChannel() throws Exception {
     manualSetUp();
@@ -297,7 +296,6 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
     assertEquals(e, captor.getValue().asException().getCause());
     assertEquals(Code.UNKNOWN, captor.getValue().getCode());
   }
-  */
 
   @Test
   public void closeShouldCloseChannel() throws Exception {


### PR DESCRIPTION
This builds on https://github.com/grpc/grpc-java/pull/3395 and adds client-side support for full-stream decompression.

This is successfully interoperating with the C++ server sending gzipped streams. The next step on the Java side is to improve the test coverage for full-stream compression by adding (or mocking) a server that sends gzipped streams. This will enable adding something along the lines of `FullStreamCompressionTest extends AbstractInteropTest`, similar to our existing `TransportCompressionTest`, `AutoWindowSizingOnTest`, etc. I already have such a server working and these tests passing locally with the client-side code included here.

@ejona86 This PR doesn't include a hard-coded 'don't do full-stream compression' flag yet. It's easier to test this and future work with compression enabled by default, but a circuit-breaker can be added once this gets closer to merging to make sure the feature is rolled out properly. 