### PR TITLE
Make AbstractInteropTest runnable in GAE+jdk7

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -38,6 +38,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.instrumentation.stats.RpcConstants;
 import com.google.instrumentation.stats.StatsContextFactory;
 import com.google.instrumentation.stats.TagValue;
@@ -102,6 +103,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -969,6 +971,7 @@ public abstract class AbstractInteropTest {
 
   @Test(timeout = 10000)
   public void sendsTimeoutHeader() {
+    Assume.assumeTrue("can capture request headers on server side", server != null);
     long configuredTimeoutMinutes = 100;
     TestServiceGrpc.TestServiceBlockingStub stub =
         blockingStub.withDeadlineAfter(configuredTimeoutMinutes, TimeUnit.MINUTES);
@@ -1208,22 +1211,46 @@ public abstract class AbstractInteropTest {
                 .setBody(ByteString.copyFrom(new byte[4])))
             .build());
 
-    @SuppressWarnings("unchecked")
-    StreamObserver<StreamingOutputCallResponse> responseObserver = mock(StreamObserver.class);
+    final ArrayBlockingQueue<StreamingOutputCallResponse> responses =
+        new ArrayBlockingQueue<StreamingOutputCallResponse>(3);
+    final SettableFuture<Void> completed = SettableFuture.create();
+    final AtomicBoolean errorSeen = new AtomicBoolean();
+    StreamObserver<StreamingOutputCallResponse> responseObserver =
+        new StreamObserver<StreamingOutputCallResponse>() {
+
+          @Override
+          public void onNext(StreamingOutputCallResponse value) {
+            responses.add(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            errorSeen.set(true);
+          }
+
+          @Override
+          public void onCompleted() {
+            completed.set(null);
+          }
+        };
     StreamObserver<StreamingOutputCallRequest> requestObserver
         = asyncStub.fullDuplexCall(responseObserver);
     requestObserver.onNext(requests.get(0));
-    verify(responseObserver, timeout(operationTimeoutMillis())).onNext(goldenResponses.get(0));
+    assertEquals(
+        goldenResponses.get(0), responses.poll(operationTimeoutMillis(), TimeUnit.MILLISECONDS));
     // Initiate graceful shutdown.
     channel.shutdown();
     requestObserver.onNext(requests.get(1));
-    verify(responseObserver, timeout(operationTimeoutMillis())).onNext(goldenResponses.get(1));
+    assertEquals(
+        goldenResponses.get(1), responses.poll(operationTimeoutMillis(), TimeUnit.MILLISECONDS));
     // The previous ping-pong could have raced with the shutdown, but this one certainly shouldn't.
     requestObserver.onNext(requests.get(2));
-    verify(responseObserver, timeout(operationTimeoutMillis())).onNext(goldenResponses.get(2));
+    assertEquals(
+        goldenResponses.get(2), responses.poll(operationTimeoutMillis(), TimeUnit.MILLISECONDS));
+    assertFalse(completed.isDone());
     requestObserver.onCompleted();
-    verify(responseObserver, timeout(operationTimeoutMillis())).onCompleted();
-    verifyNoMoreInteractions(responseObserver);
+    completed.get(operationTimeoutMillis(), TimeUnit.MILLISECONDS);
+    assertFalse(errorSeen.get());
   }
 
   @Test(timeout = 10000)

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -971,7 +971,7 @@ public abstract class AbstractInteropTest {
 
   @Test(timeout = 10000)
   public void sendsTimeoutHeader() {
-    Assume.assumeTrue("can capture request headers on server side", server != null);
+    Assume.assumeTrue("can not capture server side request headers", server != null);
     long configuredTimeoutMinutes = 100;
     TestServiceGrpc.TestServiceBlockingStub stub =
         blockingStub.withDeadlineAfter(configuredTimeoutMinutes, TimeUnit.MINUTES);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -103,7 +103,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -1214,7 +1213,7 @@ public abstract class AbstractInteropTest {
     final ArrayBlockingQueue<StreamingOutputCallResponse> responses =
         new ArrayBlockingQueue<StreamingOutputCallResponse>(3);
     final SettableFuture<Void> completed = SettableFuture.create();
-    final AtomicBoolean errorSeen = new AtomicBoolean();
+    final SettableFuture<Void> errorSeen = SettableFuture.create();
     StreamObserver<StreamingOutputCallResponse> responseObserver =
         new StreamObserver<StreamingOutputCallResponse>() {
 
@@ -1225,7 +1224,7 @@ public abstract class AbstractInteropTest {
 
           @Override
           public void onError(Throwable t) {
-            errorSeen.set(true);
+            errorSeen.set(null);
           }
 
           @Override
@@ -1250,7 +1249,7 @@ public abstract class AbstractInteropTest {
     assertFalse(completed.isDone());
     requestObserver.onCompleted();
     completed.get(operationTimeoutMillis(), TimeUnit.MILLISECONDS);
-    assertFalse(errorSeen.get());
+    assertFalse(errorSeen.isDone());
   }
 
   @Test(timeout = 10000)


### PR DESCRIPTION
Mocks fail in GAE+jdk7 with this exception, so avoid using mocks.
```
Caused by: java.lang.NoClassDefFoundError: Could not initialize class com.google.apphosting.runtime.security.shared.stub.sun.reflect.ReflectionFactory
	at org.objenesis.instantiator.sun.SunReflectionFactoryInstantiator.<init>(SunReflectionFactoryInstantiator.java:24)
	at org.objenesis.strategy.StdInstantiatorStrategy.newInstantiatorOf(StdInstantiatorStrategy.java:65)
	at org.objenesis.ObjenesisBase.getInstantiatorOf(ObjenesisBase.java:76)
	at org.objenesis.ObjenesisBase.newInstance(ObjenesisBase.java:59)
	at org.mockito.internal.creation.jmock.ClassImposterizer.createProxy(ClassImposterizer.java:128)
	at org.mockito.internal.creation.jmock.ClassImposterizer.imposterise(ClassImposterizer.java:63)
	at org.mockito.internal.creation.jmock.ClassImposterizer.imposterise(ClassImposterizer.java:56)
	at org.mockito.internal.creation.CglibMockMaker.createMock(CglibMockMaker.java:23)
	at org.mockito.internal.util.MockUtil.createMock(MockUtil.java:26)
	at org.mockito.internal.MockitoCore.mock(MockitoCore.java:51)
	at org.mockito.Mockito.mock(Mockito.java:1243)
	at org.mockito.Mockito.mock(Mockito.java:1120)
	at io.grpc.testing.integration.AbstractInteropTest.gracefulShutdown(AbstractInteropTest.java:1213)
	... 30 more
```

Also, `sendsTimeoutHeader` assumes have a server in the same process, which we obviously don't if we're testing against grpc-test.sandbox.googleapis.com:443.