### PR TITLE
cronet: pass TransportTracer instead of null.

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -31,6 +31,7 @@ import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ProxyParameters;
 import io.grpc.internal.SharedResourceHolder;
+import io.grpc.internal.TransportTracer;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.Executor;
@@ -130,7 +131,7 @@ public final class CronetChannelBuilder extends
   @Override
   protected final ClientTransportFactory buildTransportFactory() {
     return new CronetTransportFactory(streamFactory, MoreExecutors.directExecutor(),
-        maxMessageSize, alwaysUsePut);
+        maxMessageSize, alwaysUsePut, transportTracerFactory.create());
   }
 
   @Override
@@ -147,16 +148,19 @@ public final class CronetChannelBuilder extends
     private final int maxMessageSize;
     private final boolean alwaysUsePut;
     private final StreamBuilderFactory streamFactory;
+    private final TransportTracer transportTracer;
 
     private CronetTransportFactory(
         StreamBuilderFactory streamFactory,
         Executor executor,
         int maxMessageSize,
-        boolean alwaysUsePut) {
+        boolean alwaysUsePut,
+        TransportTracer transportTracer) {
       this.maxMessageSize = maxMessageSize;
       this.alwaysUsePut = alwaysUsePut;
       this.streamFactory = streamFactory;
       this.executor = Preconditions.checkNotNull(executor, "executor");
+      this.transportTracer = Preconditions.checkNotNull(transportTracer, "transportTracer");
     }
 
     @Override
@@ -164,7 +168,7 @@ public final class CronetChannelBuilder extends
         @Nullable String userAgent, @Nullable ProxyParameters proxy) {
       InetSocketAddress inetSocketAddr = (InetSocketAddress) addr;
       return new CronetClientTransport(streamFactory, inetSocketAddr, authority, userAgent,
-          executor, maxMessageSize, alwaysUsePut);
+          executor, maxMessageSize, alwaysUsePut, transportTracer);
     }
 
     @Override

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -38,6 +38,7 @@ import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.StreamListener.MessageProducer;
+import io.grpc.internal.TransportTracer;
 import io.grpc.internal.WritableBuffer;
 import io.grpc.testing.TestMethodDescriptors;
 import java.io.ByteArrayInputStream;
@@ -72,6 +73,7 @@ public final class CronetClientStreamTest {
   @Mock private ClientStreamListener clientListener;
   @Mock private ExperimentalBidirectionalStream.Builder builder;
   private final Object lock = new Object();
+  private final TransportTracer transportTracer = TransportTracer.getDefaultFactory().create();
   CronetClientStream clientStream;
 
   private MethodDescriptor.Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
@@ -115,7 +117,8 @@ public final class CronetClientStreamTest {
             false /* alwaysUsePut */,
             method,
             StatsTraceContext.NOOP,
-            CallOptions.DEFAULT);
+            CallOptions.DEFAULT,
+            transportTracer);
     callback.setStream(clientStream);
     when(factory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
@@ -573,7 +576,8 @@ public final class CronetClientStreamTest {
             false /* alwaysUsePut */,
             method,
             StatsTraceContext.NOOP,
-            CallOptions.DEFAULT.withOption(CronetCallOptions.CRONET_ANNOTATION_KEY, annotation));
+            CallOptions.DEFAULT.withOption(CronetCallOptions.CRONET_ANNOTATION_KEY, annotation),
+            transportTracer);
     callback.setStream(stream);
     when(factory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
@@ -605,7 +609,8 @@ public final class CronetClientStreamTest {
             false /* alwaysUsePut */,
             method,
             StatsTraceContext.NOOP,
-            callOptions);
+            callOptions,
+            transportTracer);
     callback.setStream(stream);
     when(factory.newBidirectionalStreamBuilder(
             any(String.class), any(BidirectionalStream.Callback.class), any(Executor.class)))
@@ -642,7 +647,8 @@ public final class CronetClientStreamTest {
             false /* alwaysUsePut */,
             getMethod,
             StatsTraceContext.NOOP,
-            CallOptions.DEFAULT);
+            CallOptions.DEFAULT,
+            transportTracer);
     callback.setStream(stream);
     ExperimentalBidirectionalStream.Builder getBuilder =
         mock(ExperimentalBidirectionalStream.Builder.class);
@@ -696,7 +702,8 @@ public final class CronetClientStreamTest {
             false /* alwaysUsePut */,
             idempotentMethod,
             StatsTraceContext.NOOP,
-            CallOptions.DEFAULT);
+            CallOptions.DEFAULT,
+            transportTracer);
     callback.setStream(stream);
     ExperimentalBidirectionalStream.Builder builder =
         mock(ExperimentalBidirectionalStream.Builder.class);
@@ -725,7 +732,8 @@ public final class CronetClientStreamTest {
             true /* alwaysUsePut */,
             method,
             StatsTraceContext.NOOP,
-            CallOptions.DEFAULT);
+            CallOptions.DEFAULT,
+            transportTracer);
     callback.setStream(stream);
     ExperimentalBidirectionalStream.Builder builder =
         mock(ExperimentalBidirectionalStream.Builder.class);
@@ -762,7 +770,8 @@ public final class CronetClientStreamTest {
             false /* alwaysUsePut */,
             method,
             StatsTraceContext.NOOP,
-            CallOptions.DEFAULT);
+            CallOptions.DEFAULT,
+            transportTracer);
     callback.setStream(stream);
     ExperimentalBidirectionalStream.Builder builder =
         mock(ExperimentalBidirectionalStream.Builder.class);

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -30,6 +30,7 @@ import io.grpc.Status;
 import io.grpc.cronet.CronetChannelBuilder.StreamBuilderFactory;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ManagedClientTransport;
+import io.grpc.internal.TransportTracer;
 import io.grpc.testing.TestMethodDescriptors;
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
@@ -64,7 +65,8 @@ public final class CronetClientTransportTest {
             null,
             executor,
             5000,
-            false);
+            false,
+            TransportTracer.getDefaultFactory().create());
     Runnable callback = transport.start(clientTransportListener);
     assertTrue(callback != null);
     callback.run();


### PR DESCRIPTION
AbstractStream now requires TransportTracer to be non-null.