### PR TITLE
compiler: Build on aarch64

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -48,6 +48,7 @@ model {
     }
     gcc(Gcc) {
       target("ppcle_64")
+      target("aarch_64")
     }
     clang(Clang) {
     }
@@ -63,11 +64,14 @@ model {
     ppcle_64 {
       architecture "ppcle_64"
     }
+    aarch_64 {
+      architecture "aarch_64"
+    }
   }
 
   components {
     java_plugin(NativeExecutableSpec) {
-      if (arch in ['x86_32', 'x86_64', 'ppcle_64']) {
+      if (arch in ['x86_32', 'x86_64', 'ppcle_64', 'aarch_64']) {
         // If arch is not within the defined platforms, we do not specify the
         // targetPlatform so that Gradle will choose what is appropriate.
         targetPlatform arch


### PR DESCRIPTION
Useful when building bazel and tensorflow for some nvidia devices.