### PR TITLE
core: remove static field in ManagedChannelImplTest

### DIFF
--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -124,7 +125,6 @@ public class ManagedChannelImplTest {
           .build();
   private static final Attributes.Key<String> SUBCHANNEL_ATTR_KEY =
       Attributes.Key.of("subchannel-attr-key");
-  private static int unterminatedChannels;
   private final String serviceName = "fake.example.com";
   private final String authority = serviceName;
   private final String userAgent = "userAgent";
@@ -248,17 +248,13 @@ public class ManagedChannelImplTest {
     // would ignore any time-sensitive tasks, e.g., back-off and the idle timer.
     assertTrue(timer.getDueTasks() + " should be empty", timer.getDueTasks().isEmpty());
     assertEquals(executor.getPendingTasks() + " should be empty", 0, executor.numPendingTasks());
-    helper = null; // helper retains a ref to the channel
     if (channel != null) {
       channel.shutdownNow();
       if (!channel.isTerminated()) {
-        // Since there are no real transports in this test, if shutdownNow doesn't result in
-        // termination, then it will never happen.  It would be very cumbersome to make all the
-        // tests in this file clean up fully after themselves, so instead just keep track of how
-        // many don't.  This is used to see how many should be ignored in the phantom cleanup.
-        unterminatedChannels++;
+        // Ensure the transports in this test clean up properly. Otherwise, the stray reference can
+        // break the orphanedChannelsAreLogged cleanup tests.
+        fail("Channel not properly terminated");
       }
-      channel = null;
     }
   }
 
@@ -651,6 +647,10 @@ public class ManagedChannelImplTest {
     // The bad transport was never used.
     verify(badTransportInfo.transport, times(0)).newStream(any(MethodDescriptor.class),
         any(Metadata.class), any(CallOptions.class));
+
+    channel.shutdownNow();
+    badTransportInfo.listener.transportTerminated();
+    goodTransportInfo.listener.transportTerminated();
   }
 
   /**
@@ -738,6 +738,9 @@ public class ManagedChannelImplTest {
         .newStream(any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class));
     verify(transportInfo2.transport, times(0))
         .newStream(any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class));
+
+    transportInfo1.listener.transportTerminated();
+    transportInfo2.listener.transportTerminated();
   }
 
   @Test
@@ -1127,6 +1130,9 @@ public class ManagedChannelImplTest {
     assertEquals("testValue", testKey.get(newStreamContexts.poll()));
 
     assertNull(testKey.get());
+
+    channel.shutdownNow();
+    transportInfo.listener.transportTerminated();
   }
 
   @Test
@@ -1160,6 +1166,9 @@ public class ManagedChannelImplTest {
     // The factories are safely not stubbed because we do not expect any usage of them.
     verifyZeroInteractions(factory1);
     verifyZeroInteractions(factory2);
+
+    channel.shutdownNow();
+    transportInfo.listener.transportTerminated();
   }
 
   @Test
@@ -1195,6 +1204,9 @@ public class ManagedChannelImplTest {
     // The factories are safely not stubbed because we do not expect any usage of them.
     verifyZeroInteractions(factory1);
     verifyZeroInteractions(factory2);
+
+    channel.shutdownNow();
+    transportInfo.listener.transportTerminated();
   }
 
   @Test
@@ -1394,6 +1406,11 @@ public class ManagedChannelImplTest {
     executor.runDueTasks();
     verify(mockTransport).newStream(same(method), any(Metadata.class), any(CallOptions.class));
     verify(mockStream).start(any(ClientStreamListener.class));
+
+    channel.shutdownNow();
+    transportListener.transportTerminated();
+    MockClientTransportInfo secondTransportInfo = transports.poll();
+    secondTransportInfo.listener.transportTerminated();
   }
 
   @Test
@@ -1413,17 +1430,6 @@ public class ManagedChannelImplTest {
 
   @Test
   public void orphanedChannelsAreLogged() throws Exception {
-    int remaining = unterminatedChannels;
-    for (int retry = 0; retry < 3; retry++) {
-      System.gc();
-      System.runFinalization();
-      if ((remaining -= ManagedChannelReference.cleanQueue()) <= 0) {
-        break;
-      }
-      Thread.sleep(100L * (1L << retry));
-    }
-    assertThat(remaining).isAtMost(0);
-
     createChannel(
         new FakeNameResolverFactory(true),
         NO_INTERCEPTOR,

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1430,6 +1430,17 @@ public class ManagedChannelImplTest {
 
   @Test
   public void orphanedChannelsAreLogged() throws Exception {
+    // This test relies on having a known number of orphaned channels, so first try to clean up any
+    // stray references from other test classes.
+    for (int retry = 0; retry < 3; retry++) {
+      System.gc();
+      System.runFinalization();
+      if (ManagedChannelReference.cleanQueue() == 0) {
+        break;
+      }
+      Thread.sleep(100L * (1L << retry));
+    }
+
     createChannel(
         new FakeNameResolverFactory(true),
         NO_INTERCEPTOR,


### PR DESCRIPTION
Several test cases were not properly shutting down the channel, requiring a static `unterminatedChannels` variable to track across all tests the number of remaining channels, which were then garbage collected as a preprocessing step in `#orphanedChannelsAreLogged`. This relies on a timeout to wait for the garbage collector to run, and failed twice on Travis for https://github.com/grpc/grpc-java/pull/3403 (was able to reproduce locally on master branch with 1500+ plus runs) with the following exception:

```
io.grpc.internal.ManagedChannelImplTest > orphanedChannelsAreLogged FAILED
    java.lang.AssertionError: Not true that <1> is at most <0>
        at com.google.common.truth.FailureStrategy.fail(FailureStrategy.java:24)
        at com.google.common.truth.FailureStrategy.fail(FailureStrategy.java:20)
        at com.google.common.truth.Subject.failComparingToStrings(Subject.java:295)
        at com.google.common.truth.Subject.fail(Subject.java:272)
        at com.google.common.truth.ComparableSubject.isAtMost(ComparableSubject.java:104)
        at io.grpc.internal.ManagedChannelImplTest.orphanedChannelsAreLogged(ManagedChannelImplTest.java:1425)
```

This PR cleans up the channels for the test cases that were not doing so, removes the static counter variable and replaces it with an assertion in the `@After` method that the channel was properly terminated.