### PR TITLE
cronet,okhttp: add internal API to disable stats and/or tracing

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -139,6 +139,16 @@ public final class CronetChannelBuilder extends
         .set(NameResolver.Factory.PARAMS_DEFAULT_PORT, GrpcUtil.DEFAULT_PORT_SSL).build();
   }
 
+  @Override
+  protected void setTracingEnabled(boolean value) {
+    super.setTracingEnabled(value);
+  }
+
+  @Override
+  protected void setStatsEnabled(boolean value) {
+    super.setStatsEnabled(value);
+  }
+
   @VisibleForTesting
   static class CronetTransportFactory implements ClientTransportFactory {
     private final ScheduledExecutorService timeoutService =

--- a/cronet/src/main/java/io/grpc/cronet/InternalCronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/InternalCronetChannelBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.cronet;
+
+import io.grpc.Internal;
+
+/**
+ * Internal {@link CronetChannelBuilder} accessor.  This is intended for usage internal to the gRPC
+ * team.  If you *really* think you need to use this, contact the gRPC team first.
+ */
+@Internal
+public class InternalCronetChannelBuilder {
+  public static void setStatsEnabled(CronetChannelBuilder builder, boolean value) {
+    builder.setStatsEnabled(value);
+  }
+
+  public static void setTracingEnabled(CronetChannelBuilder builder, boolean value) {
+    builder.setTracingEnabled(value);
+  }
+
+  private InternalCronetChannelBuilder() {}
+}

--- a/okhttp/src/main/java/io/grpc/okhttp/InternalOkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/InternalOkHttpChannelBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.okhttp;
+
+import io.grpc.Internal;
+
+/**
+ * Internal {@link OkHttpChannelBuilder} accessor.  This is intended for usage internal to the gRPC
+ * team.  If you *really* think you need to use this, contact the gRPC team first.
+ */
+@Internal
+public class InternalOkHttpChannelBuilder {
+  public static void setStatsEnabled(OkHttpChannelBuilder builder, boolean value) {
+    builder.setStatsEnabled(value);
+  }
+
+  public static void setTracingEnabled(OkHttpChannelBuilder builder, boolean value) {
+    builder.setTracingEnabled(value);
+  }
+
+  private InternalOkHttpChannelBuilder() {}
+}

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -369,6 +369,16 @@ public class OkHttpChannelBuilder extends
     }
   }
 
+  @Override
+  protected void setTracingEnabled(boolean value) {
+    super.setTracingEnabled(value);
+  }
+
+  @Override
+  protected void setStatsEnabled(boolean value) {
+    super.setStatsEnabled(value);
+  }
+
   /**
    * Creates OkHttp transports. Exposed for internal use, as it should be private.
    */


### PR DESCRIPTION
There may be some issues (will confirm before getting this merged) with our Census\*Module's usage of Atomic\*FieldUpdater on some Android platform, due to varied support for reflection (see prior art: https://github.com/ReactiveX/RxJava/issues/3459). This PR disables stats and tracing on Android as a temporary solution.

@zhangkun83 Could this impact any users? I'm not sure of the release status of Census or if stats/tracing on Android could already have users with Census.