### PR TITLE
core: nonnull pendingStreams in DelayedClientTransport

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -312,9 +312,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
         // than IDLE_MODE_DEFAULT_TIMEOUT_MILLIS (1 second).
         channelExecutor.executeLater(reportTransportNotInUse);
         if (shutdownStatus != null && reportTransportTerminated != null) {
-          Runnable savedReportTransportTerminated = reportTransportTerminated;
+          channelExecutor.executeLater(reportTransportTerminated);
           reportTransportTerminated = null;
-          channelExecutor.executeLater(savedReportTransportTerminated);
         } else {
           // Because delayed transport is long-lived, we take this opportunity to down-size the
           // hashmap.
@@ -360,9 +359,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
           if (pendingStreams.isEmpty() && justRemovedAnElement) {
             channelExecutor.executeLater(reportTransportNotInUse);
             if (shutdownStatus != null) {
-              Runnable savedReportTransportTerminated = reportTransportTerminated;
+              channelExecutor.executeLater(reportTransportTerminated);
               reportTransportTerminated = null;
-              channelExecutor.executeLater(savedReportTransportTerminated);
             }
           }
         }

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -312,8 +312,9 @@ final class DelayedClientTransport implements ManagedClientTransport {
         // than IDLE_MODE_DEFAULT_TIMEOUT_MILLIS (1 second).
         channelExecutor.executeLater(reportTransportNotInUse);
         if (shutdownStatus != null && reportTransportTerminated != null) {
-          channelExecutor.executeLater(reportTransportTerminated);
+          Runnable savedReportTransportTerminated = reportTransportTerminated;
           reportTransportTerminated = null;
+          channelExecutor.executeLater(savedReportTransportTerminated);
         } else {
           // Because delayed transport is long-lived, we take this opportunity to down-size the
           // hashmap.
@@ -359,8 +360,9 @@ final class DelayedClientTransport implements ManagedClientTransport {
           if (pendingStreams.isEmpty() && justRemovedAnElement) {
             channelExecutor.executeLater(reportTransportNotInUse);
             if (shutdownStatus != null) {
-              channelExecutor.executeLater(reportTransportTerminated);
+              Runnable savedReportTransportTerminated = reportTransportTerminated;
               reportTransportTerminated = null;
+              channelExecutor.executeLater(savedReportTransportTerminated);
             }
           }
         }


### PR DESCRIPTION
Make `pendingStreams` in `DelayedClientTransport` non-null.  These two versions are equivalent, but I might be going to introduce `Collection<PendingStream2> pendingStreams2` for a short period of time for implementing retry, and I will have to check a lot of complicated conditions like 
```java
 if ((pendingStreams == null || pendingStreams.isEmpty()) && (pendingStreams2 == null || pendingStreams2.isEmpty()) ) {
  return;
}
if (pendingStream != null) {
  toProcess = new ArrayList<PendingStream>(pendingStreams);
}
if (pendingStream2 != null) {
  toProcess2 = new ArrayList<PendingStream2>(pendingStreams2);
}
```

```java
```
Making `pendingStreams` non-null will make the above situation a lot easier.