### PR TITLE
core: retry support part 1, RetriableStream

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -279,6 +279,9 @@ final class DelayedClientTransport implements ManagedClientTransport {
 
   final void addUncommittedRetriableStream(RetriableStream<?> retriableStream) {
     synchronized (lock) {
+      if (shutdownStatus != null) {
+        return;
+      }
       uncommittedRetriableStreams.add(retriableStream);
       if (getPendingStreamsCount() == 1) {
         channelExecutor.executeLater(reportTransportInUse);

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -277,15 +277,21 @@ final class DelayedClientTransport implements ManagedClientTransport {
     }
   }
 
-  final void addUncommittedRetriableStream(RetriableStream<?> retriableStream) {
+  /**
+   * Registers a RetriableStream and return null if not shutdown, otherwise just returns the
+   * shutdown Status.
+   */
+  @Nullable
+  final Status addUncommittedRetriableStream(RetriableStream<?> retriableStream) {
     synchronized (lock) {
       if (shutdownStatus != null) {
-        return;
+        return shutdownStatus;
       }
       uncommittedRetriableStreams.add(retriableStream);
       if (getPendingStreamsCount() == 1) {
         channelExecutor.executeLater(reportTransportInUse);
       }
+      return null;
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -29,6 +29,7 @@ import io.grpc.Status;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -62,8 +63,11 @@ final class DelayedClientTransport implements ManagedClientTransport {
   @GuardedBy("lock")
   private Collection<PendingStream> pendingStreams = new LinkedHashSet<PendingStream>();
 
+  @GuardedBy("lock")
+  private Collection<ClientStream> uncommittedRetriableStreams = new HashSet<ClientStream>();
+
   /**
-   * When shutdownStatus != null and pendingStreams.isEmpty(), then the transport is considered
+   * When {@code shutdownStatus != null && !hasPendingStreams()}, then the transport is considered
    * terminated.
    */
   @GuardedBy("lock")
@@ -168,6 +172,11 @@ final class DelayedClientTransport implements ManagedClientTransport {
     }
   }
 
+  // TODO: API plumbing to enable retry.
+  private boolean retryEnabled() {
+    return false;
+  }
+
   /**
    * Caller must call {@code channelExecutor.drain()} outside of lock because this method may
    * schedule tasks on channelExecutor.
@@ -176,7 +185,7 @@ final class DelayedClientTransport implements ManagedClientTransport {
   private PendingStream createPendingStream(PickSubchannelArgs args) {
     PendingStream pendingStream = new PendingStream(args);
     pendingStreams.add(pendingStream);
-    if (pendingStreams.size() == 1) {
+    if (getPendingStreamsCount() == 1) {
       channelExecutor.executeLater(reportTransportInUse);
     }
     return pendingStream;
@@ -212,7 +221,7 @@ final class DelayedClientTransport implements ManagedClientTransport {
             listener.transportShutdown(status);
           }
         });
-      if (pendingStreams.isEmpty() && reportTransportTerminated != null) {
+      if (!hasPendingStreams() && reportTransportTerminated != null) {
         channelExecutor.executeLater(reportTransportTerminated);
         reportTransportTerminated = null;
       }
@@ -228,17 +237,25 @@ final class DelayedClientTransport implements ManagedClientTransport {
   public final void shutdownNow(Status status) {
     shutdown(status);
     Collection<PendingStream> savedPendingStreams;
+    Collection<ClientStream> savedUncommittedRetriableStreams;
     Runnable savedReportTransportTerminated;
     synchronized (lock) {
       savedPendingStreams = pendingStreams;
+      savedUncommittedRetriableStreams = uncommittedRetriableStreams;
       savedReportTransportTerminated = reportTransportTerminated;
       reportTransportTerminated = null;
       if (!pendingStreams.isEmpty()) {
         pendingStreams = Collections.<PendingStream>emptyList();
       }
+      if (!uncommittedRetriableStreams.isEmpty()) {
+        uncommittedRetriableStreams = Collections.<ClientStream>emptyList();
+      }
     }
     if (savedReportTransportTerminated != null) {
       for (PendingStream stream : savedPendingStreams) {
+        stream.cancel(status);
+      }
+      for (ClientStream stream : savedUncommittedRetriableStreams) {
         stream.cancel(status);
       }
       channelExecutor.executeLater(savedReportTransportTerminated).drain();
@@ -249,14 +266,40 @@ final class DelayedClientTransport implements ManagedClientTransport {
 
   public final boolean hasPendingStreams() {
     synchronized (lock) {
-      return !pendingStreams.isEmpty();
+      return !pendingStreams.isEmpty() || !uncommittedRetriableStreams.isEmpty();
     }
   }
 
   @VisibleForTesting
   final int getPendingStreamsCount() {
     synchronized (lock) {
-      return pendingStreams.size();
+      return pendingStreams.size() + uncommittedRetriableStreams.size();
+    }
+  }
+
+  final void addUncommittedRetriableStream(RetriableStream<?> retriableStream) {
+    synchronized (lock) {
+      uncommittedRetriableStreams.add(retriableStream);
+      if (getPendingStreamsCount() == 1) {
+        channelExecutor.executeLater(reportTransportInUse);
+      }
+    }
+  }
+
+  final void removeUncommittedRetriableStream(RetriableStream<?> retriableStream) {
+    synchronized (lock) {
+      uncommittedRetriableStreams.remove(retriableStream);
+      if (!hasPendingStreams()) {
+        channelExecutor.executeLater(reportTransportNotInUse);
+        if (shutdownStatus != null && reportTransportTerminated != null) {
+          channelExecutor.executeLater(reportTransportTerminated);
+          reportTransportTerminated = null;
+        } else {
+          // Because delayed transport is long-lived, we take this opportunity to down-size the
+          // hashmap.
+          uncommittedRetriableStreams = new HashSet<ClientStream>();
+        }
+      }
     }
   }
 
@@ -276,7 +319,7 @@ final class DelayedClientTransport implements ManagedClientTransport {
     synchronized (lock) {
       lastPicker = picker;
       lastPickerVersion++;
-      if (pendingStreams.isEmpty()) {
+      if (!hasPendingStreams()) {
         return;
       }
       toProcess = new ArrayList<PendingStream>(pendingStreams);
@@ -309,11 +352,16 @@ final class DelayedClientTransport implements ManagedClientTransport {
       // Between this synchronized and the previous one:
       //   - Streams may have been cancelled, which may turn pendingStreams into emptiness.
       //   - shutdown() may be called, which may turn pendingStreams into null.
-      if (pendingStreams.isEmpty()) {
+      if (!hasPendingStreams()) {
         return;
       }
       pendingStreams.removeAll(toRemove);
+      // Because delayed transport is long-lived, we take this opportunity to down-size the
+      // hashmap.
       if (pendingStreams.isEmpty()) {
+        pendingStreams = new LinkedHashSet<PendingStream>();
+      }
+      if (!hasPendingStreams()) {
         // There may be a brief gap between delayed transport clearing in-use state, and first real
         // transport starting streams and setting in-use state.  During the gap the whole channel's
         // in-use state may be false. However, it shouldn't cause spurious switching to idleness
@@ -323,10 +371,6 @@ final class DelayedClientTransport implements ManagedClientTransport {
         if (shutdownStatus != null && reportTransportTerminated != null) {
           channelExecutor.executeLater(reportTransportTerminated);
           reportTransportTerminated = null;
-        } else {
-          // Because delayed transport is long-lived, we take this opportunity to down-size the
-          // hashmap.
-          pendingStreams = new LinkedHashSet<PendingStream>();
         }
       }
     }
@@ -365,7 +409,7 @@ final class DelayedClientTransport implements ManagedClientTransport {
       synchronized (lock) {
         if (reportTransportTerminated != null) {
           boolean justRemovedAnElement = pendingStreams.remove(this);
-          if (pendingStreams.isEmpty() && justRemovedAnElement) {
+          if (!hasPendingStreams() && justRemovedAnElement) {
             channelExecutor.executeLater(reportTransportNotInUse);
             if (shutdownStatus != null) {
               channelExecutor.executeLater(reportTransportTerminated);

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -386,6 +386,11 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       }
       return delayedTransport;
     }
+
+    @Override
+    public DelayedClientTransport getDelayedTransport() {
+      return delayedTransport;
+    }
   };
 
   ManagedChannelImpl(

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -397,8 +397,8 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
         final Context context) {
       return new RetriableStream<ReqT>(method) {
         @Override
-        void prestart() {
-          delayedTransport.addUncommittedRetriableStream(this);
+        Status prestart() {
+          return delayedTransport.addUncommittedRetriableStream(this);
         }
 
         @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -395,7 +395,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
         final CallOptions callOptions,
         final Metadata headers,
         final Context context) {
-      return new RetriableStream<ReqT>(method, callOptions, headers, context) {
+      return new RetriableStream<ReqT>(method) {
         @Override
         void prestart() {
           delayedTransport.addUncommittedRetriableStream(this);

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -76,7 +76,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
     @Override
     public <ReqT> RetriableStream<ReqT> newRetriableStream(MethodDescriptor<ReqT, ?> method,
         CallOptions callOptions, Metadata headers, Context context) {
-      return null;
+      throw new UnsupportedOperationException("OobChannel should not create retriable streams");
     }
   };
 

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -23,6 +23,7 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ConnectivityStateInfo;
+import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer;
@@ -30,6 +31,7 @@ import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
@@ -72,8 +74,9 @@ final class OobChannel extends ManagedChannel implements WithLogId {
     }
 
     @Override
-    public DelayedClientTransport getDelayedTransport() {
-      return delayedTransport;
+    public <ReqT> RetriableStream<ReqT> newRetriableStream(MethodDescriptor<ReqT, ?> method,
+        CallOptions callOptions, Metadata headers, Context context) {
+      return null;
     }
   };
 

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -70,6 +70,11 @@ final class OobChannel extends ManagedChannel implements WithLogId {
       // critical path.
       return delayedTransport;
     }
+
+    @Override
+    public DelayedClientTransport getDelayedTransport() {
+      return delayedTransport;
+    }
   };
 
   OobChannel(

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -418,7 +418,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
     @Override
     public void closed(Status status, Metadata trailers) {
-      if (shouldRetry()) {
+      if (state.winningSubstream == null && shouldRetry()) {
+        // The check state.winningSubstream == null, checking if is not already committed, is racy,
+        // but is still safe b/c the retry will also handle committed/cancellation
         // TODO(zdapeng): backoff and schedule; retry() should run in an executor
         retry();
       } else if (!hasHedging()) {

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -406,7 +406,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     }
 
     @Override
-    public void closed(final Status status, final Metadata trailers) {
+    public void closed(Status status, Metadata trailers) {
       if (shouldRetry()) {
         // TODO(zdapeng): backoff and schedule; retry() should run in an executor
         retry();

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -423,7 +423,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
         retry();
       } else if (!hasHedging()) {
         commit(substream);
-        masterListener.closed(status, trailers);
+        if (state.winningSubstream == substream) {
+          masterListener.closed(status, trailers);
+        }
       }
       // TODO(zdapeng): in hedge case, if this is a fatal status, cancel all the other attempts, and
       // close the masterListener.

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -20,9 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import io.grpc.Attributes;
-import io.grpc.CallOptions;
 import io.grpc.Compressor;
-import io.grpc.Context;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -44,9 +42,6 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       Status.CANCELLED.withDescription("Stream thrown away because RetriableStream committed");
 
   private final MethodDescriptor<ReqT, ?> method;
-  private final CallOptions callOptions;
-  private final Metadata headers;
-  private final Context context;
 
   /** Must be held when updating state or accessing state.buffer. */
   private final Object lock = new Object();
@@ -57,15 +52,8 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
   private ClientStreamListener masterListener;
 
-  RetriableStream(
-      MethodDescriptor<ReqT, ?> method,
-      CallOptions callOptions,
-      Metadata headers,
-      Context context) {
+  RetriableStream(MethodDescriptor<ReqT, ?> method) {
     this.method = method;
-    this.callOptions = callOptions;
-    this.headers = headers;
-    this.context = context;
   }
 
   private boolean commit(ClientStream winningSubstream) {

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -396,9 +396,8 @@ final class RetriableStream<ReqT> implements ClientStream {
 
   @Override
   public Attributes getAttributes() {
-    // TODO(zdapeng): Hedging case need be handled properly.
-    if (state.drainedSubstreams.size() == 1) {
-      return state.drainedSubstreams.iterator().next().getAttributes();
+    if (state.winningSubstream != null) {
+      return state.winningSubstream.getAttributes();
     }
     return Attributes.EMPTY;
   }

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -51,7 +51,7 @@ final class RetriableStream<ReqT> implements ClientStream {
   private final DelayedClientTransport delayedClientTransport;
   private final Context context;
 
-  /** For reading and updating state. */
+  /** Must be held when updating state or accessing state.buffer. */
   private final Object lock = new Object();
 
   private volatile State state =

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -155,9 +155,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   /** Starts the first PRC attempt. */
   @Override
   public final void start(ClientStreamListener listener) {
-    Status shutdownStatus = prestart();
-
     masterListener = listener;
+
+    Status shutdownStatus = prestart();
 
     if (shutdownStatus != null) {
       cancel(shutdownStatus);

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -108,11 +108,11 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
       synchronized (lock) {
         savedState = state;
+        if (savedState.winningSubstream != null && savedState.winningSubstream != substream) {
+          // committed but not me
+          break;
+        }
         if (index == savedState.buffer.size()) { // I'm drained
-          if (savedState.winningSubstream != null && savedState.winningSubstream != substream) {
-            // committed but not me
-            break;
-          }
           state = savedState.drained(substream);
           return;
         }

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -1,0 +1,555 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.Compressor;
+import io.grpc.Context;
+import io.grpc.DecompressorRegistry;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+/** A logical {@link ClientStream} that is retriable. */
+final class RetriableStream<ReqT> implements ClientStream {
+  private static final String CANCELLED_BECAUSE_HEDGE_COMMITTED =
+      "Cancelled because a hedged RPC is committed";
+
+  private final MethodDescriptor<ReqT, ?> method;
+  private final CallOptions callOptions;
+  private final Metadata headers;
+  private final ClientTransportProvider clientTransportProvider;
+  private final DelayedClientTransport delayedClientTransport;
+  private final Context context;
+
+  /** For reading and updating state. */
+  private final Object lock = new Object();
+
+  private volatile State state =
+      new State(
+          new ArrayList<BufferEntry>(), Collections.<ClientStream>emptySet(), null, null, false);
+
+  private ClientStreamListener masterListener;
+
+  RetriableStream(
+      MethodDescriptor<ReqT, ?> method,
+      CallOptions callOptions,
+      Metadata headers,
+      ClientTransportProvider clientTransportProvider,
+      Context context) {
+    this.method = method;
+    this.callOptions = callOptions;
+    this.headers = headers;
+    this.clientTransportProvider = clientTransportProvider;
+    delayedClientTransport = clientTransportProvider.getDelayedTransport();
+    this.context = context;
+  }
+
+  private boolean commit(ClientStream winningSubstream) {
+    delayedClientTransport.removeUncommittedRetriableStream(this);
+
+    Collection<ClientStream> savedDrainedSubstreams;
+    synchronized (lock) {
+      if (state.winningSubstream != null) {
+        return false;
+      }
+
+      savedDrainedSubstreams = state.drainedSubstreams;
+
+      state = state.committed(winningSubstream);
+    }
+
+    // For hedging only, not needed for normal retry
+    // TODO(zdapeng): also cancel all the scheduled hedges.
+    for (ClientStream substream : savedDrainedSubstreams) {
+      if (substream != winningSubstream) {
+        substream.cancel(Status.CANCELLED.withDescription(CANCELLED_BECAUSE_HEDGE_COMMITTED));
+      }
+    }
+
+    return true;
+  }
+
+  private void retry() {
+    ClientStream substream = newSubstream();
+
+    // TODO(zdapeng): update "grpc-retry-attempts" header
+
+    drain(substream);
+  }
+
+  private ClientStream newSubstream() {
+    ClientTransport transport =
+        clientTransportProvider.get(new PickSubchannelArgsImpl(method, headers, callOptions));
+    Context origContext = context.attach();
+    try {
+      return transport.newStream(method, headers, callOptions);
+    } finally {
+      context.detach(origContext);
+    }
+  }
+
+  private void drain(ClientStream substream) {
+    int index = 0;
+    int chunk = 0x80;
+    List<BufferEntry> list = null;
+    Status status;
+
+    while (true) {
+      synchronized (lock) {
+        int stop = Math.min(index + chunk, state.buffer.size());
+        if (list == null) {
+          list = new ArrayList<BufferEntry>(stop - index);
+        }
+        list.clear();
+        list.addAll(state.buffer.subList(index, stop));
+        index = stop;
+      }
+
+      for (BufferEntry bufferEntry : list) {
+        State savedState = state;
+        if (savedState.cancellingStatus != null) {
+          substream.cancel(savedState.cancellingStatus);
+          return;
+        }
+        if (savedState.winningSubstream != null && savedState.winningSubstream != substream) {
+          // committed but not me
+          substream.cancel(Status.CANCELLED.withDescription(CANCELLED_BECAUSE_HEDGE_COMMITTED));
+          return;
+        }
+        bufferEntry.runWith(substream);
+      }
+
+      synchronized (lock) {
+        if (index != state.buffer.size()) { // I'm not drained
+          continue;
+        }
+
+        if (state.cancellingStatus != null) {
+          status = state.cancellingStatus;
+          break;
+        }
+        if (state.winningSubstream != null && state.winningSubstream != substream) {
+          // committed but not me
+          status = Status.CANCELLED.withDescription(CANCELLED_BECAUSE_HEDGE_COMMITTED);
+          break;
+        }
+
+        state = state.drained(substream);
+        return;
+      }
+    }
+
+    substream.cancel(status);
+  }
+
+  /** Starts the first PRC attempt. */
+  @Override
+  public void start(ClientStreamListener listener) {
+    masterListener = listener;
+    delayedClientTransport.addUncommittedRetriableStream(this);
+
+    class StartEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.start(new Sublistener(substream));
+      }
+    }
+
+    synchronized (lock) {
+      state.buffer.add(new StartEntry());
+    }
+
+    ClientStream substream = newSubstream();
+    drain(substream);
+
+    // TODO(zdapeng): schedule hedging if needed
+  }
+
+  @Override
+  public void cancel(Status reason) {
+    delayedClientTransport.removeUncommittedRetriableStream(this);
+
+    Collection<ClientStream> drainedSubstreams;
+    synchronized (lock) {
+      state = state.cancelled(reason);
+      drainedSubstreams = state.drainedSubstreams;
+    }
+
+    for (ClientStream substream : drainedSubstreams) {
+      substream.cancel(reason);
+    }
+
+    // TODO(zdapeng): also cancel all the scheduled attempts.
+  }
+
+  private void delayOrExecute(BufferEntry bufferEntry) {
+    Collection<ClientStream> savedDrainedSubstreams;
+    synchronized (lock) {
+      if (!state.passThrough) {
+        state.buffer.add(bufferEntry);
+      }
+      savedDrainedSubstreams = state.drainedSubstreams;
+    }
+
+    for (ClientStream substream : savedDrainedSubstreams) {
+      bufferEntry.runWith(substream);
+    }
+  }
+
+  /**
+   * Do not use it directly. Use {@link #sendMessage(ReqT)} instead because we don't use InputStream
+   * for buffering.
+   */
+  @Override
+  public void writeMessage(InputStream message) {
+    throw new IllegalStateException("RetriableStream.writeMessage() should not be called directly");
+  }
+
+  void sendMessage(final ReqT message) {
+    State savedState = state;
+    if (savedState.passThrough) {
+      savedState.winningSubstream.writeMessage(method.streamRequest(message));
+      return;
+    }
+
+    class SendMessageEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.writeMessage(method.streamRequest(message));
+      }
+    }
+
+    delayOrExecute(new SendMessageEntry());
+  }
+
+  @Override
+  public void request(final int numMessages) {
+    State savedState = state;
+    if (savedState.passThrough) {
+      savedState.winningSubstream.request(numMessages);
+      return;
+    }
+
+    class RequestEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.request(numMessages);
+      }
+    }
+
+    delayOrExecute(new RequestEntry());
+  }
+
+  @Override
+  public void flush() {
+    State savedState = state;
+    if (savedState.passThrough) {
+      savedState.winningSubstream.flush();
+      return;
+    }
+
+    class FlushEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.flush();
+      }
+    }
+
+    delayOrExecute(new FlushEntry());
+  }
+
+  @Override
+  public boolean isReady() {
+    for (ClientStream substream : state.drainedSubstreams) {
+      if (substream.isReady()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void setCompressor(final Compressor compressor) {
+    class CompressorEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.setCompressor(compressor);
+      }
+    }
+
+    delayOrExecute(new CompressorEntry());
+  }
+
+  @Override
+  public void setFullStreamDecompression(final boolean fullStreamDecompression) {
+    class FullStreamDecompressionEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.setFullStreamDecompression(fullStreamDecompression);
+      }
+    }
+
+    delayOrExecute(new FullStreamDecompressionEntry());
+  }
+
+  @Override
+  public void setMessageCompression(final boolean enable) {
+    class MessageCompressionEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.setMessageCompression(enable);
+      }
+    }
+
+    delayOrExecute(new MessageCompressionEntry());
+  }
+
+  @Override
+  public void halfClose() {
+    class HalfCloseEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.halfClose();
+      }
+    }
+
+    delayOrExecute(new HalfCloseEntry());
+  }
+
+  @Override
+  public void setAuthority(final String authority) {
+    class AuthorityEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.setAuthority(authority);
+      }
+    }
+
+    delayOrExecute(new AuthorityEntry());
+  }
+
+  @Override
+  public void setDecompressorRegistry(final DecompressorRegistry decompressorRegistry) {
+    class DecompressorRegistryEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.setDecompressorRegistry(decompressorRegistry);
+      }
+    }
+
+    delayOrExecute(new DecompressorRegistryEntry());
+  }
+
+  @Override
+  public void setMaxInboundMessageSize(final int maxSize) {
+    class MaxInboundMessageSizeEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.setMaxInboundMessageSize(maxSize);
+      }
+    }
+
+    delayOrExecute(new MaxInboundMessageSizeEntry());
+  }
+
+  @Override
+  public void setMaxOutboundMessageSize(final int maxSize) {
+    class MaxOutboundMessageSizeEntry implements BufferEntry {
+      @Override
+      public void runWith(ClientStream substream) {
+        substream.setMaxOutboundMessageSize(maxSize);
+      }
+    }
+
+    delayOrExecute(new MaxOutboundMessageSizeEntry());
+  }
+
+  @Override
+  public Attributes getAttributes() {
+    // TODO(zdapeng): Hedging case need be handled properly.
+    if (state.drainedSubstreams.size() == 1) {
+      return state.drainedSubstreams.iterator().next().getAttributes();
+    }
+    return Attributes.EMPTY;
+  }
+
+  // TODO(zdapeng): implement retry policy.
+  // Retry policy is obtained from the combination of the name resolver plus channel builder, and
+  // passed all the way down to this class.
+  private boolean shouldRetry() {
+    return false;
+  }
+
+  private boolean hasHedging() {
+    return false;
+  }
+
+  private interface BufferEntry {
+    /** Replays the buffer entry with the given stream. */
+    void runWith(ClientStream substream);
+  }
+
+  private final class Sublistener implements ClientStreamListener {
+    final ClientStream substream;
+
+    Sublistener(ClientStream substream) {
+      this.substream = substream;
+    }
+
+    @Override
+    public void headersRead(Metadata headers) {
+      if (commit(substream)) {
+        masterListener.headersRead(headers);
+      }
+    }
+
+    @Override
+    public void closed(Status status, Metadata trailers) {
+      if (shouldRetry()) {
+        // TODO(zdapeng): backoff and schedule; retry() should run in an executor
+        retry();
+      } else if (!hasHedging()) {
+        delayedClientTransport.removeUncommittedRetriableStream(RetriableStream.this);
+        masterListener.closed(status, trailers);
+      }
+      // TODO(zdapeng): in hedge case, if this is a fatal status, cancel all the other attempts, and
+      // close the masterListener.
+    }
+
+    @Override
+    public void messagesAvailable(MessageProducer producer) {
+      State savedState = state;
+      checkState(
+          savedState.winningSubstream != null, "Headers should be received prior to messages.");
+      if (savedState.winningSubstream != substream) {
+        return;
+      }
+      masterListener.messagesAvailable(producer);
+    }
+
+    @Override
+    public void onReady() {
+      // TODO(zdapeng): the more correct way to handle onReady
+      if (state.drainedSubstreams.contains(substream)) {
+        masterListener.onReady();
+      }
+    }
+  }
+
+  private static final class State {
+    /** Committed and the winning substream drained. */
+    final boolean passThrough;
+
+    /** A list of buffered ClientStream runnables. Set to Null once passThrough. */
+    @Nullable final List<BufferEntry> buffer;
+
+    /**
+     * Unmodifiable collection of all the substreams that are drained. Exceptional cases: Singleton
+     * once passThrough; Empty if committed but not passTrough.
+     */
+    final Collection<ClientStream> drainedSubstreams;
+
+    /** Null until committed. */
+    @Nullable final ClientStream winningSubstream;
+
+    @Nullable final Status cancellingStatus;
+
+    State(
+        @Nullable List<BufferEntry> buffer,
+        Collection<ClientStream> drainedSubstreams,
+        @Nullable ClientStream winningSubstream,
+        @Nullable Status cancellingStatus,
+        boolean passThrough) {
+      this.buffer = buffer;
+      this.drainedSubstreams =
+          Collections.unmodifiableCollection(checkNotNull(drainedSubstreams, "drainedSubstreams"));
+      this.winningSubstream = winningSubstream;
+      this.cancellingStatus = cancellingStatus;
+      this.passThrough = passThrough;
+
+      checkState(!passThrough || buffer == null, "passThrough should imply buffer is null");
+      checkState(
+          !passThrough || winningSubstream != null,
+          "passThrough should imply winningSubstream != null");
+      checkState(
+          !passThrough
+              || (drainedSubstreams.size() == 1 && drainedSubstreams.contains(winningSubstream)),
+          "assThrough should imply winningSubstream is drained");
+    }
+
+    @CheckReturnValue
+    @GuardedBy("lock")
+    State cancelled(Status cancellingStatus) {
+      return new State(buffer, drainedSubstreams, winningSubstream, cancellingStatus, passThrough);
+    }
+
+    /** The given substream is drained. */
+    @CheckReturnValue
+    @GuardedBy("lock")
+    State drained(ClientStream substream) {
+      checkState(!passThrough, "Already passThrough");
+
+      Set<ClientStream> drainedSubstreams = new HashSet<ClientStream>();
+      drainedSubstreams.addAll(this.drainedSubstreams);
+      drainedSubstreams.add(substream);
+
+      boolean passThrough = winningSubstream != null;
+
+      List<BufferEntry> buffer = this.buffer;
+      if (passThrough) {
+        checkState(winningSubstream == substream, "Another RPC attempt has already committed");
+        buffer = null;
+      }
+
+      return new State(buffer, drainedSubstreams, winningSubstream, cancellingStatus, passThrough);
+    }
+
+    @CheckReturnValue
+    @GuardedBy("lock")
+    State committed(ClientStream winningSubstream) {
+      checkState(this.winningSubstream == null, "Already committed");
+
+      boolean passThrough = false;
+      List<BufferEntry> buffer = this.buffer;
+      Collection<ClientStream> drainedSubstreams = Collections.emptySet();
+
+      if (this.drainedSubstreams.contains(winningSubstream)) {
+        passThrough = true;
+        buffer = null;
+        drainedSubstreams = Collections.singleton(winningSubstream);
+      }
+
+      return new State(buffer, drainedSubstreams, winningSubstream, cancellingStatus, passThrough);
+    }
+  }
+}

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -1,0 +1,557 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.Compressor;
+import io.grpc.DecompressorRegistry;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.Status;
+import io.grpc.StringMarshaller;
+import java.io.InputStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+/**
+ * Unit tests for {@link RetriableStream}.
+ */
+@RunWith(JUnit4.class)
+public class RetriableStreamTest {
+  private static final String CANCELLED_BECAUSE_COMMITTED =
+      "Stream thrown away because RetriableStream committed";
+  private static final String AUTHORITY = "fakeAuthority";
+  private static final Compressor COMPRESSOR = mock(Compressor.class);
+  private static final DecompressorRegistry DECOMPRESSOR_REGISTRY =
+      DecompressorRegistry.getDefaultInstance();
+  private static final int MAX_INBOUND_MESSAGE_SIZE = 1234;
+  private static final int MAX_OUTNBOUND_MESSAGE_SIZE = 5678;
+
+  private final MethodDescriptor<String, String> method =
+      MethodDescriptor.<String, String>newBuilder().setType(MethodType.BIDI_STREAMING)
+          .setFullMethodName(MethodDescriptor.generateFullMethodName("service_foo", "method_bar"))
+          .setRequestMarshaller(new StringMarshaller())
+          .setResponseMarshaller(new StringMarshaller()).build();
+  private final ClientStreamListener masterListener = mock(ClientStreamListener.class);
+
+  // TODO(zdapeng): for mockito 2.7+: instead of spy(an_impl),
+  // use mock(RetriableStream.class, withSettings().useConstructorArgs(method))
+  private final RetriableStream<String> retriableStream = spy(new RetriableStream<String>(method) {
+    @Override
+    void postCommit() {
+    }
+
+    @Override
+    ClientStream newSubstream() {
+      return null;
+    }
+
+    @Override
+    Status prestart() {
+      return null;
+    }
+  });
+
+  private void setShouldRetry(boolean shouldRetry) {
+    doReturn(shouldRetry).when(retriableStream).shouldRetry();
+  }
+
+  private void setNextSubstream(ClientStream clientStream) {
+    doReturn(clientStream).when(retriableStream).newSubstream();
+  }
+
+
+  @Test
+  public void retry_everythingDrained() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    setNextSubstream(mockStream1);
+    InOrder inOrder = inOrder(retriableStream, masterListener, mockStream1);
+
+    // stream settings before start
+    retriableStream.setAuthority(AUTHORITY);
+    retriableStream.setCompressor(COMPRESSOR);
+    retriableStream.setDecompressorRegistry(DECOMPRESSOR_REGISTRY);
+    retriableStream.setFullStreamDecompression(false);
+    retriableStream.setFullStreamDecompression(true);
+    retriableStream.setMaxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE);
+    retriableStream.setMessageCompression(true);
+    retriableStream.setMaxOutboundMessageSize(MAX_OUTNBOUND_MESSAGE_SIZE);
+    retriableStream.setMessageCompression(false);
+
+    inOrder.verifyNoMoreInteractions();
+
+    // start
+    retriableStream.start(masterListener);
+
+    inOrder.verify(retriableStream).prestart();
+    inOrder.verify(retriableStream).newSubstream();
+
+    inOrder.verify(mockStream1).setAuthority(AUTHORITY);
+    inOrder.verify(mockStream1).setCompressor(COMPRESSOR);
+    inOrder.verify(mockStream1).setDecompressorRegistry(DECOMPRESSOR_REGISTRY);
+    inOrder.verify(mockStream1).setFullStreamDecompression(false);
+    inOrder.verify(mockStream1).setFullStreamDecompression(true);
+    inOrder.verify(mockStream1).setMaxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE);
+    inOrder.verify(mockStream1).setMessageCompression(true);
+    inOrder.verify(mockStream1).setMaxOutboundMessageSize(MAX_OUTNBOUND_MESSAGE_SIZE);
+    inOrder.verify(mockStream1).setMessageCompression(false);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    inOrder.verify(mockStream1).start(sublistenerCaptor1.capture());
+    inOrder.verifyNoMoreInteractions();
+
+    retriableStream.sendMessage("msg1");
+    retriableStream.sendMessage("msg2");
+    retriableStream.request(345);
+    retriableStream.flush();
+    retriableStream.flush();
+    retriableStream.sendMessage("msg3");
+    retriableStream.request(456);
+
+    inOrder.verify(mockStream1, times(2)).writeMessage(any(InputStream.class));
+    inOrder.verify(mockStream1).request(345);
+    inOrder.verify(mockStream1, times(2)).flush();
+    inOrder.verify(mockStream1).writeMessage(any(InputStream.class));
+    inOrder.verify(mockStream1).request(456);
+    inOrder.verifyNoMoreInteractions();
+
+    // retry1
+    ClientStream mockStream2 = mock(ClientStream.class);
+    setNextSubstream(mockStream2);
+    inOrder = inOrder(retriableStream, masterListener, mockStream1, mockStream2);
+    setShouldRetry(true);
+    sublistenerCaptor1.getValue().closed(Status.UNAVAILABLE, new Metadata());
+
+    inOrder.verify(retriableStream).shouldRetry();
+    // TODO(zdapeng): send more messages dureing backoff, then forward backoff ticker
+    inOrder.verify(retriableStream).newSubstream();
+    inOrder.verify(mockStream2).setAuthority(AUTHORITY);
+    inOrder.verify(mockStream2).setCompressor(COMPRESSOR);
+    inOrder.verify(mockStream2).setDecompressorRegistry(DECOMPRESSOR_REGISTRY);
+    inOrder.verify(mockStream2).setFullStreamDecompression(false);
+    inOrder.verify(mockStream2).setFullStreamDecompression(true);
+    inOrder.verify(mockStream2).setMaxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE);
+    inOrder.verify(mockStream2).setMessageCompression(true);
+    inOrder.verify(mockStream2).setMaxOutboundMessageSize(MAX_OUTNBOUND_MESSAGE_SIZE);
+    inOrder.verify(mockStream2).setMessageCompression(false);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    inOrder.verify(mockStream2).start(sublistenerCaptor2.capture());
+    inOrder.verify(mockStream2, times(2)).writeMessage(any(InputStream.class));
+    inOrder.verify(mockStream2).request(345);
+    inOrder.verify(mockStream2, times(2)).flush();
+    inOrder.verify(mockStream2).writeMessage(any(InputStream.class));
+    inOrder.verify(mockStream2).request(456);
+    inOrder.verifyNoMoreInteractions();
+
+    // send more messages
+    retriableStream.sendMessage("msg1 after retry1");
+    retriableStream.sendMessage("msg2 after retry1");
+
+    // retry2
+    ClientStream mockStream3 = mock(ClientStream.class);
+    setNextSubstream(mockStream3);
+    inOrder = inOrder(retriableStream, masterListener, mockStream1, mockStream2, mockStream3);
+    setShouldRetry(true);
+    sublistenerCaptor2.getValue().closed(Status.UNAVAILABLE, new Metadata());
+
+    inOrder.verify(retriableStream).shouldRetry();
+    // TODO(zdapeng): send more messages dureing backoff, then forward backoff ticker
+    inOrder.verify(retriableStream).newSubstream();
+    inOrder.verify(mockStream3).setAuthority(AUTHORITY);
+    inOrder.verify(mockStream3).setCompressor(COMPRESSOR);
+    inOrder.verify(mockStream3).setDecompressorRegistry(DECOMPRESSOR_REGISTRY);
+    inOrder.verify(mockStream3).setFullStreamDecompression(false);
+    inOrder.verify(mockStream3).setFullStreamDecompression(true);
+    inOrder.verify(mockStream3).setMaxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE);
+    inOrder.verify(mockStream3).setMessageCompression(true);
+    inOrder.verify(mockStream3).setMaxOutboundMessageSize(MAX_OUTNBOUND_MESSAGE_SIZE);
+    inOrder.verify(mockStream3).setMessageCompression(false);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor3 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    inOrder.verify(mockStream3).start(sublistenerCaptor3.capture());
+    inOrder.verify(mockStream3, times(2)).writeMessage(any(InputStream.class));
+    inOrder.verify(mockStream3).request(345);
+    inOrder.verify(mockStream3, times(2)).flush();
+    inOrder.verify(mockStream3).writeMessage(any(InputStream.class));
+    inOrder.verify(mockStream3).request(456);
+    inOrder.verify(mockStream3, times(2)).writeMessage(any(InputStream.class));
+    inOrder.verifyNoMoreInteractions();
+
+
+    // no more retry
+    setShouldRetry(false);
+    sublistenerCaptor3.getValue().closed(Status.UNAVAILABLE, new Metadata());
+
+    inOrder.verify(retriableStream).shouldRetry();
+    inOrder.verify(retriableStream).postCommit();
+    inOrder.verify(masterListener).closed(any(Status.class), any(Metadata.class));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void headersRead_cancel() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    setNextSubstream(mockStream1);
+    InOrder inOrder = inOrder(retriableStream);
+
+    retriableStream.start(masterListener);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream1).start(sublistenerCaptor1.capture());
+
+    sublistenerCaptor1.getValue().headersRead(new Metadata());
+
+    inOrder.verify(retriableStream).postCommit();
+
+    retriableStream.cancel(Status.CANCELLED);
+
+    inOrder.verify(retriableStream, never()).postCommit();
+  }
+
+  @Test
+  public void retry_headersRead_cancel() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    setNextSubstream(mockStream1);
+    InOrder inOrder = inOrder(retriableStream);
+
+    retriableStream.start(masterListener);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream1).start(sublistenerCaptor1.capture());
+
+    // retry
+    // TODO(zdapeng): forward backoff ticker
+    setShouldRetry(true);
+    ClientStream mockStream2 = mock(ClientStream.class);
+    setNextSubstream(mockStream2);
+    sublistenerCaptor1.getValue().closed(Status.UNAVAILABLE, new Metadata());
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream2).start(sublistenerCaptor2.capture());
+    inOrder.verify(retriableStream, never()).postCommit();
+
+    // headersRead
+    sublistenerCaptor2.getValue().headersRead(new Metadata());
+
+    inOrder.verify(retriableStream).postCommit();
+
+    // cancel
+    retriableStream.cancel(Status.CANCELLED);
+
+    inOrder.verify(retriableStream, never()).postCommit();
+  }
+
+  @Test
+  public void headersRead_closed() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    setNextSubstream(mockStream1);
+    InOrder inOrder = inOrder(retriableStream);
+
+    retriableStream.start(masterListener);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream1).start(sublistenerCaptor1.capture());
+
+    sublistenerCaptor1.getValue().headersRead(new Metadata());
+
+    inOrder.verify(retriableStream).postCommit();
+
+    Status status = Status.UNAVAILABLE;
+    Metadata metadata = new Metadata();
+    sublistenerCaptor1.getValue().closed(status, metadata);
+
+    inOrder.verify(retriableStream, never()).postCommit();
+    verify(masterListener).closed(status, metadata);
+  }
+
+  @Test
+  public void retry_headersRead_closed() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    setNextSubstream(mockStream1);
+    InOrder inOrder = inOrder(retriableStream);
+
+    retriableStream.start(masterListener);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream1).start(sublistenerCaptor1.capture());
+
+    // retry
+    // TODO(zdapeng): forward backoff ticker
+    setShouldRetry(true);
+    ClientStream mockStream2 = mock(ClientStream.class);
+    setNextSubstream(mockStream2);
+    sublistenerCaptor1.getValue().closed(Status.UNAVAILABLE, new Metadata());
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream2).start(sublistenerCaptor2.capture());
+    inOrder.verify(retriableStream, never()).postCommit();
+
+    // headersRead
+    sublistenerCaptor2.getValue().headersRead(new Metadata());
+
+    inOrder.verify(retriableStream).postCommit();
+
+    // closed
+    setShouldRetry(false);
+    Status status = Status.UNAVAILABLE;
+    Metadata metadata = new Metadata();
+    sublistenerCaptor2.getValue().closed(status, metadata);
+
+    inOrder.verify(retriableStream, never()).postCommit();
+    verify(masterListener).closed(status, metadata);
+  }
+
+  @Test
+  public void cancel_closed() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    setNextSubstream(mockStream1);
+    InOrder inOrder = inOrder(retriableStream);
+
+    retriableStream.start(masterListener);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream1).start(sublistenerCaptor1.capture());
+
+    // cancel
+    retriableStream.cancel(Status.CANCELLED);
+
+    inOrder.verify(retriableStream).postCommit();
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+    verify(mockStream1).cancel(statusCaptor.capture());
+    assertEquals(Status.CANCELLED.getCode(), statusCaptor.getValue().getCode());
+    assertEquals(CANCELLED_BECAUSE_COMMITTED, statusCaptor.getValue().getDescription());
+
+    // closed
+    setShouldRetry(false);
+    Status status = Status.UNAVAILABLE;
+    Metadata metadata = new Metadata();
+    sublistenerCaptor1.getValue().closed(status, metadata);
+    inOrder.verify(retriableStream, never()).postCommit();
+  }
+
+  @Test
+  public void retry_cancel_closed() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    setNextSubstream(mockStream1);
+    InOrder inOrder = inOrder(retriableStream);
+
+    retriableStream.start(masterListener);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream1).start(sublistenerCaptor1.capture());
+
+    // retry
+    // TODO(zdapeng): forward backoff ticker
+    setShouldRetry(true);
+    ClientStream mockStream2 = mock(ClientStream.class);
+    setNextSubstream(mockStream2);
+    sublistenerCaptor1.getValue().closed(Status.UNAVAILABLE, new Metadata());
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream2).start(sublistenerCaptor2.capture());
+    inOrder.verify(retriableStream, never()).postCommit();
+
+    // cancel
+    retriableStream.cancel(Status.CANCELLED);
+
+    inOrder.verify(retriableStream).postCommit();
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+    verify(mockStream2).cancel(statusCaptor.capture());
+    assertEquals(Status.CANCELLED.getCode(), statusCaptor.getValue().getCode());
+    assertEquals(CANCELLED_BECAUSE_COMMITTED, statusCaptor.getValue().getDescription());
+
+    // closed
+    setShouldRetry(false);
+    Status status = Status.UNAVAILABLE;
+    Metadata metadata = new Metadata();
+    sublistenerCaptor2.getValue().closed(status, metadata);
+    inOrder.verify(retriableStream, never()).postCommit();
+  }
+
+  @Test
+  public void unretriableClosed_cancel() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    setNextSubstream(mockStream1);
+    InOrder inOrder = inOrder(retriableStream);
+
+    retriableStream.start(masterListener);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream1).start(sublistenerCaptor1.capture());
+
+    // closed
+    Status status = Status.UNAVAILABLE;
+    Metadata metadata = new Metadata();
+    sublistenerCaptor1.getValue().closed(status, metadata);
+
+    inOrder.verify(retriableStream).postCommit();
+    verify(masterListener).closed(status, metadata);
+
+    // cancel
+    retriableStream.cancel(Status.CANCELLED);
+    inOrder.verify(retriableStream, never()).postCommit();
+  }
+
+  @Test
+  public void retry_unretriableClosed_cancel() {
+    ClientStream mockStream1 = mock(ClientStream.class);
+    setNextSubstream(mockStream1);
+    InOrder inOrder = inOrder(retriableStream);
+
+    retriableStream.start(masterListener);
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream1).start(sublistenerCaptor1.capture());
+
+    // retry
+    // TODO(zdapeng): forward backoff ticker
+    setShouldRetry(true);
+    ClientStream mockStream2 = mock(ClientStream.class);
+    setNextSubstream(mockStream2);
+    sublistenerCaptor1.getValue().closed(Status.UNAVAILABLE, new Metadata());
+
+    ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    verify(mockStream2).start(sublistenerCaptor2.capture());
+    inOrder.verify(retriableStream, never()).postCommit();
+
+    // closed
+    setShouldRetry(false);
+    Status status = Status.UNAVAILABLE;
+    Metadata metadata = new Metadata();
+    sublistenerCaptor2.getValue().closed(status, metadata);
+
+    inOrder.verify(retriableStream).postCommit();
+    verify(masterListener).closed(status, metadata);
+
+    // cancel
+    retriableStream.cancel(Status.CANCELLED);
+    inOrder.verify(retriableStream, never()).postCommit();
+  }
+
+  @Test
+  public void retry_cancelWhileBackoff() {
+    // TODO(zdapeng)
+  }
+
+
+  @Test
+  public void operationsWhileDraining() {
+    final ArgumentCaptor<ClientStreamListener> sublistenerCaptor1 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    final ArgumentCaptor<ClientStreamListener> sublistenerCaptor2 =
+        ArgumentCaptor.forClass(ClientStreamListener.class);
+    final Status cancelStatus = Status.CANCELLED.withDescription("c");
+    ClientStream mockStream1 = spy(new NoopClientStream() {
+      @Override
+      public void request(int numMessages) {
+        retriableStream.sendMessage("substream1 request " + numMessages);
+        if (numMessages > 1) {
+          retriableStream.request(--numMessages);
+        }
+      }
+    });
+
+    ClientStream mockStream2 = spy(new NoopClientStream() {
+      @Override
+      public void request(int numMessages) {
+        retriableStream.sendMessage("substream2 request " + numMessages);
+
+        if (numMessages == 3) {
+          verify(this).start(sublistenerCaptor2.capture());
+          sublistenerCaptor2.getValue().headersRead(new Metadata());
+        }
+        if (numMessages == 2) {
+          retriableStream.request(100);
+        }
+        if (numMessages == 100) {
+          retriableStream.cancel(cancelStatus);
+        }
+      }
+    });
+
+    InOrder inOrder = inOrder(retriableStream, mockStream1, mockStream2);
+
+    setNextSubstream(mockStream1);
+    retriableStream.start(masterListener);
+
+    inOrder.verify(mockStream1).start(sublistenerCaptor1.capture());
+
+    retriableStream.request(3);
+
+    inOrder.verify(mockStream1).request(3);
+    inOrder.verify(mockStream1).writeMessage(any(InputStream.class)); // msg "substream1 request 3"
+    inOrder.verify(mockStream1).request(2);
+    inOrder.verify(mockStream1).writeMessage(any(InputStream.class)); // msg "substream1 request 2"
+    inOrder.verify(mockStream1).request(1);
+    inOrder.verify(mockStream1).writeMessage(any(InputStream.class)); // msg "substream1 request 1"
+
+    // retry
+    // TODO(zdapeng): send more messages dureing backoff, then forward backoff ticker
+    setShouldRetry(true);
+    setNextSubstream(mockStream2);
+    sublistenerCaptor1.getValue().closed(Status.UNAVAILABLE, new Metadata());
+
+    inOrder.verify(mockStream2).start(sublistenerCaptor2.capture());
+
+    inOrder.verify(mockStream2).request(3);
+    inOrder.verify(retriableStream).postCommit();
+    inOrder.verify(mockStream2).writeMessage(any(InputStream.class)); // msg "substream1 request 3"
+    inOrder.verify(mockStream2).request(2);
+    inOrder.verify(mockStream2).writeMessage(any(InputStream.class)); // msg "substream1 request 2"
+    inOrder.verify(mockStream2).request(1);
+
+    // msg "substream1 request 1"
+    // msg "substream2 request 3"
+    // msg "substream2 request 2"
+    inOrder.verify(mockStream2, times(3)).writeMessage(any(InputStream.class));
+    inOrder.verify(mockStream2).request(100);
+
+    verify(mockStream2).cancel(cancelStatus);
+
+    // "substream2 request 1" will never be sent
+    inOrder.verify(mockStream2, never()).writeMessage(any(InputStream.class));
+  }
+}

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -364,7 +364,8 @@ public class RetriableStreamTest {
     assertEquals(CANCELLED_BECAUSE_COMMITTED, statusCaptor.getValue().getDescription());
 
     // closed
-    doReturn(false).when(retriableStreamRecorder).shouldRetry();
+    // even shouldRetry() returns true
+    doReturn(true).when(retriableStreamRecorder).shouldRetry();
     Status status = Status.UNAVAILABLE;
     Metadata metadata = new Metadata();
     sublistenerCaptor1.getValue().closed(status, metadata);


### PR DESCRIPTION
With an approach using a variant of `DelayedStream` - `RetriableStream`.

`RetriableStream` is a logical stream per call that can create a sequence of `substreams`, the physical streams for the retry attempts. It could also create a family of substreams in parallel in hedging case.
 
`RetriableStream` buffers, delays and executes stream operations before `passThrough`, where `passThrough` is meant by `commit` as well as the buffer `drained` by the winning substream.

This PR only implements buffering messages and replaying buffered messages when retry.
Retry policy, hedging, transparent retry, backoff, max buffer size and APIs that users can enable retry are not included in this PR.