### PR TITLE
core,okhttp: handle unresolved proxy addresses (backport to v1.8.x)

### DIFF
--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -184,7 +184,8 @@ class ProxyDetectorImpl implements ProxyDetector {
             + "be removed in a future release. Use the JVM flags "
             + "\"-Dhttps.proxyHost=HOST -Dhttps.proxyPort=PORT\" to set the https proxy for "
             + "this JVM.");
-    return new InetSocketAddress(parts[0], port);
+    // Return an unresolved InetSocketAddress to avoid DNS lookup
+    return InetSocketAddress.createUnresolved(parts[0], port);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -184,8 +184,7 @@ class ProxyDetectorImpl implements ProxyDetector {
             + "be removed in a future release. Use the JVM flags "
             + "\"-Dhttps.proxyHost=HOST -Dhttps.proxyPort=PORT\" to set the https proxy for "
             + "this JVM.");
-    // Return an unresolved InetSocketAddress to avoid DNS lookup
-    return InetSocketAddress.createUnresolved(parts[0], port);
+    return new InetSocketAddress(parts[0], port);
   }
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -472,7 +472,13 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   private Socket createHttpProxySocket(InetSocketAddress address, InetSocketAddress proxyAddress,
       String proxyUsername, String proxyPassword) throws IOException, StatusException {
     try {
-      Socket sock = new Socket(proxyAddress.getAddress(), proxyAddress.getPort());
+      Socket sock;
+      // The proxy address may not be resolved
+      if (proxyAddress.getAddress() != null) {
+        sock = new Socket(proxyAddress.getAddress(), proxyAddress.getPort());
+      } else {
+        sock = new Socket(proxyAddress.getHostName(), proxyAddress.getPort());
+      }
       sock.setTcpNoDelay(true);
 
       Source source = Okio.source(sock);


### PR DESCRIPTION
Backport of https://github.com/grpc/grpc-java/pull/3789