### PR TITLE
core: Add port to proxy URL for Authenticator

### DIFF
--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -49,7 +49,7 @@ class ProxyDetectorImpl implements ProxyDetector {
         String host, InetAddress addr, int port, String protocol, String prompt, String scheme) {
       URL url = null;
       try {
-        url = new URL(protocol, host, "");
+        url = new URL(protocol, host, port, "");
       } catch (MalformedURLException e) {
         // let url be null
         log.log(


### PR DESCRIPTION
Otherwise the scheme (https) is used to determine the port.