### PR TITLE
netty: bump correct value of outbound msg counter

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -64,7 +64,7 @@ public abstract class AbstractClientStream extends AbstractStream
      * @param endOfStream {@code true} if this is the last frame; {@code flush} is guaranteed to be
      *     {@code true} if this is {@code true}
      * @param flush {@code true} if more data may not be arriving soon
-     * @Param numMessages the number of messages this series of frames represents
+     * @Param numMessages the number of messages this series of frames represents, must be >= 0.
      */
     void writeFrame(
         @Nullable WritableBuffer frame, boolean endOfStream, boolean flush, int numMessages);

--- a/core/src/main/java/io/grpc/internal/TransportTracer.java
+++ b/core/src/main/java/io/grpc/internal/TransportTracer.java
@@ -76,7 +76,7 @@ public final class TransportTracer {
   }
 
   /**
-   * Reports that some messages were successfully sent. {@code numMessages} must be at least 1.
+   * Reports that some messages were successfully sent. {@code numMessages} must be at least 0.
    */
   public void reportMessageSent(int numMessages) {
     if (numMessages == 0) {

--- a/core/src/main/java/io/grpc/internal/TransportTracer.java
+++ b/core/src/main/java/io/grpc/internal/TransportTracer.java
@@ -76,10 +76,11 @@ public final class TransportTracer {
   }
 
   /**
-   * Reports that a message was successfully sent. This method is thread safe.
+   * Reports that some messages were successfully sent. {@code numMessages} must be at least 1.
    */
-  public void reportMessageSent() {
-    messagesSent++;
+  public void reportMessageSent(int numMessages) {
+    Preconditions.checkArgument(numMessages > 0);
+    messagesSent += numMessages;
     lastMessageSentTimeNanos = currentTimeNanos();
   }
 

--- a/core/src/main/java/io/grpc/internal/TransportTracer.java
+++ b/core/src/main/java/io/grpc/internal/TransportTracer.java
@@ -79,7 +79,9 @@ public final class TransportTracer {
    * Reports that some messages were successfully sent. {@code numMessages} must be at least 1.
    */
   public void reportMessageSent(int numMessages) {
-    Preconditions.checkArgument(numMessages > 0);
+    if (numMessages == 0) {
+      return;
+    }
     messagesSent += numMessages;
     lastMessageSentTimeNanos = currentTimeNanos();
   }

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -585,6 +585,7 @@ class NettyServerHandler extends AbstractNettyHandler {
     }
     // Call the base class to write the HTTP/2 DATA frame.
     encoder().writeData(ctx, cmd.streamId(), cmd.content(), 0, cmd.endStream(), promise);
+    transportTracer.reportMessageSent(cmd.getNumMessages());
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -585,7 +585,6 @@ class NettyServerHandler extends AbstractNettyHandler {
     }
     // Call the base class to write the HTTP/2 DATA frame.
     encoder().writeData(ctx, cmd.streamId(), cmd.content(), 0, cmd.endStream(), promise);
-    transportTracer.reportMessageSent(cmd.getNumMessages());
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -129,9 +129,6 @@ class NettyServerStream extends AbstractServerStream {
               // Remove the bytes from outbound flow control, optionally notifying
               // the client that they can send more bytes.
               transportState().onSentBytes(numBytes);
-              if (future.isSuccess()) {
-                transportTracer.reportMessageSent();
-              }
             }
           }), flush);
     }

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -18,6 +18,7 @@ package io.grpc.netty;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -112,7 +113,8 @@ class NettyServerStream extends AbstractServerStream {
     }
 
     @Override
-    public void writeFrame(WritableBuffer frame, boolean flush, int numMessages) {
+    public void writeFrame(WritableBuffer frame, boolean flush, final int numMessages) {
+      Preconditions.checkArgument(numMessages >= 0);
       if (frame == null) {
         writeQueue.scheduleFlush();
         return;
@@ -122,13 +124,16 @@ class NettyServerStream extends AbstractServerStream {
       // Add the bytes to outbound flow control.
       onSendingBytes(numBytes);
       writeQueue.enqueue(
-          new SendGrpcFrameCommand(transportState(), bytebuf, false, numMessages),
+          new SendGrpcFrameCommand(transportState(), bytebuf, false),
           channel.newPromise().addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
               // Remove the bytes from outbound flow control, optionally notifying
               // the client that they can send more bytes.
               transportState().onSentBytes(numBytes);
+              if (future.isSuccess()) {
+                transportTracer.reportMessageSent(numMessages);
+              }
             }
           }), flush);
     }

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -28,16 +28,13 @@ import io.netty.channel.ChannelPromise;
 class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.QueuedCommand {
   private final StreamIdHolder stream;
   private final boolean endStream;
-  private final int numMessages;
 
   private ChannelPromise promise;
 
-  SendGrpcFrameCommand(
-      StreamIdHolder stream, ByteBuf content, boolean endStream, int numMessages) {
+  SendGrpcFrameCommand(StreamIdHolder stream, ByteBuf content, boolean endStream) {
     super(content);
     this.stream = stream;
     this.endStream = endStream;
-    this.numMessages = numMessages;
   }
 
   int streamId() {
@@ -50,12 +47,12 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.Qu
 
   @Override
   public ByteBufHolder copy() {
-    return new SendGrpcFrameCommand(stream, content().copy(), endStream, numMessages);
+    return new SendGrpcFrameCommand(stream, content().copy(), endStream);
   }
 
   @Override
   public ByteBufHolder duplicate() {
-    return new SendGrpcFrameCommand(stream, content().duplicate(), endStream, numMessages);
+    return new SendGrpcFrameCommand(stream, content().duplicate(), endStream);
   }
 
   @Override
@@ -89,14 +86,13 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.Qu
     }
     SendGrpcFrameCommand thatCmd = (SendGrpcFrameCommand) that;
     return thatCmd.stream.equals(stream) && thatCmd.endStream == endStream
-        && thatCmd.content().equals(content()) && thatCmd.numMessages == numMessages;
+        && thatCmd.content().equals(content());
   }
 
   @Override
   public String toString() {
     return getClass().getSimpleName() + "(streamId=" + streamId()
         + ", endStream=" + endStream + ", content=" + content()
-        + ", numMessages=" + numMessages
         + ")";
   }
 
@@ -107,7 +103,6 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.Qu
     if (endStream) {
       hash = -hash;
     }
-    hash = hash * 31 + numMessages;
     return hash;
   }
 
@@ -124,10 +119,5 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.Qu
   @Override
   public final void run(Channel channel) {
     channel.write(this, promise);
-  }
-
-  /** Returns the number of messages that this frame represents. */
-  public int getNumMessages() {
-    return numMessages;
   }
 }

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -125,4 +125,9 @@ class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.Qu
   public final void run(Channel channel) {
     channel.write(this, promise);
   }
+
+  /** Returns the number of messages that this frame represents. */
+  public int getNumMessages() {
+    return numMessages;
+  }
 }

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -268,7 +268,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
 
     // Send a frame and verify that it was written.
     ChannelFuture future
-        = enqueue(new SendGrpcFrameCommand(streamTransportState, content(), true, 1));
+        = enqueue(new SendGrpcFrameCommand(streamTransportState, content(), true));
 
     assertTrue(future.isSuccess());
     verifyWrite().writeData(eq(ctx()), eq(3), eq(content()), eq(0), eq(true),
@@ -280,7 +280,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
   @Test
   public void sendForUnknownStreamShouldFail() throws Exception {
     ChannelFuture future
-        = enqueue(new SendGrpcFrameCommand(streamTransportState, content(), true, 1));
+        = enqueue(new SendGrpcFrameCommand(streamTransportState, content(), true));
     assertTrue(future.isDone());
     assertFalse(future.isSuccess());
   }

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -176,7 +176,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     stream.writeMessage(new ByteArrayInputStream(msg));
     stream.flush();
     verify(writeQueue).enqueue(
-        eq(new SendGrpcFrameCommand(stream.transportState(), messageFrame(MESSAGE), false, 1)),
+        eq(new SendGrpcFrameCommand(stream.transportState(), messageFrame(MESSAGE), false)),
         any(ChannelPromise.class),
         eq(true));
   }
@@ -192,12 +192,12 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     // The framer reports the message count when the payload is completely written
     verify(writeQueue).enqueue(
             eq(new SendGrpcFrameCommand(
-                stream.transportState(), messageFrame(MESSAGE).slice(0, 5), false, 0)),
+                stream.transportState(), messageFrame(MESSAGE).slice(0, 5), false)),
             any(ChannelPromise.class),
             eq(false));
     verify(writeQueue).enqueue(
         eq(new SendGrpcFrameCommand(
-            stream.transportState(), messageFrame(MESSAGE).slice(5, 11), false, 1)),
+            stream.transportState(), messageFrame(MESSAGE).slice(5, 11), false)),
         any(ChannelPromise.class),
         eq(true));
   }

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -202,7 +202,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
 
     // Send a frame and verify that it was written.
     ChannelFuture future = enqueue(
-        new SendGrpcFrameCommand(stream.transportState(), content(), false, 1));
+        new SendGrpcFrameCommand(stream.transportState(), content(), false));
     assertTrue(future.isSuccess());
     verifyWrite().writeData(eq(ctx()), eq(STREAM_ID), eq(content()), eq(0), eq(false),
         any(ChannelPromise.class));
@@ -559,7 +559,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
     payload.writeLong(1);
     for (int i = 0; i < 10; i++) {
       future = enqueue(
-          new SendGrpcFrameCommand(stream.transportState(), content().retainedSlice(), false, 1));
+          new SendGrpcFrameCommand(stream.transportState(), content().retainedSlice(), false));
       future.get();
       channel().releaseOutbound();
       channelRead(pingFrame(false /* isAck */, payload.slice()));

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -124,7 +124,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     stream.flush();
 
     verify(writeQueue).enqueue(
-        eq(new SendGrpcFrameCommand(stream.transportState(), messageFrame(MESSAGE), false, 1)),
+        eq(new SendGrpcFrameCommand(stream.transportState(), messageFrame(MESSAGE), false)),
         isA(ChannelPromise.class),
         eq(true));
   }


### PR DESCRIPTION
Bugfix for 9fac15d4f8fb09106fc4a80d761afbe1594b4d0c which always bumps the value by 1. Also remove msgCount from SendGrpcFrameCommand because it is no longer necessary.