### PR TITLE
interop-testing: start a new server for each test method.

### DIFF
--- a/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
@@ -157,12 +157,6 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
       return false;
     }
 
-    @Override
-    protected boolean serverInProcess() {
-      // Server-side metrics won't be found because the server is running remotely.
-      return false;
-    }
-
     // grpc-test.sandbox.googleapis.com does not support these tests
     @Override
     public void customMetadata() { }

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -101,12 +101,6 @@ public final class NettyClientInteropServlet extends HttpServlet {
       return false;
     }
 
-    @Override
-    protected boolean serverInProcess() {
-      // Server-side metrics won't be found because the server is running remotely.
-      return false;
-    }
-
     // grpc-test.sandbox.googleapis.com does not support these tests
     @Override
     public void customMetadata() { }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -214,7 +214,6 @@ public abstract class AbstractInteropTest {
         .add(TestUtils.recordRequestHeadersInterceptor(requestHeadersCapture))
         .add(recordContextInterceptor(contextCapture))
         .addAll(TestServiceImpl.interceptors())
-        .addAll(getServerInterceptors())
         .build();
 
     builder
@@ -309,10 +308,6 @@ public abstract class AbstractInteropTest {
   @Nullable
   protected AbstractServerImplBuilder<?> getServerBuilder() {
     return null;
-  }
-
-  protected List<? extends ServerInterceptor> getServerInterceptors() {
-    return Collections.emptyList();
   }
 
   protected final CensusStatsModule createClientCensusStatsModule() {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1858,7 +1858,7 @@ public abstract class AbstractInteropTest {
       assertNotNull(serverEndRecord);
       checkStartTags(serverStartRecord, method);
       checkEndTags(serverEndRecord, method, code);
-      if (requests != null && responses != null) {
+      if (server != null && requests != null && responses != null) {
         checkCensus(serverEndRecord, true, requests, responses);
       }
     }
@@ -1947,7 +1947,7 @@ public abstract class AbstractInteropTest {
     for (MessageLite response : responses) {
       uncompressedResponsesSize += response.getSerializedSize();
     }
-    if (isServer && server != null) {
+    if (isServer) {
       assertEquals(
           requests.size(),
           record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_REQUEST_COUNT));
@@ -1965,8 +1965,7 @@ public abstract class AbstractInteropTest {
       // check if they are recorded.
       assertNotNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_REQUEST_BYTES));
       assertNotNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_RESPONSE_BYTES));
-    }
-    if (!isServer) {
+    } else {
       assertEquals(
           requests.size(),
           record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_REQUEST_COUNT));

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1426,9 +1426,7 @@ public abstract class AbstractInteropTest {
 
   @Test(timeout = 10000)
   public void censusContextsPropagated() {
-    if (server == null) {
-      return;
-    }
+    Assume.assumeTrue("Skip the test because server is not in the same process.", server != null);
     Span clientParentSpan = MockableSpan.generateRandomSpan(new Random());
     Context ctx =
         Context.ROOT.withValues(

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -121,6 +121,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import org.junit.After;
@@ -147,21 +148,23 @@ public abstract class AbstractInteropTest {
   public static final int MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
   public static final Metadata.Key<Messages.SimpleContext> METADATA_KEY =
       ProtoUtils.keyForProto(Messages.SimpleContext.getDefaultInstance());
-  private static final AtomicReference<ServerCall<?, ?>> serverCallCapture =
-      new AtomicReference<ServerCall<?, ?>>();
-  private static final AtomicReference<Metadata> requestHeadersCapture =
-      new AtomicReference<Metadata>();
-  private static final AtomicReference<Context> contextCapture =
-      new AtomicReference<Context>();
-  private static ScheduledExecutorService testServiceExecutor;
-  private static Server server;
+
   private static final FakeTagger tagger = new FakeTagger();
   private static final FakeTagContextBinarySerializer tagContextBinarySerializer =
       new FakeTagContextBinarySerializer();
-  private static final FakeStatsRecorder clientStatsRecorder = new FakeStatsRecorder();
-  private static final FakeStatsRecorder serverStatsRecorder = new FakeStatsRecorder();
 
-  private static final LinkedBlockingQueue<ServerStreamTracerInfo> serverStreamTracers =
+  private final AtomicReference<ServerCall<?, ?>> serverCallCapture =
+      new AtomicReference<ServerCall<?, ?>>();
+  private final AtomicReference<Metadata> requestHeadersCapture =
+      new AtomicReference<Metadata>();
+  private final AtomicReference<Context> contextCapture =
+      new AtomicReference<Context>();
+  private ScheduledExecutorService testServiceExecutor;
+  private Server server;
+  private FakeStatsRecorder clientStatsRecorder;
+  private FakeStatsRecorder serverStatsRecorder;
+
+  private final LinkedBlockingQueue<ServerStreamTracerInfo> serverStreamTracers =
       new LinkedBlockingQueue<ServerStreamTracerInfo>();
 
   private static final class ServerStreamTracerInfo {
@@ -184,7 +187,7 @@ public abstract class AbstractInteropTest {
     }
   }
 
-  private static final ServerStreamTracer.Factory serverStreamTracerFactory =
+  private final ServerStreamTracer.Factory serverStreamTracerFactory =
       new ServerStreamTracer.Factory() {
         @Override
         public ServerStreamTracer newServerStreamTracer(String fullMethodName, Metadata headers) {
@@ -197,8 +200,12 @@ public abstract class AbstractInteropTest {
 
   protected static final Empty EMPTY = Empty.getDefaultInstance();
 
-  protected static void startStaticServer(
-      AbstractServerImplBuilder<?> builder, ServerInterceptor ... interceptors) {
+  private void startServer() {
+    AbstractServerImplBuilder<?> builder = getServerBuilder();
+    if (builder == null) {
+      server = null;
+      return;
+    }
     testServiceExecutor = Executors.newScheduledThreadPool(2);
 
     List<ServerInterceptor> allInterceptors = ImmutableList.<ServerInterceptor>builder()
@@ -206,7 +213,7 @@ public abstract class AbstractInteropTest {
         .add(TestUtils.recordRequestHeadersInterceptor(requestHeadersCapture))
         .add(recordContextInterceptor(contextCapture))
         .addAll(TestServiceImpl.interceptors())
-        .add(interceptors)
+        .addAll(getServerInterceptors())
         .build();
 
     builder
@@ -230,13 +237,17 @@ public abstract class AbstractInteropTest {
     }
   }
 
-  protected static void stopStaticServer() {
-    server.shutdownNow();
-    testServiceExecutor.shutdown();
+  private void stopServer() {
+    if (server != null) {
+      server.shutdownNow();
+    }
+    if (testServiceExecutor != null) {
+      testServiceExecutor.shutdown();
+    }
   }
 
   @VisibleForTesting
-  static int getPort() {
+  final int getPort() {
     return server.getPort();
   }
 
@@ -270,15 +281,15 @@ public abstract class AbstractInteropTest {
    */
   @Before
   public void setUp() {
+    clientStatsRecorder = new FakeStatsRecorder();
+    serverStatsRecorder = new FakeStatsRecorder();
+    startServer();
     channel = createChannel();
 
     blockingStub =
         TestServiceGrpc.newBlockingStub(channel).withInterceptors(tracerSetupInterceptor);
     asyncStub = TestServiceGrpc.newStub(channel).withInterceptors(tracerSetupInterceptor);
     requestHeadersCapture.set(null);
-    clientStatsRecorder.rolloverRecords();
-    serverStatsRecorder.rolloverRecords();
-    serverStreamTracers.clear();
   }
 
   /** Clean up. */
@@ -287,9 +298,23 @@ public abstract class AbstractInteropTest {
     if (channel != null) {
       channel.shutdown();
     }
+    stopServer();
   }
 
   protected abstract ManagedChannel createChannel();
+
+  /**
+   * Returns the server builder used to create server for each test run.  Return {@code null} if
+   * it shouldn't start a server in the same process.
+   */
+  @Nullable
+  protected AbstractServerImplBuilder<?> getServerBuilder() {
+    return null;
+  }
+
+  protected List<? extends ServerInterceptor> getServerInterceptors() {
+    return Collections.emptyList();
+  }
 
   protected final CensusStatsModule createClientCensusStatsModule() {
     return new CensusStatsModule(
@@ -300,13 +325,6 @@ public abstract class AbstractInteropTest {
    * Return true if exact metric values should be checked.
    */
   protected boolean metricsExpected() {
-    return true;
-  }
-
-  /**
-   * Return true if the server is in the same process as the test methods.
-   */
-  protected boolean serverInProcess() {
     return true;
   }
 
@@ -1414,7 +1432,7 @@ public abstract class AbstractInteropTest {
 
   @Test(timeout = 10000)
   public void censusContextsPropagated() {
-    if (!serverInProcess()) {
+    if (server == null) {
       return;
     }
     Span clientParentSpan = MockableSpan.generateRandomSpan(new Random());
@@ -1826,86 +1844,48 @@ public abstract class AbstractInteropTest {
   @SuppressWarnings("AssertionFailureIgnored") // Failure is checked in the end by the passed flag.
   private void assertServerStatsTrace(String method, Status.Code code,
       Collection<? extends MessageLite> requests, Collection<? extends MessageLite> responses) {
-    if (!serverInProcess()) {
+    if (server == null) {
+      // Server is not in the same process.  We can't check server-side stats.
       return;
     }
     AssertionError checkFailure = null;
     boolean passed = false;
 
     if (metricsExpected()) {
-      // Because the server doesn't restart between tests, it may still be processing the requests
-      // from the previous tests when a new test starts, thus the test may see metrics from previous
-      // tests.  The best we can do here is to exhaust all records and find one that matches the
-      // given conditions.
-      while (true) {
-        MetricsRecord serverStartRecord;
-        MetricsRecord serverEndRecord;
-        try {
-          // On the server, the stats is finalized in ServerStreamListener.closed(), which can be
-          // run after the client receives the final status.  So we use a timeout.
-          serverStartRecord = serverStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-          serverEndRecord = serverStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-        if (serverEndRecord == null) {
-          break;
-        }
-        try {
-          checkStartTags(serverStartRecord, method);
-          checkEndTags(serverEndRecord, method, code);
-          if (requests != null && responses != null) {
-            checkCensus(serverEndRecord, true, requests, responses);
-          }
-          passed = true;
-          break;
-        } catch (AssertionError e) {
-          // May be the fallout from a previous test, continue trying
-          checkFailure = e;
-        }
+      MetricsRecord serverStartRecord;
+      MetricsRecord serverEndRecord;
+      try {
+        // On the server, the stats is finalized in ServerStreamListener.closed(), which can be
+        // run after the client receives the final status.  So we use a timeout.
+        serverStartRecord = serverStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
+        serverEndRecord = serverStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
       }
-      if (!passed) {
-        if (checkFailure == null) {
-          throw new AssertionError("No record found");
-        }
-        throw checkFailure;
+      assertNotNull(serverStartRecord);
+      assertNotNull(serverEndRecord);
+      checkStartTags(serverStartRecord, method);
+      checkEndTags(serverEndRecord, method, code);
+      if (requests != null && responses != null) {
+        checkCensus(serverEndRecord, true, requests, responses);
       }
     }
 
-    // Use the same trick to check ServerStreamTracer records
-    passed = false;
-    while (true) {
-      ServerStreamTracerInfo tracerInfo;
-      tracerInfo = serverStreamTracers.poll();
-      if (tracerInfo == null) {
-        break;
-      }
-      try {
-        assertEquals(method, tracerInfo.fullMethodName);
-        assertNotNull(tracerInfo.tracer.contextCapture);
-        // On the server, streamClosed() may be called after the client receives the final status.
-        // So we use a timeout.
-        try {
-          assertTrue(tracerInfo.tracer.await(1, TimeUnit.SECONDS));
-        } catch (InterruptedException e) {
-          throw new AssertionError(e);
-        }
-        assertEquals(code, tracerInfo.tracer.getStatus().getCode());
-        if (requests != null && responses != null) {
-          checkTracers(tracerInfo.tracer, responses, requests);
-        }
-        passed = true;
-        break;
-      } catch (AssertionError e) {
-        // May be the fallout from a previous test, continue trying
-        checkFailure = e;
-      }
+    ServerStreamTracerInfo tracerInfo;
+    tracerInfo = serverStreamTracers.poll();
+    assertNotNull(tracerInfo);
+    assertEquals(method, tracerInfo.fullMethodName);
+    assertNotNull(tracerInfo.tracer.contextCapture);
+    // On the server, streamClosed() may be called after the client receives the final status.
+    // So we use a timeout.
+    try {
+      assertTrue(tracerInfo.tracer.await(1, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      throw new AssertionError(e);
     }
-    if (!passed) {
-      if (checkFailure == null) {
-        throw new AssertionError("No ServerStreamTracer found");
-      }
-      throw checkFailure;
+    assertEquals(code, tracerInfo.tracer.getStatus().getCode());
+    if (requests != null && responses != null) {
+      checkTracers(tracerInfo.tracer, responses, requests);
     }
   }
 
@@ -1965,7 +1945,7 @@ public abstract class AbstractInteropTest {
   /**
    * Check information recorded by Census.
    */
-  private void checkCensus(MetricsRecord record, boolean server,
+  private void checkCensus(MetricsRecord record, boolean isServer,
       Collection<? extends MessageLite> requests, Collection<? extends MessageLite> responses) {
     int uncompressedRequestsSize = 0;
     for (MessageLite request : requests) {
@@ -1975,7 +1955,7 @@ public abstract class AbstractInteropTest {
     for (MessageLite response : responses) {
       uncompressedResponsesSize += response.getSerializedSize();
     }
-    if (server && serverInProcess()) {
+    if (isServer && server != null) {
       assertEquals(
           requests.size(),
           record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_REQUEST_COUNT));
@@ -1994,7 +1974,7 @@ public abstract class AbstractInteropTest {
       assertNotNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_REQUEST_BYTES));
       assertNotNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_RESPONSE_BYTES));
     }
-    if (!server) {
+    if (!isServer) {
       assertEquals(
           requests.size(),
           record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_REQUEST_COUNT));

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -159,10 +159,11 @@ public abstract class AbstractInteropTest {
       new AtomicReference<Metadata>();
   private final AtomicReference<Context> contextCapture =
       new AtomicReference<Context>();
+  private final FakeStatsRecorder clientStatsRecorder = new FakeStatsRecorder();
+  private final FakeStatsRecorder serverStatsRecorder = new FakeStatsRecorder();
+
   private ScheduledExecutorService testServiceExecutor;
   private Server server;
-  private FakeStatsRecorder clientStatsRecorder;
-  private FakeStatsRecorder serverStatsRecorder;
 
   private final LinkedBlockingQueue<ServerStreamTracerInfo> serverStreamTracers =
       new LinkedBlockingQueue<ServerStreamTracerInfo>();
@@ -281,8 +282,6 @@ public abstract class AbstractInteropTest {
    */
   @Before
   public void setUp() {
-    clientStatsRecorder = new FakeStatsRecorder();
-    serverStatsRecorder = new FakeStatsRecorder();
     startServer();
     channel = createChannel();
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -371,12 +371,6 @@ public class TestServiceClient {
     }
 
     @Override
-    protected boolean serverInProcess() {
-      // Server is a separate process.
-      return false;
-    }
-
-    @Override
     protected boolean metricsExpected() {
       // Exact message size doesn't match when testing with Go servers:
       // https://github.com/grpc/grpc-go/issues/1572

--- a/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
@@ -17,11 +17,11 @@
 package io.grpc.testing.integration;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.netty.InternalHandlerSettings;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,14 +33,11 @@ public class AutoWindowSizingOnTest extends AbstractInteropTest {
   public static void turnOnAutoWindow() {
     InternalHandlerSettings.enable(true);
     InternalHandlerSettings.autoWindowOn(true);
-    startStaticServer(
-        NettyServerBuilder.forPort(0)
-            .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE));
   }
 
-  @AfterClass
-  public static void shutdown() {
-    stopStaticServer();
+  @Override
+  protected AbstractServerImplBuilder<?> getServerBuilder() {
+    return NettyServerBuilder.forPort(0).maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
   }
 
   @Override

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -17,14 +17,13 @@
 package io.grpc.testing.integration;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.NettyServerBuilder;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -34,21 +33,13 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class Http2NettyLocalChannelTest extends AbstractInteropTest {
 
-  /** Start server. */
-  @BeforeClass
-  public static void startServer() {
-    startStaticServer(
-        NettyServerBuilder
-            .forAddress(new LocalAddress("in-process-1"))
-            .flowControlWindow(65 * 1024)
-            .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
-            .channelType(LocalServerChannel.class));
-  }
-
-  /** Stop server. */
-  @AfterClass
-  public static void stopServer() {
-    stopStaticServer();
+  @Override
+  protected AbstractServerImplBuilder<?> getServerBuilder() {
+    return NettyServerBuilder
+        .forAddress(new LocalAddress("in-process-1"))
+        .flowControlWindow(65 * 1024)
+        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+        .channelType(LocalServerChannel.class);
   }
 
   @Override

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import io.grpc.ManagedChannel;
+import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
@@ -30,8 +31,6 @@ import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,11 +41,11 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class Http2NettyTest extends AbstractInteropTest {
 
-  /** Starts the server with HTTPS. */
-  @BeforeClass
-  public static void startServer() {
+  @Override
+  protected AbstractServerImplBuilder<?> getServerBuilder() {
+    // Starts the server with HTTPS.
     try {
-      startStaticServer(NettyServerBuilder.forPort(0)
+      return NettyServerBuilder.forPort(0)
           .flowControlWindow(65 * 1024)
           .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(GrpcSslContexts
@@ -55,15 +54,10 @@ public class Http2NettyTest extends AbstractInteropTest {
               .trustManager(TestUtils.loadCert("ca.pem"))
               .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
               .sslProvider(SslProvider.OPENSSL)
-              .build()));
+              .build());
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }
-  }
-
-  @AfterClass
-  public static void stopServer() {
-    stopStaticServer();
   }
 
   @Override

--- a/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java
@@ -19,8 +19,7 @@ package io.grpc.testing.integration;
 import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import io.grpc.internal.AbstractServerImplBuilder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -30,15 +29,10 @@ public class InProcessTest extends AbstractInteropTest {
 
   private static final String SERVER_NAME = "test";
 
-  /** Starts the in-process server. */
-  @BeforeClass
-  public static void startServer() {
-    startStaticServer(InProcessServerBuilder.forName(SERVER_NAME));
-  }
-
-  @AfterClass
-  public static void stopServer() {
-    stopStaticServer();
+  @Override
+  protected AbstractServerImplBuilder<?> getServerBuilder() {
+    // Starts the in-process server.
+    return InProcessServerBuilder.forName(SERVER_NAME);
   }
 
   @Override

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -50,8 +50,6 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Collections;
-import java.util.List;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -90,22 +88,17 @@ public class TransportCompressionTest extends AbstractInteropTest {
     return NettyServerBuilder.forPort(0)
         .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .compressorRegistry(compressors)
-        .decompressorRegistry(decompressors);
-  }
-
-  @Override
-  protected List<? extends ServerInterceptor> getServerInterceptors() {
-    return Collections.singletonList(
-        new ServerInterceptor() {
-          @Override
-          public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
-              Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-            Listener<ReqT> listener = next.startCall(call, headers);
-            // TODO(carl-mastrangelo): check that encoding was set.
-            call.setMessageCompression(true);
-            return listener;
-          }
-      });
+        .decompressorRegistry(decompressors)
+        .intercept(new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+                Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+              Listener<ReqT> listener = next.startCall(call, headers);
+              // TODO(carl-mastrangelo): check that encoding was set.
+              call.setMessageCompression(true);
+              return listener;
+            }
+          });
   }
 
   @Test


### PR DESCRIPTION
By doing this we can isolate the Census records for each test, and
eliminate the trial-and-error workaround in AbstractInteropTest.

This is a preferred fix for #3777 and supersedes #3803