### PR TITLE
codecov: Restore GitHub status notifications

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,8 +7,4 @@ coverage:
       default:
         target: auto
         threshold: 1
-    changes:
-      default:
-        branches:
-          - nonExistantBranchToDisableTheFeature
 comment: off


### PR DESCRIPTION
I'm not sure when they stopped, but Travis OS X builds being delayed is
likely the reason we didn't notice. 'changes: no' is apparently now the
default, so it doesn't need to be explicitly disabled any more. And
removing the config for 'changes' seems to restore the old statuses.