### PR TITLE
testing: bazel build targets

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -10,6 +10,7 @@ def grpc_java_repositories(
     omit_com_google_protobuf=False,
     omit_com_google_protobuf_java=False,
     omit_com_google_protobuf_nano_protobuf_javanano=False,
+    omit_com_google_truth_truth=False,
     omit_com_squareup_okhttp=False,
     omit_com_squareup_okio=False,
     omit_io_netty_buffer=False,
@@ -24,7 +25,8 @@ def grpc_java_repositories(
     omit_io_netty_resolver=False,
     omit_io_netty_tcnative_boringssl_static=False,
     omit_io_opencensus_api=False,
-    omit_io_opencensus_grpc_metrics=False):
+    omit_io_opencensus_grpc_metrics=False,
+    omit_junit_junit=False):
   """Imports dependencies for grpc-java."""
   if not omit_com_google_api_grpc_google_common_protos:
     com_google_api_grpc_google_common_protos()
@@ -44,6 +46,8 @@ def grpc_java_repositories(
     com_google_protobuf_java()
   if not omit_com_google_protobuf_nano_protobuf_javanano:
     com_google_protobuf_nano_protobuf_javanano()
+  if not omit_com_google_truth_truth:
+    com_google_truth_truth()
   if not omit_com_squareup_okhttp:
     com_squareup_okhttp()
   if not omit_com_squareup_okio:
@@ -74,6 +78,9 @@ def grpc_java_repositories(
     io_opencensus_api()
   if not omit_io_opencensus_grpc_metrics:
     io_opencensus_grpc_metrics()
+  if not omit_junit_junit:
+    junit_junit()
+
   native.bind(
     name = "guava",
     actual = "@com_google_guava_guava//jar",
@@ -151,6 +158,13 @@ def com_google_protobuf_nano_protobuf_javanano():
       name = "com_google_protobuf_nano_protobuf_javanano",
       artifact = "com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-5",
       sha1 = "357e60f95cebb87c72151e49ba1f570d899734f8",
+  )
+
+def com_google_truth_truth():
+  native.maven_jar(
+      name = "com_google_truth_truth",
+      artifact = "com.google.truth:truth:0.36",
+      sha1 = "7485219d2c1d341097a19382c02bde07e69ff5d2",
   )
 
 def com_squareup_okhttp():
@@ -256,4 +270,11 @@ def io_opencensus_grpc_metrics():
       name = "io_opencensus_opencensus_contrib_grpc_metrics",
       artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.8.0",
       sha1 = "5e54d0e6dd946fe097e63ad68243e0006fbb1fbc",
+  )
+
+def junit_junit():
+  native.maven_jar(
+      name = "junit_junit",
+      artifact = "junit:junit:4.12",
+      sha1 = "2973d150c0dc1fefe998f834810d68f278ea58ec",
   )

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -1,0 +1,36 @@
+java_library(
+    name = "testing",
+    srcs = glob([
+        "src/main/java/io/grpc/testing/*.java",
+    ]),
+    resources = glob([
+        "src/main/resources/**",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//context",
+        "//core",
+        "//core:inprocess",
+        "//core:util",
+        "//stub",
+
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_truth_truth//jar",
+        "@junit_junit//jar",
+    ],
+    testonly = 1,
+)
+
+java_library(
+    name = "internal",
+    srcs = glob([
+        "src/main/java/io/grpc/internal/*.java",
+    ]),
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//core",
+        "//core:internal",
+        "@com_google_instrumentation_instrumentation_api//jar",
+    ],
+)


### PR DESCRIPTION
Adds necessary dependencies and bazel build rules to create `@grpc_java//testing`.

I tried to follow bazel conventions and style I found in `code/BUILD.bazel`.