### PR TITLE
Update proto Skylark rule to allow gRPC Java to build using Bazel

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -94,7 +94,7 @@ def com_google_api_grpc_google_common_protos():
   native.maven_jar(
       name = "com_google_api_grpc_proto_google_common_protos",
       artifact = "com.google.api.grpc:proto-google-common-protos:1.0.0",
-      sha1 = "de4e859c3530f7e9f854e40b0a8b7074d95e3aff",
+      sha1 = "86f070507e28b930e50d218ee5b6788ef0dd05e6",
   )
 
 def com_google_code_findbugs_jsr305():


### PR DESCRIPTION
Updating SHA-1 checksum for com_google_api_grpc_google_common_protos Skylark rule.

The new value is reported as the expected value when performing

$ bazel build //...

on a clean pull of this repo. The new value can also be confirmed via

$ curl http://central.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/1.0.0/proto-google-common-protos-1.0.0.jar | sha1sum