### PR TITLE
core/compiler: register Span names for code-generated methods.

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -26,6 +26,21 @@ public final class BenchmarkServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.BenchmarkService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.BenchmarkService", "UnaryCall"),
+        generateFullMethodName(
+            "grpc.testing.BenchmarkService", "StreamingCall"),
+        generateFullMethodName(
+            "grpc.testing.BenchmarkService", "StreamingFromClient"),
+        generateFullMethodName(
+            "grpc.testing.BenchmarkService", "StreamingFromServer"),
+        generateFullMethodName(
+            "grpc.testing.BenchmarkService", "StreamingBothWays")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
@@ -26,6 +26,13 @@ public final class ReportQpsScenarioServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.ReportQpsScenarioService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.ReportQpsScenarioService", "ReportScenario")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult,

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -26,6 +26,19 @@ public final class WorkerServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.WorkerService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.WorkerService", "RunServer"),
+        generateFullMethodName(
+            "grpc.testing.WorkerService", "RunClient"),
+        generateFullMethodName(
+            "grpc.testing.WorkerService", "CoreCount"),
+        generateFullMethodName(
+            "grpc.testing.WorkerService", "QuitWorker")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs,

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ subprojects {
     repositories {
         mavenCentral()
         mavenLocal()
+        maven {
+          url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 
     [compileJava, compileTestJava, compileJmhJava].each() {
@@ -190,7 +193,8 @@ subprojects {
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.4.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
                 okio: 'com.squareup.okio:okio:1.6.0',
-                opencensus_api: 'io.opencensus:opencensus-api:0.5.1',
+                opencensus_api: 'io.opencensus:opencensus-api:0.7.0-SNAPSHOT',
+                opencensus_impl: 'io.opencensus:opencensus-impl:0.7.0-SNAPSHOT',
                 instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -304,14 +304,29 @@ static void PrintSamplingRegistration(
   p->Print("// Register methods for tracing.\n");
   p->Print("static {\n");
   p->Indent();
-  p->Print("Grpc.registerMethodsForTracing(new String[] {\n");
+  p->Print(
+      (*vars),
+      "$Grpc$.registerSampledMethodsForTracing(new String[] {\n");
+  p->Indent();
   p->Indent();
   (*vars)["service_name"] = service->name();
-  for (int i = 0; i < service->method_count(); ++i) {
+  size_t method_count = service->method_count();
+  for (size_t i = 0; i < service->method_count(); ++i) {
     const MethodDescriptor* method = service->method(i);
     (*vars)["method_name"] = method->name();
-    p->Print("
-    
+    p->Print(
+        (*vars),
+        "generateFullMethodName(\n"
+        "    \"$Package$$service_name$\", \"$method_name$\")");
+    if (i < method_count - 1) {
+      p->Print(",\n");
+    }
+  }
+  p->Outdent();
+  p->Outdent();
+  p->Print("});\n");
+  p->Outdent();
+  p->Print("}\n\n");
 }
 
 static void PrintMethodFields(
@@ -1102,6 +1117,7 @@ static void PrintService(const ServiceDescriptor* service,
       "public static final String SERVICE_NAME = "
       "\"$Package$$service_name$\";\n\n");
 
+  PrintSamplingRegistration(service, vars, p);
   PrintMethodFields(service, vars, p, flavor);
 
   // TODO(nmittler): Replace with WriteDocComment once included by protobuf distro.
@@ -1250,6 +1266,7 @@ void GenerateService(const ServiceDescriptor* service,
   vars["StreamObserver"] = "io.grpc.stub.StreamObserver";
   vars["Iterator"] = "java.util.Iterator";
   vars["Generated"] = "javax.annotation.Generated";
+  vars["Grpc"] = "io.grpc.Grpc";
   vars["ListenableFuture"] =
       "com.google.common.util.concurrent.ListenableFuture";
   vars["ExperimentalApi"] = "io.grpc.ExperimentalApi";

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -298,6 +298,22 @@ void GrpcWriteMethodDocComment(Printer* printer,
   printer->Print(" */\n");
 }
 
+static void PrintSamplingRegistration(
+    const ServiceDescriptor* service, std::map<string, string>* vars,
+    Printer* p) {
+  p->Print("// Register methods for tracing.\n");
+  p->Print("static {\n");
+  p->Indent();
+  p->Print("Grpc.registerMethodsForTracing(new String[] {\n");
+  p->Indent();
+  (*vars)["service_name"] = service->name();
+  for (int i = 0; i < service->method_count(); ++i) {
+    const MethodDescriptor* method = service->method(i);
+    (*vars)["method_name"] = method->name();
+    p->Print("
+    
+}
+
 static void PrintMethodFields(
     const ServiceDescriptor* service, std::map<string, string>* vars,
     Printer* p, ProtoFlavor flavor) {

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -29,6 +29,21 @@ public final class TestServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.TestService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.TestService", "UnaryCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "StreamingOutputCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "StreamingInputCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "FullBidiCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "HalfBidiCall")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -29,6 +29,21 @@ public final class TestServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.TestService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.TestService", "UnaryCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "StreamingOutputCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "StreamingInputCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "FullBidiCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "HalfBidiCall")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -31,6 +31,21 @@ public final class TestServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.TestService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.TestService", "UnaryCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "StreamingOutputCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "StreamingInputCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "FullBidiCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "HalfBidiCall")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   private static final int ARG_IN_METHOD_UNARY_CALL = 0;
   private static final int ARG_OUT_METHOD_UNARY_CALL = 1;

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -28,6 +28,8 @@ import io.grpc.ClientStreamTracer;
 import io.grpc.Context;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Grpc;
+import io.grpc.Grpc.Side;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
@@ -110,10 +112,6 @@ final class CensusTracingModule {
     return clientInterceptor;
   }
 
-  private static String makeSpanName(String prefix, String fullMethodName) {
-    return prefix + "." + fullMethodName.replace('/', '.');
-  }
-
   @VisibleForTesting
   static Status convertStatus(io.grpc.Status grpcStatus) {
     Status status;
@@ -192,7 +190,8 @@ final class CensusTracingModule {
       checkNotNull(fullMethodName, "fullMethodName");
       this.span =
           censusTracer
-              .spanBuilderWithExplicitParent(makeSpanName("Sent", fullMethodName), parentSpan)
+              .spanBuilderWithExplicitParent(
+                  Grpc.makeTraceSpanName(Side.CLIENT, fullMethodName), parentSpan)
               .setRecordEvents(true)
               .startSpan();
     }
@@ -226,7 +225,8 @@ final class CensusTracingModule {
       checkNotNull(fullMethodName, "fullMethodName");
       this.span =
           censusTracer
-              .spanBuilderWithRemoteParent(makeSpanName("Recv", fullMethodName), remoteSpan)
+              .spanBuilderWithRemoteParent(
+                  Grpc.makeTraceSpanName(Side.SERVER, fullMethodName), remoteSpan)
               .setRecordEvents(true)
               .startSpan();
     }

--- a/core/src/test/java/io/grpc/GrpcTest.java
+++ b/core/src/test/java/io/grpc/GrpcTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static org.junit.Assert.assertEquals;
+
+import io.grpc.Grpc.Side;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Grpc}. */
+@RunWith(JUnit4.class)
+public class GrpcTest {
+
+  @Test
+  public void makeTraceSpanName() {
+    assertEquals("Sent.io.grpc.Foo", Grpc.makeTraceSpanName(Side.CLIENT, "io.grpc/Foo"));
+    assertEquals("Recv.io.grpc.Bar", Grpc.makeTraceSpanName(Side.SERVER, "io.grpc/Bar"));
+  }
+}

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -713,6 +713,7 @@ public class CensusModulesTest {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void addAttributes(Map<String, AttributeValue> attributes) {}
 
     @Override

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -26,6 +26,13 @@ public final class LoadBalancerGrpc {
 
   public static final String SERVICE_NAME = "grpc.lb.v1.LoadBalancer";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.lb.v1.LoadBalancer", "BalanceLoad")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest,

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -26,6 +26,15 @@ public final class MetricsServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.MetricsService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.MetricsService", "GetAllGauges"),
+        generateFullMethodName(
+            "grpc.testing.MetricsService", "GetGauge")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -29,6 +29,15 @@ public final class ReconnectServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.ReconnectService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.ReconnectService", "Start"),
+        generateFullMethodName(
+            "grpc.testing.ReconnectService", "Stop")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -30,6 +30,27 @@ public final class TestServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.TestService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.TestService", "EmptyCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "UnaryCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "CacheableUnaryCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "StreamingOutputCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "StreamingInputCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "FullDuplexCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "HalfDuplexCall"),
+        generateFullMethodName(
+            "grpc.testing.TestService", "UnimplementedCall")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -30,6 +30,13 @@ public final class UnimplementedServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.UnimplementedService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.UnimplementedService", "UnimplementedCall")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -26,6 +26,13 @@ public final class HealthGrpc {
 
   public static final String SERVICE_NAME = "grpc.health.v1.Health";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.health.v1.Health", "Check")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest,

--- a/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
@@ -26,6 +26,21 @@ public final class MonitoringGrpc {
 
   public static final String SERVICE_NAME = "grpc.instrumentation.v1alpha.Monitoring";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.instrumentation.v1alpha.Monitoring", "GetCanonicalRpcStats"),
+        generateFullMethodName(
+            "grpc.instrumentation.v1alpha.Monitoring", "GetStats"),
+        generateFullMethodName(
+            "grpc.instrumentation.v1alpha.Monitoring", "WatchStats"),
+        generateFullMethodName(
+            "grpc.instrumentation.v1alpha.Monitoring", "GetRequestTraces"),
+        generateFullMethodName(
+            "grpc.instrumentation.v1alpha.Monitoring", "GetCustomMonitoringData")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<com.google.protobuf.Empty,

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -26,6 +26,13 @@ public final class ServerReflectionGrpc {
 
   public static final String SERVICE_NAME = "grpc.reflection.v1alpha.ServerReflection";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.reflection.v1alpha.ServerReflection", "ServerReflectionInfo")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest,

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -29,6 +29,13 @@ public final class AnotherDynamicServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.reflection.testing.AnotherDynamicService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.reflection.testing.AnotherDynamicService", "Method")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -29,6 +29,13 @@ public final class DynamicServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.reflection.testing.DynamicService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.reflection.testing.DynamicService", "Method")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -26,6 +26,13 @@ public final class ReflectableServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.reflection.testing.ReflectableService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.reflection.testing.ReflectableService", "Method")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request,

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -13,6 +13,9 @@ buildscript {
 dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub')
+    testCompile libraries.opencensus_api,
+                libraries.truth
+    testRuntime libraries.opencensus_impl
 }
 
 configureProtoCompilation()

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
@@ -29,6 +29,19 @@ public final class SimpleServiceGrpc {
 
   public static final String SERVICE_NAME = "grpc.testing.SimpleService";
 
+  // Register methods for tracing.
+  static {
+    io.grpc.Grpc.registerSampledMethodsForTracing(new String[] {
+        generateFullMethodName(
+            "grpc.testing.SimpleService", "UnaryRpc"),
+        generateFullMethodName(
+            "grpc.testing.SimpleService", "ClientStreamingRpc"),
+        generateFullMethodName(
+            "grpc.testing.SimpleService", "ServerStreamingRpc"),
+        generateFullMethodName(
+            "grpc.testing.SimpleService", "BidiStreamingRpc")});
+  }
+
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,


### PR DESCRIPTION
Resolves #3359

TODOs: switch to a released version of opencensus, and file issues for the added experimental methods.