### PR TITLE
services: add proto generated classes to intellij path

### DIFF
--- a/services/build.gradle
+++ b/services/build.gradle
@@ -24,5 +24,7 @@ idea {
     module {
         sourceDirs += file("${projectDir}/src/generated/main/java");
         sourceDirs += file("${projectDir}/src/generated/main/grpc");
+        testSourceDirs += file("${projectDir}/src/generated/test/java")
+        testSourceDirs += file("${projectDir}/src/generated/test/grpc")
     }
 }


### PR DESCRIPTION
Opening ProtoReflectionServiceTest in intellij fails to find these classes, which makes it hard to run other tests because this class fails to compile:

```
import io.grpc.reflection.testing.AnotherDynamicServiceGrpc;
import io.grpc.reflection.testing.DynamicReflectionTestDepthTwoProto;
import io.grpc.reflection.testing.DynamicServiceGrpc;
import io.grpc.reflection.testing.ReflectableServiceGrpc;
import io.grpc.reflection.testing.ReflectionTestDepthThreeProto;
import io.grpc.reflection.testing.ReflectionTestDepthTwoAlternateProto;
import io.grpc.reflection.testing.ReflectionTestDepthTwoProto;
import io.grpc.reflection.testing.ReflectionTestProto;
import io.grpc.reflection.v1alpha.ExtensionNumberResponse;
import io.grpc.reflection.v1alpha.ExtensionRequest;
import io.grpc.reflection.v1alpha.FileDescriptorResponse;
import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
import io.grpc.reflection.v1alpha.ServerReflectionRequest;
import io.grpc.reflection.v1alpha.ServerReflectionResponse;
import io.grpc.reflection.v1alpha.ServiceResponse;
```