### PR TITLE
Link JavaDoc to protobuf JavaDoc

### DIFF
--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -29,3 +29,5 @@ dependencies {
 
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
+
+javadoc.options.links 'https://developers.google.com/protocol-buffers/docs/reference/java/'


### PR DESCRIPTION
This breaks javanano links, but the value to normal and lite proto seems
more important.

Trivia: I've had this branch lying around for a while... "Tue Aug 18 14:04:30 2015 -0700". All I did is replace "FIXME: breaks javanano documentation" in the commit message. :smile: 