### PR TITLE
bazel build includes all core classes

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -1,7 +1,7 @@
 java_library(
     name = "core",
     srcs = glob([
-        "src/main/java/io/grpc/*.java",
+        "src/main/java/io/grpc/**/*.java",
     ]),
     resources = glob([
         "src/main/resources/**",


### PR DESCRIPTION
Before, grpc_java//core only included top-level java classes, and with this change, all core classes are available via this bazel dependency.