### PR TITLE
core: record individual messages with sizes to Census/tracing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ subprojects {
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.4.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
                 okio: 'com.squareup.okio:okio:1.6.0',
-                opencensus_api: 'io.opencensus:opencensus-api:0.5.1',
+                opencensus_api: 'io.opencensus:opencensus-api:0.6.0',
                 instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,6 +12,8 @@ dependencies {
         exclude group: 'io.grpc', module: 'grpc-context'
     }
     compile (libraries.opencensus_api) {
+        // prefer 3.0.0 from libraries instead of 3.0.1
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
         // prefer 2.0.19 from libraries instead of 2.0.11
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         // we'll always be more up-to-date

--- a/core/src/main/java/io/grpc/StreamTracer.java
+++ b/core/src/main/java/io/grpc/StreamTracer.java
@@ -48,7 +48,8 @@ public abstract class StreamTracer {
    * about the message, but doesn't have further guarantee such as whether the message is serialized
    * or not.
    *
-   * @param seqNo the sequential number of the message within the stream, starting from 0
+   * @param seqNo the sequential number of the message within the stream, starting from 0.  It can
+   *              be used to correlate with {@link #outboundMessageSent} for the same message.
    */
   public void outboundMessage(int seqNo) {
   }
@@ -69,7 +70,8 @@ public abstract class StreamTracer {
    * about the message, but doesn't have further guarantee such as whether the message is
    * deserialized or not.
    *
-   * @param seqNo the sequential number of the message within the stream, starting from 0
+   * @param seqNo the sequential number of the message within the stream, starting from 0.  It can
+   *              be used to correlate with {@link #inboundMessageRead} for the same message.
    */
   public void inboundMessage(int seqNo) {
   }
@@ -77,7 +79,8 @@ public abstract class StreamTracer {
   /**
    * An outbound message has been serialized and sent to the transport.
    *
-   * @param seqNo the sequential number of the message within the stream, starting from 0
+   * @param seqNo the sequential number of the message within the stream, starting from 0.  It can
+   *              be used to correlate with {@link #outboundMessage(int)} for the same message.
    * @param optionalWireSize the wire size of the message. -1 if unknown
    * @param optionalUncompressedSize the uncompressed serialized size of the message. -1 if unknown
    */
@@ -87,7 +90,8 @@ public abstract class StreamTracer {
   /**
    * An inbound message has been fully read from the transport.
    *
-   * @param seqNo the sequential number of the message within the stream, starting from 0
+   * @param seqNo the sequential number of the message within the stream, starting from 0.  It can
+   *              be used to correlate with {@link #inboundMessage(int)} for the same message.
    * @param optionalWireSize the wire size of the message. -1 if unknown
    * @param optionalUncompressedSize the uncompressed serialized size of the message. -1 if unknown
    */

--- a/core/src/main/java/io/grpc/StreamTracer.java
+++ b/core/src/main/java/io/grpc/StreamTracer.java
@@ -78,20 +78,20 @@ public abstract class StreamTracer {
    * An outbound message has been serialized and sent to the transport.
    *
    * @param seqNo the sequential number of the message within the stream, starting from 0
-   * @param optionalUncompressedSize the uncompressed serialized size of the message. -1 if unknown
    * @param optionalWireSize the wire size of the message. -1 if unknown
+   * @param optionalUncompressedSize the uncompressed serialized size of the message. -1 if unknown
    */
-  public void outboundMessageSent(int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+  public void outboundMessageSent(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
   }
 
   /**
    * An inbound message has been fully read from the transport.
    *
    * @param seqNo the sequential number of the message within the stream, starting from 0
-   * @param optionalUncompressedSize the uncompressed serialized size of the message. -1 if unknown
    * @param optionalWireSize the wire size of the message. -1 if unknown
+   * @param optionalUncompressedSize the uncompressed serialized size of the message. -1 if unknown
    */
-  public void inboundMessageRead(int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+  public void inboundMessageRead(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
   }
 
   /**

--- a/core/src/main/java/io/grpc/StreamTracer.java
+++ b/core/src/main/java/io/grpc/StreamTracer.java
@@ -36,16 +36,62 @@ public abstract class StreamTracer {
    * An outbound message has been passed to the stream.  This is called as soon as the stream knows
    * about the message, but doesn't have further guarantee such as whether the message is serialized
    * or not.
+   *
+   * @deprecated use {@link #outboundMessage(int)}
    */
+  @Deprecated
   public void outboundMessage() {
+  }
+
+  /**
+   * An outbound message has been passed to the stream.  This is called as soon as the stream knows
+   * about the message, but doesn't have further guarantee such as whether the message is serialized
+   * or not.
+   *
+   * @param seqNo the sequential number of the message within the stream, starting from 0
+   */
+  public void outboundMessage(int seqNo) {
   }
 
   /**
    * An inbound message has been received by the stream.  This is called as soon as the stream knows
    * about the message, but doesn't have further guarantee such as whether the message is
    * deserialized or not.
+   *
+   * @deprecated use {@link #inboundMessage(int)}
    */
+  @Deprecated
   public void inboundMessage() {
+  }
+
+  /**
+   * An inbound message has been received by the stream.  This is called as soon as the stream knows
+   * about the message, but doesn't have further guarantee such as whether the message is
+   * deserialized or not.
+   *
+   * @param seqNo the sequential number of the message within the stream, starting from 0
+   */
+  public void inboundMessage(int seqNo) {
+  }
+
+  /**
+   * An outbound message has been serialized and sent to the transport.
+   *
+   * @param seqNo the sequential number of the message within the stream, starting from 0
+   * @param optionalUncompressedSize the uncompressed serialized size of the message. -1 if unknown
+   * @param optionalWireSize the wire size of the message. -1 if unknown
+   */
+  public void outboundMessageSent(int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+  }
+
+  /**
+   * An inbound message has been fully read from the transport.
+   *
+   * @param seqNo the sequential number of the message within the stream, starting from 0
+   * @param optionalUncompressedSize the uncompressed serialized size of the message. -1 if unknown
+   * @param optionalWireSize the wire size of the message. -1 if unknown
+   */
+  public void inboundMessageRead(int seqNo, long optionalUncompressedSize, long optionalWireSize) {
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -359,7 +359,8 @@ public abstract class AbstractClientStream extends AbstractStream
       } catch (java.io.IOException ex) {
         throw new RuntimeException(ex);
       }
-      statsTraceCtx.outboundMessage();
+      statsTraceCtx.outboundMessage(0);
+      statsTraceCtx.outboundMessageSent(0, payload.length, payload.length);
       statsTraceCtx.outboundUncompressedSize(payload.length);
       // NB(zhangkun83): this is not accurate, because the underlying transport will probably encode
       // it using e.g., base64.  However, we are not supposed to know such detail here.

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -161,12 +161,12 @@ final class CensusStatsModule {
     }
 
     @Override
-    public void inboundMessage() {
+    public void inboundMessage(int seqNo) {
       inboundMessageCount.incrementAndGet();
     }
 
     @Override
-    public void outboundMessage() {
+    public void outboundMessage(int seqNo) {
       outboundMessageCount.incrementAndGet();
     }
   }
@@ -282,12 +282,12 @@ final class CensusStatsModule {
     }
 
     @Override
-    public void inboundMessage() {
+    public void inboundMessage(int seqNo) {
       inboundMessageCount.incrementAndGet();
     }
 
     @Override
-    public void outboundMessage() {
+    public void outboundMessage(int seqNo) {
       outboundMessageCount.incrementAndGet();
     }
 

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -239,16 +239,16 @@ final class CensusTracingModule {
 
     @Override
     public void outboundMessageSent(
-        int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+        int seqNo, long optionalWireSize, long optionalUncompressedSize) {
       recordNetworkEvent(
-          span, NetworkEvent.Type.SENT, seqNo, optionalUncompressedSize, optionalWireSize);
+          span, NetworkEvent.Type.SENT, seqNo, optionalWireSize, optionalUncompressedSize);
     }
 
     @Override
     public void inboundMessageRead(
-        int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+        int seqNo, long optionalWireSize, long optionalUncompressedSize) {
       recordNetworkEvent(
-          span, NetworkEvent.Type.RECV, seqNo, optionalUncompressedSize, optionalWireSize);
+          span, NetworkEvent.Type.RECV, seqNo, optionalWireSize, optionalUncompressedSize);
     }
   }
 
@@ -289,16 +289,16 @@ final class CensusTracingModule {
 
     @Override
     public void outboundMessageSent(
-        int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+        int seqNo, long optionalWireSize, long optionalUncompressedSize) {
       recordNetworkEvent(
-          span, NetworkEvent.Type.SENT, seqNo, optionalUncompressedSize, optionalWireSize);
+          span, NetworkEvent.Type.SENT, seqNo, optionalWireSize, optionalUncompressedSize);
     }
 
     @Override
     public void inboundMessageRead(
-        int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+        int seqNo, long optionalWireSize, long optionalUncompressedSize) {
       recordNetworkEvent(
-          span, NetworkEvent.Type.RECV, seqNo, optionalUncompressedSize, optionalWireSize);
+          span, NetworkEvent.Type.RECV, seqNo, optionalWireSize, optionalUncompressedSize);
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -33,6 +33,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
 import io.grpc.StreamTracer;
 import io.opencensus.trace.EndSpanOptions;
+import io.opencensus.trace.NetworkEvent;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Status;
@@ -56,8 +57,6 @@ import javax.annotation.Nullable;
  */
 final class CensusTracingModule {
   private static final Logger logger = Logger.getLogger(CensusTracingModule.class.getName());
-  // TODO(zhangkun83): record NetworkEvent to Span for each message
-  private static final ClientStreamTracer noopClientTracer = new ClientStreamTracer() {};
 
   private final Tracer censusTracer;
   @VisibleForTesting
@@ -182,6 +181,19 @@ final class CensusTracingModule {
     return EndSpanOptions.builder().setStatus(convertStatus(status)).build();
   }
 
+  private static void recordNetworkEvent(
+      Span span, NetworkEvent.Type type,
+      int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+    NetworkEvent.Builder eventBuilder = NetworkEvent.builder(type, seqNo);
+    if (optionalUncompressedSize != -1) {
+      eventBuilder.setUncompressedMessageSize(optionalUncompressedSize);
+    }
+    if (optionalWireSize != -1) {
+      eventBuilder.setCompressedMessageSize(optionalWireSize);
+    }
+    span.addNetworkEvent(eventBuilder.build());
+  }
+
   @VisibleForTesting
   final class ClientCallTracer extends ClientStreamTracer.Factory {
 
@@ -201,7 +213,7 @@ final class CensusTracingModule {
     public ClientStreamTracer newClientStreamTracer(CallOptions callOptions, Metadata headers) {
       headers.discardAll(tracingHeader);
       headers.put(tracingHeader, span.getContext());
-      return noopClientTracer;
+      return new ClientTracer(span);
     }
 
     /**
@@ -215,6 +227,28 @@ final class CensusTracingModule {
         return;
       }
       span.end(createEndSpanOptions(status));
+    }
+  }
+
+  private static final class ClientTracer extends ClientStreamTracer {
+    private final Span span;
+
+    ClientTracer(Span span) {
+      this.span = checkNotNull(span, "span");
+    }
+
+    @Override
+    public void outboundMessageSent(
+        int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+      recordNetworkEvent(
+          span, NetworkEvent.Type.SENT, seqNo, optionalUncompressedSize, optionalWireSize);
+    }
+
+    @Override
+    public void inboundMessageRead(
+        int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+      recordNetworkEvent(
+          span, NetworkEvent.Type.RECV, seqNo, optionalUncompressedSize, optionalWireSize);
     }
   }
 
@@ -251,6 +285,20 @@ final class CensusTracingModule {
       // because gRPC always creates a new Context for each of the server calls and does not
       // inherit from the parent Context.
       return context.withValue(CONTEXT_SPAN_KEY, span);
+    }
+
+    @Override
+    public void outboundMessageSent(
+        int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+      recordNetworkEvent(
+          span, NetworkEvent.Type.SENT, seqNo, optionalUncompressedSize, optionalWireSize);
+    }
+
+    @Override
+    public void inboundMessageRead(
+        int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+      recordNetworkEvent(
+          span, NetworkEvent.Type.RECV, seqNo, optionalUncompressedSize, optionalWireSize);
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -183,7 +183,7 @@ final class CensusTracingModule {
 
   private static void recordNetworkEvent(
       Span span, NetworkEvent.Type type,
-      int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+      int seqNo, long optionalWireSize, long optionalUncompressedSize) {
     NetworkEvent.Builder eventBuilder = NetworkEvent.builder(type, seqNo);
     if (optionalUncompressedSize != -1) {
       eventBuilder.setUncompressedMessageSize(optionalUncompressedSize);

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -288,7 +288,9 @@ public class MessageDeframer implements Closeable, Deframer {
       // There is no reliable way to get the uncompressed size per message when it's compressed,
       // because the uncompressed bytes are provided through an InputStream whose total size is
       // unknown until all bytes are read, and we don't know when it happens.
-      statsTraceCtx.inboundMessageRead(currentMessageSeqNo, -1, requiredLength);
+      if (state == State.BODY) {
+        statsTraceCtx.inboundMessageRead(currentMessageSeqNo, requiredLength, -1);
+      }
       return true;
     } finally {
       if (totalBytesRead > 0) {

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -151,7 +151,7 @@ public class MessageFramer implements Framer {
     }
     statsTraceCtx.outboundUncompressedSize(written);
     statsTraceCtx.outboundWireSize(currentMessageWireSize);
-    statsTraceCtx.outboundMessageSent(currentMessageSeqNo, written, currentMessageWireSize);
+    statsTraceCtx.outboundMessageSent(currentMessageSeqNo, currentMessageWireSize, written);
   }
 
   private int writeUncompressed(InputStream message, int messageLength) throws IOException {

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -76,6 +76,10 @@ public class MessageFramer implements Framer {
   private final StatsTraceContext statsTraceCtx;
   private boolean closed;
 
+  // Tracing and stats-related states
+  private int currentMessageSeqNo = -1;
+  private long currentMessageWireSize;
+
   /**
    * Creates a {@code MessageFramer}.
    *
@@ -115,7 +119,9 @@ public class MessageFramer implements Framer {
   @Override
   public void writePayload(InputStream message) {
     verifyNotClosed();
-    statsTraceCtx.outboundMessage();
+    currentMessageSeqNo++;
+    currentMessageWireSize = 0;
+    statsTraceCtx.outboundMessage(currentMessageSeqNo);
     boolean compressed = messageCompression && compressor != Codec.Identity.NONE;
     int written = -1;
     int messageLength = -2;
@@ -144,11 +150,13 @@ public class MessageFramer implements Framer {
       throw Status.INTERNAL.withDescription(err).asRuntimeException();
     }
     statsTraceCtx.outboundUncompressedSize(written);
+    statsTraceCtx.outboundWireSize(currentMessageWireSize);
+    statsTraceCtx.outboundMessageSent(currentMessageSeqNo, written, currentMessageWireSize);
   }
 
   private int writeUncompressed(InputStream message, int messageLength) throws IOException {
     if (messageLength != -1) {
-      statsTraceCtx.outboundWireSize(messageLength);
+      currentMessageWireSize = messageLength;
       return writeKnownLengthUncompressed(message, messageLength);
     }
     BufferChainOutputStream bufferChain = new BufferChainOutputStream();
@@ -241,7 +249,7 @@ public class MessageFramer implements Framer {
     // Assign the current buffer to the last in the chain so it can be used
     // for future writes or written with end-of-stream=true on close.
     buffer = bufferList.get(bufferList.size() - 1);
-    statsTraceCtx.outboundWireSize(messageLength);
+    currentMessageWireSize = messageLength;
   }
 
   private static int writeToOutputStream(InputStream message, OutputStream outputStream)

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -180,9 +180,9 @@ public final class StatsTraceContext {
    *
    * <p>Called from {@link io.grpc.internal.Framer}.
    */
-  public void outboundMessageSent(int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+  public void outboundMessageSent(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
     for (StreamTracer tracer : tracers) {
-      tracer.outboundMessageSent(seqNo, optionalUncompressedSize, optionalWireSize);
+      tracer.outboundMessageSent(seqNo, optionalWireSize, optionalUncompressedSize);
     }
   }
 
@@ -191,9 +191,9 @@ public final class StatsTraceContext {
    *
    * <p>Called from {@link io.grpc.internal.MessageDeframer}.
    */
-  public void inboundMessageRead(int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+  public void inboundMessageRead(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
     for (StreamTracer tracer : tracers) {
-      tracer.inboundMessageRead(seqNo, optionalUncompressedSize, optionalWireSize);
+      tracer.inboundMessageRead(seqNo, optionalWireSize, optionalUncompressedSize);
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -150,24 +150,50 @@ public final class StatsTraceContext {
   }
 
   /**
-   * See {@link StreamTracer#outboundMessage}.
+   * See {@link StreamTracer#outboundMessage(int)}.
    *
    * <p>Called from {@link io.grpc.internal.Framer}.
    */
-  public void outboundMessage() {
+  @SuppressWarnings("deprecation")
+  public void outboundMessage(int seqNo) {
     for (StreamTracer tracer : tracers) {
+      tracer.outboundMessage(seqNo);
       tracer.outboundMessage();
     }
   }
 
   /**
-   * See {@link StreamTracer#inboundMessage}.
+   * See {@link StreamTracer#inboundMessage(int)}.
    *
    * <p>Called from {@link io.grpc.internal.MessageDeframer}.
    */
-  public void inboundMessage() {
+  @SuppressWarnings("deprecation")
+  public void inboundMessage(int seqNo) {
     for (StreamTracer tracer : tracers) {
+      tracer.inboundMessage(seqNo);
       tracer.inboundMessage();
+    }
+  }
+
+  /**
+   * See {@link StreamTracer#outboundMessageSent}.
+   *
+   * <p>Called from {@link io.grpc.internal.Framer}.
+   */
+  public void outboundMessageSent(int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+    for (StreamTracer tracer : tracers) {
+      tracer.outboundMessageSent(seqNo, optionalUncompressedSize, optionalWireSize);
+    }
+  }
+
+  /**
+   * See {@link StreamTracer#inboundMessageRead}.
+   *
+   * <p>Called from {@link io.grpc.internal.MessageDeframer}.
+   */
+  public void inboundMessageRead(int seqNo, long optionalUncompressedSize, long optionalWireSize) {
+    for (StreamTracer tracer : tracers) {
+      tracer.inboundMessageRead(seqNo, optionalUncompressedSize, optionalWireSize);
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -16,8 +16,10 @@
 
 package io.grpc.internal;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -239,7 +241,11 @@ public class AbstractClientStreamTest {
     // GET requests don't have BODY.
     verify(sink, never())
         .writeFrame(any(WritableBuffer.class), any(Boolean.class), any(Boolean.class));
-    assertEquals(1, tracer.getOutboundMessageCount());
+    assertThat(tracer.nextOutboundEvent()).isEqualTo("outboundMessage(0)");
+    assertThat(tracer.nextOutboundEvent()).isEqualTo("outboundMessage()");
+    assertThat(tracer.nextOutboundEvent()).matches("outboundMessageSent\\(0, [0-9]+, [0-9]+\\)");
+    assertNull(tracer.nextOutboundEvent());
+    assertNull(tracer.nextInboundEvent());
     assertEquals(1, tracer.getOutboundWireSize());
     assertEquals(1, tracer.getOutboundUncompressedSize());
   }

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -322,20 +322,20 @@ public class CensusModulesTest {
     tracer.outboundHeaders();
 
     fakeClock.forwardTime(100, MILLISECONDS);
-    tracer.outboundMessage();
+    tracer.outboundMessage(0);
     tracer.outboundWireSize(1028);
     tracer.outboundUncompressedSize(1128);
 
     fakeClock.forwardTime(16, MILLISECONDS);
-    tracer.inboundMessage();
+    tracer.inboundMessage(0);
     tracer.inboundWireSize(33);
     tracer.inboundUncompressedSize(67);
-    tracer.outboundMessage();
+    tracer.outboundMessage(1);
     tracer.outboundWireSize(99);
     tracer.outboundUncompressedSize(865);
 
     fakeClock.forwardTime(24, MILLISECONDS);
-    tracer.inboundMessage();
+    tracer.inboundMessage(1);
     tracer.inboundWireSize(154);
     tracer.inboundUncompressedSize(552);
     tracer.streamClosed(Status.OK);
@@ -593,20 +593,20 @@ public class CensusModulesTest {
             .with(RpcConstants.RPC_SERVER_METHOD, TagValue.create(method.getFullMethodName())),
         statsCtx);
 
-    tracer.inboundMessage();
+    tracer.inboundMessage(0);
     tracer.inboundWireSize(34);
     tracer.inboundUncompressedSize(67);
 
     fakeClock.forwardTime(100, MILLISECONDS);
-    tracer.outboundMessage();
+    tracer.outboundMessage(0);
     tracer.outboundWireSize(1028);
     tracer.outboundUncompressedSize(1128);
 
     fakeClock.forwardTime(16, MILLISECONDS);
-    tracer.inboundMessage();
+    tracer.inboundMessage(1);
     tracer.inboundWireSize(154);
     tracer.inboundUncompressedSize(552);
-    tracer.outboundMessage();
+    tracer.outboundMessage(1);
     tracer.outboundWireSize(99);
     tracer.outboundUncompressedSize(865);
 
@@ -713,6 +713,7 @@ public class CensusModulesTest {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void addAttributes(Map<String, AttributeValue> attributes) {}
 
     @Override

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -31,8 +31,10 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -63,6 +65,7 @@ import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.EndSpanOptions;
 import io.opencensus.trace.Link;
 import io.opencensus.trace.NetworkEvent;
+import io.opencensus.trace.NetworkEvent.Type;
 import io.opencensus.trace.Sampler;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanBuilder;
@@ -90,6 +93,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -166,6 +170,8 @@ public class CensusModulesTest {
   private ArgumentCaptor<ClientCall.Listener<String>> clientCallListenerCaptor;
   @Captor
   private ArgumentCaptor<Status> statusCaptor;
+  @Captor
+  private ArgumentCaptor<NetworkEvent> networkEventCaptor;
 
   private CensusStatsModule censusStats;
   private CensusTracingModule censusTracing;
@@ -372,11 +378,32 @@ public class CensusModulesTest {
         eq("Sent.package1.service2.method3"), isNull(Span.class));
     verify(spyClientSpan, never()).end(any(EndSpanOptions.class));
 
+    clientStreamTracer.outboundMessage(0);
+    clientStreamTracer.outboundMessageSent(0, 882, -1);
+    clientStreamTracer.inboundMessage(0);
+    clientStreamTracer.outboundMessage(1);
+    clientStreamTracer.outboundMessageSent(1, -1, 27);
+    clientStreamTracer.inboundMessageRead(0, 255, 90);
+
     clientStreamTracer.streamClosed(Status.OK);
     callTracer.callEnded(Status.OK);
 
-    verify(spyClientSpan).end(
+    InOrder inOrder = inOrder(spyClientSpan);
+    inOrder.verify(spyClientSpan, times(3)).addNetworkEvent(networkEventCaptor.capture());
+    List<NetworkEvent> events = networkEventCaptor.getAllValues();
+    assertEquals(
+        NetworkEvent.builder(Type.SENT, 0).setCompressedMessageSize(882).build(), events.get(0));
+    assertEquals(
+        NetworkEvent.builder(Type.SENT, 1).setUncompressedMessageSize(27).build(), events.get(1));
+    assertEquals(
+        NetworkEvent.builder(Type.RECV, 0)
+            .setCompressedMessageSize(255)
+            .setUncompressedMessageSize(90)
+            .build(),
+        events.get(2));
+    inOrder.verify(spyClientSpan).end(
         EndSpanOptions.builder().setStatus(io.opencensus.trace.Status.OK).build());
+    verifyNoMoreInteractions(spyClientSpan);
     verifyNoMoreInteractions(tracer);
   }
 
@@ -424,7 +451,7 @@ public class CensusModulesTest {
                 io.opencensus.trace.Status.DEADLINE_EXCEEDED
                     .withDescription("3 seconds"))
             .build());
-    verify(spyClientSpan, never()).end();
+    verifyNoMoreInteractions(spyClientSpan);
   }
 
   @Test
@@ -648,12 +675,33 @@ public class CensusModulesTest {
     assertSame(spyServerSpan, ContextUtils.CONTEXT_SPAN_KEY.get(filteredContext));
 
     verify(spyServerSpan, never()).end(any(EndSpanOptions.class));
+
+    serverStreamTracer.outboundMessage(0);
+    serverStreamTracer.outboundMessageSent(0, 882, -1);
+    serverStreamTracer.inboundMessage(0);
+    serverStreamTracer.outboundMessage(1);
+    serverStreamTracer.outboundMessageSent(1, -1, 27);
+    serverStreamTracer.inboundMessageRead(0, 255, 90);
+
     serverStreamTracer.streamClosed(Status.CANCELLED);
 
-    verify(spyServerSpan).end(
+    InOrder inOrder = inOrder(spyServerSpan);
+    inOrder.verify(spyServerSpan, times(3)).addNetworkEvent(networkEventCaptor.capture());
+    List<NetworkEvent> events = networkEventCaptor.getAllValues();
+    assertEquals(
+        NetworkEvent.builder(Type.SENT, 0).setCompressedMessageSize(882).build(), events.get(0));
+    assertEquals(
+        NetworkEvent.builder(Type.SENT, 1).setUncompressedMessageSize(27).build(), events.get(1));
+    assertEquals(
+        NetworkEvent.builder(Type.RECV, 0)
+            .setCompressedMessageSize(255)
+            .setUncompressedMessageSize(90)
+            .build(),
+        events.get(2));
+    inOrder.verify(spyServerSpan).end(
         EndSpanOptions.builder()
             .setStatus(io.opencensus.trace.Status.CANCELLED).build());
-    verify(spyServerSpan, never()).end();
+    verifyNoMoreInteractions(spyServerSpan);
   }
 
   @Test

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
@@ -117,7 +117,7 @@ final class GrpclbClientLoadRecorder extends ClientStreamTracer.Factory {
     }
 
     @Override
-    public void inboundMessage() {
+    public void inboundMessage(int seqNo) {
       anythingReceived.set(true);
     }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1795,7 +1795,8 @@ public abstract class AbstractInteropTest {
       assertThat(tracer.nextOutboundEvent()).isEqualTo(String.format("outboundMessage(%d)", seqNo));
       assertThat(tracer.nextOutboundEvent()).isEqualTo("outboundMessage()");
       assertThat(tracer.nextOutboundEvent()).matches(
-          String.format("outboundMessageSent\\(%d, [0-9]+, %d\\)", seqNo, msg.getSerializedSize()));
+          String.format(
+              "outboundMessageSent\\(%d, -?[0-9]+, %d\\)", seqNo, msg.getSerializedSize()));
       seqNo++;
       uncompressedSentSize += msg.getSerializedSize();
     }
@@ -1806,8 +1807,9 @@ public abstract class AbstractInteropTest {
       assertThat(tracer.nextInboundEvent()).isEqualTo(String.format("inboundMessage(%d)", seqNo));
       assertThat(tracer.nextInboundEvent()).isEqualTo("inboundMessage()");
       assertThat(tracer.nextInboundEvent()).matches(
-          String.format("inboundMessageRead\\(%d, [0-9]+, -1\\)", seqNo)); 
+          String.format("inboundMessageRead\\(%d, -?[0-9]+, -?[0-9]+\\)", seqNo)); 
       uncompressedReceivedSize += msg.getSerializedSize();
+      seqNo++;
     }
     assertNull(tracer.nextInboundEvent());
     assertEquals(uncompressedSentSize, tracer.getOutboundUncompressedSize());

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1789,18 +1789,27 @@ public abstract class AbstractInteropTest {
       TestStreamTracer tracer,
       Collection<? extends MessageLite> sentMessages,
       Collection<? extends MessageLite> receivedMessages) {
-    assertEquals(sentMessages.size(), tracer.getOutboundMessageCount());
-    assertEquals(receivedMessages.size(), tracer.getInboundMessageCount());
-
     long uncompressedSentSize = 0;
+    int seqNo = 0;
     for (MessageLite msg : sentMessages) {
+      assertThat(tracer.nextOutboundEvent()).isEqualTo(String.format("outboundMessage(%d)", seqNo));
+      assertThat(tracer.nextOutboundEvent()).isEqualTo("outboundMessage()");
+      assertThat(tracer.nextOutboundEvent()).matches(
+          String.format("outboundMessageSent\\(%d, [0-9]+, %d\\)", seqNo, msg.getSerializedSize()));
+      seqNo++;
       uncompressedSentSize += msg.getSerializedSize();
     }
+    assertNull(tracer.nextOutboundEvent());
     long uncompressedReceivedSize = 0;
+    seqNo = 0;
     for (MessageLite msg : receivedMessages) {
+      assertThat(tracer.nextInboundEvent()).isEqualTo(String.format("inboundMessage(%d)", seqNo));
+      assertThat(tracer.nextInboundEvent()).isEqualTo("inboundMessage()");
+      assertThat(tracer.nextInboundEvent()).matches(
+          String.format("inboundMessageRead\\(%d, [0-9]+, -1\\)", seqNo)); 
       uncompressedReceivedSize += msg.getSerializedSize();
     }
-
+    assertNull(tracer.nextInboundEvent());
     assertEquals(uncompressedSentSize, tracer.getOutboundUncompressedSize());
     assertEquals(uncompressedReceivedSize, tracer.getInboundUncompressedSize());
   }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -732,7 +732,8 @@ public abstract class AbstractTransportTest {
     assertTrue(clientStream.isReady());
     clientStream.writeMessage(methodDescriptor.streamRequest("Hello!"));
     if (metricsExpected()) {
-      assertThat(clientStreamTracer1.getOutboundMessageCount()).isGreaterThan(0);
+      assertThat(clientStreamTracer1.nextOutboundEvent()).isEqualTo("outboundMessage(0)");
+      assertThat(clientStreamTracer1.nextOutboundEvent()).isEqualTo("outboundMessage()");
     }
 
     clientStream.flush();
@@ -740,10 +741,12 @@ public abstract class AbstractTransportTest {
     assertEquals("Hello!", methodDescriptor.parseRequest(message));
     message.close();
     if (metricsExpected()) {
-      assertThat(clientStreamTracer1.getOutboundMessageCount()).isGreaterThan(0);
+      assertThat(clientStreamTracer1.nextOutboundEvent())
+          .matches("outboundMessageSent\\(0, [0-9]+, [0-9]+\\)");
       assertThat(clientStreamTracer1.getOutboundWireSize()).isGreaterThan(0L);
       assertThat(clientStreamTracer1.getOutboundUncompressedSize()).isGreaterThan(0L);
-      assertEquals(1, serverStreamTracer1.getInboundMessageCount());
+      assertThat(serverStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage(0)");
+      assertThat(serverStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage()");
     }
     assertNull("no additional message expected", serverStreamMessageQueue.poll());
 
@@ -753,6 +756,8 @@ public abstract class AbstractTransportTest {
     if (metricsExpected()) {
       assertThat(serverStreamTracer1.getInboundWireSize()).isGreaterThan(0L);
       assertThat(serverStreamTracer1.getInboundUncompressedSize()).isGreaterThan(0L);
+      assertThat(serverStreamTracer1.nextInboundEvent())
+          .matches("inboundMessageRead\\(0, [0-9]+, [0-9]+\\)");
     }
 
     Metadata serverHeaders = new Metadata();
@@ -774,7 +779,8 @@ public abstract class AbstractTransportTest {
     assertTrue(serverStream.isReady());
     serverStream.writeMessage(methodDescriptor.streamResponse("Hi. Who are you?"));
     if (metricsExpected()) {
-      assertEquals(1, serverStreamTracer1.getOutboundMessageCount());
+      assertThat(serverStreamTracer1.nextOutboundEvent()).isEqualTo("outboundMessage(0)");
+      assertThat(serverStreamTracer1.nextOutboundEvent()).isEqualTo("outboundMessage()");
     }
 
     serverStream.flush();
@@ -782,13 +788,18 @@ public abstract class AbstractTransportTest {
         .messagesAvailable(any(StreamListener.MessageProducer.class));
     message = clientStreamMessageQueue.poll(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     if (metricsExpected()) {
+      assertThat(serverStreamTracer1.nextOutboundEvent())
+          .matches("outboundMessageSent\\(0, [0-9]+, [0-9]+\\)");
       assertThat(serverStreamTracer1.getOutboundWireSize()).isGreaterThan(0L);
       assertThat(serverStreamTracer1.getOutboundUncompressedSize()).isGreaterThan(0L);
       assertTrue(clientStreamTracer1.getInboundHeaders());
-      assertThat(clientStreamTracer1.getInboundMessageCount()).isGreaterThan(0);
+      assertThat(clientStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage(0)");
+      assertThat(clientStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage()");
     }
     assertEquals("Hi. Who are you?", methodDescriptor.parseResponse(message));
     if (metricsExpected()) {
+      assertThat(clientStreamTracer1.nextInboundEvent())
+          .matches("inboundMessageRead\\(0, [0-9]+, [0-9]+\\)");
       assertThat(clientStreamTracer1.getInboundWireSize()).isGreaterThan(0L);
       assertThat(clientStreamTracer1.getInboundUncompressedSize()).isGreaterThan(0L);
     }
@@ -804,6 +815,8 @@ public abstract class AbstractTransportTest {
     serverStream.close(status, trailers);
     if (metricsExpected()) {
       assertSame(status, serverStreamTracer1.getStatus());
+      assertNull(serverStreamTracer1.nextInboundEvent());
+      assertNull(serverStreamTracer1.nextOutboundEvent());
     }
     verify(mockServerStreamListener, timeout(TIMEOUT_MS)).closed(statusCaptor.capture());
     assertCodeEquals(Status.OK, statusCaptor.getValue());
@@ -811,6 +824,8 @@ public abstract class AbstractTransportTest {
         .closed(statusCaptor.capture(), metadataCaptor.capture());
     if (metricsExpected()) {
       assertSame(statusCaptor.getValue(), clientStreamTracer1.getStatus());
+      assertNull(clientStreamTracer1.nextInboundEvent());
+      assertNull(clientStreamTracer1.nextOutboundEvent());
     }
     assertEquals(status.getCode(), statusCaptor.getValue().getCode());
     assertEquals(status.getDescription(), statusCaptor.getValue().getDescription());
@@ -1118,11 +1133,9 @@ public abstract class AbstractTransportTest {
     if (metricsExpected()) {
       assertTrue(clientStreamTracer1.getOutboundHeaders());
       assertTrue(clientStreamTracer1.getInboundHeaders());
-      assertEquals(1, clientStreamTracer1.getInboundMessageCount());
       assertThat(clientStreamTracer1.getInboundWireSize()).isGreaterThan(0L);
       assertThat(clientStreamTracer1.getInboundUncompressedSize()).isGreaterThan(0L);
       assertSame(status, clientStreamTracer1.getStatus());
-      assertEquals(1, serverStreamTracer1.getOutboundMessageCount());
       assertThat(serverStreamTracer1.getOutboundWireSize()).isGreaterThan(0L);
       assertThat(serverStreamTracer1.getOutboundUncompressedSize()).isGreaterThan(0L);
       // There is a race between client cancelling and server closing.  The final status seen by the

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -742,7 +742,7 @@ public abstract class AbstractTransportTest {
     message.close();
     if (metricsExpected()) {
       assertThat(clientStreamTracer1.nextOutboundEvent())
-          .matches("outboundMessageSent\\(0, [0-9]+, [0-9]+\\)");
+          .matches("outboundMessageSent\\(0, -?[0-9]+, -?[0-9]+\\)");
       assertThat(clientStreamTracer1.getOutboundWireSize()).isGreaterThan(0L);
       assertThat(clientStreamTracer1.getOutboundUncompressedSize()).isGreaterThan(0L);
       assertThat(serverStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage(0)");
@@ -757,7 +757,7 @@ public abstract class AbstractTransportTest {
       assertThat(serverStreamTracer1.getInboundWireSize()).isGreaterThan(0L);
       assertThat(serverStreamTracer1.getInboundUncompressedSize()).isGreaterThan(0L);
       assertThat(serverStreamTracer1.nextInboundEvent())
-          .matches("inboundMessageRead\\(0, [0-9]+, [0-9]+\\)");
+          .matches("inboundMessageRead\\(0, -?[0-9]+, -?[0-9]+\\)");
     }
 
     Metadata serverHeaders = new Metadata();
@@ -789,7 +789,7 @@ public abstract class AbstractTransportTest {
     message = clientStreamMessageQueue.poll(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     if (metricsExpected()) {
       assertThat(serverStreamTracer1.nextOutboundEvent())
-          .matches("outboundMessageSent\\(0, [0-9]+, [0-9]+\\)");
+          .matches("outboundMessageSent\\(0, -?[0-9]+, -?[0-9]+\\)");
       assertThat(serverStreamTracer1.getOutboundWireSize()).isGreaterThan(0L);
       assertThat(serverStreamTracer1.getOutboundUncompressedSize()).isGreaterThan(0L);
       assertTrue(clientStreamTracer1.getInboundHeaders());
@@ -799,7 +799,7 @@ public abstract class AbstractTransportTest {
     assertEquals("Hi. Who are you?", methodDescriptor.parseResponse(message));
     if (metricsExpected()) {
       assertThat(clientStreamTracer1.nextInboundEvent())
-          .matches("inboundMessageRead\\(0, [0-9]+, [0-9]+\\)");
+          .matches("inboundMessageRead\\(0, -?[0-9]+, -?[0-9]+\\)");
       assertThat(clientStreamTracer1.getInboundWireSize()).isGreaterThan(0L);
       assertThat(clientStreamTracer1.getInboundUncompressedSize()).isGreaterThan(0L);
     }

--- a/testing/src/main/java/io/grpc/internal/testing/TestClientStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestClientStreamTracer.java
@@ -54,11 +54,6 @@ public class TestClientStreamTracer extends ClientStreamTracer implements TestSt
   }
 
   @Override
-  public int getInboundMessageCount() {
-    return delegate.getInboundMessageCount();
-  }
-
-  @Override
   public Status getStatus() {
     return delegate.getStatus();
   }
@@ -74,11 +69,6 @@ public class TestClientStreamTracer extends ClientStreamTracer implements TestSt
   }
 
   @Override
-  public int getOutboundMessageCount() {
-    return delegate.getOutboundMessageCount();
-  }
-
-  @Override
   public long getOutboundWireSize() {
     return delegate.getOutboundWireSize();
   }
@@ -86,6 +76,16 @@ public class TestClientStreamTracer extends ClientStreamTracer implements TestSt
   @Override
   public long getOutboundUncompressedSize() {
     return delegate.getOutboundUncompressedSize();
+  }
+
+  @Override
+  public String nextOutboundEvent() {
+    return delegate.nextOutboundEvent();
+  }
+
+  @Override
+  public String nextInboundEvent() {
+    return delegate.nextInboundEvent();
   }
 
   @Override
@@ -114,13 +114,35 @@ public class TestClientStreamTracer extends ClientStreamTracer implements TestSt
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public void inboundMessage() {
     delegate.inboundMessage();
   }
 
   @Override
+  public void inboundMessage(int seqNo) {
+    delegate.inboundMessage(seqNo);
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
   public void outboundMessage() {
     delegate.outboundMessage();
+  }
+
+  @Override
+  public void outboundMessage(int seqNo) {
+    delegate.outboundMessage(seqNo);
+  }
+
+  @Override
+  public void outboundMessageSent(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
+    delegate.outboundMessageSent(seqNo, optionalWireSize, optionalUncompressedSize);
+  }
+
+  @Override
+  public void inboundMessageRead(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
+    delegate.inboundMessageRead(seqNo, optionalWireSize, optionalUncompressedSize);
   }
 
   @Override

--- a/testing/src/main/java/io/grpc/internal/testing/TestServerStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestServerStreamTracer.java
@@ -48,11 +48,6 @@ public class TestServerStreamTracer extends ServerStreamTracer implements TestSt
   }
 
   @Override
-  public int getInboundMessageCount() {
-    return delegate.getInboundMessageCount();
-  }
-
-  @Override
   public Status getStatus() {
     return delegate.getStatus();
   }
@@ -68,11 +63,6 @@ public class TestServerStreamTracer extends ServerStreamTracer implements TestSt
   }
 
   @Override
-  public int getOutboundMessageCount() {
-    return delegate.getOutboundMessageCount();
-  }
-
-  @Override
   public long getOutboundWireSize() {
     return delegate.getOutboundWireSize();
   }
@@ -80,6 +70,16 @@ public class TestServerStreamTracer extends ServerStreamTracer implements TestSt
   @Override
   public long getOutboundUncompressedSize() {
     return delegate.getOutboundUncompressedSize();
+  }
+
+  @Override
+  public String nextOutboundEvent() {
+    return delegate.nextOutboundEvent();
+  }
+
+  @Override
+  public String nextInboundEvent() {
+    return delegate.nextInboundEvent();
   }
 
   @Override
@@ -108,13 +108,35 @@ public class TestServerStreamTracer extends ServerStreamTracer implements TestSt
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public void inboundMessage() {
     delegate.inboundMessage();
   }
 
   @Override
+  public void inboundMessage(int seqNo) {
+    delegate.inboundMessage(seqNo);
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
   public void outboundMessage() {
     delegate.outboundMessage();
+  }
+
+  @Override
+  public void outboundMessage(int seqNo) {
+    delegate.outboundMessage(seqNo);
+  }
+
+  @Override
+  public void outboundMessageSent(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
+    delegate.outboundMessageSent(seqNo, optionalWireSize, optionalUncompressedSize);
+  }
+
+  @Override
+  public void inboundMessageRead(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
+    delegate.inboundMessageRead(seqNo, optionalWireSize, optionalUncompressedSize);
   }
 
   @Override

--- a/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;

--- a/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
@@ -19,11 +19,13 @@ package io.grpc.internal.testing;
 import io.grpc.Status;
 import io.grpc.StreamTracer;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 /**
  * A {@link StreamTracer} suitable for testing.
@@ -39,16 +41,6 @@ public interface TestStreamTracer {
    * Waits for the stream to be done.
    */
   boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException;
-
-  /**
-   * Returns how many times {@link StreamTracer#inboundMessage} has been called.
-   */
-  int getInboundMessageCount();
-
-  /**
-   * Returns how many times {@link StreamTracer#outboundMessage} has been called.
-   */
-  int getOutboundMessageCount();
 
   /**
    * Returns the status passed to {@link StreamTracer#streamClosed}.
@@ -76,6 +68,17 @@ public interface TestStreamTracer {
   long getOutboundUncompressedSize();
 
   /**
+   * Returns the next captured outbound message event.
+   */
+  @Nullable
+  String nextOutboundEvent();
+
+  /**
+   * Returns the next captured outbound message event.
+   */
+  String nextInboundEvent();
+
+  /**
    * A {@link StreamTracer} suitable for testing.
    */
   public static class TestBaseStreamTracer extends StreamTracer implements TestStreamTracer {
@@ -84,8 +87,8 @@ public interface TestStreamTracer {
     protected final AtomicLong inboundWireSize = new AtomicLong();
     protected final AtomicLong outboundUncompressedSize = new AtomicLong();
     protected final AtomicLong inboundUncompressedSize = new AtomicLong();
-    protected final AtomicInteger inboundMessageCount = new AtomicInteger();
-    protected final AtomicInteger outboundMessageCount = new AtomicInteger();
+    protected final LinkedBlockingQueue<String> outboundEvents = new LinkedBlockingQueue<String>();
+    protected final LinkedBlockingQueue<String> inboundEvents = new LinkedBlockingQueue<String>();
     protected final AtomicReference<Status> streamClosedStatus = new AtomicReference<Status>();
     protected final CountDownLatch streamClosed = new CountDownLatch(1);
     protected final AtomicBoolean failDuplicateCallbacks = new AtomicBoolean(true);
@@ -98,16 +101,6 @@ public interface TestStreamTracer {
     @Override
     public boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException {
       return streamClosed.await(timeout, timeUnit);
-    }
-
-    @Override
-    public int getInboundMessageCount() {
-      return inboundMessageCount.get();
-    }
-
-    @Override
-    public int getOutboundMessageCount() {
-      return outboundMessageCount.get();
     }
 
     @Override
@@ -167,13 +160,52 @@ public interface TestStreamTracer {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void inboundMessage() {
-      inboundMessageCount.incrementAndGet();
+      inboundEvents.add("inboundMessage()");
     }
 
     @Override
+    public void inboundMessage(int seqNo) {
+      inboundEvents.add("inboundMessage(" + seqNo + ")");
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
     public void outboundMessage() {
-      outboundMessageCount.incrementAndGet();
+      outboundEvents.add("outboundMessage()");
+    }
+
+    @Override
+    public void outboundMessage(int seqNo) {
+      outboundEvents.add("outboundMessage(" + seqNo + ")");
+    }
+
+    @Override
+    public void outboundMessageSent(
+        int seqNo, long optionalWireSize, long optionalUncompressedSize) {
+      outboundEvents.add(
+          String.format(
+              "outboundMessageSent(%d, %d, %d)",
+              seqNo, optionalWireSize, optionalUncompressedSize));
+    }
+
+    @Override
+    public void inboundMessageRead(
+        int seqNo, long optionalWireSize, long optionalUncompressedSize) {
+      inboundEvents.add(
+          String.format(
+              "inboundMessageRead(%d, %d, %d)", seqNo, optionalWireSize, optionalUncompressedSize));
+    }
+
+    @Override
+    public String nextOutboundEvent() {
+      return outboundEvents.poll();
+    }
+
+    @Override
+    public String nextInboundEvent() {
+      return inboundEvents.poll();
     }
   }
 }


### PR DESCRIPTION
Two methods, `outboundMessageSent()` and `inboundMessageRead()` are added to StreamTracer in order to associate individual messages with sizes. Both types of sizes are optional, as allowed by Census tracing.

Both methods accept a sequence number as the type ID as required by Census. The original `outboundMesage()` and `inboundMessage()` are also replaced by overrides that take the sequence number, to better match the new methods. The deprecation of the old overrides are tracked by #3460 
