### PR TITLE
Fix broken method names in tests that include leading '/'

### DIFF
--- a/core/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/core/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -34,10 +34,10 @@ public class MethodDescriptorTest {
   public void createMethodDescriptor() {
     @SuppressWarnings("deprecation") // MethodDescriptor.create
     MethodDescriptor<String, String> descriptor = MethodDescriptor.<String, String>create(
-        MethodType.CLIENT_STREAMING, "/package.service/method", new StringMarshaller(),
+        MethodType.CLIENT_STREAMING, "package.service/method", new StringMarshaller(),
         new StringMarshaller());
     assertEquals(MethodType.CLIENT_STREAMING, descriptor.getType());
-    assertEquals("/package.service/method", descriptor.getFullMethodName());
+    assertEquals("package.service/method", descriptor.getFullMethodName());
     assertFalse(descriptor.isIdempotent());
     assertFalse(descriptor.isSafe());
   }
@@ -46,7 +46,7 @@ public class MethodDescriptorTest {
   public void idempotent() {
     MethodDescriptor<String, String> descriptor = MethodDescriptor.<String, String>newBuilder()
         .setType(MethodType.SERVER_STREAMING)
-        .setFullMethodName("/package.service/method")
+        .setFullMethodName("package.service/method")
         .setRequestMarshaller(new StringMarshaller())
         .setResponseMarshaller(new StringMarshaller())
         .build();
@@ -59,14 +59,14 @@ public class MethodDescriptorTest {
     assertTrue(newDescriptor.isIdempotent());
     // All other fields should staty the same
     assertEquals(MethodType.SERVER_STREAMING, newDescriptor.getType());
-    assertEquals("/package.service/method", newDescriptor.getFullMethodName());
+    assertEquals("package.service/method", newDescriptor.getFullMethodName());
   }
 
   @Test
   public void safe() {
     MethodDescriptor<String, String> descriptor = MethodDescriptor.<String, String>newBuilder()
         .setType(MethodType.UNARY)
-        .setFullMethodName("/package.service/method")
+        .setFullMethodName("package.service/method")
         .setRequestMarshaller(new StringMarshaller())
         .setResponseMarshaller(new StringMarshaller())
         .build();
@@ -77,14 +77,14 @@ public class MethodDescriptorTest {
     assertTrue(newDescriptor.isSafe());
     // All other fields should staty the same
     assertEquals(MethodType.UNARY, newDescriptor.getType());
-    assertEquals("/package.service/method", newDescriptor.getFullMethodName());
+    assertEquals("package.service/method", newDescriptor.getFullMethodName());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void safeAndNonUnary() {
     MethodDescriptor<String, String> descriptor = MethodDescriptor.<String, String>newBuilder()
         .setType(MethodType.SERVER_STREAMING)
-        .setFullMethodName("/package.service/method")
+        .setFullMethodName("package.service/method")
         .setRequestMarshaller(new StringMarshaller())
         .setResponseMarshaller(new StringMarshaller())
         .build();
@@ -99,7 +99,7 @@ public class MethodDescriptorTest {
   public void sampledToLocalTracing() {
     MethodDescriptor<String, String> md1 = MethodDescriptor.<String, String>newBuilder()
         .setType(MethodType.SERVER_STREAMING)
-        .setFullMethodName("/package.service/method")
+        .setFullMethodName("package.service/method")
         .setRequestMarshaller(new StringMarshaller())
         .setResponseMarshaller(new StringMarshaller())
         .setSampledToLocalTracing(true)
@@ -107,21 +107,21 @@ public class MethodDescriptorTest {
     assertTrue(md1.isSampledToLocalTracing());
 
     MethodDescriptor<String, String> md2 = md1.toBuilder()
-        .setFullMethodName("/package.service/method2")
+        .setFullMethodName("package.service/method2")
         .build();
     assertTrue(md2.isSampledToLocalTracing());
 
     // Same method name as md1, but not setting sampledToLocalTracing
     MethodDescriptor<String, String> md3 = MethodDescriptor.<String, String>newBuilder()
         .setType(MethodType.SERVER_STREAMING)
-        .setFullMethodName("/package.service/method")
+        .setFullMethodName("package.service/method")
         .setRequestMarshaller(new StringMarshaller())
         .setResponseMarshaller(new StringMarshaller())
         .build();
     assertFalse(md3.isSampledToLocalTracing());
 
     MethodDescriptor<String, String> md4 = md3.toBuilder()
-        .setFullMethodName("/package.service/method2")
+        .setFullMethodName("package.service/method2")
         .setSampledToLocalTracing(true)
         .build();
     assertTrue(md4.isSampledToLocalTracing());

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -81,7 +81,7 @@ public class CallCredentialsApplyingTest {
   private static final MethodDescriptor<String, Integer> method =
       MethodDescriptor.<String, Integer>newBuilder()
           .setType(MethodDescriptor.MethodType.UNKNOWN)
-          .setFullMethodName("/service/method")
+          .setFullMethodName("service/method")
           .setRequestMarshaller(new StringMarshaller())
           .setResponseMarshaller(new IntegerMarshaller())
           .build();

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -84,12 +84,12 @@ public class DelayedClientTransportTest {
   private final MethodDescriptor<String, Integer> method =
       MethodDescriptor.<String, Integer>newBuilder()
           .setType(MethodType.UNKNOWN)
-          .setFullMethodName("/service/method")
+          .setFullMethodName("service/method")
           .setRequestMarshaller(new StringMarshaller())
           .setResponseMarshaller(new IntegerMarshaller())
           .build();
   private final MethodDescriptor<String, Integer> method2 =
-      method.toBuilder().setFullMethodName("/service/method").build();
+      method.toBuilder().setFullMethodName("service/method").build();
   private final Metadata headers = new Metadata();
   private final Metadata headers2 = new Metadata();
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -87,7 +87,7 @@ public class ManagedChannelImplIdlenessTest {
   private final MethodDescriptor<String, Integer> method =
       MethodDescriptor.<String, Integer>newBuilder()
           .setType(MethodType.UNKNOWN)
-          .setFullMethodName("/service/method")
+          .setFullMethodName("service/method")
           .setRequestMarshaller(new StringMarshaller())
           .setResponseMarshaller(new IntegerMarshaller())
           .build();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -118,7 +118,7 @@ public class ManagedChannelImplTest {
   private static final MethodDescriptor<String, Integer> method =
       MethodDescriptor.<String, Integer>newBuilder()
           .setType(MethodType.UNKNOWN)
-          .setFullMethodName("/service/method")
+          .setFullMethodName("service/method")
           .setRequestMarshaller(new StringMarshaller())
           .setResponseMarshaller(new IntegerMarshaller())
           .build();

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -67,7 +67,7 @@ public class ServerCallImplTest {
   private static final MethodDescriptor<Long, Long> UNARY_METHOD =
       MethodDescriptor.<Long, Long>newBuilder()
           .setType(MethodType.UNARY)
-          .setFullMethodName("/service/method")
+          .setFullMethodName("service/method")
           .setRequestMarshaller(new LongMarshaller())
           .setResponseMarshaller(new LongMarshaller())
           .build();
@@ -75,7 +75,7 @@ public class ServerCallImplTest {
   private static final MethodDescriptor<Long, Long> CLIENT_STREAMING_METHOD =
       MethodDescriptor.<Long, Long>newBuilder()
           .setType(MethodType.UNARY)
-          .setFullMethodName("/service/method")
+          .setFullMethodName("service/method")
           .setRequestMarshaller(new LongMarshaller())
           .setResponseMarshaller(new LongMarshaller())
           .build();

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -93,7 +93,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
   // Must be initialized before @Before, because it is used by createStream()
   private MethodDescriptor<?, ?> methodDescriptor = MethodDescriptor.<Void, Void>newBuilder()
       .setType(MethodDescriptor.MethodType.UNARY)
-      .setFullMethodName("/testService/test")
+      .setFullMethodName("testService/test")
       .setRequestMarshaller(marshaller)
       .setResponseMarshaller(marshaller)
       .build();
@@ -423,7 +423,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     // Creating a GET method
     MethodDescriptor<?, ?> descriptor = MethodDescriptor.<Void, Void>newBuilder()
         .setType(MethodDescriptor.MethodType.UNARY)
-        .setFullMethodName("/testService/test")
+        .setFullMethodName("testService/test")
         .setRequestMarshaller(marshaller)
         .setResponseMarshaller(marshaller)
         .setIdempotent(true)
@@ -451,7 +451,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     assertThat(headers)
         .containsEntry(
             AsciiString.of(":path"),
-            AsciiString.of("//testService/test?" + BaseEncoding.base64().encode(msg)));
+            AsciiString.of("/testService/test?" + BaseEncoding.base64().encode(msg)));
   }
 
   @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -587,7 +587,7 @@ public class NettyClientTransportTest {
     static final MethodDescriptor<String, String> METHOD =
         MethodDescriptor.<String, String>newBuilder()
             .setType(MethodDescriptor.MethodType.UNARY)
-            .setFullMethodName("/testService/test")
+            .setFullMethodName("testService/test")
             .setRequestMarshaller(StringMarshaller.INSTANCE)
             .setResponseMarshaller(StringMarshaller.INSTANCE)
             .build();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -71,7 +71,7 @@ public class OkHttpClientStreamTest {
     MockitoAnnotations.initMocks(this);
     methodDescriptor = MethodDescriptor.<Void, Void>newBuilder()
         .setType(MethodDescriptor.MethodType.UNARY)
-        .setFullMethodName("/testService/test")
+        .setFullMethodName("testService/test")
         .setRequestMarshaller(marshaller)
         .setResponseMarshaller(marshaller)
         .build();
@@ -169,7 +169,7 @@ public class OkHttpClientStreamTest {
   public void getUnaryRequest() {
     MethodDescriptor<?, ?> getMethod = MethodDescriptor.<Void, Void>newBuilder()
         .setType(MethodDescriptor.MethodType.UNARY)
-        .setFullMethodName("/service/method")
+        .setFullMethodName("service/method")
         .setIdempotent(true)
         .setSafe(true)
         .setRequestMarshaller(marshaller)


### PR DESCRIPTION
The method name passed to MethodDescriptor does not include the leading
'/'. If it does, on the wire it will actually cause two slashes. This
has been this way for a _long_ time, but in tests that ignore the method
name or use the same MethodDescriptor no client and server the extra /
"works fine." But it's misleading, so let's remove it.