### PR TITLE
core: no ProxyDetector for GAE+JDK7

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -116,8 +116,6 @@ public abstract class AbstractManagedChannelImplBuilder
   String authorityOverride;
 
 
-  private ProxyDetector proxyDetector = ProxyDetector.DEFAULT_INSTANCE;
-
   LoadBalancer.Factory loadBalancerFactory = DEFAULT_LOAD_BALANCER_FACTORY;
 
   boolean fullStreamDecompression;
@@ -338,7 +336,7 @@ public abstract class AbstractManagedChannelImplBuilder
         SharedResourcePool.forResource(GrpcUtil.SHARED_CHANNEL_EXECUTOR),
         GrpcUtil.STOPWATCH_SUPPLIER,
         getEffectiveInterceptors(),
-        proxyDetector);
+        GrpcUtil.getProxyDetector());
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -48,7 +48,7 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
           "the path component (%s) of the target (%s) must start with '/'", targetPath, targetUri);
       String name = targetPath.substring(1);
       return new DnsNameResolver(targetUri.getAuthority(), name, params, GrpcUtil.TIMER_SERVICE,
-          GrpcUtil.SHARED_CHANNEL_EXECUTOR, ProxyDetector.DEFAULT_INSTANCE);
+          GrpcUtil.SHARED_CHANNEL_EXECUTOR, GrpcUtil.getProxyDetector());
     } else {
       return null;
     }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -43,6 +43,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -222,6 +223,29 @@ public final class GrpcUtil {
    * The magic keepalive time value that disables keepalive.
    */
   public static final long SERVER_KEEPALIVE_TIME_NANOS_DISABLED = Long.MAX_VALUE;
+
+  /** The default proxy detector. */
+  public static final ProxyDetector DEFAULT_PROXY_DETECTOR = new ProxyDetectorImpl();
+
+  /** A proxy detector that always claims no proxy is needed. */
+  public static final ProxyDetector NOOP_PROXY_DETECTOR = new ProxyDetector() {
+    @Nullable
+    @Override
+    public ProxyParameters proxyFor(SocketAddress targetServerAddress) {
+      return null;
+    }
+  };
+
+  /**
+   * Returns a proxy detector appropriate for the current environment.
+   */
+  public static ProxyDetector getProxyDetector() {
+    if (IS_RESTRICTED_APPENGINE) {
+      return NOOP_PROXY_DETECTOR;
+    } else {
+      return DEFAULT_PROXY_DETECTOR;
+    }
+  }
 
   /**
    * Maps HTTP error response status codes to transport codes, as defined in <a

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -224,10 +224,14 @@ public final class GrpcUtil {
    */
   public static final long SERVER_KEEPALIVE_TIME_NANOS_DISABLED = Long.MAX_VALUE;
 
-  /** The default proxy detector. */
+  /**
+   * The default proxy detector.
+   */
   public static final ProxyDetector DEFAULT_PROXY_DETECTOR = new ProxyDetectorImpl();
 
-  /** A proxy detector that always claims no proxy is needed. */
+  /**
+   * A proxy detector that always claims no proxy is needed.
+   */
   public static final ProxyDetector NOOP_PROXY_DETECTOR = new ProxyDetector() {
     @Nullable
     @Override

--- a/core/src/main/java/io/grpc/internal/ProxyDetector.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetector.java
@@ -24,17 +24,6 @@ import javax.annotation.Nullable;
  * {@link java.net.SocketAddress}.
  */
 public interface ProxyDetector {
-  ProxyDetector DEFAULT_INSTANCE = new ProxyDetectorImpl();
-
-  /** A proxy detector that always claims no proxy is needed, for unit test convenience. */
-  ProxyDetector NOOP_INSTANCE = new ProxyDetector() {
-    @Nullable
-    @Override
-    public ProxyParameters proxyFor(SocketAddress targetServerAddress) {
-      return null;
-    }
-  };
-
   /**
    * Given a target address, returns which proxy address should be used. If no proxy should be
    * used, then return value will be null.

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -112,7 +112,7 @@ public class DnsNameResolverTest {
   private ArgumentCaptor<Status> statusCaptor;
 
   private DnsNameResolver newResolver(String name, int port) {
-    return newResolver(name, port, mockResolver, ProxyDetector.NOOP_INSTANCE);
+    return newResolver(name, port, mockResolver, GrpcUtil.NOOP_PROXY_DETECTOR);
   }
 
   private DnsNameResolver newResolver(

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -885,7 +885,7 @@ public class InternalSubchannelTest {
   }
 
   private void createInternalSubchannel(SocketAddress ... addrs) {
-    createInternalSubChannelWithProxy(ProxyDetector.NOOP_INSTANCE, addrs);
+    createInternalSubChannelWithProxy(GrpcUtil.NOOP_PROXY_DETECTOR, addrs);
   }
 
   private void createInternalSubChannelWithProxy(

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -143,7 +143,7 @@ public class ManagedChannelImplIdlenessTest {
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         oobExecutorPool, timer.getStopwatchSupplier(),
         Collections.<ClientInterceptor>emptyList(),
-        ProxyDetector.NOOP_INSTANCE);
+        GrpcUtil.NOOP_PROXY_DETECTOR);
     newTransports = TestUtils.captureTransports(mockTransportFactory);
 
     for (int i = 0; i < 2; i++) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -215,7 +215,7 @@ public class ManagedChannelImplTest {
     checkState(channel == null);
     channel = new ManagedChannelImpl(
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
-        oobExecutorPool, timer.getStopwatchSupplier(), interceptors, ProxyDetector.NOOP_INSTANCE);
+        oobExecutorPool, timer.getStopwatchSupplier(), interceptors, GrpcUtil.NOOP_PROXY_DETECTOR);
 
     if (requestConnection) {
       // Force-exit the initial idle-mode


### PR DESCRIPTION
This is a workaround of the security restrictions, but effectively turns off proxy support in GAE+JDK7.

I can't seem to get AccessController to work in GAE, the checkPermission API fails:
```
Can not use checkPermission:
Caused by: java.lang.SecurityException: AccessController.checkPermission is unsupported.
```

And doPriviledged also fails:
```
  Caused by: io.grpc.StatusRuntimeException: INTERNAL: Thrown from handleResolvedAddresses(): java.lang.NoClassDefFoundError: java.net.ProxySelector is a restricted class. Please see the Google App Engine developer's guide for more details.
```

Let's use the usual technique of checking for the `IS_RESTRICTED_APPENGINE` flag.

Fixes https://github.com/grpc/grpc-java/issues/3676