### PR TITLE
core: Disable handshakeTimeout for InProcess

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -85,7 +85,7 @@ public final class InProcessServerBuilder
     setStatsRecordStartedRpcs(false);
     setStatsRecordFinishedRpcs(false);
     // Disable handshake timeout because it is unnecessary, and can trigger Thread creation that can
-    // break some environemnts (like tests).
+    // break some environments (like tests).
     handshakeTimeout(Long.MAX_VALUE, TimeUnit.SECONDS);
   }
 

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -23,6 +23,7 @@ import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.GrpcUtil;
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Builder for a server that services in-process requests. Clients identify the in-process server by
@@ -83,6 +84,9 @@ public final class InProcessServerBuilder
     // https://github.com/grpc/grpc-java/issues/2284
     setStatsRecordStartedRpcs(false);
     setStatsRecordFinishedRpcs(false);
+    // Disable handshake timeout because it is unnecessary, and can trigger Thread creation that can
+    // break some environemnts (like tests).
+    handshakeTimeout(Long.MAX_VALUE, TimeUnit.SECONDS);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -357,8 +358,15 @@ public final class ServerImpl extends io.grpc.Server implements WithLogId {
         }
       }
 
-      handshakeTimeoutFuture = transport.getScheduledExecutorService()
-          .schedule(new TransportShutdownNow(), handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
+      if (handshakeTimeoutMillis != Long.MAX_VALUE) {
+        handshakeTimeoutFuture = transport.getScheduledExecutorService()
+            .schedule(new TransportShutdownNow(), handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
+      } else {
+        // Noop, to avoid triggering Thread creation in InProcessServer
+        handshakeTimeoutFuture = new FutureTask<Void>(new Runnable() {
+          @Override public void run() {}
+        }, null);
+      }
     }
 
     @Override


### PR DESCRIPTION
handshakeTimeout is unnecessary for InProcess, and the scheduling is causing
Thread creation that is breaking restrictive test environments. Those
environments are mostly broken already because client-side will try to create
Threads as well, but they are currently lucking out that the exception on
client-side doesn't break much.