### PR TITLE
Preserve ManagedChannel when stub.withInterceptors() is invoked

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelChain.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelChain.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.InternalChannelStats;
+import io.grpc.InternalLogId;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+
+import java.util.concurrent.TimeUnit;
+
+public class ManagedChannelChain extends ManagedChannel {
+  private final ManagedChannel base;
+  private final Channel head;
+
+  public ManagedChannelChain(Channel head, ManagedChannel base) {
+    this.head = head;
+    this.base = base;
+  }
+
+  // Channel Methods
+  @Override
+  public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+      MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+    return head.newCall(methodDescriptor, callOptions);
+  }
+
+  @Override
+  public String authority() {
+    return head.authority();
+  }
+
+  // ManagedChannel Methods
+  @Override
+  public ManagedChannel shutdown() {
+    return base.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return base.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return base.isTerminated();
+  }
+
+  @Override
+  public ManagedChannel shutdownNow() {
+    return base.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return base.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public ListenableFuture<InternalChannelStats> getStats() {
+    return base.getStats();
+  }
+
+  @Override
+  public InternalLogId getLogId() {
+    return base.getLogId();
+  }
+}

--- a/stub/src/test/java/io/grpc/stub/AbstractStubTest.java
+++ b/stub/src/test/java/io/grpc/stub/AbstractStubTest.java
@@ -22,9 +22,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import io.grpc.CallOptions;
-import io.grpc.Channel;
+import io.grpc.*;
+
 import java.util.concurrent.Executor;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +38,9 @@ public class AbstractStubTest {
 
   @Mock
   Channel channel;
+
+  @Mock
+  ManagedChannel managedChannel;
 
   @Before
   public void setup() {
@@ -97,5 +101,19 @@ public class AbstractStubTest {
     callOptions = stub.getCallOptions();
 
     assertEquals(callOptions.getExecutor(), executor);
+  }
+
+  @Test
+  public void withInterceptorIsManagedChannel() {
+    NoopStub stub = new NoopStub(managedChannel);
+
+    stub = stub.withInterceptors(new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        return next.newCall(method, callOptions);
+      }
+    });
+
+    assertTrue(stub.getChannel() instanceof ManagedChannel);
   }
 }


### PR DESCRIPTION
Creating a stub around a `ManagedChannel` creates a stub who's `getChannel()` method returns a `ManagedChannel`. 

While `getChannel()`'s return type is only `Channel`, it is convenient to downcast `getChannel()`'s result to a `ManagedChannel` to shut down the `Channel`'s supporting `ManagedChannel`. However, if the stub's user adds an interceptor to the stub by calling `withInterceptors()`, `getChannel()` returns a `Channel` instead of a `ManagedChannel` (technically, an `InterceptorChannel`).

Technically, changing a `ManagedChannel` to a `Channel` complies with the public API for `AbstractStub`. While `stub.getChannel()` makes no guarantees about the type of `Channel` it returns, it does make sense that the type would be the same as the `Channel` that started the stub. 

This PR makes `getChannel()` behave more consistently. If a stub is started around a `ManagedChannel`, `stub.getChannel()` will return a `ManagedChannel`, even after one or more interceptors are added with `stub.withInterceptors()`.