### PR TITLE
core: retry support part 2, buffer size limit

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -163,6 +163,18 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
     return thisT();
   }
 
+  @Override
+  public T retryBufferSize(long bytes) {
+    delegate().retryBufferSize(bytes);
+    return thisT();
+  }
+
+  @Override
+  public T perRpcBufferLimit(long bytes) {
+    delegate().perRpcBufferLimit(bytes);
+    return thisT();
+  }
+
   /**
    * Returns the {@link ManagedChannel} built by the delegate by default. Overriding method can
    * return different value.

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -328,18 +328,18 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
-   * Sets the retry buffer size in bytes. The implementation may only estimate the buffer size being
-   * used instead of counting the exact memory allocated. It does not have any effect if retry is
-   * disabled.
+   * Sets the retry buffer size in bytes. All RPCs are not retriable if the buffer limit is
+   * exceeded. The implementation may only estimate the buffer size being used rather than count
+   * the exact physical memory allocated. It does not have any effect if retry is disabled.
    */
   public T retryBufferSize(long bytes) {
     throw new UnsupportedOperationException();
   }
 
   /**
-   * Sets the per RPC buffer limit in bytes used for retry.  The implementation may only estimate
-   * the buffer size being used instead of counting the exact memory allocated. It does not have any
-   * effect if retry is disabled.
+   * Sets the per RPC buffer limit in bytes used for retry. The RPC is not retriable if its buffer
+   * limit is exceeded. The implementation may only estimate the buffer size being used rather than
+   * count the exact physical memory allocated. It does not have any effect if retry is disabled.
    */
   public T perRpcBufferLimit(long bytes) {
     throw new UnsupportedOperationException();

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -328,9 +328,10 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
-   * Sets the retry buffer size in bytes. All RPCs are not retriable if the buffer limit is
-   * exceeded. The implementation may only estimate the buffer size being used rather than count
-   * the exact physical memory allocated. It does not have any effect if retry is disabled.
+   * Sets the retry buffer size in bytes. If the buffer limit is exceeded, no RPC
+   * could retry at the moment, and in hedging case all hedges but one of the same RPC will cancel.
+   * The implementation may only estimate the buffer size being used rather than count the
+   * exact physical memory allocated. The method does not have any effect if retry is disabled.
    */
   public T retryBufferSize(long bytes) {
     throw new UnsupportedOperationException();

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -331,8 +331,15 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * Sets the retry buffer size in bytes. If the buffer limit is exceeded, no RPC
    * could retry at the moment, and in hedging case all hedges but one of the same RPC will cancel.
    * The implementation may only estimate the buffer size being used rather than count the
-   * exact physical memory allocated. The method does not have any effect if retry is disabled.
+   * exact physical memory allocated. The method does not have any effect if retry is disabled by
+   * the client.
+   *
+   * <p>This method may not work as expected for the current release because retry is not fully
+   * implemented yet.
+   *
+   * @since 1.10.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3982")
   public T retryBufferSize(long bytes) {
     throw new UnsupportedOperationException();
   }
@@ -340,8 +347,15 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   /**
    * Sets the per RPC buffer limit in bytes used for retry. The RPC is not retriable if its buffer
    * limit is exceeded. The implementation may only estimate the buffer size being used rather than
-   * count the exact physical memory allocated. It does not have any effect if retry is disabled.
+   * count the exact physical memory allocated. It does not have any effect if retry is disabled by
+   * the client.
+   *
+   * <p>This method may not work as expected for the current release because retry is not fully
+   * implemented yet.
+   *
+   * @since 1.10.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3982")
   public T perRpcBufferLimit(long bytes) {
     throw new UnsupportedOperationException();
   }

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -328,6 +328,24 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
+   * Sets the retry buffer size in bytes. The implementation may only estimate the buffer size being
+   * used instead of counting the exact memory allocated. It does not have any effect if retry is
+   * disabled.
+   */
+  public T retryBufferSize(long bytes) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Sets the per RPC buffer limit in bytes used for retry.  The implementation may only estimate
+   * the buffer size being used instead of counting the exact memory allocated. It does not have any
+   * effect if retry is disabled.
+   */
+  public T perRpcBufferLimit(long bytes) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Builds a channel using the given parameters.
    *
    * @since 1.0.0

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -90,6 +90,9 @@ public abstract class AbstractManagedChannelImplBuilder
   private static final CompressorRegistry DEFAULT_COMPRESSOR_REGISTRY =
       CompressorRegistry.getDefaultInstance();
 
+  private static final long DEFAULT_RETRY_BUFFER_SIZE_IN_BYTES = 1 << 24;  // 16M
+  private static final long DEFAULT_PER_RPC_BUFFER_LIMIT_IN_BYTES = 1 << 20; // 1M
+
   ObjectPool<? extends Executor> executorPool = DEFAULT_EXECUTOR_POOL;
 
   private final List<ClientInterceptor> interceptors = new ArrayList<ClientInterceptor>();
@@ -118,6 +121,9 @@ public abstract class AbstractManagedChannelImplBuilder
   CompressorRegistry compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
 
   long idleTimeoutMillis = IDLE_MODE_DEFAULT_TIMEOUT_MILLIS;
+
+  long retryBufferSize = DEFAULT_RETRY_BUFFER_SIZE_IN_BYTES;
+  long perRpcBufferLimit = DEFAULT_PER_RPC_BUFFER_LIMIT_IN_BYTES;
 
   protected TransportTracer.Factory transportTracerFactory = TransportTracer.getDefaultFactory();
 
@@ -270,6 +276,18 @@ public abstract class AbstractManagedChannelImplBuilder
     } else {
       this.idleTimeoutMillis = Math.max(unit.toMillis(value), IDLE_MODE_MIN_TIMEOUT_MILLIS);
     }
+    return thisT();
+  }
+
+  @Override
+  public final T retryBufferSize(long bytes) {
+    retryBufferSize = bytes;
+    return thisT();
+  }
+
+  @Override
+  public final T perRpcBufferLimit(long bytes) {
+    perRpcBufferLimit = bytes;
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -90,8 +90,8 @@ public abstract class AbstractManagedChannelImplBuilder
   private static final CompressorRegistry DEFAULT_COMPRESSOR_REGISTRY =
       CompressorRegistry.getDefaultInstance();
 
-  private static final long DEFAULT_RETRY_BUFFER_SIZE_IN_BYTES = 1 << 24;  // 16M
-  private static final long DEFAULT_PER_RPC_BUFFER_LIMIT_IN_BYTES = 1 << 20; // 1M
+  private static final long DEFAULT_RETRY_BUFFER_SIZE_IN_BYTES = 1L << 24;  // 16M
+  private static final long DEFAULT_PER_RPC_BUFFER_LIMIT_IN_BYTES = 1L << 20; // 1M
 
   ObjectPool<? extends Executor> executorPool = DEFAULT_EXECUTOR_POOL;
 
@@ -281,12 +281,14 @@ public abstract class AbstractManagedChannelImplBuilder
 
   @Override
   public final T retryBufferSize(long bytes) {
+    checkArgument(bytes > 0L, "retry buffer size must be positive");
     retryBufferSize = bytes;
     return thisT();
   }
 
   @Override
   public final T perRpcBufferLimit(long bytes) {
+    checkArgument(bytes > 0L, "per RPC buffer limit must be positive");
     perRpcBufferLimit = bytes;
     return thisT();
   }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -205,7 +205,7 @@ public final class ManagedChannelImpl
   // One instance per channel.
   private final AtomicLong channelBufferUsed = new AtomicLong();
 
-  private final long perRpcBufferLimit ;
+  private final long perRpcBufferLimit;
   private final long channelBufferLimit;
 
   // Called from channelExecutor
@@ -447,7 +447,7 @@ public final class ManagedChannelImpl
 
         @Override
         ClientStream newStream(ClientStreamTracer.Factory tracerFactory) {
-          // TODO(zdapeng): only add tracer when retry is not disabled.
+          // TODO(zdapeng): only add tracer when retry is enabled.
           CallOptions newOptions = callOptions.withStreamTracerFactory(tracerFactory);
           ClientTransport transport =
               get(new PickSubchannelArgsImpl(method, headers, newOptions));

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -54,6 +54,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
+import io.grpc.internal.RetriableStream.ChannelBufferMeter;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
@@ -72,7 +73,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -203,7 +203,7 @@ public final class ManagedChannelImpl
   private final ChannelTracer channelTracer;
 
   // One instance per channel.
-  private final AtomicLong channelBufferUsed = new AtomicLong();
+  private final ChannelBufferMeter channelBufferUsed = new ChannelBufferMeter();
 
   private final long perRpcBufferLimit;
   private final long channelBufferLimit;

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -688,12 +688,12 @@ abstract class RetriableStream<ReqT> implements ClientStream {
           // Only update channelBufferUsed when perRpcBufferUsed is not exceeding perRpcBufferLimit.
           long savedChannelBufferUsed =
               channelBufferUsed.addAndGet(bufferNeeded - perRpcBufferUsed);
+          perRpcBufferUsed = bufferNeeded;
 
           if (savedChannelBufferUsed > channelBufferLimit) {
             substream.bufferLimitExceeded = true;
           }
         }
-        perRpcBufferUsed = bufferNeeded;
 
         if (substream.bufferLimitExceeded) {
           postCommitTask = commit(substream);

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -653,6 +653,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     // Each buffer size tracer is dedicated to one specific substream.
     private final Substream substream;
 
+    @GuardedBy("lock")
     long bufferNeeded;
 
     BufferSizeTracer(Substream substream) {
@@ -706,6 +707,11 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     }
   }
 
+
+  /**
+   *  Used to keep track of the total amount of memory used to buffer retryable or hedged RPCs for
+   *  the Channel. There should be a single instance of it for each channel.
+   */
   static final class ChannelBufferMeter {
     private final AtomicLong bufferUsed = new AtomicLong();
 

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -660,7 +660,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
     /**
      * A message is sent to the wire, so its reference would be released if no retry or
-     * hedging were involved. So at this point we have to held the reference of the message longer
+     * hedging were involved. So at this point we have to hold the reference of the message longer
      * for retry, and we need to increment {@code substream.bufferNeeded}.
      */
     @Override

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -669,6 +669,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
         return;
       }
 
+      // TODO(zdapeng): avoid using the same lock for both in-bound and out-bound.
       synchronized (lock) {
         if (state.winningSubstream != null || substream.closed) {
           return;
@@ -693,7 +694,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       }
 
       if (substream.bufferLimitExceeded) {
-        commit(substream);
+        commitAndRun(substream);
       }
     }
   }

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -485,7 +485,10 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       // handle a race between buffer limit exceeded and closed, when setting
       // substream.bufferLimitExceeded = true happens before state.substreamClosed(substream).
       if (substream.bufferLimitExceeded) {
-        masterListener.closed(status, trailers);
+        commit(substream);
+        if (state.winningSubstream == substream) {
+          masterListener.closed(status, trailers);
+        }
         return;
       }
 

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -675,9 +675,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
         }
         substream.bufferNeeded += bytes;
         if (substream.bufferNeeded > perRpcBufferUsed) {
-          perRpcBufferUsed = substream.bufferNeeded;
           long savedChannelBufferUsed =
-              channelBufferUsed.addAndGet(bytes);
+              channelBufferUsed.addAndGet(substream.bufferNeeded - perRpcBufferUsed);
+          perRpcBufferUsed = substream.bufferNeeded;
           if (perRpcBufferUsed > perRpcBufferLimit || savedChannelBufferUsed > channelBufferLimit) {
             substream.bufferLimitExceeded = true;
           }

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -130,11 +130,13 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   }
 
   private Substream createSubstream() {
-    final Substream sub = new Substream();
+    Substream sub = new Substream();
+    // one tracer per substream
+    final ClientStreamTracer bufferSizeTracer = new BufferSizeTracer(sub);
     ClientStreamTracer.Factory tracerFactory = new ClientStreamTracer.Factory() {
       @Override
       public ClientStreamTracer newClientStreamTracer(CallOptions callOptions, Metadata headers) {
-        return new BufferSizeTracer(sub);
+        return bufferSizeTracer;
       }
     };
     // NOTICE: This set _must_ be done before stream.start() and it actually is.

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -666,7 +666,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
      */
     @Override
     public void outboundWireSize(long bytes) {
-      if (state.winningSubstream != null || substream.closed) {
+      if (state.winningSubstream != null) {
         return;
       }
 

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -333,19 +333,31 @@ public class AbstractManagedChannelImplBuilderTest {
   @Test
   public void retryBufferSize() {
     Builder builder = new Builder("target");
-    assertEquals(1 << 24, builder.retryBufferSize);
+    assertEquals(1L << 24, builder.retryBufferSize);
 
-    builder.retryBufferSize(3456);
-    assertEquals(3456, builder.retryBufferSize);
+    builder.retryBufferSize(3456L);
+    assertEquals(3456L, builder.retryBufferSize);
   }
 
   @Test
   public void perRpcBufferLimit() {
     Builder builder = new Builder("target");
-    assertEquals(1 << 20, builder.perRpcBufferLimit);
+    assertEquals(1L << 20, builder.perRpcBufferLimit);
 
-    builder.perRpcBufferLimit(3456);
-    assertEquals(3456, builder.perRpcBufferLimit);
+    builder.perRpcBufferLimit(3456L);
+    assertEquals(3456L, builder.perRpcBufferLimit);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void retryBufferSizeInvalidArg() {
+    Builder builder = new Builder("target");
+    builder.retryBufferSize(0L);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void perRpcBufferLimitInvalidArg() {
+    Builder builder = new Builder("target");
+    builder.perRpcBufferLimit(0L);
   }
 
   static class Builder extends AbstractManagedChannelImplBuilder<Builder> {

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -330,6 +330,24 @@ public class AbstractManagedChannelImplBuilderTest {
     assertEquals(TimeUnit.SECONDS.toMillis(30), builder.getIdleTimeoutMillis());
   }
 
+  @Test
+  public void retryBufferSize() {
+    Builder builder = new Builder("target");
+    assertEquals(1 << 24, builder.retryBufferSize);
+
+    builder.retryBufferSize(3456);
+    assertEquals(3456, builder.retryBufferSize);
+  }
+
+  @Test
+  public void perRpcBufferLimit() {
+    Builder builder = new Builder("target");
+    assertEquals(1 << 20, builder.perRpcBufferLimit);
+
+    builder.perRpcBufferLimit(3456);
+    assertEquals(3456, builder.perRpcBufferLimit);
+  }
+
   static class Builder extends AbstractManagedChannelImplBuilder<Builder> {
     Builder(String target) {
       super(target);

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -748,9 +748,15 @@ public class RetriableStreamTest {
     retriableStream.start(masterListener);
 
     bufferSizeTracer.outboundWireSize(PER_RPC_BUFFER_LIMIT);
+
+    assertEquals(PER_RPC_BUFFER_LIMIT, channelBufferUsed.addAndGet(0));
+
     verify(retriableStreamRecorder, never()).postCommit();
     bufferSizeTracer.outboundWireSize(2);
     verify(retriableStreamRecorder).postCommit();
+
+    // verify channel buffer is adjusted
+    assertEquals(0, channelBufferUsed.addAndGet(0));
   }
 
   @Test
@@ -760,11 +766,17 @@ public class RetriableStreamTest {
 
     retriableStream.start(masterListener);
 
-    bufferSizeTracer.outboundWireSize(1);
-    channelBufferUsed.addAndGet(CHANNEL_BUFFER_LIMIT);
+    bufferSizeTracer.outboundWireSize(100);
+
+    assertEquals(100, channelBufferUsed.addAndGet(0));
+
+    channelBufferUsed.addAndGet(CHANNEL_BUFFER_LIMIT - 200);
     verify(retriableStreamRecorder, never()).postCommit();
-    bufferSizeTracer.outboundWireSize(1);
+    bufferSizeTracer.outboundWireSize(100 + 1);
     verify(retriableStreamRecorder).postCommit();
+
+    // verify channel buffer is adjusted
+    assertEquals(CHANNEL_BUFFER_LIMIT - 200, channelBufferUsed.addAndGet(0));
   }
 
   /**


### PR DESCRIPTION
Implement buffer size counting with `ClientStreamTracer` and buffer size limit following the spce https://github.com/grpc/proposal/blob/master/A6-client-retries.md#memory-management-buffering