### PR TITLE
Added methods in AbstractStub to identify type of Stub

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -240,6 +240,11 @@ public final class BenchmarkServiceGrpc {
       return new BenchmarkServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One request followed by one response.
@@ -320,6 +325,11 @@ public final class BenchmarkServiceGrpc {
       return new BenchmarkServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One request followed by one response.
@@ -360,6 +370,11 @@ public final class BenchmarkServiceGrpc {
     protected BenchmarkServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new BenchmarkServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
@@ -110,6 +110,11 @@ public final class ReportQpsScenarioServiceGrpc {
       return new ReportQpsScenarioServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * Report results of a QPS test benchmark scenario.
@@ -140,6 +145,11 @@ public final class ReportQpsScenarioServiceGrpc {
       return new ReportQpsScenarioServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * Report results of a QPS test benchmark scenario.
@@ -167,6 +177,11 @@ public final class ReportQpsScenarioServiceGrpc {
     protected ReportQpsScenarioServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new ReportQpsScenarioServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -213,6 +213,11 @@ public final class WorkerServiceGrpc {
       return new WorkerServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * Start server with specified workload.
@@ -286,6 +291,11 @@ public final class WorkerServiceGrpc {
       return new WorkerServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * Just return the core count - unary call
@@ -323,6 +333,11 @@ public final class WorkerServiceGrpc {
     protected WorkerServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new WorkerServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -494,6 +494,7 @@ static void PrintStub(
   (*vars)["abstract_name"] = service_name + "ImplBase";
   string stub_name = service_name;
   string client_name = service_name;
+  string stub_type = "";
   CallType call_type;
   bool impl_base = false;
   bool interface = false;
@@ -505,6 +506,7 @@ static void PrintStub(
     case ASYNC_CLIENT_IMPL:
       call_type = ASYNC_CALL;
       stub_name += "Stub";
+      stub_type += "AsyncStub";
       break;
     case BLOCKING_CLIENT_INTERFACE:
       interface = true;
@@ -513,6 +515,7 @@ static void PrintStub(
       call_type = BLOCKING_CALL;
       stub_name += "BlockingStub";
       client_name += "BlockingClient";
+      stub_type += "BlockingStub";
       break;
     case FUTURE_CLIENT_INTERFACE:
       interface = true;
@@ -521,6 +524,7 @@ static void PrintStub(
       call_type = FUTURE_CALL;
       stub_name += "FutureStub";
       client_name += "FutureClient";
+      stub_type += "FutureStub";
       break;
     case ASYNC_INTERFACE:
       call_type = ASYNC_CALL;
@@ -531,6 +535,7 @@ static void PrintStub(
   }
   (*vars)["stub_name"] = stub_name;
   (*vars)["client_name"] = client_name;
+  (*vars)["stub_type"] = stub_type;
 
   // Class head
   if (!interface) {
@@ -594,6 +599,16 @@ static void PrintStub(
     p->Print(
         *vars,
         "return new $stub_name$(channel, callOptions);\n");
+    p->Outdent();
+    p->Print("}\n\n");
+    p->Print(
+      *vars,
+      "@$Override$\n"
+      "public boolean is$stub_type$() {\n");
+    p->Indent();
+    p->Print(
+      *vars,
+      "return true;\n");
     p->Outdent();
     p->Print("}\n");
   }

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -251,6 +251,11 @@ public final class TestServiceGrpc {
       return new TestServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One request followed by one response.
@@ -336,6 +341,11 @@ public final class TestServiceGrpc {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One request followed by one response.
@@ -379,6 +389,11 @@ public final class TestServiceGrpc {
     protected TestServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new TestServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -246,6 +246,11 @@ public final class TestServiceGrpc {
       return new TestServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One request followed by one response.
@@ -331,6 +336,11 @@ public final class TestServiceGrpc {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One request followed by one response.
@@ -374,6 +384,11 @@ public final class TestServiceGrpc {
     protected TestServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new TestServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -309,6 +309,11 @@ public final class TestServiceGrpc {
       return new TestServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One request followed by one response.
@@ -394,6 +399,11 @@ public final class TestServiceGrpc {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One request followed by one response.
@@ -437,6 +447,11 @@ public final class TestServiceGrpc {
     protected TestServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new TestServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -110,6 +110,11 @@ public final class LoadBalancerGrpc {
       return new LoadBalancerStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * Bidirectional rpc to get a list of servers.
@@ -139,6 +144,11 @@ public final class LoadBalancerGrpc {
         io.grpc.CallOptions callOptions) {
       return new LoadBalancerBlockingStub(channel, callOptions);
     }
+
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
   }
 
   /**
@@ -157,6 +167,11 @@ public final class LoadBalancerGrpc {
     protected LoadBalancerFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new LoadBalancerFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
   }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -142,6 +142,11 @@ public final class MetricsServiceGrpc {
       return new MetricsServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * Returns the values of all the gauges that are currently being maintained by
@@ -184,6 +189,11 @@ public final class MetricsServiceGrpc {
       return new MetricsServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * Returns the values of all the gauges that are currently being maintained by
@@ -223,6 +233,11 @@ public final class MetricsServiceGrpc {
     protected MetricsServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new MetricsServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -144,6 +144,11 @@ public final class ReconnectServiceGrpc {
       return new ReconnectServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      */
     public void start(com.google.protobuf.EmptyProtos.Empty request,
@@ -182,6 +187,11 @@ public final class ReconnectServiceGrpc {
       return new ReconnectServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      */
     public com.google.protobuf.EmptyProtos.Empty start(com.google.protobuf.EmptyProtos.Empty request) {
@@ -216,6 +226,11 @@ public final class ReconnectServiceGrpc {
     protected ReconnectServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new ReconnectServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -349,6 +349,11 @@ public final class TestServiceGrpc {
       return new TestServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One empty request followed by one empty response.
@@ -470,6 +475,11 @@ public final class TestServiceGrpc {
       return new TestServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * One empty request followed by one empty response.
@@ -546,6 +556,11 @@ public final class TestServiceGrpc {
     protected TestServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new TestServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -122,6 +122,11 @@ public final class UnimplementedServiceGrpc {
       return new UnimplementedServiceStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isAsyncStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * A call that no server should implement
@@ -156,6 +161,11 @@ public final class UnimplementedServiceGrpc {
       return new UnimplementedServiceBlockingStub(channel, callOptions);
     }
 
+    @java.lang.Override
+    public boolean isBlockingStub() {
+      return true;
+    }
+
     /**
      * <pre>
      * A call that no server should implement
@@ -187,6 +197,11 @@ public final class UnimplementedServiceGrpc {
     protected UnimplementedServiceFutureStub build(io.grpc.Channel channel,
         io.grpc.CallOptions callOptions) {
       return new UnimplementedServiceFutureStub(channel, callOptions);
+    }
+
+    @java.lang.Override
+    public boolean isFutureStub() {
+      return true;
     }
 
     /**

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -207,4 +207,28 @@ public abstract class AbstractStub<S extends AbstractStub<S>> {
   public final S withMaxOutboundMessageSize(int maxSize) {
     return build(channel, callOptions.withMaxOutboundMessageSize(maxSize));
   }
+
+  /**
+   * Returns if this stub is a Blocking Style Stub
+   * @return boolean
+   */
+  public boolean isBlockingStub() {
+    return false;
+  }
+
+  /**
+   * Returns if this stub is a ListenableFuture-style Stub
+   * @return boolean
+   */
+  public boolean isFutureStub() {
+    return false;
+  }
+
+  /**
+   * Returns if this stub is a Async Stub
+   * @return boolean
+   */
+  public boolean isAsyncStub() {
+    return false;
+  }
 }


### PR DESCRIPTION
Currently once a Stub is generated extending from AbstractStub, there is no way to identify whether is a BlockingStub, FutureStub or simple AsnycStub except from the name which is NOT ideal. Identification of Stub, will help enforce any application level checks such as enforcing deadlines for BlockingStub in the enviornment.
Added the following methods in AbstractStub
isBlockingStub
isFutureStub
isAsyncStub
which return false by default. 

The generator code is changed in such a way that the specific method is overridden for that type of stub and returns true. For example for BlockingStub, isBlockingStub is overridden and true is returned.

Issue [3513](https://github.com/grpc/grpc-java/issues/3513)