### PR TITLE
kokoro: Initial config files for macos

### DIFF
--- a/buildscripts/kokoro/macos.cfg
+++ b/buildscripts/kokoro/macos.cfg
@@ -1,0 +1,5 @@
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-java/buildscripts/kokoro/unix.sh"
+timeout_mins: 45

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This file is used for both Linux and OSX builds
+
+# Currently an empty placeholder script that always succeeds.

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# This file is used for both Linux and OSX builds
+# This file is used for both Linux and OSX builds.
 
 # Currently an empty placeholder script that always succeeds.


### PR DESCRIPTION
An initial noop task, so that our internal build system always succeeds for osx.

The end goal is to move macos builds from travis to kokoro.