### PR TITLE
buildscripts: Remove dependency on 7za

### DIFF
--- a/buildscripts/jenkins-pre.bat
+++ b/buildscripts/jenkins-pre.bat
@@ -1,10 +1,6 @@
 if NOT EXIST grpc-java-helper mkdir grpc-java-helper
 cd grpc-java-helper
 
-REM check if 7za is available
-7za > NUL
-if ERRORLEVEL 1 call gsutil cp gs://grpc-jenkins-helpers/java/7za.exe .
-
 call "%VS120COMNTOOLS%\vsvars32.bat"
 call "%WORKSPACE%\buildscripts\make_dependencies.bat"
 

--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -12,13 +12,6 @@ set ESCWORKSPACE=%WORKSPACE:\=\\%
 
 mkdir grpc-java-helper
 
-@rem Install 7za
-@rem TODO(mattkwong): After Windows tests are no longer running on Jenkins, 7za
-@rem doesn't need to be installed and make_dependencies.bat can use unzip instead
-wget -q http://www.7-zip.org/a/7za920.zip >NUL
-unzip 7za920.zip >NUL
-mv 7za.exe grpc-java-helper
-
 cd grpc-java-helper
 
 call "%VS120COMNTOOLS%\vsvars32.bat"

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,9 +1,3 @@
-REM installer http://www.7-zip.org/a/7z1507-x64.exe
-REM 7za is in http://www.7-zip.org/a/7z1507-extra.7z
-
-REM Prerequisite:
-REM   7za.exe in current directory or PATH
-
 set PROTOBUF_VER=3.5.0
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
@@ -23,7 +17,7 @@ if not exist "%CMAKE_NAME%" (
 )
 set PATH=%PATH%;%cd%\%CMAKE_NAME%\bin
 powershell -command "& { iwr https://github.com/google/protobuf/archive/v%PROTOBUF_VER%.zip -OutFile protobuf.zip }"
-7za X protobuf.zip
+powershell -command "& { Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('protobuf.zip', '.') }"
 del protobuf.zip
 pushd protobuf-%PROTOBUF_VER%\cmake
 mkdir build
@@ -38,6 +32,6 @@ goto :eof
 :installCmake
 
 powershell -command "& { iwr https://cmake.org/files/v3.3/%CMAKE_NAME%.zip -OutFile cmake.zip }"
-7za X cmake.zip
+powershell -command "& { Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('cmake.zip', '.') }"
 del cmake.zip
 goto :eof


### PR DESCRIPTION
We already depend on Powershell, so this should make it easier to use the
script with less set-up.