### PR TITLE
Add ChannelStats and tests

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -346,7 +346,7 @@ public abstract class AbstractManagedChannelImplBuilder
         GrpcUtil.STOPWATCH_SUPPLIER,
         getEffectiveInterceptors(),
         GrpcUtil.getProxyDetector(),
-        new ChannelStats());
+        ChannelStats.getDefaultFactory());
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -346,7 +346,7 @@ public abstract class AbstractManagedChannelImplBuilder
         GrpcUtil.STOPWATCH_SUPPLIER,
         getEffectiveInterceptors(),
         GrpcUtil.getProxyDetector(),
-        new ChannelTraceStats());
+        new ChannelStats());
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -345,7 +345,8 @@ public abstract class AbstractManagedChannelImplBuilder
         SharedResourcePool.forResource(GrpcUtil.SHARED_CHANNEL_EXECUTOR),
         GrpcUtil.STOPWATCH_SUPPLIER,
         getEffectiveInterceptors(),
-        GrpcUtil.getProxyDetector());
+        GrpcUtil.getProxyDetector(),
+        new ChannelTraceStats());
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/internal/ChannelStats.java
+++ b/core/src/main/java/io/grpc/internal/ChannelStats.java
@@ -28,7 +28,7 @@ final class ChannelStats {
   private final LongCounter callsFailed = LongCounterFactory.create();
   private volatile long lastCallStartedMillis;
 
-  ChannelStats() {
+  private ChannelStats() {
     timeProvider = SYSTEM_TIME_PROVIDER;
   }
 

--- a/core/src/main/java/io/grpc/internal/ChannelStats.java
+++ b/core/src/main/java/io/grpc/internal/ChannelStats.java
@@ -21,19 +21,19 @@ import com.google.common.annotations.VisibleForTesting;
 /**
  * A collection of channel level stats for channelz.
  */
-final class ChannelTraceStats {
+final class ChannelStats {
   private final TimeProvider timeProvider;
   private final LongCounter callsStarted = LongCounterFactory.create();
   private final LongCounter callsSucceeded = LongCounterFactory.create();
   private final LongCounter callsFailed = LongCounterFactory.create();
   private volatile long lastCallStartedMillis;
 
-  ChannelTraceStats() {
+  ChannelStats() {
     timeProvider = SYSTEM_TIME_PROVIDER;
   }
 
   @VisibleForTesting
-  ChannelTraceStats(TimeProvider timeProvider) {
+  ChannelStats(TimeProvider timeProvider) {
     this.timeProvider = timeProvider;
   }
 

--- a/core/src/main/java/io/grpc/internal/ChannelStats.java
+++ b/core/src/main/java/io/grpc/internal/ChannelStats.java
@@ -78,4 +78,18 @@ final class ChannelStats {
       return System.currentTimeMillis();
     }
   };
+  private static final Factory DEFAULT_FACTORY = new Factory() {
+    @Override
+    public ChannelStats create() {
+      return new ChannelStats(SYSTEM_TIME_PROVIDER);
+    }
+  };
+
+  public static Factory getDefaultFactory() {
+    return DEFAULT_FACTORY;
+  }
+
+  public interface Factory {
+    ChannelStats create();
+  }
 }

--- a/core/src/main/java/io/grpc/internal/ChannelTraceStats.java
+++ b/core/src/main/java/io/grpc/internal/ChannelTraceStats.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * A collection of channel level stats for channelz.
+ */
+final class ChannelTraceStats {
+  private final TimeProvider timeProvider;
+  private final LongCounter callsStarted = LongCounterFactory.create();
+  private final LongCounter callsSucceeded = LongCounterFactory.create();
+  private final LongCounter callsFailed = LongCounterFactory.create();
+  private volatile long lastCallStartedMillis;
+
+  ChannelTraceStats() {
+    timeProvider = SYSTEM_TIME_PROVIDER;
+  }
+
+  @VisibleForTesting
+  ChannelTraceStats(TimeProvider timeProvider) {
+    this.timeProvider = timeProvider;
+  }
+
+  public void reportCallStarted() {
+    callsStarted.add(1);
+    lastCallStartedMillis = timeProvider.currentTimeMillis();
+  }
+
+  public void reportCallEnded(boolean success) {
+    if (success) {
+      callsSucceeded.add(1);
+    } else {
+      callsFailed.add(1);
+    }
+  }
+
+  long getCallsStarted() {
+    return callsStarted.value();
+  }
+
+  long getCallsSucceeded() {
+    return callsSucceeded.value();
+  }
+
+  long getCallsFailed() {
+    return callsFailed.value();
+  }
+
+  long getLastCallStartedMillis() {
+    return lastCallStartedMillis;
+  }
+
+  @VisibleForTesting
+  interface TimeProvider {
+    /** Returns the current milli time. */
+    long currentTimeMillis();
+  }
+
+  private static final TimeProvider SYSTEM_TIME_PROVIDER = new TimeProvider() {
+    @Override
+    public long currentTimeMillis() {
+      return System.currentTimeMillis();
+    }
+  };
+}

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -68,7 +68,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
 
   private final MethodDescriptor<ReqT, RespT> method;
   private final Executor callExecutor;
-  private final ChannelTraceStats channelStats;
+  private final ChannelStats channelStats;
   private final Context context;
   private volatile ScheduledFuture<?> deadlineCancellationFuture;
   private final boolean unaryRequest;
@@ -88,7 +88,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       MethodDescriptor<ReqT, RespT> method, Executor executor, CallOptions callOptions,
       ClientTransportProvider clientTransportProvider,
       ScheduledExecutorService deadlineCancellationExecutor,
-      ChannelTraceStats channelStats) {
+      ChannelStats channelStats) {
     this.method = method;
     // If we know that the executor is a direct executor, we don't need to wrap it with a
     // SerializingExecutor. This is purely for performance reasons.

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -217,7 +217,6 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     } else {
       compressor = Codec.Identity.NONE;
     }
-
     prepareHeaders(headers, decompressorRegistry, compressor, fullStreamDecompression);
 
     Deadline effectiveDeadline = effectiveDeadline();
@@ -249,6 +248,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     stream.setCompressor(compressor);
     stream.setFullStreamDecompression(fullStreamDecompression);
     stream.setDecompressorRegistry(decompressorRegistry);
+    channelStats.reportCallStarted();
     stream.start(new ClientStreamListenerImpl(observer));
 
     // Delay any sources of cancellation after start(), because most of the transports are broken if
@@ -270,7 +270,6 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       // was cancelled.
       removeContextListenerAndCancelDeadlineFuture();
     }
-    channelStats.reportCallStarted();
   }
 
   /**
@@ -527,9 +526,9 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       cancelListenersShouldBeRemoved = true;
       try {
         closeObserver(observer, status, trailers);
-        channelStats.reportCallEnded(status.isOk());
       } finally {
         removeContextListenerAndCancelDeadlineFuture();
+        channelStats.reportCallEnded(status.isOk());
       }
     }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -185,7 +185,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   private final ManagedChannelReference phantom;
 
   @VisibleForTesting
-  final ChannelTraceStats channelStats;
+  final ChannelStats channelStats;
 
   // Called from channelExecutor
   private final ManagedClientTransport.Listener delayedTransportListener =
@@ -399,7 +399,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
       Supplier<Stopwatch> stopwatchSupplier,
       List<ClientInterceptor> interceptors,
       ProxyDetector proxyDetector,
-      ChannelTraceStats channelTraceStats) {
+      ChannelStats channelStats) {
     this.target = checkNotNull(builder.target, "target");
     this.nameResolverFactory = builder.getNameResolverFactory();
     this.nameResolverParams = checkNotNull(builder.getNameResolverParams(), "nameResolverParams");
@@ -432,7 +432,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
     this.proxyDetector = proxyDetector;
 
     phantom = new ManagedChannelReference(this);
-    this.channelStats = channelTraceStats;
+    this.channelStats = channelStats;
     logger.log(Level.FINE, "[{0}] Created with target {1}", new Object[] {getLogId(), target});
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -185,7 +185,6 @@ public final class ManagedChannelImpl extends ManagedChannel implements WithLogI
   private final ManagedChannelReference phantom;
 
   private final ChannelStats.Factory channelStatsFactory; // to create new stats for each oobchannel
-  @VisibleForTesting
   final ChannelStats channelStats;
 
   // Called from channelExecutor

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -54,6 +54,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   private SubchannelPicker subchannelPicker;
 
   private final LogId logId = LogId.allocate(getClass().getName());
+  private final ChannelTraceStats channelStats = new ChannelTraceStats();
   private final String authority;
   private final DelayedClientTransport delayedTransport;
   private final ObjectPool<? extends Executor> executorPool;
@@ -155,7 +156,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
       MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
     return new ClientCallImpl<RequestT, ResponseT>(methodDescriptor,
         callOptions.getExecutor() == null ? executor : callOptions.getExecutor(),
-        callOptions, transportProvider, deadlineCancellationExecutor);
+        callOptions, transportProvider, deadlineCancellationExecutor, channelStats);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -54,7 +54,6 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   private SubchannelPicker subchannelPicker;
 
   private final LogId logId = LogId.allocate(getClass().getName());
-  private final ChannelStats channelStats = new ChannelStats();
   private final String authority;
   private final DelayedClientTransport delayedTransport;
   private final ObjectPool<? extends Executor> executorPool;
@@ -62,6 +61,8 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   private final ScheduledExecutorService deadlineCancellationExecutor;
   private final CountDownLatch terminatedLatch = new CountDownLatch(1);
   private volatile boolean shutdown;
+  @VisibleForTesting
+  final ChannelStats channelStats;
 
   private final ClientTransportProvider transportProvider = new ClientTransportProvider() {
     @Override
@@ -75,7 +76,8 @@ final class OobChannel extends ManagedChannel implements WithLogId {
 
   OobChannel(
       String authority, ObjectPool<? extends Executor> executorPool,
-      ScheduledExecutorService deadlineCancellationExecutor, ChannelExecutor channelExecutor) {
+      ScheduledExecutorService deadlineCancellationExecutor, ChannelExecutor channelExecutor,
+      ChannelStats channelStats) {
     this.authority = checkNotNull(authority, "authority");
     this.executorPool = checkNotNull(executorPool, "executorPool");
     this.executor = checkNotNull(executorPool.getObject(), "executor");
@@ -103,6 +105,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
           // Don't care
         }
       });
+    this.channelStats = channelStats;
   }
 
   // Must be called only once, right after the OobChannel is created.

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -54,7 +54,7 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   private SubchannelPicker subchannelPicker;
 
   private final LogId logId = LogId.allocate(getClass().getName());
-  private final ChannelTraceStats channelStats = new ChannelTraceStats();
+  private final ChannelStats channelStats = new ChannelStats();
   private final String authority;
   private final DelayedClientTransport delayedTransport;
   private final ObjectPool<? extends Executor> executorPool;

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -61,7 +61,6 @@ final class OobChannel extends ManagedChannel implements WithLogId {
   private final ScheduledExecutorService deadlineCancellationExecutor;
   private final CountDownLatch terminatedLatch = new CountDownLatch(1);
   private volatile boolean shutdown;
-  @VisibleForTesting
   final ChannelStats channelStats;
 
   private final ClientTransportProvider transportProvider = new ClientTransportProvider() {

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -89,6 +89,7 @@ public class ClientCallImplTest {
   private final FakeClock fakeClock = new FakeClock();
   private final ScheduledExecutorService deadlineCancellationExecutor =
       fakeClock.getScheduledExecutorService();
+  private final ChannelTraceStats channaleStats = new ChannelTraceStats();
   private final DecompressorRegistry decompressorRegistry =
       DecompressorRegistry.getDefaultInstance().with(new Codec.Gzip(), true);
   private final MethodDescriptor<Void, Void> method = MethodDescriptor.<Void, Void>newBuilder()
@@ -149,7 +150,8 @@ public class ClientCallImplTest {
         executor,
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
@@ -169,7 +171,8 @@ public class ClientCallImplTest {
         executor,
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
@@ -204,7 +207,8 @@ public class ClientCallImplTest {
         executor,
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
@@ -237,7 +241,8 @@ public class ClientCallImplTest {
         executor,
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
@@ -269,7 +274,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor)
+        deadlineCancellationExecutor,
+        channaleStats)
             .setDecompressorRegistry(decompressorRegistry);
 
     call.start(callListener, new Metadata());
@@ -291,7 +297,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         baseCallOptions.withAuthority("overridden-authority"),
         provider,
-        deadlineCancellationExecutor)
+        deadlineCancellationExecutor,
+        channaleStats)
             .setDecompressorRegistry(decompressorRegistry);
 
     call.start(callListener, new Metadata());
@@ -306,7 +313,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         callOptions,
         provider,
-        deadlineCancellationExecutor)
+        deadlineCancellationExecutor,
+        channaleStats)
         .setDecompressorRegistry(decompressorRegistry);
     final Metadata metadata = new Metadata();
 
@@ -323,7 +331,8 @@ public class ClientCallImplTest {
         // Don't provide an authority
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor)
+        deadlineCancellationExecutor,
+        channaleStats)
             .setDecompressorRegistry(decompressorRegistry);
 
     call.start(callListener, new Metadata());
@@ -491,7 +500,8 @@ public class ClientCallImplTest {
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor)
+        deadlineCancellationExecutor,
+        channaleStats)
             .setDecompressorRegistry(decompressorRegistry);
 
     Context.ROOT.attach();
@@ -564,7 +574,8 @@ public class ClientCallImplTest {
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor)
+        deadlineCancellationExecutor,
+        channaleStats)
             .setDecompressorRegistry(decompressorRegistry);
 
     previous.attach();
@@ -592,7 +603,8 @@ public class ClientCallImplTest {
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor)
+        deadlineCancellationExecutor,
+        channaleStats)
         .setDecompressorRegistry(decompressorRegistry);
 
     previous.attach();
@@ -635,7 +647,8 @@ public class ClientCallImplTest {
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         callOptions,
         provider,
-        deadlineCancellationExecutor)
+        deadlineCancellationExecutor,
+        channaleStats)
             .setDecompressorRegistry(decompressorRegistry);
     call.start(callListener, new Metadata());
     verify(transport, times(0))
@@ -657,7 +670,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
 
     Metadata headers = new Metadata();
 
@@ -684,7 +698,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         callOpts,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
 
     Metadata headers = new Metadata();
 
@@ -711,7 +726,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         callOpts,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
 
     Metadata headers = new Metadata();
 
@@ -736,7 +752,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         baseCallOptions.withDeadline(Deadline.after(1, TimeUnit.SECONDS)),
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
 
     call.start(callListener, new Metadata());
 
@@ -759,7 +776,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
 
     call.start(callListener, new Metadata());
 
@@ -778,7 +796,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         baseCallOptions.withDeadline(Deadline.after(1, TimeUnit.SECONDS)),
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
     call.start(callListener, new Metadata());
     call.cancel("canceled", null);
 
@@ -801,7 +820,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
 
     Metadata headers = new Metadata();
 
@@ -817,7 +837,8 @@ public class ClientCallImplTest {
         MoreExecutors.directExecutor(),
         baseCallOptions,
         provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor,
+        channaleStats);
     final Exception cause = new Exception();
     ClientCall.Listener<Void> callListener =
         new ClientCall.Listener<Void>() {
@@ -853,7 +874,8 @@ public class ClientCallImplTest {
         new SerializingExecutor(Executors.newSingleThreadExecutor()),
         callOptions,
         provider,
-        deadlineCancellationExecutor)
+        deadlineCancellationExecutor,
+        channaleStats)
             .setDecompressorRegistry(decompressorRegistry);
 
     call.start(callListener, new Metadata());
@@ -866,7 +888,7 @@ public class ClientCallImplTest {
   public void getAttributes() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method, MoreExecutors.directExecutor(), baseCallOptions, provider,
-        deadlineCancellationExecutor);
+        deadlineCancellationExecutor, channaleStats);
     Attributes attrs =
         Attributes.newBuilder().set(Key.<String>of("fake key"), "fake value").build();
     when(stream.getAttributes()).thenReturn(attrs);

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -89,7 +89,7 @@ public class ClientCallImplTest {
   private final FakeClock fakeClock = new FakeClock();
   private final ScheduledExecutorService deadlineCancellationExecutor =
       fakeClock.getScheduledExecutorService();
-  private final ChannelTraceStats channaleStats = new ChannelTraceStats();
+  private final ChannelStats channaleStats = new ChannelStats();
   private final DecompressorRegistry decompressorRegistry =
       DecompressorRegistry.getDefaultInstance().with(new Codec.Gzip(), true);
   private final MethodDescriptor<Void, Void> method = MethodDescriptor.<Void, Void>newBuilder()

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -89,7 +89,7 @@ public class ClientCallImplTest {
   private final FakeClock fakeClock = new FakeClock();
   private final ScheduledExecutorService deadlineCancellationExecutor =
       fakeClock.getScheduledExecutorService();
-  private final ChannelStats channaleStats = new ChannelStats();
+  private final ChannelStats channaleStats = ChannelStats.getDefaultFactory().create();
   private final DecompressorRegistry decompressorRegistry =
       DecompressorRegistry.getDefaultInstance().with(new Codec.Gzip(), true);
   private final MethodDescriptor<Void, Void> method = MethodDescriptor.<Void, Void>newBuilder()

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -143,7 +143,7 @@ public class ManagedChannelImplIdlenessTest {
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         oobExecutorPool, timer.getStopwatchSupplier(),
         Collections.<ClientInterceptor>emptyList(),
-        GrpcUtil.NOOP_PROXY_DETECTOR, new ChannelTraceStats());
+        GrpcUtil.NOOP_PROXY_DETECTOR, new ChannelStats());
     newTransports = TestUtils.captureTransports(mockTransportFactory);
 
     for (int i = 0; i < 2; i++) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -143,7 +143,7 @@ public class ManagedChannelImplIdlenessTest {
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         oobExecutorPool, timer.getStopwatchSupplier(),
         Collections.<ClientInterceptor>emptyList(),
-        GrpcUtil.NOOP_PROXY_DETECTOR, new ChannelStats());
+        GrpcUtil.NOOP_PROXY_DETECTOR, ChannelStats.getDefaultFactory());
     newTransports = TestUtils.captureTransports(mockTransportFactory);
 
     for (int i = 0; i < 2; i++) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -143,7 +143,7 @@ public class ManagedChannelImplIdlenessTest {
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         oobExecutorPool, timer.getStopwatchSupplier(),
         Collections.<ClientInterceptor>emptyList(),
-        GrpcUtil.NOOP_PROXY_DETECTOR);
+        GrpcUtil.NOOP_PROXY_DETECTOR, new ChannelTraceStats());
     newTransports = TestUtils.captureTransports(mockTransportFactory);
 
     for (int i = 0; i < 2; i++) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -216,7 +216,7 @@ public class ManagedChannelImplTest {
     channel = new ManagedChannelImpl(
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         oobExecutorPool, timer.getStopwatchSupplier(), interceptors, GrpcUtil.NOOP_PROXY_DETECTOR,
-        new ChannelTraceStats(new ChannelTraceStats.TimeProvider() {
+        new ChannelStats(new ChannelStats.TimeProvider() {
           @Override
           public long currentTimeMillis() {
             return executor.currentTimeMillis();
@@ -1652,7 +1652,7 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void channelTrace_callStarted() throws Exception {
+  public void channelStat_callStarted() throws Exception {
     createChannel(new FakeNameResolverFactory(true), NO_INTERCEPTOR);
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     assertEquals(0, channel.channelStats.getCallsStarted());
@@ -1662,7 +1662,7 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void channelTrace_callEndSuccess() throws Exception {
+  public void channelStat_callEndSuccess() throws Exception {
     // set up
     Metadata headers = new Metadata();
     ClientStream mockStream = mock(ClientStream.class);
@@ -1703,7 +1703,7 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void channelTrace_callEndFail() throws Exception {
+  public void channelStat_callEndFail() throws Exception {
     createChannel(new FakeNameResolverFactory(true), NO_INTERCEPTOR);
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, new Metadata());

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -137,6 +137,17 @@ public class ManagedChannelImplTest {
   private final FakeClock timer = new FakeClock();
   private final FakeClock executor = new FakeClock();
   private final FakeClock oobExecutor = new FakeClock();
+  private final ChannelStats.Factory channelStatsFactory = new ChannelStats.Factory() {
+    @Override
+    public ChannelStats create() {
+      return new ChannelStats(new ChannelStats.TimeProvider() {
+          @Override
+          public long currentTimeMillis() {
+            return executor.currentTimeMillis();
+          }
+        });
+    }
+  };
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
@@ -216,12 +227,7 @@ public class ManagedChannelImplTest {
     channel = new ManagedChannelImpl(
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         oobExecutorPool, timer.getStopwatchSupplier(), interceptors, GrpcUtil.NOOP_PROXY_DETECTOR,
-        new ChannelStats(new ChannelStats.TimeProvider() {
-          @Override
-          public long currentTimeMillis() {
-            return executor.currentTimeMillis();
-          }
-        }));
+        channelStatsFactory);
 
     if (requestConnection) {
       // Force-exit the initial idle-mode
@@ -1715,6 +1721,77 @@ public class ManagedChannelImplTest {
     verify(mockCallListener).onClose(any(Status.class), any(Metadata.class));
     assertEquals(0, channel.channelStats.getCallsSucceeded());
     assertEquals(1, channel.channelStats.getCallsFailed());
+  }
+
+  @Test
+  public void channelStat_callStarted_oob() throws Exception {
+    createChannel(new FakeNameResolverFactory(true), NO_INTERCEPTOR);
+    OobChannel oob1 = (OobChannel) helper.createOobChannel(addressGroup, "oob1authority");
+    ClientCall<String, Integer> call = oob1.newCall(method, CallOptions.DEFAULT);
+
+    assertEquals(0, channel.channelStats.getCallsStarted());
+    call.start(mockCallListener, new Metadata());
+    // only oob channel stats updated
+    assertEquals(1, oob1.channelStats.getCallsStarted());
+    assertEquals(0, channel.channelStats.getCallsStarted());
+    assertEquals(executor.currentTimeMillis(), oob1.channelStats.getLastCallStartedMillis());
+  }
+
+  @Test
+  public void channelStat_callEndSuccess_oob() throws Exception {
+    // set up
+    ClientStream mockStream = mock(ClientStream.class);
+    createChannel(new FakeNameResolverFactory(true), NO_INTERCEPTOR);
+
+    OobChannel oobChannel = (OobChannel) helper.createOobChannel(addressGroup, "oobauthority");
+    FakeClock callExecutor = new FakeClock();
+    CallOptions options =
+        CallOptions.DEFAULT.withExecutor(callExecutor.getScheduledExecutorService());
+    ClientCall<String, Integer> call = oobChannel.newCall(method, options);
+    Metadata headers = new Metadata();
+    call.start(mockCallListener, headers);
+
+    MockClientTransportInfo transportInfo = transports.poll();
+    ConnectionClientTransport mockTransport = transportInfo.transport;
+    ManagedClientTransport.Listener transportListener = transportInfo.listener;
+    when(mockTransport.newStream(same(method), same(headers), any(CallOptions.class)))
+        .thenReturn(mockStream);
+    transportListener.transportReady();
+    callExecutor.runDueTasks();
+    verify(mockStream).start(streamListenerCaptor.capture());
+    // end set up
+
+    // the actual test
+    ClientStreamListener streamListener = streamListenerCaptor.getValue();
+    call.halfClose();
+    assertEquals(0, oobChannel.channelStats.getCallsSucceeded());
+    assertEquals(0, oobChannel.channelStats.getCallsFailed());
+    streamListener.closed(Status.OK, new Metadata());
+    callExecutor.runDueTasks();
+    // only oob channel stats updated
+    assertEquals(1, oobChannel.channelStats.getCallsSucceeded());
+    assertEquals(0, oobChannel.channelStats.getCallsFailed());
+    assertEquals(0, channel.channelStats.getCallsSucceeded());
+    assertEquals(0, channel.channelStats.getCallsFailed());
+  }
+
+  @Test
+  public void channelStat_callEndFail_oob() throws Exception {
+    createChannel(new FakeNameResolverFactory(true), NO_INTERCEPTOR);
+    OobChannel oob1 = (OobChannel) helper.createOobChannel(addressGroup, "oob1authority");
+    ClientCall<String, Integer> call = oob1.newCall(method, CallOptions.DEFAULT);
+    call.start(mockCallListener, new Metadata());
+    call.cancel("msg", null);
+
+    assertEquals(0, channel.channelStats.getCallsSucceeded());
+    assertEquals(0, channel.channelStats.getCallsFailed());
+    oobExecutor.runDueTasks();
+    // only oob channel stats updated
+    verify(mockCallListener).onClose(any(Status.class), any(Metadata.class));
+    assertEquals(0, oob1.channelStats.getCallsSucceeded());
+    assertEquals(1, oob1.channelStats.getCallsFailed());
+    assertEquals(0, channel.channelStats.getCallsSucceeded());
+    assertEquals(0, channel.channelStats.getCallsFailed());
   }
 
   private static class FakeBackoffPolicyProvider implements BackoffPolicy.Provider {


### PR DESCRIPTION
The call begin stat is bumped when the application calls `.start` and call end stats are bumped when the  `ClientStreamListener.closed` callback is called. This means the begin stat on the channel will be bumped immediately but the transport level stats may come later because of  `DelayedClientTransport`. The call end stats may be bumped on the transport first, and will finally be bumped on the channel when the callback gets triggered.