### PR TITLE
gae-interop-testing: disable serverInProcess tests

### DIFF
--- a/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
@@ -147,6 +147,12 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
       return false;
     }
 
+    @Override
+    protected boolean serverInProcess() {
+      // Server-side metrics won't be found because the server is running remotely.
+      return false;
+    }
+
     // grpc-test.sandbox.googleapis.com does not support these tests
     @Override
     public void customMetadata() { }

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -97,6 +97,12 @@ public final class NettyClientInteropServlet extends HttpServlet {
       return false;
     }
 
+    @Override
+    protected boolean serverInProcess() {
+      // Server-side metrics won't be found because the server is running remotely.
+      return false;
+    }
+
     // grpc-test.sandbox.googleapis.com does not support these tests
     @Override
     public void customMetadata() { }


### PR DESCRIPTION
Tests that require serverInProcess() will not work because the server
is remote.