### PR TITLE
grpclb: switch to fallback mode if all connections are lost

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -142,7 +142,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
           grpclbState.propagateError(Status.UNAVAILABLE.withDescription(
                   "NameResolver returned no LB address while asking for GRPCLB"));
         } else {
-          grpclbState.updateAddresses(newLbAddressGroups, newBackendServers);
+          grpclbState.handleAddresses(newLbAddressGroups, newBackendServers);
         }
         break;
       default:

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -138,12 +138,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
         delegate.handleResolvedAddressGroups(newBackendServers, attributes);
         break;
       case GRPCLB:
-        if (newLbAddressGroups.isEmpty()) {
-          grpclbState.propagateError(Status.UNAVAILABLE.withDescription(
-                  "NameResolver returned no LB address while asking for GRPCLB"));
-        } else {
-          grpclbState.handleAddresses(newLbAddressGroups, newBackendServers);
-        }
+        grpclbState.handleAddresses(newLbAddressGroups, newBackendServers);
         break;
       default:
         // Do nothing

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -180,27 +180,31 @@ final class GrpclbState {
    * Start the fallback timer if it's not already started and all connections are lost.
    */
   private void maybeStartFallbackTimer() {
-    if (fallbackTimer == null) {
-      if (fallbackBackendList.isEmpty()) {
-        return;
-      }
-      if (balancerWorking) {
-        return;
-      }
-      int numReadySubchannels = 0;
-      for (Subchannel subchannel : subchannels.values()) {
-        if (subchannel.getAttributes().get(STATE_INFO).get().getState() == READY) {
-          numReadySubchannels++;
-        }
-      }
-      if (numReadySubchannels > 0) {
-        return;
-      }
-      logger.log(Level.FINE, "[{0}] Starting fallback timer.", new Object[] {logId});
-      fallbackTimer = new FallbackModeTask();
-      fallbackTimer.scheduledFuture =
-          timerService.schedule(fallbackTimer, FALLBACK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    if (fallbackTimer != null) {
+      return;
     }
+    if (fallbackBackendList.isEmpty()) {
+      return;
+    }
+    if (balancerWorking) {
+      return;
+    }
+    if (usingFallbackBackends) {
+      return;
+    }
+    int numReadySubchannels = 0;
+    for (Subchannel subchannel : subchannels.values()) {
+      if (subchannel.getAttributes().get(STATE_INFO).get().getState() == READY) {
+        numReadySubchannels++;
+      }
+    }
+    if (numReadySubchannels > 0) {
+      return;
+    }
+    logger.log(Level.FINE, "[{0}] Starting fallback timer.", new Object[] {logId});
+    fallbackTimer = new FallbackModeTask();
+    fallbackTimer.scheduledFuture =
+        timerService.schedule(fallbackTimer, FALLBACK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
   }
 
   /**

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -153,6 +153,11 @@ final class GrpclbState {
    */
   void handleAddresses(
       List<LbAddressGroup> newLbAddressGroups, List<EquivalentAddressGroup> newBackendServers) {
+    if (newLbAddressGroups.isEmpty()) {
+      propagateError(Status.UNAVAILABLE.withDescription(
+              "NameResolver returned no LB address while asking for GRPCLB"));
+      return;
+    }
     LbAddressGroup newLbAddressGroup = flattenLbAddressGroups(newLbAddressGroups);
     startLbComm(newLbAddressGroup);
     // Avoid creating a new RPC just because the addresses were updated, as it can cause a

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -174,6 +174,10 @@ final class GrpclbState {
     }
   }
 
+  /**
+   * If conditions for using fallback backends are met, populate the round-robin lists with the
+   * fallback backends.
+   */
   private void maybeUseFallbackBackends() {
     if (fallbackBackendList.isEmpty()) {
       return;
@@ -277,6 +281,9 @@ final class GrpclbState {
     return lbStream.loadRecorder;
   }
 
+  /**
+   * Populate the round-robin lists with the given values.
+   */
   private void useRoundRobinLists(
       List<DropEntry> newDropList, List<BackendAddressGroup> newBackendAddrList,
       @Nullable GrpclbClientLoadRecorder loadRecorder) {

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -203,8 +203,7 @@ final class GrpclbState {
     }
     logger.log(Level.FINE, "[{0}] Starting fallback timer.", new Object[] {logId});
     fallbackTimer = new FallbackModeTask();
-    fallbackTimer.scheduledFuture =
-        timerService.schedule(fallbackTimer, FALLBACK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    fallbackTimer.schedule();
   }
 
   /**
@@ -378,6 +377,11 @@ final class GrpclbState {
     void cancel() {
       scheduledFuture.cancel(false);
       cancelled = true;
+    }
+
+    void schedule() {
+      checkState(scheduledFuture == null, "FallbackModeTask already scheduled");
+      scheduledFuture = timerService.schedule(this, FALLBACK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
   }
 

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -1446,8 +1446,16 @@ public class GrpclbLoadBalancerTest {
         fakeClock.forwardTime(GrpclbState.FALLBACK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         assertEquals(0, fakeClock.numPendingTasks(FALLBACK_MODE_TASK_FILTER));
 
-        fallbackTestVerifyUseOfFallbackBackendLists(
+        // Going into fallback
+        subchannels = fallbackTestVerifyUseOfFallbackBackendLists(
             inOrder, helper, Arrays.asList(resolutionList.get(0), resolutionList.get(2)));
+
+        // When in fallback mode, fallback timer should not be scheduled when all backend
+        // connections are lost
+        for (Subchannel subchannel : subchannels) {
+          deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(IDLE));
+        }
+        assertEquals(0, fakeClock.numPendingTasks(FALLBACK_MODE_TASK_FILTER));
       } else {
         fakeClock.forwardTime(GrpclbState.FALLBACK_TIMEOUT_MS - 1, TimeUnit.MILLISECONDS);
       }


### PR DESCRIPTION
Previously fallback mode can be entered only if the client has not
received any server list and the fallback timeout has expired.

Now the fallback timer is started when the stream to the balancer is broken
AND there is no ready Subchannels. Fallback mode is activated when the
timer expires. When a new server list is received from the balancer, either
the fallback timer is cancelled, or fallback mode is exited.

Also fixed a bug that the fallback timer should've been cancelled when GrpcState
is shut down.