### PR TITLE
core: refresh name resolution when an OOB connection is closed.

### DIFF
--- a/core/src/main/java/io/grpc/internal/BackoffPolicy.java
+++ b/core/src/main/java/io/grpc/internal/BackoffPolicy.java
@@ -25,7 +25,7 @@ interface BackoffPolicy {
   }
 
   /**
-   * @return The number of milliseconds to wait.
+   * @return The number of nanoseconds to wait.
    */
   long nextBackoffNanos();
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -641,7 +641,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
 
     // Must be called from channelExecutor
     private void handleInternalSubchannelState(ConnectivityStateInfo newState) {
-      if ((newState.getState() == TRANSIENT_FAILURE || newState.getState() == IDLE)) {
+      if (newState.getState() == TRANSIENT_FAILURE || newState.getState() == IDLE) {
         nr.refresh();
       }
     }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -639,6 +639,13 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       this.nr = checkNotNull(nr, "NameResolver");
     }
 
+    // Must be called from channelExecutor
+    private void handleInternalSubchannelState(ConnectivityStateInfo newState) {
+      if ((newState.getState() == TRANSIENT_FAILURE || newState.getState() == IDLE)) {
+        nr.refresh();
+      }
+    }
+
     @Override
     public AbstractSubchannel createSubchannel(
         EquivalentAddressGroup addressGroup, Attributes attrs) {
@@ -660,9 +667,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
 
               @Override
               void onStateChange(InternalSubchannel is, ConnectivityStateInfo newState) {
-                if ((newState.getState() == TRANSIENT_FAILURE || newState.getState() == IDLE)) {
-                  nr.refresh();
-                }
+                handleInternalSubchannelState(newState);
                 // Call LB only if it's not shutdown.  If LB is shutdown, lbHelper won't match.
                 if (LbHelperImpl.this == ManagedChannelImpl.this.lbHelper) {
                   lb.handleSubchannelState(subchannel, newState);
@@ -757,6 +762,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
 
             @Override
             void onStateChange(InternalSubchannel is, ConnectivityStateInfo newState) {
+              handleInternalSubchannelState(newState);
               oobChannel.handleSubchannelStateChange(newState);
             }
           },

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -18,11 +18,13 @@ package io.grpc.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
@@ -222,5 +224,10 @@ final class OobChannel extends ManagedChannel implements WithLogId {
     // both delayedTransport and subchannel have terminated.
     executorPool.returnObject(executor);
     terminatedLatch.countDown();
+  }
+
+  @VisibleForTesting
+  Subchannel getSubchannel() {
+    return subchannelImpl;
   }
 }


### PR DESCRIPTION
This is required by an internal use case.  We have already been doing
so for Subchannels.