### PR TITLE
core,netty,okhttp,protobuf-lite: avoid @Beta guava classes

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -483,7 +483,9 @@ public final class GrpcUtil {
    */
   public static ThreadFactory getThreadFactory(String nameFormat, boolean daemon) {
     if (IS_RESTRICTED_APPENGINE) {
-      return MoreExecutors.platformThreadFactory();
+      @SuppressWarnings("BetaApi")
+      ThreadFactory factory = MoreExecutors.platformThreadFactory();
+      return factory;
     } else {
       return new ThreadFactoryBuilder()
           .setDaemon(daemon)

--- a/core/src/main/java/io/grpc/internal/IoUtils.java
+++ b/core/src/main/java/io/grpc/internal/IoUtils.java
@@ -16,27 +16,41 @@
 
 package io.grpc.internal;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 
 /** Common IoUtils for thrift and nanopb to convert inputstream to bytes. */
 public final class IoUtils {
 
   /** maximum buffer to be read is 16 KB. */
-  private static final int MAX_BUFFER_LENGTH = 16384; 
-  
+  private static final int MAX_BUFFER_LENGTH = 16384;
+
   /** Returns the byte array. */
-  public static byte[] toByteArray(InputStream is) throws IOException {
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    int nRead;
-    byte[] bytes = new byte[MAX_BUFFER_LENGTH];
+  public static byte[] toByteArray(InputStream in) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    copy(in, out);
+    return out.toByteArray();
+  }
 
-    while ((nRead = is.read(bytes, 0, bytes.length)) != -1) {
-      buffer.write(bytes, 0, nRead);
+  /** Copies the data from input stream to output stream. */
+  public static long copy(InputStream from, OutputStream to) throws IOException {
+    // Copied from guava com.google.common.io.ByteStreams because its API is unstable (beta)
+    checkNotNull(from);
+    checkNotNull(to);
+    byte[] buf = new byte[MAX_BUFFER_LENGTH];
+    long total = 0;
+    while (true) {
+      int r = from.read(buf);
+      if (r == -1) {
+        break;
+      }
+      to.write(buf, 0, r);
+      total += r;
     }
-
-    buffer.flush();
-    return buffer.toByteArray();
+    return total;
   }
 }

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Math.min;
 
-import com.google.common.io.ByteStreams;
 import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.Drainable;
@@ -251,7 +250,7 @@ public class MessageFramer implements Framer {
     } else {
       // This makes an unnecessary copy of the bytes when bytebuf supports array(). However, we
       // expect performance-critical code to support flushTo().
-      long written = ByteStreams.copy(message, outputStream);
+      long written = IoUtils.copy(message, outputStream);
       checkArgument(written <= Integer.MAX_VALUE, "Message size overflow: %s", written);
       return (int) written;
     }

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -24,6 +24,7 @@ import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Attributes;
 import io.grpc.Codec;
@@ -37,7 +38,6 @@ import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import java.io.InputStream;
-import java.util.List;
 import java.util.logging.Logger;
 
 final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
@@ -90,9 +90,9 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
     } else {
       if (messageAcceptEncoding != null) {
         // TODO(carl-mastrangelo): remove the string allocation.
-        List<String> acceptedEncodingsList = ACCEPT_ENCODING_SPLITTER.splitToList(
-            new String(messageAcceptEncoding, GrpcUtil.US_ASCII));
-        if (!acceptedEncodingsList.contains(compressor.getMessageEncoding())) {
+        if (!Iterables.contains(
+            ACCEPT_ENCODING_SPLITTER.split(new String(messageAcceptEncoding, GrpcUtil.US_ASCII)),
+            compressor.getMessageEncoding())) {
           // resort to using no compression.
           compressor = Codec.Identity.NONE;
         }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -21,7 +21,6 @@ import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Ticker;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
@@ -167,8 +166,13 @@ class NettyClientTransport implements ConnectionClientTransport {
           keepAliveWithoutCalls);
     }
 
-    handler = NettyClientHandler.newHandler(lifecycleManager, keepAliveManager, flowControlWindow,
-        maxHeaderListSize, Ticker.systemTicker(), tooManyPingsRunnable);
+    handler = NettyClientHandler.newHandler(
+        lifecycleManager,
+        keepAliveManager,
+        flowControlWindow,
+        maxHeaderListSize,
+        GrpcUtil.STOPWATCH_SUPPLIER,
+        tooManyPingsRunnable);
     NettyHandlerSettings.setAutoWindow(handler);
 
     negotiationHandler = negotiator.newHandler(handler);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -22,7 +22,7 @@ import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
-import com.google.common.base.Ticker;
+import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.SettableFuture;
 import com.squareup.okhttp.Credentials;
 import com.squareup.okhttp.HttpUrl;
@@ -124,7 +124,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   private final String defaultAuthority;
   private final String userAgent;
   private final Random random = new Random();
-  private final Ticker ticker;
+  // Returns new unstarted stopwatches
+  private final Supplier<Stopwatch> stopwatchFactory;
   private Listener listener;
   private FrameReader testFrameReader;
   private AsyncFrameWriter frameWriter;
@@ -199,7 +200,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     this.sslSocketFactory = sslSocketFactory;
     this.hostnameVerifier = hostnameVerifier;
     this.connectionSpec = Preconditions.checkNotNull(connectionSpec, "connectionSpec");
-    this.ticker = Ticker.systemTicker();
+    this.stopwatchFactory = GrpcUtil.STOPWATCH_SUPPLIER;
     this.userAgent = GrpcUtil.getGrpcUserAgent("okhttp", userAgent);
     this.proxyAddress = proxyAddress;
     this.proxyUsername = proxyUsername;
@@ -212,10 +213,18 @@ class OkHttpClientTransport implements ConnectionClientTransport {
    * Create a transport connected to a fake peer for test.
    */
   @VisibleForTesting
-  OkHttpClientTransport(String userAgent, Executor executor, FrameReader frameReader,
-      FrameWriter testFrameWriter, int nextStreamId, Socket socket, Ticker ticker,
-      @Nullable Runnable connectingCallback, SettableFuture<Void> connectedFuture,
-      int maxMessageSize, Runnable tooManyPingsRunnable) {
+  OkHttpClientTransport(
+      String userAgent,
+      Executor executor,
+      FrameReader frameReader,
+      FrameWriter testFrameWriter,
+      int nextStreamId,
+      Socket socket,
+      Supplier<Stopwatch> stopwatchFactory,
+      @Nullable Runnable connectingCallback,
+      SettableFuture<Void> connectedFuture,
+      int maxMessageSize,
+      Runnable tooManyPingsRunnable) {
     address = null;
     this.maxMessageSize = maxMessageSize;
     defaultAuthority = "notarealauthority:80";
@@ -226,7 +235,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     this.testFrameWriter = Preconditions.checkNotNull(testFrameWriter, "testFrameWriter");
     this.socket = Preconditions.checkNotNull(socket, "socket");
     this.nextStreamId = nextStreamId;
-    this.ticker = ticker;
+    this.stopwatchFactory = stopwatchFactory;
     this.connectionSpec = null;
     this.connectingCallback = connectingCallback;
     this.connectedFuture = Preconditions.checkNotNull(connectedFuture, "connectedFuture");
@@ -271,7 +280,9 @@ class OkHttpClientTransport implements ConnectionClientTransport {
       } else {
         // set outstanding operation and then write the ping after releasing lock
         data = random.nextLong();
-        p = ping = new Http2Ping(data, Stopwatch.createStarted(ticker));
+        Stopwatch stopwatch = stopwatchFactory.get();
+        stopwatch.start();
+        p = ping = new Http2Ping(data, stopwatch);
         writePing = true;
       }
     }
@@ -317,7 +328,6 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     // For unary and server streaming, there will be a data frame soon, no need to flush the header.
     if ((stream.getType() != MethodType.UNARY && stream.getType() != MethodType.SERVER_STREAMING)
         || stream.useGet()) {
-      frameWriter.flush();
     }
     if (nextStreamId >= Integer.MAX_VALUE - 2) {
       // Make sure nextStreamId greater than all used id, so that mayHaveCreatedStream() performs

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -328,6 +328,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     // For unary and server streaming, there will be a data frame soon, no need to flush the header.
     if ((stream.getType() != MethodType.UNARY && stream.getType() != MethodType.SERVER_STREAMING)
         || stream.useGet()) {
+      frameWriter.flush();
     }
     if (nextStreamId >= Integer.MAX_VALUE - 2) {
       // Make sure nextStreamId greater than all used id, so that mayHaveCreatedStream() performs

--- a/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoInputStream.java
+++ b/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoInputStream.java
@@ -16,7 +16,6 @@
 
 package io.grpc.protobuf.lite;
 
-import com.google.common.io.ByteStreams;
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.Parser;
@@ -53,7 +52,7 @@ class ProtoInputStream extends InputStream implements Drainable, KnownLength {
       message.writeTo(target);
       message = null;
     } else if (partial != null) {
-      written = (int) ByteStreams.copy(partial, target);
+      written = (int) ProtoLiteUtils.copy(partial, target);
       partial = null;
     } else {
       written = 0;

--- a/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
+++ b/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
@@ -32,6 +32,7 @@ import io.grpc.Status;
 import io.grpc.internal.GrpcUtil;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 
@@ -43,6 +44,8 @@ public class ProtoLiteUtils {
 
   private static volatile ExtensionRegistryLite globalRegistry =
       ExtensionRegistryLite.getEmptyRegistry();
+
+  private static final int BUF_SIZE = 8192;
 
   /**
    * Sets the global registry for proto marshalling shared across all servers and clients.
@@ -200,6 +203,24 @@ public class ProtoLiteUtils {
         }
       }
     };
+  }
+
+  /** Copies the data from input stream to output stream. */
+  static long copy(InputStream from, OutputStream to) throws IOException {
+    // Copied from guava com.google.common.io.ByteStreams because its API is unstable (beta)
+    checkNotNull(from);
+    checkNotNull(to);
+    byte[] buf = new byte[BUF_SIZE];
+    long total = 0;
+    while (true) {
+      int r = from.read(buf);
+      if (r == -1) {
+        break;
+      }
+      to.write(buf, 0, r);
+      total += r;
+    }
+    return total;
   }
 
   private ProtoLiteUtils() {


### PR DESCRIPTION
Fix more of these usages so we can enable `@Beta` checks

For `Ticker`: replace with a factory for StopWatch. We can make
fake stop watches from unit tests, where `@Beta` doesn't matter.