### PR TITLE
java_grpc_library: add test for remote proto in srcs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,26 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(":java_grpc_library.bzl", "java_grpc_library")
+
+java_proto_library(
+    name = "api_proto_java",
+    deps = ["@com_google_protobuf//:api_proto"],
+)
+
+java_grpc_library(
+    name = "java_grpc_library__external_repo_test",
+    srcs = ["@com_google_protobuf//:api_proto"],
+    deps = [":api_proto_java"],
+)


### PR DESCRIPTION
I'm planning to wait for when we update to the next protobuf release before merging this.