### PR TITLE
core: InternalInstrumented<T> for instrumented classes

### DIFF
--- a/core/src/main/java/io/grpc/Instrumented.java
+++ b/core/src/main/java/io/grpc/Instrumented.java
@@ -16,12 +16,12 @@
 
 package io.grpc;
 
-import java.util.concurrent.Future;
+import com.google.common.util.concurrent.ListenableFuture;
 
 /**
  * An interface for types that <b>may</b> support instrumentation. If the actual type does not
  * support instrumentation, then the future will return a {@code null}.
  */
 interface Instrumented<T> extends WithLogId {
-  Future<T> getStats();
+  ListenableFuture<T> getStats();
 }

--- a/core/src/main/java/io/grpc/Instrumented.java
+++ b/core/src/main/java/io/grpc/Instrumented.java
@@ -16,22 +16,12 @@
 
 package io.grpc;
 
-/**
- * Do not use this. This is an internal accessor class.
- */
-@Internal
-public final class InternalLogId extends LogId {
-  private InternalLogId(String tag, long id) {
-    super(tag, id);
-  }
+import java.util.concurrent.Future;
 
-  /**
-   * An accessor method for {@link LogId#allocate(String)}.
-   *
-   * @param tag a loggable tag associated with this tag. The ID that is allocated is guaranteed
-   *            to be unique and increasing, irrespective of the tag.
-   */
-  public static InternalLogId allocate(String tag) {
-    return new InternalLogId(tag, LogId.getNextId());
-  }
+/**
+ * An interface for types that <b>may</b> support instrumentation. If the actual type does not
+ * support instrumentation, then the future will return a {@code null}.
+ */
+interface Instrumented<T> extends WithLogId {
+  Future<T> getStats();
 }

--- a/core/src/main/java/io/grpc/InternalInstrumented.java
+++ b/core/src/main/java/io/grpc/InternalInstrumented.java
@@ -16,15 +16,9 @@
 
 package io.grpc;
 
-import java.util.concurrent.Future;
-
 /**
  * This is an gRPC internal interface. Do not use this.
- *
- * <p>An interface for types that <b>may</b> support instrumentation. If the actual type does not
- * support instrumentation, then the future will return a {@code null}.
  */
 @Internal
-public interface InternalInstrumented<T> extends InternalWithLogId {
-  Future<T> getStats();
+public interface InternalInstrumented<T> extends Instrumented<T>, InternalWithLogId {
 }

--- a/core/src/main/java/io/grpc/InternalInstrumented.java
+++ b/core/src/main/java/io/grpc/InternalInstrumented.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import javax.annotation.Nullable;
+
+/**
+ * This is an gRPC internal interface. Do not use this.
+ *
+ * <p>An interface for types that <b>may</b> support instrumentation. If the concrete
+ * type does not support instrumentation, then the stat passed to {@link Consumer}
+ * will be {@code null}. The actual consumption of the stat T does not necessarily happen
+ * on the current thread.
+ */
+@Internal
+public interface InternalInstrumented<T> extends InternalWithLogId {
+  void produceStat(Consumer<T> consumer);
+
+  /**
+   * An interface for consuming an arbitrary stat of type T.
+   */
+  interface Consumer<T> {
+    void consume(@Nullable T stat);
+  }
+}

--- a/core/src/main/java/io/grpc/InternalInstrumented.java
+++ b/core/src/main/java/io/grpc/InternalInstrumented.java
@@ -16,24 +16,15 @@
 
 package io.grpc;
 
-import javax.annotation.Nullable;
+import java.util.concurrent.Future;
 
 /**
  * This is an gRPC internal interface. Do not use this.
  *
- * <p>An interface for types that <b>may</b> support instrumentation. If the concrete
- * type does not support instrumentation, then the stat passed to {@link Consumer}
- * will be {@code null}. The actual consumption of the stat T does not necessarily happen
- * on the current thread.
+ * <p>An interface for types that <b>may</b> support instrumentation. If the actual type does not
+ * support instrumentation, then the future will return a {@code null}.
  */
 @Internal
 public interface InternalInstrumented<T> extends InternalWithLogId {
-  void produceStat(Consumer<T> consumer);
-
-  /**
-   * An interface for consuming an arbitrary stat of type T.
-   */
-  interface Consumer<T> {
-    void consume(@Nullable T stat);
-  }
+  Future<T> getStats();
 }

--- a/core/src/main/java/io/grpc/InternalLogId.java
+++ b/core/src/main/java/io/grpc/InternalLogId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, gRPC Authors All rights reserved.
+ * Copyright 2016, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/grpc/InternalWithLogId.java
+++ b/core/src/main/java/io/grpc/InternalWithLogId.java
@@ -22,13 +22,7 @@ package io.grpc;
  * <p>An object that has an ID that is unique within the JVM, primarily for debug logging.
  */
 @Internal
-public interface InternalWithLogId {
-  /**
-   * Returns an ID that is primarily used in debug logs. It usually contains the class name and a
-   * numeric ID that is unique among the instances.
-   *
-   * <p>The subclasses of this interface usually want to include the log ID in their {@link
-   * #toString} results.
-   */
+public interface InternalWithLogId extends WithLogId {
+  @Override
   InternalLogId getLogId();
 }

--- a/core/src/main/java/io/grpc/LogId.java
+++ b/core/src/main/java/io/grpc/LogId.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * A loggable ID, unique for the duration of the program.
  */
- // not final so that InternalLogId can make this class visible outside of io.grpc
+// not final so that InternalLogId can make this class visible outside of io.grpc
 class LogId {
   private static final AtomicLong idAlloc = new AtomicLong();
 

--- a/core/src/main/java/io/grpc/LogId.java
+++ b/core/src/main/java/io/grpc/LogId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, gRPC Authors All rights reserved.
+ * Copyright 2017, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/grpc/LogId.java
+++ b/core/src/main/java/io/grpc/LogId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, gRPC Authors All rights reserved.
+ * Copyright 2016, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,44 @@
 
 package io.grpc;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
- * Do not use this. This is an internal accessor class.
+ * A loggable ID, unique for the duration of the program.
  */
-@Internal
-public final class InternalLogId extends LogId {
-  private InternalLogId(String tag, long id) {
-    super(tag, id);
-  }
+class LogId {
+  private static final AtomicLong idAlloc = new AtomicLong();
 
   /**
-   * An accessor method for {@link LogId#allocate(String)}.
-   *
    * @param tag a loggable tag associated with this tag. The ID that is allocated is guaranteed
    *            to be unique and increasing, irrespective of the tag.
    */
-  public static InternalLogId allocate(String tag) {
-    return new InternalLogId(tag, LogId.getNextId());
+  public static LogId allocate(String tag) {
+    return new LogId(tag, getNextId());
+  }
+
+  static long getNextId() {
+    return idAlloc.incrementAndGet();
+  }
+
+  private final String tag;
+  private final long id;
+
+  protected LogId(String tag, long id) {
+    this.tag = tag;
+    this.id = id;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public String getTag() {
+    return tag;
+  }
+
+  @Override
+  public String toString() {
+    return tag + "-" + id;
   }
 }

--- a/core/src/main/java/io/grpc/LogId.java
+++ b/core/src/main/java/io/grpc/LogId.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * A loggable ID, unique for the duration of the program.
  */
+ // not final so that InternalLogId can make this class visible outside of io.grpc
 class LogId {
   private static final AtomicLong idAlloc = new AtomicLong();
 

--- a/core/src/main/java/io/grpc/WithLogId.java
+++ b/core/src/main/java/io/grpc/WithLogId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, gRPC Authors All rights reserved.
+ * Copyright 2017, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/grpc/WithLogId.java
+++ b/core/src/main/java/io/grpc/WithLogId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, gRPC Authors All rights reserved.
+ * Copyright 2016, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,21 +17,15 @@
 package io.grpc;
 
 /**
- * Do not use this. This is an internal accessor class.
+ * An object that has an ID that is unique within the JVM, primarily for debug logging.
  */
-@Internal
-public final class InternalLogId extends LogId {
-  private InternalLogId(String tag, long id) {
-    super(tag, id);
-  }
-
+interface WithLogId {
   /**
-   * An accessor method for {@link LogId#allocate(String)}.
+   * Returns an ID that is primarily used in debug logs. It usually contains the class name and a
+   * numeric ID that is unique among the instances.
    *
-   * @param tag a loggable tag associated with this tag. The ID that is allocated is guaranteed
-   *            to be unique and increasing, irrespective of the tag.
+   * <p>The subclasses of this interface usually want to include the log ID in their {@link
+   * #toString} results.
    */
-  public static InternalLogId allocate(String tag) {
-    return new InternalLogId(tag, LogId.getNextId());
-  }
+  LogId getLogId();
 }

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -18,6 +18,7 @@ package io.grpc.inprocess;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
@@ -50,7 +51,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -221,7 +221,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   }
 
   @Override
-  public Future<InternalTransportStats> getStats() {
+  public ListenableFuture<InternalTransportStats> getStats() {
     // TODO(zpencer): add transport tracing to in-process server
     SettableFuture<InternalTransportStats> ret = SettableFuture.create();
     ret.set(null);

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -18,6 +18,7 @@ package io.grpc.inprocess;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Compressor;
@@ -49,6 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -219,8 +221,11 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   }
 
   @Override
-  public void produceStat(Consumer<InternalTransportStats> consumer) {
-    consumer.consume(null);
+  public Future<InternalTransportStats> getStats() {
+    // TODO(zpencer): add transport tracing to in-process server
+    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
+    ret.set(null);
+    return ret;
   }
 
   private synchronized void notifyShutdown(Status s) {

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -18,7 +18,6 @@ package io.grpc.inprocess;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Compressor;
@@ -50,7 +49,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -221,11 +219,8 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   }
 
   @Override
-  public Future<InternalTransportStats> getTransportStats() {
-    // TODO(zpencer): add transport tracing to in-process server
-    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
-    ret.set(null);
-    return ret;
+  public void produceStat(Consumer<InternalTransportStats> consumer) {
+    consumer.consume(null);
   }
 
   private synchronized void notifyShutdown(Status s) {

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -17,11 +17,11 @@
 package io.grpc.internal;
 
 import io.grpc.CallOptions;
+import io.grpc.InternalInstrumented;
 import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * are expected to execute quickly.
  */
 @ThreadSafe
-public interface ClientTransport {
+public interface ClientTransport extends InternalInstrumented<InternalTransportStats> {
 
   /**
    * Creates a new stream for sending messages to a remote end-point.
@@ -63,12 +63,6 @@ public interface ClientTransport {
    * remote endpoint may throw {@link UnsupportedOperationException}.
    */
   void ping(PingCallback callback, Executor executor);
-
-  /**
-   * Returns a Future representing the transport level stats. If this transport does not support
-   * stats, the return value will be a Future of a null value.
-   */
-  Future<InternalTransportStats> getTransportStats();
 
   /**
    * A callback that is invoked when the acknowledgement to a {@link #ping} is received. Exactly one

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
 import io.grpc.Context;
@@ -34,7 +35,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -199,7 +199,7 @@ final class DelayedClientTransport implements ManagedClientTransport {
   }
 
   @Override
-  public Future<InternalTransportStats> getStats() {
+  public ListenableFuture<InternalTransportStats> getStats() {
     SettableFuture<InternalTransportStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.InternalLogId;
@@ -33,6 +34,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -197,8 +199,10 @@ final class DelayedClientTransport implements ManagedClientTransport {
   }
 
   @Override
-  public void produceStat(Consumer<InternalTransportStats> consumer) {
-    consumer.consume(null);
+  public Future<InternalTransportStats> getStats() {
+    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
+    ret.set(null);
+    return ret;
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -17,7 +17,6 @@
 package io.grpc.internal;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.InternalLogId;
@@ -34,7 +33,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -199,10 +197,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
   }
 
   @Override
-  public Future<InternalTransportStats> getTransportStats() {
-    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
-    ret.set(null);
-    return ret;
+  public void produceStat(Consumer<InternalTransportStats> consumer) {
+    consumer.consume(null);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -18,20 +18,18 @@ package io.grpc.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
+import io.grpc.InternalLogId;
 import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 
 /**
  * A client transport that creates streams that will immediately fail when started.
  */
 class FailingClientTransport implements ClientTransport {
-
   @VisibleForTesting
   final Status error;
 
@@ -56,9 +54,12 @@ class FailingClientTransport implements ClientTransport {
   }
 
   @Override
-  public Future<InternalTransportStats> getTransportStats() {
-    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
-    ret.set(null);
-    return ret;
+  public void produceStat(Consumer<InternalTransportStats> consumer) {
+    throw new UnsupportedOperationException("Not a real transport");
+  }
+
+  @Override
+  public InternalLogId getLogId() {
+    throw new UnsupportedOperationException("Not a real transport");
   }
 }

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
 import io.grpc.InternalLogId;
 import io.grpc.InternalTransportStats;
@@ -25,6 +26,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 
 /**
  * A client transport that creates streams that will immediately fail when started.
@@ -54,8 +56,10 @@ class FailingClientTransport implements ClientTransport {
   }
 
   @Override
-  public void produceStat(Consumer<InternalTransportStats> consumer) {
-    throw new UnsupportedOperationException("Not a real transport");
+  public Future<InternalTransportStats> getStats() {
+    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
+    ret.set(null);
+    return ret;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
 import io.grpc.InternalLogId;
@@ -26,7 +27,6 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 
 /**
  * A client transport that creates streams that will immediately fail when started.
@@ -56,7 +56,7 @@ class FailingClientTransport implements ClientTransport {
   }
 
   @Override
-  public Future<InternalTransportStats> getStats() {
+  public ListenableFuture<InternalTransportStats> getStats() {
     SettableFuture<InternalTransportStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.InternalLogId;
@@ -24,7 +25,6 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 
 abstract class ForwardingConnectionClientTransport implements ConnectionClientTransport {
   @Override
@@ -69,7 +69,7 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
   }
 
   @Override
-  public Future<InternalTransportStats> getStats() {
+  public ListenableFuture<InternalTransportStats> getStats() {
     return delegate().getStats();
   }
 

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -16,7 +16,6 @@
 
 package io.grpc.internal;
 
-import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.InternalLogId;
@@ -25,7 +24,6 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 
 abstract class ForwardingConnectionClientTransport implements ConnectionClientTransport {
   @Override
@@ -70,10 +68,8 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
   }
 
   @Override
-  public Future<InternalTransportStats> getTransportStats() {
-    SettableFuture<InternalTransportStats> ret = SettableFuture.create();
-    ret.set(null);
-    return ret;
+  public void produceStat(Consumer<InternalTransportStats> consumer) {
+    delegate().produceStat(consumer);
   }
 
   protected abstract ConnectionClientTransport delegate();

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -24,6 +24,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 
 abstract class ForwardingConnectionClientTransport implements ConnectionClientTransport {
   @Override
@@ -68,8 +69,8 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
   }
 
   @Override
-  public void produceStat(Consumer<InternalTransportStats> consumer) {
-    delegate().produceStat(consumer);
+  public Future<InternalTransportStats> getStats() {
+    return delegate().getStats();
   }
 
   protected abstract ConnectionClientTransport delegate();

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -53,6 +53,7 @@ import java.util.Collection;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -687,8 +688,8 @@ public final class GrpcUtil {
         }
 
         @Override
-        public void produceStat(Consumer<InternalTransportStats> consumer) {
-          transport.produceStat(consumer);
+        public Future<InternalTransportStats> getStats() {
+          return transport.getStats();
         }
       };
     }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
+import io.grpc.InternalLogId;
 import io.grpc.InternalMetadata;
 import io.grpc.InternalMetadata.TrustedAsciiMarshaller;
 import io.grpc.InternalTransportStats;
@@ -52,7 +53,6 @@ import java.util.Collection;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -681,10 +681,14 @@ public final class GrpcUtil {
           transport.ping(callback, executor);
         }
 
-        @Nullable
         @Override
-        public Future<InternalTransportStats> getTransportStats() {
-          return transport.getTransportStats();
+        public InternalLogId getLogId() {
+          return transport.getLogId();
+        }
+
+        @Override
+        public void produceStat(Consumer<InternalTransportStats> consumer) {
+          transport.produceStat(consumer);
         }
       };
     }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.grpc.CallOptions;
@@ -53,7 +54,6 @@ import java.util.Collection;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -688,7 +688,7 @@ public final class GrpcUtil {
         }
 
         @Override
-        public Future<InternalTransportStats> getStats() {
+        public ListenableFuture<InternalTransportStats> getStats() {
           return transport.getStats();
         }
       };

--- a/core/src/main/java/io/grpc/internal/ServerTransport.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransport.java
@@ -16,14 +16,13 @@
 
 package io.grpc.internal;
 
+import io.grpc.InternalInstrumented;
 import io.grpc.InternalTransportStats;
-import io.grpc.InternalWithLogId;
 import io.grpc.Status;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** An inbound connection. */
-public interface ServerTransport extends InternalWithLogId {
+public interface ServerTransport extends InternalInstrumented<InternalTransportStats> {
   /**
    * Initiates an orderly shutdown of the transport. Existing streams continue, but new streams will
    * eventually begin failing. New streams "eventually" begin failing because shutdown may need to
@@ -45,10 +44,4 @@ public interface ServerTransport extends InternalWithLogId {
    * outstanding tasks are cancelled when the transport terminates.
    */
   ScheduledExecutorService getScheduledExecutorService();
-
-  /**
-   * Returns a Future representing the transport level stats. If this transport does not support
-   * stats, the return value will be a Future of a null value.
-   */
-  Future<InternalTransportStats> getTransportStats();
 }

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -43,7 +43,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.Compressor;
 import io.grpc.Context;
@@ -77,7 +76,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1275,10 +1273,8 @@ public class ServerImplTest {
     }
 
     @Override
-    public Future<InternalTransportStats> getTransportStats() {
-      SettableFuture<InternalTransportStats> ret = SettableFuture.create();
-      ret.set(null);
-      return ret;
+    public void produceStat(Consumer<InternalTransportStats> consumer) {
+      consumer.consume(null);
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.Compressor;
 import io.grpc.Context;
@@ -76,6 +77,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1273,8 +1275,10 @@ public class ServerImplTest {
     }
 
     @Override
-    public void produceStat(Consumer<InternalTransportStats> consumer) {
-      consumer.consume(null);
+    public Future<InternalTransportStats> getStats() {
+      SettableFuture<InternalTransportStats> ret = SettableFuture.create();
+      ret.set(null);
+      return ret;
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.truth.Truth;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
@@ -77,7 +78,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1275,7 +1275,7 @@ public class ServerImplTest {
     }
 
     @Override
-    public Future<InternalTransportStats> getStats() {
+    public ListenableFuture<InternalTransportStats> getStats() {
       SettableFuture<InternalTransportStats> ret = SettableFuture.create();
       ret.set(null);
       return ret;

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -19,6 +19,7 @@ package io.grpc.netty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.InternalLogId;
 import io.grpc.InternalTransportStats;
@@ -33,8 +34,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -176,21 +175,22 @@ class NettyServerTransport implements ServerTransport {
   }
 
   @Override
-  public Future<InternalTransportStats> getStats() {
+  public ListenableFuture<InternalTransportStats> getStats() {
+    final SettableFuture<InternalTransportStats> result = SettableFuture.create();
     if (channel.eventLoop().inEventLoop()) {
       // This is necessary, otherwise we will block forever if we get the future from inside
       // the event loop.
-      SettableFuture<InternalTransportStats> result = SettableFuture.create();
       result.set(transportTracer.getStats());
       return result;
     }
-    return channel.eventLoop().submit(
-        new Callable<InternalTransportStats>() {
+    channel.eventLoop().submit(
+        new Runnable() {
           @Override
-          public InternalTransportStats call() throws Exception {
-            return transportTracer.getStats();
+          public void run() {
+            result.set(transportTracer.getStats());
           }
         });
+    return result;
   }
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -71,7 +71,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.squareup.okhttp.Credentials;
 import com.squareup.okhttp.HttpUrl;
@@ -70,7 +71,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -892,7 +892,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public Future<InternalTransportStats> getTransportStats() {
+  public ListenableFuture<InternalTransportStats> getTransportStats() {
     synchronized (lock) {
       SettableFuture<InternalTransportStats> ret = SettableFuture.create();
       ret.set(transportTracer.getStats());

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -892,7 +892,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public ListenableFuture<InternalTransportStats> getTransportStats() {
+  public ListenableFuture<InternalTransportStats> getStats() {
     synchronized (lock) {
       SettableFuture<InternalTransportStats> ret = SettableFuture.create();
       ret.set(transportTracer.getStats());

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -547,7 +547,7 @@ public class OkHttpClientTransportTest {
   @Test
   public void transportTracer_windowSizeDefault() throws Exception {
     initTransport();
-    InternalTransportStats stats = clientTransport.getTransportStats().get();
+    InternalTransportStats stats = clientTransport.getStats().get();
     assertEquals(Utils.DEFAULT_WINDOW_SIZE, stats.remoteFlowControlWindow);
     // okhttp does not track local window sizes
     assertEquals(-1, stats.localFlowControlWindow);
@@ -556,13 +556,13 @@ public class OkHttpClientTransportTest {
   @Test
   public void transportTracer_windowSize_remote() throws Exception {
     initTransport();
-    InternalTransportStats before = clientTransport.getTransportStats().get();
+    InternalTransportStats before = clientTransport.getStats().get();
     assertEquals(Utils.DEFAULT_WINDOW_SIZE, before.remoteFlowControlWindow);
     // okhttp does not track local window sizes
     assertEquals(-1, before.localFlowControlWindow);
 
     frameHandler().windowUpdate(0, 1000);
-    InternalTransportStats after = clientTransport.getTransportStats().get();
+    InternalTransportStats after = clientTransport.getStats().get();
     assertEquals(Utils.DEFAULT_WINDOW_SIZE + 1000, after.remoteFlowControlWindow);
     // okhttp does not track local window sizes
     assertEquals(-1, after.localFlowControlWindow);
@@ -1278,11 +1278,11 @@ public class OkHttpClientTransportTest {
     initTransport();
     PingCallbackImpl callback1 = new PingCallbackImpl();
     clientTransport.ping(callback1, MoreExecutors.directExecutor());
-    assertEquals(1, clientTransport.getTransportStats().get().keepAlivesSent);
+    assertEquals(1, clientTransport.getStats().get().keepAlivesSent);
     // add'l ping will be added as listener to outstanding operation
     PingCallbackImpl callback2 = new PingCallbackImpl();
     clientTransport.ping(callback2, MoreExecutors.directExecutor());
-    assertEquals(1, clientTransport.getTransportStats().get().keepAlivesSent);
+    assertEquals(1, clientTransport.getStats().get().keepAlivesSent);
 
     ArgumentCaptor<Integer> captor1 = ArgumentCaptor.forClass(int.class);
     ArgumentCaptor<Integer> captor2 = ArgumentCaptor.forClass(int.class);
@@ -1315,7 +1315,7 @@ public class OkHttpClientTransportTest {
     // now that previous ping is done, next request returns a different future
     callback1 = new PingCallbackImpl();
     clientTransport.ping(callback1, MoreExecutors.directExecutor());
-    assertEquals(2, clientTransport.getTransportStats().get().keepAlivesSent);
+    assertEquals(2, clientTransport.getStats().get().keepAlivesSent);
     assertEquals(0, callback1.invocationCount);
     shutdownAndVerify();
   }
@@ -1325,7 +1325,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     PingCallbackImpl callback = new PingCallbackImpl();
     clientTransport.ping(callback, MoreExecutors.directExecutor());
-    assertEquals(1, clientTransport.getTransportStats().get().keepAlivesSent);
+    assertEquals(1, clientTransport.getStats().get().keepAlivesSent);
     assertEquals(0, callback.invocationCount);
 
     clientTransport.shutdown(SHUTDOWN_REASON);
@@ -1337,7 +1337,7 @@ public class OkHttpClientTransportTest {
     // now that handler is in terminal state, all future pings fail immediately
     callback = new PingCallbackImpl();
     clientTransport.ping(callback, MoreExecutors.directExecutor());
-    assertEquals(1, clientTransport.getTransportStats().get().keepAlivesSent);
+    assertEquals(1, clientTransport.getStats().get().keepAlivesSent);
     assertEquals(1, callback.invocationCount);
     assertTrue(callback.failureCause instanceof StatusException);
     assertSame(SHUTDOWN_REASON, ((StatusException) callback.failureCause).getStatus());
@@ -1349,7 +1349,7 @@ public class OkHttpClientTransportTest {
     initTransport();
     PingCallbackImpl callback = new PingCallbackImpl();
     clientTransport.ping(callback, MoreExecutors.directExecutor());
-    assertEquals(1, clientTransport.getTransportStats().get().keepAlivesSent);
+    assertEquals(1, clientTransport.getStats().get().keepAlivesSent);
     assertEquals(0, callback.invocationCount);
 
     clientTransport.onException(new IOException());
@@ -1362,7 +1362,7 @@ public class OkHttpClientTransportTest {
     // now that handler is in terminal state, all future pings fail immediately
     callback = new PingCallbackImpl();
     clientTransport.ping(callback, MoreExecutors.directExecutor());
-    assertEquals(1, clientTransport.getTransportStats().get().keepAlivesSent);
+    assertEquals(1, clientTransport.getStats().get().keepAlivesSent);
     assertEquals(1, callback.invocationCount);
     assertTrue(callback.failureCause instanceof StatusException);
     assertEquals(Status.Code.UNAVAILABLE,

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -48,7 +48,6 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Grpc;
-import io.grpc.InternalInstrumented;
 import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -76,7 +75,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1408,10 +1406,10 @@ public abstract class AbstractTransportTest {
     long serverFirstTimestampNanos;
     long clientFirstTimestampNanos;
     {
-      InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
+      InternalTransportStats serverBefore = serverTransportListener.transport.getStats().get();
       assertEquals(0, serverBefore.streamsStarted);
       assertEquals(0, serverBefore.lastStreamCreatedTimeNanos);
-      InternalTransportStats clientBefore = getStats(client);
+      InternalTransportStats clientBefore = client.getStats().get();
       assertEquals(0, clientBefore.streamsStarted);
       assertEquals(0, clientBefore.lastStreamCreatedTimeNanos);
 
@@ -1421,14 +1419,14 @@ public abstract class AbstractTransportTest {
       StreamCreation serverStreamCreation = serverTransportListener
           .takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-      InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
+      InternalTransportStats serverAfter = serverTransportListener.transport.getStats().get();
       assertEquals(1, serverAfter.streamsStarted);
       serverFirstTimestampNanos = serverAfter.lastStreamCreatedTimeNanos;
       assertEquals(
           currentTimeMillis(),
           TimeUnit.NANOSECONDS.toMillis(serverAfter.lastStreamCreatedTimeNanos));
 
-      InternalTransportStats clientAfter = getStats(client);
+      InternalTransportStats clientAfter = client.getStats().get();
       assertEquals(1, clientAfter.streamsStarted);
       clientFirstTimestampNanos = clientAfter.lastStreamCreatedTimeNanos;
       assertEquals(
@@ -1444,9 +1442,9 @@ public abstract class AbstractTransportTest {
 
     // start second stream
     {
-      InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
+      InternalTransportStats serverBefore = serverTransportListener.transport.getStats().get();
       assertEquals(1, serverBefore.streamsStarted);
-      InternalTransportStats clientBefore = getStats(client);
+      InternalTransportStats clientBefore = client.getStats().get();
       assertEquals(1, clientBefore.streamsStarted);
 
       ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
@@ -1455,7 +1453,7 @@ public abstract class AbstractTransportTest {
       StreamCreation serverStreamCreation = serverTransportListener
           .takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-      InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
+      InternalTransportStats serverAfter = serverTransportListener.transport.getStats().get();
       assertEquals(2, serverAfter.streamsStarted);
       assertEquals(
           TimeUnit.MILLISECONDS.toNanos(elapsedMillis),
@@ -1464,7 +1462,7 @@ public abstract class AbstractTransportTest {
           TimeUnit.NANOSECONDS.toMillis(serverAfter.lastStreamCreatedTimeNanos);
       assertEquals(currentTimeMillis(), serverSecondTimestamp);
 
-      InternalTransportStats clientAfter = getStats(client);
+      InternalTransportStats clientAfter = client.getStats().get();
       assertEquals(2, clientAfter.streamsStarted);
       assertEquals(
           TimeUnit.MILLISECONDS.toNanos(elapsedMillis),
@@ -1495,10 +1493,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
+    InternalTransportStats serverBefore = serverTransportListener.transport.getStats().get();
     assertEquals(0, serverBefore.streamsSucceeded);
     assertEquals(0, serverBefore.streamsFailed);
-    InternalTransportStats clientBefore = getStats(client);
+    InternalTransportStats clientBefore = client.getStats().get();
     assertEquals(0, clientBefore.streamsSucceeded);
     assertEquals(0, clientBefore.streamsFailed);
 
@@ -1509,10 +1507,10 @@ public abstract class AbstractTransportTest {
     assertNotNull(clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
 
-    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
+    InternalTransportStats serverAfter = serverTransportListener.transport.getStats().get();
     assertEquals(1, serverAfter.streamsSucceeded);
     assertEquals(0, serverAfter.streamsFailed);
-    InternalTransportStats clientAfter = getStats(client);
+    InternalTransportStats clientAfter = client.getStats().get();
     assertEquals(1, clientAfter.streamsSucceeded);
     assertEquals(0, clientAfter.streamsFailed);
   }
@@ -1534,10 +1532,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
+    InternalTransportStats serverBefore = serverTransportListener.transport.getStats().get();
     assertEquals(0, serverBefore.streamsFailed);
     assertEquals(0, serverBefore.streamsSucceeded);
-    InternalTransportStats clientBefore = getStats(client);
+    InternalTransportStats clientBefore = client.getStats().get();
     assertEquals(0, clientBefore.streamsFailed);
     assertEquals(0, clientBefore.streamsSucceeded);
 
@@ -1547,10 +1545,10 @@ public abstract class AbstractTransportTest {
     assertNotNull(clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
 
-    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
+    InternalTransportStats serverAfter = serverTransportListener.transport.getStats().get();
     assertEquals(1, serverAfter.streamsFailed);
     assertEquals(0, serverAfter.streamsSucceeded);
-    InternalTransportStats clientAfter = getStats(client);
+    InternalTransportStats clientAfter = client.getStats().get();
     assertEquals(1, clientAfter.streamsFailed);
     assertEquals(0, clientAfter.streamsSucceeded);
 
@@ -1573,10 +1571,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
+    InternalTransportStats serverBefore = serverTransportListener.transport.getStats().get();
     assertEquals(0, serverBefore.streamsFailed);
     assertEquals(0, serverBefore.streamsSucceeded);
-    InternalTransportStats clientBefore = getStats(client);
+    InternalTransportStats clientBefore = client.getStats().get();
     assertEquals(0, clientBefore.streamsFailed);
     assertEquals(0, clientBefore.streamsSucceeded);
 
@@ -1584,10 +1582,10 @@ public abstract class AbstractTransportTest {
     // do not validate stats until close() has been called on server
     assertNotNull(serverStreamCreation.listener.status.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
+    InternalTransportStats serverAfter = serverTransportListener.transport.getStats().get();
     assertEquals(1, serverAfter.streamsFailed);
     assertEquals(0, serverAfter.streamsSucceeded);
-    InternalTransportStats clientAfter = getStats(client);
+    InternalTransportStats clientAfter = client.getStats().get();
     assertEquals(1, clientAfter.streamsFailed);
     assertEquals(0, clientAfter.streamsSucceeded);
   }
@@ -1610,10 +1608,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
+    InternalTransportStats serverBefore = serverTransportListener.transport.getStats().get();
     assertEquals(0, serverBefore.messagesReceived);
     assertEquals(0, serverBefore.lastMessageReceivedTimeNanos);
-    InternalTransportStats clientBefore = getStats(client);
+    InternalTransportStats clientBefore = client.getStats().get();
     assertEquals(0, clientBefore.messagesSent);
     assertEquals(0, clientBefore.lastMessageSentTimeNanos);
 
@@ -1623,12 +1621,12 @@ public abstract class AbstractTransportTest {
     clientStream.halfClose();
     verifyMessageCountAndClose(serverStreamListener.messageQueue, 1);
 
-    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
+    InternalTransportStats serverAfter = serverTransportListener.transport.getStats().get();
     assertEquals(1, serverAfter.messagesReceived);
     long serverTimestamp =
         TimeUnit.NANOSECONDS.toMillis(serverAfter.lastMessageReceivedTimeNanos);
     assertEquals(currentTimeMillis(), serverTimestamp);
-    InternalTransportStats clientAfter = getStats(client);
+    InternalTransportStats clientAfter = client.getStats().get();
     assertEquals(1, clientAfter.messagesSent);
     long clientTimestamp =
         TimeUnit.NANOSECONDS.toMillis(clientAfter.lastMessageSentTimeNanos);
@@ -1654,10 +1652,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
+    InternalTransportStats serverBefore = serverTransportListener.transport.getStats().get();
     assertEquals(0, serverBefore.messagesSent);
     assertEquals(0, serverBefore.lastMessageSentTimeNanos);
-    InternalTransportStats clientBefore = getStats(client);
+    InternalTransportStats clientBefore = client.getStats().get();
     assertEquals(0, clientBefore.messagesReceived);
     assertEquals(0, clientBefore.lastMessageReceivedTimeNanos);
 
@@ -1667,11 +1665,11 @@ public abstract class AbstractTransportTest {
     serverStream.flush();
     verifyMessageCountAndClose(clientStreamListener.messageQueue, 1);
 
-    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
+    InternalTransportStats serverAfter = serverTransportListener.transport.getStats().get();
     assertEquals(1, serverAfter.messagesSent);
     long serverTimestmap = TimeUnit.NANOSECONDS.toMillis(serverAfter.lastMessageSentTimeNanos);
     assertEquals(currentTimeMillis(), serverTimestmap);
-    InternalTransportStats clientAfter = getStats(client);
+    InternalTransportStats clientAfter = client.getStats().get();
     assertEquals(1, clientAfter.messagesReceived);
     long clientTimestmap =
         TimeUnit.NANOSECONDS.toMillis(clientAfter.lastMessageReceivedTimeNanos);
@@ -1975,17 +1973,5 @@ public abstract class AbstractTransportTest {
     public String parseBytes(byte[] serialized) {
       return new String(serialized, UTF_8);
     }
-  }
-
-  private static <T> T getStats(InternalInstrumented<T> transport)
-      throws ExecutionException, InterruptedException {
-    final SettableFuture<T> future = SettableFuture.create();
-    transport.produceStat(new InternalInstrumented.Consumer<T>() {
-      @Override
-      public void consume(@Nullable T stat) {
-        future.set(stat);
-      }
-    });
-    return future.get();
   }
 }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -48,6 +48,7 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Grpc;
+import io.grpc.InternalInstrumented;
 import io.grpc.InternalTransportStats;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -75,6 +76,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1406,11 +1408,10 @@ public abstract class AbstractTransportTest {
     long serverFirstTimestampNanos;
     long clientFirstTimestampNanos;
     {
-      InternalTransportStats serverBefore =
-          serverTransportListener.transport.getTransportStats().get();
+      InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
       assertEquals(0, serverBefore.streamsStarted);
       assertEquals(0, serverBefore.lastStreamCreatedTimeNanos);
-      InternalTransportStats clientBefore = client.getTransportStats().get();
+      InternalTransportStats clientBefore = getStats(client);
       assertEquals(0, clientBefore.streamsStarted);
       assertEquals(0, clientBefore.lastStreamCreatedTimeNanos);
 
@@ -1420,15 +1421,14 @@ public abstract class AbstractTransportTest {
       StreamCreation serverStreamCreation = serverTransportListener
           .takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-      InternalTransportStats serverAfter =
-          serverTransportListener.transport.getTransportStats().get();
+      InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
       assertEquals(1, serverAfter.streamsStarted);
       serverFirstTimestampNanos = serverAfter.lastStreamCreatedTimeNanos;
       assertEquals(
           currentTimeMillis(),
           TimeUnit.NANOSECONDS.toMillis(serverAfter.lastStreamCreatedTimeNanos));
 
-      InternalTransportStats clientAfter = client.getTransportStats().get();
+      InternalTransportStats clientAfter = getStats(client);
       assertEquals(1, clientAfter.streamsStarted);
       clientFirstTimestampNanos = clientAfter.lastStreamCreatedTimeNanos;
       assertEquals(
@@ -1444,10 +1444,9 @@ public abstract class AbstractTransportTest {
 
     // start second stream
     {
-      InternalTransportStats serverBefore =
-          serverTransportListener.transport.getTransportStats().get();
+      InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
       assertEquals(1, serverBefore.streamsStarted);
-      InternalTransportStats clientBefore = client.getTransportStats().get();
+      InternalTransportStats clientBefore = getStats(client);
       assertEquals(1, clientBefore.streamsStarted);
 
       ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
@@ -1456,8 +1455,7 @@ public abstract class AbstractTransportTest {
       StreamCreation serverStreamCreation = serverTransportListener
           .takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-      InternalTransportStats serverAfter =
-          serverTransportListener.transport.getTransportStats().get();
+      InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
       assertEquals(2, serverAfter.streamsStarted);
       assertEquals(
           TimeUnit.MILLISECONDS.toNanos(elapsedMillis),
@@ -1466,7 +1464,7 @@ public abstract class AbstractTransportTest {
           TimeUnit.NANOSECONDS.toMillis(serverAfter.lastStreamCreatedTimeNanos);
       assertEquals(currentTimeMillis(), serverSecondTimestamp);
 
-      InternalTransportStats clientAfter = client.getTransportStats().get();
+      InternalTransportStats clientAfter = getStats(client);
       assertEquals(2, clientAfter.streamsStarted);
       assertEquals(
           TimeUnit.MILLISECONDS.toNanos(elapsedMillis),
@@ -1497,11 +1495,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.streamsSucceeded);
     assertEquals(0, serverBefore.streamsFailed);
-    InternalTransportStats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = getStats(client);
     assertEquals(0, clientBefore.streamsSucceeded);
     assertEquals(0, clientBefore.streamsFailed);
 
@@ -1512,11 +1509,10 @@ public abstract class AbstractTransportTest {
     assertNotNull(clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
 
-    InternalTransportStats serverAfter =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.streamsSucceeded);
     assertEquals(0, serverAfter.streamsFailed);
-    InternalTransportStats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = getStats(client);
     assertEquals(1, clientAfter.streamsSucceeded);
     assertEquals(0, clientAfter.streamsFailed);
   }
@@ -1538,11 +1534,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.streamsFailed);
     assertEquals(0, serverBefore.streamsSucceeded);
-    InternalTransportStats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = getStats(client);
     assertEquals(0, clientBefore.streamsFailed);
     assertEquals(0, clientBefore.streamsSucceeded);
 
@@ -1552,11 +1547,10 @@ public abstract class AbstractTransportTest {
     assertNotNull(clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
 
-    InternalTransportStats serverAfter =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.streamsFailed);
     assertEquals(0, serverAfter.streamsSucceeded);
-    InternalTransportStats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = getStats(client);
     assertEquals(1, clientAfter.streamsFailed);
     assertEquals(0, clientAfter.streamsSucceeded);
 
@@ -1579,11 +1573,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.streamsFailed);
     assertEquals(0, serverBefore.streamsSucceeded);
-    InternalTransportStats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = getStats(client);
     assertEquals(0, clientBefore.streamsFailed);
     assertEquals(0, clientBefore.streamsSucceeded);
 
@@ -1591,11 +1584,10 @@ public abstract class AbstractTransportTest {
     // do not validate stats until close() has been called on server
     assertNotNull(serverStreamCreation.listener.status.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-    InternalTransportStats serverAfter =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.streamsFailed);
     assertEquals(0, serverAfter.streamsSucceeded);
-    InternalTransportStats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = getStats(client);
     assertEquals(1, clientAfter.streamsFailed);
     assertEquals(0, clientAfter.streamsSucceeded);
   }
@@ -1618,11 +1610,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.messagesReceived);
     assertEquals(0, serverBefore.lastMessageReceivedTimeNanos);
-    InternalTransportStats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = getStats(client);
     assertEquals(0, clientBefore.messagesSent);
     assertEquals(0, clientBefore.lastMessageSentTimeNanos);
 
@@ -1632,13 +1623,12 @@ public abstract class AbstractTransportTest {
     clientStream.halfClose();
     verifyMessageCountAndClose(serverStreamListener.messageQueue, 1);
 
-    InternalTransportStats serverAfter =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.messagesReceived);
     long serverTimestamp =
         TimeUnit.NANOSECONDS.toMillis(serverAfter.lastMessageReceivedTimeNanos);
     assertEquals(currentTimeMillis(), serverTimestamp);
-    InternalTransportStats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = getStats(client);
     assertEquals(1, clientAfter.messagesSent);
     long clientTimestamp =
         TimeUnit.NANOSECONDS.toMillis(clientAfter.lastMessageSentTimeNanos);
@@ -1664,11 +1654,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    InternalTransportStats serverBefore =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverBefore = getStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.messagesSent);
     assertEquals(0, serverBefore.lastMessageSentTimeNanos);
-    InternalTransportStats clientBefore = client.getTransportStats().get();
+    InternalTransportStats clientBefore = getStats(client);
     assertEquals(0, clientBefore.messagesReceived);
     assertEquals(0, clientBefore.lastMessageReceivedTimeNanos);
 
@@ -1678,12 +1667,11 @@ public abstract class AbstractTransportTest {
     serverStream.flush();
     verifyMessageCountAndClose(clientStreamListener.messageQueue, 1);
 
-    InternalTransportStats serverAfter =
-        serverTransportListener.transport.getTransportStats().get();
+    InternalTransportStats serverAfter = getStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.messagesSent);
     long serverTimestmap = TimeUnit.NANOSECONDS.toMillis(serverAfter.lastMessageSentTimeNanos);
     assertEquals(currentTimeMillis(), serverTimestmap);
-    InternalTransportStats clientAfter = client.getTransportStats().get();
+    InternalTransportStats clientAfter = getStats(client);
     assertEquals(1, clientAfter.messagesReceived);
     long clientTimestmap =
         TimeUnit.NANOSECONDS.toMillis(clientAfter.lastMessageReceivedTimeNanos);
@@ -1987,5 +1975,17 @@ public abstract class AbstractTransportTest {
     public String parseBytes(byte[] serialized) {
       return new String(serialized, UTF_8);
     }
+  }
+
+  private static <T> T getStats(InternalInstrumented<T> transport)
+      throws ExecutionException, InterruptedException {
+    final SettableFuture<T> future = SettableFuture.create();
+    transport.produceStat(new InternalInstrumented.Consumer<T>() {
+      @Override
+      public void consume(@Nullable T stat) {
+        future.set(stat);
+      }
+    });
+    return future.get();
   }
 }


### PR DESCRIPTION
This allows the channelz class to keep collections of type `Map<Long, InternalInstrumented<T>>`, where `T` is an `@Internal` class that lives in `io.grpc`.