### PR TITLE
core: initial binary log class

### DIFF
--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -19,7 +19,6 @@ package io.grpc;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Preconditions;
-import io.grpc.internal.BinaryLog;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import javax.annotation.CheckReturnValue;
@@ -47,7 +46,6 @@ public final class MethodDescriptor<ReqT, RespT> {
   private final boolean idempotent;
   private final boolean safe;
   private final boolean sampledToLocalTracing;
-  private final BinaryLog binaryLog;
 
   // Must be set to InternalKnownTransport.values().length
   // Not referenced to break the dependency.
@@ -213,8 +211,7 @@ public final class MethodDescriptor<ReqT, RespT> {
       Marshaller<RequestT> requestMarshaller,
       Marshaller<ResponseT> responseMarshaller) {
     return new MethodDescriptor<RequestT, ResponseT>(
-        type, fullMethodName, requestMarshaller, responseMarshaller, null, false, false, false,
-        BinaryLog.getLog(fullMethodName));
+        type, fullMethodName, requestMarshaller, responseMarshaller, null, false, false, false);
   }
 
   private MethodDescriptor(
@@ -225,8 +222,7 @@ public final class MethodDescriptor<ReqT, RespT> {
       Object schemaDescriptor,
       boolean idempotent,
       boolean safe,
-      boolean sampledToLocalTracing,
-      BinaryLog binaryLog) {
+      boolean sampledToLocalTracing) {
 
     this.type = Preconditions.checkNotNull(type, "type");
     this.fullMethodName = Preconditions.checkNotNull(fullMethodName, "fullMethodName");
@@ -238,8 +234,6 @@ public final class MethodDescriptor<ReqT, RespT> {
     this.sampledToLocalTracing = sampledToLocalTracing;
     Preconditions.checkArgument(!safe || type == MethodType.UNARY,
         "Only unary methods can be specified safe");
-    // The binlog may be a noop log
-    this.binaryLog = Preconditions.checkNotNull(binaryLog);
   }
 
   /**
@@ -574,8 +568,7 @@ public final class MethodDescriptor<ReqT, RespT> {
           schemaDescriptor,
           idempotent,
           safe,
-          sampledToLocalTracing,
-          BinaryLog.getLog(fullMethodName));
+          sampledToLocalTracing);
     }
   }
 }

--- a/core/src/main/java/io/grpc/internal/BinaryLog.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLog.java
@@ -90,6 +90,7 @@ public final class BinaryLog {
     // The form: {h:256,m:256}
     private static final Pattern bothRe = Pattern.compile("\\{h(?::(\\d+))?;m(?::(\\d+))?}");
 
+    private final boolean enabled;
     private final Map<String, BinaryLog> perMethodLogs = new HashMap<String, BinaryLog>();
     private final Map<String, BinaryLog> perServiceLogs = new HashMap<String, BinaryLog>();
     private final BinaryLog globalLog;
@@ -101,6 +102,7 @@ public final class BinaryLog {
     Factory(String configurationString) {
       if (configurationString == null || configurationString.length() == 0) {
         globalLog = NOOP_LOG;
+        enabled = false;
         return;
       }
       String[] configurations = configurationString.split(",");
@@ -135,6 +137,7 @@ public final class BinaryLog {
           logger.info(String.format("Method binlog: method=%s log=%s", methodOrSvc, binLog));
         }
       }
+      enabled = true;
       this.globalLog = globalLog == null ? NOOP_LOG : globalLog;
     }
 
@@ -142,6 +145,9 @@ public final class BinaryLog {
      * Accepts a full method name and returns the log that should be used.
      */
     public BinaryLog getLog(String fullMethodName) {
+      if (!enabled) {
+        return NOOP_LOG;
+      }
       BinaryLog methodLog = perMethodLogs.get(fullMethodName);
       if (methodLog != null) {
         return methodLog;

--- a/core/src/main/java/io/grpc/internal/BinaryLog.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLog.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import io.grpc.MethodDescriptor;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+/**
+ * A binary log class that is configured for a specific {@link MethodDescriptor}.
+ */
+public final class BinaryLog {
+  private static final Logger logger = Logger.getLogger(BinaryLog.class.getName());
+  private static final BinaryLog NOOP_LOG =
+      new BinaryLog(/*maxHeaderBytes=*/ 0, /*maxMessageBytes=*/ 0);
+  private final int maxHeaderBytes;
+  private final int maxMessageBytes;
+
+  @VisibleForTesting
+  BinaryLog(int maxHeaderBytes, int maxMessageBytes) {
+    this.maxHeaderBytes = maxHeaderBytes;
+    this.maxMessageBytes = maxMessageBytes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof BinaryLog)) {
+      return false;
+    }
+    BinaryLog that = (BinaryLog) o;
+    return this.maxHeaderBytes == that.maxHeaderBytes
+        && this.maxMessageBytes == that.maxMessageBytes;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(maxHeaderBytes, maxMessageBytes);
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + '['
+        + "maxHeaderBytes=" + maxHeaderBytes + ", "
+        + "maxMessageBytes=" + maxMessageBytes + "]";
+  }
+
+  private static final Factory DEFAULT_FACTORY =
+      new Factory(System.getenv("GRPC_BINARY_LOG_CONFIG"));
+
+  /**
+   * Accepts the fullMethodName and returns the binary log that should be used. The log may be
+   * a log that does nothing.
+   */
+  public static BinaryLog getLog(String fullMethodName) {
+    return DEFAULT_FACTORY.getLog(fullMethodName);
+  }
+
+  static final class Factory {
+    // '*' for global, 'service/*' for service glob, or 'service/method' for fully qualified.
+    private static final Pattern logPatternRe = Pattern.compile("[^{]+");
+    // A curly brace wrapped expression. Will be further matched with the more specified REs below.
+    private static final Pattern logOptionsRe = Pattern.compile("\\{[^}]+}");
+    private static final Pattern configRe = Pattern.compile(
+        String.format("^(%s)(%s)?$", logPatternRe.pattern(), logOptionsRe.pattern()));
+    // Regexes to extract per-binlog options
+    // The form: {m:256}
+    private static final Pattern msgRe = Pattern.compile("\\{m(?::(\\d+))?}");
+    // The form: {h:256}
+    private static final Pattern headerRe = Pattern.compile("\\{h(?::(\\d+))?}");
+    // The form: {h:256,m:256}
+    private static final Pattern bothRe = Pattern.compile("\\{h(?::(\\d+))?;m(?::(\\d+))?}");
+
+    private final Map<String, BinaryLog> perMethodLogs = new HashMap<String, BinaryLog>();
+    private final Map<String, BinaryLog> perServiceLogs = new HashMap<String, BinaryLog>();
+    private final BinaryLog globalLog;
+
+    /**
+     * Accepts a string in the format specified by the binary log spec.
+     */
+    @VisibleForTesting
+    Factory(String configurationString) {
+      if (configurationString == null || configurationString.length() == 0) {
+        globalLog = NOOP_LOG;
+        return;
+      }
+      String[] configurations = configurationString.split(",");
+      BinaryLog globalLog = null;
+      for (String configuration : configurations) {
+        Matcher configMatcher = configRe.matcher(configuration);
+        if (!configMatcher.matches()) {
+          throw new IllegalArgumentException("Bad input: " + configuration);
+        }
+        String methodOrSvc = configMatcher.group(1);
+        String binlogOptionStr = configMatcher.group(2);
+        BinaryLog binLog = createBinaryLog(binlogOptionStr);
+        if (methodOrSvc.equals("*")) {
+          if (globalLog != null) {
+            throw new IllegalArgumentException("Duplicate log config for: *");
+          }
+          globalLog = binLog;
+          logger.info("Global binlog: " + globalLog);
+        } else if (isServiceGlob(methodOrSvc)) {
+          String service = MethodDescriptor.extractFullServiceName(methodOrSvc);
+          if (perServiceLogs.containsKey(service)) {
+            throw new IllegalArgumentException("Duplicate log config for service: " + methodOrSvc);
+          }
+          perServiceLogs.put(service, binLog);
+          logger.info(String.format("Service binlog: service=%s log=%s", service, binLog));
+        } else {
+          // assume fully qualified method name
+          if (perMethodLogs.containsKey(methodOrSvc)) {
+            throw new IllegalArgumentException("Duplicate log config for method: " + methodOrSvc);
+          }
+          perMethodLogs.put(methodOrSvc, binLog);
+          logger.info(String.format("Method binlog: method=%s log=%s", methodOrSvc, binLog));
+        }
+      }
+      this.globalLog = globalLog == null ? NOOP_LOG : globalLog;
+    }
+
+    /**
+     * Accepts a full method name and returns the log that should be used.
+     */
+    public BinaryLog getLog(String fullMethodName) {
+      BinaryLog methodLog = perMethodLogs.get(fullMethodName);
+      if (methodLog != null) {
+        return methodLog;
+      }
+      BinaryLog serviceLog = perServiceLogs.get(
+          MethodDescriptor.extractFullServiceName(fullMethodName));
+      if (serviceLog != null) {
+        return serviceLog;
+      }
+      return globalLog;
+    }
+
+    /**
+     * Returns a binlog with the correct header and message limits. The input should be a string
+     * that is in one of these forms:
+     *
+     * <p>{@code {h(:\d+)?}, {m(:\d+)?}, {h(:\d+)?,m(:\d+)?}}
+     *
+     * <p>If the {@code logConfig} is null, the returned binlog will have a limit of
+     * Integer.MAX_VALUE.
+     */
+    @VisibleForTesting
+    static BinaryLog createBinaryLog(@Nullable String logConfig) {
+      if (logConfig == null) {
+        return new BinaryLog(Integer.MAX_VALUE, Integer.MAX_VALUE);
+      }
+      Matcher headerMatcher;
+      Matcher msgMatcher;
+      Matcher bothMatcher;
+      final int maxHeaderBytes;
+      final int maxMsgBytes;
+      if ((headerMatcher = headerRe.matcher(logConfig)).matches()) {
+        maxMsgBytes = 0;
+        String maxHeaderStr = headerMatcher.group(1);
+        maxHeaderBytes = maxHeaderStr != null ? Integer.parseInt(maxHeaderStr) : Integer.MAX_VALUE;
+      } else if ((msgMatcher = msgRe.matcher(logConfig)).matches()) {
+        maxHeaderBytes = 0;
+        String maxMsgStr = msgMatcher.group(1);
+        maxMsgBytes = maxMsgStr != null ? Integer.parseInt(maxMsgStr) : Integer.MAX_VALUE;
+      } else if ((bothMatcher = bothRe.matcher(logConfig)).matches()) {
+        String maxHeaderStr = bothMatcher.group(1);
+        String maxMsgStr = bothMatcher.group(2);
+        maxHeaderBytes = maxHeaderStr != null ? Integer.parseInt(maxHeaderStr) : Integer.MAX_VALUE;
+        maxMsgBytes = maxMsgStr != null ? Integer.parseInt(maxMsgStr) : Integer.MAX_VALUE;
+      } else {
+        throw new IllegalArgumentException("Illegal log config pattern: " + logConfig);
+      }
+      return new BinaryLog(maxHeaderBytes, maxMsgBytes);
+    }
+
+    /**
+     * Returns true if the input string is a glob of the form: {@code <package-service>/*}.
+     */
+    static boolean isServiceGlob(String input) {
+      return input.substring(input.lastIndexOf('/')).equals("/*");
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -82,6 +82,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
   private boolean fullStreamDecompression;
   private DecompressorRegistry decompressorRegistry = DecompressorRegistry.getDefaultInstance();
   private CompressorRegistry compressorRegistry = CompressorRegistry.getDefaultInstance();
+  private final BinaryLog binlog;
 
   ClientCallImpl(
       MethodDescriptor<ReqT, RespT> method, Executor executor, CallOptions callOptions,
@@ -101,6 +102,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     this.callOptions = callOptions;
     this.clientTransportProvider = clientTransportProvider;
     this.deadlineCancellationExecutor = deadlineCancellationExecutor;
+    this.binlog = BinaryLog.getLog(method.getFullMethodName());
   }
 
   private final class ContextCancellationListener implements CancellationListener {

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -54,6 +54,7 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
   private final byte[] messageAcceptEncoding;
   private final DecompressorRegistry decompressorRegistry;
   private final CompressorRegistry compressorRegistry;
+  private final BinaryLog binlog;
 
   // state
   private volatile boolean cancelled;
@@ -71,6 +72,7 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
     this.messageAcceptEncoding = inboundHeaders.get(MESSAGE_ACCEPT_ENCODING_KEY);
     this.decompressorRegistry = decompressorRegistry;
     this.compressorRegistry = compressorRegistry;
+    binlog = BinaryLog.getLog(method.getFullMethodName());
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/BinaryLogTest.java
+++ b/core/src/test/java/io/grpc/internal/BinaryLogTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.grpc.internal.BinaryLog.Factory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link BinaryLog}. */
+@RunWith(JUnit4.class)
+public final class BinaryLogTest {
+  private static final BinaryLog NONE = new Builder().build();
+  private static final BinaryLog HEADER_ONLY = new Builder().header(Integer.MAX_VALUE).build();
+  private static final BinaryLog MSG_ONLY = new Builder().msg(Integer.MAX_VALUE).build();
+  private static final BinaryLog BOTH =
+      new Builder().header(Integer.MAX_VALUE).msg(Integer.MAX_VALUE).build();
+
+  @Test
+  public void noConfiguration() throws Exception {
+    Factory factory = new Factory(null);
+    assertEquals(NONE, factory.getLog("p.s/m"));
+    assertEquals(NONE, factory.getLog("/p.s/m"));
+  }
+
+  @Test
+  public void configBinLog_global() throws Exception {
+    assertEquals(BOTH, new Factory("*").getLog("p.s/m"));
+    assertEquals(BOTH, new Factory("*{h;m}").getLog("p.s/m"));
+    assertEquals(HEADER_ONLY, new Factory("*{h}").getLog("p.s/m"));
+    assertEquals(MSG_ONLY, new Factory("*{m}").getLog("p.s/m"));
+    assertEquals(new Builder().header(256).build(), new Factory("*{h:256}").getLog("p.s/m"));
+    assertEquals(new Builder().msg(256).build(), new Factory("*{m:256}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().header(256).msg(256).build(),
+        new Factory("*{h:256;m:256}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().header(Integer.MAX_VALUE).msg(256).build(),
+        new Factory("*{h;m:256}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().header(256).msg(Integer.MAX_VALUE).build(),
+        new Factory("*{h:256;m}").getLog("p.s/m"));
+  }
+
+  @Test
+  public void configBinLog_method() throws Exception {
+    assertEquals(BOTH, new Factory("p.s/m").getLog("p.s/m"));
+    assertEquals(BOTH, new Factory("p.s/m{h;m}").getLog("p.s/m"));
+    assertEquals(HEADER_ONLY, new Factory("p.s/m{h}").getLog("p.s/m"));
+    assertEquals(MSG_ONLY, new Factory("p.s/m{m}").getLog("p.s/m"));
+    assertEquals(new Builder().header(256).build(), new Factory("p.s/m{h:256}").getLog("p.s/m"));
+    assertEquals(new Builder().msg(256).build(), new Factory("p.s/m{m:256}").getLog("p.s/m"));
+    assertEquals(new Builder().header(256).msg(256).build(),
+        new Factory("p.s/m{h:256;m:256}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().header(Integer.MAX_VALUE).msg(256).build(),
+        new Factory("p.s/m{h;m:256}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().header(256).msg(Integer.MAX_VALUE).build(),
+        new Factory("p.s/m{h:256;m}").getLog("p.s/m"));
+  }
+
+  @Test
+  public void configBinLog_method_absent() throws Exception {
+    assertEquals(NONE, new Factory("p.s/m").getLog("p.s/absent"));
+  }
+
+  @Test
+  public void configBinLog_service() throws Exception {
+    assertEquals(BOTH, new Factory("p.s/*").getLog("p.s/m"));
+    assertEquals(BOTH, new Factory("p.s/*{h;m}").getLog("p.s/m"));
+    assertEquals(HEADER_ONLY, new Factory("p.s/*{h}").getLog("p.s/m"));
+    assertEquals(MSG_ONLY, new Factory("p.s/*{m}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().header(256).build(), new Factory("p.s/*{h:256}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().msg(256).build(), new Factory("p.s/*{m:256}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().header(256).msg(256).build(),
+        new Factory("p.s/*{h:256;m:256}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().header(Integer.MAX_VALUE).msg(256).build(),
+        new Factory("p.s/*{h;m:256}").getLog("p.s/m"));
+    assertEquals(
+        new Builder().header(256).msg(Integer.MAX_VALUE).build(),
+        new Factory("p.s/*{h:256;m}").getLog("p.s/m"));
+  }
+
+  @Test
+  public void configBinLog_service_absent() throws Exception {
+    assertEquals(NONE, new Factory("p.s/*").getLog("p.other/m"));
+  }
+
+  @Test
+  public void createLogFromOptionString() throws Exception {
+    assertEquals(BOTH, Factory.createBinaryLog(/*logConfig=*/ null));
+    assertEquals(HEADER_ONLY, Factory.createBinaryLog("{h}"));
+    assertEquals(MSG_ONLY, Factory.createBinaryLog("{m}"));
+    assertEquals(new Builder().header(256).build(), Factory.createBinaryLog("{h:256}"));
+    assertEquals(new Builder().msg(256).build(), Factory.createBinaryLog("{m:256}"));
+    assertEquals(
+        new Builder().header(256).msg(256).build(),
+        Factory.createBinaryLog("{h:256;m:256}"));
+    assertEquals(
+        new Builder().header(Integer.MAX_VALUE).msg(256).build(),
+        Factory.createBinaryLog("{h;m:256}"));
+    assertEquals(
+        new Builder().header(256).msg(Integer.MAX_VALUE).build(),
+        Factory.createBinaryLog("{h:256;m}"));
+  }
+
+  @Test
+  public void configBinLog_multiConfig_withGlobal() throws Exception {
+    Factory factory = new Factory(
+        "*{h},"
+        + "package.both256/*{h:256;m:256},"
+        + "package.service1/both128{h:128;m:128},"
+        + "package.service2/method_messageOnly{m}");
+    assertEquals(
+        HEADER_ONLY, factory.getLog("otherpackage.service/method"));
+
+    assertEquals(
+        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method1"));
+    assertEquals(
+        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method2"));
+    assertEquals(
+        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method3"));
+
+    assertEquals(
+        new Builder().header(128).msg(128).build(), factory.getLog("package.service1/both128"));
+    // the global config is in effect
+    assertEquals(HEADER_ONLY, factory.getLog("package.service1/absent"));
+
+    assertEquals(MSG_ONLY, factory.getLog("package.service2/method_messageOnly"));
+    // the global config is in effect
+    assertEquals(HEADER_ONLY, factory.getLog("package.service2/absent"));
+  }
+
+  @Test
+  public void configBinLog_multiConfig_noGlobal() throws Exception {
+    Factory factory = new Factory(
+        "package.both256/*{h:256;m:256},"
+        + "package.service1/both128{h:128;m:128},"
+        + "package.service2/method_messageOnly{m}");
+    assertEquals(NONE, factory.getLog("otherpackage.service/method"));
+
+    assertEquals(
+        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method1"));
+    assertEquals(
+        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method2"));
+    assertEquals(
+        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method3"));
+
+    assertEquals(
+        new Builder().header(128).msg(128).build(), factory.getLog("package.service1/both128"));
+    // no global config in effect
+    assertEquals(NONE, factory.getLog("package.service1/absent"));
+
+    assertEquals(MSG_ONLY, factory.getLog("package.service2/method_messageOnly"));
+    // no global config in effect
+    assertEquals(NONE, factory.getLog("package.service2/absent"));
+  }
+
+  @Test
+  public void configBinLog_duplicateGlobal() throws Exception {
+    try {
+      new Factory("*{h},p.s/m,*{h:256}");
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().equals("Duplicate log config for: *"));
+    }
+  }
+
+  @Test
+  public void configBinLog_duplicateMethod() throws Exception {
+    try {
+      new Factory("p.s/m,*{h:256},p.s/m{h}");
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().startsWith("Duplicate log config for method:"));
+    }
+  }
+
+  @Test
+  public void configBinLog_duplicateService() throws Exception {
+    try {
+      new Factory("p.s/*,*{h:256},p.s/*{h}");
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().startsWith("Duplicate log config for service:"));
+    }
+  }
+
+  /** A builder class to make unit test code more readable. */
+  private static final class Builder {
+    int maxHeaderBytes = 0;
+    int maxMessageBytes = 0;
+
+    Builder header(int bytes) {
+      maxHeaderBytes = bytes;
+      return this;
+    }
+
+    Builder msg(int bytes) {
+      maxMessageBytes = bytes;
+      return this;
+    }
+
+    BinaryLog build() {
+      return new BinaryLog(maxHeaderBytes, maxMessageBytes);
+    }
+  }
+}

--- a/core/src/test/java/io/grpc/internal/BinaryLogTest.java
+++ b/core/src/test/java/io/grpc/internal/BinaryLogTest.java
@@ -29,10 +29,14 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class BinaryLogTest {
   private static final BinaryLog NONE = new Builder().build();
-  private static final BinaryLog HEADER_ONLY = new Builder().header(Integer.MAX_VALUE).build();
-  private static final BinaryLog MSG_ONLY = new Builder().msg(Integer.MAX_VALUE).build();
-  private static final BinaryLog BOTH =
+  private static final BinaryLog HEADER_FULL = new Builder().header(Integer.MAX_VALUE).build();
+  private static final BinaryLog HEADER_256 = new Builder().header(256).build();
+  private static final BinaryLog MSG_FULL = new Builder().msg(Integer.MAX_VALUE).build();
+  private static final BinaryLog MSG_256 = new Builder().msg(256).build();
+  private static final BinaryLog BOTH_256 = new Builder().header(256).msg(256).build();
+  private static final BinaryLog BOTH_FULL =
       new Builder().header(Integer.MAX_VALUE).msg(Integer.MAX_VALUE).build();
+  
 
   @Test
   public void noConfiguration() throws Exception {
@@ -43,15 +47,13 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_global() throws Exception {
-    assertEquals(BOTH, new Factory("*").getLog("p.s/m"));
-    assertEquals(BOTH, new Factory("*{h;m}").getLog("p.s/m"));
-    assertEquals(HEADER_ONLY, new Factory("*{h}").getLog("p.s/m"));
-    assertEquals(MSG_ONLY, new Factory("*{m}").getLog("p.s/m"));
-    assertEquals(new Builder().header(256).build(), new Factory("*{h:256}").getLog("p.s/m"));
-    assertEquals(new Builder().msg(256).build(), new Factory("*{m:256}").getLog("p.s/m"));
-    assertEquals(
-        new Builder().header(256).msg(256).build(),
-        new Factory("*{h:256;m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new Factory("*").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new Factory("*{h;m}").getLog("p.s/m"));
+    assertEquals(HEADER_FULL, new Factory("*{h}").getLog("p.s/m"));
+    assertEquals(MSG_FULL, new Factory("*{m}").getLog("p.s/m"));
+    assertEquals(HEADER_256, new Factory("*{h:256}").getLog("p.s/m"));
+    assertEquals(MSG_256, new Factory("*{m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_256, new Factory("*{h:256;m:256}").getLog("p.s/m"));
     assertEquals(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
         new Factory("*{h;m:256}").getLog("p.s/m"));
@@ -62,14 +64,13 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_method() throws Exception {
-    assertEquals(BOTH, new Factory("p.s/m").getLog("p.s/m"));
-    assertEquals(BOTH, new Factory("p.s/m{h;m}").getLog("p.s/m"));
-    assertEquals(HEADER_ONLY, new Factory("p.s/m{h}").getLog("p.s/m"));
-    assertEquals(MSG_ONLY, new Factory("p.s/m{m}").getLog("p.s/m"));
-    assertEquals(new Builder().header(256).build(), new Factory("p.s/m{h:256}").getLog("p.s/m"));
-    assertEquals(new Builder().msg(256).build(), new Factory("p.s/m{m:256}").getLog("p.s/m"));
-    assertEquals(new Builder().header(256).msg(256).build(),
-        new Factory("p.s/m{h:256;m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new Factory("p.s/m").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new Factory("p.s/m{h;m}").getLog("p.s/m"));
+    assertEquals(HEADER_FULL, new Factory("p.s/m{h}").getLog("p.s/m"));
+    assertEquals(MSG_FULL, new Factory("p.s/m{m}").getLog("p.s/m"));
+    assertEquals(HEADER_256, new Factory("p.s/m{h:256}").getLog("p.s/m"));
+    assertEquals(MSG_256, new Factory("p.s/m{m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_256, new Factory("p.s/m{h:256;m:256}").getLog("p.s/m"));
     assertEquals(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
         new Factory("p.s/m{h;m:256}").getLog("p.s/m"));
@@ -85,17 +86,13 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_service() throws Exception {
-    assertEquals(BOTH, new Factory("p.s/*").getLog("p.s/m"));
-    assertEquals(BOTH, new Factory("p.s/*{h;m}").getLog("p.s/m"));
-    assertEquals(HEADER_ONLY, new Factory("p.s/*{h}").getLog("p.s/m"));
-    assertEquals(MSG_ONLY, new Factory("p.s/*{m}").getLog("p.s/m"));
-    assertEquals(
-        new Builder().header(256).build(), new Factory("p.s/*{h:256}").getLog("p.s/m"));
-    assertEquals(
-        new Builder().msg(256).build(), new Factory("p.s/*{m:256}").getLog("p.s/m"));
-    assertEquals(
-        new Builder().header(256).msg(256).build(),
-        new Factory("p.s/*{h:256;m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new Factory("p.s/*").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new Factory("p.s/*{h;m}").getLog("p.s/m"));
+    assertEquals(HEADER_FULL, new Factory("p.s/*{h}").getLog("p.s/m"));
+    assertEquals(MSG_FULL, new Factory("p.s/*{m}").getLog("p.s/m"));
+    assertEquals(HEADER_256, new Factory("p.s/*{h:256}").getLog("p.s/m"));
+    assertEquals(MSG_256, new Factory("p.s/*{m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_256, new Factory("p.s/*{h:256;m:256}").getLog("p.s/m"));
     assertEquals(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
         new Factory("p.s/*{h;m:256}").getLog("p.s/m"));
@@ -111,14 +108,12 @@ public final class BinaryLogTest {
 
   @Test
   public void createLogFromOptionString() throws Exception {
-    assertEquals(BOTH, Factory.createBinaryLog(/*logConfig=*/ null));
-    assertEquals(HEADER_ONLY, Factory.createBinaryLog("{h}"));
-    assertEquals(MSG_ONLY, Factory.createBinaryLog("{m}"));
-    assertEquals(new Builder().header(256).build(), Factory.createBinaryLog("{h:256}"));
-    assertEquals(new Builder().msg(256).build(), Factory.createBinaryLog("{m:256}"));
-    assertEquals(
-        new Builder().header(256).msg(256).build(),
-        Factory.createBinaryLog("{h:256;m:256}"));
+    assertEquals(BOTH_FULL, Factory.createBinaryLog(/*logConfig=*/ null));
+    assertEquals(HEADER_FULL, Factory.createBinaryLog("{h}"));
+    assertEquals(MSG_FULL, Factory.createBinaryLog("{m}"));
+    assertEquals(HEADER_256, Factory.createBinaryLog("{h:256}"));
+    assertEquals(MSG_256, Factory.createBinaryLog("{m:256}"));
+    assertEquals(BOTH_256, Factory.createBinaryLog("{h:256;m:256}"));
     assertEquals(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
         Factory.createBinaryLog("{h;m:256}"));
@@ -134,24 +129,20 @@ public final class BinaryLogTest {
         + "package.both256/*{h:256;m:256},"
         + "package.service1/both128{h:128;m:128},"
         + "package.service2/method_messageOnly{m}");
-    assertEquals(
-        HEADER_ONLY, factory.getLog("otherpackage.service/method"));
+    assertEquals(HEADER_FULL, factory.getLog("otherpackage.service/method"));
 
-    assertEquals(
-        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method1"));
-    assertEquals(
-        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method2"));
-    assertEquals(
-        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method3"));
+    assertEquals(BOTH_256, factory.getLog("package.both256/method1"));
+    assertEquals(BOTH_256, factory.getLog("package.both256/method2"));
+    assertEquals(BOTH_256, factory.getLog("package.both256/method3"));
 
     assertEquals(
         new Builder().header(128).msg(128).build(), factory.getLog("package.service1/both128"));
     // the global config is in effect
-    assertEquals(HEADER_ONLY, factory.getLog("package.service1/absent"));
+    assertEquals(HEADER_FULL, factory.getLog("package.service1/absent"));
 
-    assertEquals(MSG_ONLY, factory.getLog("package.service2/method_messageOnly"));
+    assertEquals(MSG_FULL, factory.getLog("package.service2/method_messageOnly"));
     // the global config is in effect
-    assertEquals(HEADER_ONLY, factory.getLog("package.service2/absent"));
+    assertEquals(HEADER_FULL, factory.getLog("package.service2/absent"));
   }
 
   @Test
@@ -162,19 +153,16 @@ public final class BinaryLogTest {
         + "package.service2/method_messageOnly{m}");
     assertEquals(NONE, factory.getLog("otherpackage.service/method"));
 
-    assertEquals(
-        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method1"));
-    assertEquals(
-        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method2"));
-    assertEquals(
-        new Builder().header(256).msg(256).build(), factory.getLog("package.both256/method3"));
+    assertEquals(BOTH_256, factory.getLog("package.both256/method1"));
+    assertEquals(BOTH_256, factory.getLog("package.both256/method2"));
+    assertEquals(BOTH_256, factory.getLog("package.both256/method3"));
 
     assertEquals(
         new Builder().header(128).msg(128).build(), factory.getLog("package.service1/both128"));
     // no global config in effect
     assertEquals(NONE, factory.getLog("package.service1/absent"));
 
-    assertEquals(MSG_ONLY, factory.getLog("package.service2/method_messageOnly"));
+    assertEquals(MSG_FULL, factory.getLog("package.service2/method_messageOnly"));
     // no global config in effect
     assertEquals(NONE, factory.getLog("package.service2/absent"));
   }

--- a/core/src/test/java/io/grpc/internal/BinaryLogTest.java
+++ b/core/src/test/java/io/grpc/internal/BinaryLogTest.java
@@ -19,7 +19,7 @@ package io.grpc.internal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import io.grpc.internal.BinaryLog.Factory;
+import io.grpc.internal.BinaryLog.FactoryImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -39,98 +39,98 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_global() throws Exception {
-    assertEquals(BOTH_FULL, new Factory("*").getLog("p.s/m"));
-    assertEquals(BOTH_FULL, new Factory("*{h;m}").getLog("p.s/m"));
-    assertEquals(HEADER_FULL, new Factory("*{h}").getLog("p.s/m"));
-    assertEquals(MSG_FULL, new Factory("*{m}").getLog("p.s/m"));
-    assertEquals(HEADER_256, new Factory("*{h:256}").getLog("p.s/m"));
-    assertEquals(MSG_256, new Factory("*{m:256}").getLog("p.s/m"));
-    assertEquals(BOTH_256, new Factory("*{h:256;m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new FactoryImpl("*").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new FactoryImpl("*{h;m}").getLog("p.s/m"));
+    assertEquals(HEADER_FULL, new FactoryImpl("*{h}").getLog("p.s/m"));
+    assertEquals(MSG_FULL, new FactoryImpl("*{m}").getLog("p.s/m"));
+    assertEquals(HEADER_256, new FactoryImpl("*{h:256}").getLog("p.s/m"));
+    assertEquals(MSG_256, new FactoryImpl("*{m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_256, new FactoryImpl("*{h:256;m:256}").getLog("p.s/m"));
     assertEquals(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        new Factory("*{h;m:256}").getLog("p.s/m"));
+        new FactoryImpl("*{h;m:256}").getLog("p.s/m"));
     assertEquals(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        new Factory("*{h:256;m}").getLog("p.s/m"));
+        new FactoryImpl("*{h:256;m}").getLog("p.s/m"));
   }
 
   @Test
   public void configBinLog_method() throws Exception {
-    assertEquals(BOTH_FULL, new Factory("p.s/m").getLog("p.s/m"));
-    assertEquals(BOTH_FULL, new Factory("p.s/m{h;m}").getLog("p.s/m"));
-    assertEquals(HEADER_FULL, new Factory("p.s/m{h}").getLog("p.s/m"));
-    assertEquals(MSG_FULL, new Factory("p.s/m{m}").getLog("p.s/m"));
-    assertEquals(HEADER_256, new Factory("p.s/m{h:256}").getLog("p.s/m"));
-    assertEquals(MSG_256, new Factory("p.s/m{m:256}").getLog("p.s/m"));
-    assertEquals(BOTH_256, new Factory("p.s/m{h:256;m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new FactoryImpl("p.s/m").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new FactoryImpl("p.s/m{h;m}").getLog("p.s/m"));
+    assertEquals(HEADER_FULL, new FactoryImpl("p.s/m{h}").getLog("p.s/m"));
+    assertEquals(MSG_FULL, new FactoryImpl("p.s/m{m}").getLog("p.s/m"));
+    assertEquals(HEADER_256, new FactoryImpl("p.s/m{h:256}").getLog("p.s/m"));
+    assertEquals(MSG_256, new FactoryImpl("p.s/m{m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_256, new FactoryImpl("p.s/m{h:256;m:256}").getLog("p.s/m"));
     assertEquals(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        new Factory("p.s/m{h;m:256}").getLog("p.s/m"));
+        new FactoryImpl("p.s/m{h;m:256}").getLog("p.s/m"));
     assertEquals(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        new Factory("p.s/m{h:256;m}").getLog("p.s/m"));
+        new FactoryImpl("p.s/m{h:256;m}").getLog("p.s/m"));
   }
 
   @Test
   public void configBinLog_method_absent() throws Exception {
-    assertEquals(NONE, new Factory("p.s/m").getLog("p.s/absent"));
+    assertEquals(NONE, new FactoryImpl("p.s/m").getLog("p.s/absent"));
   }
 
   @Test
   public void configBinLog_service() throws Exception {
-    assertEquals(BOTH_FULL, new Factory("p.s/*").getLog("p.s/m"));
-    assertEquals(BOTH_FULL, new Factory("p.s/*{h;m}").getLog("p.s/m"));
-    assertEquals(HEADER_FULL, new Factory("p.s/*{h}").getLog("p.s/m"));
-    assertEquals(MSG_FULL, new Factory("p.s/*{m}").getLog("p.s/m"));
-    assertEquals(HEADER_256, new Factory("p.s/*{h:256}").getLog("p.s/m"));
-    assertEquals(MSG_256, new Factory("p.s/*{m:256}").getLog("p.s/m"));
-    assertEquals(BOTH_256, new Factory("p.s/*{h:256;m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new FactoryImpl("p.s/*").getLog("p.s/m"));
+    assertEquals(BOTH_FULL, new FactoryImpl("p.s/*{h;m}").getLog("p.s/m"));
+    assertEquals(HEADER_FULL, new FactoryImpl("p.s/*{h}").getLog("p.s/m"));
+    assertEquals(MSG_FULL, new FactoryImpl("p.s/*{m}").getLog("p.s/m"));
+    assertEquals(HEADER_256, new FactoryImpl("p.s/*{h:256}").getLog("p.s/m"));
+    assertEquals(MSG_256, new FactoryImpl("p.s/*{m:256}").getLog("p.s/m"));
+    assertEquals(BOTH_256, new FactoryImpl("p.s/*{h:256;m:256}").getLog("p.s/m"));
     assertEquals(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        new Factory("p.s/*{h;m:256}").getLog("p.s/m"));
+        new FactoryImpl("p.s/*{h;m:256}").getLog("p.s/m"));
     assertEquals(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        new Factory("p.s/*{h:256;m}").getLog("p.s/m"));
+        new FactoryImpl("p.s/*{h:256;m}").getLog("p.s/m"));
   }
 
   @Test
   public void configBinLog_service_absent() throws Exception {
-    assertEquals(NONE, new Factory("p.s/*").getLog("p.other/m"));
+    assertEquals(NONE, new FactoryImpl("p.s/*").getLog("p.other/m"));
   }
 
   @Test
   public void createLogFromOptionString() throws Exception {
-    assertEquals(BOTH_FULL, Factory.createBinaryLog(/*logConfig=*/ null));
-    assertEquals(HEADER_FULL, Factory.createBinaryLog("{h}"));
-    assertEquals(MSG_FULL, Factory.createBinaryLog("{m}"));
-    assertEquals(HEADER_256, Factory.createBinaryLog("{h:256}"));
-    assertEquals(MSG_256, Factory.createBinaryLog("{m:256}"));
-    assertEquals(BOTH_256, Factory.createBinaryLog("{h:256;m:256}"));
+    assertEquals(BOTH_FULL, FactoryImpl.createBinaryLog(/*logConfig=*/ null));
+    assertEquals(HEADER_FULL, FactoryImpl.createBinaryLog("{h}"));
+    assertEquals(MSG_FULL, FactoryImpl.createBinaryLog("{m}"));
+    assertEquals(HEADER_256, FactoryImpl.createBinaryLog("{h:256}"));
+    assertEquals(MSG_256, FactoryImpl.createBinaryLog("{m:256}"));
+    assertEquals(BOTH_256, FactoryImpl.createBinaryLog("{h:256;m:256}"));
     assertEquals(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        Factory.createBinaryLog("{h;m:256}"));
+        FactoryImpl.createBinaryLog("{h;m:256}"));
     assertEquals(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        Factory.createBinaryLog("{h:256;m}"));
+        FactoryImpl.createBinaryLog("{h:256;m}"));
   }
 
   @Test
   public void createLogFromOptionString_malformed() throws Exception {
-    assertNull(Factory.createBinaryLog("bad"));
-    assertNull(Factory.createBinaryLog("{bad}"));
-    assertNull(Factory.createBinaryLog("{x;y}"));
-    assertNull(Factory.createBinaryLog("{h:abc}"));
-    assertNull(Factory.createBinaryLog("{2}"));
-    assertNull(Factory.createBinaryLog("{2;2}"));
+    assertNull(FactoryImpl.createBinaryLog("bad"));
+    assertNull(FactoryImpl.createBinaryLog("{bad}"));
+    assertNull(FactoryImpl.createBinaryLog("{x;y}"));
+    assertNull(FactoryImpl.createBinaryLog("{h:abc}"));
+    assertNull(FactoryImpl.createBinaryLog("{2}"));
+    assertNull(FactoryImpl.createBinaryLog("{2;2}"));
     // The grammar specifies that if both h and m are present, h comes before m
-    assertNull(Factory.createBinaryLog("{m:123;h:123}"));
+    assertNull(FactoryImpl.createBinaryLog("{m:123;h:123}"));
     // NumberFormatException
-    assertNull(Factory.createBinaryLog("{h:99999999999999}"));
+    assertNull(FactoryImpl.createBinaryLog("{h:99999999999999}"));
   }
 
   @Test
   public void configBinLog_multiConfig_withGlobal() throws Exception {
-    Factory factory = new Factory(
+    FactoryImpl factory = new FactoryImpl(
         "*{h},"
         + "package.both256/*{h:256;m:256},"
         + "package.service1/both128{h:128;m:128},"
@@ -153,7 +153,7 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_multiConfig_noGlobal() throws Exception {
-    Factory factory = new Factory(
+    FactoryImpl factory = new FactoryImpl(
         "package.both256/*{h:256;m:256},"
         + "package.service1/both128{h:128;m:128},"
         + "package.service2/method_messageOnly{m}");
@@ -175,7 +175,7 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_ignoreDuplicates_global() throws Exception {
-    Factory factory = new Factory("*{h},p.s/m,*{h:256}");
+    FactoryImpl factory = new FactoryImpl("*{h},p.s/m,*{h:256}");
     // The duplicate
     assertEquals(HEADER_FULL, factory.getLog("p.other1/m"));
     assertEquals(HEADER_FULL, factory.getLog("p.other2/m"));
@@ -185,7 +185,7 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_ignoreDuplicates_service() throws Exception {
-    Factory factory = new Factory("p.s/*,*{h:256},p.s/*{h}");
+    FactoryImpl factory = new FactoryImpl("p.s/*,*{h:256},p.s/*{h}");
     // The duplicate
     assertEquals(BOTH_FULL, factory.getLog("p.s/m1"));
     assertEquals(BOTH_FULL, factory.getLog("p.s/m2"));
@@ -196,7 +196,7 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_ignoreDuplicates_method() throws Exception {
-    Factory factory = new Factory("p.s/m,*{h:256},p.s/m{h}");
+    FactoryImpl factory = new FactoryImpl("p.s/m,*{h:256},p.s/m{h}");
     // The duplicate
     assertEquals(BOTH_FULL, factory.getLog("p.s/m"));
     // Other


### PR DESCRIPTION
ServerCallImpl and ClientCallImpl will each have a BinaryLog
field. Each time the constructor is called, we will do a lookup
for the log. Performance is not critical for binlog, but if it
becomes a problem MethodDescriptor can have a setter to store
it as an Object (to avoid a depdency on `internal`).

The binary log class is a skeleton class at the moment, but does
contain the max header and message length info. The limits are
determined by parsing the shell variable GRPC_BINARY_LOG_CONFIG.