### PR TITLE
stub: make it harder to construct special client observers

### DIFF
--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -95,4 +95,18 @@ public abstract class CallStreamObserver<V> implements StreamObserver<V> {
    * @param enable whether to enable compression.
    */
   public abstract void setMessageCompression(boolean enable);
+
+  static final Object KEY_FOR_20171102 =
+      "I know what I'm doing and make my own observers. Today's password is actinide.";
+
+
+  /**
+   * Do not call this, it is for the gRPC library to construct.
+   */
+  @Deprecated
+  public CallStreamObserver(Object key) {
+    if (!KEY_FOR_20171102.equals(key)) {
+      throw new IllegalArgumentException("Don't create your own CallStreamObservers");
+    }
+  }
 }

--- a/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1788")
 @DoNotMock
 public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> {
+
   /**
    * Prevent any further processing for this {@code ClientCallStreamObserver}. No further messages
    * will be received. The server is informed of cancellations, but may not stop processing the
@@ -44,4 +45,12 @@ public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> 
    * @param cause if not {@code null}, will appear as the cause of the CANCELLED status
    */
   public abstract void cancel(@Nullable String message, @Nullable Throwable cause);
+
+  /**
+   * Do not call this, it is for the gRPC library to construct.
+   */
+  @Deprecated
+  public ClientCallStreamObserver(Object key) {
+    super(key);
+  }
 }

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -306,7 +306,9 @@ public final class ClientCalls {
     private boolean autoFlowControlEnabled = true;
 
     // Non private to avoid synthetic class
+    @SuppressWarnings("deprecation")
     CallToStreamObserverAdapter(ClientCall<T, ?> call) {
+      super(ClientCallStreamObserver.KEY_FOR_20171102);
       this.call = call;
     }
 

--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -51,4 +51,12 @@ public abstract class ServerCallStreamObserver<V> extends CallStreamObserver<V> 
    * @param compression the compression algorithm to use.
    */
   public abstract void setCompression(String compression);
+
+  /**
+   * Do not call this, it is for the gRPC library to construct.
+   */
+  @Deprecated
+  public ServerCallStreamObserver(Object key) {
+    super(key);
+  }
 }

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -311,7 +311,9 @@ public final class ServerCalls {
     private Runnable onCancelHandler;
 
     // Non private to avoid synthetic class
+    @SuppressWarnings("deprecation")
     ServerCallStreamObserverImpl(ServerCall<ReqT, RespT> call) {
+      super(ClientCallStreamObserver.KEY_FOR_20171102);
       this.call = call;
     }
 


### PR DESCRIPTION
This is an alternative way to expose an abstract class.  The user is not expected to create these (instead they implement SteamObserver directly).  This allows us to add abstract methods and more extensions without risking breakage.  The API to construct it is intentionally difficult, using dates, words, and passing by object.

If other projects want to (correctly) construct these objects, we can expose an InternalCallStreamObserver, which will expose the key.

This pattern is used by JMH for Blackholes.