### PR TITLE
core: Add description for Status mapped from error-less Context

### DIFF
--- a/core/src/main/java/io/grpc/Contexts.java
+++ b/core/src/main/java/io/grpc/Contexts.java
@@ -133,7 +133,7 @@ public final class Contexts {
 
     Throwable cancellationCause = context.cancellationCause();
     if (cancellationCause == null) {
-      return Status.CANCELLED;
+      return Status.CANCELLED.withDescription("io.grpc.Context was cancelled without error");
     }
     if (cancellationCause instanceof TimeoutException) {
       return Status.DEADLINE_EXCEEDED


### PR DESCRIPTION
The message isn't great, but _much_ better than no message.