### PR TITLE
android-interop-testing,examples: bump minimumSdkVersion to 14

### DIFF
--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -7,7 +7,8 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.android.integrationtest"
-        minSdkVersion 9
+        // API level 14+ is required for TLS since Google Play Services v10.2
+        minSdkVersion 14
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/android-interop-testing/app/src/main/AndroidManifest.xml
+++ b/android-interop-testing/app/src/main/AndroidManifest.xml
@@ -2,8 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.grpc.android.integrationtest" >
 
+    <!-- API level 14+ is required for TLS since Google Play Services v10.2 -->
     <uses-sdk
-        android:minSdkVersion="9"
+        android:minSdkVersion="14"
         android:targetSdkVersion="22"/>
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -7,7 +7,8 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.android.helloworldexample"
-        minSdkVersion 9
+        // API level 14+ is required for TLS since Google Play Services v10.2
+        minSdkVersion 14
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Bumps `minSdkVersion` to 14. This is the minimum API level supported by recent Google Play Services, and also required by some internal Android tooling. This also bumps the minSdkVersion for the helloworld example (our routeguide example already has a higher minSdkVersion set, so just left that alone).