### PR TITLE
compiler: interfaces with java7 support

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -548,11 +548,11 @@ static void PrintStub(
   } else {
     if (options.enable_client_interfaces) {
       if (interface) {
-    	if (options.enable_deprecated) {
+        if (options.enable_deprecated) {
           p->Print(
               *vars,
-	          "@$Deprecated$ ");
-    	}
+              "@$Deprecated$ ");
+        }
         p->Print(
             *vars,
            "public static interface $client_name$ {\n");
@@ -635,7 +635,7 @@ static void PrintStub(
     }
 
     if (interface && options.java_version >= JAVA_7) {
-    	p->Print("default ");
+        p->Print("default ");
     }
 
     p->Print("public ");
@@ -686,9 +686,9 @@ static void PrintStub(
     if (interface) {
       if (options.java_version >= JAVA_7) {
           p->Print(*vars,
-        		   "{\n"
-        		   "    throw new RuntimeException(\"Method $lower_method_name$ is unimplemented\");\n"
-        		   "}\n");
+                   "{\n"
+                   "    throw new RuntimeException(\"Method $lower_method_name$ is unimplemented\");\n"
+                   "}\n");
       } else {
         p->Print(";\n");
       }
@@ -799,7 +799,7 @@ static void PrintMethodHandlerClass(const ServiceDescriptor* service,
                                    std::map<string, string>* vars,
                                    Printer* p,
                                    bool generate_nano,
-								   Options& options) {
+                                   Options& options) {
   // Sort method ids based on client_streaming() so switch tables are compact.
   std::vector<const MethodDescriptor*> sorted_methods(service->method_count());
   for (int i = 0; i < service->method_count(); ++i) {
@@ -1072,8 +1072,8 @@ static void PrintBindServiceMethodBody(const ServiceDescriptor* service,
 static void PrintService(const ServiceDescriptor* service,
                          std::map<string, string>* vars,
                          Printer* p,
-						 Options& options
-						 ) {
+                         Options& options
+                         ) {
   (*vars)["service_name"] = service->name();
   (*vars)["file_name"] = service->file()->name();
   (*vars)["service_class_name"] = ServiceClassName(service);
@@ -1150,33 +1150,33 @@ static void PrintService(const ServiceDescriptor* service,
   PrintStub(service, vars, p, FUTURE_CLIENT_IMPL, generate_nano, options);
 
   if (options.enable_client_interfaces) {
-	if (options.enable_deprecated) {
+    if (options.enable_deprecated) {
       PrintDeprecatedDocComment(service, vars, p);
-	}
+    }
     PrintStub(service, vars, p, ASYNC_INTERFACE, generate_nano, options);
-	if (options.enable_deprecated) {
+    if (options.enable_deprecated) {
       PrintDeprecatedDocComment(service, vars, p);
-	}
+    }
     PrintStub(service, vars, p, BLOCKING_CLIENT_INTERFACE, generate_nano, options);
-	if (options.enable_deprecated) {
+    if (options.enable_deprecated) {
       PrintDeprecatedDocComment(service, vars, p);
-	}
+    }
     PrintStub(service, vars, p, FUTURE_CLIENT_INTERFACE, generate_nano, options);
 
-	if (options.enable_deprecated) {
+    if (options.enable_deprecated) {
       PrintDeprecatedDocComment(service, vars, p);
       p->Print(*vars, "@$Deprecated$ ");
-	}
+    }
     p->Print(
         *vars,
         "public static abstract class Abstract$service_name$"
         " extends $service_name$ImplBase {}\n\n");
 
     // static bindService method
-	if (options.enable_deprecated) {
+    if (options.enable_deprecated) {
       PrintDeprecatedDocComment(service, vars, p);
       p->Print(*vars, "@$Deprecated$ ");
-	}
+    }
     p->Print(
         *vars,
         "public static $ServerServiceDefinition$ bindService("
@@ -1230,8 +1230,8 @@ void PrintImports(Printer* p, bool generate_nano) {
 
 void GenerateService(const ServiceDescriptor* service,
                      google::protobuf::io::ZeroCopyOutputStream* out,
-					 Options& options
-					 ) {
+                     Options& options
+                     ) {
   // All non-generated classes must be referred by fully qualified names to
   // avoid collision with generated classes.
   std::map<string, string> vars;
@@ -1266,7 +1266,7 @@ void GenerateService(const ServiceDescriptor* service,
 
   Printer printer(out, '$');
   string package_name = ServiceJavaPackage(service->file(),
-		  options.flavor == ProtoFlavor::NANO);
+          options.flavor == ProtoFlavor::NANO);
   if (!package_name.empty()) {
     printer.Print(
         "package $package_name$;\n\n",

--- a/compiler/src/java_plugin/cpp/java_generator.h
+++ b/compiler/src/java_plugin/cpp/java_generator.h
@@ -39,6 +39,20 @@ enum ProtoFlavor {
   NORMAL, LITE, NANO
 };
 
+#define JAVA_6 6
+#define JAVA_7 7
+#define JAVA_8 8
+
+class Options {
+  public:
+    bool generate_nano = false;
+    bool enable_deprecated = false;
+    bool disable_version = false;
+    bool enable_client_interfaces = false;
+    int java_version = JAVA_6;
+    ProtoFlavor flavor = ProtoFlavor::NORMAL;
+};
+
 // Returns the package name of the gRPC services defined in the given file.
 string ServiceJavaPackage(const google::protobuf::FileDescriptor* file, bool nano);
 
@@ -49,9 +63,7 @@ string ServiceClassName(const google::protobuf::ServiceDescriptor* service);
 // Writes the generated service interface into the given ZeroCopyOutputStream
 void GenerateService(const google::protobuf::ServiceDescriptor* service,
                      google::protobuf::io::ZeroCopyOutputStream* out,
-                     ProtoFlavor flavor,
-                     bool enable_deprecated,
-                     bool disable_version);
+					 Options& options);
 
 }  // namespace java_grpc_generator
 

--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -42,7 +42,8 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
         generatorOptions.flavor = java_grpc_generator::ProtoFlavor::LITE;
       } else if (options[i].first == "enable_deprecated") {
         generatorOptions.enable_deprecated = options[i].second == "true";
-        generatorOptions.enable_client_interfaces = true;
+        if (generatorOptions.enable_deprecated)
+          generatorOptions.enable_client_interfaces = true;
       } else if (options[i].first == "enable_client_interface") {
         generatorOptions.enable_client_interfaces = options[i].second == "true";
       } else if (options[i].first == "java_version") {

--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -34,25 +34,26 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
     std::vector<std::pair<string, string> > options;
     google::protobuf::compiler::ParseGeneratorParameter(parameter, &options);
 
-    java_grpc_generator::ProtoFlavor flavor =
-        java_grpc_generator::ProtoFlavor::NORMAL;
-
-    bool enable_deprecated = false;
-    bool disable_version = false;
+    java_grpc_generator::Options generatorOptions;
     for (size_t i = 0; i < options.size(); i++) {
       if (options[i].first == "nano") {
-        flavor = java_grpc_generator::ProtoFlavor::NANO;
+        generatorOptions.flavor = java_grpc_generator::ProtoFlavor::NANO;
       } else if (options[i].first == "lite") {
-        flavor = java_grpc_generator::ProtoFlavor::LITE;
+        generatorOptions.flavor = java_grpc_generator::ProtoFlavor::LITE;
       } else if (options[i].first == "enable_deprecated") {
-        enable_deprecated = options[i].second == "true";
+        generatorOptions.enable_deprecated = options[i].second == "true";
+        generatorOptions.enable_client_interfaces = true;
+      } else if (options[i].first == "enable_client_interface") {
+        generatorOptions.enable_client_interfaces = options[i].second == "true";
+      } else if (options[i].first == "java_version") {
+        generatorOptions.java_version = stoi(options[i].second);
       } else if (options[i].first == "noversion") {
-        disable_version = true;
+        generatorOptions.disable_version = true;
       }
     }
 
     string package_name = java_grpc_generator::ServiceJavaPackage(
-        file, flavor == java_grpc_generator::ProtoFlavor::NANO);
+        file, generatorOptions.flavor == java_grpc_generator::ProtoFlavor::NANO);
     string package_filename = JavaPackageToDir(package_name);
     for (int i = 0; i < file->service_count(); ++i) {
       const google::protobuf::ServiceDescriptor* service = file->service(i);
@@ -61,7 +62,7 @@ class JavaGrpcGenerator : public google::protobuf::compiler::CodeGenerator {
       std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> output(
           context->Open(filename));
       java_grpc_generator::GenerateService(
-          service, output.get(), flavor, enable_deprecated, disable_version);
+          service, output.get(), generatorOptions);
     }
     return true;
   }


### PR DESCRIPTION
Generated stubs cannot be mocked which makes testing very cumbersome.  This PR introduces an option to generate client interfaces that are not deprecated.  I've also added an option to specify java version compatibility so that generated interfaces can have default methods for java 7+ where the default implementation is to throw an exception. 

These options may be specified using the gradle plugin like so,

```
grpc {
  option 'enable_client_interface=true'
  option 'java_version=7'
}
```
