### PR TITLE
Fix interop tests in IDEA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,7 @@ subprojects {
                 junit: 'junit:junit:4.12',
                 mockito: 'org.mockito:mockito-core:1.9.5',
                 truth: 'com.google.truth:truth:0.36',
+                conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:1.0.0.RC14',
 
                 // Benchmark dependencies
                 hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10',

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -27,7 +27,8 @@ dependencies {
             libraries.oauth_client,
             libraries.truth
     runtime libraries.opencensus_impl
-    testCompile project(':grpc-context').sourceSets.test.output
+    testCompile project(':grpc-context').sourceSets.test.output,
+            libraries.conscrypt
 }
 
 configureProtoCompilation()


### PR DESCRIPTION
Interop tests fail to run in IDEA due to a missing dependency on Conscrypt. Without the Conscrypt dependency, you cannot debug these tests.