### PR TITLE
core: Fix naming style of string constants

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -958,10 +958,10 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     private static final ConcurrentMap<ManagedChannelReference, ManagedChannelReference> refs =
         new ConcurrentHashMap<ManagedChannelReference, ManagedChannelReference>();
 
-    private static final String allocationSitePropertyName =
+    private static final String ALLOCATION_SITE_PROPERTY_NAME =
         "io.grpc.ManagedChannel.enableAllocationTracking";
 
-    private static final boolean enableAllocationTracking =
+    private static final boolean ENABLE_ALLOCATION_TRACKING =
         Boolean.parseBoolean(System.getProperty(allocationSitePropertyName, "true"));
     private static final RuntimeException missingCallSite = missingCallSite();
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -962,7 +962,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
         "io.grpc.ManagedChannel.enableAllocationTracking";
 
     private static final boolean ENABLE_ALLOCATION_TRACKING =
-        Boolean.parseBoolean(System.getProperty(allocationSitePropertyName, "true"));
+        Boolean.parseBoolean(System.getProperty(ALLOCATION_SITE_PROPERTY_NAME, "true"));
     private static final RuntimeException missingCallSite = missingCallSite();
 
     private final LogId logId;
@@ -975,7 +975,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     ManagedChannelReference(ManagedChannelImpl chan) {
       super(chan, refQueue);
       allocationSite = new SoftReference<RuntimeException>(
-          enableAllocationTracking
+          ENABLE_ALLOCATION_TRACKING
               ? new RuntimeException("ManagedChannel allocation site")
               : missingCallSite);
       logId = chan.logId;
@@ -1037,7 +1037,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     private static RuntimeException missingCallSite() {
       RuntimeException e = new RuntimeException(
           "ManagedChannel allocation site not recorded.  Set -D"
-              + allocationSitePropertyName + "=true to enable it");
+              + ALLOCATION_SITE_PROPERTY_NAME + "=true to enable it");
       e.setStackTrace(new StackTraceElement[0]);
       return e;
     }


### PR DESCRIPTION
CC @carl-mastrangelo 