### PR TITLE
context: Make CancellableContext implement Closeable

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -683,7 +683,7 @@ public class Context {
    * }
    * </pre>
    *
-   * Asynchronous code will have to manually track the end of the CancellableContext's lifetime,
+   * <p>Asynchronous code will have to manually track the end of the CancellableContext's lifetime,
    * and call either {@link #cancel} or {@link #close} at that time.
    */
   public static final class CancellableContext extends Context implements Closeable {


### PR DESCRIPTION
This achieves two things:
* communicates that `CancellableContext` is a resource that must be freed
* provides the ability to use the try-with-resources idiom to cancel the context when we finish up some blocking work. For users, this may be a better API than `runAndCancel` and `callAndCancel`.

@ejona86 and I considered adding a try-with-resources API that attaches the CancellableContext before the `try`, and *both* cancels as well as detaches at the `close`. But the problem is that the close runs before any catch statements, so users will not be able to use the exception as the cancellation cause unless they use a nested try/catch.

We also considered adding a try-with-resources API to attach/detach a context without cancelling, so that the two `try` statements in the example will look more symmetrical. But the syntactic sugar it provides is very minor. 

Internal use cases that kick off work asynchronously and use `ListenableFuture` will use an internal helper utility. We can not easily open source that code because `grpc-context` must have minimal dependencies and can not use guava.