### PR TITLE
Fix compilation in Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,16 @@ script:
   - ./gradlew check :grpc-all:jacocoTestReport
 
 after_success:
-  - if \[ "$TRAVIS_OS_NAME" = linux \]; then ./gradlew :grpc-all:coveralls; fi
+    # Upload to coveralls once, instead of for each job in the matrix
+  - if \[\[ "$TRAVIS_JOB_NUMBER" == *.1 \]\]; then ./gradlew :grpc-all:coveralls; fi
   - bash <(curl -s https://codecov.io/bash)
 
 os:
   - linux
+
+jdk:
+  - oraclejdk8
+  - oraclejdk9
 
 notifications:
   email: false

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -37,6 +37,7 @@ dependencies {
             libraries.netty_tcnative,
             libraries.netty_epoll,
             libraries.math
+    compileOnly libraries.javax_annotation
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -192,6 +192,7 @@ subprojects {
                 gson: "com.google.code.gson:gson:2.7",
                 guava: "com.google.guava:guava:${guavaVersion}",
                 hpack: 'com.twitter:hpack:0.10.1',
+                javax_annotation: 'javax.annotation:javax.annotation-api:1.2',
                 jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
                 oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.9.0',
                 google_api_protos: 'com.google.api.grpc:proto-google-common-protos:1.0.0',

--- a/core/src/test/java/io/grpc/AttributesTest.java
+++ b/core/src/test/java/io/grpc/AttributesTest.java
@@ -53,11 +53,20 @@ public class AttributesTest {
   }
 
   @Test
-  @SuppressWarnings("BoxedPrimitiveConstructor")
   public void valueEquality() {
-    Attributes.Key<Integer> key = Attributes.Key.of("ints");
-    Integer v1 = new Integer(100000);
-    Integer v2 = new Integer(100000);
+    class EqualObject {
+      @Override public boolean equals(Object o) {
+        return o instanceof EqualObject;
+      }
+
+      @Override public int hashCode() {
+        return 42;
+      }
+    }
+
+    Attributes.Key<EqualObject> key = Attributes.Key.of("ints");
+    EqualObject v1 = new EqualObject();
+    EqualObject v2 = new EqualObject();
 
     assertNotSame(v1, v2);
     assertEquals(v1, v2);

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   compile "io.grpc:grpc-netty:${grpcVersion}"
   compile "io.grpc:grpc-protobuf:${grpcVersion}"
   compile "io.grpc:grpc-stub:${grpcVersion}"
+  compileOnly "javax.annotation:javax.annotation-api:1.2"
 
   // Used for TLS in HelloWorldServerTls
   compile "io.netty:netty-tcnative-boringssl-static:${nettyTcNativeVersion}"

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -17,6 +17,7 @@ dependencies {
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.protobuf
+    compileOnly libraries.javax_annotation
     testCompile libraries.truth,
                 project(':grpc-core').sourceSets.test.output
 }

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -29,6 +29,7 @@ dependencies {
             libraries.mockito,
             libraries.oauth_client,
             libraries.truth
+    compileOnly libraries.javax_annotation
     runtime libraries.opencensus_impl,
             libraries.netty_tcnative
     testCompile project(':grpc-context').sourceSets.test.output

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -22,6 +22,7 @@ dependencies {
         // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
     }
+    compileOnly libraries.javax_annotation
     testCompile project(':grpc-testing'),
             libraries.netty_epoll // for DomainSocketAddress
     signature "org.codehaus.mojo.signature:java16:1.1@signature"

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub')
+    compileOnly libraries.javax_annotation
     testCompile libraries.truth
 }
 


### PR DESCRIPTION
~~Tests still fail; at the very least because of missing Jetty ALPN.~~ I
don't know why the dependency on javax.annotations is unnecessary in the
compiler tests and the example when using Maven.

This depends on #3637. This isn't quite enough for #3633, because we've
not yet clear in our README what's necessary. The annotations stuff is still
very confusing to me; I think our users will suffer unless we have a pretty good
understanding of what's going on and clearly document what they need to do.

CC @carl-mastrangelo 