### PR TITLE
buildscripts: set -u, set -o pipefail

### DIFF
--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -4,7 +4,7 @@
 # TODO(zpencer): test this script for Linux
 
 # This script assumes `set -e`. Removing it may lead to undefined behavior.
-set -ex
+set -exu -o pipefail
 
 export GRADLE_OPTS=-Xmx512m
 export PROTOBUF_VERSION=3.4.0

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Build protoc
-set -evx
+set -evux -o pipefail
 
 DOWNLOAD_DIR=/tmp/source
 INSTALL_DIR="/tmp/protobuf-$PROTOBUF_VERSION/$(uname -s)-$(uname -p)"


### PR DESCRIPTION
Be even more defensive with our shell scripts, to avoid future mistakes:
`set -u` : reading an unset env variable will fail. In conditional statements we must always check the variable is bound `-v FOO && ` before reading its value. When combined with `set -e` causes the script to exit if we use an unbound variable.

`set -o pipefail`: When used with `set -e` causes the script to exit if any part of a pipe expression fails