### PR TITLE
core: allow to fallback to ServiceLoader.load withouth classloader to make GRCP more OSGi friendly.

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/core/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -70,7 +70,14 @@ public abstract class ManagedChannelProvider {
   @VisibleForTesting
   public static Iterable<ManagedChannelProvider> getCandidatesViaServiceLoader(
       ClassLoader classLoader) {
-    return ServiceLoader.load(ManagedChannelProvider.class, classLoader);
+    Iterable<ManagedChannelProvider> i
+        = ServiceLoader.load(ManagedChannelProvider.class, classLoader);
+    // Attempt to load using the context class loader and ServiceLoader.
+    // This allows frameworks like http://aries.apache.org/modules/spi-fly.html to plug in.
+    if (!i.iterator().hasNext()) {
+      i = ServiceLoader.load(ManagedChannelProvider.class);
+    }
+    return i;
   }
 
   /**

--- a/core/src/main/java/io/grpc/NameResolverProvider.java
+++ b/core/src/main/java/io/grpc/NameResolverProvider.java
@@ -71,10 +71,21 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
     return Collections.unmodifiableList(list);
   }
 
+  /**
+   * Loads service providers for the {@link NameResolverProvider} service using
+   * {@link ServiceLoader}.
+   */
   @VisibleForTesting
   public static Iterable<NameResolverProvider> getCandidatesViaServiceLoader(
       ClassLoader classLoader) {
-    return ServiceLoader.load(NameResolverProvider.class, classLoader);
+    Iterable<NameResolverProvider> i
+        = ServiceLoader.load(NameResolverProvider.class, classLoader);
+    // Attempt to load using the context class loader and ServiceLoader.
+    // This allows frameworks like http://aries.apache.org/modules/spi-fly.html to plug in.
+    if (!i.iterator().hasNext()) {
+      i = ServiceLoader.load(NameResolverProvider.class);
+    }
+    return i;
   }
 
   /**

--- a/core/src/main/java/io/grpc/ServerProvider.java
+++ b/core/src/main/java/io/grpc/ServerProvider.java
@@ -35,6 +35,13 @@ public abstract class ServerProvider {
   @VisibleForTesting
   static final ServerProvider load(ClassLoader cl) {
     ServiceLoader<ServerProvider> providers = ServiceLoader.load(ServerProvider.class, cl);
+
+    // Attempt to load using the context class loader and ServiceLoader.
+    // This allows frameworks like http://aries.apache.org/modules/spi-fly.html to plug in.
+    if (!providers.iterator().hasNext()) {
+      providers = ServiceLoader.load(ServerProvider.class);
+    }
+
     ServerProvider best = null;
 
     for (ServerProvider current : providers) {
@@ -81,4 +88,3 @@ public abstract class ServerProvider {
    */
   protected abstract ServerBuilder<?> builderForPort(int port);
 }
-

--- a/core/src/test/java/io/grpc/ServerProviderTest.java
+++ b/core/src/test/java/io/grpc/ServerProviderTest.java
@@ -49,6 +49,25 @@ public class ServerProviderTest {
     assertNull(ServerProvider.load(cl));
   }
 
+  @Test
+  public void contextClassLoaderProvider() {
+    ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+    try {
+      ClassLoader cl = new ReplacingClassLoader(
+              getClass().getClassLoader(), serviceFile,
+              "io/grpc/ServerProviderTest-empty.txt");
+
+      // test that the context classloader is used as fallback
+      ClassLoader rcll = new ReplacingClassLoader(
+          getClass().getClassLoader(), serviceFile,
+          "io/grpc/ServerProviderTest-multipleProvider.txt");
+      Thread.currentThread().setContextClassLoader(rcll);
+      assertSame(Available7Provider.class, ServerProvider.load(cl).getClass());
+    } finally {
+      Thread.currentThread().setContextClassLoader(ccl);
+    }
+  }
+
   private static class BaseProvider extends ServerProvider {
     private final boolean isAvailable;
     private final int priority;
@@ -103,4 +122,3 @@ public class ServerProviderTest {
     }
   }
 }
-


### PR DESCRIPTION
Rebased code of https://github.com/grpc/grpc-java/pull/3453 on master.
@ejona86 / @carl-mastrangelo 