### PR TITLE
protobuf-nano: do not use preexisting IoUtils internal class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -344,7 +344,7 @@ subprojects {
             }
         }
         if (!(project.name in
-            ["grpc-stub", "grpc-protobuf", "grpc-protobuf-lite", "grpc-thrift"])) {
+            ["grpc-stub", "grpc-protobuf", "grpc-protobuf-lite", "grpc-protobuf-nano", "grpc-thrift"])) {
           def core = pom.dependencies.find {dep -> dep.artifactId == 'grpc-core'}
           if (core != null) {
             // Depend on specific version of grpc-core because internal package is unstable

--- a/protobuf-nano/src/main/java/io/grpc/protobuf/nano/NanoUtils.java
+++ b/protobuf-nano/src/main/java/io/grpc/protobuf/nano/NanoUtils.java
@@ -16,14 +16,16 @@
 
 package io.grpc.protobuf.nano;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.protobuf.nano.CodedInputByteBufferNano;
 import com.google.protobuf.nano.MessageNano;
 import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.Status;
-import io.grpc.internal.IoUtils;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Utility methods for using nano proto with grpc.
@@ -48,7 +50,7 @@ public class NanoUtils {
         try {
           // TODO(simonma): Investigate whether we can do 0-copy here. 
           CodedInputByteBufferNano input =
-              CodedInputByteBufferNano.newInstance(IoUtils.toByteArray(stream));
+              CodedInputByteBufferNano.newInstance(toByteArray(stream));
           input.setSizeLimit(Integer.MAX_VALUE);
           T message = factory.newInstance();
           message.mergeFrom(input);
@@ -59,5 +61,29 @@ public class NanoUtils {
         }
       }
     };
+  }
+
+  // Copied from guava com.google.common.io.ByteStreams because its API is unstable (beta)
+  private static byte[] toByteArray(InputStream in) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    copy(in, out);
+    return out.toByteArray();
+  }
+
+  // Copied from guava com.google.common.io.ByteStreams because its API is unstable (beta)
+  private static long copy(InputStream from, OutputStream to) throws IOException {
+    checkNotNull(from);
+    checkNotNull(to);
+    byte[] buf = new byte[BUF_SIZE];
+    long total = 0;
+    while (true) {
+      int r = from.read(buf);
+      if (r == -1) {
+        break;
+      }
+      to.write(buf, 0, r);
+      total += r;
+    }
+    return total;
   }
 }


### PR DESCRIPTION
This reverts commit 671783f912539b41450117a6c81e1009fde5471d

The dependency on `core` caused some problems with
Proguard. There are android builds that should include
`protobuf-*` but expect the rest of gRPC to be bundled with the
runtime environment. In that case, when Proguard inspects the
output, it will find a reference to IoUtil but fail to find the
class itself. It makes the builds easier to just avoid this
dependency.
