### PR TITLE
okhttp,netty: move StreamIdHolder to internal

### DIFF
--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -28,7 +28,8 @@ import javax.annotation.Nullable;
 /**
  * Base implementation for client streams using HTTP2 as the transport.
  */
-public abstract class Http2ClientStreamTransportState extends AbstractClientStream.TransportState {
+public abstract class Http2ClientStreamTransportState
+    extends AbstractClientStream.TransportState implements StreamIdHolder {
 
   /**
    * Metadata marshaller for HTTP status lines.

--- a/core/src/main/java/io/grpc/internal/StreamIdHolder.java
+++ b/core/src/main/java/io/grpc/internal/StreamIdHolder.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package io.grpc.netty;
+package io.grpc.internal;
 
 /** Container for stream ids. */
-interface StreamIdHolder {
+public interface StreamIdHolder {
   /**
    * Returns the id.
    */

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -343,6 +343,15 @@ public class Http2ClientStreamTransportStateTest {
   }
 
   private static class BaseTransportState extends Http2ClientStreamTransportState {
+    private static int ids = 1;
+
+    private final int id = ids++;
+
+    @Override
+    public int id() {
+      return id;
+    }
+
     public BaseTransportState(TransportTracer transportTracer) {
       super(DEFAULT_MAX_MESSAGE_SIZE, StatsTraceContext.NOOP, transportTracer);
     }

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -198,8 +198,7 @@ class NettyClientStream extends AbstractClientStream {
   }
 
   /** This should only called from the transport thread. */
-  public abstract static class TransportState extends Http2ClientStreamTransportState
-      implements StreamIdHolder {
+  public abstract static class TransportState extends Http2ClientStreamTransportState {
     private final NettyClientHandler handler;
     private final EventLoop eventLoop;
     private int id;

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -23,6 +23,7 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.AbstractServerStream;
 import io.grpc.internal.StatsTraceContext;
+import io.grpc.internal.StreamIdHolder;
 import io.grpc.internal.TransportTracer;
 import io.grpc.internal.WritableBuffer;
 import io.netty.buffer.ByteBuf;

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -16,6 +16,7 @@
 
 package io.grpc.netty;
 
+import io.grpc.internal.StreamIdHolder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;

--- a/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
@@ -19,6 +19,7 @@ package io.grpc.netty;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import io.grpc.Status;
+import io.grpc.internal.StreamIdHolder;
 import io.netty.handler.codec.http2.Http2Headers;
 
 /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -53,7 +53,7 @@ class OkHttpClientStream extends AbstractClientStream {
   private final StatsTraceContext statsTraceCtx;
   private String authority;
   private Object outboundFlowState;
-  private volatile int id = ABSENT_ID;
+  private int id = ABSENT_ID;
   private final TransportState state;
   private final Sink sink = new Sink();
 
@@ -99,10 +99,6 @@ class OkHttpClientStream extends AbstractClientStream {
    */
   public MethodDescriptor.MethodType getType() {
     return method.getType();
-  }
-
-  public int id() {
-    return id;
   }
 
   /**
@@ -205,6 +201,11 @@ class OkHttpClientStream extends AbstractClientStream {
       this.frameWriter = frameWriter;
       this.outboundFlow = outboundFlow;
       this.transport = transport;
+    }
+
+    @Override
+    public int id() {
+      return id;
     }
 
     @GuardedBy("lock")

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -323,7 +323,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   @GuardedBy("lock")
   private void startStream(OkHttpClientStream stream) {
     Preconditions.checkState(
-        stream.id() == OkHttpClientStream.ABSENT_ID, "StreamId already assigned");
+        stream.transportState().id() == OkHttpClientStream.ABSENT_ID, "StreamId already assigned");
     streams.put(nextStreamId, stream);
     setInUse();
     stream.transportState().start(nextStreamId);

--- a/okhttp/src/main/java/io/grpc/okhttp/OutboundFlowController.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OutboundFlowController.java
@@ -231,7 +231,7 @@ class OutboundFlowController {
     }
 
     OutboundFlowState(OkHttpClientStream stream) {
-      this(stream.id());
+      this(stream.transportState().id());
       this.stream = stream;
     }
 


### PR DESCRIPTION
This makes streamId holder common between okhttp and netty.  In a
subsequent PR, I am going to make it used by ClientCallImpl callbacks
as a debugging identifier in toString()

The reason is that sometimes a callback throws an exception and is
logged, but the client call is still alive for some reason.  It's nice
to be able to associate an exception from a callback with a particular
RPC.

One other note: this makes the `id` in Okhttp non volatile.  I looked
at all the accesses, and think this was a hold over from before
the transport state change.