### PR TITLE
core,netty: Add server negotiation timeout before client preface

### DIFF
--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -18,6 +18,7 @@ package io.grpc;
 
 import java.io.File;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -171,6 +172,20 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1704")
   public abstract T compressorRegistry(@Nullable CompressorRegistry registry);
+
+  /**
+   * Sets the permitted time for new connections to complete negotiation handshakes before being
+   * killed.
+   *
+   * @return this
+   * @throws IllegalArgumentException if timeout is negative
+   * @throws UnsupportedOperationException if unsupported
+   * @since 1.8.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3706")
+  public T handshakeTimeout(long timeout, TimeUnit unit) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Builds a server using the given parameters.

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -39,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -71,6 +73,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
       DecompressorRegistry.getDefaultInstance();
   private static final CompressorRegistry DEFAULT_COMPRESSOR_REGISTRY =
       CompressorRegistry.getDefaultInstance();
+  private static final long DEFAULT_HANDSHAKE_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(20);
 
   final InternalHandlerRegistry.Builder registryBuilder =
       new InternalHandlerRegistry.Builder();
@@ -93,6 +96,8 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   DecompressorRegistry decompressorRegistry = DEFAULT_DECOMPRESSOR_REGISTRY;
 
   CompressorRegistry compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
+
+  long handshakeTimeoutMillis = DEFAULT_HANDSHAKE_TIMEOUT_MILLIS;
 
   @Nullable
   private CensusStatsModule censusStatsOverride;
@@ -175,6 +180,13 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
     } else {
       compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
     }
+    return thisT();
+  }
+
+  @Override
+  public final T handshakeTimeout(long timeout, TimeUnit unit) {
+    checkArgument(timeout > 0, "handshake timeout is %s, but must be positive", timeout);
+    handshakeTimeoutMillis = unit.toMillis(timeout);
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -82,6 +83,7 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
   // This is iterated on a per-call basis.  Use an array instead of a Collection to avoid iterator
   // creations.
   private final ServerInterceptor[] interceptors;
+  private final long handshakeTimeoutMillis;
   @GuardedBy("lock") private boolean started;
   @GuardedBy("lock") private boolean shutdown;
   /** non-{@code null} if immediate shutdown has been requested. */
@@ -127,6 +129,7 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
         new ArrayList<ServerTransportFilter>(builder.transportFilters));
     this.interceptors =
         builder.interceptors.toArray(new ServerInterceptor[builder.interceptors.size()]);
+    this.handshakeTimeoutMillis = builder.handshakeTimeoutMillis;
   }
 
   /**
@@ -308,7 +311,9 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
       synchronized (lock) {
         transports.add(transport);
       }
-      return new ServerTransportListenerImpl(transport);
+      ServerTransportListenerImpl stli = new ServerTransportListenerImpl(transport);
+      stli.init();
+      return stli;
     }
 
     @Override
@@ -338,14 +343,29 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
 
   private final class ServerTransportListenerImpl implements ServerTransportListener {
     private final ServerTransport transport;
+    private Future<?> handshakeTimeoutFuture;
     private Attributes attributes;
 
     ServerTransportListenerImpl(ServerTransport transport) {
       this.transport = transport;
     }
 
+    public void init() {
+      class TransportShutdownNow implements Runnable {
+        @Override public void run() {
+          transport.shutdownNow(Status.CANCELLED.withDescription("Handshake timeout exceeded"));
+        }
+      }
+
+      handshakeTimeoutFuture = transport.getScheduledExecutorService()
+          .schedule(new TransportShutdownNow(), handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
     @Override
     public Attributes transportReady(Attributes attributes) {
+      handshakeTimeoutFuture.cancel(false);
+      handshakeTimeoutFuture = null;
+
       for (ServerTransportFilter filter : transportFilters) {
         attributes = Preconditions.checkNotNull(filter.transportReady(attributes),
             "Filter %s returned null", filter);
@@ -356,6 +376,10 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
 
     @Override
     public void transportTerminated() {
+      if (handshakeTimeoutFuture != null) {
+        handshakeTimeoutFuture.cancel(false);
+        handshakeTimeoutFuture = null;
+      }
       for (ServerTransportFilter filter : transportFilters) {
         filter.transportTerminated(attributes);
       }


### PR DESCRIPTION
The two commits here are easiest to review separately and will be committed separately. The first adds support for a negotiation timeout to core and the second improves transportReady callback placement in Netty so the negotiation timeout applies to more phases.

Before merging I'll reserve an issue for `negotiationTimeout`'s `@ExperimentalApi` and update the annotation.