### PR TITLE
core,okhttp: handle unresolved proxy addresses

### DIFF
--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -184,7 +184,8 @@ class ProxyDetectorImpl implements ProxyDetector {
             + "be removed in a future release. Use the JVM flags "
             + "\"-Dhttps.proxyHost=HOST -Dhttps.proxyPort=PORT\" to set the https proxy for "
             + "this JVM.");
-    return new InetSocketAddress(parts[0], port);
+    // Return an unresolved InetSocketAddress to avoid DNS lookup
+    return InetSocketAddress.createUnresolved(parts[0], port);
   }
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -472,7 +472,13 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   private Socket createHttpProxySocket(InetSocketAddress address, InetSocketAddress proxyAddress,
       String proxyUsername, String proxyPassword) throws IOException, StatusException {
     try {
-      Socket sock = new Socket(proxyAddress.getAddress(), proxyAddress.getPort());
+      Socket sock;
+      // The proxy address may not be resolved
+      if (proxyAddress.getAddress() != null) {
+        sock = new Socket(proxyAddress.getAddress(), proxyAddress.getPort());
+      } else {
+        sock = new Socket(proxyAddress.getHostName(), proxyAddress.getPort());
+      }
       sock.setTcpNoDelay(true);
 
       Source source = Okio.source(sock);


### PR DESCRIPTION
This fixes a NullPointerException in OkHttpClientTransport when the proxy returns an unresolved address, in which case `InetSocketAddress#getAddress` will return null. This also changes the `GRPC_PROXY_EXP` handling to explicitly return an unresolved `InetSocketAddress` to avoid I/O at channel creation. Our other uses of the `InetSocketAddress(String, int)` are all in tests or interop/benchmark clients, and as far as I can tell not problematic.

@ejona86 Should this fix (modified to the pre-`ProxySelector` code) be backported? If so, to which releases?