### PR TITLE
 compiler: add methods for accessing method descriptors

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -28,75 +28,165 @@ public final class BenchmarkServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_UNARY_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.BenchmarkService", "UnaryCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("UnaryCall"))
-          .build();
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getUnaryCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.BenchmarkService", "StreamingCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("StreamingCall"))
-          .build();
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getUnaryCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getUnaryCallMethod;
+    if ((getUnaryCallMethod = BenchmarkServiceGrpc.getUnaryCallMethod) == null) {
+      synchronized (BenchmarkServiceGrpc.class) {
+        if ((getUnaryCallMethod = BenchmarkServiceGrpc.getUnaryCallMethod) == null) {
+          BenchmarkServiceGrpc.getUnaryCallMethod = getUnaryCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.BenchmarkService", "UnaryCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("UnaryCall"))
+                  .build();
+          }
+        }
+     }
+     return getUnaryCallMethod;
+  }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_FROM_CLIENT =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.BenchmarkService", "StreamingFromClient"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("StreamingFromClient"))
-          .build();
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_CALL = getStreamingCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_FROM_SERVER =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.BenchmarkService", "StreamingFromServer"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("StreamingFromServer"))
-          .build();
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingCallMethod;
+    if ((getStreamingCallMethod = BenchmarkServiceGrpc.getStreamingCallMethod) == null) {
+      synchronized (BenchmarkServiceGrpc.class) {
+        if ((getStreamingCallMethod = BenchmarkServiceGrpc.getStreamingCallMethod) == null) {
+          BenchmarkServiceGrpc.getStreamingCallMethod = getStreamingCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.BenchmarkService", "StreamingCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("StreamingCall"))
+                  .build();
+          }
+        }
+     }
+     return getStreamingCallMethod;
+  }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingFromClientMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_BOTH_WAYS =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.BenchmarkService", "StreamingBothWays"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("StreamingBothWays"))
-          .build();
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_FROM_CLIENT = getStreamingFromClientMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromClientMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromClientMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromClientMethod;
+    if ((getStreamingFromClientMethod = BenchmarkServiceGrpc.getStreamingFromClientMethod) == null) {
+      synchronized (BenchmarkServiceGrpc.class) {
+        if ((getStreamingFromClientMethod = BenchmarkServiceGrpc.getStreamingFromClientMethod) == null) {
+          BenchmarkServiceGrpc.getStreamingFromClientMethod = getStreamingFromClientMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.BenchmarkService", "StreamingFromClient"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("StreamingFromClient"))
+                  .build();
+          }
+        }
+     }
+     return getStreamingFromClientMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingFromServerMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_FROM_SERVER = getStreamingFromServerMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromServerMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromServerMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromServerMethod;
+    if ((getStreamingFromServerMethod = BenchmarkServiceGrpc.getStreamingFromServerMethod) == null) {
+      synchronized (BenchmarkServiceGrpc.class) {
+        if ((getStreamingFromServerMethod = BenchmarkServiceGrpc.getStreamingFromServerMethod) == null) {
+          BenchmarkServiceGrpc.getStreamingFromServerMethod = getStreamingFromServerMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.BenchmarkService", "StreamingFromServer"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("StreamingFromServer"))
+                  .build();
+          }
+        }
+     }
+     return getStreamingFromServerMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingBothWaysMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_BOTH_WAYS = getStreamingBothWaysMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingBothWaysMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingBothWaysMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingBothWaysMethod;
+    if ((getStreamingBothWaysMethod = BenchmarkServiceGrpc.getStreamingBothWaysMethod) == null) {
+      synchronized (BenchmarkServiceGrpc.class) {
+        if ((getStreamingBothWaysMethod = BenchmarkServiceGrpc.getStreamingBothWaysMethod) == null) {
+          BenchmarkServiceGrpc.getStreamingBothWaysMethod = getStreamingBothWaysMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.BenchmarkService", "StreamingBothWays"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Messages.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new BenchmarkServiceMethodDescriptorSupplier("StreamingBothWays"))
+                  .build();
+          }
+        }
+     }
+     return getStreamingBothWaysMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -133,7 +223,7 @@ public final class BenchmarkServiceGrpc {
      */
     public void unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
     }
 
     /**
@@ -145,7 +235,7 @@ public final class BenchmarkServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingCall(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingCallMethod(), responseObserver);
     }
 
     /**
@@ -156,7 +246,7 @@ public final class BenchmarkServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingFromClient(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_FROM_CLIENT, responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingFromClientMethod(), responseObserver);
     }
 
     /**
@@ -167,7 +257,7 @@ public final class BenchmarkServiceGrpc {
      */
     public void streamingFromServer(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STREAMING_FROM_SERVER, responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingFromServerMethod(), responseObserver);
     }
 
     /**
@@ -178,7 +268,7 @@ public final class BenchmarkServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingBothWays(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_BOTH_WAYS, responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingBothWaysMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -249,7 +339,7 @@ public final class BenchmarkServiceGrpc {
     public void unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -262,7 +352,7 @@ public final class BenchmarkServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingCall(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -274,7 +364,7 @@ public final class BenchmarkServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingFromClient(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_FROM_CLIENT, getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingFromClientMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -286,7 +376,7 @@ public final class BenchmarkServiceGrpc {
     public void streamingFromServer(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_FROM_SERVER, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingFromServerMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -298,7 +388,7 @@ public final class BenchmarkServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingBothWays(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_BOTH_WAYS, getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingBothWaysMethod(), getCallOptions()), responseObserver);
     }
   }
 
@@ -328,7 +418,7 @@ public final class BenchmarkServiceGrpc {
      */
     public io.grpc.benchmarks.proto.Messages.SimpleResponse unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
+          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
     }
 
     /**
@@ -340,7 +430,7 @@ public final class BenchmarkServiceGrpc {
     public java.util.Iterator<io.grpc.benchmarks.proto.Messages.SimpleResponse> streamingFromServer(
         io.grpc.benchmarks.proto.Messages.SimpleRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), METHOD_STREAMING_FROM_SERVER, getCallOptions(), request);
+          getChannel(), getStreamingFromServerMethod(), getCallOptions(), request);
     }
   }
 
@@ -371,7 +461,7 @@ public final class BenchmarkServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Messages.SimpleResponse> unaryCall(
         io.grpc.benchmarks.proto.Messages.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
     }
   }
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
@@ -28,19 +28,37 @@ public final class ReportQpsScenarioServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getReportScenarioMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult,
-      io.grpc.benchmarks.proto.Control.Void> METHOD_REPORT_SCENARIO =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.ScenarioResult, io.grpc.benchmarks.proto.Control.Void>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.ReportQpsScenarioService", "ReportScenario"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.ScenarioResult.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
-          .setSchemaDescriptor(new ReportQpsScenarioServiceMethodDescriptorSupplier("ReportScenario"))
-          .build();
+      io.grpc.benchmarks.proto.Control.Void> METHOD_REPORT_SCENARIO = getReportScenarioMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult,
+      io.grpc.benchmarks.proto.Control.Void> getReportScenarioMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult,
+      io.grpc.benchmarks.proto.Control.Void> getReportScenarioMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult, io.grpc.benchmarks.proto.Control.Void> getReportScenarioMethod;
+    if ((getReportScenarioMethod = ReportQpsScenarioServiceGrpc.getReportScenarioMethod) == null) {
+      synchronized (ReportQpsScenarioServiceGrpc.class) {
+        if ((getReportScenarioMethod = ReportQpsScenarioServiceGrpc.getReportScenarioMethod) == null) {
+          ReportQpsScenarioServiceGrpc.getReportScenarioMethod = getReportScenarioMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.ScenarioResult, io.grpc.benchmarks.proto.Control.Void>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.ReportQpsScenarioService", "ReportScenario"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.ScenarioResult.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
+                  .setSchemaDescriptor(new ReportQpsScenarioServiceMethodDescriptorSupplier("ReportScenario"))
+                  .build();
+          }
+        }
+     }
+     return getReportScenarioMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -76,7 +94,7 @@ public final class ReportQpsScenarioServiceGrpc {
      */
     public void reportScenario(io.grpc.benchmarks.proto.Control.ScenarioResult request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_REPORT_SCENARIO, responseObserver);
+      asyncUnimplementedUnaryCall(getReportScenarioMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -118,7 +136,7 @@ public final class ReportQpsScenarioServiceGrpc {
     public void reportScenario(io.grpc.benchmarks.proto.Control.ScenarioResult request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_REPORT_SCENARIO, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getReportScenarioMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -147,7 +165,7 @@ public final class ReportQpsScenarioServiceGrpc {
      */
     public io.grpc.benchmarks.proto.Control.Void reportScenario(io.grpc.benchmarks.proto.Control.ScenarioResult request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_REPORT_SCENARIO, getCallOptions(), request);
+          getChannel(), getReportScenarioMethod(), getCallOptions(), request);
     }
   }
 
@@ -177,7 +195,7 @@ public final class ReportQpsScenarioServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.Void> reportScenario(
         io.grpc.benchmarks.proto.Control.ScenarioResult request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_REPORT_SCENARIO, getCallOptions()), request);
+          getChannel().newCall(getReportScenarioMethod(), getCallOptions()), request);
     }
   }
 

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -28,61 +28,133 @@ public final class WorkerServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getRunServerMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs,
-      io.grpc.benchmarks.proto.Control.ServerStatus> METHOD_RUN_SERVER =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.ServerArgs, io.grpc.benchmarks.proto.Control.ServerStatus>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.WorkerService", "RunServer"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.ServerArgs.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.ServerStatus.getDefaultInstance()))
-          .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("RunServer"))
-          .build();
+      io.grpc.benchmarks.proto.Control.ServerStatus> METHOD_RUN_SERVER = getRunServerMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs,
+      io.grpc.benchmarks.proto.Control.ServerStatus> getRunServerMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs,
+      io.grpc.benchmarks.proto.Control.ServerStatus> getRunServerMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs, io.grpc.benchmarks.proto.Control.ServerStatus> getRunServerMethod;
+    if ((getRunServerMethod = WorkerServiceGrpc.getRunServerMethod) == null) {
+      synchronized (WorkerServiceGrpc.class) {
+        if ((getRunServerMethod = WorkerServiceGrpc.getRunServerMethod) == null) {
+          WorkerServiceGrpc.getRunServerMethod = getRunServerMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.ServerArgs, io.grpc.benchmarks.proto.Control.ServerStatus>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.WorkerService", "RunServer"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.ServerArgs.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.ServerStatus.getDefaultInstance()))
+                  .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("RunServer"))
+                  .build();
+          }
+        }
+     }
+     return getRunServerMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getRunClientMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs,
-      io.grpc.benchmarks.proto.Control.ClientStatus> METHOD_RUN_CLIENT =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.ClientArgs, io.grpc.benchmarks.proto.Control.ClientStatus>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.WorkerService", "RunClient"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.ClientArgs.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.ClientStatus.getDefaultInstance()))
-          .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("RunClient"))
-          .build();
+      io.grpc.benchmarks.proto.Control.ClientStatus> METHOD_RUN_CLIENT = getRunClientMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs,
+      io.grpc.benchmarks.proto.Control.ClientStatus> getRunClientMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs,
+      io.grpc.benchmarks.proto.Control.ClientStatus> getRunClientMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs, io.grpc.benchmarks.proto.Control.ClientStatus> getRunClientMethod;
+    if ((getRunClientMethod = WorkerServiceGrpc.getRunClientMethod) == null) {
+      synchronized (WorkerServiceGrpc.class) {
+        if ((getRunClientMethod = WorkerServiceGrpc.getRunClientMethod) == null) {
+          WorkerServiceGrpc.getRunClientMethod = getRunClientMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.ClientArgs, io.grpc.benchmarks.proto.Control.ClientStatus>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.WorkerService", "RunClient"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.ClientArgs.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.ClientStatus.getDefaultInstance()))
+                  .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("RunClient"))
+                  .build();
+          }
+        }
+     }
+     return getRunClientMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getCoreCountMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest,
-      io.grpc.benchmarks.proto.Control.CoreResponse> METHOD_CORE_COUNT =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.CoreRequest, io.grpc.benchmarks.proto.Control.CoreResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.WorkerService", "CoreCount"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.CoreRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.CoreResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("CoreCount"))
-          .build();
+      io.grpc.benchmarks.proto.Control.CoreResponse> METHOD_CORE_COUNT = getCoreCountMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest,
+      io.grpc.benchmarks.proto.Control.CoreResponse> getCoreCountMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest,
+      io.grpc.benchmarks.proto.Control.CoreResponse> getCoreCountMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest, io.grpc.benchmarks.proto.Control.CoreResponse> getCoreCountMethod;
+    if ((getCoreCountMethod = WorkerServiceGrpc.getCoreCountMethod) == null) {
+      synchronized (WorkerServiceGrpc.class) {
+        if ((getCoreCountMethod = WorkerServiceGrpc.getCoreCountMethod) == null) {
+          WorkerServiceGrpc.getCoreCountMethod = getCoreCountMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.CoreRequest, io.grpc.benchmarks.proto.Control.CoreResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.WorkerService", "CoreCount"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.CoreRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.CoreResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("CoreCount"))
+                  .build();
+          }
+        }
+     }
+     return getCoreCountMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getQuitWorkerMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void,
-      io.grpc.benchmarks.proto.Control.Void> METHOD_QUIT_WORKER =
-      io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.Void, io.grpc.benchmarks.proto.Control.Void>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.WorkerService", "QuitWorker"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
-          .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("QuitWorker"))
-          .build();
+      io.grpc.benchmarks.proto.Control.Void> METHOD_QUIT_WORKER = getQuitWorkerMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void,
+      io.grpc.benchmarks.proto.Control.Void> getQuitWorkerMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void,
+      io.grpc.benchmarks.proto.Control.Void> getQuitWorkerMethod() {
+    io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void, io.grpc.benchmarks.proto.Control.Void> getQuitWorkerMethod;
+    if ((getQuitWorkerMethod = WorkerServiceGrpc.getQuitWorkerMethod) == null) {
+      synchronized (WorkerServiceGrpc.class) {
+        if ((getQuitWorkerMethod = WorkerServiceGrpc.getQuitWorkerMethod) == null) {
+          WorkerServiceGrpc.getQuitWorkerMethod = getQuitWorkerMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.benchmarks.proto.Control.Void, io.grpc.benchmarks.proto.Control.Void>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.WorkerService", "QuitWorker"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.benchmarks.proto.Control.Void.getDefaultInstance()))
+                  .setSchemaDescriptor(new WorkerServiceMethodDescriptorSupplier("QuitWorker"))
+                  .build();
+          }
+        }
+     }
+     return getQuitWorkerMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -123,7 +195,7 @@ public final class WorkerServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerArgs> runServer(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerStatus> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_RUN_SERVER, responseObserver);
+      return asyncUnimplementedStreamingCall(getRunServerMethod(), responseObserver);
     }
 
     /**
@@ -138,7 +210,7 @@ public final class WorkerServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientArgs> runClient(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientStatus> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_RUN_CLIENT, responseObserver);
+      return asyncUnimplementedStreamingCall(getRunClientMethod(), responseObserver);
     }
 
     /**
@@ -148,7 +220,7 @@ public final class WorkerServiceGrpc {
      */
     public void coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.CoreResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_CORE_COUNT, responseObserver);
+      asyncUnimplementedUnaryCall(getCoreCountMethod(), responseObserver);
     }
 
     /**
@@ -158,7 +230,7 @@ public final class WorkerServiceGrpc {
      */
     public void quitWorker(io.grpc.benchmarks.proto.Control.Void request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_QUIT_WORKER, responseObserver);
+      asyncUnimplementedUnaryCall(getQuitWorkerMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -226,7 +298,7 @@ public final class WorkerServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerArgs> runServer(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerStatus> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_RUN_SERVER, getCallOptions()), responseObserver);
+          getChannel().newCall(getRunServerMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -242,7 +314,7 @@ public final class WorkerServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientArgs> runClient(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientStatus> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_RUN_CLIENT, getCallOptions()), responseObserver);
+          getChannel().newCall(getRunClientMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -253,7 +325,7 @@ public final class WorkerServiceGrpc {
     public void coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.CoreResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_CORE_COUNT, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getCoreCountMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -264,7 +336,7 @@ public final class WorkerServiceGrpc {
     public void quitWorker(io.grpc.benchmarks.proto.Control.Void request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_QUIT_WORKER, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getQuitWorkerMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -293,7 +365,7 @@ public final class WorkerServiceGrpc {
      */
     public io.grpc.benchmarks.proto.Control.CoreResponse coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_CORE_COUNT, getCallOptions(), request);
+          getChannel(), getCoreCountMethod(), getCallOptions(), request);
     }
 
     /**
@@ -303,7 +375,7 @@ public final class WorkerServiceGrpc {
      */
     public io.grpc.benchmarks.proto.Control.Void quitWorker(io.grpc.benchmarks.proto.Control.Void request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_QUIT_WORKER, getCallOptions(), request);
+          getChannel(), getQuitWorkerMethod(), getCallOptions(), request);
     }
   }
 
@@ -333,7 +405,7 @@ public final class WorkerServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.CoreResponse> coreCount(
         io.grpc.benchmarks.proto.Control.CoreRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_CORE_COUNT, getCallOptions()), request);
+          getChannel().newCall(getCoreCountMethod(), getCallOptions()), request);
     }
 
     /**
@@ -344,7 +416,7 @@ public final class WorkerServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.Void> quitWorker(
         io.grpc.benchmarks.proto.Control.Void request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_QUIT_WORKER, getCallOptions()), request);
+          getChannel().newCall(getQuitWorkerMethod(), getCallOptions()), request);
     }
   }
 

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/SingleThreadBlockingQpsBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/SingleThreadBlockingQpsBenchmark.java
@@ -65,8 +65,8 @@ public class SingleThreadBlockingQpsBenchmark extends AbstractBenchmark {
    * Issue a unary call and wait for the response.
    */
   @Benchmark
-  public void blockingUnary() throws Exception {
-    ClientCalls.blockingUnaryCall(
+  public Object blockingUnary() throws Exception {
+    return ClientCalls.blockingUnaryCall(
         channels[0].newCall(unaryMethod, CallOptions.DEFAULT), Unpooled.EMPTY_BUFFER);
   }
 

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadServer.java
@@ -60,14 +60,14 @@ final class LoadServer {
    * Generic version of the unary method call.
    */
   static final MethodDescriptor<ByteBuf, ByteBuf> GENERIC_UNARY_METHOD =
-      BenchmarkServiceGrpc.METHOD_UNARY_CALL.toBuilder(marshaller, marshaller)
+      BenchmarkServiceGrpc.getUnaryCallMethod().toBuilder(marshaller, marshaller)
           .build();
 
   /**
    * Generic version of the streaming ping-pong method call.
    */
   static final MethodDescriptor<ByteBuf, ByteBuf> GENERIC_STREAMING_PING_PONG_METHOD =
-      BenchmarkServiceGrpc.METHOD_STREAMING_CALL.toBuilder(marshaller, marshaller)
+      BenchmarkServiceGrpc.getStreamingCallMethod().toBuilder(marshaller, marshaller)
           .build();
 
   private static final Logger log = Logger.getLogger(LoadServer.class.getName());

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -31,75 +31,165 @@ public final class TestServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
-      io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.SimpleRequest, io.grpc.testing.integration.Test.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "UnaryCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("UnaryCall"))
-          .build();
+      io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
+      io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
+      io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest, io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod;
+    if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
+          TestServiceGrpc.getUnaryCallMethod = getUnaryCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.SimpleRequest, io.grpc.testing.integration.Test.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "UnaryCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("UnaryCall"))
+                  .build();
+          }
+        }
+     }
+     return getUnaryCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingOutputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "StreamingOutputCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingOutputCall"))
-          .build();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
+    if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
+          TestServiceGrpc.getStreamingOutputCallMethod = getStreamingOutputCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "StreamingOutputCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingOutputCall"))
+                  .build();
+          }
+        }
+     }
+     return getStreamingOutputCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingInputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
-      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "StreamingInputCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingInputCall"))
-          .build();
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "FullBidiCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("FullBidiCall"))
-          .build();
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
+    if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
+          TestServiceGrpc.getStreamingInputCallMethod = getStreamingInputCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "StreamingInputCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingInputCall"))
+                  .build();
+          }
+        }
+     }
+     return getStreamingInputCallMethod;
+  }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getFullBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "HalfBidiCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("HalfBidiCall"))
-          .build();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL = getFullBidiCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
+    if ((getFullBidiCallMethod = TestServiceGrpc.getFullBidiCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getFullBidiCallMethod = TestServiceGrpc.getFullBidiCallMethod) == null) {
+          TestServiceGrpc.getFullBidiCallMethod = getFullBidiCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "FullBidiCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("FullBidiCall"))
+                  .build();
+          }
+        }
+     }
+     return getFullBidiCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getHalfBidiCallMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL = getHalfBidiCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
+    if ((getHalfBidiCallMethod = TestServiceGrpc.getHalfBidiCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getHalfBidiCallMethod = TestServiceGrpc.getHalfBidiCallMethod) == null) {
+          TestServiceGrpc.getHalfBidiCallMethod = getHalfBidiCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "HalfBidiCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("HalfBidiCall"))
+                  .build();
+          }
+        }
+     }
+     return getHalfBidiCallMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -139,7 +229,7 @@ public final class TestServiceGrpc {
      */
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
     }
 
     /**
@@ -150,7 +240,7 @@ public final class TestServiceGrpc {
      */
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingOutputCallMethod(), responseObserver);
     }
 
     /**
@@ -161,7 +251,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingInputCallMethod(), responseObserver);
     }
 
     /**
@@ -173,7 +263,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_FULL_BIDI_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getFullBidiCallMethod(), responseObserver);
     }
 
     /**
@@ -186,7 +276,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_HALF_BIDI_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getHalfBidiCallMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -260,7 +350,7 @@ public final class TestServiceGrpc {
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -272,7 +362,7 @@ public final class TestServiceGrpc {
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingOutputCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -284,7 +374,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_INPUT_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingInputCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -297,7 +387,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_FULL_BIDI_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getFullBidiCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -311,7 +401,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_HALF_BIDI_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getHalfBidiCallMethod(), getCallOptions()), responseObserver);
     }
   }
 
@@ -344,7 +434,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
+          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
     }
 
     /**
@@ -356,7 +446,7 @@ public final class TestServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), METHOD_STREAMING_OUTPUT_CALL, getCallOptions(), request);
+          getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
     }
   }
 
@@ -390,7 +480,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
     }
   }
 

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -31,70 +31,160 @@ public final class TestServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
-      io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.SimpleRequest, io.grpc.testing.integration.Test.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "UnaryCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.SimpleResponse.getDefaultInstance()))
-          .build();
+      io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
+      io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
+      io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest, io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod;
+    if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
+          TestServiceGrpc.getUnaryCallMethod = getUnaryCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.SimpleRequest, io.grpc.testing.integration.Test.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "UnaryCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.SimpleResponse.getDefaultInstance()))
+                  .build();
+          }
+        }
+     }
+     return getUnaryCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingOutputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "StreamingOutputCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
-          .build();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
+    if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
+          TestServiceGrpc.getStreamingOutputCallMethod = getStreamingOutputCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "StreamingOutputCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+                  .build();
+          }
+        }
+     }
+     return getStreamingOutputCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingInputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
-      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "StreamingInputCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()))
-          .build();
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "FullBidiCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
-          .build();
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
+    if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
+          TestServiceGrpc.getStreamingInputCallMethod = getStreamingInputCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "StreamingInputCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()))
+                  .build();
+          }
+        }
+     }
+     return getStreamingInputCallMethod;
+  }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getFullBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "HalfBidiCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
-              io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
-          .build();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL = getFullBidiCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
+    if ((getFullBidiCallMethod = TestServiceGrpc.getFullBidiCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getFullBidiCallMethod = TestServiceGrpc.getFullBidiCallMethod) == null) {
+          TestServiceGrpc.getFullBidiCallMethod = getFullBidiCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "FullBidiCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+                  .build();
+          }
+        }
+     }
+     return getFullBidiCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getHalfBidiCallMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL = getHalfBidiCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
+    if ((getHalfBidiCallMethod = TestServiceGrpc.getHalfBidiCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getHalfBidiCallMethod = TestServiceGrpc.getHalfBidiCallMethod) == null) {
+          TestServiceGrpc.getHalfBidiCallMethod = getHalfBidiCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "HalfBidiCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingOutputCallResponse.getDefaultInstance()))
+                  .build();
+          }
+        }
+     }
+     return getHalfBidiCallMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -134,7 +224,7 @@ public final class TestServiceGrpc {
      */
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
     }
 
     /**
@@ -145,7 +235,7 @@ public final class TestServiceGrpc {
      */
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingOutputCallMethod(), responseObserver);
     }
 
     /**
@@ -156,7 +246,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingInputCallMethod(), responseObserver);
     }
 
     /**
@@ -168,7 +258,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_FULL_BIDI_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getFullBidiCallMethod(), responseObserver);
     }
 
     /**
@@ -181,7 +271,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_HALF_BIDI_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getHalfBidiCallMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -255,7 +345,7 @@ public final class TestServiceGrpc {
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -267,7 +357,7 @@ public final class TestServiceGrpc {
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingOutputCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -279,7 +369,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_INPUT_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingInputCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -292,7 +382,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_FULL_BIDI_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getFullBidiCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -306,7 +396,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_HALF_BIDI_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getHalfBidiCallMethod(), getCallOptions()), responseObserver);
     }
   }
 
@@ -339,7 +429,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
+          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
     }
 
     /**
@@ -351,7 +441,7 @@ public final class TestServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), METHOD_STREAMING_OUTPUT_CALL, getCallOptions(), request);
+          getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
     }
   }
 
@@ -385,7 +475,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
     }
   }
 

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -35,78 +35,168 @@ public final class TestServiceGrpc {
   private static final int ARG_IN_METHOD_UNARY_CALL = 0;
   private static final int ARG_OUT_METHOD_UNARY_CALL = 1;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.SimpleRequest,
-      io.grpc.testing.integration.nano.Test.SimpleResponse> METHOD_UNARY_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.SimpleRequest, io.grpc.testing.integration.nano.Test.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "UnaryCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.SimpleRequest>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.SimpleRequest>(ARG_IN_METHOD_UNARY_CALL)))
-          .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.SimpleResponse>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.SimpleResponse>(ARG_OUT_METHOD_UNARY_CALL)))
-          .build();
+      io.grpc.testing.integration.nano.Test.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.SimpleRequest,
+      io.grpc.testing.integration.nano.Test.SimpleResponse> getUnaryCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.SimpleRequest,
+      io.grpc.testing.integration.nano.Test.SimpleResponse> getUnaryCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.SimpleRequest, io.grpc.testing.integration.nano.Test.SimpleResponse> getUnaryCallMethod;
+    if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
+          TestServiceGrpc.getUnaryCallMethod = getUnaryCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.SimpleRequest, io.grpc.testing.integration.nano.Test.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "UnaryCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.SimpleRequest>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.SimpleRequest>(ARG_IN_METHOD_UNARY_CALL)))
+              .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.SimpleResponse>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.SimpleResponse>(ARG_OUT_METHOD_UNARY_CALL)))
+              .build();
+        }
+      }
+    }
+    return getUnaryCallMethod;
+  }
   private static final int ARG_IN_METHOD_STREAMING_OUTPUT_CALL = 2;
   private static final int ARG_OUT_METHOD_STREAMING_OUTPUT_CALL = 3;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingOutputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "StreamingOutputCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>(ARG_IN_METHOD_STREAMING_OUTPUT_CALL)))
-          .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(ARG_OUT_METHOD_STREAMING_OUTPUT_CALL)))
-          .build();
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
+    if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
+          TestServiceGrpc.getStreamingOutputCallMethod = getStreamingOutputCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "StreamingOutputCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>(ARG_IN_METHOD_STREAMING_OUTPUT_CALL)))
+              .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(ARG_OUT_METHOD_STREAMING_OUTPUT_CALL)))
+              .build();
+        }
+      }
+    }
+    return getStreamingOutputCallMethod;
+  }
   private static final int ARG_IN_METHOD_STREAMING_INPUT_CALL = 4;
   private static final int ARG_OUT_METHOD_STREAMING_INPUT_CALL = 5;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingInputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
-      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest, io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "StreamingInputCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>(ARG_IN_METHOD_STREAMING_INPUT_CALL)))
-          .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>(ARG_OUT_METHOD_STREAMING_INPUT_CALL)))
-          .build();
+      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getStreamingInputCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest, io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
+    if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
+          TestServiceGrpc.getStreamingInputCallMethod = getStreamingInputCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest, io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "StreamingInputCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>(ARG_IN_METHOD_STREAMING_INPUT_CALL)))
+              .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>(ARG_OUT_METHOD_STREAMING_INPUT_CALL)))
+              .build();
+        }
+      }
+    }
+    return getStreamingInputCallMethod;
+  }
   private static final int ARG_IN_METHOD_FULL_BIDI_CALL = 6;
   private static final int ARG_OUT_METHOD_FULL_BIDI_CALL = 7;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getFullBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "FullBidiCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>(ARG_IN_METHOD_FULL_BIDI_CALL)))
-          .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(ARG_OUT_METHOD_FULL_BIDI_CALL)))
-          .build();
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL = getFullBidiCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getFullBidiCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
+    if ((getFullBidiCallMethod = TestServiceGrpc.getFullBidiCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getFullBidiCallMethod = TestServiceGrpc.getFullBidiCallMethod) == null) {
+          TestServiceGrpc.getFullBidiCallMethod = getFullBidiCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "FullBidiCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>(ARG_IN_METHOD_FULL_BIDI_CALL)))
+              .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(ARG_OUT_METHOD_FULL_BIDI_CALL)))
+              .build();
+        }
+      }
+    }
+    return getFullBidiCallMethod;
+  }
   private static final int ARG_IN_METHOD_HALF_BIDI_CALL = 8;
   private static final int ARG_OUT_METHOD_HALF_BIDI_CALL = 9;
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getHalfBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "HalfBidiCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>(ARG_IN_METHOD_HALF_BIDI_CALL)))
-          .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
-              new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(ARG_OUT_METHOD_HALF_BIDI_CALL)))
-          .build();
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL = getHalfBidiCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getHalfBidiCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
+    if ((getHalfBidiCallMethod = TestServiceGrpc.getHalfBidiCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getHalfBidiCallMethod = TestServiceGrpc.getHalfBidiCallMethod) == null) {
+          TestServiceGrpc.getHalfBidiCallMethod = getHalfBidiCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "HalfBidiCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest>(ARG_IN_METHOD_HALF_BIDI_CALL)))
+              .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(ARG_OUT_METHOD_HALF_BIDI_CALL)))
+              .build();
+        }
+      }
+    }
+    return getHalfBidiCallMethod;
+  }
 
   private static final class NanoFactory<T extends com.google.protobuf.nano.MessageNano>
       implements io.grpc.protobuf.nano.MessageNanoFactory<T> {
@@ -197,7 +287,7 @@ public final class TestServiceGrpc {
      */
     public void unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
     }
 
     /**
@@ -208,7 +298,7 @@ public final class TestServiceGrpc {
      */
     public void streamingOutputCall(io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingOutputCallMethod(), responseObserver);
     }
 
     /**
@@ -219,7 +309,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingInputCallMethod(), responseObserver);
     }
 
     /**
@@ -231,7 +321,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_FULL_BIDI_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getFullBidiCallMethod(), responseObserver);
     }
 
     /**
@@ -244,7 +334,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_HALF_BIDI_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getHalfBidiCallMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -318,7 +408,7 @@ public final class TestServiceGrpc {
     public void unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -330,7 +420,7 @@ public final class TestServiceGrpc {
     public void streamingOutputCall(io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingOutputCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -342,7 +432,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_INPUT_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingInputCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -355,7 +445,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_FULL_BIDI_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getFullBidiCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -369,7 +459,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_HALF_BIDI_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getHalfBidiCallMethod(), getCallOptions()), responseObserver);
     }
   }
 
@@ -402,7 +492,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.nano.Test.SimpleResponse unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
+          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
     }
 
     /**
@@ -414,7 +504,7 @@ public final class TestServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), METHOD_STREAMING_OUTPUT_CALL, getCallOptions(), request);
+          getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
     }
   }
 
@@ -448,7 +538,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.nano.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.nano.Test.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
     }
   }
 

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -28,19 +28,37 @@ public final class LoadBalancerGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getBalanceLoadMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest,
-      io.grpc.grpclb.LoadBalanceResponse> METHOD_BALANCE_LOAD =
-      io.grpc.MethodDescriptor.<io.grpc.grpclb.LoadBalanceRequest, io.grpc.grpclb.LoadBalanceResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.lb.v1.LoadBalancer", "BalanceLoad"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.grpclb.LoadBalanceRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.grpclb.LoadBalanceResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new LoadBalancerMethodDescriptorSupplier("BalanceLoad"))
-          .build();
+      io.grpc.grpclb.LoadBalanceResponse> METHOD_BALANCE_LOAD = getBalanceLoadMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest,
+      io.grpc.grpclb.LoadBalanceResponse> getBalanceLoadMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest,
+      io.grpc.grpclb.LoadBalanceResponse> getBalanceLoadMethod() {
+    io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest, io.grpc.grpclb.LoadBalanceResponse> getBalanceLoadMethod;
+    if ((getBalanceLoadMethod = LoadBalancerGrpc.getBalanceLoadMethod) == null) {
+      synchronized (LoadBalancerGrpc.class) {
+        if ((getBalanceLoadMethod = LoadBalancerGrpc.getBalanceLoadMethod) == null) {
+          LoadBalancerGrpc.getBalanceLoadMethod = getBalanceLoadMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.grpclb.LoadBalanceRequest, io.grpc.grpclb.LoadBalanceResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.lb.v1.LoadBalancer", "BalanceLoad"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.grpclb.LoadBalanceRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.grpclb.LoadBalanceResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new LoadBalancerMethodDescriptorSupplier("BalanceLoad"))
+                  .build();
+          }
+        }
+     }
+     return getBalanceLoadMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -76,7 +94,7 @@ public final class LoadBalancerGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceRequest> balanceLoad(
         io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_BALANCE_LOAD, responseObserver);
+      return asyncUnimplementedStreamingCall(getBalanceLoadMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -118,7 +136,7 @@ public final class LoadBalancerGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceRequest> balanceLoad(
         io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_BALANCE_LOAD, getCallOptions()), responseObserver);
+          getChannel().newCall(getBalanceLoadMethod(), getCallOptions()), responseObserver);
     }
   }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -28,33 +28,69 @@ public final class MetricsServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getGetAllGaugesMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,
-      io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_ALL_GAUGES =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Metrics.EmptyMessage, io.grpc.testing.integration.Metrics.GaugeResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.MetricsService", "GetAllGauges"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Metrics.EmptyMessage.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new MetricsServiceMethodDescriptorSupplier("GetAllGauges"))
-          .build();
+      io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_ALL_GAUGES = getGetAllGaugesMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,
+      io.grpc.testing.integration.Metrics.GaugeResponse> getGetAllGaugesMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,
+      io.grpc.testing.integration.Metrics.GaugeResponse> getGetAllGaugesMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage, io.grpc.testing.integration.Metrics.GaugeResponse> getGetAllGaugesMethod;
+    if ((getGetAllGaugesMethod = MetricsServiceGrpc.getGetAllGaugesMethod) == null) {
+      synchronized (MetricsServiceGrpc.class) {
+        if ((getGetAllGaugesMethod = MetricsServiceGrpc.getGetAllGaugesMethod) == null) {
+          MetricsServiceGrpc.getGetAllGaugesMethod = getGetAllGaugesMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Metrics.EmptyMessage, io.grpc.testing.integration.Metrics.GaugeResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.MetricsService", "GetAllGauges"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Metrics.EmptyMessage.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new MetricsServiceMethodDescriptorSupplier("GetAllGauges"))
+                  .build();
+          }
+        }
+     }
+     return getGetAllGaugesMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getGetGaugeMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest,
-      io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_GAUGE =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Metrics.GaugeRequest, io.grpc.testing.integration.Metrics.GaugeResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.MetricsService", "GetGauge"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Metrics.GaugeRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new MetricsServiceMethodDescriptorSupplier("GetGauge"))
-          .build();
+      io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_GAUGE = getGetGaugeMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest,
+      io.grpc.testing.integration.Metrics.GaugeResponse> getGetGaugeMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest,
+      io.grpc.testing.integration.Metrics.GaugeResponse> getGetGaugeMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest, io.grpc.testing.integration.Metrics.GaugeResponse> getGetGaugeMethod;
+    if ((getGetGaugeMethod = MetricsServiceGrpc.getGetGaugeMethod) == null) {
+      synchronized (MetricsServiceGrpc.class) {
+        if ((getGetGaugeMethod = MetricsServiceGrpc.getGetGaugeMethod) == null) {
+          MetricsServiceGrpc.getGetGaugeMethod = getGetGaugeMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Metrics.GaugeRequest, io.grpc.testing.integration.Metrics.GaugeResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.MetricsService", "GetGauge"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Metrics.GaugeRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Metrics.GaugeResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new MetricsServiceMethodDescriptorSupplier("GetGauge"))
+                  .build();
+          }
+        }
+     }
+     return getGetGaugeMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -91,7 +127,7 @@ public final class MetricsServiceGrpc {
      */
     public void getAllGauges(io.grpc.testing.integration.Metrics.EmptyMessage request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_GET_ALL_GAUGES, responseObserver);
+      asyncUnimplementedUnaryCall(getGetAllGaugesMethod(), responseObserver);
     }
 
     /**
@@ -101,7 +137,7 @@ public final class MetricsServiceGrpc {
      */
     public void getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_GET_GAUGE, responseObserver);
+      asyncUnimplementedUnaryCall(getGetGaugeMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -151,7 +187,7 @@ public final class MetricsServiceGrpc {
     public void getAllGauges(io.grpc.testing.integration.Metrics.EmptyMessage request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(METHOD_GET_ALL_GAUGES, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetAllGaugesMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -162,7 +198,7 @@ public final class MetricsServiceGrpc {
     public void getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_GET_GAUGE, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetGaugeMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -193,7 +229,7 @@ public final class MetricsServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.Metrics.GaugeResponse> getAllGauges(
         io.grpc.testing.integration.Metrics.EmptyMessage request) {
       return blockingServerStreamingCall(
-          getChannel(), METHOD_GET_ALL_GAUGES, getCallOptions(), request);
+          getChannel(), getGetAllGaugesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -203,7 +239,7 @@ public final class MetricsServiceGrpc {
      */
     public io.grpc.testing.integration.Metrics.GaugeResponse getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_GET_GAUGE, getCallOptions(), request);
+          getChannel(), getGetGaugeMethod(), getCallOptions(), request);
     }
   }
 
@@ -233,7 +269,7 @@ public final class MetricsServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Metrics.GaugeResponse> getGauge(
         io.grpc.testing.integration.Metrics.GaugeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_GET_GAUGE, getCallOptions()), request);
+          getChannel().newCall(getGetGaugeMethod(), getCallOptions()), request);
     }
   }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -31,33 +31,69 @@ public final class ReconnectServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStartMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      com.google.protobuf.EmptyProtos.Empty> METHOD_START =
-      io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.ReconnectService", "Start"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
-          .setSchemaDescriptor(new ReconnectServiceMethodDescriptorSupplier("Start"))
-          .build();
+      com.google.protobuf.EmptyProtos.Empty> METHOD_START = getStartMethod();
+
+  private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getStartMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getStartMethod() {
+    io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty> getStartMethod;
+    if ((getStartMethod = ReconnectServiceGrpc.getStartMethod) == null) {
+      synchronized (ReconnectServiceGrpc.class) {
+        if ((getStartMethod = ReconnectServiceGrpc.getStartMethod) == null) {
+          ReconnectServiceGrpc.getStartMethod = getStartMethod = 
+              io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.ReconnectService", "Start"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+                  .setSchemaDescriptor(new ReconnectServiceMethodDescriptorSupplier("Start"))
+                  .build();
+          }
+        }
+     }
+     return getStartMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStopMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      io.grpc.testing.integration.Messages.ReconnectInfo> METHOD_STOP =
-      io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, io.grpc.testing.integration.Messages.ReconnectInfo>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.ReconnectService", "Stop"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.ReconnectInfo.getDefaultInstance()))
-          .setSchemaDescriptor(new ReconnectServiceMethodDescriptorSupplier("Stop"))
-          .build();
+      io.grpc.testing.integration.Messages.ReconnectInfo> METHOD_STOP = getStopMethod();
+
+  private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      io.grpc.testing.integration.Messages.ReconnectInfo> getStopMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      io.grpc.testing.integration.Messages.ReconnectInfo> getStopMethod() {
+    io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, io.grpc.testing.integration.Messages.ReconnectInfo> getStopMethod;
+    if ((getStopMethod = ReconnectServiceGrpc.getStopMethod) == null) {
+      synchronized (ReconnectServiceGrpc.class) {
+        if ((getStopMethod = ReconnectServiceGrpc.getStopMethod) == null) {
+          ReconnectServiceGrpc.getStopMethod = getStopMethod = 
+              io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, io.grpc.testing.integration.Messages.ReconnectInfo>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.ReconnectService", "Stop"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.ReconnectInfo.getDefaultInstance()))
+                  .setSchemaDescriptor(new ReconnectServiceMethodDescriptorSupplier("Stop"))
+                  .build();
+          }
+        }
+     }
+     return getStopMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -93,14 +129,14 @@ public final class ReconnectServiceGrpc {
      */
     public void start(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_START, responseObserver);
+      asyncUnimplementedUnaryCall(getStartMethod(), responseObserver);
     }
 
     /**
      */
     public void stop(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.ReconnectInfo> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STOP, responseObserver);
+      asyncUnimplementedUnaryCall(getStopMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -149,7 +185,7 @@ public final class ReconnectServiceGrpc {
     public void start(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_START, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStartMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -157,7 +193,7 @@ public final class ReconnectServiceGrpc {
     public void stop(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.ReconnectInfo> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_STOP, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStopMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -186,14 +222,14 @@ public final class ReconnectServiceGrpc {
      */
     public com.google.protobuf.EmptyProtos.Empty start(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_START, getCallOptions(), request);
+          getChannel(), getStartMethod(), getCallOptions(), request);
     }
 
     /**
      */
     public io.grpc.testing.integration.Messages.ReconnectInfo stop(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_STOP, getCallOptions(), request);
+          getChannel(), getStopMethod(), getCallOptions(), request);
     }
   }
 
@@ -223,7 +259,7 @@ public final class ReconnectServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> start(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_START, getCallOptions()), request);
+          getChannel().newCall(getStartMethod(), getCallOptions()), request);
     }
 
     /**
@@ -231,7 +267,7 @@ public final class ReconnectServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.ReconnectInfo> stop(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_STOP, getCallOptions()), request);
+          getChannel().newCall(getStopMethod(), getCallOptions()), request);
     }
   }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -32,117 +32,261 @@ public final class TestServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getEmptyCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      com.google.protobuf.EmptyProtos.Empty> METHOD_EMPTY_CALL =
-      io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "EmptyCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("EmptyCall"))
-          .build();
+      com.google.protobuf.EmptyProtos.Empty> METHOD_EMPTY_CALL = getEmptyCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getEmptyCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getEmptyCallMethod() {
+    io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty> getEmptyCallMethod;
+    if ((getEmptyCallMethod = TestServiceGrpc.getEmptyCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getEmptyCallMethod = TestServiceGrpc.getEmptyCallMethod) == null) {
+          TestServiceGrpc.getEmptyCallMethod = getEmptyCallMethod = 
+              io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "EmptyCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("EmptyCall"))
+                  .build();
+          }
+        }
+     }
+     return getEmptyCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
-      io.grpc.testing.integration.Messages.SimpleResponse> METHOD_UNARY_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.SimpleRequest, io.grpc.testing.integration.Messages.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "UnaryCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("UnaryCall"))
-          .build();
+      io.grpc.testing.integration.Messages.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
+      io.grpc.testing.integration.Messages.SimpleResponse> getUnaryCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
+      io.grpc.testing.integration.Messages.SimpleResponse> getUnaryCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest, io.grpc.testing.integration.Messages.SimpleResponse> getUnaryCallMethod;
+    if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
+          TestServiceGrpc.getUnaryCallMethod = getUnaryCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.SimpleRequest, io.grpc.testing.integration.Messages.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "UnaryCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("UnaryCall"))
+                  .build();
+          }
+        }
+     }
+     return getUnaryCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getCacheableUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
-      io.grpc.testing.integration.Messages.SimpleResponse> METHOD_CACHEABLE_UNARY_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.SimpleRequest, io.grpc.testing.integration.Messages.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "CacheableUnaryCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("CacheableUnaryCall"))
-          .build();
+      io.grpc.testing.integration.Messages.SimpleResponse> METHOD_CACHEABLE_UNARY_CALL = getCacheableUnaryCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
+      io.grpc.testing.integration.Messages.SimpleResponse> getCacheableUnaryCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
+      io.grpc.testing.integration.Messages.SimpleResponse> getCacheableUnaryCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest, io.grpc.testing.integration.Messages.SimpleResponse> getCacheableUnaryCallMethod;
+    if ((getCacheableUnaryCallMethod = TestServiceGrpc.getCacheableUnaryCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getCacheableUnaryCallMethod = TestServiceGrpc.getCacheableUnaryCallMethod) == null) {
+          TestServiceGrpc.getCacheableUnaryCallMethod = getCacheableUnaryCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.SimpleRequest, io.grpc.testing.integration.Messages.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "CacheableUnaryCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("CacheableUnaryCall"))
+                  .build();
+          }
+        }
+     }
+     return getCacheableUnaryCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingOutputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "StreamingOutputCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingOutputCall"))
-          .build();
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getStreamingOutputCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getStreamingOutputCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getStreamingOutputCallMethod;
+    if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
+          TestServiceGrpc.getStreamingOutputCallMethod = getStreamingOutputCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "StreamingOutputCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingOutputCall"))
+                  .build();
+          }
+        }
+     }
+     return getStreamingOutputCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getStreamingInputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
-      io.grpc.testing.integration.Messages.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.StreamingInputCallRequest, io.grpc.testing.integration.Messages.StreamingInputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "StreamingInputCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.StreamingInputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.StreamingInputCallResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingInputCall"))
-          .build();
+      io.grpc.testing.integration.Messages.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingInputCallResponse> getStreamingInputCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingInputCallResponse> getStreamingInputCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest, io.grpc.testing.integration.Messages.StreamingInputCallResponse> getStreamingInputCallMethod;
+    if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
+          TestServiceGrpc.getStreamingInputCallMethod = getStreamingInputCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.StreamingInputCallRequest, io.grpc.testing.integration.Messages.StreamingInputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "StreamingInputCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.StreamingInputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.StreamingInputCallResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("StreamingInputCall"))
+                  .build();
+          }
+        }
+     }
+     return getStreamingInputCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getFullDuplexCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "FullDuplexCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("FullDuplexCall"))
-          .build();
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL = getFullDuplexCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getFullDuplexCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getFullDuplexCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getFullDuplexCallMethod;
+    if ((getFullDuplexCallMethod = TestServiceGrpc.getFullDuplexCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getFullDuplexCallMethod = TestServiceGrpc.getFullDuplexCallMethod) == null) {
+          TestServiceGrpc.getFullDuplexCallMethod = getFullDuplexCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "FullDuplexCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("FullDuplexCall"))
+                  .build();
+          }
+        }
+     }
+     return getFullDuplexCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getHalfDuplexCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL =
-      io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "HalfDuplexCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("HalfDuplexCall"))
-          .build();
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL = getHalfDuplexCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getHalfDuplexCallMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getHalfDuplexCallMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getHalfDuplexCallMethod;
+    if ((getHalfDuplexCallMethod = TestServiceGrpc.getHalfDuplexCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getHalfDuplexCallMethod = TestServiceGrpc.getHalfDuplexCallMethod) == null) {
+          TestServiceGrpc.getHalfDuplexCallMethod = getHalfDuplexCallMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "HalfDuplexCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.StreamingOutputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Messages.StreamingOutputCallResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("HalfDuplexCall"))
+                  .build();
+          }
+        }
+     }
+     return getHalfDuplexCallMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getUnimplementedCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL =
-      io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.TestService", "UnimplementedCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
-          .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("UnimplementedCall"))
-          .build();
+      com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL = getUnimplementedCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod() {
+    io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod;
+    if ((getUnimplementedCallMethod = TestServiceGrpc.getUnimplementedCallMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getUnimplementedCallMethod = TestServiceGrpc.getUnimplementedCallMethod) == null) {
+          TestServiceGrpc.getUnimplementedCallMethod = getUnimplementedCallMethod = 
+              io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "UnimplementedCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("UnimplementedCall"))
+                  .build();
+          }
+        }
+     }
+     return getUnimplementedCallMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -182,7 +326,7 @@ public final class TestServiceGrpc {
      */
     public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_EMPTY_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getEmptyCallMethod(), responseObserver);
     }
 
     /**
@@ -192,7 +336,7 @@ public final class TestServiceGrpc {
      */
     public void unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
     }
 
     /**
@@ -204,7 +348,7 @@ public final class TestServiceGrpc {
      */
     public void cacheableUnaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_CACHEABLE_UNARY_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getCacheableUnaryCallMethod(), responseObserver);
     }
 
     /**
@@ -215,7 +359,7 @@ public final class TestServiceGrpc {
      */
     public void streamingOutputCall(io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_STREAMING_OUTPUT_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingOutputCallMethod(), responseObserver);
     }
 
     /**
@@ -226,7 +370,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_STREAMING_INPUT_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingInputCallMethod(), responseObserver);
     }
 
     /**
@@ -238,7 +382,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_FULL_DUPLEX_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getFullDuplexCallMethod(), responseObserver);
     }
 
     /**
@@ -251,7 +395,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_HALF_DUPLEX_CALL, responseObserver);
+      return asyncUnimplementedStreamingCall(getHalfDuplexCallMethod(), responseObserver);
     }
 
     /**
@@ -262,7 +406,7 @@ public final class TestServiceGrpc {
      */
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNIMPLEMENTED_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getUnimplementedCallMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -357,7 +501,7 @@ public final class TestServiceGrpc {
     public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_EMPTY_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getEmptyCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -368,7 +512,7 @@ public final class TestServiceGrpc {
     public void unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -381,7 +525,7 @@ public final class TestServiceGrpc {
     public void cacheableUnaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_CACHEABLE_UNARY_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getCacheableUnaryCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -393,7 +537,7 @@ public final class TestServiceGrpc {
     public void streamingOutputCall(io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_OUTPUT_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingOutputCallMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -405,7 +549,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(METHOD_STREAMING_INPUT_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingInputCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -418,7 +562,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_FULL_DUPLEX_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getFullDuplexCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -432,7 +576,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_HALF_DUPLEX_CALL, getCallOptions()), responseObserver);
+          getChannel().newCall(getHalfDuplexCallMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -444,7 +588,7 @@ public final class TestServiceGrpc {
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_UNIMPLEMENTED_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnimplementedCallMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -477,7 +621,7 @@ public final class TestServiceGrpc {
      */
     public com.google.protobuf.EmptyProtos.Empty emptyCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_EMPTY_CALL, getCallOptions(), request);
+          getChannel(), getEmptyCallMethod(), getCallOptions(), request);
     }
 
     /**
@@ -487,7 +631,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.Messages.SimpleResponse unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_UNARY_CALL, getCallOptions(), request);
+          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
     }
 
     /**
@@ -499,7 +643,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.Messages.SimpleResponse cacheableUnaryCall(io.grpc.testing.integration.Messages.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_CACHEABLE_UNARY_CALL, getCallOptions(), request);
+          getChannel(), getCacheableUnaryCallMethod(), getCallOptions(), request);
     }
 
     /**
@@ -511,7 +655,7 @@ public final class TestServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Messages.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), METHOD_STREAMING_OUTPUT_CALL, getCallOptions(), request);
+          getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
     }
 
     /**
@@ -522,7 +666,7 @@ public final class TestServiceGrpc {
      */
     public com.google.protobuf.EmptyProtos.Empty unimplementedCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_UNIMPLEMENTED_CALL, getCallOptions(), request);
+          getChannel(), getUnimplementedCallMethod(), getCallOptions(), request);
     }
   }
 
@@ -556,7 +700,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> emptyCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_EMPTY_CALL, getCallOptions()), request);
+          getChannel().newCall(getEmptyCallMethod(), getCallOptions()), request);
     }
 
     /**
@@ -567,7 +711,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Messages.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_UNARY_CALL, getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
     }
 
     /**
@@ -580,7 +724,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> cacheableUnaryCall(
         io.grpc.testing.integration.Messages.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_CACHEABLE_UNARY_CALL, getCallOptions()), request);
+          getChannel().newCall(getCacheableUnaryCallMethod(), getCallOptions()), request);
     }
 
     /**
@@ -592,7 +736,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> unimplementedCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_UNIMPLEMENTED_CALL, getCallOptions()), request);
+          getChannel().newCall(getUnimplementedCallMethod(), getCallOptions()), request);
     }
   }
 

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -32,19 +32,37 @@ public final class UnimplementedServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getUnimplementedCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL =
-      io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.UnimplementedService", "UnimplementedCall"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
-          .setSchemaDescriptor(new UnimplementedServiceMethodDescriptorSupplier("UnimplementedCall"))
-          .build();
+      com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL = getUnimplementedCallMethod();
+
+  private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod() {
+    io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod;
+    if ((getUnimplementedCallMethod = UnimplementedServiceGrpc.getUnimplementedCallMethod) == null) {
+      synchronized (UnimplementedServiceGrpc.class) {
+        if ((getUnimplementedCallMethod = UnimplementedServiceGrpc.getUnimplementedCallMethod) == null) {
+          UnimplementedServiceGrpc.getUnimplementedCallMethod = getUnimplementedCallMethod = 
+              io.grpc.MethodDescriptor.<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.UnimplementedService", "UnimplementedCall"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.EmptyProtos.Empty.getDefaultInstance()))
+                  .setSchemaDescriptor(new UnimplementedServiceMethodDescriptorSupplier("UnimplementedCall"))
+                  .build();
+          }
+        }
+     }
+     return getUnimplementedCallMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -84,7 +102,7 @@ public final class UnimplementedServiceGrpc {
      */
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNIMPLEMENTED_CALL, responseObserver);
+      asyncUnimplementedUnaryCall(getUnimplementedCallMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -130,7 +148,7 @@ public final class UnimplementedServiceGrpc {
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_UNIMPLEMENTED_CALL, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnimplementedCallMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -163,7 +181,7 @@ public final class UnimplementedServiceGrpc {
      */
     public com.google.protobuf.EmptyProtos.Empty unimplementedCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_UNIMPLEMENTED_CALL, getCallOptions(), request);
+          getChannel(), getUnimplementedCallMethod(), getCallOptions(), request);
     }
   }
 
@@ -197,7 +215,7 @@ public final class UnimplementedServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> unimplementedCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_UNIMPLEMENTED_CALL, getCallOptions()), request);
+          getChannel().newCall(getUnimplementedCallMethod(), getCallOptions()), request);
     }
   }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -303,7 +303,7 @@ public abstract class AbstractInteropTest {
   public void cacheableUnary() {
     // Set safe to true.
     MethodDescriptor<SimpleRequest, SimpleResponse> safeCacheableUnaryCallMethod =
-        TestServiceGrpc.METHOD_CACHEABLE_UNARY_CALL.toBuilder().setSafe(true).build();
+        TestServiceGrpc.getCacheableUnaryCallMethod().toBuilder().setSafe(true).build();
     // Set fake user IP since some proxies (GFE) won't cache requests from localhost.
     Metadata.Key<String> userIpKey = Metadata.Key.of("x-user-ip", Metadata.ASCII_STRING_MARSHALLER);
     Metadata metadata = new Metadata();
@@ -837,7 +837,7 @@ public abstract class AbstractInteropTest {
 
     final ArrayBlockingQueue<Object> queue = new ArrayBlockingQueue<Object>(10);
     ClientCall<StreamingOutputCallRequest, StreamingOutputCallResponse> call =
-        channel.newCall(TestServiceGrpc.METHOD_STREAMING_OUTPUT_CALL, CallOptions.DEFAULT);
+        channel.newCall(TestServiceGrpc.getStreamingOutputCallMethod(), CallOptions.DEFAULT);
     call.start(new ClientCall.Listener<StreamingOutputCallResponse>() {
       @Override
       public void onHeaders(Metadata headers) {}

--- a/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
+++ b/interop-testing/src/test/java/io/grpc/stub/StubConfigTest.java
@@ -86,11 +86,11 @@ public class StubConfigTest {
     CallOptions options1 = stub.getCallOptions();
     SimpleRequest request = SimpleRequest.getDefaultInstance();
     stub.unaryCall(request, responseObserver);
-    verify(channel).newCall(same(TestServiceGrpc.METHOD_UNARY_CALL), same(options1));
+    verify(channel).newCall(same(TestServiceGrpc.getUnaryCallMethod()), same(options1));
     stub = stub.withDeadlineAfter(2, NANOSECONDS);
     CallOptions options2 = stub.getCallOptions();
     assertNotSame(options1, options2);
     stub.unaryCall(request, responseObserver);
-    verify(channel).newCall(same(TestServiceGrpc.METHOD_UNARY_CALL), same(options2));
+    verify(channel).newCall(same(TestServiceGrpc.getUnaryCallMethod()), same(options2));
   }
 }

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -28,19 +28,37 @@ public final class HealthGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getCheckMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest,
-      io.grpc.health.v1.HealthCheckResponse> METHOD_CHECK =
-      io.grpc.MethodDescriptor.<io.grpc.health.v1.HealthCheckRequest, io.grpc.health.v1.HealthCheckResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.health.v1.Health", "Check"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.health.v1.HealthCheckRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.health.v1.HealthCheckResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new HealthMethodDescriptorSupplier("Check"))
-          .build();
+      io.grpc.health.v1.HealthCheckResponse> METHOD_CHECK = getCheckMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest,
+      io.grpc.health.v1.HealthCheckResponse> getCheckMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest,
+      io.grpc.health.v1.HealthCheckResponse> getCheckMethod() {
+    io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest, io.grpc.health.v1.HealthCheckResponse> getCheckMethod;
+    if ((getCheckMethod = HealthGrpc.getCheckMethod) == null) {
+      synchronized (HealthGrpc.class) {
+        if ((getCheckMethod = HealthGrpc.getCheckMethod) == null) {
+          HealthGrpc.getCheckMethod = getCheckMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.health.v1.HealthCheckRequest, io.grpc.health.v1.HealthCheckResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.health.v1.Health", "Check"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.health.v1.HealthCheckRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.health.v1.HealthCheckResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new HealthMethodDescriptorSupplier("Check"))
+                  .build();
+          }
+        }
+     }
+     return getCheckMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -73,7 +91,7 @@ public final class HealthGrpc {
      */
     public void check(io.grpc.health.v1.HealthCheckRequest request,
         io.grpc.stub.StreamObserver<io.grpc.health.v1.HealthCheckResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_CHECK, responseObserver);
+      asyncUnimplementedUnaryCall(getCheckMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -112,7 +130,7 @@ public final class HealthGrpc {
     public void check(io.grpc.health.v1.HealthCheckRequest request,
         io.grpc.stub.StreamObserver<io.grpc.health.v1.HealthCheckResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_CHECK, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getCheckMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -138,7 +156,7 @@ public final class HealthGrpc {
      */
     public io.grpc.health.v1.HealthCheckResponse check(io.grpc.health.v1.HealthCheckRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_CHECK, getCallOptions(), request);
+          getChannel(), getCheckMethod(), getCallOptions(), request);
     }
   }
 
@@ -165,7 +183,7 @@ public final class HealthGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.health.v1.HealthCheckResponse> check(
         io.grpc.health.v1.HealthCheckRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_CHECK, getCallOptions()), request);
+          getChannel().newCall(getCheckMethod(), getCallOptions()), request);
     }
   }
 

--- a/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
@@ -28,75 +28,165 @@ public final class MonitoringGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getGetCanonicalRpcStatsMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.Empty,
-      io.grpc.instrumentation.v1alpha.CanonicalRpcStats> METHOD_GET_CANONICAL_RPC_STATS =
-      io.grpc.MethodDescriptor.<com.google.protobuf.Empty, io.grpc.instrumentation.v1alpha.CanonicalRpcStats>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.instrumentation.v1alpha.Monitoring", "GetCanonicalRpcStats"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              com.google.protobuf.Empty.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.instrumentation.v1alpha.CanonicalRpcStats.getDefaultInstance()))
-          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetCanonicalRpcStats"))
-          .build();
+      io.grpc.instrumentation.v1alpha.CanonicalRpcStats> METHOD_GET_CANONICAL_RPC_STATS = getGetCanonicalRpcStatsMethod();
+
+  private static volatile io.grpc.MethodDescriptor<com.google.protobuf.Empty,
+      io.grpc.instrumentation.v1alpha.CanonicalRpcStats> getGetCanonicalRpcStatsMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.google.protobuf.Empty,
+      io.grpc.instrumentation.v1alpha.CanonicalRpcStats> getGetCanonicalRpcStatsMethod() {
+    io.grpc.MethodDescriptor<com.google.protobuf.Empty, io.grpc.instrumentation.v1alpha.CanonicalRpcStats> getGetCanonicalRpcStatsMethod;
+    if ((getGetCanonicalRpcStatsMethod = MonitoringGrpc.getGetCanonicalRpcStatsMethod) == null) {
+      synchronized (MonitoringGrpc.class) {
+        if ((getGetCanonicalRpcStatsMethod = MonitoringGrpc.getGetCanonicalRpcStatsMethod) == null) {
+          MonitoringGrpc.getGetCanonicalRpcStatsMethod = getGetCanonicalRpcStatsMethod = 
+              io.grpc.MethodDescriptor.<com.google.protobuf.Empty, io.grpc.instrumentation.v1alpha.CanonicalRpcStats>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.instrumentation.v1alpha.Monitoring", "GetCanonicalRpcStats"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.instrumentation.v1alpha.CanonicalRpcStats.getDefaultInstance()))
+                  .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetCanonicalRpcStats"))
+                  .build();
+          }
+        }
+     }
+     return getGetCanonicalRpcStatsMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getGetStatsMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
-      io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_GET_STATS =
-      io.grpc.MethodDescriptor.<io.grpc.instrumentation.v1alpha.StatsRequest, io.grpc.instrumentation.v1alpha.StatsResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.instrumentation.v1alpha.Monitoring", "GetStats"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.instrumentation.v1alpha.StatsRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.instrumentation.v1alpha.StatsResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetStats"))
-          .build();
+      io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_GET_STATS = getGetStatsMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
+      io.grpc.instrumentation.v1alpha.StatsResponse> getGetStatsMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
+      io.grpc.instrumentation.v1alpha.StatsResponse> getGetStatsMethod() {
+    io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest, io.grpc.instrumentation.v1alpha.StatsResponse> getGetStatsMethod;
+    if ((getGetStatsMethod = MonitoringGrpc.getGetStatsMethod) == null) {
+      synchronized (MonitoringGrpc.class) {
+        if ((getGetStatsMethod = MonitoringGrpc.getGetStatsMethod) == null) {
+          MonitoringGrpc.getGetStatsMethod = getGetStatsMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.instrumentation.v1alpha.StatsRequest, io.grpc.instrumentation.v1alpha.StatsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.instrumentation.v1alpha.Monitoring", "GetStats"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.instrumentation.v1alpha.StatsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.instrumentation.v1alpha.StatsResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetStats"))
+                  .build();
+          }
+        }
+     }
+     return getGetStatsMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getWatchStatsMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
-      io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_WATCH_STATS =
-      io.grpc.MethodDescriptor.<io.grpc.instrumentation.v1alpha.StatsRequest, io.grpc.instrumentation.v1alpha.StatsResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.instrumentation.v1alpha.Monitoring", "WatchStats"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.instrumentation.v1alpha.StatsRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.instrumentation.v1alpha.StatsResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("WatchStats"))
-          .build();
+      io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_WATCH_STATS = getWatchStatsMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
+      io.grpc.instrumentation.v1alpha.StatsResponse> getWatchStatsMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
+      io.grpc.instrumentation.v1alpha.StatsResponse> getWatchStatsMethod() {
+    io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest, io.grpc.instrumentation.v1alpha.StatsResponse> getWatchStatsMethod;
+    if ((getWatchStatsMethod = MonitoringGrpc.getWatchStatsMethod) == null) {
+      synchronized (MonitoringGrpc.class) {
+        if ((getWatchStatsMethod = MonitoringGrpc.getWatchStatsMethod) == null) {
+          MonitoringGrpc.getWatchStatsMethod = getWatchStatsMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.instrumentation.v1alpha.StatsRequest, io.grpc.instrumentation.v1alpha.StatsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.instrumentation.v1alpha.Monitoring", "WatchStats"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.instrumentation.v1alpha.StatsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.instrumentation.v1alpha.StatsResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("WatchStats"))
+                  .build();
+          }
+        }
+     }
+     return getWatchStatsMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getGetRequestTracesMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest,
-      io.grpc.instrumentation.v1alpha.TraceResponse> METHOD_GET_REQUEST_TRACES =
-      io.grpc.MethodDescriptor.<io.grpc.instrumentation.v1alpha.TraceRequest, io.grpc.instrumentation.v1alpha.TraceResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.instrumentation.v1alpha.Monitoring", "GetRequestTraces"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.instrumentation.v1alpha.TraceRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.instrumentation.v1alpha.TraceResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetRequestTraces"))
-          .build();
+      io.grpc.instrumentation.v1alpha.TraceResponse> METHOD_GET_REQUEST_TRACES = getGetRequestTracesMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest,
+      io.grpc.instrumentation.v1alpha.TraceResponse> getGetRequestTracesMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest,
+      io.grpc.instrumentation.v1alpha.TraceResponse> getGetRequestTracesMethod() {
+    io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest, io.grpc.instrumentation.v1alpha.TraceResponse> getGetRequestTracesMethod;
+    if ((getGetRequestTracesMethod = MonitoringGrpc.getGetRequestTracesMethod) == null) {
+      synchronized (MonitoringGrpc.class) {
+        if ((getGetRequestTracesMethod = MonitoringGrpc.getGetRequestTracesMethod) == null) {
+          MonitoringGrpc.getGetRequestTracesMethod = getGetRequestTracesMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.instrumentation.v1alpha.TraceRequest, io.grpc.instrumentation.v1alpha.TraceResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.instrumentation.v1alpha.Monitoring", "GetRequestTraces"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.instrumentation.v1alpha.TraceRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.instrumentation.v1alpha.TraceResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetRequestTraces"))
+                  .build();
+          }
+        }
+     }
+     return getGetRequestTracesMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getGetCustomMonitoringDataMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
-      io.grpc.instrumentation.v1alpha.CustomMonitoringData> METHOD_GET_CUSTOM_MONITORING_DATA =
-      io.grpc.MethodDescriptor.<io.grpc.instrumentation.v1alpha.MonitoringDataGroup, io.grpc.instrumentation.v1alpha.CustomMonitoringData>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.instrumentation.v1alpha.Monitoring", "GetCustomMonitoringData"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.instrumentation.v1alpha.MonitoringDataGroup.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.instrumentation.v1alpha.CustomMonitoringData.getDefaultInstance()))
-          .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetCustomMonitoringData"))
-          .build();
+      io.grpc.instrumentation.v1alpha.CustomMonitoringData> METHOD_GET_CUSTOM_MONITORING_DATA = getGetCustomMonitoringDataMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
+      io.grpc.instrumentation.v1alpha.CustomMonitoringData> getGetCustomMonitoringDataMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
+      io.grpc.instrumentation.v1alpha.CustomMonitoringData> getGetCustomMonitoringDataMethod() {
+    io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup, io.grpc.instrumentation.v1alpha.CustomMonitoringData> getGetCustomMonitoringDataMethod;
+    if ((getGetCustomMonitoringDataMethod = MonitoringGrpc.getGetCustomMonitoringDataMethod) == null) {
+      synchronized (MonitoringGrpc.class) {
+        if ((getGetCustomMonitoringDataMethod = MonitoringGrpc.getGetCustomMonitoringDataMethod) == null) {
+          MonitoringGrpc.getGetCustomMonitoringDataMethod = getGetCustomMonitoringDataMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.instrumentation.v1alpha.MonitoringDataGroup, io.grpc.instrumentation.v1alpha.CustomMonitoringData>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.instrumentation.v1alpha.Monitoring", "GetCustomMonitoringData"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.instrumentation.v1alpha.MonitoringDataGroup.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.instrumentation.v1alpha.CustomMonitoringData.getDefaultInstance()))
+                  .setSchemaDescriptor(new MonitoringMethodDescriptorSupplier("GetCustomMonitoringData"))
+                  .build();
+          }
+        }
+     }
+     return getGetCustomMonitoringDataMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -132,7 +222,7 @@ public final class MonitoringGrpc {
      */
     public void getCanonicalRpcStats(com.google.protobuf.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.CanonicalRpcStats> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_GET_CANONICAL_RPC_STATS, responseObserver);
+      asyncUnimplementedUnaryCall(getGetCanonicalRpcStatsMethod(), responseObserver);
     }
 
     /**
@@ -142,7 +232,7 @@ public final class MonitoringGrpc {
      */
     public void getStats(io.grpc.instrumentation.v1alpha.StatsRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.StatsResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_GET_STATS, responseObserver);
+      asyncUnimplementedUnaryCall(getGetStatsMethod(), responseObserver);
     }
 
     /**
@@ -152,7 +242,7 @@ public final class MonitoringGrpc {
      */
     public void watchStats(io.grpc.instrumentation.v1alpha.StatsRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.StatsResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_WATCH_STATS, responseObserver);
+      asyncUnimplementedUnaryCall(getWatchStatsMethod(), responseObserver);
     }
 
     /**
@@ -162,7 +252,7 @@ public final class MonitoringGrpc {
      */
     public void getRequestTraces(io.grpc.instrumentation.v1alpha.TraceRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.TraceResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_GET_REQUEST_TRACES, responseObserver);
+      asyncUnimplementedUnaryCall(getGetRequestTracesMethod(), responseObserver);
     }
 
     /**
@@ -175,7 +265,7 @@ public final class MonitoringGrpc {
      */
     public void getCustomMonitoringData(io.grpc.instrumentation.v1alpha.MonitoringDataGroup request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.CustomMonitoringData> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_GET_CUSTOM_MONITORING_DATA, responseObserver);
+      asyncUnimplementedUnaryCall(getGetCustomMonitoringDataMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -245,7 +335,7 @@ public final class MonitoringGrpc {
     public void getCanonicalRpcStats(com.google.protobuf.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.CanonicalRpcStats> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_GET_CANONICAL_RPC_STATS, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetCanonicalRpcStatsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -256,7 +346,7 @@ public final class MonitoringGrpc {
     public void getStats(io.grpc.instrumentation.v1alpha.StatsRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.StatsResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_GET_STATS, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetStatsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -267,7 +357,7 @@ public final class MonitoringGrpc {
     public void watchStats(io.grpc.instrumentation.v1alpha.StatsRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.StatsResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(METHOD_WATCH_STATS, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getWatchStatsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -278,7 +368,7 @@ public final class MonitoringGrpc {
     public void getRequestTraces(io.grpc.instrumentation.v1alpha.TraceRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.TraceResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_GET_REQUEST_TRACES, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetRequestTracesMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -292,7 +382,7 @@ public final class MonitoringGrpc {
     public void getCustomMonitoringData(io.grpc.instrumentation.v1alpha.MonitoringDataGroup request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.CustomMonitoringData> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_GET_CUSTOM_MONITORING_DATA, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetCustomMonitoringDataMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -321,7 +411,7 @@ public final class MonitoringGrpc {
      */
     public io.grpc.instrumentation.v1alpha.CanonicalRpcStats getCanonicalRpcStats(com.google.protobuf.Empty request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_GET_CANONICAL_RPC_STATS, getCallOptions(), request);
+          getChannel(), getGetCanonicalRpcStatsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -331,7 +421,7 @@ public final class MonitoringGrpc {
      */
     public io.grpc.instrumentation.v1alpha.StatsResponse getStats(io.grpc.instrumentation.v1alpha.StatsRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_GET_STATS, getCallOptions(), request);
+          getChannel(), getGetStatsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -342,7 +432,7 @@ public final class MonitoringGrpc {
     public java.util.Iterator<io.grpc.instrumentation.v1alpha.StatsResponse> watchStats(
         io.grpc.instrumentation.v1alpha.StatsRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), METHOD_WATCH_STATS, getCallOptions(), request);
+          getChannel(), getWatchStatsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -352,7 +442,7 @@ public final class MonitoringGrpc {
      */
     public io.grpc.instrumentation.v1alpha.TraceResponse getRequestTraces(io.grpc.instrumentation.v1alpha.TraceRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_GET_REQUEST_TRACES, getCallOptions(), request);
+          getChannel(), getGetRequestTracesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -365,7 +455,7 @@ public final class MonitoringGrpc {
      */
     public io.grpc.instrumentation.v1alpha.CustomMonitoringData getCustomMonitoringData(io.grpc.instrumentation.v1alpha.MonitoringDataGroup request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_GET_CUSTOM_MONITORING_DATA, getCallOptions(), request);
+          getChannel(), getGetCustomMonitoringDataMethod(), getCallOptions(), request);
     }
   }
 
@@ -395,7 +485,7 @@ public final class MonitoringGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.instrumentation.v1alpha.CanonicalRpcStats> getCanonicalRpcStats(
         com.google.protobuf.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_GET_CANONICAL_RPC_STATS, getCallOptions()), request);
+          getChannel().newCall(getGetCanonicalRpcStatsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -406,7 +496,7 @@ public final class MonitoringGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.instrumentation.v1alpha.StatsResponse> getStats(
         io.grpc.instrumentation.v1alpha.StatsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_GET_STATS, getCallOptions()), request);
+          getChannel().newCall(getGetStatsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -417,7 +507,7 @@ public final class MonitoringGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.instrumentation.v1alpha.TraceResponse> getRequestTraces(
         io.grpc.instrumentation.v1alpha.TraceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_GET_REQUEST_TRACES, getCallOptions()), request);
+          getChannel().newCall(getGetRequestTracesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -431,7 +521,7 @@ public final class MonitoringGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.instrumentation.v1alpha.CustomMonitoringData> getCustomMonitoringData(
         io.grpc.instrumentation.v1alpha.MonitoringDataGroup request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_GET_CUSTOM_MONITORING_DATA, getCallOptions()), request);
+          getChannel().newCall(getGetCustomMonitoringDataMethod(), getCallOptions()), request);
     }
   }
 

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -28,19 +28,37 @@ public final class ServerReflectionGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getServerReflectionInfoMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest,
-      io.grpc.reflection.v1alpha.ServerReflectionResponse> METHOD_SERVER_REFLECTION_INFO =
-      io.grpc.MethodDescriptor.<io.grpc.reflection.v1alpha.ServerReflectionRequest, io.grpc.reflection.v1alpha.ServerReflectionResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.reflection.v1alpha.ServerReflection", "ServerReflectionInfo"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.reflection.v1alpha.ServerReflectionRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.reflection.v1alpha.ServerReflectionResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new ServerReflectionMethodDescriptorSupplier("ServerReflectionInfo"))
-          .build();
+      io.grpc.reflection.v1alpha.ServerReflectionResponse> METHOD_SERVER_REFLECTION_INFO = getServerReflectionInfoMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest,
+      io.grpc.reflection.v1alpha.ServerReflectionResponse> getServerReflectionInfoMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest,
+      io.grpc.reflection.v1alpha.ServerReflectionResponse> getServerReflectionInfoMethod() {
+    io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest, io.grpc.reflection.v1alpha.ServerReflectionResponse> getServerReflectionInfoMethod;
+    if ((getServerReflectionInfoMethod = ServerReflectionGrpc.getServerReflectionInfoMethod) == null) {
+      synchronized (ServerReflectionGrpc.class) {
+        if ((getServerReflectionInfoMethod = ServerReflectionGrpc.getServerReflectionInfoMethod) == null) {
+          ServerReflectionGrpc.getServerReflectionInfoMethod = getServerReflectionInfoMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.reflection.v1alpha.ServerReflectionRequest, io.grpc.reflection.v1alpha.ServerReflectionResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.reflection.v1alpha.ServerReflection", "ServerReflectionInfo"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.reflection.v1alpha.ServerReflectionRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.reflection.v1alpha.ServerReflectionResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new ServerReflectionMethodDescriptorSupplier("ServerReflectionInfo"))
+                  .build();
+          }
+        }
+     }
+     return getServerReflectionInfoMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -77,7 +95,7 @@ public final class ServerReflectionGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.reflection.v1alpha.ServerReflectionRequest> serverReflectionInfo(
         io.grpc.stub.StreamObserver<io.grpc.reflection.v1alpha.ServerReflectionResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_SERVER_REFLECTION_INFO, responseObserver);
+      return asyncUnimplementedStreamingCall(getServerReflectionInfoMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -120,7 +138,7 @@ public final class ServerReflectionGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.reflection.v1alpha.ServerReflectionRequest> serverReflectionInfo(
         io.grpc.stub.StreamObserver<io.grpc.reflection.v1alpha.ServerReflectionResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_SERVER_REFLECTION_INFO, getCallOptions()), responseObserver);
+          getChannel().newCall(getServerReflectionInfoMethod(), getCallOptions()), responseObserver);
     }
   }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -31,19 +31,37 @@ public final class AnotherDynamicServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getMethodMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
-      io.grpc.reflection.testing.DynamicReply> METHOD_METHOD =
-      io.grpc.MethodDescriptor.<io.grpc.reflection.testing.DynamicRequest, io.grpc.reflection.testing.DynamicReply>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.reflection.testing.AnotherDynamicService", "Method"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.reflection.testing.DynamicRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.reflection.testing.DynamicReply.getDefaultInstance()))
-          .setSchemaDescriptor(new AnotherDynamicServiceMethodDescriptorSupplier("Method"))
-          .build();
+      io.grpc.reflection.testing.DynamicReply> METHOD_METHOD = getMethodMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
+      io.grpc.reflection.testing.DynamicReply> getMethodMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
+      io.grpc.reflection.testing.DynamicReply> getMethodMethod() {
+    io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest, io.grpc.reflection.testing.DynamicReply> getMethodMethod;
+    if ((getMethodMethod = AnotherDynamicServiceGrpc.getMethodMethod) == null) {
+      synchronized (AnotherDynamicServiceGrpc.class) {
+        if ((getMethodMethod = AnotherDynamicServiceGrpc.getMethodMethod) == null) {
+          AnotherDynamicServiceGrpc.getMethodMethod = getMethodMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.reflection.testing.DynamicRequest, io.grpc.reflection.testing.DynamicReply>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.reflection.testing.AnotherDynamicService", "Method"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.reflection.testing.DynamicRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.reflection.testing.DynamicReply.getDefaultInstance()))
+                  .setSchemaDescriptor(new AnotherDynamicServiceMethodDescriptorSupplier("Method"))
+                  .build();
+          }
+        }
+     }
+     return getMethodMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -82,7 +100,7 @@ public final class AnotherDynamicServiceGrpc {
      */
     public void method(io.grpc.reflection.testing.DynamicRequest request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.DynamicReply> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_METHOD, responseObserver);
+      asyncUnimplementedUnaryCall(getMethodMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -127,7 +145,7 @@ public final class AnotherDynamicServiceGrpc {
     public void method(io.grpc.reflection.testing.DynamicRequest request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.DynamicReply> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_METHOD, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getMethodMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -159,7 +177,7 @@ public final class AnotherDynamicServiceGrpc {
      */
     public io.grpc.reflection.testing.DynamicReply method(io.grpc.reflection.testing.DynamicRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_METHOD, getCallOptions(), request);
+          getChannel(), getMethodMethod(), getCallOptions(), request);
     }
   }
 
@@ -192,7 +210,7 @@ public final class AnotherDynamicServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.reflection.testing.DynamicReply> method(
         io.grpc.reflection.testing.DynamicRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_METHOD, getCallOptions()), request);
+          getChannel().newCall(getMethodMethod(), getCallOptions()), request);
     }
   }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -31,19 +31,37 @@ public final class DynamicServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getMethodMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
-      io.grpc.reflection.testing.DynamicReply> METHOD_METHOD =
-      io.grpc.MethodDescriptor.<io.grpc.reflection.testing.DynamicRequest, io.grpc.reflection.testing.DynamicReply>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.reflection.testing.DynamicService", "Method"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.reflection.testing.DynamicRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.reflection.testing.DynamicReply.getDefaultInstance()))
-          .setSchemaDescriptor(new DynamicServiceMethodDescriptorSupplier("Method"))
-          .build();
+      io.grpc.reflection.testing.DynamicReply> METHOD_METHOD = getMethodMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
+      io.grpc.reflection.testing.DynamicReply> getMethodMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
+      io.grpc.reflection.testing.DynamicReply> getMethodMethod() {
+    io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest, io.grpc.reflection.testing.DynamicReply> getMethodMethod;
+    if ((getMethodMethod = DynamicServiceGrpc.getMethodMethod) == null) {
+      synchronized (DynamicServiceGrpc.class) {
+        if ((getMethodMethod = DynamicServiceGrpc.getMethodMethod) == null) {
+          DynamicServiceGrpc.getMethodMethod = getMethodMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.reflection.testing.DynamicRequest, io.grpc.reflection.testing.DynamicReply>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.reflection.testing.DynamicService", "Method"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.reflection.testing.DynamicRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.reflection.testing.DynamicReply.getDefaultInstance()))
+                  .setSchemaDescriptor(new DynamicServiceMethodDescriptorSupplier("Method"))
+                  .build();
+          }
+        }
+     }
+     return getMethodMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -82,7 +100,7 @@ public final class DynamicServiceGrpc {
      */
     public void method(io.grpc.reflection.testing.DynamicRequest request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.DynamicReply> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_METHOD, responseObserver);
+      asyncUnimplementedUnaryCall(getMethodMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -127,7 +145,7 @@ public final class DynamicServiceGrpc {
     public void method(io.grpc.reflection.testing.DynamicRequest request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.DynamicReply> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_METHOD, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getMethodMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -159,7 +177,7 @@ public final class DynamicServiceGrpc {
      */
     public io.grpc.reflection.testing.DynamicReply method(io.grpc.reflection.testing.DynamicRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_METHOD, getCallOptions(), request);
+          getChannel(), getMethodMethod(), getCallOptions(), request);
     }
   }
 
@@ -192,7 +210,7 @@ public final class DynamicServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.reflection.testing.DynamicReply> method(
         io.grpc.reflection.testing.DynamicRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_METHOD, getCallOptions()), request);
+          getChannel().newCall(getMethodMethod(), getCallOptions()), request);
     }
   }
 

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -28,19 +28,37 @@ public final class ReflectableServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getMethodMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request,
-      io.grpc.reflection.testing.Reply> METHOD_METHOD =
-      io.grpc.MethodDescriptor.<io.grpc.reflection.testing.Request, io.grpc.reflection.testing.Reply>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.reflection.testing.ReflectableService", "Method"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.reflection.testing.Request.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.reflection.testing.Reply.getDefaultInstance()))
-          .setSchemaDescriptor(new ReflectableServiceMethodDescriptorSupplier("Method"))
-          .build();
+      io.grpc.reflection.testing.Reply> METHOD_METHOD = getMethodMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request,
+      io.grpc.reflection.testing.Reply> getMethodMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request,
+      io.grpc.reflection.testing.Reply> getMethodMethod() {
+    io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request, io.grpc.reflection.testing.Reply> getMethodMethod;
+    if ((getMethodMethod = ReflectableServiceGrpc.getMethodMethod) == null) {
+      synchronized (ReflectableServiceGrpc.class) {
+        if ((getMethodMethod = ReflectableServiceGrpc.getMethodMethod) == null) {
+          ReflectableServiceGrpc.getMethodMethod = getMethodMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.reflection.testing.Request, io.grpc.reflection.testing.Reply>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.reflection.testing.ReflectableService", "Method"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.reflection.testing.Request.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.reflection.testing.Reply.getDefaultInstance()))
+                  .setSchemaDescriptor(new ReflectableServiceMethodDescriptorSupplier("Method"))
+                  .build();
+          }
+        }
+     }
+     return getMethodMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -73,7 +91,7 @@ public final class ReflectableServiceGrpc {
      */
     public void method(io.grpc.reflection.testing.Request request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.Reply> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_METHOD, responseObserver);
+      asyncUnimplementedUnaryCall(getMethodMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -112,7 +130,7 @@ public final class ReflectableServiceGrpc {
     public void method(io.grpc.reflection.testing.Request request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.Reply> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_METHOD, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getMethodMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -138,7 +156,7 @@ public final class ReflectableServiceGrpc {
      */
     public io.grpc.reflection.testing.Reply method(io.grpc.reflection.testing.Request request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_METHOD, getCallOptions(), request);
+          getChannel(), getMethodMethod(), getCallOptions(), request);
     }
   }
 
@@ -165,7 +183,7 @@ public final class ReflectableServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.reflection.testing.Reply> method(
         io.grpc.reflection.testing.Request request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_METHOD, getCallOptions()), request);
+          getChannel().newCall(getMethodMethod(), getCallOptions()), request);
     }
   }
 

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
@@ -31,61 +31,133 @@ public final class SimpleServiceGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getUnaryRpcMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
-      io.grpc.testing.protobuf.SimpleResponse> METHOD_UNARY_RPC =
-      io.grpc.MethodDescriptor.<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.SimpleService", "UnaryRpc"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.protobuf.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.protobuf.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new SimpleServiceMethodDescriptorSupplier("UnaryRpc"))
-          .build();
+      io.grpc.testing.protobuf.SimpleResponse> METHOD_UNARY_RPC = getUnaryRpcMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getUnaryRpcMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
-      io.grpc.testing.protobuf.SimpleResponse> METHOD_CLIENT_STREAMING_RPC =
-      io.grpc.MethodDescriptor.<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.SimpleService", "ClientStreamingRpc"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.protobuf.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.protobuf.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new SimpleServiceMethodDescriptorSupplier("ClientStreamingRpc"))
-          .build();
+  public static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getUnaryRpcMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse> getUnaryRpcMethod;
+    if ((getUnaryRpcMethod = SimpleServiceGrpc.getUnaryRpcMethod) == null) {
+      synchronized (SimpleServiceGrpc.class) {
+        if ((getUnaryRpcMethod = SimpleServiceGrpc.getUnaryRpcMethod) == null) {
+          SimpleServiceGrpc.getUnaryRpcMethod = getUnaryRpcMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.SimpleService", "UnaryRpc"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.protobuf.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.protobuf.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new SimpleServiceMethodDescriptorSupplier("UnaryRpc"))
+                  .build();
+          }
+        }
+     }
+     return getUnaryRpcMethod;
+  }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getClientStreamingRpcMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
-      io.grpc.testing.protobuf.SimpleResponse> METHOD_SERVER_STREAMING_RPC =
-      io.grpc.MethodDescriptor.<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.SimpleService", "ServerStreamingRpc"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.protobuf.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.protobuf.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new SimpleServiceMethodDescriptorSupplier("ServerStreamingRpc"))
-          .build();
+      io.grpc.testing.protobuf.SimpleResponse> METHOD_CLIENT_STREAMING_RPC = getClientStreamingRpcMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getClientStreamingRpcMethod;
+
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getClientStreamingRpcMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse> getClientStreamingRpcMethod;
+    if ((getClientStreamingRpcMethod = SimpleServiceGrpc.getClientStreamingRpcMethod) == null) {
+      synchronized (SimpleServiceGrpc.class) {
+        if ((getClientStreamingRpcMethod = SimpleServiceGrpc.getClientStreamingRpcMethod) == null) {
+          SimpleServiceGrpc.getClientStreamingRpcMethod = getClientStreamingRpcMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.SimpleService", "ClientStreamingRpc"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.protobuf.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.protobuf.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new SimpleServiceMethodDescriptorSupplier("ClientStreamingRpc"))
+                  .build();
+          }
+        }
+     }
+     return getClientStreamingRpcMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getServerStreamingRpcMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
-      io.grpc.testing.protobuf.SimpleResponse> METHOD_BIDI_STREAMING_RPC =
-      io.grpc.MethodDescriptor.<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse>newBuilder()
-          .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-          .setFullMethodName(generateFullMethodName(
-              "grpc.testing.SimpleService", "BidiStreamingRpc"))
-          .setRegisterForTracing(true)
-          .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.protobuf.SimpleRequest.getDefaultInstance()))
-          .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              io.grpc.testing.protobuf.SimpleResponse.getDefaultInstance()))
-          .setSchemaDescriptor(new SimpleServiceMethodDescriptorSupplier("BidiStreamingRpc"))
-          .build();
+      io.grpc.testing.protobuf.SimpleResponse> METHOD_SERVER_STREAMING_RPC = getServerStreamingRpcMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getServerStreamingRpcMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getServerStreamingRpcMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse> getServerStreamingRpcMethod;
+    if ((getServerStreamingRpcMethod = SimpleServiceGrpc.getServerStreamingRpcMethod) == null) {
+      synchronized (SimpleServiceGrpc.class) {
+        if ((getServerStreamingRpcMethod = SimpleServiceGrpc.getServerStreamingRpcMethod) == null) {
+          SimpleServiceGrpc.getServerStreamingRpcMethod = getServerStreamingRpcMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.SimpleService", "ServerStreamingRpc"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.protobuf.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.protobuf.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new SimpleServiceMethodDescriptorSupplier("ServerStreamingRpc"))
+                  .build();
+          }
+        }
+     }
+     return getServerStreamingRpcMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link getBidiStreamingRpcMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> METHOD_BIDI_STREAMING_RPC = getBidiStreamingRpcMethod();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getBidiStreamingRpcMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getBidiStreamingRpcMethod() {
+    io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse> getBidiStreamingRpcMethod;
+    if ((getBidiStreamingRpcMethod = SimpleServiceGrpc.getBidiStreamingRpcMethod) == null) {
+      synchronized (SimpleServiceGrpc.class) {
+        if ((getBidiStreamingRpcMethod = SimpleServiceGrpc.getBidiStreamingRpcMethod) == null) {
+          SimpleServiceGrpc.getBidiStreamingRpcMethod = getBidiStreamingRpcMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.SimpleService", "BidiStreamingRpc"))
+              .setRegisterForTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.protobuf.SimpleRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.protobuf.SimpleResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new SimpleServiceMethodDescriptorSupplier("BidiStreamingRpc"))
+                  .build();
+          }
+        }
+     }
+     return getBidiStreamingRpcMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -124,7 +196,7 @@ public final class SimpleServiceGrpc {
      */
     public void unaryRpc(io.grpc.testing.protobuf.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_UNARY_RPC, responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryRpcMethod(), responseObserver);
     }
 
     /**
@@ -134,7 +206,7 @@ public final class SimpleServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleRequest> clientStreamingRpc(
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_CLIENT_STREAMING_RPC, responseObserver);
+      return asyncUnimplementedStreamingCall(getClientStreamingRpcMethod(), responseObserver);
     }
 
     /**
@@ -144,7 +216,7 @@ public final class SimpleServiceGrpc {
      */
     public void serverStreamingRpc(io.grpc.testing.protobuf.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_SERVER_STREAMING_RPC, responseObserver);
+      asyncUnimplementedUnaryCall(getServerStreamingRpcMethod(), responseObserver);
     }
 
     /**
@@ -154,7 +226,7 @@ public final class SimpleServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleRequest> bidiStreamingRpc(
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(METHOD_BIDI_STREAMING_RPC, responseObserver);
+      return asyncUnimplementedStreamingCall(getBidiStreamingRpcMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -220,7 +292,7 @@ public final class SimpleServiceGrpc {
     public void unaryRpc(io.grpc.testing.protobuf.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_UNARY_RPC, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryRpcMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -231,7 +303,7 @@ public final class SimpleServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleRequest> clientStreamingRpc(
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(METHOD_CLIENT_STREAMING_RPC, getCallOptions()), responseObserver);
+          getChannel().newCall(getClientStreamingRpcMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -242,7 +314,7 @@ public final class SimpleServiceGrpc {
     public void serverStreamingRpc(io.grpc.testing.protobuf.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(METHOD_SERVER_STREAMING_RPC, getCallOptions()), request, responseObserver);
+          getChannel().newCall(getServerStreamingRpcMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -253,7 +325,7 @@ public final class SimpleServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleRequest> bidiStreamingRpc(
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(METHOD_BIDI_STREAMING_RPC, getCallOptions()), responseObserver);
+          getChannel().newCall(getBidiStreamingRpcMethod(), getCallOptions()), responseObserver);
     }
   }
 
@@ -285,7 +357,7 @@ public final class SimpleServiceGrpc {
      */
     public io.grpc.testing.protobuf.SimpleResponse unaryRpc(io.grpc.testing.protobuf.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_UNARY_RPC, getCallOptions(), request);
+          getChannel(), getUnaryRpcMethod(), getCallOptions(), request);
     }
 
     /**
@@ -296,7 +368,7 @@ public final class SimpleServiceGrpc {
     public java.util.Iterator<io.grpc.testing.protobuf.SimpleResponse> serverStreamingRpc(
         io.grpc.testing.protobuf.SimpleRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), METHOD_SERVER_STREAMING_RPC, getCallOptions(), request);
+          getChannel(), getServerStreamingRpcMethod(), getCallOptions(), request);
     }
   }
 
@@ -329,7 +401,7 @@ public final class SimpleServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.protobuf.SimpleResponse> unaryRpc(
         io.grpc.testing.protobuf.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_UNARY_RPC, getCallOptions()), request);
+          getChannel().newCall(getUnaryRpcMethod(), getCallOptions()), request);
     }
   }
 

--- a/testing-proto/src/test/java/io/grpc/testing/protobuf/SimpleServiceTest.java
+++ b/testing-proto/src/test/java/io/grpc/testing/protobuf/SimpleServiceTest.java
@@ -45,16 +45,16 @@ public class SimpleServiceTest {
   public void serviceMethodDescriotrs() {
     MethodDescriptor<SimpleRequest, SimpleResponse> genericTypeShouldMatchWhenAssigned;
 
-    genericTypeShouldMatchWhenAssigned = SimpleServiceGrpc.METHOD_UNARY_RPC;
+    genericTypeShouldMatchWhenAssigned = SimpleServiceGrpc.getUnaryRpcMethod();
     assertEquals(UNARY, genericTypeShouldMatchWhenAssigned.getType());
 
-    genericTypeShouldMatchWhenAssigned = SimpleServiceGrpc.METHOD_CLIENT_STREAMING_RPC;
+    genericTypeShouldMatchWhenAssigned = SimpleServiceGrpc.getClientStreamingRpcMethod();
     assertEquals(CLIENT_STREAMING, genericTypeShouldMatchWhenAssigned.getType());
 
-    genericTypeShouldMatchWhenAssigned = SimpleServiceGrpc.METHOD_SERVER_STREAMING_RPC;
+    genericTypeShouldMatchWhenAssigned = SimpleServiceGrpc.getServerStreamingRpcMethod();
     assertEquals(SERVER_STREAMING, genericTypeShouldMatchWhenAssigned.getType());
 
-    genericTypeShouldMatchWhenAssigned = SimpleServiceGrpc.METHOD_BIDI_STREAMING_RPC;
+    genericTypeShouldMatchWhenAssigned = SimpleServiceGrpc.getBidiStreamingRpcMethod();
     assertEquals(BIDI_STREAMING, genericTypeShouldMatchWhenAssigned.getType());
   }
 


### PR DESCRIPTION
Several commits so you can see the changes

Key things:
* MethodDescriptor is lazy loaded, so protobuf loading only happens on demand.  This also means tracing registration happens  on demand.  
* The names of the getters all being with `method`.  This makes it harder for autocomplete to pick them up.
* A new field is used, which matches the getter name.  Rather than make the new-getters reference the old-fields, make the old-fields reference the new getters.  This makes removal of the old-fields a simple operation.  
* The getters may not be inlineable, but thats an easy fix if it ends up being a problem.  Not worth premature optimization (but is worth future work).

The expected timeline for this is adding this to the 1.8 cut, and deprecating the old-fields.  They will be removed in 1.9.