### PR TITLE
core,netty,okhttp: move TransportTracer.Stats to io.grpc

### DIFF
--- a/core/src/main/java/io/grpc/InternalTransportStats.java
+++ b/core/src/main/java/io/grpc/InternalTransportStats.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+/**
+ * Do not use.
+ *
+ * <p>A read only copy of stats from the transport tracer.
+ */
+@Internal
+public final class InternalTransportStats {
+  public final long streamsStarted;
+  public final long lastStreamCreatedTimeNanos;
+  public final long streamsSucceeded;
+  public final long streamsFailed;
+  public final long messagesSent;
+  public final long messagesReceived;
+  public final long keepAlivesSent;
+  public final long lastMessageSentTimeNanos;
+  public final long lastMessageReceivedTimeNanos;
+  public final long localFlowControlWindow;
+  public final long remoteFlowControlWindow;
+
+  /**
+   * Creates an instance.
+   */
+  public InternalTransportStats(
+      long streamsStarted,
+      long lastStreamCreatedTimeNanos,
+      long streamsSucceeded,
+      long streamsFailed,
+      long messagesSent,
+      long messagesReceived,
+      long keepAlivesSent,
+      long lastMessageSentTimeNanos,
+      long lastMessageReceivedTimeNanos,
+      long localFlowControlWindow,
+      long remoteFlowControlWindow) {
+    this.streamsStarted = streamsStarted;
+    this.lastStreamCreatedTimeNanos = lastStreamCreatedTimeNanos;
+    this.streamsSucceeded = streamsSucceeded;
+    this.streamsFailed = streamsFailed;
+    this.messagesSent = messagesSent;
+    this.messagesReceived = messagesReceived;
+    this.keepAlivesSent = keepAlivesSent;
+    this.lastMessageSentTimeNanos = lastMessageSentTimeNanos;
+    this.lastMessageReceivedTimeNanos = lastMessageReceivedTimeNanos;
+    this.localFlowControlWindow = localFlowControlWindow;
+    this.remoteFlowControlWindow = remoteFlowControlWindow;
+  }
+}

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -25,6 +25,7 @@ import io.grpc.Compressor;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Grpc;
+import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
@@ -42,7 +43,6 @@ import io.grpc.internal.ServerTransport;
 import io.grpc.internal.ServerTransportListener;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.StreamListener;
-import io.grpc.internal.TransportTracer;
 import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -221,9 +221,9 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   }
 
   @Override
-  public Future<TransportTracer.Stats> getTransportStats() {
+  public Future<InternalTransportStats> getTransportStats() {
     // TODO(zpencer): add transport tracing to in-process server
-    SettableFuture<TransportTracer.Stats> ret = SettableFuture.create();
+    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;
   }

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import io.grpc.CallOptions;
+import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import java.util.concurrent.Executor;
@@ -67,7 +68,7 @@ public interface ClientTransport {
    * Returns a Future representing the transport level stats. If this transport does not support
    * stats, the return value will be a Future of a null value.
    */
-  Future<TransportTracer.Stats> getTransportStats();
+  Future<InternalTransportStats> getTransportStats();
 
   /**
    * A callback that is invoked when the acknowledgement to a {@link #ping} is received. Exactly one

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
 import io.grpc.Context;
+import io.grpc.InternalTransportStats;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.SubchannelPicker;
@@ -188,8 +189,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
   }
 
   @Override
-  public Future<TransportTracer.Stats> getTransportStats() {
-    SettableFuture<TransportTracer.Stats> ret = SettableFuture.create();
+  public Future<InternalTransportStats> getTransportStats() {
+    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;
   }

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
+import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -55,8 +56,8 @@ class FailingClientTransport implements ClientTransport {
   }
 
   @Override
-  public Future<TransportTracer.Stats> getTransportStats() {
-    SettableFuture<TransportTracer.Stats> ret = SettableFuture.create();
+  public Future<InternalTransportStats> getTransportStats() {
+    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;
   }

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -68,8 +69,8 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
   }
 
   @Override
-  public Future<TransportTracer.Stats> getTransportStats() {
-    SettableFuture<TransportTracer.Stats> ret = SettableFuture.create();
+  public Future<InternalTransportStats> getTransportStats() {
+    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;
   }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -30,6 +30,7 @@ import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.InternalMetadata;
 import io.grpc.InternalMetadata.TrustedAsciiMarshaller;
+import io.grpc.InternalTransportStats;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.Metadata;
@@ -682,7 +683,7 @@ public final class GrpcUtil {
 
         @Nullable
         @Override
-        public Future<TransportTracer.Stats> getTransportStats() {
+        public Future<InternalTransportStats> getTransportStats() {
           return transport.getTransportStats();
         }
       };

--- a/core/src/main/java/io/grpc/internal/ServerTransport.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransport.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import io.grpc.InternalTransportStats;
 import io.grpc.Status;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -48,5 +49,5 @@ public interface ServerTransport extends WithLogId {
    * Returns a Future representing the transport level stats. If this transport does not support
    * stats, the return value will be a Future of a null value.
    */
-  Future<TransportTracer.Stats> getTransportStats();
+  Future<InternalTransportStats> getTransportStats();
 }

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -35,6 +35,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Bytes;
 import io.grpc.Codec;
+import io.grpc.InternalTransportStats;
 import io.grpc.StatusRuntimeException;
 import io.grpc.StreamTracer;
 import io.grpc.internal.MessageDeframer.Listener;
@@ -482,7 +483,7 @@ public class MessageDeframerTest {
    * @param sizes in the format {wire0, uncompressed0, wire1, uncompressed1, ...}
    */
   private static void checkStats(
-      TestBaseStreamTracer tracer, TransportTracer.Stats transportStats, long... sizes) {
+      TestBaseStreamTracer tracer, InternalTransportStats transportStats, long... sizes) {
     assertEquals(0, sizes.length % 2);
     int count = sizes.length / 2;
     long expectedWireSize = 0;

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -50,6 +50,7 @@ import io.grpc.Context;
 import io.grpc.Grpc;
 import io.grpc.HandlerRegistry;
 import io.grpc.IntegerMarshaller;
+import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
@@ -1273,8 +1274,8 @@ public class ServerImplTest {
     }
 
     @Override
-    public Future<TransportTracer.Stats> getTransportStats() {
-      SettableFuture<TransportTracer.Stats> ret = SettableFuture.create();
+    public Future<InternalTransportStats> getTransportStats() {
+      SettableFuture<InternalTransportStats> ret = SettableFuture.create();
       ret.set(null);
       return ret;
     }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -309,18 +310,18 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public Future<TransportTracer.Stats> getTransportStats() {
+  public Future<InternalTransportStats> getTransportStats() {
     if (channel.eventLoop().inEventLoop()) {
       // This is necessary, otherwise we will block forever if we get the future from inside
       // the event loop.
-      SettableFuture<TransportTracer.Stats> result = SettableFuture.create();
+      SettableFuture<InternalTransportStats> result = SettableFuture.create();
       result.set(transportTracer.getStats());
       return result;
     }
     return channel.eventLoop().submit(
-        new Callable<TransportTracer.Stats>() {
+        new Callable<InternalTransportStats>() {
           @Override
-          public TransportTracer.Stats call() throws Exception {
+          public InternalTransportStats call() throws Exception {
             return transportTracer.getStats();
           }
         });

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.InternalTransportStats;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.internal.LogId;
@@ -176,18 +177,18 @@ class NettyServerTransport implements ServerTransport {
   }
 
   @Override
-  public Future<TransportTracer.Stats> getTransportStats() {
+  public Future<InternalTransportStats> getTransportStats() {
     if (channel.eventLoop().inEventLoop()) {
       // This is necessary, otherwise we will block forever if we get the future from inside
       // the event loop.
-      SettableFuture<TransportTracer.Stats> result = SettableFuture.create();
+      SettableFuture<InternalTransportStats> result = SettableFuture.create();
       result.set(transportTracer.getStats());
       return result;
     }
     return channel.eventLoop().submit(
-        new Callable<TransportTracer.Stats>() {
+        new Callable<InternalTransportStats>() {
           @Override
-          public TransportTracer.Stats call() throws Exception {
+          public InternalTransportStats call() throws Exception {
             return transportTracer.getStats();
           }
         });

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.grpc.InternalTransportStats;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.MessageFramer;
 import io.grpc.internal.StatsTraceContext;
@@ -459,30 +460,30 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
   @Test
   public void transportTracer_windowSizeDefault() throws Exception {
     manualSetUp();
-    TransportTracer.Stats stats = transportTracer.getStats();
-    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, stats.remoteFlowControlWindow);
-    assertEquals(flowControlWindow, stats.localFlowControlWindow);
+    InternalTransportStats transportStats = transportTracer.getStats();
+    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, transportStats.remoteFlowControlWindow);
+    assertEquals(flowControlWindow, transportStats.localFlowControlWindow);
   }
 
   @Test
   public void transportTracer_windowSize() throws Exception {
     flowControlWindow = 1024 * 1024;
     manualSetUp();
-    TransportTracer.Stats stats = transportTracer.getStats();
-    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, stats.remoteFlowControlWindow);
-    assertEquals(flowControlWindow, stats.localFlowControlWindow);
+    InternalTransportStats transportStats = transportTracer.getStats();
+    assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, transportStats.remoteFlowControlWindow);
+    assertEquals(flowControlWindow, transportStats.localFlowControlWindow);
   }
 
   @Test
   public void transportTracer_windowUpdate_remote() throws Exception {
     manualSetUp();
-    TransportTracer.Stats before = transportTracer.getStats();
+    InternalTransportStats before = transportTracer.getStats();
     assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, before.remoteFlowControlWindow);
     assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, before.localFlowControlWindow);
 
     ByteBuf serializedSettings = windowUpdate(0, 1000);
     channelRead(serializedSettings);
-    TransportTracer.Stats after = transportTracer.getStats();
+    InternalTransportStats after = transportTracer.getStats();
     assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE + 1000,
         after.remoteFlowControlWindow);
     assertEquals(flowControlWindow, after.localFlowControlWindow);
@@ -491,7 +492,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
   @Test
   public void transportTracer_windowUpdate_local() throws Exception {
     manualSetUp();
-    TransportTracer.Stats before = transportTracer.getStats();
+    InternalTransportStats before = transportTracer.getStats();
     assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, before.remoteFlowControlWindow);
     assertEquals(flowControlWindow, before.localFlowControlWindow);
 
@@ -500,7 +501,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
     connection().local().flowController().incrementWindowSize(
         connection().connectionStream(), 8 * Http2CodecUtil.DEFAULT_WINDOW_SIZE);
 
-    TransportTracer.Stats after = transportTracer.getStats();
+    InternalTransportStats after = transportTracer.getStats();
     assertEquals(Http2CodecUtil.DEFAULT_WINDOW_SIZE, after.remoteFlowControlWindow);
     assertEquals(flowControlWindow + 8 * Http2CodecUtil.DEFAULT_WINDOW_SIZE,
         connection().local().flowController().windowSize(connection().connectionStream()));

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -30,6 +30,7 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.internal.http.StatusLine;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
@@ -45,7 +46,6 @@ import io.grpc.internal.LogId;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.StatsTraceContext;
-import io.grpc.internal.TransportTracer;
 import io.grpc.okhttp.internal.ConnectionSpec;
 import io.grpc.okhttp.internal.framed.ErrorCode;
 import io.grpc.okhttp.internal.framed.FrameReader;
@@ -851,8 +851,8 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public Future<TransportTracer.Stats> getTransportStats() {
-    SettableFuture<TransportTracer.Stats> ret = SettableFuture.create();
+  public Future<InternalTransportStats> getTransportStats() {
+    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;
   }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -48,6 +48,7 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Grpc;
+import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
@@ -62,7 +63,6 @@ import io.grpc.internal.ServerStream;
 import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.ServerTransport;
 import io.grpc.internal.ServerTransportListener;
-import io.grpc.internal.TransportTracer;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1406,11 +1406,11 @@ public abstract class AbstractTransportTest {
     long serverFirstTimestampNanos;
     long clientFirstTimestampNanos;
     {
-      TransportTracer.Stats serverBefore =
+      InternalTransportStats serverBefore =
           serverTransportListener.transport.getTransportStats().get();
       assertEquals(0, serverBefore.streamsStarted);
       assertEquals(0, serverBefore.lastStreamCreatedTimeNanos);
-      TransportTracer.Stats clientBefore = client.getTransportStats().get();
+      InternalTransportStats clientBefore = client.getTransportStats().get();
       assertEquals(0, clientBefore.streamsStarted);
       assertEquals(0, clientBefore.lastStreamCreatedTimeNanos);
 
@@ -1420,7 +1420,7 @@ public abstract class AbstractTransportTest {
       StreamCreation serverStreamCreation = serverTransportListener
           .takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-      TransportTracer.Stats serverAfter =
+      InternalTransportStats serverAfter =
           serverTransportListener.transport.getTransportStats().get();
       assertEquals(1, serverAfter.streamsStarted);
       serverFirstTimestampNanos = serverAfter.lastStreamCreatedTimeNanos;
@@ -1428,7 +1428,7 @@ public abstract class AbstractTransportTest {
           currentTimeMillis(),
           TimeUnit.NANOSECONDS.toMillis(serverAfter.lastStreamCreatedTimeNanos));
 
-      TransportTracer.Stats clientAfter = client.getTransportStats().get();
+      InternalTransportStats clientAfter = client.getTransportStats().get();
       assertEquals(1, clientAfter.streamsStarted);
       clientFirstTimestampNanos = clientAfter.lastStreamCreatedTimeNanos;
       assertEquals(
@@ -1444,10 +1444,10 @@ public abstract class AbstractTransportTest {
 
     // start second stream
     {
-      TransportTracer.Stats serverBefore =
+      InternalTransportStats serverBefore =
           serverTransportListener.transport.getTransportStats().get();
       assertEquals(1, serverBefore.streamsStarted);
-      TransportTracer.Stats clientBefore = client.getTransportStats().get();
+      InternalTransportStats clientBefore = client.getTransportStats().get();
       assertEquals(1, clientBefore.streamsStarted);
 
       ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
@@ -1456,7 +1456,7 @@ public abstract class AbstractTransportTest {
       StreamCreation serverStreamCreation = serverTransportListener
           .takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-      TransportTracer.Stats serverAfter =
+      InternalTransportStats serverAfter =
           serverTransportListener.transport.getTransportStats().get();
       assertEquals(2, serverAfter.streamsStarted);
       assertEquals(
@@ -1466,7 +1466,7 @@ public abstract class AbstractTransportTest {
           TimeUnit.NANOSECONDS.toMillis(serverAfter.lastStreamCreatedTimeNanos);
       assertEquals(currentTimeMillis(), serverSecondTimestamp);
 
-      TransportTracer.Stats clientAfter = client.getTransportStats().get();
+      InternalTransportStats clientAfter = client.getTransportStats().get();
       assertEquals(2, clientAfter.streamsStarted);
       assertEquals(
           TimeUnit.MILLISECONDS.toNanos(elapsedMillis),
@@ -1497,11 +1497,11 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportTracer.Stats serverBefore =
+    InternalTransportStats serverBefore =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(0, serverBefore.streamsSucceeded);
     assertEquals(0, serverBefore.streamsFailed);
-    TransportTracer.Stats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = client.getTransportStats().get();
     assertEquals(0, clientBefore.streamsSucceeded);
     assertEquals(0, clientBefore.streamsFailed);
 
@@ -1512,11 +1512,11 @@ public abstract class AbstractTransportTest {
     assertNotNull(clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
 
-    TransportTracer.Stats serverAfter =
+    InternalTransportStats serverAfter =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(1, serverAfter.streamsSucceeded);
     assertEquals(0, serverAfter.streamsFailed);
-    TransportTracer.Stats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = client.getTransportStats().get();
     assertEquals(1, clientAfter.streamsSucceeded);
     assertEquals(0, clientAfter.streamsFailed);
   }
@@ -1538,11 +1538,11 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportTracer.Stats serverBefore =
+    InternalTransportStats serverBefore =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(0, serverBefore.streamsFailed);
     assertEquals(0, serverBefore.streamsSucceeded);
-    TransportTracer.Stats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = client.getTransportStats().get();
     assertEquals(0, clientBefore.streamsFailed);
     assertEquals(0, clientBefore.streamsSucceeded);
 
@@ -1552,11 +1552,11 @@ public abstract class AbstractTransportTest {
     assertNotNull(clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
 
-    TransportTracer.Stats serverAfter =
+    InternalTransportStats serverAfter =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(1, serverAfter.streamsFailed);
     assertEquals(0, serverAfter.streamsSucceeded);
-    TransportTracer.Stats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = client.getTransportStats().get();
     assertEquals(1, clientAfter.streamsFailed);
     assertEquals(0, clientAfter.streamsSucceeded);
 
@@ -1579,11 +1579,11 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportTracer.Stats serverBefore =
+    InternalTransportStats serverBefore =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(0, serverBefore.streamsFailed);
     assertEquals(0, serverBefore.streamsSucceeded);
-    TransportTracer.Stats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = client.getTransportStats().get();
     assertEquals(0, clientBefore.streamsFailed);
     assertEquals(0, clientBefore.streamsSucceeded);
 
@@ -1591,11 +1591,11 @@ public abstract class AbstractTransportTest {
     // do not validate stats until close() has been called on server
     assertNotNull(serverStreamCreation.listener.status.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-    TransportTracer.Stats serverAfter =
+    InternalTransportStats serverAfter =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(1, serverAfter.streamsFailed);
     assertEquals(0, serverAfter.streamsSucceeded);
-    TransportTracer.Stats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = client.getTransportStats().get();
     assertEquals(1, clientAfter.streamsFailed);
     assertEquals(0, clientAfter.streamsSucceeded);
   }
@@ -1618,11 +1618,11 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportTracer.Stats serverBefore =
+    InternalTransportStats serverBefore =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(0, serverBefore.messagesReceived);
     assertEquals(0, serverBefore.lastMessageReceivedTimeNanos);
-    TransportTracer.Stats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = client.getTransportStats().get();
     assertEquals(0, clientBefore.messagesSent);
     assertEquals(0, clientBefore.lastMessageSentTimeNanos);
 
@@ -1632,13 +1632,13 @@ public abstract class AbstractTransportTest {
     clientStream.halfClose();
     verifyMessageCountAndClose(serverStreamListener.messageQueue, 1);
 
-    TransportTracer.Stats serverAfter =
+    InternalTransportStats serverAfter =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(1, serverAfter.messagesReceived);
     long serverTimestamp =
         TimeUnit.NANOSECONDS.toMillis(serverAfter.lastMessageReceivedTimeNanos);
     assertEquals(currentTimeMillis(), serverTimestamp);
-    TransportTracer.Stats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = client.getTransportStats().get();
     assertEquals(1, clientAfter.messagesSent);
     long clientTimestamp =
         TimeUnit.NANOSECONDS.toMillis(clientAfter.lastMessageSentTimeNanos);
@@ -1664,11 +1664,11 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportTracer.Stats serverBefore =
+    InternalTransportStats serverBefore =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(0, serverBefore.messagesSent);
     assertEquals(0, serverBefore.lastMessageSentTimeNanos);
-    TransportTracer.Stats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = client.getTransportStats().get();
     assertEquals(0, clientBefore.messagesReceived);
     assertEquals(0, clientBefore.lastMessageReceivedTimeNanos);
 
@@ -1678,12 +1678,12 @@ public abstract class AbstractTransportTest {
     serverStream.flush();
     verifyMessageCountAndClose(clientStreamListener.messageQueue, 1);
 
-    TransportTracer.Stats serverAfter =
+    InternalTransportStats serverAfter =
         serverTransportListener.transport.getTransportStats().get();
     assertEquals(1, serverAfter.messagesSent);
     long serverTimestmap = TimeUnit.NANOSECONDS.toMillis(serverAfter.lastMessageSentTimeNanos);
     assertEquals(currentTimeMillis(), serverTimestmap);
-    TransportTracer.Stats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = client.getTransportStats().get();
     assertEquals(1, clientAfter.messagesReceived);
     long clientTimestmap =
         TimeUnit.NANOSECONDS.toMillis(clientAfter.lastMessageReceivedTimeNanos);


### PR DESCRIPTION
io.grpc can not refer to io.grpc.internal so this needs to be moved
out. The end state will have the channelz class in io.grpc, which
needs to refer to stats like this.