### PR TITLE
interop-testing:  make max size tests more deterministic

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1187,7 +1187,7 @@ public abstract class AbstractInteropTest {
         md.toBuilder(mar, md.getResponseMarshaller()).build(),
         blockingStub.getCallOptions(),
         request)
-            .next();
+        .next();
 
     int size = mar.lastOutSize;
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -18,6 +18,7 @@ package io.grpc.testing.integration;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.instrumentation.stats.ContextUtils.STATS_CONTEXT_KEY;
+import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.testing.integration.Messages.PayloadType.COMPRESSABLE;
 import static io.opencensus.trace.unsafe.ContextUtils.CONTEXT_SPAN_KEY;
 import static org.junit.Assert.assertEquals;
@@ -97,6 +98,7 @@ import io.grpc.testing.integration.Messages.StreamingOutputCallRequest;
 import io.grpc.testing.integration.Messages.StreamingOutputCallResponse;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.unsafe.ContextUtils;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.cert.Certificate;
@@ -1116,7 +1118,19 @@ public abstract class AbstractInteropTest {
     StreamingOutputCallRequest request = StreamingOutputCallRequest.newBuilder()
         .addResponseParameters(ResponseParameters.newBuilder().setSize(1))
         .build();
-    int size = blockingStub.streamingOutputCall(request).next().getSerializedSize();
+
+    MethodDescriptor<StreamingOutputCallRequest, StreamingOutputCallResponse> md =
+        TestServiceGrpc.getStreamingOutputCallMethod();
+    ByteSizeMarshaller<StreamingOutputCallResponse> mar =
+        new ByteSizeMarshaller<StreamingOutputCallResponse>(md.getResponseMarshaller());
+    blockingServerStreamingCall(
+        blockingStub.getChannel(),
+        md.toBuilder(md.getRequestMarshaller(), mar).build(),
+        blockingStub.getCallOptions(),
+        request)
+            .next();
+
+    int size = mar.lastInSize;
 
     TestServiceGrpc.TestServiceBlockingStub stub =
         blockingStub.withMaxInboundMessageSize(size);
@@ -1129,7 +1143,19 @@ public abstract class AbstractInteropTest {
     StreamingOutputCallRequest request = StreamingOutputCallRequest.newBuilder()
         .addResponseParameters(ResponseParameters.newBuilder().setSize(1))
         .build();
-    int size = blockingStub.streamingOutputCall(request).next().getSerializedSize();
+    
+    MethodDescriptor<StreamingOutputCallRequest, StreamingOutputCallResponse> md =
+        TestServiceGrpc.getStreamingOutputCallMethod();
+    ByteSizeMarshaller<StreamingOutputCallRequest> mar =
+        new ByteSizeMarshaller<StreamingOutputCallRequest>(md.getRequestMarshaller());
+    blockingServerStreamingCall(
+        blockingStub.getChannel(),
+        md.toBuilder(mar, md.getResponseMarshaller()).build(),
+        blockingStub.getCallOptions(),
+        request)
+        .next();
+
+    int size = mar.lastOutSize;
 
     TestServiceGrpc.TestServiceBlockingStub stub =
         blockingStub.withMaxInboundMessageSize(size - 1);
@@ -1146,29 +1172,50 @@ public abstract class AbstractInteropTest {
 
   @Test
   public void maxOutboundSize_exact() {
-    // warm up the channel and JVM
-    blockingStub.emptyCall(Empty.getDefaultInstance());
-
-    // set at least one field to ensure the size is non-zero.
     StreamingOutputCallRequest request = StreamingOutputCallRequest.newBuilder()
         .addResponseParameters(ResponseParameters.newBuilder().setSize(1))
         .build();
+
+    MethodDescriptor<StreamingOutputCallRequest, StreamingOutputCallResponse> md =
+        TestServiceGrpc.getStreamingOutputCallMethod();
+    ByteSizeMarshaller<StreamingOutputCallRequest> mar =
+        new ByteSizeMarshaller<StreamingOutputCallRequest>(md.getRequestMarshaller());
+    blockingServerStreamingCall(
+        blockingStub.getChannel(),
+        md.toBuilder(mar, md.getResponseMarshaller()).build(),
+        blockingStub.getCallOptions(),
+        request)
+            .next();
+
+    int size = mar.lastOutSize;
+
     TestServiceGrpc.TestServiceBlockingStub stub =
-        blockingStub.withMaxOutboundMessageSize(request.getSerializedSize());
+        blockingStub.withMaxOutboundMessageSize(size);
 
     stub.streamingOutputCall(request).next();
   }
 
   @Test
   public void maxOutboundSize_tooBig() {
-    // warm up the channel and JVM
-    blockingStub.emptyCall(Empty.getDefaultInstance());
     // set at least one field to ensure the size is non-zero.
     StreamingOutputCallRequest request = StreamingOutputCallRequest.newBuilder()
         .addResponseParameters(ResponseParameters.newBuilder().setSize(1))
         .build();
+
+
+    MethodDescriptor<StreamingOutputCallRequest, StreamingOutputCallResponse> md =
+        TestServiceGrpc.getStreamingOutputCallMethod();
+    ByteSizeMarshaller<StreamingOutputCallRequest> mar =
+        new ByteSizeMarshaller<StreamingOutputCallRequest>(md.getRequestMarshaller());
+    blockingServerStreamingCall(
+        blockingStub.getChannel(),
+        md.toBuilder(mar, md.getResponseMarshaller()).build(),
+        blockingStub.getCallOptions(),
+        request)
+        .next();
+
     TestServiceGrpc.TestServiceBlockingStub stub =
-        blockingStub.withMaxOutboundMessageSize(request.getSerializedSize() - 1);
+        blockingStub.withMaxOutboundMessageSize(mar.lastOutSize - 1);
     try {
       stub.streamingOutputCall(request).next();
       fail();
@@ -1965,5 +2012,54 @@ public abstract class AbstractInteropTest {
         return next.startCall(call, requestHeaders);
       }
     };
+  }
+
+  /**
+   * A marshaller that record input and output sizes.
+   */
+  private static final class ByteSizeMarshaller<T> implements MethodDescriptor.Marshaller<T> {
+
+    private final MethodDescriptor.Marshaller<T> delegate;
+    volatile int lastOutSize;
+    volatile int lastInSize;
+
+    ByteSizeMarshaller(MethodDescriptor.Marshaller<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public InputStream stream(T value) {
+      InputStream is = delegate.stream(value);
+      byte[] dst = new byte[16 * 1024 * 1024];
+      int total = 0;
+      try {
+        for (int r; (r = is.read(dst, total, dst.length - total)) != -1; total += r) {
+          if (r == 0 && total == dst.length) {
+            throw new RuntimeException("out of space");
+          }
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      lastOutSize = total;
+      return new ByteArrayInputStream(dst, 0, total);
+    }
+
+    @Override
+    public T parse(InputStream stream) {
+      byte[] dst = new byte[16 * 1024 * 1024];
+      int total = 0;
+      try {
+        for (int r; (r = stream.read(dst, total, dst.length - total)) != -1; total += r) {
+          if (r == 0 && total == dst.length) {
+            throw new RuntimeException("out of space");
+          }
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      lastInSize = total;
+      return delegate.parse(new ByteArrayInputStream(dst, 0, total));
+    }
   }
 }


### PR DESCRIPTION
This change removes some of the non deterministic size outputs for
proto.  Instead of serializing the message and measuring the size,
measure before serialization.  As long as the remote always returns
using the same encoder, this should be stable.

Fixes: #3547