### PR TITLE
bazel: Fix protobuf checksums

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -138,7 +138,7 @@ def com_google_protobuf():
   # This statement defines the @com_google_protobuf repo.
   native.http_archive(
       name = "com_google_protobuf",
-      sha256 = "542703acadc3f690d998f4641e1b988f15ba57ebca05fdfb1cd9095bec007948",
+      sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
       strip_prefix = "protobuf-3.5.0",
       urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
   )
@@ -148,7 +148,7 @@ def com_google_protobuf_java():
   # which is the Java proto runtime (base classes and common utilities).
   native.http_archive(
       name = "com_google_protobuf_java",
-      sha256 = "542703acadc3f690d998f4641e1b988f15ba57ebca05fdfb1cd9095bec007948",
+      sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
       strip_prefix = "protobuf-3.5.0",
       urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
   )


### PR DESCRIPTION
The protobuf checksums were simply not updated when changing the
version.