### PR TITLE
core: add resetConnectBackoff() method to ManagedChannel

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -104,4 +104,22 @@ public abstract class ManagedChannel extends Channel {
   public void notifyWhenStateChanged(ConnectivityState source, Runnable callback) {
     throw new UnsupportedOperationException("Not implemented");
   }
+
+  /**
+   * Notifies the channel that a reconnect attempt should be made. This will attempt to invoke
+   * {@link NameResolver#refresh} and short-circuit the backoff timer for subchannel reconnection
+   * attempts.
+   *
+   * <p>This is primarily intended for Android users, where the network may experience frequent
+   * temporary drops. Rather than waiting for gRPC's name resolution and reconnect timers to elapse
+   * before reconnecting, the app may use this method as a mechanism to notify gRPC that the network
+   * is now available and a reconnection attempt may occur immediately.
+   *
+   * @throws UnsupportedOperationException if not supported by implementation
+   * @since 1.8.0
+   */
+  @ExperimentalApi
+  public void reconnectNow() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 }

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -106,20 +106,19 @@ public abstract class ManagedChannel extends Channel {
   }
 
   /**
-   * Notifies the channel that a reconnect attempt should be made. This will attempt to invoke
-   * {@link NameResolver#refresh} and short-circuit the backoff timer for subchannel reconnection
-   * attempts.
+   * Notifies the channel that a reconnect attempt should be made. The implementation may attempt to
+   * invoke {@link NameResolver#refresh} and short-circuit the backoff timer for subchannel
+   * reconnection attempts.
    *
    * <p>This is primarily intended for Android users, where the network may experience frequent
    * temporary drops. Rather than waiting for gRPC's name resolution and reconnect timers to elapse
    * before reconnecting, the app may use this method as a mechanism to notify gRPC that the network
    * is now available and a reconnection attempt may occur immediately.
    *
-   * @throws UnsupportedOperationException if not supported by implementation
+   * <p>No-op if not supported by the implementation.
+   *
    * @since 1.8.0
    */
   @ExperimentalApi
-  public void reconnectNow() {
-    throw new UnsupportedOperationException("Not implemented");
-  }
+  public void reconnectNow() {}
 }

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -120,5 +120,5 @@ public abstract class ManagedChannel extends Channel {
    * @since 1.8.0
    */
   @ExperimentalApi
-  public void reconnectNow() {}
+  public void resetConnectBackoff() {}
 }

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -106,9 +106,8 @@ public abstract class ManagedChannel extends Channel {
   }
 
   /**
-   * Notifies the channel that a reconnect attempt should be made. The implementation may attempt to
-   * invoke {@link NameResolver#refresh} and short-circuit the backoff timer for subchannel
-   * reconnection attempts.
+   * For subchannels that are in TRANSIENT_FAILURE state, short-circuit the backoff timer and make
+   * them reconnect immediately. May also attempt to invoke {@link NameResolver#refresh}.
    *
    * <p>This is primarily intended for Android users, where the network may experience frequent
    * temporary drops. Rather than waiting for gRPC's name resolution and reconnect timers to elapse

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -268,7 +268,7 @@ final class InternalSubchannel implements WithLogId {
    * Immediately attempt to reconnect if the current state is TRANSIENT_FAILURE. Otherwise this
    * method has no effect.
    */
-  void networkAvailable() {
+  void reconnectNow() {
     try {
       synchronized (lock) {
         if (state.getState() != TRANSIENT_FAILURE) {

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -20,6 +20,7 @@ import static io.grpc.ConnectivityState.CONNECTING;
 import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.SHUTDOWN;
+import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -96,6 +97,9 @@ final class InternalSubchannel implements WithLogId {
   @GuardedBy("lock")
   @Nullable
   private ScheduledFuture<?> reconnectTask;
+
+  @GuardedBy("lock")
+  private boolean reconnectCanceled;
 
   /**
    * All transports that are not terminated. At the very least the value of {@link #activeTransport}
@@ -227,9 +231,9 @@ final class InternalSubchannel implements WithLogId {
         try {
           synchronized (lock) {
             reconnectTask = null;
-            if (state.getState() == SHUTDOWN) {
-              // Even though shutdown() will cancel this task, the task may have already started
-              // when it's being cancelled.
+            if (reconnectCanceled) {
+              // Even though cancelReconnectTask() will cancel this task, the task may have already
+              // started when it's being canceled.
               return;
             }
             gotoNonErrorState(CONNECTING);
@@ -253,10 +257,30 @@ final class InternalSubchannel implements WithLogId {
       log.log(Level.FINE, "[{0}] Scheduling backoff for {1} ns", new Object[]{logId, delayNanos});
     }
     Preconditions.checkState(reconnectTask == null, "previous reconnectTask is not done");
+    reconnectCanceled = false;
     reconnectTask = scheduledExecutor.schedule(
         new LogExceptionRunnable(new EndOfCurrentBackoff()),
         delayNanos,
         TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Immediately attempt to reconnect if the current state is TRANSIENT_FAILURE. Otherwise this
+   * method has no effect.
+   */
+  void networkAvailable() {
+    try {
+      synchronized (lock) {
+        if (state.getState() != TRANSIENT_FAILURE) {
+          return;
+        }
+        cancelReconnectTask();
+        gotoNonErrorState(CONNECTING);
+        startNewTransport();
+      }
+    } finally {
+      channelExecutor.drain();
+    }
   }
 
   @GuardedBy("lock")
@@ -400,6 +424,7 @@ final class InternalSubchannel implements WithLogId {
   private void cancelReconnectTask() {
     if (reconnectTask != null) {
       reconnectTask.cancel(false);
+      reconnectCanceled = true;
       reconnectTask = null;
     }
   }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -83,7 +83,8 @@ final class InternalSubchannel implements WithLogId {
   private int addressIndex;
 
   /**
-   * The policy to control back off between reconnects. Non-{@code null} when last connect failed.
+   * The policy to control back off between reconnects. Non-{@code null} when a reconnect task is
+   * scheduled.
    */
   @GuardedBy("lock")
   private BackoffPolicy reconnectPolicy;
@@ -268,7 +269,7 @@ final class InternalSubchannel implements WithLogId {
    * Immediately attempt to reconnect if the current state is TRANSIENT_FAILURE. Otherwise this
    * method has no effect.
    */
-  void reconnectNow() {
+  void resetConnectBackoff() {
     try {
       synchronized (lock) {
         if (state.getState() != TRANSIENT_FAILURE) {
@@ -426,6 +427,7 @@ final class InternalSubchannel implements WithLogId {
       reconnectTask.cancel(false);
       reconnectCanceled = true;
       reconnectTask = null;
+      reconnectPolicy = null;
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -650,10 +650,10 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
               nameResolver.refresh();
             }
             for (InternalSubchannel subchannel : subchannels) {
-              subchannel.networkAvailable();
+              subchannel.reconnectNow();
             }
             for (InternalSubchannel oobChannel : oobChannels) {
-              oobChannel.networkAvailable();
+              oobChannel.reconnectNow();
             }
           }
         }).drain();

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -135,6 +135,9 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
 
   private final ProxyDetector proxyDetector;
 
+  // Must be accessed from the channelExecutor.
+  private boolean nameResolverStarted;
+
   // null when channel is in idle mode.  Must be assigned from channelExecutor.
   @Nullable
   private LbHelperImpl lbHelper;
@@ -210,6 +213,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
           if (nameResolver != null) {
             nameResolver.shutdown();
             nameResolver = null;
+            nameResolverStarted = false;
           }
 
           // Until LoadBalancer is shutdown, it may still create new subchannels.  We catch them
@@ -266,6 +270,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       // either the idleModeTimer ran twice without exiting the idle mode, or the task in shutdown()
       // did not cancel idleModeTimer, both of which are bugs.
       nameResolver.shutdown();
+      nameResolverStarted = false;
       nameResolver = getNameResolver(target, nameResolverFactory, nameResolverParams);
       lbHelper.lb.shutdown();
       lbHelper = null;
@@ -312,6 +317,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     NameResolverListenerImpl listener = new NameResolverListenerImpl(lbHelper);
     try {
       nameResolver.start(listener);
+      nameResolverStarted = true;
     } catch (Throwable t) {
       listener.onError(Status.fromThrowable(t));
     }
@@ -627,6 +633,28 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
           @Override
           public void run() {
             channelStateManager.notifyWhenStateChanged(callback, executor, source);
+          }
+        }).drain();
+  }
+
+  @Override
+  public void reconnectNow() {
+    channelExecutor.executeLater(
+        new Runnable() {
+          @Override
+          public void run() {
+            if (shutdown.get()) {
+              return;
+            }
+            if (nameResolverStarted) {
+              nameResolver.refresh();
+            }
+            for (InternalSubchannel subchannel : subchannels) {
+              subchannel.networkAvailable();
+            }
+            for (InternalSubchannel oobChannel : oobChannels) {
+              oobChannel.networkAvailable();
+            }
           }
         }).drain();
   }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -638,7 +638,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   }
 
   @Override
-  public void reconnectNow() {
+  public void resetConnectBackoff() {
     channelExecutor.executeLater(
         new Runnable() {
           @Override
@@ -650,10 +650,10 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
               nameResolver.refresh();
             }
             for (InternalSubchannel subchannel : subchannels) {
-              subchannel.reconnectNow();
+              subchannel.resetConnectBackoff();
             }
             for (InternalSubchannel oobChannel : oobChannels) {
-              oobChannel.reconnectNow();
+              oobChannel.resetConnectBackoff();
             }
           }
         }).drain();

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -912,7 +912,7 @@ public class InternalSubchannelTest {
 
     // Call reconnectNow() and move out of TRANSIENT_FAILURE (this allows verifying that
     // reconnectTask.command.run() is a no-op)
-    internalSubchannel.networkAvailable();
+    internalSubchannel.reconnectNow();
     assertExactCallbackInvokes("onStateChange:CONNECTING");
     transports.poll().listener.transportReady();
     assertExactCallbackInvokes("onStateChange:READY");
@@ -931,7 +931,7 @@ public class InternalSubchannelTest {
     createInternalSubchannel(addr);
     assertEquals(IDLE, internalSubchannel.getState());
 
-    internalSubchannel.networkAvailable();
+    internalSubchannel.reconnectNow();
 
     assertNoCallbackInvoke();
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1541,6 +1541,43 @@ public class ManagedChannelImplTest {
   }
 
   @Test
+  public void networkAvailable_refreshesNameResolver() {
+    FakeNameResolverFactory nameResolverFactory = new FakeNameResolverFactory(true);
+    createChannel(nameResolverFactory, NO_INTERCEPTOR);
+    FakeNameResolverFactory.FakeNameResolver nameResolver = nameResolverFactory.resolvers.get(0);
+    assertEquals(0, nameResolver.refreshCalled);
+
+    channel.reconnectNow();
+
+    assertEquals(1, nameResolver.refreshCalled);
+  }
+
+  @Test
+  public void networkAvailable_noOpWhenChannelShutdown() {
+    FakeNameResolverFactory nameResolverFactory = new FakeNameResolverFactory(true);
+    createChannel(nameResolverFactory, NO_INTERCEPTOR);
+
+    channel.shutdown();
+    assertTrue(channel.isShutdown());
+    channel.reconnectNow();
+
+    FakeNameResolverFactory.FakeNameResolver nameResolver = nameResolverFactory.resolvers.get(0);
+    assertEquals(0, nameResolver.refreshCalled);
+  }
+
+  @Test
+  public void networkAvailable_noOpWhenNameResolverNotStarted() {
+    FakeNameResolverFactory nameResolverFactory = new FakeNameResolverFactory(true);
+    createChannel(nameResolverFactory, NO_INTERCEPTOR, false /* requestConnection */,
+            ManagedChannelImpl.IDLE_TIMEOUT_MILLIS_DISABLE);
+
+    channel.reconnectNow();
+
+    FakeNameResolverFactory.FakeNameResolver nameResolver = nameResolverFactory.resolvers.get(0);
+    assertEquals(0, nameResolver.refreshCalled);
+  }
+
+  @Test
   public void orphanedChannelsAreLogged() throws Exception {
     int remaining = unterminatedChannels;
     for (int retry = 0; retry < 3; retry++) {
@@ -1679,6 +1716,7 @@ public class ManagedChannelImplTest {
       }
 
       @Override public void refresh() {
+        assertNotNull(listener);
         refreshCalled++;
       }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1541,37 +1541,37 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void networkAvailable_refreshesNameResolver() {
+  public void resetConnectBackoff_refreshesNameResolver() {
     FakeNameResolverFactory nameResolverFactory = new FakeNameResolverFactory(true);
     createChannel(nameResolverFactory, NO_INTERCEPTOR);
     FakeNameResolverFactory.FakeNameResolver nameResolver = nameResolverFactory.resolvers.get(0);
     assertEquals(0, nameResolver.refreshCalled);
 
-    channel.reconnectNow();
+    channel.resetConnectBackoff();
 
     assertEquals(1, nameResolver.refreshCalled);
   }
 
   @Test
-  public void networkAvailable_noOpWhenChannelShutdown() {
+  public void resetConnectBackoff_noOpWhenChannelShutdown() {
     FakeNameResolverFactory nameResolverFactory = new FakeNameResolverFactory(true);
     createChannel(nameResolverFactory, NO_INTERCEPTOR);
 
     channel.shutdown();
     assertTrue(channel.isShutdown());
-    channel.reconnectNow();
+    channel.resetConnectBackoff();
 
     FakeNameResolverFactory.FakeNameResolver nameResolver = nameResolverFactory.resolvers.get(0);
     assertEquals(0, nameResolver.refreshCalled);
   }
 
   @Test
-  public void networkAvailable_noOpWhenNameResolverNotStarted() {
+  public void resetConnectBackoff_noOpWhenNameResolverNotStarted() {
     FakeNameResolverFactory nameResolverFactory = new FakeNameResolverFactory(true);
     createChannel(nameResolverFactory, NO_INTERCEPTOR, false /* requestConnection */,
             ManagedChannelImpl.IDLE_TIMEOUT_MILLIS_DISABLE);
 
-    channel.reconnectNow();
+    channel.resetConnectBackoff();
 
     FakeNameResolverFactory.FakeNameResolver nameResolver = nameResolverFactory.resolvers.get(0);
     assertEquals(0, nameResolver.refreshCalled);


### PR DESCRIPTION
This addresses https://github.com/grpc/grpc-java/issues/2169. Currently users of OkHttp may have to wait up to 60 seconds (for DNS resolution to be re-attempted) or longer (if in exponential backoff to reconnect after `TRANSIENT_FAILURE`) for RPCs to succeed after the network connection is re-established. This provides a hook for apps to tell gRPC that the network is available and name resolution and reconnection attempts may occur immediately.