### PR TITLE
protobuf-lite: add javalite generated sources to intellij path

### DIFF
--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -18,6 +18,11 @@ dependencies {
             libraries.guava
 
     testProtobuf libraries.protobuf
+    // TODO(zpencer): fix proto plugin wrt testProtobuf and intellij
+    // Using testProtobuf to add the protobuf libriaries did not add the built-in
+    // types like com.google.protobuf.Empty to intellij's class path.
+    // Adding testCompile is a workaround.
+    testCompile libraries.protobuf
 
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -18,11 +18,6 @@ dependencies {
             libraries.guava
 
     testProtobuf libraries.protobuf
-    // TODO(zpencer): fix proto plugin wrt testProtobuf and intellij
-    // Using testProtobuf to add the protobuf libriaries did not add the built-in
-    // types like com.google.protobuf.Empty to intellij's class path.
-    // Adding testCompile is a workaround.
-    testCompile libraries.protobuf
 
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
@@ -61,4 +56,10 @@ protobuf {
       }
     }
   }
+}
+
+idea {
+    module {
+        sourceDirs += file("${projectDir}/build/generated/source/proto/test/javalite/")
+    }
 }


### PR DESCRIPTION
This seems to be an intellij-only problem, everything compiles and tests fine from the gradle CLI. Intellij complains that in `ProtoLiteUtilsTest`  com.google.protobuf.{Empty, Enum, Type} can not be found unless this is added.

Not sure if this one is related: https://github.com/grpc/grpc-java/pull/3598