### PR TITLE
core: support user-agent in InProcess

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -142,7 +142,7 @@ public final class InProcessChannelBuilder extends
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
-      return new InProcessTransport(name, authority);
+      return new InProcessTransport(name, authority, userAgent);
     }
 
     @Override

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -34,6 +34,7 @@ import io.grpc.Status;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ConnectionClientTransport;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.NoopClientStream;
 import io.grpc.internal.ObjectPool;
@@ -66,6 +67,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final String name;
   private final String authority;
+  private final String userAgent;
   private ObjectPool<ScheduledExecutorService> serverSchedulerPool;
   private ScheduledExecutorService serverScheduler;
   private ServerTransportListener serverTransportListener;
@@ -82,9 +84,10 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   @GuardedBy("this")
   private List<ServerStreamTracer.Factory> serverStreamTracerFactories;
 
-  public InProcessTransport(String name, String authority) {
+  public InProcessTransport(String name, String authority, String userAgent) {
     this.name = name;
     this.authority = authority;
+    this.userAgent = userAgent;
   }
 
   @CheckReturnValue
@@ -143,6 +146,9 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
         }
       };
     }
+    headers.put(
+        GrpcUtil.USER_AGENT_KEY,
+        GrpcUtil.getGrpcUserAgent("inprocess", userAgent));
     return new InProcessStream(method, headers, callOptions, authority).clientStream;
   }
 

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -30,6 +30,7 @@ import org.junit.runners.JUnit4;
 public class InProcessTransportTest extends AbstractTransportTest {
   private static final String TRANSPORT_NAME = "perfect-for-testing";
   private static final String AUTHORITY = "a-testing-authority";
+  private static final String USER_AGENT = "a-testing-user-agent";
 
   @Override
   protected InternalServer newServer(List<ServerStreamTracer.Factory> streamTracerFactories) {
@@ -49,7 +50,7 @@ public class InProcessTransportTest extends AbstractTransportTest {
 
   @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
-    return new InProcessTransport(TRANSPORT_NAME, testAuthority(server));
+    return new InProcessTransport(TRANSPORT_NAME, testAuthority(server), USER_AGENT);
   }
 
   @Override


### PR DESCRIPTION
Currently, InProcess(io.grpc.inprocess) does not support the use of a user-agent, but it may be useful for testing of `LoggingInterceptor`(It is just an example, it records the status, responses, user-agent, etc to log files).