### PR TITLE
gae-interop-testing: concrete channel builders

### DIFF
--- a/gae-interop-testing/gae-jdk7/build.gradle
+++ b/gae-interop-testing/gae-jdk7/build.gradle
@@ -45,10 +45,7 @@ dependencies {
   compile project(":grpc-okhttp")
   compile project(":grpc-protobuf")
   compile project(":grpc-stub")
-  compile (project(":grpc-interop-testing")) {
-    // We want the gRPC and service definitions but NOT grpc-netty for jdk7
-     exclude module: ":grpc-netty"
-  }
+  compile project(":grpc-interop-testing")
 }
 
 // [START model]

--- a/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
@@ -16,10 +16,7 @@
 
 package io.grpc.testing.integration;
 
-import static junit.framework.TestCase.assertTrue;
-
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -134,10 +131,9 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
   public static final class Tester extends AbstractInteropTest {
     @Override
     protected ManagedChannel createChannel() {
-      ManagedChannelBuilder<?> builder =
-          ManagedChannelBuilder.forTarget(INTEROP_TEST_ADDRESS)
+      OkHttpChannelBuilder builder =
+          OkHttpChannelBuilder.forTarget(INTEROP_TEST_ADDRESS)
               .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
-      assertTrue(builder instanceof OkHttpChannelBuilder);
       return builder.build();
     }
 

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -16,10 +16,7 @@
 
 package io.grpc.testing.integration;
 
-import static junit.framework.TestCase.assertTrue;
-
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -82,12 +79,11 @@ public final class NettyClientInteropServlet extends HttpServlet {
   public static final class Tester extends AbstractInteropTest {
     @Override
     protected ManagedChannel createChannel() {
-      ManagedChannelBuilder<?> builder =
-          ManagedChannelBuilder.forTarget(INTEROP_TEST_ADDRESS)
+      NettyChannelBuilder builder =
+          NettyChannelBuilder.forTarget(INTEROP_TEST_ADDRESS)
               .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
 
-      assertTrue(builder instanceof NettyChannelBuilder);
-      ((NettyChannelBuilder) builder).flowControlWindow(65 * 1024);
+      builder.flowControlWindow(65 * 1024);
       return builder.build();
     }
 


### PR DESCRIPTION
Do not rely on ManagedChannelBuilder to select the correct concrete
type; directly instantiate the required type.