### PR TITLE
gae-interop-testing: use ManagedChannelBuilder, abort if devserver

### DIFF
--- a/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
@@ -16,7 +16,11 @@
 
 package io.grpc.testing.integration;
 
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -131,9 +135,18 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
   public static final class Tester extends AbstractInteropTest {
     @Override
     protected ManagedChannel createChannel() {
-      OkHttpChannelBuilder builder =
-          OkHttpChannelBuilder.forTarget(INTEROP_TEST_ADDRESS)
+      assertEquals(
+          "jdk7 required",
+          "1.7",
+          System.getProperty("java.specification.version"));
+      assertEquals(
+          "Can not run in dev servers because they lack org.conscrypt.OpenSSLProvider support",
+          "Production",
+          System.getProperty("com.google.appengine.runtime.environment"));
+      ManagedChannelBuilder<?> builder =
+          ManagedChannelBuilder.forTarget(INTEROP_TEST_ADDRESS)
               .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
+      assertTrue(builder instanceof OkHttpChannelBuilder);
       return builder.build();
     }
 

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -16,7 +16,11 @@
 
 package io.grpc.testing.integration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -79,11 +83,15 @@ public final class NettyClientInteropServlet extends HttpServlet {
   public static final class Tester extends AbstractInteropTest {
     @Override
     protected ManagedChannel createChannel() {
-      NettyChannelBuilder builder =
-          NettyChannelBuilder.forTarget(INTEROP_TEST_ADDRESS)
+      assertEquals(
+          "jdk8 required",
+          "1.8",
+          System.getProperty("java.specification.version"));
+      ManagedChannelBuilder<?> builder =
+          ManagedChannelBuilder.forTarget(INTEROP_TEST_ADDRESS)
               .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
-
-      builder.flowControlWindow(65 * 1024);
+      assertTrue(builder instanceof NettyChannelBuilder);
+      ((NettyChannelBuilder) builder).flowControlWindow(65 * 1024);
       return builder.build();
     }
 


### PR DESCRIPTION
Turns out the ManagedChannelBuilder was misbehaving because the
devserver launcher ignores the app's jdk7 configuration and uses
whatever jdk is in JAVA_HOME. This is the reason
GrpcUtil.IS_RESTRICTED_APPENGINE was wrong.

Changing JAVA_HOME to point to jdk7 reveals that devservers lack
conscrypt. Adding an explicit check to make sure the jdk7 test is not
running in a dev server.