### PR TITLE
core: record RPC upstarts to Census.

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -71,7 +71,8 @@ public final class InProcessChannelBuilder extends
     this.name = Preconditions.checkNotNull(name, "name");
     // In-process transport should not record its traffic to the stats module.
     // https://github.com/grpc/grpc-java/issues/2284
-    setRecordStats(false);
+    setStatsRecordStartedRpcs(false);
+    setStatsRecordFinishedRpcs(false);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -81,7 +81,8 @@ public final class InProcessServerBuilder
     this.name = Preconditions.checkNotNull(name, "name");
     // In-process transport should not record its traffic to the stats module.
     // https://github.com/grpc/grpc-java/issues/2284
-    setRecordStats(false);
+    setStatsRecordStartedRpcs(false);
+    setStatsRecordFinishedRpcs(false);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -144,7 +144,8 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   private boolean statsEnabled = true;
-  private boolean recordStats = true;
+  private boolean recordStartedRpcs = true;
+  private boolean recordFinishedRpcs = true;
   private boolean tracingEnabled = true;
 
   @Nullable
@@ -296,11 +297,19 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   /**
-   * Disable or enable stats recording.  Effective only if {@link #setStatsEnabled} is set to true.
-   * Enabled by default.
+   * Disable or enable stats recording for RPC upstarts.  Effective only if {@link
+   * #setStatsEnabled} is set to true.  Enabled by default.
    */
-  protected void setRecordStats(boolean value) {
-    recordStats = value;
+  protected void setStatsRecordStartedRpcs(boolean value) {
+    recordStartedRpcs = value;
+  }
+
+  /**
+   * Disable or enable stats recording for RPC completions.  Effective only if {@link
+   * #setStatsEnabled} is set to true.  Enabled by default.
+   */
+  protected void setStatsRecordFinishedRpcs(boolean value) {
+    recordFinishedRpcs = value;
   }
 
   /**
@@ -348,7 +357,8 @@ public abstract class AbstractManagedChannelImplBuilder
       }
       // First interceptor runs last (see ClientInterceptors.intercept()), so that no
       // other interceptor can override the tracer factory we set in CallOptions.
-      effectiveInterceptors.add(0, censusStats.getClientInterceptor(recordStats));
+      effectiveInterceptors.add(
+          0, censusStats.getClientInterceptor(recordStartedRpcs, recordFinishedRpcs));
     }
     if (tracingEnabled) {
       CensusTracingModule censusTracing =

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -98,7 +98,8 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   private CensusStatsModule censusStatsOverride;
 
   private boolean statsEnabled = true;
-  private boolean recordStats = true;
+  private boolean recordStartedRpcs = true;
+  private boolean recordFinishedRpcs = true;
   private boolean tracingEnabled = true;
 
   @Override
@@ -195,11 +196,19 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   }
 
   /**
-   * Disable or enable stats recording.  Effective only if {@link #setStatsEnabled} is set to true.
-   * Enabled by default.
+   * Disable or enable stats recording for RPC upstarts.  Effective only if {@link
+   * #setStatsEnabled} is set to true.  Enabled by default.
    */
-  protected void setRecordStats(boolean value) {
-    recordStats = value;
+  protected void setStatsRecordStartedRpcs(boolean value) {
+    recordStartedRpcs = value;
+  }
+
+  /**
+   * Disable or enable stats recording for RPC completions.  Effective only if {@link
+   * #setStatsEnabled} is set to true.  Enabled by default.
+   */
+  protected void setStatsRecordFinishedRpcs(boolean value) {
+    recordFinishedRpcs = value;
   }
 
   /**
@@ -230,7 +239,8 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
       if (censusStats == null) {
         censusStats = new CensusStatsModule(GrpcUtil.STOPWATCH_SUPPLIER, true);
       }
-      tracerFactories.add(censusStats.getServerTracerFactory(recordStats));
+      tracerFactories.add(
+          censusStats.getServerTracerFactory(recordStartedRpcs, recordFinishedRpcs));
     }
     if (tracingEnabled) {
       CensusTracingModule censusTracing =

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -104,6 +104,11 @@ public class StatsTestUtils {
       }
       return longValue;
     }
+
+    @Override
+    public String toString() {
+      return "[tags=" + tags + ", metrics=" + metrics + "]";
+    }
   }
 
   /**


### PR DESCRIPTION
RPC upstarts are counted into metrics `RPC_{CLIENT,SERVER}_STARTED_COUNT`. In addition, RPC completions are counted into metrics `RPC_{CLIENT,SERVER}_FINISHED_COUNT`.  From these
metrics, users will be able to derive count of RPCs that are currently active.

/cc @dinooliva, @sebright 