### PR TITLE
context: log severe warning if ancestry chain > 1000

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -100,10 +100,9 @@ public class Context {
       new PersistentHashArrayMappedTrie<Key<?>, Object>();
 
   // Long chains of contexts are suspicious and usually indicate a misuse of Context.
-  // The threshold and interval are arbitrarily chosen.
+  // The threshold is arbitrarily chosen.
   // VisibleForTesting
-  static final int CONTEXT_DEPTH_WARN_THRESH = 200;
-  private static final int CONTEXT_WARN_INTERVAL = 20;
+  static final int CONTEXT_DEPTH_WARN_THRESH = 1000;
 
   /**
    * The logical root context which is the ultimate ancestor of all contexts. This context
@@ -1011,13 +1010,12 @@ public class Context {
    * the stack trace.
    */
   private static void validateGeneration(int generation) {
-    if (generation >= CONTEXT_DEPTH_WARN_THRESH
-        && (generation - CONTEXT_DEPTH_WARN_THRESH) % CONTEXT_WARN_INTERVAL == 0) {
+    if (generation == CONTEXT_DEPTH_WARN_THRESH) {
       log.log(
           Level.SEVERE,
-          String.format("Context ancestry chain length is abnormally long. "
+          "Context ancestry chain length is abnormally long. "
               + "This suggests an error in application code. "
-              + "length=%s", generation),
+              + "Length exceeded: " + CONTEXT_DEPTH_WARN_THRESH,
           new Exception());
     }
   }

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -207,7 +207,7 @@ public class Context {
   private Context(Context parent, PersistentHashArrayMappedTrie<Key<?>, Object> keyValueEntries) {
     cancellableAncestor = cancellableAncestor(parent);
     this.keyValueEntries = keyValueEntries;
-    this.generation = parent == null ? 1 : parent.generation + 1;
+    this.generation = parent == null ? 0 : parent.generation + 1;
     validateGeneration(generation);
   }
 

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -943,7 +943,7 @@ public class ContextTest {
     try {
       logger.addHandler(handler);
       Context ctx = Context.current();
-      for (int i = 0; i < Context.CONTEXT_DEPTH_WARN_THRESH - 1; i++) {
+      for (int i = 0; i < Context.CONTEXT_DEPTH_WARN_THRESH ; i++) {
         assertNull(logRef.get());
         ctx = ctx.fork();
       }

--- a/context/src/test/java/io/grpc/ContextTest.java
+++ b/context/src/test/java/io/grpc/ContextTest.java
@@ -922,6 +922,40 @@ public class ContextTest {
     assertNull(fork.cancellableAncestor);
   }
 
+  @Test
+  public void errorWhenAncestryLengthLong() {
+    final AtomicReference<LogRecord> logRef = new AtomicReference<LogRecord>();
+    Handler handler = new Handler() {
+      @Override
+      public void publish(LogRecord record) {
+        logRef.set(record);
+      }
+
+      @Override
+      public void flush() {
+      }
+
+      @Override
+      public void close() throws SecurityException {
+      }
+    };
+    Logger logger = Logger.getLogger(Context.class.getName());
+    try {
+      logger.addHandler(handler);
+      Context ctx = Context.current();
+      for (int i = 0; i < Context.CONTEXT_DEPTH_WARN_THRESH - 1; i++) {
+        assertNull(logRef.get());
+        ctx = ctx.fork();
+      }
+      ctx = ctx.fork();
+      assertNotNull(logRef.get());
+      assertNotNull(logRef.get().getThrown());
+      assertEquals(Level.SEVERE, logRef.get().getLevel());
+    } finally {
+      logger.removeHandler(handler);
+    }
+  }
+
   // UsedReflectively
   public static final class LoadMeWithStaticTestingClassLoader implements Runnable {
     @Override


### PR DESCRIPTION
If a context has an unreasonable number of ancestors, then
chances are this is an application error. Log the stack trace to
notify the user and aid in debugging.