### PR TITLE
Allow tests to run on IPv6-less machines

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -99,6 +99,7 @@ import io.opencensus.trace.Span;
 import io.opencensus.trace.unsafe.ContextUtils;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.SocketAddress;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -1623,19 +1624,14 @@ public abstract class AbstractInteropTest {
     }
   }
 
-  /** Helper for asserting remote address {@link io.grpc.ServerCall#getAttributes()} */
-  protected void assertRemoteAddr(String expectedRemoteAddress) {
+  /** Helper for getting remote address {@link io.grpc.ServerCall#getAttributes()} */
+  protected SocketAddress obtainRemoteClientAddr() {
     TestServiceGrpc.TestServiceBlockingStub stub =
         blockingStub.withDeadlineAfter(5, TimeUnit.SECONDS);
 
     stub.unaryCall(SimpleRequest.getDefaultInstance());
 
-    String inetSocketString = serverCallCapture.get().getAttributes()
-        .get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR).toString();
-    // The substring is simply host:port, even if host is IPv6 as it fails to use []. Can't use
-    // standard parsing because the string isn't following any standard.
-    String host = inetSocketString.substring(0, inetSocketString.lastIndexOf(':'));
-    assertEquals(expectedRemoteAddress, host);
+    return serverCallCapture.get().getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
   }
 
   /** Helper for asserting TLS info in SSLSession {@link io.grpc.ServerCall#getAttributes()} */

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -16,6 +16,9 @@
 
 package io.grpc.testing.integration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
 import io.grpc.ManagedChannel;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.GrpcSslContexts;
@@ -25,6 +28,8 @@ import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -83,8 +88,11 @@ public class Http2NettyTest extends AbstractInteropTest {
   }
 
   @Test
-  public void remoteAddr() {
-    assertRemoteAddr("/0:0:0:0:0:0:0:1");
+  public void remoteAddr() throws Exception {
+    InetSocketAddress isa = (InetSocketAddress) obtainRemoteClientAddr();
+    assertEquals(InetAddress.getLoopbackAddress(), isa.getAddress());
+    // It should not be the same as the server
+    assertNotEquals(getPort(), isa.getPort());
   }
 
   @Test

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -97,7 +97,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
   }
 
   private OkHttpChannelBuilder createChannelBuilder() {
-    OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("::1", getPort())
+    OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("localhost", getPort())
         .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .connectionSpec(new ConnectionSpec.Builder(OkHttpChannelBuilder.DEFAULT_CONNECTION_SPEC)
             .cipherSuites(TestUtils.preferredTestCiphers().toArray(new String[0]))

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -36,7 +36,7 @@ import org.junit.runners.JUnit4;
 public class OkHttpTransportTest extends AbstractTransportTest {
   private ClientTransportFactory clientFactory = OkHttpChannelBuilder
       // Although specified here, address is ignored because we never call build.
-      .forAddress("::1", 0)
+      .forAddress("localhost", 0)
       .negotiationType(NegotiationType.PLAINTEXT)
       .buildTransportFactory();
 
@@ -67,14 +67,14 @@ public class OkHttpTransportTest extends AbstractTransportTest {
 
   @Override
   protected String testAuthority(InternalServer server) {
-    return "[::1]:" + server.getPort();
+    return "thebestauthority:" + server.getPort();
   }
 
   @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
     int port = server.getPort();
     return clientFactory.newClientTransport(
-        new InetSocketAddress("::1", port),
+        new InetSocketAddress("localhost", port),
         testAuthority(server),
         null /* agent */,
         null /* proxy */);

--- a/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
@@ -67,7 +67,7 @@ public class TestUtils {
    */
   public static InetSocketAddress testServerAddress(int port) {
     try {
-      InetAddress inetAddress = InetAddress.getByName("::1");
+      InetAddress inetAddress = InetAddress.getByName("localhost");
       inetAddress = InetAddress.getByAddress(TEST_SERVER_HOST, inetAddress.getAddress());
       return new InetSocketAddress(inetAddress, port);
     } catch (UnknownHostException e) {


### PR DESCRIPTION
Our Travis-CI builds are failing with `Protocol family unavailable` due
to the usage of ::1. Although it's 2017 and we'd expect to have ipv6
_loopback_ anywhere that mattered, apparently that's not the case.

The tests now work equally well on IPv4-only and IPv6-only machines.