### PR TITLE
core: move census registration into internal

### DIFF
--- a/core/src/main/java/io/grpc/InternalMethodDescriptor.java
+++ b/core/src/main/java/io/grpc/InternalMethodDescriptor.java
@@ -38,9 +38,10 @@ public final class InternalMethodDescriptor {
     md.setRawMethodName(transport.ordinal(), o);
   }
 
-  public interface RegisterCallback extends MethodDescriptor.RegisterCallback {}
+  public interface RegisterForTracingCallback extends
+      MethodDescriptor.Registrations.RegisterForTracingCallback {}
 
-  public static void setRegisterCallback(RegisterCallback registerCallback) {
-    MethodDescriptor.setRegisterCallback(registerCallback);
+  public static void setRegisterCallback(RegisterForTracingCallback registerCallback) {
+    MethodDescriptor.Registrations.setRegisterCallback(registerCallback);
   }
 }

--- a/core/src/main/java/io/grpc/InternalMethodDescriptor.java
+++ b/core/src/main/java/io/grpc/InternalMethodDescriptor.java
@@ -38,7 +38,9 @@ public final class InternalMethodDescriptor {
     md.setRawMethodName(transport.ordinal(), o);
   }
 
-  public static String generateTraceSpanName(boolean isServer, String fullMethodName) {
-    return MethodDescriptor.generateTraceSpanName(isServer, fullMethodName);
+  public interface RegisterCallback extends MethodDescriptor.RegisterCallback {}
+
+  public static void setRegisterCallback(RegisterCallback registerCallback) {
+    MethodDescriptor.setRegisterCallback(registerCallback);
   }
 }

--- a/core/src/main/java/io/grpc/InternalMethodDescriptor.java
+++ b/core/src/main/java/io/grpc/InternalMethodDescriptor.java
@@ -42,6 +42,6 @@ public final class InternalMethodDescriptor {
       MethodDescriptor.Registrations.RegisterForTracingCallback {}
 
   public static void setRegisterCallback(RegisterForTracingCallback registerCallback) {
-    MethodDescriptor.Registrations.setRegisterCallback(registerCallback);
+    MethodDescriptor.Registrations.setRegisterForTracingCallback(registerCallback);
   }
 }

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -29,7 +29,7 @@ import io.grpc.Context;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.InternalMethodDescriptor;
-import io.grpc.InternalMethodDescriptor.RegisterCallback;
+import io.grpc.InternalMethodDescriptor.RegisterForTracingCallback;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
@@ -73,9 +73,9 @@ final class CensusTracingModule {
   private static final boolean isRegistered = registerCensusTracer();
 
   private static boolean registerCensusTracer() {
-    InternalMethodDescriptor.setRegisterCallback(new RegisterCallback() {
+    InternalMethodDescriptor.setRegisterCallback(new RegisterForTracingCallback() {
       @Override
-      public void onBuild(MethodDescriptor<?, ?> md) {
+      public void onRegister(MethodDescriptor<?, ?> md) {
         SampledSpanStore sampledStore = Tracing.getExportComponent().getSampledSpanStore();
         if (sampledStore != null) {
           List<String> spanNames = new ArrayList<String>(2);

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -29,6 +29,7 @@ import io.grpc.Context;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.InternalMethodDescriptor;
+import io.grpc.InternalMethodDescriptor.RegisterCallback;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
@@ -39,7 +40,11 @@ import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.export.SampledSpanStore;
 import io.opencensus.trace.propagation.BinaryFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -64,6 +69,24 @@ final class CensusTracingModule {
   final Metadata.Key<SpanContext> tracingHeader;
   private final TracingClientInterceptor clientInterceptor = new TracingClientInterceptor();
   private final ServerTracerFactory serverTracerFactory = new ServerTracerFactory();
+
+  private static final boolean isRegistered = registerCensusTracer();
+
+  private static boolean registerCensusTracer() {
+    InternalMethodDescriptor.setRegisterCallback(new RegisterCallback() {
+      @Override
+      public void onBuild(MethodDescriptor<?, ?> md) {
+        SampledSpanStore sampledStore = Tracing.getExportComponent().getSampledSpanStore();
+        if (sampledStore != null) {
+          List<String> spanNames = new ArrayList<String>(2);
+          spanNames.add(generateTraceSpanName(false, md.getFullMethodName()));
+          spanNames.add(generateTraceSpanName(true, md.getFullMethodName()));
+          sampledStore.registerSpanNamesForCollection(spanNames);
+        }
+      }
+    });
+    return true;
+  }
 
   CensusTracingModule(
       Tracer censusTracer, final BinaryFormat censusPropagationBinaryFormat) {
@@ -202,7 +225,7 @@ final class CensusTracingModule {
       this.span =
           censusTracer
               .spanBuilderWithExplicitParent(
-                  InternalMethodDescriptor.generateTraceSpanName(false, fullMethodName),
+                  generateTraceSpanName(false, fullMethodName),
                   parentSpan)
               .setRecordEvents(true)
               .startSpan();
@@ -260,7 +283,7 @@ final class CensusTracingModule {
       this.span =
           censusTracer
               .spanBuilderWithRemoteParent(
-                  InternalMethodDescriptor.generateTraceSpanName(true, fullMethodName),
+                  generateTraceSpanName(true, fullMethodName),
                   remoteSpan)
               .setRecordEvents(true)
               .startSpan();
@@ -345,4 +368,19 @@ final class CensusTracingModule {
       };
     }
   }
+
+  /**
+   * Convert a full method name to a tracing span name.
+   *
+   * @param isServer {@code false} if the span is on the client-side, {@code true} if on the
+   *                 server-side
+   * @param fullMethodName the method name as returned by
+   *        {@link MethodDescriptor#getFullMethodName}.
+   */
+  @VisibleForTesting
+  static String generateTraceSpanName(boolean isServer, String fullMethodName) {
+    String prefix = isServer ? "Recv" : "Sent";
+    return prefix + "." + fullMethodName.replace('/', '.');
+  }
+
 }

--- a/core/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/core/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -94,12 +94,4 @@ public class MethodDescriptorTest {
     // Never reached
     assert discard == null;
   }
-
-  @Test
-  public void generateTraceSpanName() {
-    assertEquals(
-        "Sent.io.grpc.Foo", MethodDescriptor.generateTraceSpanName(false, "io.grpc/Foo"));
-    assertEquals(
-        "Recv.io.grpc.Bar", MethodDescriptor.generateTraceSpanName(true, "io.grpc/Bar"));
-  }
 }

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -725,6 +725,15 @@ public class CensusModulesTest {
     }
   }
 
+
+  @Test
+  public void generateTraceSpanName() {
+    assertEquals(
+        "Sent.io.grpc.Foo", CensusTracingModule.generateTraceSpanName(false, "io.grpc/Foo"));
+    assertEquals(
+        "Recv.io.grpc.Bar", CensusTracingModule.generateTraceSpanName(true, "io.grpc/Bar"));
+  }
+
   private static void assertNoServerContent(StatsTestUtils.MetricsRecord record) {
     assertNull(record.getMetric(RpcConstants.RPC_SERVER_ERROR_COUNT));
     assertNull(record.getMetric(RpcConstants.RPC_SERVER_REQUEST_COUNT));


### PR DESCRIPTION
move census registration into internal, and preserve tracing bit when rebuilding a MethodDescriptor