### PR TITLE
testing: Remove DeadlineSubject

### DIFF
--- a/context/build.gradle
+++ b/context/build.gradle
@@ -1,7 +1,6 @@
 description = 'gRPC: Context'
 
 dependencies {
-    testCompile project(':grpc-testing')
-    testCompile project(':grpc-core').sourceSets.test.output
+    testCompile libraries.jsr305
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }

--- a/context/src/test/java/io/grpc/StaticTestingClassLoader.java
+++ b/context/src/test/java/io/grpc/StaticTestingClassLoader.java
@@ -17,7 +17,7 @@
 package io.grpc;
 
 import com.google.common.base.Preconditions;
-import io.grpc.internal.IoUtils;
+import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.regex.Pattern;
@@ -45,7 +45,7 @@ public final class StaticTestingClassLoader extends ClassLoader {
     }
     byte[] b;
     try {
-      b = IoUtils.toByteArray(is);
+      b = ByteStreams.toByteArray(is);
     } catch (IOException ex) {
       throw new ClassNotFoundException(name, ex);
     }

--- a/context/src/test/java/io/grpc/testing/DeadlineSubject.java
+++ b/context/src/test/java/io/grpc/testing/DeadlineSubject.java
@@ -23,7 +23,6 @@ import com.google.common.truth.ComparableSubject;
 import com.google.common.truth.FailureStrategy;
 import com.google.common.truth.SubjectFactory;
 import io.grpc.Deadline;
-import io.grpc.ExperimentalApi;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckReturnValue;
@@ -32,7 +31,6 @@ import javax.annotation.Nullable;
 /**
  * Propositions for {@link Deadline} subjects.
  */
-@ExperimentalApi("https://github.com/grpc/grpc-java/issues/3613")
 public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, Deadline> {
   private static final SubjectFactory<DeadlineSubject, Deadline> deadlineFactory =
       new DeadlineSubjectFactory();
@@ -79,7 +77,6 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
    * A partially specified proposition about an approximate relationship to a {@code deadline}
    * subject using a tolerance.
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3613")
   public abstract static class TolerantDeadlineComparison {
 
     private TolerantDeadlineComparison() {}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,7 +26,8 @@ dependencies {
         exclude group: 'io.grpc', module: 'grpc-context'
     }
 
-    testCompile project(':grpc-testing')
+    testCompile project(':grpc-context').sourceSets.test.output,
+                project(':grpc-testing')
 
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -27,6 +27,7 @@ dependencies {
             libraries.oauth_client,
             libraries.truth
     runtime libraries.opencensus_impl
+    testCompile project(':grpc-context').sourceSets.test.output
 }
 
 configureProtoCompilation()


### PR DESCRIPTION
The class is still used internally, so we move it to context's tests for
it to be reused. To avoid a circular dependency with context's tests
depending on core's tests, StaticTestingClassLoader was also moved to
context's tests.

This is driven by a need to modernize DeadlineSubject for newer versions
of Truth, but the newer versions of Truth update Guava. To avoid leaking
the Guava update to all users of grpc-testing, we're removing the
Subject. In our internal tests we can update the Truth dependency with
less issue.

CC @JiangJi 

Some discussion in #3779