### PR TITLE
Review Only: retry take 2

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -78,6 +78,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
   private boolean halfCloseCalled;
   private final ClientTransportProvider clientTransportProvider;
   private final CancellationListener cancellationListener = new ContextCancellationListener();
+  private final RetryOrHedgingBuffer<ReqT> retryBuffer;
   private ScheduledExecutorService deadlineCancellationExecutor;
   private boolean fullStreamDecompression;
   private DecompressorRegistry decompressorRegistry = DecompressorRegistry.getDefaultInstance();
@@ -98,6 +99,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     this.context = Context.current();
     this.unaryRequest = method.getType() == MethodType.UNARY
         || method.getType() == MethodType.SERVER_STREAMING;
+    retryBuffer = new RetryOrHedgingBuffer<ReqT>(method);
     this.callOptions = callOptions;
     this.clientTransportProvider = clientTransportProvider;
     this.deadlineCancellationExecutor = deadlineCancellationExecutor;
@@ -120,6 +122,8 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
      * @param args object containing call arguments.
      */
     ClientTransport get(PickSubchannelArgs args);
+
+    DelayedClientTransport getDelayedTransport();
   }
 
   ClientCallImpl<ReqT, RespT> setFullStreamDecompression(boolean fullStreamDecompression) {
@@ -222,30 +226,36 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     if (!deadlineExceeded) {
       updateTimeoutHeaders(effectiveDeadline, callOptions.getDeadline(),
           context.getDeadline(), headers);
-      ClientTransport transport = clientTransportProvider.get(
-          new PickSubchannelArgsImpl(method, headers, callOptions));
-      Context origContext = context.attach();
-      try {
-        stream = transport.newStream(method, headers, callOptions);
-      } finally {
-        context.detach(origContext);
+      if (retryEnabled()) {
+        stream = new RetriableStream<ReqT>(
+            method, retryBuffer, compressor, decompressorRegistry, callOptions, headers,
+            clientTransportProvider, context, fullStreamDecompression);
+      } else {
+        ClientTransport transport = clientTransportProvider.get(
+            new PickSubchannelArgsImpl(method, headers, callOptions));
+        Context origContext = context.attach();
+        try {
+          stream = transport.newStream(method, headers, callOptions);
+        } finally {
+          context.detach(origContext);
+        }
+        if (callOptions.getAuthority() != null) {
+          stream.setAuthority(callOptions.getAuthority());
+        }
+        if (callOptions.getMaxInboundMessageSize() != null) {
+          stream.setMaxInboundMessageSize(callOptions.getMaxInboundMessageSize());
+        }
+        if (callOptions.getMaxOutboundMessageSize() != null) {
+          stream.setMaxOutboundMessageSize(callOptions.getMaxOutboundMessageSize());
+        }
+        stream.setCompressor(compressor);
+        stream.setFullStreamDecompression(fullStreamDecompression);
+        stream.setDecompressorRegistry(decompressorRegistry);
       }
     } else {
       stream = new FailingClientStream(DEADLINE_EXCEEDED);
     }
 
-    if (callOptions.getAuthority() != null) {
-      stream.setAuthority(callOptions.getAuthority());
-    }
-    if (callOptions.getMaxInboundMessageSize() != null) {
-      stream.setMaxInboundMessageSize(callOptions.getMaxInboundMessageSize());
-    }
-    if (callOptions.getMaxOutboundMessageSize() != null) {
-      stream.setMaxOutboundMessageSize(callOptions.getMaxOutboundMessageSize());
-    }
-    stream.setCompressor(compressor);
-    stream.setFullStreamDecompression(fullStreamDecompression);
-    stream.setDecompressorRegistry(decompressorRegistry);
     stream.start(new ClientStreamListenerImpl(observer));
 
     // Delay any sources of cancellation after start(), because most of the transports are broken if
@@ -267,6 +277,11 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       // was cancelled.
       removeContextListenerAndCancelDeadlineFuture();
     }
+  }
+
+  // TODO: API plumbing to enable retry.
+  private boolean retryEnabled() {
+    return false;
   }
 
   /**
@@ -405,9 +420,16 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     checkState(!cancelCalled, "call was cancelled");
     checkState(!halfCloseCalled, "call was half-closed");
     try {
-      // TODO(notcarl): Find out if messageIs needs to be closed.
-      InputStream messageIs = method.streamRequest(message);
-      stream.writeMessage(messageIs);
+      // TODO: add the case for hedgingStream.
+      if (stream instanceof RetriableStream) {
+        @SuppressWarnings("unchecked")
+        RetriableStream<ReqT> retriableStream = ((RetriableStream<ReqT>) stream);
+        retriableStream.sendMessage(message);
+      } else {
+        // TODO(notcarl): Find out if messageIs needs to be closed.
+        InputStream messageIs = method.streamRequest(message);
+        stream.writeMessage(messageIs);
+      }
     } catch (Throwable e) {
       stream.cancel(Status.CANCELLED.withCause(e).withDescription("Failed to stream message"));
       return;

--- a/core/src/main/java/io/grpc/internal/DelayedStream2.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream2.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.internal.RetriableStream.BUFFER_KEY;
+import static io.grpc.internal.RetriableStream.SUBSTREAM_KEY;
+
+import io.grpc.Attributes;
+import io.grpc.Compressor;
+import io.grpc.DecompressorRegistry;
+import io.grpc.Status;
+import java.io.InputStream;
+
+/**
+ * A forwarding ClientStream all public methods of which can only get called after pass-through.
+ * Before pass-through, all actions are buffered in a {@link RetryOrHedgingBuffer}. {@link
+ * RetryOrHedgingBuffer#resume(Substream)} will quit immediately if the underlying stream is an
+ * instance of {@code DelayedStream2} and not yet pass-through.
+ */
+class DelayedStream2 implements ClientStream {
+
+  private final Substream substream;
+  private final RetryOrHedgingBuffer<?> buffer;
+  /** Must hold {@code substream} lock when setting. */
+  private ClientStream realStream;
+
+  DelayedStream2() {
+    // This is a hacky way to pass substream and buffer to DelayedStream2.
+    // Try alternatives, if a better way exists.
+    substream = checkNotNull(SUBSTREAM_KEY.get(), "substream");
+    buffer = checkNotNull(BUFFER_KEY.get(), "buffer");
+  }
+
+  /**
+   * Transfers all pending and future requests and mutations to the given stream.
+   */
+  final void passThrough(ClientStream realStream) {
+    synchronized (substream) {
+      if (this.realStream != null) {
+        return;
+      }
+      this.realStream = checkNotNull(realStream, "realStream");
+    }
+    buffer.resume(substream);
+  }
+
+  /** Returns {@code true} once realStream is valid. */
+  final boolean isPassThrough() {
+    return realStream != null;
+  }
+
+  @Override
+  public void setMaxInboundMessageSize(int maxSize) {
+    realStream.setMaxInboundMessageSize(maxSize);
+  }
+
+  @Override
+  public void setMaxOutboundMessageSize(int maxSize) {
+    realStream.setMaxOutboundMessageSize(maxSize);
+  }
+
+  @Override
+  public void setAuthority(String authority) {
+    checkState(isPassThrough(), "The delayed stream should pass through");
+    realStream.setAuthority(authority);
+  }
+
+  @Override
+  public void setFullStreamDecompression(boolean fullStreamDecompression) {
+    realStream.setFullStreamDecompression(fullStreamDecompression);
+  }
+
+  @Override
+  public void start(ClientStreamListener listener) {
+    checkState(isPassThrough(), "The delayed stream should pass through");
+    realStream.start(listener);
+  }
+
+  @Override
+  public Attributes getAttributes() {
+    return realStream.getAttributes();
+  }
+
+  @Override
+  public void writeMessage(InputStream message) {
+    realStream.writeMessage(message);
+  }
+
+  @Override
+  public void flush() {
+    realStream.flush();
+  }
+
+  @Override
+  public void cancel(Status reason) {
+    realStream.cancel(reason);
+  }
+
+  @Override
+  public void halfClose() {
+    realStream.halfClose();
+  }
+
+  @Override
+  public void request(int numMessages) {
+    realStream.request(numMessages);
+  }
+
+  @Override
+  public void setCompressor(Compressor compressor) {
+    realStream.setCompressor(compressor);
+  }
+
+  @Override
+  public void setDecompressorRegistry(DecompressorRegistry decompressorRegistry) {
+    checkState(isPassThrough(), "The delayed stream should pass through");
+    realStream.setDecompressorRegistry(decompressorRegistry);
+  }
+
+  @Override
+  public boolean isReady() {
+    return realStream.isReady();
+  }
+
+  @Override
+  public void setMessageCompression(boolean enable) {
+    realStream.setMessageCompression(enable);
+  }
+}

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -379,6 +379,11 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       }
       return delayedTransport;
     }
+
+    @Override
+    public DelayedClientTransport getDelayedTransport() {
+      return delayedTransport;
+    }
   };
 
   ManagedChannelImpl(

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -68,6 +68,11 @@ final class OobChannel extends ManagedChannel implements WithLogId {
       // critical path.
       return delayedTransport;
     }
+
+    @Override
+    public DelayedClientTransport getDelayedTransport() {
+      return delayedTransport;
+    }
   };
 
   OobChannel(

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.internal.Substream.Progress.CANCELLED;
+import static io.grpc.internal.Substream.Progress.START;
+
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.Compressor;
+import io.grpc.Context;
+import io.grpc.Context.Key;
+import io.grpc.DecompressorRegistry;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
+import java.io.InputStream;
+
+/**
+ * A logical {@link ClientStream} that is retriable. It contains one active {@link Substream}
+ * representing the current retry attempt. The first method to be called after constructor is {@code
+ * start(ClientStreamListener masterListener)}.
+ */
+final class RetriableStream<ReqT> implements ClientStream {
+  static final Key<Substream> SUBSTREAM_KEY = Context.<Substream>key("substream");
+  static final Key<RetryOrHedgingBuffer<?>> BUFFER_KEY =
+      Context.<RetryOrHedgingBuffer<?>>key("buffer");
+  private final MethodDescriptor<ReqT, ?> method;
+  private final RetryOrHedgingBuffer<ReqT> buffer;
+  private final Compressor compressor;
+  private final DecompressorRegistry decompressorRegistry;
+  private final CallOptions callOptions;
+  private final Metadata headers;
+  private final ClientTransportProvider clientTransportProvider;
+  private final DelayedClientTransport delayedClientTransport;
+  private final Context context;
+  private final boolean fullStreamDecompression;
+  /** Lock for synchronizing {@link #retry()} and {@link #cancel(Status)}. */
+  private final Object lock = new Object();
+  /** No need to synchronize its callbacks b/c no hedging involved. */
+  private ClientStreamListener masterListener;
+
+  private Status cancellingStatus;
+  private Substream substream;
+
+  RetriableStream(
+      MethodDescriptor<ReqT, ?> method,
+      RetryOrHedgingBuffer<ReqT> buffer,
+      Compressor compressor,
+      DecompressorRegistry decompressorRegistry,
+      CallOptions callOptions,
+      Metadata headers,
+      ClientTransportProvider clientTransportProvider,
+      Context context,
+      boolean fullStreamDecompression) {
+    this.method = method;
+    this.buffer = buffer;
+    this.compressor = compressor;
+    this.decompressorRegistry = decompressorRegistry;
+    this.callOptions = callOptions;
+    this.headers = headers;
+    this.clientTransportProvider = clientTransportProvider;
+    delayedClientTransport = clientTransportProvider.getDelayedTransport();
+    this.context = context;
+    this.fullStreamDecompression = fullStreamDecompression;
+  }
+
+  /**
+   * Requests if committed, or buffers it first and then requests on the current
+   * substream.
+   */
+  @Override
+  public void request(int numMessages) {
+    if (buffer.enqueueRequest(numMessages)) {
+      buffer.resume(substream);
+    } else {
+      clientStream().request(numMessages);
+    }
+  }
+
+  /**
+   * Do not use it. Use {@link #sendMessage(ReqT)} instead because we don't use InputStream for
+   * buffering.
+   */
+  @Override
+  public void writeMessage(InputStream message) {
+    throw new UnsupportedOperationException("unsupported");
+  }
+
+  /**
+   * Sends out the message if committed, or buffers it first and then sends it out on the current
+   * substream.
+   */
+  void sendMessage(ReqT message) {
+    if (buffer.enqueueMessage(message)) {
+      buffer.resume(substream);
+    } else {
+      // TODO(notcarl): Find out if streamRequest needs to be closed.
+      clientStream().writeMessage(method.streamRequest(message));
+    }
+  }
+
+  /** Flushes if committed, or buffers it first and then flushes on the current substream. */
+  @Override
+  public void flush() {
+    if (buffer.enqueueFlush()) {
+      buffer.resume(substream);
+    } else {
+      clientStream().flush();
+    }
+  }
+
+  @Override
+  public boolean isReady() {
+    return clientStream().isReady();
+  }
+
+  /**
+   * Sets the compressor if committed, or buffers it first and then sets it on the current
+   * substream.
+   */
+  @Override
+  public void setCompressor(Compressor compressor) {
+    if (buffer.enqueueCompressor(compressor)) {
+      buffer.resume(substream);
+    } else {
+      clientStream().setCompressor(compressor);
+    }
+  }
+
+  /**
+   * Sets the fullStreamDecompression if committed, or buffers it first and then sets it on the
+   * current substream.
+   */
+  @Override
+  public void setFullStreamDecompression(boolean fullStreamDecompression) {
+    if (buffer.enqueueFullStreamDecompression(fullStreamDecompression)) {
+      buffer.resume(substream);
+    } else {
+      clientStream().setFullStreamDecompression(fullStreamDecompression);
+    }
+  }
+
+  /**
+   * Set enable message compression if committed, or buffers it first and then sets it on the
+   * current substream.
+   */
+  @Override
+  public void setMessageCompression(boolean enable) {
+    if (buffer.enqueueMessageCompression(enable)) {
+      buffer.resume(substream);
+    } else {
+      clientStream().setMessageCompression(enable);
+    }
+  }
+
+  @Override
+  public void cancel(Status reason) {
+    synchronized (lock) {
+      cancellingStatus = reason;
+    }
+    substream.updateProgress(CANCELLED);
+    buffer.commit(substream);
+    substream.clientStream().cancel(cancellingStatus);
+    delayedClientTransport.removeRetryOrHedgingStream(this);
+  }
+
+  private boolean cancelled() {
+    return cancellingStatus != null;
+  }
+
+  /** Half-closes if committed, or buffers it first and then half-closes the current substream. */
+  @Override
+  public void halfClose() {
+    if (buffer.enqueueHalfClose()) {
+      buffer.resume(substream);
+    } else {
+      clientStream().halfClose();
+    }
+  }
+
+  @Override
+  public void setAuthority(String authority) {
+    throw new IllegalStateException("setAuthority() may only be called when starting a substream");
+  }
+
+  @Override
+  public void setDecompressorRegistry(DecompressorRegistry decompressorRegistry) {
+    throw new IllegalStateException(
+        "setDecompressorRegistry() may only be called when starting a substream");
+  }
+
+  /**
+   * Sets the max inbound message size if committed, or buffers it first and then sets it on the
+   * current substream.
+   */
+  @Override
+  public void setMaxInboundMessageSize(int maxSize) {
+    if (buffer.enqueueMaxInboundMessageSize(maxSize)) {
+      buffer.resume(substream);
+    } else {
+      clientStream().setMaxInboundMessageSize(maxSize);
+    }
+  }
+
+  /**
+   * Sets the max outbound message size if committed, or buffers it first and then sets it on the
+   * current substream.
+   */
+  @Override
+  public void setMaxOutboundMessageSize(int maxSize) {
+    if (buffer.enqueueMaxOutboundMessageSize(maxSize)) {
+      buffer.resume(substream);
+    } else {
+      clientStream().setMaxOutboundMessageSize(maxSize);
+    }
+  }
+
+  /**
+   * Starts the first PRC attempt, and in the mean time also buffer the task.
+   */
+  @Override
+  public void start(ClientStreamListener masterListener) {
+    this.masterListener = masterListener;
+    delayedClientTransport.addRetryOrHedgingStream(this);
+    // This is the first RPC attempt.
+    substream = new RetrySubstream();
+
+    checkState(buffer.enqueueStart(), "The RPC shouldn't be committed before start");
+    buffer.resume(substream);
+  }
+
+  @Override
+  public Attributes getAttributes() {
+    return clientStream().getAttributes();
+  }
+
+  private ClientStream clientStream() {
+    return substream.clientStream();
+  }
+
+  // TODO: implement retry policy.
+  // Retry policy is obtained from the combination of the name resolver plus channel builder, and
+  // passed all the way down to this class.
+  private boolean shouldRetry() {
+    return false;
+  }
+
+  private void retry() {
+    synchronized (lock) {
+      if (cancelled()) {
+        return;
+      }
+    }
+
+    // This is a retry RPC attempt.
+    // This must be outside of the lock b/c it is expensive.
+    Substream sub = new RetrySubstream(); // TODO: update "grpc-retry-attempts" header
+
+    synchronized (lock) {
+      if (!cancelled()) {
+        substream = sub;
+      }
+      // else: Do not update substream. The subsequent buffer.resume(sub) will run start() first,
+      // which cancels this orphan sub immediately.
+    }
+
+    // This must be outside of the lock b/c it is expensive.
+    buffer.resume(sub);
+  }
+
+  private final class RetrySubstream implements Substream {
+
+    final ClientStream stream;
+    // @GuadedBy("this")
+    Progress progress = START;
+    // @GuadedBy("this")
+    boolean isResuming;
+
+    RetrySubstream() {
+      ClientTransport transport =
+          clientTransportProvider.get(new PickSubchannelArgsImpl(method, headers, callOptions));
+      // Must create a new stream in the given context.
+      Context context =
+          RetriableStream.this.context
+              // The line below is a hacky way to pass substream and buffer to DelayedStream2.
+              // Try alternatives, if a better way exists.
+              .withValues(SUBSTREAM_KEY, this, BUFFER_KEY, buffer);
+      Context origContext = context.attach();
+      try {
+        stream = transport.newStream(method, headers, callOptions);
+      } finally {
+        context.detach(origContext);
+      }
+    }
+
+    @Override
+    public void start() {
+      if (callOptions.getAuthority() != null) {
+        stream.setAuthority(callOptions.getAuthority());
+      }
+      if (callOptions.getMaxInboundMessageSize() != null) {
+        stream.setMaxInboundMessageSize(callOptions.getMaxInboundMessageSize());
+      }
+      if (callOptions.getMaxOutboundMessageSize() != null) {
+        stream.setMaxOutboundMessageSize(callOptions.getMaxOutboundMessageSize());
+      }
+      stream.setCompressor(compressor);
+      stream.setFullStreamDecompression(fullStreamDecompression);
+      stream.setDecompressorRegistry(decompressorRegistry);
+      stream.start(new RetrySublistener());
+      if (cancelled()) {
+        // In case this is the orphan sub created in retry().
+        stream.cancel(cancellingStatus);
+      }
+    }
+
+    @Override
+    public ClientStream clientStream() {
+      return stream;
+    }
+
+    @Override
+    // @GuadedBy("this")
+    public boolean isPending() {
+      if (stream instanceof DelayedStream2) {
+        return !((DelayedStream2) stream).isPassThrough();
+      }
+      return false;
+    }
+
+    @Override
+    // @GuadedBy("this")
+    public boolean isResuming() {
+      return isResuming;
+    }
+
+    @Override
+    // @GuadedBy("this")
+    public void setResuming(boolean resuming) {
+      this.isResuming = resuming;
+    }
+
+    @Override
+    public synchronized Progress progress() {
+      return progress;
+    }
+
+    @Override
+    public synchronized void updateProgress(Progress progress) {
+      if (this.progress == CANCELLED) {
+        return;
+      }
+      this.progress = progress;
+    }
+
+    final class RetrySublistener implements ClientStreamListener {
+      private boolean commited;
+
+      @Override
+      public void headersRead(Metadata headers) {
+        if (!commited) {
+          buffer.commit(RetrySubstream.this);
+          commited = true;
+          delayedClientTransport.removeRetryOrHedgingStream(RetriableStream.this);
+        }
+        masterListener.headersRead(headers);
+      }
+
+      @Override
+      public void closed(Status status, Metadata trailers) {
+        if (!commited && !cancelled() && shouldRetry()) {
+          // TODO: backoff
+          retry();
+        } else {
+          masterListener.closed(status, trailers);
+        }
+      }
+
+      @Override
+      public void messagesAvailable(MessageProducer producer) {
+        masterListener.messagesAvailable(producer);
+      }
+
+      @Override
+      public void onReady() {
+        masterListener.onReady();
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/RetryOrHedgingBuffer.java
+++ b/core/src/main/java/io/grpc/internal/RetryOrHedgingBuffer.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.internal.Substream.Progress.CANCELLED;
+import static io.grpc.internal.Substream.Progress.COMPLETED;
+
+import io.grpc.ClientCall;
+import io.grpc.Compressor;
+import io.grpc.MethodDescriptor;
+import io.grpc.internal.Substream.Progress;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+
+/** A storage for buffering messages that could be used for retry or hedging. */
+@ThreadSafe
+final class RetryOrHedgingBuffer<ReqT> {
+  private static final BufferEntry HALF_CLOSE_ENTRY =
+      new BufferEntry() {
+        @Override
+        public void runWith(Substream substream) {
+          substream.clientStream().halfClose();
+        }
+      };
+  private static final BufferEntry FLUSH_ENTRY =
+      new BufferEntry() {
+        @Override
+        public void runWith(Substream substream) {
+          substream.clientStream().flush();
+        }
+      };
+  // Lock for synchronizing enqueue actions and commit().
+  private final Object lock = new Object();
+  private final MethodDescriptor<ReqT, ?> method;
+  private volatile boolean committed;
+  private volatile Substream winningSubstream;
+  private List<BufferEntry> buffer = new ArrayList<BufferEntry>();
+
+  RetryOrHedgingBuffer(MethodDescriptor<ReqT, ?> method) {
+    this.method = method;
+  }
+
+  boolean enqueueStart() {
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(
+          new BufferEntry() {
+            @Override
+            public void runWith(Substream substream) {
+              substream.start();
+            }
+          });
+      return true;
+    }
+  }
+
+  /**
+   * Enqueues a message.
+   *
+   * @return true if enqueued, indicating a resume on all substreams is required; otherwise
+   *     indicating that the buffer has been committed already
+   */
+  boolean enqueueMessage(final ReqT message) {
+    if (committed) {
+      return false;
+    }
+
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(
+          new BufferEntry() {
+            @Override
+            public void runWith(Substream substream) {
+              // TODO(notcarl): Find out if streamRequest needs to be closed.
+              substream.clientStream().writeMessage(method.streamRequest(message));
+            }
+          });
+      return true;
+    }
+  }
+
+  /**
+   * Enqueues a {@link ClientCall#request(int)} instruction.
+   *
+   * @return true if enqueued, indicating a resume on all substreams is required; otherwise
+   *     indicating that the buffer has been committed already
+   */
+  boolean enqueueRequest(final int requests) {
+    if (committed) {
+      return false;
+    }
+
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(
+          new BufferEntry() {
+            @Override
+            public void runWith(Substream substream) {
+              substream.clientStream().request(requests);
+            }
+          });
+      return true;
+    }
+  }
+
+  /** Enqueues a {@link ClientCall#halfClose()} instruction. */
+  boolean enqueueHalfClose() {
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(HALF_CLOSE_ENTRY);
+      return true;
+    }
+  }
+
+  boolean enqueueFlush() {
+    if (committed) {
+      return false;
+    }
+
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(FLUSH_ENTRY);
+      return true;
+    }
+  }
+
+  boolean enqueueMessageCompression(final boolean enable) {
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(
+          new BufferEntry() {
+            @Override
+            public void runWith(Substream substream) {
+              substream.clientStream().setMessageCompression(enable);
+            }
+          });
+      return true;
+    }
+  }
+
+  boolean enqueueCompressor(final Compressor compressor) {
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(
+          new BufferEntry() {
+            @Override
+            public void runWith(Substream substream) {
+              substream.clientStream().setCompressor(compressor);
+            }
+          });
+      return true;
+    }
+  }
+
+  boolean enqueueFullStreamDecompression(final boolean fullStreamDecompression) {
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(
+          new BufferEntry() {
+            @Override
+            public void runWith(Substream substream) {
+              substream.clientStream().setFullStreamDecompression(fullStreamDecompression);
+            }
+          });
+      return true;
+    }
+  }
+
+  boolean enqueueMaxInboundMessageSize(final int maxSize) {
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(
+          new BufferEntry() {
+            @Override
+            public void runWith(Substream substream) {
+              substream.clientStream().setMaxInboundMessageSize(maxSize);
+            }
+          });
+      return true;
+    }
+  }
+
+  boolean enqueueMaxOutboundMessageSize(final int maxSize) {
+    synchronized (lock) {
+      if (committed) {
+        return false;
+      }
+      buffer.add(
+          new BufferEntry() {
+            @Override
+            public void runWith(Substream substream) {
+              substream.clientStream().setMaxOutboundMessageSize(maxSize);
+            }
+          });
+      return true;
+    }
+  }
+
+  /** Resume replay if new messages or requests have been enqueued. */
+  void resume(Substream substream) {
+    checkNotNull(substream, "substream");
+
+    synchronized (substream) {
+      if (substream.isResuming()) {
+        return;
+      }
+      if (substream.isPending()) {
+        return;
+      }
+      substream.setResuming(true);
+    }
+
+    // Only one instance of resume() can execute below at a time until substream.setResuming(false)
+    // is called.
+    Progress progress = substream.progress();
+
+    if (progress == CANCELLED || progress == COMPLETED) {
+      return;
+    }
+
+    List<BufferEntry> savedBuffer = buffer;
+    int size = savedBuffer.size();
+    int i = progress.currentPosition();
+    while (true) {
+      if (winningSubstream != null) {
+        if (winningSubstream != substream) {
+          substream.updateProgress(CANCELLED);
+        } else {
+          // release buffer
+          buffer = null;
+          // drain
+          while (i < savedBuffer.size()) {
+            if (substream.progress() == CANCELLED) {
+              return;
+            }
+            savedBuffer.get(i).runWith(substream);
+            savedBuffer.set(i, null);
+            i++;
+          }
+          substream.updateProgress(COMPLETED);
+        }
+        return;
+      }
+
+      if (i < size) {
+        BufferEntry bufferEntry = savedBuffer.get(i);
+        if (bufferEntry != null) {
+          bufferEntry.runWith(substream);
+          i++;
+        }
+      } else {
+        synchronized (substream) {
+          substream.setResuming(false);
+          substream.updateProgress(new Progress(size));
+          break;
+        }
+      }
+    }
+
+    // Just in case another concurrent instance of resume() with new enqueued stuffs quited
+    // immediately. Here resume the new stuffs.
+    if (i < savedBuffer.size()) {
+      resume(substream);
+    }
+  }
+
+  /**
+   * The call is committed. All retrying/hedging substreams except the winner need be cancelled
+   * immediately. The winner need drain the buffer immediately.
+   */
+  void commit(Substream winningSubstream) {
+    synchronized (lock) {
+      if (committed) {
+        return;
+      }
+      committed = true;
+      this.winningSubstream = winningSubstream;
+    }
+  }
+
+  private interface BufferEntry {
+    /** Replays the buffer entry with the given stream. */
+    void runWith(Substream substream);
+  }
+}

--- a/core/src/main/java/io/grpc/internal/Substream.java
+++ b/core/src/main/java/io/grpc/internal/Substream.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Represents a retry/hedging RPC attempt, likely connecting to a different backend to what other
+ * ones connect to.
+ */
+interface Substream {
+  /** Gets the underlying {@link ClientStream}. */
+  ClientStream clientStream();
+
+  /** Starts the substream. */
+  void start();
+
+  /** True if the underlying stream is a {@link DelayedStream2} and is not pass-through. */
+  // @GuadedBy("this")
+  boolean isPending();
+
+  /**
+   * Whether the substream is currently in resuming. If in resuming, another {@link
+   * RetryOrHedgingBuffer#resume} will return immediately.
+   */
+  // @GuadedBy("this")
+  boolean isResuming();
+
+  /** Sets whether the substream is currently in resuming. */
+  // @GuadedBy("this")
+  void setResuming(boolean resuming);
+
+  /** Gets the replay {@link Progress}. */
+  // @GuadedBy("this")
+  Progress progress();
+
+  /** Updates the replay {@link Progress}. */
+  // @GuadedBy("this")
+  void updateProgress(Progress progress);
+
+  /** Marks the progress of the replay of a substream. */
+  @Immutable
+  final class Progress {
+    static final Progress START = new Progress(0);
+    static final Progress COMPLETED = new Progress(Integer.MAX_VALUE);
+    static final Progress CANCELLED = new Progress(Integer.MAX_VALUE);
+
+    private final int position;
+
+    Progress(int position) {
+      checkArgument(position >= 0, "position should not be negative");
+
+      this.position = position;
+    }
+
+    /**
+     * The current position in the {@link RetryOrHedgingBuffer} that the substream should resume the
+     * replay.
+     */
+    int currentPosition() {
+      return position;
+    }
+  }
+}


### PR DESCRIPTION
This only implements buffering messages and replay buffered messages when retry.
Retry policy, hedging, transparent retry and APIs that users can enable retry are not included in this PR.

**Implementation details:**

The old code path for without retrying is kept. The switch `retryEnabled()` always returns false for the moment.

In retry case: Every RPC creates a logical `ClientStream`: `RetriableStream`.  The `RetriableStream` is always recorded in a list in `DelayedClientTransport` until commit.

Messages and other stream operations are buffered in `RetryOrHedgingBuffer`. The buffer is not cleared until commit.

The `RetriableStream` manages a sequence of `Substream`s which are the individual retry attempts. Each `substream` is backed by a physical `ClientStream` which can be either a `PendingStream2` or a real stream.  `RetryOrHedgingBuffer` + `PendingStream2` together is similar to `PendingStream`v1 except that the buffer is still enqueuing for the period after pass-through and prior to commit; and that the buffer can be reused for multiple times if retry is applied for multiple times.

Each `substream` has a `Progress` that tracks the current position in the buffer that this `substream` is to resume replay.


TODO: tests.