### PR TITLE
Update to Truth 0.36

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ subprojects {
                 // Test dependencies.
                 junit: 'junit:junit:4.12',
                 mockito: 'org.mockito:mockito-core:1.9.5',
-                truth: 'com.google.truth:truth:0.28',
+                truth: 'com.google.truth:truth:0.36',
 
                 // Benchmark dependencies
                 hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10',

--- a/context/src/test/java/io/grpc/testing/DeadlineSubject.java
+++ b/context/src/test/java/io/grpc/testing/DeadlineSubject.java
@@ -20,8 +20,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import com.google.common.truth.ComparableSubject;
-import com.google.common.truth.FailureStrategy;
-import com.google.common.truth.SubjectFactory;
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.Subject;
 import io.grpc.Deadline;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
@@ -32,15 +32,15 @@ import javax.annotation.Nullable;
  * Propositions for {@link Deadline} subjects.
  */
 public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, Deadline> {
-  private static final SubjectFactory<DeadlineSubject, Deadline> deadlineFactory =
-      new DeadlineSubjectFactory();
+  private static final Subject.Factory<DeadlineSubject, Deadline> deadlineFactory =
+      new Factory();
 
-  public static SubjectFactory<DeadlineSubject, Deadline> deadline() {
+  public static Subject.Factory<DeadlineSubject, Deadline> deadline() {
     return deadlineFactory;
   }
 
-  private DeadlineSubject(FailureStrategy failureStrategy, Deadline subject) {
-    super(failureStrategy, subject);
+  private DeadlineSubject(FailureMetadata metadata, Deadline subject) {
+    super(metadata, subject);
   }
 
   /**
@@ -52,7 +52,7 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
     return new TolerantDeadlineComparison() {
       @Override
       public void of(Deadline expected) {
-        Deadline actual = getSubject();
+        Deadline actual = actual();
         checkNotNull(actual, "actual value cannot be null. expected=%s", expected);
 
         // This is probably overkill, but easier than thinking about overflow.
@@ -62,7 +62,7 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
         if (actualTimeRemaining.subtract(expectedTimeRemaining).abs().compareTo(deltaNanos) > 0) {
           failWithRawMessage(
               "%s and <%s> should have been within <%sns> of each other",
-              getDisplaySubject(),
+              actualAsString(),
               expected,
               deltaNanos);
         }
@@ -119,11 +119,10 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
     }
   }
 
-  private static final class DeadlineSubjectFactory
-      extends SubjectFactory<DeadlineSubject, Deadline>  {
+  private static final class Factory implements Subject.Factory<DeadlineSubject, Deadline>  {
     @Override
-    public DeadlineSubject getSubject(FailureStrategy fs, Deadline that) {
-      return new DeadlineSubject(fs, that);
+    public DeadlineSubject createSubject(FailureMetadata metadata, Deadline that) {
+      return new DeadlineSubject(metadata, that);
     }
   }
 }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -248,7 +248,7 @@ public class TestServiceClient {
         break;
 
       case SERVICE_ACCOUNT_CREDS: {
-        String jsonKey = Files.toString(new File(serviceAccountKeyFile), UTF_8);
+        String jsonKey = Files.asCharSource(new File(serviceAccountKeyFile), UTF_8).read();
         FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));
         tester.serviceAccountCreds(jsonKey, credentialsStream, oauthScope);
         break;
@@ -261,14 +261,14 @@ public class TestServiceClient {
       }
 
       case OAUTH2_AUTH_TOKEN: {
-        String jsonKey = Files.toString(new File(serviceAccountKeyFile), UTF_8);
+        String jsonKey = Files.asCharSource(new File(serviceAccountKeyFile), UTF_8).read();
         FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));
         tester.oauth2AuthToken(jsonKey, credentialsStream, oauthScope);
         break;
       }
 
       case PER_RPC_CREDS: {
-        String jsonKey = Files.toString(new File(serviceAccountKeyFile), UTF_8);
+        String jsonKey = Files.asCharSource(new File(serviceAccountKeyFile), UTF_8).read();
         FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));
         tester.perRpcCreds(jsonKey, credentialsStream, oauthScope);
         break;


### PR DESCRIPTION
Due to transitive dependencies, this also upgrades Guava to 22. However
Truth is only used in our tests, so our users should be unimpacted.

CC @JiangJi. Sorry for the delay; I've been quite busy.