### PR TITLE
examples: fix Bazel build

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -17,6 +17,36 @@ java_grpc_library(
 )
 
 proto_library(
+    name = "helloworld_streaming_proto",
+    srcs = [
+        ":helloworld.proto",
+        "src/main/proto/helloworld_streaming.proto",
+    ],
+)
+
+java_proto_library(
+    name = "helloworld_streaming_java_proto",
+    deps = [":helloworld_streaming_proto"],
+)
+
+java_grpc_library(
+    name = "helloworld_streaming_java_grpc",
+    srcs = [":helloworld_streaming_proto"],
+    deps = [":helloworld_streaming_java_proto"],
+)
+
+# Work around the problem that proto_library's import path must be relative WORKSPACE path,
+# that is, in helloworld_streaming.proto file, 'import "helloworld.proto"' does not work for Bazel.
+# If 'import "src/main/proto/helloworld.proto"', that works for Bazel, but Gradle and Maven
+# would fail.
+genrule(
+    name = "cp_helloworld_proto_to_root_output_dir",
+    srcs = ["src/main/proto/helloworld.proto"],
+    outs = [":helloworld.proto"],
+    cmd = "cp $(location src/main/proto/helloworld.proto) $(location helloworld.proto)",
+)
+
+proto_library(
     name = "route_guide_proto",
     srcs = ["src/main/proto/route_guide.proto"],
 )
@@ -44,6 +74,8 @@ java_library(
     deps = [
         ":helloworld_java_grpc",
         ":helloworld_java_proto",
+        ":helloworld_streaming_java_grpc",
+        ":helloworld_streaming_java_proto",
         ":route_guide_java_grpc",
         ":route_guide_java_proto",
         "@com_google_api_grpc_proto_google_common_protos//jar",
@@ -91,6 +123,26 @@ java_binary(
     name = "route-guide-server",
     testonly = 1,
     main_class = "io.grpc.examples.routeguide.RouteGuideServer",
+    runtime_deps = [
+        ":examples",
+        "@grpc_java//netty",
+    ],
+)
+
+java_binary(
+    name = "manual-flow-control-client",
+    testonly = 1,
+    main_class = "io.grpc.examples.manualflowcontrol.ManualFlowControlClient",
+    runtime_deps = [
+        ":examples",
+        "@grpc_java//netty",
+    ],
+)
+
+java_binary(
+    name = "manual-flow-control-server",
+    testonly = 1,
+    main_class = "io.grpc.examples.manualflowcontrol.ManualFlowControlServer",
     runtime_deps = [
         ":examples",
         "@grpc_java//netty",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -17,33 +17,21 @@ java_grpc_library(
 )
 
 proto_library(
-    name = "helloworld_streaming_proto",
+    name = "hello_streaming_proto",
     srcs = [
-        ":helloworld.proto",
-        "src/main/proto/helloworld_streaming.proto",
+        "src/main/proto/hello_streaming.proto",
     ],
 )
 
 java_proto_library(
-    name = "helloworld_streaming_java_proto",
-    deps = [":helloworld_streaming_proto"],
+    name = "hello_streaming_java_proto",
+    deps = [":hello_streaming_proto"],
 )
 
 java_grpc_library(
-    name = "helloworld_streaming_java_grpc",
-    srcs = [":helloworld_streaming_proto"],
-    deps = [":helloworld_streaming_java_proto"],
-)
-
-# Work around the problem that proto_library's import path must be relative WORKSPACE path,
-# that is, in helloworld_streaming.proto file, 'import "helloworld.proto"' does not work for Bazel.
-# If 'import "src/main/proto/helloworld.proto"', that works for Bazel, but Gradle and Maven
-# would fail.
-genrule(
-    name = "cp_helloworld_proto_to_root_output_dir",
-    srcs = ["src/main/proto/helloworld.proto"],
-    outs = [":helloworld.proto"],
-    cmd = "cp $(location src/main/proto/helloworld.proto) $(location helloworld.proto)",
+    name = "hello_streaming_java_grpc",
+    srcs = [":hello_streaming_proto"],
+    deps = [":hello_streaming_java_proto"],
 )
 
 proto_library(
@@ -74,8 +62,8 @@ java_library(
     deps = [
         ":helloworld_java_grpc",
         ":helloworld_java_proto",
-        ":helloworld_streaming_java_grpc",
-        ":helloworld_streaming_java_proto",
+        ":hello_streaming_java_grpc",
+        ":hello_streaming_java_proto",
         ":route_guide_java_grpc",
         ":route_guide_java_proto",
         "@com_google_api_grpc_proto_google_common_protos//jar",

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlClient.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlClient.java
@@ -18,9 +18,6 @@ package io.grpc.examples.manualflowcontrol;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.examples.helloworld.HelloReply;
-import io.grpc.examples.helloworld.HelloRequest;
-import io.grpc.examples.helloworld.StreamingGreeterGrpc;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 

--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java
@@ -19,9 +19,6 @@ package io.grpc.examples.manualflowcontrol;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.Status;
-import io.grpc.examples.helloworld.HelloReply;
-import io.grpc.examples.helloworld.HelloRequest;
-import io.grpc.examples.helloworld.StreamingGreeterGrpc;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 

--- a/examples/src/main/proto/hello_streaming.proto
+++ b/examples/src/main/proto/hello_streaming.proto
@@ -15,16 +15,24 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "io.grpc.examples.helloworld";
-option java_outer_classname = "HelloWorldStreamingProto";
+option java_package = "io.grpc.examples.manualflowcontrol";
+option java_outer_classname = "HelloStreamingProto";
 option objc_class_prefix = "HLWS";
 
-import "helloworld.proto";
-
-package helloworld;
+package manualflowcontrol;
 
 // The greeting service definition.
 service StreamingGreeter {
   // Streams a many greetings
   rpc SayHelloStreaming (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
 }


### PR DESCRIPTION
Refactor the proto file `helloworld_streaming.proto` because Bazel and Gradle have incompatible base directory for proto imports. Bazel's proto import is relative to WORKSPACE, whereas Gradle proto plugin's is relative to `${sourceSet}/proto/`. In `helloworld_streaming.proto` file, `import helloworld.proto` does not work for Bazel. If `import src/main/proto/helloworld.proto`, that works for Bazel, but Gradle and Maven would fail. Some workarounds are very hacky, so use independent proto without imports instead to avoid this issue.