### PR TITLE
buildscripts: make the script fail for the right reason with set -e

### DIFF
--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -29,7 +29,8 @@ echo "errorProne=true" >> $HOME/.gradle/gradle.properties
 
 # Run tests
 ./gradlew assemble generateTestProto install
-pushd examples && ./gradlew build && popd
-# --batch-mode reduces logspam
-pushd examples && mvn verify --batch-mode &&  popd
+pushd examples
+./gradlew build
+mvn verify --batch-mode
+popd
 # TODO(zpencer): also build the GAE examples

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -31,6 +31,7 @@ echo "errorProne=true" >> $HOME/.gradle/gradle.properties
 ./gradlew assemble generateTestProto install
 pushd examples
 ./gradlew build
+# --batch-mode reduces log spam
 mvn verify --batch-mode
 popd
 # TODO(zpencer): also build the GAE examples


### PR DESCRIPTION
Remove the `&&`s so that the script will fail due to the build command failing, instead of `pushd` failing