### PR TITLE
core,netty,okhttp: add TransportTracer param to ClientStream and Http2ClientStreamTransportState

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -97,8 +97,12 @@ public abstract class AbstractClientStream extends AbstractStream
    */
   private volatile boolean cancelled;
 
-  protected AbstractClientStream(WritableBufferAllocator bufferAllocator,
-      StatsTraceContext statsTraceCtx, Metadata headers, boolean useGet) {
+  protected AbstractClientStream(
+      WritableBufferAllocator bufferAllocator,
+      StatsTraceContext statsTraceCtx,
+      @Nullable TransportTracer transportTracer,
+      Metadata headers,
+      boolean useGet) {
     Preconditions.checkNotNull(headers, "headers");
     this.useGet = useGet;
     if (!useGet) {
@@ -203,8 +207,11 @@ public abstract class AbstractClientStream extends AbstractStream
      */
     private boolean statusReported;
 
-    protected TransportState(int maxMessageSize, StatsTraceContext statsTraceCtx) {
-      super(maxMessageSize, statsTraceCtx, null);
+    protected TransportState(
+        int maxMessageSize,
+        StatsTraceContext statsTraceCtx,
+        @Nullable TransportTracer transportTracer) {
+      super(maxMessageSize, statsTraceCtx, transportTracer);
       this.statsTraceCtx = Preconditions.checkNotNull(statsTraceCtx, "statsTraceCtx");
     }
 

--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -64,8 +64,11 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
   private Charset errorCharset = Charsets.UTF_8;
   private boolean headersReceived;
 
-  protected Http2ClientStreamTransportState(int maxMessageSize, StatsTraceContext statsTraceCtx) {
-    super(maxMessageSize, statsTraceCtx);
+  protected Http2ClientStreamTransportState(
+      int maxMessageSize,
+      StatsTraceContext statsTraceCtx,
+      TransportTracer transportTracer) {
+    super(maxMessageSize, statsTraceCtx, transportTracer);
   }
 
   /**

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -49,12 +49,14 @@ public class Http2ClientStreamTransportStateTest {
   private final Metadata.Key<String> testStatusMashaller =
       InternalMetadata.keyOf(":status", Metadata.ASCII_STRING_MARSHALLER);
 
+  private TransportTracer transportTracer;
   @Mock private ClientStreamListener mockListener;
   @Captor private ArgumentCaptor<Status> statusCaptor;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
+    transportTracer = new TransportTracer();
 
     doAnswer(new Answer<Void>() {
       @Override
@@ -69,7 +71,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportHeadersReceived_notifiesListener() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(testStatusMashaller, "200");
@@ -83,7 +85,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportHeadersReceived_doesntRequire200() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(testStatusMashaller, "500");
@@ -97,7 +99,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportHeadersReceived_noHttpStatus() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(Metadata.Key.of("content-type", Metadata.ASCII_STRING_MARSHALLER),
@@ -112,7 +114,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportHeadersReceived_wrongContentType_200() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(testStatusMashaller, "200");
@@ -128,7 +130,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportHeadersReceived_wrongContentType_401() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(testStatusMashaller, "401");
@@ -145,7 +147,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportHeadersReceived_handles_1xx() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
 
     Metadata infoHeaders = new Metadata();
@@ -167,7 +169,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportHeadersReceived_twice() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(testStatusMashaller, "200");
@@ -186,7 +188,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportHeadersReceived_unknownAndTwiceLogsSecondHeaders() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(testStatusMashaller, "200");
@@ -206,7 +208,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportDataReceived_noHeaderReceived() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     String testString = "This is a test";
     state.transportDataReceived(ReadableBuffers.wrap(testString.getBytes(US_ASCII)), true);
@@ -217,7 +219,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportDataReceived_debugData() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(testStatusMashaller, "200");
@@ -232,7 +234,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportTrailersReceived_notifiesListener() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata trailers = new Metadata();
     trailers.put(testStatusMashaller, "200");
@@ -247,7 +249,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportTrailersReceived_afterHeaders() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(testStatusMashaller, "200");
@@ -264,7 +266,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportTrailersReceived_observesStatus() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata trailers = new Metadata();
     trailers.put(testStatusMashaller, "200");
@@ -279,7 +281,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportTrailersReceived_missingStatusUsesHttpStatus() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata trailers = new Metadata();
     trailers.put(testStatusMashaller, "401");
@@ -295,7 +297,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportTrailersReceived_missingHttpStatus() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata trailers = new Metadata();
     trailers.put(Metadata.Key.of("content-type", Metadata.ASCII_STRING_MARSHALLER),
@@ -310,7 +312,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportTrailersReceived_missingStatusAndMissingHttpStatus() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata trailers = new Metadata();
     trailers.put(Metadata.Key.of("content-type", Metadata.ASCII_STRING_MARSHALLER),
@@ -324,7 +326,7 @@ public class Http2ClientStreamTransportStateTest {
 
   @Test
   public void transportTrailersReceived_missingStatusAfterHeadersIgnoresHttpStatus() {
-    BaseTransportState state = new BaseTransportState();
+    BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);
     Metadata headers = new Metadata();
     headers.put(testStatusMashaller, "200");
@@ -341,8 +343,8 @@ public class Http2ClientStreamTransportStateTest {
   }
 
   private static class BaseTransportState extends Http2ClientStreamTransportState {
-    public BaseTransportState() {
-      super(DEFAULT_MAX_MESSAGE_SIZE, StatsTraceContext.NOOP);
+    public BaseTransportState(TransportTracer transportTracer) {
+      super(DEFAULT_MAX_MESSAGE_SIZE, StatsTraceContext.NOOP, transportTracer);
     }
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -207,7 +207,7 @@ class NettyClientStream extends AbstractClientStream {
 
     public TransportState(NettyClientHandler handler, EventLoop eventLoop, int maxMessageSize,
         StatsTraceContext statsTraceCtx) {
-      super(maxMessageSize, statsTraceCtx, null /* transportTracer */);
+      super(maxMessageSize, statsTraceCtx, /*transportTracer=*/null);
       this.handler = checkNotNull(handler, "handler");
       this.eventLoop = checkNotNull(eventLoop, "eventLoop");
     }

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -207,7 +207,7 @@ class NettyClientStream extends AbstractClientStream {
 
     public TransportState(NettyClientHandler handler, EventLoop eventLoop, int maxMessageSize,
         StatsTraceContext statsTraceCtx) {
-      super(maxMessageSize, statsTraceCtx, null);
+      super(maxMessageSize, statsTraceCtx, null /* transportTracer */);
       this.handler = checkNotNull(handler, "handler");
       this.eventLoop = checkNotNull(eventLoop, "eventLoop");
     }

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -65,6 +65,7 @@ class NettyClientStream extends AbstractClientStream {
       StatsTraceContext statsTraceCtx) {
     super(new NettyWritableBufferAllocator(channel.alloc()),
         statsTraceCtx,
+        null,
         headers,
         useGet(method));
     this.state = checkNotNull(state, "transportState");
@@ -206,7 +207,7 @@ class NettyClientStream extends AbstractClientStream {
 
     public TransportState(NettyClientHandler handler, EventLoop eventLoop, int maxMessageSize,
         StatsTraceContext statsTraceCtx) {
-      super(maxMessageSize, statsTraceCtx);
+      super(maxMessageSize, statsTraceCtx, null);
       this.handler = checkNotNull(handler, "handler");
       this.eventLoop = checkNotNull(eventLoop, "eventLoop");
     }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -70,7 +70,12 @@ class OkHttpClientStream extends AbstractClientStream {
       String authority,
       String userAgent,
       StatsTraceContext statsTraceCtx) {
-    super(new OkHttpWritableBufferAllocator(), statsTraceCtx, null, headers, method.isSafe());
+    super(
+        new OkHttpWritableBufferAllocator(),
+        statsTraceCtx,
+        null /* transportTracer */,
+        headers,
+        method.isSafe());
     this.statsTraceCtx = checkNotNull(statsTraceCtx, "statsTraceCtx");
     this.method = method;
     this.authority = authority;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -73,7 +73,7 @@ class OkHttpClientStream extends AbstractClientStream {
     super(
         new OkHttpWritableBufferAllocator(),
         statsTraceCtx,
-        null /* transportTracer */,
+        /*transportTracer=*/ null
         headers,
         method.isSafe());
     this.statsTraceCtx = checkNotNull(statsTraceCtx, "statsTraceCtx");
@@ -200,7 +200,7 @@ class OkHttpClientStream extends AbstractClientStream {
         AsyncFrameWriter frameWriter,
         OutboundFlowController outboundFlow,
         OkHttpClientTransport transport) {
-      super(maxMessageSize, statsTraceCtx, null /* transportTracer */);
+      super(maxMessageSize, statsTraceCtx,  /*transportTracer=*/ null);
       this.lock = checkNotNull(lock, "lock");
       this.frameWriter = frameWriter;
       this.outboundFlow = outboundFlow;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -73,7 +73,7 @@ class OkHttpClientStream extends AbstractClientStream {
     super(
         new OkHttpWritableBufferAllocator(),
         statsTraceCtx,
-        /*transportTracer=*/ null
+        /*transportTracer=*/ null,
         headers,
         method.isSafe());
     this.statsTraceCtx = checkNotNull(statsTraceCtx, "statsTraceCtx");

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -70,7 +70,7 @@ class OkHttpClientStream extends AbstractClientStream {
       String authority,
       String userAgent,
       StatsTraceContext statsTraceCtx) {
-    super(new OkHttpWritableBufferAllocator(), statsTraceCtx, headers, method.isSafe());
+    super(new OkHttpWritableBufferAllocator(), statsTraceCtx, null, headers, method.isSafe());
     this.statsTraceCtx = checkNotNull(statsTraceCtx, "statsTraceCtx");
     this.method = method;
     this.authority = authority;
@@ -195,7 +195,7 @@ class OkHttpClientStream extends AbstractClientStream {
         AsyncFrameWriter frameWriter,
         OutboundFlowController outboundFlow,
         OkHttpClientTransport transport) {
-      super(maxMessageSize, statsTraceCtx);
+      super(maxMessageSize, statsTraceCtx, null);
       this.lock = checkNotNull(lock, "lock");
       this.frameWriter = frameWriter;
       this.outboundFlow = outboundFlow;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -200,7 +200,7 @@ class OkHttpClientStream extends AbstractClientStream {
         AsyncFrameWriter frameWriter,
         OutboundFlowController outboundFlow,
         OkHttpClientTransport transport) {
-      super(maxMessageSize, statsTraceCtx, null);
+      super(maxMessageSize, statsTraceCtx, null /* transportTracer */);
       this.lock = checkNotNull(lock, "lock");
       this.frameWriter = frameWriter;
       this.outboundFlow = outboundFlow;


### PR DESCRIPTION
This diff does not actually change any behaviors yet, that will come
in the next diff along with unit tests for those new behaviors. 