### PR TITLE
netty: add internal test accessor to builder

### DIFF
--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -16,9 +16,11 @@
 
 package io.grpc.netty;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Internal;
 import io.grpc.internal.ProxyParameters;
 import java.net.SocketAddress;
+import javax.annotation.Nullable;
 
 /**
  * Internal {@link NettyChannelBuilder} accessor.  This is intended for usage internal to the gRPC
@@ -75,4 +77,25 @@ public final class InternalNettyChannelBuilder {
   }
 
   private InternalNettyChannelBuilder() {}
+
+  /**
+   * Accessor for tests.
+   */
+  @VisibleForTesting
+  public static final class TestAccessor {
+    private TestAccessor() {}
+
+    /**
+     * Gets the {@link TransportCreationParamsFilterFactory} that is dynamically set to the
+     * specified NettyChannelBuilder at the moment.
+     */
+    @Nullable
+    public static TransportCreationParamsFilterFactory getDynamicTransportParamsFactory(
+        NettyChannelBuilder builder) {
+      if (builder.dynamicParamsFactory instanceof TransportCreationParamsFilterFactory) {
+        return (TransportCreationParamsFilterFactory) builder.dynamicParamsFactory;
+      }
+      return null;
+    }
+  }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -80,7 +80,8 @@ public final class NettyChannelBuilder
   private long keepAliveTimeNanos = KEEPALIVE_TIME_NANOS_DISABLED;
   private long keepAliveTimeoutNanos = DEFAULT_KEEPALIVE_TIMEOUT_NANOS;
   private boolean keepAliveWithoutCalls;
-  private TransportCreationParamsFilterFactory dynamicParamsFactory;
+  @VisibleForTesting
+  TransportCreationParamsFilterFactory dynamicParamsFactory;
 
   /**
    * Creates a new builder with the given server address. This factory method is primarily intended

--- a/netty/src/test/java/io/grpc/netty/InternalNettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/InternalNettyChannelBuilderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import io.grpc.netty.InternalNettyChannelBuilder.TestAccessor;
+import io.grpc.netty.InternalNettyChannelBuilder.TransportCreationParamsFilterFactory;
+import java.net.SocketAddress;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link InternalNettyChannelBuilder}.
+ */
+@RunWith(JUnit4.class)
+public class InternalNettyChannelBuilderTest {
+  @Test
+  public void getTcpfFactory() {
+    NettyChannelBuilder builder = NettyChannelBuilder.forAddress(new SocketAddress() {});
+
+    assertEquals(null, TestAccessor.getDynamicTransportParamsFactory(builder));
+
+    TransportCreationParamsFilterFactory factory1 =
+        mock(TransportCreationParamsFilterFactory.class);
+    InternalNettyChannelBuilder.setDynamicTransportParamsFactory(builder, factory1);
+    assertEquals(factory1, TestAccessor.getDynamicTransportParamsFactory(builder));
+
+    TransportCreationParamsFilterFactory factory2 =
+        mock(TransportCreationParamsFilterFactory.class);
+    InternalNettyChannelBuilder.setDynamicTransportParamsFactory(builder, factory2);
+    assertEquals(factory2, TestAccessor.getDynamicTransportParamsFactory(builder));
+
+    builder.build();
+    assertEquals(factory2, TestAccessor.getDynamicTransportParamsFactory(builder));
+  }
+}


### PR DESCRIPTION
Some forwarding channel builder that wraps a `NettyChannelBuilder` configs a custom protocol negotiator. It is very difficult to unit test that the config is really set up after `builder.build()`, because currently it is very hard to access the protocol negotiator from the builder, or the channel being built.

An internal test accessor is added to address the above difficulty.