### PR TITLE
core: Use hard-coded string for version

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,6 +64,7 @@ $ MAJOR=1 MINOR=7 PATCH=0 # Set appropriately for new release
 $ VERSION_FILES=(
   build.gradle
   android-interop-testing/app/build.gradle
+  core/src/main/java/io/grpc/internal/GrpcUtil.java
   examples/build.gradle
   examples/pom.xml
   examples/android/helloworld/app/build.gradle

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -194,7 +194,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  private static final String IMPLEMENTATION_VERSION = getImplementationVersion();
+  private static final String IMPLEMENTATION_VERSION = "1.9.0-SNAPSHOT"; // CURRENT_GRPC_VERSION
 
   /**
    * The default delay in nanos before we send a keepalive.
@@ -736,12 +736,4 @@ public final class GrpcUtil {
   }
 
   private GrpcUtil() {}
-
-  private static String getImplementationVersion() {
-    String version = GrpcUtil.class.getPackage().getImplementationVersion();
-    if (version != null) {
-      return "/" + version;
-    }
-    return "";
-  }
 }


### PR DESCRIPTION
Using META-INF for loading the version is broken on Android and
frequently broken when gRPC is shaded. Having hard-coded strings be
replaced on version bumps has been working well.

Fixes #2098