### PR TITLE
java_grpc_library.bzl: fix path-manipulation bug.

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -1,7 +1,7 @@
 def _path_ignoring_repository(f):
   if (len(f.owner.workspace_root) == 0):
     return f.short_path
-  return f.path[len(f.owner.workspace_root)+1:]
+  return f.path[f.path.find(f.owner.workspace_root)+len(f.owner.workspace_root)+1:]
 
 def _gensource_impl(ctx):
   if len(ctx.attr.srcs) > 1:


### PR DESCRIPTION
_path_ignoring_repository munges bazel filesystem paths into proto import paths, in order to pass to protoc -I. Currently, the function assumes that the include's path begins with the bazel workspace root, which can therefore be sheared off the front of the path.

This assumption is incorrect. For an include living in an external repository (say, `@com_google_protobuf//:timestamp_proto`), the filesystem path is something like
`bazel-out/darwin_x86_64/fastbuild/genfiles/external/com_google_protobuf/google/protobuf/timestamp.proto`. (See also: http://docs.bazel.build/versions/master/skylark/lib/Label.html#workspace_root.)

This commit changes _path_ignoring_repository to handle this case correctly.