### PR TITLE
travis: Remove OS X build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ after_success:
 
 os:
   - linux
-  - osx
 
 notifications:
   email: false


### PR DESCRIPTION
With #3608 Kokoro is now able to handle OS X. I'm not removing the
OS X-specific parts of the .travis.yml in case we need to revert back to
using Travis.

Fixes #3466