### PR TITLE
okhttp: bump to okio 1.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ subprojects {
                 google_api_protos: 'com.google.api.grpc:proto-google-common-protos:1.0.0',
                 google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.9.0',
                 okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
-                okio: 'com.squareup.okio:okio:1.6.0',
+                okio: 'com.squareup.okio:okio:1.13.0',
                 opencensus_api: 'io.opencensus:opencensus-api:0.8.0',
                 opencensus_contrib_grpc_metrics: 'io.opencensus:opencensus-contrib-grpc-metrics:0.8.0',
                 opencensus_impl: 'io.opencensus:opencensus-impl:0.8.0',

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -177,8 +177,8 @@ def com_squareup_okhttp():
 def com_squareup_okio():
   native.maven_jar(
       name = "com_squareup_okio_okio",
-      artifact = "com.squareup.okio:okio:1.6.0",
-      sha1 = "98476622f10715998eacf9240d6b479f12c66143",
+      artifact = "com.squareup.okio:okio:1.13.0",
+      sha1 = "a9283170b7305c8d92d25aff02a6ab7e45d06cbe",
   )
 
 def io_netty_codec_http2():


### PR DESCRIPTION
Okio buffers gained some useful methods for interop with java nio.   These methods are needed to pass bytebuffers to the new proto api in 3.5.0