### PR TITLE
netty: separate connection log

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -39,6 +39,8 @@ import java.util.logging.Logger;
  */
 class NettyServerTransport implements ServerTransport {
   private static final Logger log = Logger.getLogger(NettyServerTransport.class.getName());
+  private static final Logger connectionLog = Logger.getLogger(
+      String.format("%s.connections", NettyServerTransport.class.getName()));
   // Some exceptions are not very useful and add too much noise to the log
   private static final ImmutableList<String> QUIET_ERRORS = ImmutableList.of(
       "Connection reset by peer",
@@ -156,7 +158,7 @@ class NettyServerTransport implements ServerTransport {
 
   private void notifyTerminated(Throwable t) {
     if (t != null) {
-      log.log(getLogLevel(t), "Transport failed", t);
+      connectionLog.log(getLogLevel(t), "Transport failed", t);
     }
     if (!terminated) {
       terminated = true;

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -38,7 +38,9 @@ import java.util.logging.Logger;
  * The Netty-based server transport.
  */
 class NettyServerTransport implements ServerTransport {
+  @SuppressWarnings("unused") // log is for general messages, but nothing currently uses it
   private static final Logger log = Logger.getLogger(NettyServerTransport.class.getName());
+  // connectionLog is for connection related messages only
   private static final Logger connectionLog = Logger.getLogger(
       String.format("%s.connections", NettyServerTransport.class.getName()));
   // Some exceptions are not very useful and add too much noise to the log


### PR DESCRIPTION
Move netty connection log info to a separate logger:
  io.grpc.netty.NettyServerTransport.connections

Users can redirect or disable this log using the usual way:
  -Djava.util.logging.config.file="logging.properties"

Related to #1768, #3575