### PR TITLE
core: Use literal host:port instead of computing

### DIFF
--- a/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
-import com.google.common.net.HostAndPort;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
@@ -67,13 +66,11 @@ public class ProxyDetectorImplTest {
 
   @Test
   public void override_hostPort() throws Exception {
-    final String overrideHost = "override";
-    final int overridePort = 1234;
-    HostAndPort hostPort = HostAndPort.fromParts(overrideHost, overridePort);
+    final String overrideHostWithPort = "override:1234";
     ProxyDetectorImpl proxyDetector = new ProxyDetectorImpl(
         proxySelectorSupplier,
         authenticator,
-        hostPort.toString());
+        overrideHostWithPort);
     ProxyParameters detected = proxyDetector.proxyFor(destination);
     assertNotNull(detected);
     assertEquals(

--- a/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
@@ -66,7 +66,9 @@ public class ProxyDetectorImplTest {
 
   @Test
   public void override_hostPort() throws Exception {
-    final String overrideHostWithPort = "override:1234";
+    final String overrideHost = "override";
+    final int overridePort = 1234;
+    final String overrideHostWithPort = overrideHost + ":" + overridePort;
     ProxyDetectorImpl proxyDetector = new ProxyDetectorImpl(
         proxySelectorSupplier,
         authenticator,


### PR DESCRIPTION
Using HostAndPort just complicates the code. HostAndPort is also @Beta,
which is generally fine to use in tests, but is needless here.