### PR TITLE
gae-interop-testing: Pin appengine library version (backport)

### DIFF
--- a/gae-interop-testing/gae-jdk7/build.gradle
+++ b/gae-interop-testing/gae-jdk7/build.gradle
@@ -39,7 +39,7 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
   providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-  compile 'com.google.appengine:appengine:+'
+  compile 'com.google.appengine:appengine:1.9.59'
   // Deps needed by all gRPC apps in GAE
   compile libraries.google_api_protos
   compile project(":grpc-okhttp")

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -39,13 +39,13 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
   providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-  compile 'com.google.appengine:appengine:+'
+  compile 'com.google.appengine:appengine:1.9.59'
   // Deps needed by all gRPC apps in GAE
   compile libraries.google_api_protos
   compile project(":grpc-okhttp")
   compile project(":grpc-protobuf")
   compile project(":grpc-stub")
-  compile (project(":grpc-interop-testing"))
+  compile project(":grpc-interop-testing")
   compile libraries.netty_tcnative
 }
 


### PR DESCRIPTION
While using + is convenient, it prevents builds from being
deterministic which makes it hard/impossible to reproduce a historic
build or execution results.

Backport of #3716