### PR TITLE
core: refactor transportProvider creating fewer transport instances

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -25,14 +25,11 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.grpc.CallOptions;
-import io.grpc.ClientStreamTracer;
 import io.grpc.InternalMetadata;
 import io.grpc.InternalMetadata.TrustedAsciiMarshaller;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.internal.StreamListener.MessageProducer;
@@ -43,7 +40,6 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -581,23 +577,7 @@ public final class GrpcUtil {
       transport = null;
     }
     if (transport != null) {
-      final ClientStreamTracer.Factory streamTracerFactory = result.getStreamTracerFactory();
-      if (streamTracerFactory == null) {
-        return transport;
-      }
-      return new ClientTransport() {
-        @Override
-        public ClientStream newStream(
-            MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
-          return transport.newStream(
-              method, headers, callOptions.withStreamTracerFactory(streamTracerFactory));
-        }
-
-        @Override
-        public void ping(PingCallback callback, Executor executor) {
-          transport.ping(callback, executor);
-        }
-      };
+      return transport;
     }
     if (!result.getStatus().isOk() && !isWaitForReady) {
       return new FailingClientTransport(result.getStatus());

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -30,6 +30,7 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import io.grpc.internal.ClientCallImpl.ClientCallAttributes;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -62,7 +63,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
 
   private final ClientTransportProvider transportProvider = new ClientTransportProvider() {
     @Override
-    public ClientTransport get(PickSubchannelArgs args) {
+    public ClientTransport get(ClientCallAttributes attrs) {
       // delayed transport's newStream() always acquires a lock, but concurrent performance doesn't
       // matter here because OOB communication should be sparse, and it's not on application RPC's
       // critical path.

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -54,6 +54,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
+import io.grpc.internal.ClientCallImpl.ClientCallAttributes;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 import io.grpc.internal.testing.SingleMessageProducer;
 import io.grpc.testing.TestMethodDescriptors;
@@ -128,7 +129,7 @@ public class ClientCallImplTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    when(provider.get(any(PickSubchannelArgsImpl.class))).thenReturn(transport);
+    when(provider.get(any(ClientCallAttributes.class))).thenReturn(transport);
     when(transport.newStream(
             any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class)))
         .thenReturn(stream);


### PR DESCRIPTION
Before the change:
The `ClientTransportProvider` or `GrpcUtil.getTransportFromPickResult()` produces a new wrapped transport instance for every single call. The wrapped transport instance only overrides the `newStream()` method by injecting a `streamTracerFactory` in the `callOptions`.

After the change:
Refactored `ClientTransportProvider` and `GrpcUtil.getTransportFromPickResult()` so that it does not wrap the underlying transport, and still injects `streamTracerFactory` in the `callOptions` when calling `newStream()`.

This refactoring is likely to make retry and resolving isssue #2562 easier.