### PR TITLE
core: shard SerializeExecutor queues

### DIFF
--- a/core/src/jmh/java/io/grpc/internal/SerializingExecutorBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/SerializingExecutorBenchmark.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.annotations.TearDown;
 public class SerializingExecutorBenchmark {
 
   private ExecutorService executorService = Executors.newSingleThreadExecutor();
-  private Executor executor = new SerializingExecutor(executorService);
+  private Executor executor = SerializingExecutors.wrap(executorService);
 
   private static class IncrRunnable implements Runnable {
     int val;

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -47,7 +47,6 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import java.io.InputStream;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -63,7 +62,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
   private static final Logger log = Logger.getLogger(ClientCallImpl.class.getName());
 
   private final MethodDescriptor<ReqT, RespT> method;
-  private final Executor callExecutor;
+  private final SerializingExecutor callExecutor;
   private final Context context;
   private volatile ScheduledFuture<?> deadlineCancellationFuture;
   private final boolean unaryRequest;
@@ -79,16 +78,11 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
   private CompressorRegistry compressorRegistry = CompressorRegistry.getDefaultInstance();
 
   ClientCallImpl(
-      MethodDescriptor<ReqT, RespT> method, Executor executor, CallOptions callOptions,
+      MethodDescriptor<ReqT, RespT> method, SerializingExecutor executor, CallOptions callOptions,
       ClientTransportProvider clientTransportProvider,
       ScheduledExecutorService deadlineCancellationExecutor) {
     this.method = method;
-    // If we know that the executor is a direct executor, we don't need to wrap it with a
-    // SerializingExecutor. This is purely for performance reasons.
-    // See https://github.com/grpc/grpc-java/issues/368
-    this.callExecutor = executor == directExecutor()
-        ? new SerializeReentrantCallsDirectExecutor()
-        : new SerializingExecutor(executor);
+    this.callExecutor = executor;
     // Propagate the context from the thread which initiated the call to all callbacks.
     this.context = Context.current();
     this.unaryRequest = method.getType() == MethodType.UNARY

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -388,8 +388,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     this.executorPool = checkNotNull(builder.executorPool, "executorPool");
     this.oobExecutorPool = checkNotNull(oobExecutorPool, "oobExecutorPool");
     this.executor = checkNotNull(executorPool.getObject(), "executor");
-    this.serializer =
-        SerializingExecutors.wrapFactory(this.executor, 1);
+    this.serializer = SerializingExecutors.wrapFactory(this.executor);
     this.delayedTransport = new DelayedClientTransport(this.executor, this.channelExecutor);
     this.delayedTransport.start(delayedTransportListener);
     this.backoffPolicyProvider = backoffPolicyProvider;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -46,6 +46,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
+import io.grpc.internal.SerializingExecutor.SerializingExecutorFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -98,6 +99,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   private final LoadBalancer.Factory loadBalancerFactory;
   private final ClientTransportFactory transportFactory;
   private final Executor executor;
+  private final SerializingExecutorFactory serializer;
   private final ObjectPool<? extends Executor> executorPool;
   private final ObjectPool<? extends Executor> oobExecutorPool;
   private final LogId logId = LogId.allocate(getClass().getName());
@@ -386,6 +388,8 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     this.executorPool = checkNotNull(builder.executorPool, "executorPool");
     this.oobExecutorPool = checkNotNull(oobExecutorPool, "oobExecutorPool");
     this.executor = checkNotNull(executorPool.getObject(), "executor");
+    this.serializer =
+        SerializingExecutors.wrapFactory(this.executor, 1);
     this.delayedTransport = new DelayedClientTransport(this.executor, this.channelExecutor);
     this.delayedTransport.start(delayedTransportListener);
     this.backoffPolicyProvider = backoffPolicyProvider;
@@ -545,9 +549,11 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(MethodDescriptor<ReqT, RespT> method,
         CallOptions callOptions) {
-      Executor executor = callOptions.getExecutor();
-      if (executor == null) {
-        executor = ManagedChannelImpl.this.executor;
+      SerializingExecutor executor;
+      if (callOptions.getExecutor() != null) {
+        executor = SerializingExecutors.wrap(callOptions.getExecutor());
+      } else {
+        executor = serializer.getExecutor();
       }
       return new ClientCallImpl<ReqT, RespT>(
           method,

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -78,7 +78,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
     this.authority = checkNotNull(authority, "authority");
     this.executorPool = checkNotNull(executorPool, "executorPool");
     this.executor = checkNotNull(executorPool.getObject(), "executor");
-    this.serializer = SerializingExecutors.wrapFactory(executor, 1);
+    this.serializer = SerializingExecutors.wrapFactory(executor);
     this.deadlineCancellationExecutor = checkNotNull(
         deadlineCancellationExecutor, "deadlineCancellationExecutor");
     this.delayedTransport = new DelayedClientTransport(executor, channelExecutor);

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -31,6 +31,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
+import io.grpc.internal.SerializingExecutor.SerializingExecutorFactory;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -56,6 +57,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   private final DelayedClientTransport delayedTransport;
   private final ObjectPool<? extends Executor> executorPool;
   private final Executor executor;
+  private final SerializingExecutorFactory serializer;
   private final ScheduledExecutorService deadlineCancellationExecutor;
   private final CountDownLatch terminatedLatch = new CountDownLatch(1);
   private volatile boolean shutdown;
@@ -76,6 +78,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
     this.authority = checkNotNull(authority, "authority");
     this.executorPool = checkNotNull(executorPool, "executorPool");
     this.executor = checkNotNull(executorPool.getObject(), "executor");
+    this.serializer = SerializingExecutors.wrapFactory(executor, 1);
     this.deadlineCancellationExecutor = checkNotNull(
         deadlineCancellationExecutor, "deadlineCancellationExecutor");
     this.delayedTransport = new DelayedClientTransport(executor, channelExecutor);
@@ -151,9 +154,14 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   @Override
   public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
       MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
-    return new ClientCallImpl<RequestT, ResponseT>(methodDescriptor,
-        callOptions.getExecutor() == null ? executor : callOptions.getExecutor(),
-        callOptions, transportProvider, deadlineCancellationExecutor);
+    return new ClientCallImpl<RequestT, ResponseT>(
+        methodDescriptor,
+        callOptions.getExecutor() == null
+            ? serializer.getExecutor()
+            : SerializingExecutors.wrap(callOptions.getExecutor()),
+        callOptions,
+        transportProvider,
+        deadlineCancellationExecutor);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/SerializeReentrantCallsDirectExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SerializeReentrantCallsDirectExecutor.java
@@ -18,7 +18,6 @@ package io.grpc.internal;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayDeque;
-import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -31,7 +30,9 @@ import java.util.logging.Logger;
  *
  * <p>This class is not thread-safe.
  */
-class SerializeReentrantCallsDirectExecutor implements Executor {
+final class SerializeReentrantCallsDirectExecutor implements SerializingExecutor {
+
+  SerializeReentrantCallsDirectExecutor() {}
 
   private static final Logger log =
       Logger.getLogger(SerializeReentrantCallsDirectExecutor.class.getName());

--- a/core/src/main/java/io/grpc/internal/SerializingExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SerializingExecutor.java
@@ -16,106 +16,25 @@
 
 package io.grpc.internal;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.base.Preconditions;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.annotation.Nullable;
 
 /**
  * Executor ensuring that all {@link Runnable} tasks submitted are executed in order
  * using the provided {@link Executor}, and serially such that no two will ever be
  * running at the same time.
  */
-// TODO(madongfly): figure out a way to not expose it or move it to transport package.
-public final class SerializingExecutor implements Executor, Runnable {
-  private static final Logger log =
-      Logger.getLogger(SerializingExecutor.class.getName());
-
-  private static final AtomicIntegerFieldUpdater<SerializingExecutor> runStateUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(SerializingExecutor.class, "runState");
-  private static final int STOPPED = 0;
-  private static final int RUNNING = -1;
-
-  /** Underlying executor that all submitted Runnable objects are run on. */
-  private final Executor executor;
-
-  /** A list of Runnables to be run in order. */
-  private final Queue<Runnable> runQueue = new ConcurrentLinkedQueue<Runnable>();
-
-  private volatile int runState = STOPPED;
-
-  /**
-   * Creates a SerializingExecutor, running tasks using {@code executor}.
-   *
-   * @param executor Executor in which tasks should be run. Must not be null.
-   */
-  public SerializingExecutor(Executor executor) {
-    Preconditions.checkNotNull(executor, "'executor' must not be null.");
-    this.executor = executor;
-  }
-
+public interface SerializingExecutor extends Executor {
   /**
    * Runs the given runnable strictly after all Runnables that were submitted
    * before it, and using the {@code executor} passed to the constructor.     .
    */
   @Override
-  public void execute(Runnable r) {
-    runQueue.add(checkNotNull(r, "'r' must not be null."));
-    schedule(r);
-  }
+  void execute(Runnable r);
 
-  private void schedule(@Nullable Runnable removable) {
-    if (runStateUpdater.compareAndSet(this, STOPPED, RUNNING)) {
-      boolean success = false;
-      try {
-        executor.execute(this);
-        success = true;
-      } finally {
-        // It is possible that at this point that there are still tasks in
-        // the queue, it would be nice to keep trying but the error may not
-        // be recoverable.  So we update our state and propagate so that if
-        // our caller deems it recoverable we won't be stuck.
-        if (!success) {
-          if (removable != null) {
-            // This case can only be reached if 'this' was not currently running, and we failed to
-            // reschedule.  The item should still be in the queue for removal.
-            // ConcurrentLinkedQueue claims that null elements are not allowed, but seems to not
-            // throw if the item to remove is null.  If removable is present in the queue twice,
-            // the wrong one may be removed.  It doesn't seem possible for this case to exist today.
-            // This is important to run in case of RejectedExectuionException, so that future calls
-            // to execute don't succeed and accidentally run a previous runnable.
-            runQueue.remove(removable);
-          }
-          runStateUpdater.set(this, STOPPED);
-        }
-      }
-    }
-  }
-
-  @Override
-  public void run() {
-    Runnable r;
-    try {
-      while ((r = runQueue.poll()) != null) {
-        try {
-          r.run();
-        } catch (RuntimeException e) {
-          // Log it and keep going.
-          log.log(Level.SEVERE, "Exception while executing runnable " + r, e);
-        }
-      }
-    } finally {
-      runStateUpdater.set(this, STOPPED);
-    }
-    if (!runQueue.isEmpty()) {
-      // we didn't enqueue anything but someone else did.
-      schedule(null);
-    }
+  /**
+   * Returns serializing executors.
+   */
+  interface SerializingExecutorFactory {
+    SerializingExecutor getExecutor();
   }
 }

--- a/core/src/main/java/io/grpc/internal/SerializingExecutors.java
+++ b/core/src/main/java/io/grpc/internal/SerializingExecutors.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.internal.SerializingExecutor.SerializingExecutorFactory;
+import java.util.concurrent.Executor;
+
+/**
+ * Helper class for {@link SerializingExecutor}.
+ */
+public final class SerializingExecutors {
+
+  /**
+   * Creates a serializing executor that executes all runnables on the given delegate.
+   */
+  public static SerializingExecutor wrap(Executor delegate) {
+    if (delegate instanceof SerializingExecutor) {
+      return (SerializingExecutor) delegate;
+    }
+    return wrapFactory(delegate, 1).getExecutor();
+  }
+
+  /**
+   * Creates a serializing executor factory.  The {@link SerializingExecutor}s crated will execute
+   * all runnables on the given delegate.
+   */
+  public static SerializingExecutorFactory wrapFactory(Executor delegate, int shardCount) {
+    // TODO(carl-mastrangelo): implement smarter logic about shard sizing
+    checkNotNull(delegate, "delegate");
+    if (delegate == MoreExecutors.directExecutor()) {
+      return SerializeReentrantCallsDirectExecutorFactory.INSTANCE;
+    }
+    return ShardingSerializingExecutor.newInstance(delegate, shardCount);
+  }
+
+  private SerializingExecutors() {
+    throw new AssertionError();
+  }
+
+  private enum SerializeReentrantCallsDirectExecutorFactory implements SerializingExecutorFactory {
+    INSTANCE;
+
+    @Override
+    public SerializeReentrantCallsDirectExecutor getExecutor() {
+      return new SerializeReentrantCallsDirectExecutor();
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -146,8 +146,7 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
       // Start and wait for any port to actually be bound.
       transportServer.start(new ServerListenerImpl());
       executor = Preconditions.checkNotNull(executorPool.getObject(), "executor");
-      serializer =
-          SerializingExecutors.wrapFactory(executor, 1);
+      serializer = SerializingExecutors.wrapFactory(executor);
       started = true;
       return this;
     }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -41,6 +41,7 @@ import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServerTransportFilter;
 import io.grpc.Status;
+import io.grpc.internal.SerializingExecutor.SerializingExecutorFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -76,6 +77,7 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
   private final ObjectPool<? extends Executor> executorPool;
   /** Executor for application processing. Safe to read after {@link #start()}. */
   private Executor executor;
+  private SerializingExecutorFactory serializer;
   private final InternalHandlerRegistry registry;
   private final HandlerRegistry fallbackRegistry;
   private final List<ServerTransportFilter> transportFilters;
@@ -144,6 +146,8 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
       // Start and wait for any port to actually be bound.
       transportServer.start(new ServerListenerImpl());
       executor = Preconditions.checkNotNull(executorPool.getObject(), "executor");
+      serializer =
+          SerializingExecutors.wrapFactory(executor, 1);
       started = true;
       return this;
     }
@@ -295,6 +299,7 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
         terminated = true;
         if (executor != null) {
           executor = executorPool.returnObject(executor);
+          serializer = null;
         }
         // TODO(carl-mastrangelo): move this outside the synchronized block.
         lock.notifyAll();
@@ -382,15 +387,10 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
           stream.statsTraceContext(), "statsTraceCtx not present from stream");
 
       final Context.CancellableContext context = createContext(stream, headers, statsTraceCtx);
-      final Executor wrappedExecutor;
+      final SerializingExecutor wrappedExecutor;
       // This is a performance optimization that avoids the synchronization and queuing overhead
       // that comes with SerializingExecutor.
-      if (executor == directExecutor()) {
-        wrappedExecutor = new SerializeReentrantCallsDirectExecutor();
-      } else {
-        wrappedExecutor = new SerializingExecutor(executor);
-      }
-
+      wrappedExecutor = serializer.getExecutor();
       final JumpToApplicationThreadServerStreamListener jumpListener
           = new JumpToApplicationThreadServerStreamListener(
               wrappedExecutor, executor, stream, context);
@@ -537,14 +537,14 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
    */
   @VisibleForTesting
   static final class JumpToApplicationThreadServerStreamListener implements ServerStreamListener {
-    private final Executor callExecutor;
+    private final SerializingExecutor callExecutor;
     private final Executor cancelExecutor;
     private final Context.CancellableContext context;
     private final ServerStream stream;
     // Only accessed from callExecutor.
     private ServerStreamListener listener;
 
-    public JumpToApplicationThreadServerStreamListener(Executor executor,
+    public JumpToApplicationThreadServerStreamListener(SerializingExecutor executor,
         Executor cancelExecutor, ServerStream stream, Context.CancellableContext context) {
       this.callExecutor = executor;
       this.cancelExecutor = cancelExecutor;

--- a/core/src/main/java/io/grpc/internal/ShardingSerializingExecutor.java
+++ b/core/src/main/java/io/grpc/internal/ShardingSerializingExecutor.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * Created by notcarl on 9/1/17.
+ */
+final class ShardingSerializingExecutor implements SerializingExecutor.SerializingExecutorFactory {
+  static ShardingSerializingExecutor newInstance(Executor delegate) {
+    return newInstance(delegate, 1);
+  }
+
+  static ShardingSerializingExecutor newInstance(Executor delegate, int shardCount) {
+    return new ShardingSerializingExecutor(delegate, shardCount);
+  }
+
+  private final ThreadLocalShard shardCycler;
+
+  private ShardingSerializingExecutor(Executor delegate, int shardCount) {
+    checkNotNull(delegate, "delegate");
+    checkArgument(shardCount > 0, "Invalid shard count %s", shardCount);
+    SingleSerializingExecutor[] shards = new SingleSerializingExecutor[shardCount];
+    for (int i = 0; i < shardCount; i++) {
+      shards[i] = new SingleSerializingExecutor(delegate);
+    }
+    shardCycler = new ThreadLocalShard(shards);
+  }
+
+  @Override
+  public SingleSerializingExecutor getExecutor() {
+    return shardCycler.getNext();
+  }
+
+  /**
+   * Conveniently avoids boxing (Integer) and synchronization (AtomicInteger).  Also we don't have
+   * to call set on the ThreadLocal.
+   */
+  private static final class Int {
+    int value;
+  }
+
+  private static final class ThreadLocalShard extends ThreadLocal<Int> {
+    private final SingleSerializingExecutor[] shards;
+
+    @Override
+    protected Int initialValue() {
+      return new Int();
+    }
+
+    ThreadLocalShard(SingleSerializingExecutor[] shards) {
+      this.shards = shards;
+    }
+
+    SingleSerializingExecutor getNext() {
+      Int shardIdHolder = get();
+      int shardId = shardIdHolder.value++;
+      if (shardIdHolder.value >= shards.length) {
+        shardIdHolder.value -= shards.length;
+      }
+      return shards[shardId];
+    }
+  }
+
+  @SuppressWarnings("serial")
+  static final class SingleSerializingExecutor extends ConcurrentLinkedQueue<Runnable>
+      implements SerializingExecutor, Runnable {
+    private static final Logger logger =
+        Logger.getLogger(SingleSerializingExecutor.class.getName());
+    private static final AtomicIntegerFieldUpdater<SingleSerializingExecutor> runStateUpdater =
+        AtomicIntegerFieldUpdater.newUpdater(SingleSerializingExecutor.class, "runState");
+    private static final int STOPPED = 0;
+    private static final int RUNNING = -1;
+
+    private final Executor delegate;
+    private volatile int runState;
+
+    SingleSerializingExecutor(Executor delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      add(checkNotNull(command, "command"));
+      schedule(command);
+    }
+
+    void schedule(@Nullable Runnable command) {
+      if (!runStateUpdater.compareAndSet(this, STOPPED, RUNNING)) {
+        return;
+      }
+      boolean executed = false;
+      try {
+        delegate.execute(this);
+        executed = true;
+      } finally {
+        // It is possible that at this point that there are still tasks in
+        // the queue, it would be nice to keep trying but the error may not
+        // be recoverable.  So we update our state and propagate so that if
+        // our caller deems it recoverable we won't be stuck.
+        if (!executed) {
+          if (command != null) {
+            // This case can only be reached if 'this' was not currently running, and we failed to
+            // reschedule.  The item should still be in the queue for removal.
+            // ConcurrentLinkedQueue claims that null elements are not allowed, but seems to not
+            // throw if the item to remove is null.  If removable is present in the queue twice,
+            // the wrong one may be removed.  It doesn't seem possible for this case to exist today.
+            // This is important to run in case of RejectedExectuionException, so that future calls
+            // to execute don't succeed and accidentally run a previous runnable.
+            remove(command);
+          }
+          runStateUpdater.set(this, STOPPED);
+        }
+      }
+    }
+
+    @Override
+    public void run() {
+      Runnable r;
+      try {
+        while ((r = poll()) != null) {
+          try {
+            r.run();
+          } catch (RuntimeException e) {
+            // Log it and keep going.
+            logger.log(Level.SEVERE, "Exception while executing runnable " + r, e);
+          }
+        }
+      } finally {
+        runStateUpdater.set(this, STOPPED);
+      }
+      if (!isEmpty()) {
+        // we didn't enqueue anything but someone else did.
+        schedule(null);
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
+++ b/core/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
@@ -29,6 +29,7 @@ import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.internal.SerializingExecutor;
+import io.grpc.internal.SerializingExecutors;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 
@@ -121,8 +122,8 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
   private static class SerializingServerCall<ReqT, RespT> extends
       ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT> {
     private static final String ERROR_MSG = "Encountered error during serialized access";
-    private final SerializingExecutor serializingExecutor =
-        new SerializingExecutor(MoreExecutors.directExecutor());
+    private final SerializingExecutor executor =
+        SerializingExecutors.wrap(MoreExecutors.directExecutor());
 
     SerializingServerCall(ServerCall<ReqT, RespT> delegate) {
       super(delegate);
@@ -130,7 +131,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
 
     @Override
     public void sendMessage(final RespT message) {
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           SerializingServerCall.super.sendMessage(message);
@@ -140,7 +141,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
 
     @Override
     public void request(final int numMessages) {
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           SerializingServerCall.super.request(numMessages);
@@ -150,7 +151,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
 
     @Override
     public void sendHeaders(final Metadata headers) {
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           SerializingServerCall.super.sendHeaders(headers);
@@ -160,7 +161,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
 
     @Override
     public void close(final Status status, final Metadata trailers) {
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           SerializingServerCall.super.close(status, trailers);
@@ -171,7 +172,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
     @Override
     public boolean isReady() {
       final SettableFuture<Boolean> retVal = SettableFuture.create();
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           retVal.set(SerializingServerCall.super.isReady());
@@ -189,7 +190,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
     @Override
     public boolean isCancelled() {
       final SettableFuture<Boolean> retVal = SettableFuture.create();
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           retVal.set(SerializingServerCall.super.isCancelled());
@@ -206,7 +207,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
 
     @Override
     public void setMessageCompression(final boolean enabled) {
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           SerializingServerCall.super.setMessageCompression(enabled);
@@ -216,7 +217,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
 
     @Override
     public void setCompression(final String compressor) {
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           SerializingServerCall.super.setCompression(compressor);
@@ -227,7 +228,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
     @Override
     public Attributes getAttributes() {
       final SettableFuture<Attributes> retVal = SettableFuture.create();
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           retVal.set(SerializingServerCall.super.getAttributes());
@@ -246,7 +247,7 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
     @Override
     public String getAuthority() {
       final SettableFuture<String> retVal = SettableFuture.create();
-      serializingExecutor.execute(new Runnable() {
+      executor.execute(new Runnable() {
         @Override
         public void run() {
           retVal.set(SerializingServerCall.super.getAuthority());

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.base.Objects;
-import io.grpc.internal.SerializingExecutor;
+import io.grpc.internal.SerializingExecutors;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -140,7 +140,7 @@ public class CallOptionsTest {
   public void toStringMatches_noDeadline_default() {
     String actual = allSet
         .withDeadline(null)
-        .withExecutor(new SerializingExecutor(directExecutor()))
+        .withExecutor(SerializingExecutors.wrap(directExecutor()))
         .withCallCredentials(null)
         .withMaxInboundMessageSize(44)
         .withMaxOutboundMessageSize(55)
@@ -149,7 +149,7 @@ public class CallOptionsTest {
     assertThat(actual).contains("deadline=null");
     assertThat(actual).contains("authority=authority");
     assertThat(actual).contains("callCredentials=null");
-    assertThat(actual).contains("executor=class io.grpc.internal.SerializingExecutor");
+    assertThat(actual).contains("Serializ");
     assertThat(actual).contains("compressorName=compressor");
     assertThat(actual).contains("customOptions=[[option1, value1], [option2, value2]]");
     assertThat(actual).contains("waitForReady=true");

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -63,7 +63,6 @@ import java.io.InputStream;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -266,7 +265,7 @@ public class ClientCallImplTest {
   public void advertisedEncodingsAreSent() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         baseCallOptions,
         provider,
         deadlineCancellationExecutor)
@@ -288,7 +287,7 @@ public class ClientCallImplTest {
   public void authorityPropagatedToStream() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         baseCallOptions.withAuthority("overridden-authority"),
         provider,
         deadlineCancellationExecutor)
@@ -303,7 +302,7 @@ public class ClientCallImplTest {
     final CallOptions callOptions = baseCallOptions.withAuthority("dummy_value");
     final ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         callOptions,
         provider,
         deadlineCancellationExecutor)
@@ -319,7 +318,7 @@ public class ClientCallImplTest {
   public void authorityNotPropagatedToStream() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         // Don't provide an authority
         baseCallOptions,
         provider,
@@ -415,7 +414,7 @@ public class ClientCallImplTest {
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        new SerializingExecutor(Executors.newSingleThreadExecutor()),
+        SerializingExecutors.wrap(Executors.newSingleThreadExecutor()),
         baseCallOptions,
         provider,
         deadlineCancellationExecutor)
@@ -488,7 +487,7 @@ public class ClientCallImplTest {
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        new SerializingExecutor(Executors.newSingleThreadExecutor()),
+        SerializingExecutors.wrap(Executors.newSingleThreadExecutor()),
         baseCallOptions,
         provider,
         deadlineCancellationExecutor)
@@ -516,7 +515,7 @@ public class ClientCallImplTest {
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        new SerializingExecutor(Executors.newSingleThreadExecutor()),
+        SerializingExecutors.wrap(Executors.newSingleThreadExecutor()),
         baseCallOptions,
         provider,
         deadlineCancellationExecutor)
@@ -559,7 +558,7 @@ public class ClientCallImplTest {
     fakeClock.forwardTime(System.nanoTime(), TimeUnit.NANOSECONDS);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        new SerializingExecutor(Executors.newSingleThreadExecutor()),
+        SerializingExecutors.wrap(Executors.newSingleThreadExecutor()),
         callOptions,
         provider,
         deadlineCancellationExecutor)
@@ -581,7 +580,7 @@ public class ClientCallImplTest {
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         baseCallOptions,
         provider,
         deadlineCancellationExecutor);
@@ -608,7 +607,7 @@ public class ClientCallImplTest {
     CallOptions callOpts = baseCallOptions.withDeadlineAfter(2, TimeUnit.SECONDS);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         callOpts,
         provider,
         deadlineCancellationExecutor);
@@ -635,7 +634,7 @@ public class ClientCallImplTest {
     CallOptions callOpts = baseCallOptions.withDeadlineAfter(1, TimeUnit.SECONDS);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         callOpts,
         provider,
         deadlineCancellationExecutor);
@@ -660,7 +659,7 @@ public class ClientCallImplTest {
     // the scheduled cancellation won't be created, and the call will fail early.
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         baseCallOptions.withDeadline(Deadline.after(1, TimeUnit.SECONDS)),
         provider,
         deadlineCancellationExecutor);
@@ -683,7 +682,7 @@ public class ClientCallImplTest {
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         baseCallOptions,
         provider,
         deadlineCancellationExecutor);
@@ -702,7 +701,7 @@ public class ClientCallImplTest {
 
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         baseCallOptions.withDeadline(Deadline.after(1, TimeUnit.SECONDS)),
         provider,
         deadlineCancellationExecutor);
@@ -725,7 +724,7 @@ public class ClientCallImplTest {
   public void timeoutShouldNotBeSet() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         baseCallOptions,
         provider,
         deadlineCancellationExecutor);
@@ -741,7 +740,7 @@ public class ClientCallImplTest {
   public void cancelInOnMessageShouldInvokeStreamCancel() throws Exception {
     final ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        MoreExecutors.directExecutor(),
+        SerializingExecutors.wrap(MoreExecutors.directExecutor()),
         baseCallOptions,
         provider,
         deadlineCancellationExecutor);
@@ -777,7 +776,7 @@ public class ClientCallImplTest {
         baseCallOptions.withMaxInboundMessageSize(1).withMaxOutboundMessageSize(2);
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method,
-        new SerializingExecutor(Executors.newSingleThreadExecutor()),
+        SerializingExecutors.wrap(Executors.newSingleThreadExecutor()),
         callOptions,
         provider,
         deadlineCancellationExecutor)
@@ -792,8 +791,8 @@ public class ClientCallImplTest {
   @Test
   public void getAttributes() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
-        method, MoreExecutors.directExecutor(), baseCallOptions, provider,
-        deadlineCancellationExecutor);
+        method, SerializingExecutors.wrap(MoreExecutors.directExecutor()), baseCallOptions,
+        provider, deadlineCancellationExecutor);
     Attributes attrs =
         Attributes.newBuilder().set(Key.<String>of("fake key"), "fake value").build();
     when(stream.getAttributes()).thenReturn(attrs);
@@ -810,7 +809,7 @@ public class ClientCallImplTest {
     assertTrue("timeout: " + timeout + " ns", timeout >= from);
   }
 
-  private static final class DelayedExecutor implements Executor {
+  private static final class DelayedExecutor implements SerializingExecutor {
     private final BlockingQueue<Runnable> commands = new LinkedBlockingQueue<Runnable>();
 
     @Override

--- a/core/src/test/java/io/grpc/internal/SerializingExecutorTest.java
+++ b/core/src/test/java/io/grpc/internal/SerializingExecutorTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 import com.google.common.util.concurrent.MoreExecutors;
-import io.grpc.internal.ShardingSerializingExecutor.SingleSerializingExecutor;
+import io.grpc.internal.SerializingExecutorFab.SingleSerializingExecutor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/core/src/test/java/io/grpc/internal/SerializingExecutorTest.java
+++ b/core/src/test/java/io/grpc/internal/SerializingExecutorTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.internal.ShardingSerializingExecutor.SingleSerializingExecutor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,7 +35,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class SerializingExecutorTest {
   private SingleExecutor singleExecutor = new SingleExecutor();
-  private SerializingExecutor executor = new SerializingExecutor(singleExecutor);
+  private SerializingExecutor executor = new SingleSerializingExecutor(singleExecutor);
   private List<Integer> runs = new ArrayList<Integer>();
 
   private class AddToRuns implements Runnable {
@@ -65,7 +66,7 @@ public class SerializingExecutorTest {
       }
     }
 
-    executor = new SerializingExecutor(new CoyExecutor());
+    executor = new SingleSerializingExecutor(new CoyExecutor());
     try {
       executor.execute(new AddToRuns(1));
       fail();
@@ -166,7 +167,7 @@ public class SerializingExecutorTest {
         throw ex;
       }
     });
-    executor = new SerializingExecutor(forwardingExecutor);
+    executor = new SingleSerializingExecutor(forwardingExecutor);
     try {
       executor.execute(new AddToRuns(1));
       fail("expected exception");
@@ -185,7 +186,7 @@ public class SerializingExecutorTest {
 
   @Test
   public void direct() {
-    executor = new SerializingExecutor(MoreExecutors.directExecutor());
+    executor = new SingleSerializingExecutor(MoreExecutors.directExecutor());
     executor.execute(new AddToRuns(1));
     assertEquals(Arrays.asList(1), runs);
     executor.execute(new AddToRuns(2));
@@ -196,7 +197,7 @@ public class SerializingExecutorTest {
 
   @Test
   public void testDirectReentrant() {
-    executor = new SerializingExecutor(MoreExecutors.directExecutor());
+    executor = new SingleSerializingExecutor(MoreExecutors.directExecutor());
     executor.execute(new Runnable() {
       @Override
       public void run() {

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1020,7 +1020,7 @@ public class ServerImplTest {
   public void messageRead_errorCancelsCall() throws Exception {
     JumpToApplicationThreadServerStreamListener listener
         = new JumpToApplicationThreadServerStreamListener(
-            executor.getScheduledExecutorService(),
+        SerializingExecutors.wrap(executor.getScheduledExecutorService()),
             executor.getScheduledExecutorService(),
             stream,
             Context.ROOT.withCancellation());
@@ -1045,14 +1045,14 @@ public class ServerImplTest {
   public void messageRead_runtimeExceptionCancelsCall() throws Exception {
     JumpToApplicationThreadServerStreamListener listener
         = new JumpToApplicationThreadServerStreamListener(
-            executor.getScheduledExecutorService(),
+            SerializingExecutors.wrap(executor.getScheduledExecutorService()),
             executor.getScheduledExecutorService(),
             stream,
             Context.ROOT.withCancellation());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
-    Throwable expectedT = new RuntimeException();
+    Throwable expectedT = new Error("expected");
     doThrow(expectedT).when(mockListener)
         .messagesAvailable(any(StreamListener.MessageProducer.class));
     // Closing the InputStream is done by the delegated listener (generally ServerCallImpl)
@@ -1070,7 +1070,7 @@ public class ServerImplTest {
   public void halfClosed_errorCancelsCall() {
     JumpToApplicationThreadServerStreamListener listener
         = new JumpToApplicationThreadServerStreamListener(
-            executor.getScheduledExecutorService(),
+        SerializingExecutors.wrap(executor.getScheduledExecutorService()),
             executor.getScheduledExecutorService(),
             stream,
             Context.ROOT.withCancellation());
@@ -1093,14 +1093,14 @@ public class ServerImplTest {
   public void halfClosed_runtimeExceptionCancelsCall() {
     JumpToApplicationThreadServerStreamListener listener
         = new JumpToApplicationThreadServerStreamListener(
-            executor.getScheduledExecutorService(),
+            SerializingExecutors.wrap(executor.getScheduledExecutorService()),
             executor.getScheduledExecutorService(),
             stream,
             Context.ROOT.withCancellation());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
-    Throwable expectedT = new RuntimeException();
+    Throwable expectedT = new Error("Expected");
     doThrow(expectedT).when(mockListener).halfClosed();
     listener.halfClosed();
     try {
@@ -1116,7 +1116,7 @@ public class ServerImplTest {
   public void onReady_errorCancelsCall() {
     JumpToApplicationThreadServerStreamListener listener
         = new JumpToApplicationThreadServerStreamListener(
-            executor.getScheduledExecutorService(),
+            SerializingExecutors.wrap(executor.getScheduledExecutorService()),
             executor.getScheduledExecutorService(),
             stream,
             Context.ROOT.withCancellation());
@@ -1139,14 +1139,14 @@ public class ServerImplTest {
   public void onReady_runtimeExceptionCancelsCall() {
     JumpToApplicationThreadServerStreamListener listener
         = new JumpToApplicationThreadServerStreamListener(
-            executor.getScheduledExecutorService(),
+            SerializingExecutors.wrap(executor.getScheduledExecutorService()),
             executor.getScheduledExecutorService(),
             stream,
             Context.ROOT.withCancellation());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
-    Throwable expectedT = new RuntimeException();
+    Throwable expectedT = new Error("Expected");
     doThrow(expectedT).when(mockListener).onReady();
     listener.onReady();
     try {

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -71,7 +71,7 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.ObjectPool;
-import io.grpc.internal.SerializingExecutor;
+import io.grpc.internal.SerializingExecutors;
 import io.grpc.stub.StreamObserver;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -80,6 +80,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
@@ -125,8 +126,8 @@ public class GrpclbLoadBalancerTest {
   private io.grpc.Server fakeLbServer;
   @Captor
   private ArgumentCaptor<SubchannelPicker> pickerCaptor;
-  private final SerializingExecutor channelExecutor =
-      new SerializingExecutor(MoreExecutors.directExecutor());
+  private final Executor channelExecutor =
+      SerializingExecutors.wrap(MoreExecutors.directExecutor());
   @Mock
   private LoadBalancer.Factory pickFirstBalancerFactory;
   @Mock

--- a/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/AsyncFrameWriter.java
@@ -17,7 +17,6 @@
 package io.grpc.okhttp;
 
 import com.google.common.base.Preconditions;
-import io.grpc.internal.SerializingExecutor;
 import io.grpc.okhttp.internal.framed.ErrorCode;
 import io.grpc.okhttp.internal.framed.FrameWriter;
 import io.grpc.okhttp.internal.framed.Header;
@@ -25,6 +24,7 @@ import io.grpc.okhttp.internal.framed.Settings;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import okio.Buffer;
@@ -35,10 +35,10 @@ class AsyncFrameWriter implements FrameWriter {
   private Socket socket;
   // Although writes are thread-safe, we serialize them to prevent consuming many Threads that are
   // just waiting on each other.
-  private final SerializingExecutor executor;
+  private final Executor executor;
   private final OkHttpClientTransport transport;
 
-  public AsyncFrameWriter(OkHttpClientTransport transport, SerializingExecutor executor) {
+  public AsyncFrameWriter(OkHttpClientTransport transport, Executor executor) {
     this.transport = transport;
     this.executor = executor;
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -43,6 +43,7 @@ import io.grpc.internal.KeepAliveManager;
 import io.grpc.internal.KeepAliveManager.ClientKeepAlivePinger;
 import io.grpc.internal.LogId;
 import io.grpc.internal.SerializingExecutor;
+import io.grpc.internal.SerializingExecutors;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.okhttp.internal.ConnectionSpec;
@@ -192,7 +193,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     this.defaultAuthority = authority;
     this.maxMessageSize = maxMessageSize;
     this.executor = Preconditions.checkNotNull(executor, "executor");
-    serializingExecutor = new SerializingExecutor(executor);
+    serializingExecutor = SerializingExecutors.wrap(executor);
     // Client initiated streams are odd, server initiated ones are even. Server should not need to
     // use it. We start clients at 3 to avoid conflicting with HTTP negotiation.
     nextStreamId = 3;
@@ -221,7 +222,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     defaultAuthority = "notarealauthority:80";
     this.userAgent = GrpcUtil.getGrpcUserAgent("okhttp", userAgent);
     this.executor = Preconditions.checkNotNull(executor, "executor");
-    serializingExecutor = new SerializingExecutor(executor);
+    serializingExecutor = SerializingExecutors.wrap(executor);
     this.testFrameReader = Preconditions.checkNotNull(frameReader, "frameReader");
     this.testFrameWriter = Preconditions.checkNotNull(testFrameWriter, "testFrameWriter");
     this.socket = Preconditions.checkNotNull(socket, "socket");

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -29,12 +29,12 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
+import io.grpc.internal.SerializingExecutor;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
@@ -574,7 +574,7 @@ public final class ClientCalls {
     }
   }
 
-  private static final class ThreadlessExecutor implements Executor {
+  private static final class ThreadlessExecutor implements SerializingExecutor {
     private static final Logger log = Logger.getLogger(ThreadlessExecutor.class.getName());
 
     private final BlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>();
@@ -585,7 +585,7 @@ public final class ClientCalls {
     /**
      * Waits until there is a Runnable, then executes it and all queued Runnables after it.
      */
-    public void waitAndDrain() throws InterruptedException {
+    void waitAndDrain() throws InterruptedException {
       Runnable runnable = queue.take();
       while (runnable != null) {
         try {


### PR DESCRIPTION
Motivation:
Today: each Call is passed an Executor to run its callbacks on.
This executor is wrapped in a SerializingExecutor (SE) which ensures
all callbacks happen in a serial fashion, and on the provded
executor.

This has a number of drawbacks, in that each SE has to maintain its
own queue of runnables, and is likely to schedule work on an idle
Executor thread.

Additionally, the SE API doesn't lend itself to reuse, notably in
that it doesn't handle direct executors well.

Modification:

* SE has been split into a shard called a SingleSerializingExecutor
* SE is now an interface that extends Executor.
* A new class ShardingSerializingExecutor shards access to
  SingleSerializingExecutor
* A new SerializingExecutors class is responsible for construction,
  including returning the proper type for direct executors.
* ManagedChannelImpl and ServerImpl now have a single sharded SE
  (called a SerializingExecutorFactory) which doles out SE.

Alternatives Considered:

Sharding inside the old SE has some problems.  It is specific to
an executor, so it can't share queues globally.  Effectively this
means each executor has to have its own sharded queues.

SE Was a class, but now it is an interface.  Callers of new SE()
always had to get the top level implementation, and there was no
room for returning a more specific type.  It also doesn't lend
itself to reusing itself.  Making SE an abstract class forces
an implementation, but it may be inconvenient to use.  Since
Executor is an interface SE should be one too.

Learning from the API design of ManagedChannel.builder(), the
factory for SEs is not on the SE class itself, but on a side
class.  This avoids child classes inheriting a constructor that
is not applicable.

The default sharding amount is 1 instead of num processors.
As the number of queues increases, performance gets worse.
1 is not the right number because none of our benchmarks
test when under high application load.  Clients with high load
will need to create multiple channels with this currently.

Results:
Overall performance is slightly better, with some benchmarks
being a wash.

* The TransportBenchmark suite, which measures
  blocking stub latency is mostly a wash.  This is because
  blocking stubs use their own Threadless executor, forcing a new
  SE each time.  This is unfortunate, but can be fixed in the
  future.

* The QpsClient and QpsServer benchmarks show noticeable gain,
  improving throughput and latency considerably.  I ran the
  benchmarks alternativingly a few times to make sure they
  were not a fluke.  The gain here is due to the callbacks
  ending up on the same queue.  I believe this results in less
  thread contention.

* FlowControlledMessagesPerSecond is a minor bit better for the
  new implementation.

Data:
```
BEFORE:
Benchmark                                               (direct)  (transport)    Mode      Cnt         Score     Error  Units
TransportBenchmark.unaryCall1024                            true    INPROCESS  sample  1162772      4382.065 ±  18.697  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true    INPROCESS  sample               1714.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true    INPROCESS  sample               4176.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true    INPROCESS  sample               5040.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true    INPROCESS  sample               5328.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true    INPROCESS  sample               9700.320            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true    INPROCESS  sample              18016.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true    INPROCESS  sample              62620.506            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true    INPROCESS  sample            3448832.000            ns/op
TransportBenchmark.unaryCall1024                            true        NETTY  sample   577543     69197.871 ± 281.233  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true        NETTY  sample              57664.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true        NETTY  sample              65152.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true        NETTY  sample              80128.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true        NETTY  sample              87552.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true        NETTY  sample             100480.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true        NETTY  sample             140032.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true        NETTY  sample             693642.854            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true        NETTY  sample           23920640.000            ns/op
TransportBenchmark.unaryCall1024                            true  NETTY_LOCAL  sample   748664     53346.942 ± 115.913  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true  NETTY_LOCAL  sample              38592.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true  NETTY_LOCAL  sample              50944.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true  NETTY_LOCAL  sample              61440.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true  NETTY_LOCAL  sample              66688.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true  NETTY_LOCAL  sample              79104.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true  NETTY_LOCAL  sample             110762.880            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true  NETTY_LOCAL  sample             405914.112            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true  NETTY_LOCAL  sample           11845632.000            ns/op
TransportBenchmark.unaryCall1024                            true       OKHTTP  sample   610687     65406.705 ± 268.297  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true       OKHTTP  sample              53056.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true       OKHTTP  sample              62848.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true       OKHTTP  sample              73856.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true       OKHTTP  sample              79488.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true       OKHTTP  sample              97152.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true       OKHTTP  sample             132943.872            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true       OKHTTP  sample             399219.098            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true       OKHTTP  sample           26705920.000            ns/op
TransportBenchmark.unaryCall1024                           false    INPROCESS  sample  1220966      8209.184 ±  27.438  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false    INPROCESS  sample               3576.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false    INPROCESS  sample               7704.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false    INPROCESS  sample              10656.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false    INPROCESS  sample              10992.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false    INPROCESS  sample              13104.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false    INPROCESS  sample              25952.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false    INPROCESS  sample              82419.622            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false    INPROCESS  sample            4243456.000            ns/op
TransportBenchmark.unaryCall1024                           false        NETTY  sample   475120     84078.144 ± 339.944  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false        NETTY  sample              63808.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false        NETTY  sample              79744.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false        NETTY  sample              95232.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false        NETTY  sample             102272.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false        NETTY  sample             118784.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false        NETTY  sample             166625.024            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false        NETTY  sample            1141735.219            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false        NETTY  sample           23822336.000            ns/op
TransportBenchmark.unaryCall1024                           false  NETTY_LOCAL  sample   589551     67751.608 ±  94.927  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false  NETTY_LOCAL  sample              45184.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false  NETTY_LOCAL  sample              64704.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false  NETTY_LOCAL  sample              76800.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false  NETTY_LOCAL  sample              81536.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false  NETTY_LOCAL  sample              96640.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false  NETTY_LOCAL  sample             147314.688            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false  NETTY_LOCAL  sample            1132635.750            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false  NETTY_LOCAL  sample            4440064.000            ns/op
TransportBenchmark.unaryCall1024                           false       OKHTTP  sample   489258     81651.028 ± 339.245  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false       OKHTTP  sample              59136.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false       OKHTTP  sample              78848.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false       OKHTTP  sample              91136.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false       OKHTTP  sample              96896.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false       OKHTTP  sample             114304.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false       OKHTTP  sample             156672.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false       OKHTTP  sample            1136791.757            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false       OKHTTP  sample           25788416.000            ns/op

AFTER:

TransportBenchmark.unaryCall1024                            true    INPROCESS  sample  1052629      5037.509 ±  336.117  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true    INPROCESS  sample               1724.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true    INPROCESS  sample               4352.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true    INPROCESS  sample               5216.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true    INPROCESS  sample               5448.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true    INPROCESS  sample              11136.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true    INPROCESS  sample              19831.680             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true    INPROCESS  sample              74300.672             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true    INPROCESS  sample           32014336.000             ns/op
TransportBenchmark.unaryCall1024                            true        NETTY  sample   579150     68968.436 ±  300.382  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true        NETTY  sample              55360.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true        NETTY  sample              63424.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true        NETTY  sample              80512.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true        NETTY  sample              88320.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true        NETTY  sample              99328.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true        NETTY  sample             159961.344             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true        NETTY  sample            1749339.750             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true        NETTY  sample           15482880.000             ns/op
TransportBenchmark.unaryCall1024                            true  NETTY_LOCAL  sample   712680     52533.468 ±  270.518  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true  NETTY_LOCAL  sample              38080.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true  NETTY_LOCAL  sample              49856.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true  NETTY_LOCAL  sample              61696.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true  NETTY_LOCAL  sample              67712.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true  NETTY_LOCAL  sample              80512.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true  NETTY_LOCAL  sample             117928.832             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true  NETTY_LOCAL  sample             844489.523             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true  NETTY_LOCAL  sample           49217536.000             ns/op
TransportBenchmark.unaryCall1024                            true       OKHTTP  sample   615898     64844.861 ±  276.037  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true       OKHTTP  sample              51840.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true       OKHTTP  sample              61376.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true       OKHTTP  sample              72576.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true       OKHTTP  sample              77952.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true       OKHTTP  sample              94080.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true       OKHTTP  sample             140569.856             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true       OKHTTP  sample            2522399.539             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true       OKHTTP  sample           14548992.000             ns/op
TransportBenchmark.unaryCall1024                           false    INPROCESS  sample   972517     10536.111 ±  350.760  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false    INPROCESS  sample               4144.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false    INPROCESS  sample               9984.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false    INPROCESS  sample              10912.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false    INPROCESS  sample              11392.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false    INPROCESS  sample              14064.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false    INPROCESS  sample              24736.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false    INPROCESS  sample             105758.387             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false    INPROCESS  sample           36634624.000             ns/op
TransportBenchmark.unaryCall1024                           false        NETTY  sample   432355     92429.816 ± 2968.356  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false        NETTY  sample              64320.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false        NETTY  sample              80896.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false        NETTY  sample              96896.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false        NETTY  sample             103680.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false        NETTY  sample             120832.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false        NETTY  sample             228864.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false        NETTY  sample           48893630.874             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false        NETTY  sample           65208320.000             ns/op
TransportBenchmark.unaryCall1024                           false  NETTY_LOCAL  sample   598409     66740.930 ±  440.637  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false  NETTY_LOCAL  sample              41088.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false  NETTY_LOCAL  sample              63424.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false  NETTY_LOCAL  sample              75392.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false  NETTY_LOCAL  sample              80000.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false  NETTY_LOCAL  sample              94848.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false  NETTY_LOCAL  sample             144384.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false  NETTY_LOCAL  sample            1324490.752             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false  NETTY_LOCAL  sample           42270720.000             ns/op
TransportBenchmark.unaryCall1024                           false       OKHTTP  sample   492127     81150.320 ±  301.044  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false       OKHTTP  sample              59456.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false       OKHTTP  sample              77952.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false       OKHTTP  sample              89728.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false       OKHTTP  sample              95744.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false       OKHTTP  sample             114816.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false       OKHTTP  sample             182784.000             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false       OKHTTP  sample            1817316.557             ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false       OKHTTP  sample           14532608.000             ns/op
```

```
BEFORE:

Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     361
90%ile Latency (in micros):     531
95%ile Latency (in micros):     623
99%ile Latency (in micros):     6879
99.9%ile Latency (in micros):   20095
Maximum Latency (in micros):    45311
QPS:                            73784

Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     361
90%ile Latency (in micros):     531
95%ile Latency (in micros):     619
99%ile Latency (in micros):     6719
99.9%ile Latency (in micros):   19711
Maximum Latency (in micros):    54015
QPS:                            74344

AFTER:
Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     281
90%ile Latency (in micros):     405
95%ile Latency (in micros):     465
99%ile Latency (in micros):     1207
99.9%ile Latency (in micros):   13823
Maximum Latency (in micros):    38143
QPS:                            111316

Channels:                       4
Outstanding RPCs per Channel:   10
Server Payload Size:            0
Client Payload Size:            0
50%ile Latency (in micros):     297
90%ile Latency (in micros):     467
95%ile Latency (in micros):     563
99%ile Latency (in micros):     2175
99.9%ile Latency (in micros):   15615
Maximum Latency (in micros):    49407
QPS:                            98800
```

```
BEFORE:
Benchmark                                                          (channelCount)  (clientExecutor)  (maxConcurrentStreams)  (responseSize)   Mode  Cnt        Score        Error  Units
FlowControlledMessagesPerSecondBenchmark.stream                                 1           DEFAULT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1           DEFAULT                       1           SMALL  thrpt   10   836926.126 ±  37325.889  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1           DEFAULT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1           DEFAULT                       2           SMALL  thrpt   10  1038438.240 ±  23987.448  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1           DEFAULT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1           DEFAULT                      10           SMALL  thrpt   10   848017.112 ±  20462.715  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1           DEFAULT                     100           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1           DEFAULT                     100           SMALL  thrpt   10   777973.732 ±  58326.693  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1            DIRECT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1            DIRECT                       1           SMALL  thrpt   10  1173102.184 ±  40087.200  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1            DIRECT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1            DIRECT                       2           SMALL  thrpt   10  1152203.641 ±  13516.780  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1            DIRECT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1            DIRECT                      10           SMALL  thrpt   10   993182.123 ±  49876.452  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1            DIRECT                     100           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1            DIRECT                     100           SMALL  thrpt   10  1081992.732 ±  51614.425  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2           DEFAULT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2           DEFAULT                       1           SMALL  thrpt   10  1589971.638 ±  47901.330  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2           DEFAULT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2           DEFAULT                       2           SMALL  thrpt   10  1675435.939 ±  59385.773  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2           DEFAULT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2           DEFAULT                      10           SMALL  thrpt   10  1176380.631 ±  56091.716  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2           DEFAULT                     100           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2           DEFAULT                     100           SMALL  thrpt   10          ≈ 0               ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2            DIRECT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2            DIRECT                       1           SMALL  thrpt   10  2077354.783 ±  56919.818  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2            DIRECT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2            DIRECT                       2           SMALL  thrpt   10  2165691.307 ±  59173.049  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2            DIRECT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2            DIRECT                      10           SMALL  thrpt   10  2048490.681 ±  82441.929  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2            DIRECT                     100           SMALL  thrpt   10        0.999 ±      0.002  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2            DIRECT                     100           SMALL  thrpt   10  1550338.296 ± 109440.758  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4           DEFAULT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                       1           SMALL  thrpt   10  1952956.572 ± 332496.832  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4           DEFAULT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                       2           SMALL  thrpt   10  1894090.467 ±  90412.925  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4           DEFAULT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                      10           SMALL  thrpt   10  1929209.239 ±  87914.837  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4           DEFAULT                     100           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                     100           SMALL  thrpt   10          ≈ 0               ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4            DIRECT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4            DIRECT                       1           SMALL  thrpt   10  3489687.907 ± 178412.887  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4            DIRECT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4            DIRECT                       2           SMALL  thrpt   10  3340750.767 ± 107585.155  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4            DIRECT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4            DIRECT                      10           SMALL  thrpt   10  2822271.940 ±  66783.906  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4            DIRECT                     100           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4            DIRECT                     100           SMALL  thrpt   10          ≈ 0               ops/s

AFTER:
Benchmark                                                          (channelCount)  (clientExecutor)  (maxConcurrentStreams)  (responseSize)   Mode  Cnt        Score        Error  Units
FlowControlledMessagesPerSecondBenchmark.stream                                 1           DEFAULT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1           DEFAULT                       1           SMALL  thrpt   10   854933.621 ±  36829.422  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1           DEFAULT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1           DEFAULT                       2           SMALL  thrpt   10  1039770.629 ±  30081.341  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1           DEFAULT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1           DEFAULT                      10           SMALL  thrpt   10   875908.179 ±  13283.306  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1           DEFAULT                     100           SMALL  thrpt   10        0.998 ±      0.003  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1           DEFAULT                     100           SMALL  thrpt   10   966476.024 ±  40312.336  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1            DIRECT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1            DIRECT                       1           SMALL  thrpt   10  1201733.191 ±   8039.578  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1            DIRECT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1            DIRECT                       2           SMALL  thrpt   10  1135974.782 ±  22161.114  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1            DIRECT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1            DIRECT                      10           SMALL  thrpt   10  1061129.874 ±  14442.914  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 1            DIRECT                     100           SMALL  thrpt   10        0.998 ±      0.002  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               1            DIRECT                     100           SMALL  thrpt   10  1050694.293 ±  12563.958  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2           DEFAULT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2           DEFAULT                       1           SMALL  thrpt   10  1555819.717 ±  75132.696  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2           DEFAULT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2           DEFAULT                       2           SMALL  thrpt   10  1648740.360 ±  39067.363  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2           DEFAULT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2           DEFAULT                      10           SMALL  thrpt   10  1241265.159 ±  33179.396  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2           DEFAULT                     100           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2           DEFAULT                     100           SMALL  thrpt   10          ≈ 0               ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2            DIRECT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2            DIRECT                       1           SMALL  thrpt   10  2060682.536 ±  43205.112  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2            DIRECT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2            DIRECT                       2           SMALL  thrpt   10  2116217.306 ±  54807.759  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2            DIRECT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2            DIRECT                      10           SMALL  thrpt   10  2079996.980 ±  35148.801  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 2            DIRECT                     100           SMALL  thrpt   10        0.997 ±      0.008  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               2            DIRECT                     100           SMALL  thrpt   10  1602008.434 ±  43970.690  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4           DEFAULT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                       1           SMALL  thrpt   10  2210499.121 ±  36840.014  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4           DEFAULT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                       2           SMALL  thrpt   10  2070729.378 ±  65754.428  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4           DEFAULT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                      10           SMALL  thrpt   10  1977264.163 ±  77159.763  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4           DEFAULT                     100           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4           DEFAULT                     100           SMALL  thrpt   10          ≈ 0               ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4            DIRECT                       1           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4            DIRECT                       1           SMALL  thrpt   10  3452144.953 ±  78522.679  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4            DIRECT                       2           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4            DIRECT                       2           SMALL  thrpt   10  3333460.281 ± 149099.559  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4            DIRECT                      10           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4            DIRECT                      10           SMALL  thrpt   10  2937942.365 ± 121378.372  ops/s
FlowControlledMessagesPerSecondBenchmark.stream                                 4            DIRECT                     100           SMALL  thrpt   10        0.999 ±      0.001  ops/s
FlowControlledMessagesPerSecondBenchmark.stream:messagesPerSecond               4            DIRECT                     100           SMALL  thrpt   10          ≈ 0               ops/s
```