### PR TITLE
core/grpclb: resolve TXT records in DNS name resolver and include balancer addresses

### DIFF
--- a/core/src/main/java/io/grpc/Grpc.java
+++ b/core/src/main/java/io/grpc/Grpc.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import java.net.SocketAddress;
+import java.util.List;
 import javax.net.ssl.SSLSession;
 
 /**
@@ -40,4 +41,11 @@ public final class Grpc {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
   public static final Attributes.Key<SSLSession> TRANSPORT_ATTR_SSL_SESSION =
           Attributes.Key.of("ssl-session");
+
+  /**
+   * Attribute key TXT DNS records.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9999")
+  public static final Attributes.Key<List<String>> NAME_RESOLVER_ATTR_TXT =
+      Attributes.Key.of("dns-txt");
 }

--- a/core/src/main/java/io/grpc/Grpc.java
+++ b/core/src/main/java/io/grpc/Grpc.java
@@ -17,7 +17,6 @@
 package io.grpc;
 
 import java.net.SocketAddress;
-import java.util.List;
 import javax.net.ssl.SSLSession;
 
 /**
@@ -41,11 +40,4 @@ public final class Grpc {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
   public static final Attributes.Key<SSLSession> TRANSPORT_ATTR_SSL_SESSION =
           Attributes.Key.of("ssl-session");
-
-  /**
-   * Attribute key TXT DNS records.
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/9999")
-  public static final Attributes.Key<List<String>> NAME_RESOLVER_ATTR_TXT =
-      Attributes.Key.of("dns-txt");
 }

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -68,8 +68,11 @@ final class DnsNameResolver extends NameResolver {
   // From https://github.com/grpc/proposal/blob/master/A5-grpclb-in-dns.md
   private static final String GRPCLB_NAME_PREFIX = "_grpclb._tcp.";
 
+  private static final String jndiProperty =
+      System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_jndi", "false");
+
   @VisibleForTesting
-  static boolean enableJndi = true;
+  static boolean enableJndi = Boolean.parseBoolean(jndiProperty);
 
   private DelegateResolver delegateResolver = pickDelegateResolver();
 

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -26,7 +26,7 @@ public final class GrpcAttributes {
   /**
    * Attribute key TXT DNS records.
    */
-  public static final Attributes.Key<List<String>> NAME_RESOLVER_ATTR_TXT =
+  public static final Attributes.Key<List<String>> NAME_RESOLVER_ATTR_DNS_TXT =
       Attributes.Key.of("dns-txt");
 
   /**

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.Attributes;
+import java.util.List;
+
+/**
+ * Special attributes that are only useful to gRPC.
+ */
+public final class GrpcAttributes {
+  /**
+   * Attribute key TXT DNS records.
+   */
+  public static final Attributes.Key<List<String>> NAME_RESOLVER_ATTR_TXT =
+      Attributes.Key.of("dns-txt");
+
+  /**
+   * The naming authority of a gRPC LB server address.  It is an address-group-level attribute,
+   * present when the address group is a LoadBalancer.
+   */
+  public static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
+      Attributes.Key.of("io.grpc.grpclb.lbAddrAuthority");
+
+
+  private GrpcAttributes() {}
+}

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -890,27 +890,32 @@ public final class ManagedChannelImpl extends ManagedChannel implements Internal
         onError(Status.UNAVAILABLE.withDescription("NameResolver returned an empty list"));
         return;
       }
-      logger.log(Level.FINE, "[{0}] resolved address: {1}, config={2}",
-          new Object[] {getLogId(), servers, config});
-      helper.runSerialized(new Runnable() {
-          @Override
-          public void run() {
-            // Call LB only if it's not shutdown.  If LB is shutdown, lbHelper won't match.
-            if (NameResolverListenerImpl.this.helper != ManagedChannelImpl.this.lbHelper) {
-              return;
-            }
-            try {
-              balancer.handleResolvedAddressGroups(servers, config);
-            } catch (Throwable e) {
-              logger.log(
-                  Level.WARNING, "[" + getLogId() + "] Unexpected exception from LoadBalancer", e);
-              // It must be a bug! Push the exception back to LoadBalancer in the hope that it may
-              // be propagated to the application.
-              balancer.handleNameResolutionError(Status.INTERNAL.withCause(e)
-                  .withDescription("Thrown from handleResolvedAddresses(): " + e));
-            }
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, "[{0}] resolved address: {1}, config={2}",
+            new Object[]{getLogId(), servers, config});
+      }
+
+      final class NamesResolved implements Runnable {
+        @Override
+        public void run() {
+          // Call LB only if it's not shutdown.  If LB is shutdown, lbHelper won't match.
+          if (NameResolverListenerImpl.this.helper != ManagedChannelImpl.this.lbHelper) {
+            return;
           }
-        });
+          try {
+            balancer.handleResolvedAddressGroups(servers, config);
+          } catch (Throwable e) {
+            logger.log(
+                Level.WARNING, "[" + getLogId() + "] Unexpected exception from LoadBalancer", e);
+            // It must be a bug! Push the exception back to LoadBalancer in the hope that it may
+            // be propagated to the application.
+            balancer.handleNameResolutionError(Status.INTERNAL.withCause(e)
+                .withDescription("Thrown from handleResolvedAddresses(): " + e));
+          }
+        }
+      }
+
+      helper.runSerialized(new NamesResolved());
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -323,15 +323,25 @@ public class DnsNameResolverTest {
     DelegateResolver resolver = new DnsNameResolver.CompositeResolver(jdkDelegate, jndiDelegate);
 
     List<InetAddress> jdkAnswer = createAddressList(2);
-    jdkDelegate.addAnswer(jdkAnswer, Arrays.asList("jdktxt"));
+    jdkDelegate.addAnswer(
+        jdkAnswer,
+        Arrays.asList("jdktxt"),
+        Collections.<EquivalentAddressGroup>emptyList());
 
     List<InetAddress> jdniAnswer = createAddressList(2);
-    jndiDelegate.addAnswer(jdniAnswer, Arrays.asList("jnditxt"));
+    jndiDelegate.addAnswer(
+        jdniAnswer,
+        Arrays.asList("jnditxt"),
+        Collections.singletonList(
+            new EquivalentAddressGroup(
+                Collections.<SocketAddress>singletonList(new SocketAddress() {}),
+                Attributes.EMPTY)));
 
     ResolutionResults results = resolver.resolve("abc");
 
     assertThat(results.addresses).containsExactlyElementsIn(jdkAnswer).inOrder();
     assertThat(results.txtRecords).containsExactly("jnditxt");
+    assertThat(results.srvRecords).hasSize(1);
   }
 
   @Test
@@ -418,14 +428,19 @@ public class DnsNameResolverTest {
     private final Queue<String> invocations = new LinkedList<String>();
 
     MockResolver addAnswer(List<InetAddress> addresses) {
-      return addAnswer(addresses, null);
+      return addAnswer(addresses, null, null);
     }
 
-    MockResolver addAnswer(List<InetAddress> addresses, List<String> txtRecords) {
+    MockResolver addAnswer(
+        List<InetAddress> addresses,
+        List<String> txtRecords,
+        List<EquivalentAddressGroup> balancerAddresses) {
       answers.add(
           new ResolutionResults(
               addresses,
-              MoreObjects.firstNonNull(txtRecords, Collections.<String>emptyList())));
+              MoreObjects.firstNonNull(txtRecords, Collections.<String>emptyList()),
+              MoreObjects.firstNonNull(
+                  balancerAddresses, Collections.<EquivalentAddressGroup>emptyList())));
       return this;
     }
 

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -341,7 +341,7 @@ public class DnsNameResolverTest {
 
     assertThat(results.addresses).containsExactlyElementsIn(jdkAnswer).inOrder();
     assertThat(results.txtRecords).containsExactly("jnditxt");
-    assertThat(results.srvRecords).hasSize(1);
+    assertThat(results.balancerAddresses).hasSize(1);
   }
 
   @Test

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbConstants.java
@@ -41,13 +41,6 @@ public final class GrpclbConstants {
       Attributes.Key.of("io.grpc.grpclb.lbPolicy");
 
   /**
-   * The naming authority of an LB server address.  It is an address-group-level attribute, present
-   * when the address group is a LoadBalancer.
-   */
-  public static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
-      Attributes.Key.of("io.grpc.grpclb.lbAddrAuthority");
-
-  /**
    * The opaque token given by the remote balancer for each returned server address.  The client
    * will send this token with any requests sent to the associated server.
    */

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -27,6 +27,7 @@ import io.grpc.InternalWithLogId;
 import io.grpc.LoadBalancer;
 import io.grpc.Status;
 import io.grpc.grpclb.GrpclbConstants.LbPolicy;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ObjectPool;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -104,7 +105,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements InternalWithLogId {
     List<LbAddressGroup> newLbAddressGroups = new ArrayList<LbAddressGroup>();
     List<EquivalentAddressGroup> newBackendServers = new ArrayList<EquivalentAddressGroup>();
     for (EquivalentAddressGroup server : updatedServers) {
-      String lbAddrAuthority = server.getAttributes().get(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY);
+      String lbAddrAuthority = server.getAttributes().get(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY);
       if (lbAddrAuthority != null) {
         newLbAddressGroups.add(new LbAddressGroup(server, lbAddrAuthority));
       } else {

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -71,6 +71,7 @@ import io.grpc.grpclb.GrpclbState.RoundRobinPicker;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.FakeClock;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.stub.StreamObserver;
@@ -1623,7 +1624,7 @@ public class GrpclbLoadBalancerTest {
 
   private static Attributes lbAttributes(String authority) {
     return Attributes.newBuilder()
-        .set(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY, authority)
+        .set(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY, authority)
         .build();
   }
 


### PR DESCRIPTION
This is part one of handling service config, and also enabled grpclb to work.  I manually tested this with some complex DNS data, but I dont have many unit tests because we dont have a dummy DNS server.   

Handling or the SRV records logs failures and tries to keep going.  