### PR TITLE
netty: Avoid clearing SSLParameters

### DIFF
--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -304,7 +304,7 @@ public final class ProtocolNegotiators {
         @Override
         public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
           SSLEngine sslEngine = sslContext.newEngine(ctx.alloc(), host, port);
-          SSLParameters sslParams = new SSLParameters();
+          SSLParameters sslParams = sslEngine.getSSLParameters();
           sslParams.setEndpointIdentificationAlgorithm("HTTPS");
           sslEngine.setSSLParameters(sslParams);
           ctx.pipeline().replace(this, null, new SslHandler(sslEngine, false));


### PR DESCRIPTION
Since Netty may have set some parameters already, we should modify the
existing SSLParameters instead of starting from scratch.

This may fix ALPN with JDK9, but full support for ALPN with JDK9 is
still later work and we're not supporting it yet.

Fixes #3532 

CC @vietj