### PR TITLE
android-interop-testing: fix proguard for grpc-testing dependency

### DIFF
--- a/android-interop-testing/app/proguard-rules.pro
+++ b/android-interop-testing/app/proguard-rules.pro
@@ -18,3 +18,6 @@
 -dontwarn sun.reflect.**
 # Ignores: can't find referenced class javax.lang.model.element.Modifier
 -dontwarn com.google.errorprone.annotations.**
+
+# Ignores: can't find referenced method from grpc-testing's compileOnly dependency on Truth
+-dontwarn io.grpc.testing.DeadlineSubject


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-java/issues/3635. https://github.com/grpc/grpc-java/commit/a3ff9cd784fce8a3a05054f0cd695954283e51f5 changed `grpc-testing`'s dependency on the Truth library to compileOnly, which confuses Proguard here. Adding `-whyareyoukeeping class io.grpc.testing.DeadlineSubject` to the proguard file shows that `DeadlineSubject` is indeed being stripped out by Proguard, so it seems safe to just ignore the earlier warning.