### PR TITLE
core: fix unimplemented API in ManageChannel

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
@@ -85,9 +86,10 @@ public abstract class ManagedChannel
     throw new UnsupportedOperationException("Not implemented");
   }
 
+  @Internal
   @Override
   public ListenableFuture<InternalChannelStats> getStats() {
-    throw new UnsupportedOperationException("Not implemented");
+    return Futures.immediateFuture(null);
   }
 
   /**
@@ -122,8 +124,9 @@ public abstract class ManagedChannel
   @ExperimentalApi
   public void resetConnectBackoff() {}
 
+  @Internal
   @Override
   public InternalLogId getLogId() {
-    throw new UnsupportedOperationException("Not implemented");
+    return InternalLogId.allocate(getClass().getName());
   }
 }

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -16,8 +16,8 @@
 
 package io.grpc;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -89,7 +89,9 @@ public abstract class ManagedChannel
   @Internal
   @Override
   public ListenableFuture<InternalChannelStats> getStats() {
-    return Futures.immediateFuture(null);
+    SettableFuture<InternalChannelStats> ret = SettableFuture.create();
+    ret.set(null);
+    return ret;
   }
 
   /**

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -27,6 +27,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public abstract class ManagedChannel
     extends Channel implements InternalInstrumented<InternalChannelStats> {
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
+
   /**
    * Initiates an orderly shutdown in which preexisting calls continue but new calls are immediately
    * cancelled.
@@ -128,7 +130,7 @@ public abstract class ManagedChannel
 
   @Internal
   @Override
-  public InternalLogId getLogId() {
-    return InternalLogId.allocate(getClass().getName());
+  public final InternalLogId getLogId() {
+    return logId;
   }
 }

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -84,6 +85,11 @@ public abstract class ManagedChannel
     throw new UnsupportedOperationException("Not implemented");
   }
 
+  @Override
+  public ListenableFuture<InternalChannelStats> getStats() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
   /**
    * Registers a one-off callback that will be run if the connectivity state of the channel diverges
    * from the given {@code source}, which is typically what has just been returned by {@link
@@ -115,4 +121,9 @@ public abstract class ManagedChannel
    */
   @ExperimentalApi
   public void resetConnectBackoff() {}
+
+  @Override
+  public InternalLogId getLogId() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -114,7 +114,6 @@ public final class ManagedChannelImpl extends ManagedChannel {
   private final Executor executor;
   private final ObjectPool<? extends Executor> executorPool;
   private final ObjectPool<? extends Executor> oobExecutorPool;
-  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
 
   private final ChannelExecutor channelExecutor = new ChannelExecutor();
 
@@ -975,11 +974,6 @@ public final class ManagedChannelImpl extends ManagedChannel {
     }
   }
 
-  @Override
-  public InternalLogId getLogId() {
-    return logId;
-  }
-
   private class NameResolverListenerImpl implements NameResolver.Listener {
     final LoadBalancer balancer;
     final LoadBalancer.Helper helper;
@@ -1151,7 +1145,7 @@ public final class ManagedChannelImpl extends ManagedChannel {
           ENABLE_ALLOCATION_TRACKING
               ? new RuntimeException("ManagedChannel allocation site")
               : missingCallSite);
-      logId = chan.logId;
+      logId = chan.getLogId();
       target = chan.target;
       refs.put(this, this);
       cleanQueue();

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -28,12 +28,10 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.InternalChannelStats;
-import io.grpc.InternalLogId;
-import io.grpc.InternalWithLogId;
-import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
@@ -53,14 +51,13 @@ import javax.annotation.concurrent.ThreadSafe;
  * to its own RPC needs.
  */
 @ThreadSafe
-final class OobChannel extends ManagedChannel implements InternalWithLogId {
+final class OobChannel extends ManagedChannel {
   private static final Logger log = Logger.getLogger(OobChannel.class.getName());
 
   private InternalSubchannel subchannel;
   private AbstractSubchannel subchannelImpl;
   private SubchannelPicker subchannelPicker;
 
-  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final String authority;
   private final DelayedClientTransport delayedTransport;
   private final ObjectPool<? extends Executor> executorPool;
@@ -177,11 +174,6 @@ final class OobChannel extends ManagedChannel implements InternalWithLogId {
   @Override
   public String authority() {
     return authority;
-  }
-
-  @Override
-  public InternalLogId getLogId() {
-    return logId;
   }
 
   @Override


### PR DESCRIPTION
Two APIs were added to ManageChannel. This would be API breaking if they are still abstract.