### PR TITLE
core: add finalizer checks for ManagedChannels

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -589,6 +589,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       logger.log(Level.FINE, "[{0}] Terminated", getLogId());
       terminated = true;
       phantom.terminated = true;
+      phantom.clear();
       terminatedLatch.countDown();
       executorPool.returnObject(executor);
       // Release the transport factory so that it can deallocate any resources.
@@ -996,12 +997,18 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       cleanQueue();
     }
 
+    @Override
+    public void clear() {
+      super.clear();
+      refs.remove(this);
+    }
+
     @VisibleForTesting
     static int cleanQueue() {
       ManagedChannelPhantom ref;
       int orphanedChannels = 0;
       while ((ref = (ManagedChannelPhantom) refQueue.poll()) != null) {
-        refs.remove(ref);
+        ref.clear(); // technically the reference is gone already.
         if (!(ref.shutdown && ref.terminated)) {
           orphanedChannels++;
           String fmt = new StringBuilder()

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -16,6 +16,8 @@
 
 package io.grpc.internal;
 
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
@@ -85,6 +87,10 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Filter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -117,6 +123,7 @@ public class ManagedChannelImplTest {
           .build();
   private static final Attributes.Key<String> SUBCHANNEL_ATTR_KEY =
       Attributes.Key.of("subchannel-attr-key");
+  private static int unterminatedChannels;
   private final String serviceName = "fake.example.com";
   private final String authority = serviceName;
   private final String userAgent = "userAgent";
@@ -201,6 +208,7 @@ public class ManagedChannelImplTest {
         .userAgent(userAgent);
     builder.executorPool = executorPool;
     builder.idleTimeoutMillis = idleTimeoutMillis;
+    checkState(channel == null);
     channel = new ManagedChannelImpl(
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         oobExecutorPool, timer.getStopwatchSupplier(), interceptors);
@@ -238,6 +246,18 @@ public class ManagedChannelImplTest {
     // would ignore any time-sensitive tasks, e.g., back-off and the idle timer.
     assertTrue(timer.getDueTasks() + " should be empty", timer.getDueTasks().isEmpty());
     assertEquals(executor.getPendingTasks() + " should be empty", 0, executor.numPendingTasks());
+    helper = null; // helper retains a ref to the channel
+    if (channel != null) {
+      channel.shutdownNow();
+      if (!channel.isTerminated()) {
+        // Since there are no real transports in this test, if shutdownNow doesn't result in
+        // termination, then it will never happen.  It would be very cumbersome to make all the
+        // tests in this file clean up fully after themselves, so instead just keep track of how
+        // many don't.  This is used to see how many should be ignored in the phantom cleanup.
+        unterminatedChannels++;
+      }
+      channel = null;
+    }
   }
 
   @Test
@@ -482,6 +502,15 @@ public class ManagedChannelImplTest {
     verify(mockCallListener, never()).onClose(same(Status.CANCELLED), same(trailers));
     assertEquals(1, callExecutor.runDueTasks());
     verify(mockCallListener).onClose(same(Status.CANCELLED), same(trailers));
+
+
+    transportListener.transportShutdown(Status.UNAVAILABLE);
+    transportListener.transportTerminated();
+
+    // Clean up as much as possible to allow the channel to terminate.
+    subchannel.shutdown();
+    timer.forwardNanos(
+        TimeUnit.SECONDS.toNanos(ManagedChannelImpl.SUBCHANNEL_SHUTDOWN_DELAY_SECONDS));
   }
 
   @Test
@@ -757,6 +786,13 @@ public class ManagedChannelImplTest {
 
     sub2.shutdown();
     verify(transportInfo2.transport).shutdown(same(ManagedChannelImpl.SHUTDOWN_STATUS));
+
+    // Cleanup
+    transportInfo1.listener.transportShutdown(Status.UNAVAILABLE);
+    transportInfo1.listener.transportTerminated();
+    transportInfo2.listener.transportShutdown(Status.UNAVAILABLE);
+    transportInfo2.listener.transportTerminated();
+    timer.forwardTime(ManagedChannelImpl.SUBCHANNEL_SHUTDOWN_DELAY_SECONDS, TimeUnit.SECONDS);
   }
 
   @Test
@@ -1370,6 +1406,71 @@ public class ManagedChannelImplTest {
     assertEquals(IDLE, channel.getState(false));
     executor.runDueTasks();
     verify(onStateChanged, never()).run();
+  }
+
+  @Test
+  public void orphanedChannelsAreLogged() throws Exception {
+    int remaining = unterminatedChannels;
+    for (int retry = 0; retry < 3; retry++) {
+      System.gc();
+      if ((remaining -= ManagedChannelImpl.ManagedChannelPhantom.cleanQueue()) <= 0) {
+        break;
+      }
+      Thread.sleep(100L * (1L << retry));
+    }
+    assertThat(remaining).isAtMost(0);
+
+    createChannel(
+        new FakeNameResolverFactory(true),
+        NO_INTERCEPTOR,
+        false, // Don't create a transport, Helper maintains a ref to the channel.
+        ManagedChannelImpl.IDLE_TIMEOUT_MILLIS_DISABLE);
+    assertNotNull(channel);
+    LogId logId = channel.getLogId();
+
+    // Try to capture the log output but without causing terminal noise.  Adding the filter must
+    // be done before clearing the ref or else it might be missed.
+    final List<LogRecord> records = new ArrayList<LogRecord>(1);
+    Logger channelLogger = Logger.getLogger(ManagedChannelImpl.class.getName());
+    Filter oldFilter = channelLogger.getFilter();
+    channelLogger.setFilter(new Filter() {
+
+      @Override
+      public boolean isLoggable(LogRecord record) {
+        synchronized (records) {
+          records.add(record);
+        }
+        return false;
+      }
+    });
+
+    try {
+      channel = null;
+      // That *should* have been the last reference.  Try to reclaim it.
+      boolean success = false;
+      for (int retry = 0; retry < 3; retry++) {
+        System.gc();
+        int orphans = ManagedChannelImpl.ManagedChannelPhantom.cleanQueue();
+        if (orphans == 1) {
+          success = true;
+          break;
+        }
+        assertEquals("unexpected extra orphans", 0, orphans);
+        Thread.sleep(100L * (1L << retry));
+      }
+      assertTrue("Channel was not garbage collected", success);
+
+      LogRecord lr;
+      synchronized (records) {
+        assertEquals(1, records.size());
+        lr = records.get(0);
+      }
+      assertThat(lr.getMessage()).contains("shutdown");
+      assertThat(lr.getParameters()).asList().containsExactly(logId, target).inOrder();
+      assertEquals(Level.SEVERE, lr.getLevel());
+    } finally {
+      channelLogger.setFilter(oldFilter);
+    }
   }
 
   private static class FakeBackoffPolicyProvider implements BackoffPolicy.Provider {

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -40,35 +40,50 @@ public class NettyChannelBuilderTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
   private final SslContext noSslContext = null;
 
-  @Test
-  public void authorityIsReadable() {
-    NettyChannelBuilder builder = NettyChannelBuilder.forAddress("original", 1234);
-    assertEquals("original:1234", builder.build().authority());
+  private void shutdown(ManagedChannel mc) throws Exception {
+    mc.shutdownNow();
+    assertTrue(mc.awaitTermination(1, TimeUnit.SECONDS));
   }
 
   @Test
-  public void overrideAuthorityIsReadableForAddress() {
+  public void authorityIsReadable() throws Exception {
+    NettyChannelBuilder builder = NettyChannelBuilder.forAddress("original", 1234);
+
+    ManagedChannel b = builder.build();
+    try {
+      assertEquals("original:1234", b.authority());
+    } finally {
+      shutdown(b);
+    }
+  }
+
+  @Test
+  public void overrideAuthorityIsReadableForAddress() throws Exception {
     NettyChannelBuilder builder = NettyChannelBuilder.forAddress("original", 1234);
     overrideAuthorityIsReadableHelper(builder, "override:5678");
   }
 
   @Test
-  public void overrideAuthorityIsReadableForTarget() {
+  public void overrideAuthorityIsReadableForTarget() throws Exception {
     NettyChannelBuilder builder = NettyChannelBuilder.forTarget("original:1234");
     overrideAuthorityIsReadableHelper(builder, "override:5678");
   }
 
   @Test
-  public void overrideAuthorityIsReadableForSocketAddress() {
+  public void overrideAuthorityIsReadableForSocketAddress() throws Exception {
     NettyChannelBuilder builder = NettyChannelBuilder.forAddress(new SocketAddress(){});
     overrideAuthorityIsReadableHelper(builder, "override:5678");
   }
 
   private void overrideAuthorityIsReadableHelper(NettyChannelBuilder builder,
-      String overrideAuthority) {
+      String overrideAuthority) throws Exception {
     builder.overrideAuthority(overrideAuthority);
     ManagedChannel channel = builder.build();
-    assertEquals(overrideAuthority, channel.authority());
+    try {
+      assertEquals(overrideAuthority, channel.authority());
+    } finally {
+      shutdown(channel);
+    }
   }
 
   @Test


### PR DESCRIPTION
Cleaning up channels is something users should do.  To promote this
behavior, add a log message to indicate that the channel has not
been properly cleaned.

This change users PhantomReferences to avoid keeping the channel
alive and retaining too much memory.  Only the id and the target
are kept.  Additionally, the lost references are only checked at
JVM shutdown and on new channel creation.  This is done to avoid
Object finalizers.

The test added checks to see that the message is logged.  Since
java does not allow forcing of a GC cycle, this code is best
effort, giving up after about a second.  A custom log filter is
added to hook the log messages and check to see if the correct
one is present.  Handlers are not used because they are
hierarchical, and would be annoying to restore their state after
the test.

The other tests in the file contribute a lot of bad channels.  This
is reasonable, because they aren't real channels.  Hwoever, it does
mean that less than half of them are being cleaned up properly.
After trying to fix a few, it is too hard to do.  It would only
serve to massively complicate the tests.

Instead, this code just keeps track of how many it wasn't able to
clean up, and ignores them for the test.  They are still logged,
because really they should be closed.