### PR TITLE
netty: add plain-text upgrade to server

### DIFF
--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -143,12 +143,19 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    *
    * @param certChain file containing the full certificate chain
    * @param privateKey file containing the private key
-   *
    * @return this
    * @throws UnsupportedOperationException if the server does not support TLS.
    * @since 1.0.0
    */
   public abstract T useTransportSecurity(File certChain, File privateKey);
+
+  /**
+   * Makes the server use CleartextUpgrade.
+   *
+   * @return this
+   * @throws UnsupportedOperationException if the server does not support CleartextUpgrade.
+   */
+  public abstract T usePlainTextUpgrade();
 
   /**
    * Set the decompression registry for use in the channel.  This is an advanced API call and

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -94,4 +94,9 @@ public final class InProcessServerBuilder
   public InProcessServerBuilder useTransportSecurity(File certChain, File privateKey) {
     throw new UnsupportedOperationException("TLS not supported in InProcessServer");
   }
+
+  @Override
+  public InProcessServerBuilder usePlainTextUpgrade() {
+    throw new UnsupportedOperationException("CleartextUpgrade not supported in InProcessServer");
+  }
 }

--- a/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
@@ -110,6 +110,11 @@ public class AbstractServerImplBuilderTest {
     public Builder useTransportSecurity(File certChain, File privateKey) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Builder usePlainTextUpgrade() {
+      throw new UnsupportedOperationException();
+    }
   }
 
 }

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1248,6 +1248,11 @@ public class ServerImplTest {
     @Override public Builder useTransportSecurity(File f1, File f2)  {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Builder usePlainTextUpgrade() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   /** Allows more precise catch blocks than plain Error to avoid catching AssertionError. */

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -408,4 +408,10 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
     }
     return this;
   }
+
+  @Override
+  public NettyServerBuilder usePlainTextUpgrade() {
+    protocolNegotiator = ProtocolNegotiators.serverPlaintextUpgrade();
+    return this;
+  }
 }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -329,7 +329,7 @@ public final class ProtocolNegotiators {
       HttpClientCodec httpClientCodec = new HttpClientCodec();
       final HttpClientUpgradeHandler upgrader =
           new HttpClientUpgradeHandler(httpClientCodec, upgradeCodec, 1000);
-      return new BufferingHttp2UpgradeHandler(upgrader);
+      return new BufferingHttp2UpgradeHandler(httpClientCodec, upgrader);
     }
   }
 


### PR DESCRIPTION
add HttpClientCodec in BufferingHttp2UpgradeHandler  for decode upgrade http request, reference
https://github.com/netty/netty/blob/4.1/example/src/main/java/io/netty/example/http2/helloworld/client/Http2ClientInitializer.java
configureClearText()