### PR TITLE
stub: add missing bazel dep com_google_errorprone

### DIFF
--- a/stub/BUILD.bazel
+++ b/stub/BUILD.bazel
@@ -8,6 +8,7 @@ java_library(
         "//context",
         "//core",
         "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_errorprone_error_prone_annotations//jar",
         "@com_google_guava_guava//jar",
     ],
 )


### PR DESCRIPTION
This is the error when running `bazel build ...` from the root dir:

```
external/grpc_java/stub/src/main/java/io/grpc/stub/AbstractStub.java:46: error: [strict] Using type com.google.errorprone.annotations.DoNotMock from an indirect dependency (TOOL_INFO: "@com_google_errorprone_error_prone_annotations//jar"). See command below **
@DoNotMock
 ^
 ** Please add the following dependencies: 
  @com_google_errorprone_error_prone_annotations//jar  to @grpc_java//stub 
 ** You can use the following buildozer command: 
buildozer 'add deps @com_google_errorprone_error_prone_annotations//jar ' @grpc_java//stub 
```