### PR TITLE
testing: replace deprecated truth.FailureStrategy with truth.FailureMetadata.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ subprojects {
                 // Test dependencies.
                 junit: 'junit:junit:4.12',
                 mockito: 'org.mockito:mockito-core:1.9.5',
-                truth: 'com.google.truth:truth:0.28',
+                truth: 'com.google.truth:truth:0.36',
 
                 // Benchmark dependencies
                 hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10',

--- a/testing/src/main/java/io/grpc/testing/DeadlineSubject.java
+++ b/testing/src/main/java/io/grpc/testing/DeadlineSubject.java
@@ -20,8 +20,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import com.google.common.truth.ComparableSubject;
-import com.google.common.truth.FailureStrategy;
-import com.google.common.truth.SubjectFactory;
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.Subject;
 import io.grpc.Deadline;
 import io.grpc.ExperimentalApi;
 import java.math.BigInteger;
@@ -34,15 +34,15 @@ import javax.annotation.Nullable;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3613")
 public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, Deadline> {
-  private static final SubjectFactory<DeadlineSubject, Deadline> deadlineFactory =
+  private static final Subject.Factory<DeadlineSubject, Deadline> deadlineFactory =
       new DeadlineSubjectFactory();
 
-  public static SubjectFactory<DeadlineSubject, Deadline> deadline() {
+  public static Subject.Factory<DeadlineSubject, Deadline> deadline() {
     return deadlineFactory;
   }
 
-  private DeadlineSubject(FailureStrategy failureStrategy, Deadline subject) {
-    super(failureStrategy, subject);
+  private DeadlineSubject(FailureMetadata failureMetadata, Deadline subject) {
+    super(failureMetadata, subject);
   }
 
   /**
@@ -123,10 +123,10 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
   }
 
   private static final class DeadlineSubjectFactory
-      extends SubjectFactory<DeadlineSubject, Deadline>  {
+      implements Subject.Factory<DeadlineSubject, Deadline>  {
     @Override
-    public DeadlineSubject getSubject(FailureStrategy fs, Deadline that) {
-      return new DeadlineSubject(fs, that);
+    public DeadlineSubject createSubject(FailureMetadata fm, Deadline that) {
+      return new DeadlineSubject(fm, that);
     }
   }
 }

--- a/testing/src/main/java/io/grpc/testing/DeadlineSubject.java
+++ b/testing/src/main/java/io/grpc/testing/DeadlineSubject.java
@@ -54,7 +54,7 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
     return new TolerantDeadlineComparison() {
       @Override
       public void of(Deadline expected) {
-        Deadline actual = getSubject();
+        Deadline actual = actual();
         checkNotNull(actual, "actual value cannot be null. expected=%s", expected);
 
         // This is probably overkill, but easier than thinking about overflow.
@@ -64,7 +64,7 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
         if (actualTimeRemaining.subtract(expectedTimeRemaining).abs().compareTo(deltaNanos) > 0) {
           failWithRawMessage(
               "%s and <%s> should have been within <%sns> of each other",
-              getDisplaySubject(),
+              actualAsString(),
               expected,
               deltaNanos);
         }


### PR DESCRIPTION
Truth.FailureStrategy & SubjectFactory is being deprecated and will be removed in next release. 
This changed reference of those classes to use 'FailureMetadata' and 'Subject.Factory' respectively. 
New api is added in Truth-0.36, dependency is in build.gradle is also updated to use this
version of Truth.