### PR TITLE
okhttp: disable census when in GAE+JDK7

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -119,6 +119,12 @@ public class OkHttpChannelBuilder extends
 
   private OkHttpChannelBuilder(String target) {
     super(target);
+    // TODO(zpencer): re-enable after census issue is resolved
+    // census-instrumentation/opencensus-java/issues/777
+    if (GrpcUtil.IS_RESTRICTED_APPENGINE) {
+      setTracingEnabled(false);
+      setStatsEnabled(false);
+    }
   }
 
   /**


### PR DESCRIPTION
Disable census for now due to:
https://github.com/census-instrumentation/opencensus-java/issues/777