### PR TITLE
Use Java 9 ALPN

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -156,6 +156,9 @@ public class GrpcSslContexts {
         if (JettyTlsUtil.isJettyNpnConfigured()) {
           return NPN;
         }
+        if (JettyTlsUtil.isNettyJava9AlpnAvailable()) {
+          return ALPN;
+        }
         // Use the ALPN cause since it is prefered.
         throw new IllegalArgumentException(
             "Jetty ALPN/NPN has not been properly configured.",

--- a/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
+++ b/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
@@ -96,6 +96,7 @@ final class JettyTlsUtil {
     }
     return jettyNpnUnavailabilityCause;
   }
+
   /**
    * Indicates whether Netty Java 9 ALPN is available.
    */

--- a/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
+++ b/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
@@ -16,10 +16,39 @@
 
 package io.grpc.netty;
 
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
 /**
  * Utility class for determining support for Jetty TLS ALPN/NPN.
  */
 final class JettyTlsUtil {
+  private static final boolean HAS_JAVA9_ALPN;
+
+  static {
+    Method getApplicationProtocol;
+    try {
+      SSLContext context = SSLContext.getInstance("TLS");
+      context.init(null, null, null);
+      SSLEngine engine = context.createSSLEngine();
+      getApplicationProtocol =
+          AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+            @Override
+            public Method run() throws Exception {
+              return SSLEngine.class.getMethod("getApplicationProtocol");
+            }
+          });
+      getApplicationProtocol.invoke(engine);
+    } catch (Throwable t) {
+      getApplicationProtocol = null;
+    }
+    HAS_JAVA9_ALPN = getApplicationProtocol != null;
+  }
+
   private JettyTlsUtil() {
   }
 
@@ -67,4 +96,16 @@ final class JettyTlsUtil {
     }
     return jettyNpnUnavailabilityCause;
   }
+  /**
+   * Indicates whether Netty Java 9 ALPN is available.
+   */
+  static boolean isNettyJava9AlpnAvailable() {
+    try {
+      Class.forName("io.netty.handler.ssl.Java9SslEngine");
+      return HAS_JAVA9_ALPN;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
 }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -61,7 +61,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
 
 /**
  * Common {@link ProtocolNegotiator}s used by gRPC.
@@ -304,9 +303,7 @@ public final class ProtocolNegotiators {
         @Override
         public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
           SSLEngine sslEngine = sslContext.newEngine(ctx.alloc(), host, port);
-          SSLParameters sslParams = new SSLParameters();
-          sslParams.setEndpointIdentificationAlgorithm("HTTPS");
-          sslEngine.setSSLParameters(sslParams);
+          sslEngine.getSSLParameters().setEndpointIdentificationAlgorithm("HTTPS");
           ctx.pipeline().replace(this, null, new SslHandler(sslEngine, false));
         }
       };
@@ -374,6 +371,8 @@ public final class ProtocolNegotiators {
       builder.append("    Jetty ALPN");
     } else if (JettyTlsUtil.isJettyNpnConfigured()) {
       builder.append("    Jetty NPN");
+    } else if (JettyTlsUtil.isNettyJava9AlpnAvailable()) {
+      builder.append("    JDK9 ALPN");
     }
     builder.append("\n    TLS Protocol: ");
     builder.append(engine.getSession().getProtocol());


### PR DESCRIPTION
Netty `4.1.16` supports Java 9 ALPN, gRPC should take advantage of that to ease deployment (especially on platforms without `tcnative` and/or `openssl`).

This PR determines whether Java 9 ALPN and Netty `4.1.16` is available and enables Netty Java 9 ALPN.