### PR TITLE
core: remove unused buffer methods

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/AbstractReadableBuffer.java
@@ -20,25 +20,6 @@ package io.grpc.internal;
  * Abstract base class for {@link ReadableBuffer} implementations.
  */
 public abstract class AbstractReadableBuffer implements ReadableBuffer {
-
-  @Override
-  public final int readUnsignedMedium() {
-    checkReadable(3);
-    int b1 = readUnsignedByte();
-    int b2 = readUnsignedByte();
-    int b3 = readUnsignedByte();
-    return b1 << 16 | b2 << 8 | b3;
-  }
-
-
-  @Override
-  public final int readUnsignedShort() {
-    checkReadable(2);
-    int b1 = readUnsignedByte();
-    int b2 = readUnsignedByte();
-    return b1 << 8 | b2;
-  }
-
   @Override
   public final int readInt() {
     checkReadable(4);

--- a/core/src/main/java/io/grpc/internal/ForwardingReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingReadableBuffer.java
@@ -51,16 +51,6 @@ public abstract class ForwardingReadableBuffer implements ReadableBuffer {
   }
 
   @Override
-  public int readUnsignedMedium() {
-    return buf.readUnsignedMedium();
-  }
-
-  @Override
-  public int readUnsignedShort() {
-    return buf.readUnsignedShort();
-  }
-
-  @Override
   public int readInt() {
     return buf.readInt();
   }

--- a/core/src/main/java/io/grpc/internal/ReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/ReadableBuffer.java
@@ -44,22 +44,6 @@ public interface ReadableBuffer extends Closeable {
   int readUnsignedByte();
 
   /**
-   * Reads a 3-byte unsigned integer from this buffer using big-endian byte ordering. Increments the
-   * read position by 3.
-   *
-   * @throws IndexOutOfBoundsException if required bytes are not readable
-   */
-  int readUnsignedMedium();
-
-  /**
-   * Reads a 2-byte unsigned integer from this buffer using big-endian byte ordering. Increments the
-   * read position by 2.
-   *
-   * @throws IndexOutOfBoundsException if required bytes are not readable
-   */
-  int readUnsignedShort();
-
-  /**
    * Reads a 4-byte signed integer from this buffer using big-endian byte ordering. Increments the
    * read position by 4.
    *

--- a/core/src/test/java/io/grpc/internal/AbstractReadableBufferTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractReadableBufferTest.java
@@ -42,18 +42,6 @@ public class AbstractReadableBufferTest {
   }
 
   @Test
-  public void readUnsignedShortShouldSucceed() {
-    mockBytes(0xFF, 0xEE);
-    assertEquals(0xFFEE, buffer.readUnsignedShort());
-  }
-
-  @Test
-  public void readUnsignedMediumShouldSucceed() {
-    mockBytes(0xFF, 0xEE, 0xDD);
-    assertEquals(0xFFEEDD, buffer.readUnsignedMedium());
-  }
-
-  @Test
   public void readPositiveIntShouldSucceed() {
     mockBytes(0x7F, 0xEE, 0xDD, 0xCC);
     assertEquals(0x7FEEDDCC, buffer.readInt());

--- a/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
@@ -58,20 +58,6 @@ public class ForwardingReadableBufferTest {
   }
 
   @Test
-  public void readUnsignedMedium() {
-    when(delegate.readUnsignedMedium()).thenReturn(1);
-
-    assertEquals(1, buffer.readUnsignedMedium());
-  }
-
-  @Test
-  public void readUnsignedShort() {
-    when(delegate.readUnsignedShort()).thenReturn(1);
-
-    assertEquals(1, buffer.readUnsignedShort());
-  }
-
-  @Test
   public void readInt() {
     when(delegate.readInt()).thenReturn(1);
 


### PR DESCRIPTION
These were likely added to match the ByteBuf api, but we never use them.