### PR TITLE
core: workaround for Atomic*FieldUpdater bug on some Android devices

### DIFF
--- a/core/src/main/java/io/grpc/internal/SerializingExecutor.java
+++ b/core/src/main/java/io/grpc/internal/SerializingExecutor.java
@@ -37,8 +37,24 @@ public final class SerializingExecutor implements Executor, Runnable {
   private static final Logger log =
       Logger.getLogger(SerializingExecutor.class.getName());
 
-  private static final AtomicIntegerFieldUpdater<SerializingExecutor> runStateUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(SerializingExecutor.class, "runState");
+  // When using Atomic*FieldUpdater, some Samsung Android 5.0.x devices encounter a bug in the JDK
+  // reflection API that triggers a NoSuchFieldException. When this occurs, fallback to a
+  // synchronized implementation.
+  private static final AtomicHelper atomicHelper = getAtomicHelper();
+
+  private static AtomicHelper getAtomicHelper() {
+    AtomicHelper helper;
+    try {
+      helper =
+          new FieldUpdaterAtomicHelper(
+              AtomicIntegerFieldUpdater.newUpdater(SerializingExecutor.class, "runState"));
+    } catch (Throwable t) {
+      log.log(Level.WARNING, "FieldUpdaterAtomicHelper failed", t);
+      helper = new SynchronizedAtomicHelper();
+    }
+    return helper;
+  }
+
   private static final int STOPPED = 0;
   private static final int RUNNING = -1;
 
@@ -71,7 +87,7 @@ public final class SerializingExecutor implements Executor, Runnable {
   }
 
   private void schedule(@Nullable Runnable removable) {
-    if (runStateUpdater.compareAndSet(this, STOPPED, RUNNING)) {
+    if (atomicHelper.runStateCompareAndSet(this, STOPPED, RUNNING)) {
       boolean success = false;
       try {
         executor.execute(this);
@@ -92,7 +108,7 @@ public final class SerializingExecutor implements Executor, Runnable {
             // to execute don't succeed and accidentally run a previous runnable.
             runQueue.remove(removable);
           }
-          runStateUpdater.set(this, STOPPED);
+          atomicHelper.runStateSet(this, STOPPED);
         }
       }
     }
@@ -111,11 +127,56 @@ public final class SerializingExecutor implements Executor, Runnable {
         }
       }
     } finally {
-      runStateUpdater.set(this, STOPPED);
+      atomicHelper.runStateSet(this, STOPPED);
     }
     if (!runQueue.isEmpty()) {
       // we didn't enqueue anything but someone else did.
       schedule(null);
+    }
+  }
+
+  private abstract static class AtomicHelper {
+    public abstract boolean runStateCompareAndSet(SerializingExecutor obj, int expect, int update);
+
+    public abstract void runStateSet(SerializingExecutor obj, int newValue);
+  }
+
+  private static final class FieldUpdaterAtomicHelper extends AtomicHelper {
+    private final AtomicIntegerFieldUpdater<SerializingExecutor> runStateUpdater;
+
+    private FieldUpdaterAtomicHelper(
+        AtomicIntegerFieldUpdater<SerializingExecutor> runStateUpdater) {
+      this.runStateUpdater = runStateUpdater;
+    }
+
+    @Override
+    public boolean runStateCompareAndSet(SerializingExecutor obj, int expect, int update) {
+      return runStateUpdater.compareAndSet(obj, expect, update);
+    }
+
+    @Override
+    public void runStateSet(SerializingExecutor obj, int newValue) {
+      runStateUpdater.set(obj, newValue);
+    }
+  }
+
+  private static final class SynchronizedAtomicHelper extends AtomicHelper {
+    @Override
+    public boolean runStateCompareAndSet(SerializingExecutor obj, int expect, int update) {
+      synchronized (obj) {
+        if (obj.runState == expect) {
+          obj.runState = update;
+          return true;
+        }
+        return false;
+      }
+    }
+
+    @Override
+    public void runStateSet(SerializingExecutor obj, int newValue) {
+      synchronized (obj) {
+        obj.runState = newValue;
+      }
     }
   }
 }


### PR DESCRIPTION
"This is a large but kinda sorta mechanical change..."

This adds a synchronized fallback update mechanism when use of Atomic*FieldUpdater fails. This ignores the use of atomic field updaters in grpclb and round robin load balancer. The bug in the JDK reflection API  seems to only be an issue on some Samsung Android 5.0.x devices, but there are enough of these out there that a workaround is necessary.

**Question:** The try-catch blocks in this PR catch any throwable from initialization of `FieldUpdaterAtomicHelper` objects, logs the throwable, and falls back to the synchronized implementation. Should we only catch `NoSuchFieldException`? This is the only known exception caused by the bug, so it could/should be ok to specialize the catch blocks. Guava did not do this, however. See prior art: https://github.com/google/guava/blob/fc992745150d95544fec68b9c6e89b5c3bc44b15/guava/src/com/google/common/util/concurrent/AbstractFuture.java#L147