### PR TITLE
Use java 9 ALPN if available

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -156,6 +156,9 @@ public class GrpcSslContexts {
         if (JettyTlsUtil.isJettyNpnConfigured()) {
           return NPN;
         }
+        if (JettyTlsUtil.isNettyJava9AlpnAvailable()) {
+          return ALPN;
+        }
         // Use the ALPN cause since it is prefered.
         throw new IllegalArgumentException(
             "Jetty ALPN/NPN has not been properly configured.",

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -156,7 +156,7 @@ public class GrpcSslContexts {
         if (JettyTlsUtil.isJettyNpnConfigured()) {
           return NPN;
         }
-        if (JettyTlsUtil.isNettyJava9AlpnAvailable()) {
+        if (JettyTlsUtil.isJava9AlpnAvailable()) {
           return ALPN;
         }
         // Use the ALPN cause since it is prefered.

--- a/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
+++ b/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
@@ -19,7 +19,6 @@ package io.grpc.netty;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
-
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
@@ -27,7 +26,6 @@ import javax.net.ssl.SSLEngine;
  * Utility class for determining support for Jetty TLS ALPN/NPN.
  */
 final class JettyTlsUtil {
-
   private JettyTlsUtil() {
   }
 
@@ -56,7 +54,6 @@ final class JettyTlsUtil {
         return t;
       }
     }
-
   }
 
   /**
@@ -111,5 +108,4 @@ final class JettyTlsUtil {
   static Throwable getJava9AlpnUnavailabilityCause() {
     return Java9AlpnUnavailabilityCauseHolder.cause;
   }
-
 }

--- a/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
+++ b/netty/src/main/java/io/grpc/netty/JettyTlsUtil.java
@@ -28,9 +28,17 @@ import javax.net.ssl.SSLEngine;
  */
 final class JettyTlsUtil {
 
+  private JettyTlsUtil() {
+  }
+
+  private static Throwable jettyAlpnUnavailabilityCause;
+  private static Throwable jettyNpnUnavailabilityCause;
+
   private static class Java9AlpnUnavailabilityCauseHolder {
 
-    static {
+    static final Throwable cause = checkAlpnAvailability();
+
+    static Throwable checkAlpnAvailability() {
       try {
         SSLContext context = SSLContext.getInstance("TLS");
         context.init(null, null, null);
@@ -43,20 +51,13 @@ final class JettyTlsUtil {
               }
             });
         getApplicationProtocol.invoke(engine);
-        cause = null;
+        return null;
       } catch (Throwable t) {
-        cause = t;
+        return t;
       }
     }
 
-    private static Throwable cause;
   }
-
-  private JettyTlsUtil() {
-  }
-
-  private static Throwable jettyAlpnUnavailabilityCause;
-  private static Throwable jettyNpnUnavailabilityCause;
 
   /**
    * Indicates whether or not the Jetty ALPN jar is installed in the boot classloader.

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -61,7 +61,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
 
 /**
  * Common {@link ProtocolNegotiator}s used by gRPC.
@@ -304,9 +303,7 @@ public final class ProtocolNegotiators {
         @Override
         public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
           SSLEngine sslEngine = sslContext.newEngine(ctx.alloc(), host, port);
-          SSLParameters sslParams = new SSLParameters();
-          sslParams.setEndpointIdentificationAlgorithm("HTTPS");
-          sslEngine.setSSLParameters(sslParams);
+          sslEngine.getSSLParameters().setEndpointIdentificationAlgorithm("HTTPS");
           ctx.pipeline().replace(this, null, new SslHandler(sslEngine, false));
         }
       };
@@ -374,6 +371,8 @@ public final class ProtocolNegotiators {
       builder.append("    Jetty ALPN");
     } else if (JettyTlsUtil.isJettyNpnConfigured()) {
       builder.append("    Jetty NPN");
+    } else if (JettyTlsUtil.isNettyJava9AlpnAvailable()) {
+      builder.append("    JDK9 ALPN");
     }
     builder.append("\n    TLS Protocol: ");
     builder.append(engine.getSession().getProtocol());

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -61,6 +61,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 
 /**
  * Common {@link ProtocolNegotiator}s used by gRPC.
@@ -303,7 +304,9 @@ public final class ProtocolNegotiators {
         @Override
         public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
           SSLEngine sslEngine = sslContext.newEngine(ctx.alloc(), host, port);
-          sslEngine.getSSLParameters().setEndpointIdentificationAlgorithm("HTTPS");
+          SSLParameters sslParams = sslEngine.getSSLParameters();
+          sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+          sslEngine.setSSLParameters(sslParams);
           ctx.pipeline().replace(this, null, new SslHandler(sslEngine, false));
         }
       };

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -374,7 +374,7 @@ public final class ProtocolNegotiators {
       builder.append("    Jetty ALPN");
     } else if (JettyTlsUtil.isJettyNpnConfigured()) {
       builder.append("    Jetty NPN");
-    } else if (JettyTlsUtil.isNettyJava9AlpnAvailable()) {
+    } else if (JettyTlsUtil.isJava9AlpnAvailable()) {
       builder.append("    JDK9 ALPN");
     }
     builder.append("\n    TLS Protocol: ");


### PR DESCRIPTION
Netty `4.1.16` supports Java 9 ALPN, gRPC should take advantage of that to ease deployment (especially on platforms without tcnative and/or openssl).

This PR determines whether Java 9 ALPN and Netty 4.1.16 is available and enables Netty Java 9 ALPN.