### PR TITLE
core,netty,okhttp: Collect stats on subchannels

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import io.grpc.ExperimentalApi;
 import io.grpc.Internal;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
@@ -138,7 +139,11 @@ public final class InProcessChannelBuilder extends
 
     @Override
     public ConnectionClientTransport newClientTransport(
-        SocketAddress addr, String authority, String userAgent, ProxyParameters proxy) {
+        SocketAddress addr,
+        String authority,
+        String userAgent,
+        ProxyParameters proxy,
+        ChannelTracer subchannelTracer) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -346,6 +346,7 @@ public abstract class AbstractManagedChannelImplBuilder
         GrpcUtil.STOPWATCH_SUPPLIER,
         getEffectiveInterceptors(),
         GrpcUtil.getProxyDetector(),
+        ChannelTracer.getDefaultFactory().create(),
         ChannelTracer.getDefaultFactory());
   }
 

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -43,10 +43,14 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
 
   @Override
   public ConnectionClientTransport newClientTransport(
-      SocketAddress serverAddress, String authority, @Nullable String userAgent,
-      @Nullable ProxyParameters proxy) {
+      SocketAddress serverAddress,
+      String authority,
+      @Nullable String userAgent,
+      @Nullable ProxyParameters proxy,
+      ChannelTracer subchannelTracer) {
     return new CallCredentialsApplyingTransport(
-        delegate.newClientTransport(serverAddress, authority, userAgent, proxy), authority);
+        delegate.newClientTransport(serverAddress, authority, userAgent, proxy, subchannelTracer),
+        authority);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ChannelTracer.java
+++ b/core/src/main/java/io/grpc/internal/ChannelTracer.java
@@ -22,7 +22,7 @@ import io.grpc.InternalChannelStats;
 /**
  * A collection of channel level stats for channelz.
  */
-final class ChannelTracer {
+public final class ChannelTracer {
   private final TimeProvider timeProvider;
   private final LongCounter callsStarted = LongCounterFactory.create();
   private final LongCounter callsSucceeded = LongCounterFactory.create();
@@ -33,12 +33,12 @@ final class ChannelTracer {
     this.timeProvider = timeProvider;
   }
 
-  public void reportCallStarted() {
+  void reportCallStarted() {
     callsStarted.add(1);
     lastCallStartedMillis = timeProvider.currentTimeMillis();
   }
 
-  public void reportCallEnded(boolean success) {
+  void reportCallEnded(boolean success) {
     if (success) {
       callsSucceeded.add(1);
     } else {
@@ -46,7 +46,7 @@ final class ChannelTracer {
     }
   }
 
-  public InternalChannelStats getStats() {
+  InternalChannelStats getStats() {
     return new InternalChannelStats(
         callsStarted.value(), callsSucceeded.value(), callsFailed.value(), lastCallStartedMillis);
   }

--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -29,9 +29,10 @@ public interface ClientTransportFactory extends Closeable {
    * @param serverAddress the address that the transport is connected to
    * @param authority the HTTP/2 authority of the server
    * @param proxy the proxy that should be used to connect to serverAddress
+   * @param subchannelTracer the stats object for this subchannel
    */
   ConnectionClientTransport newClientTransport(SocketAddress serverAddress, String authority,
-      @Nullable String userAgent, @Nullable ProxyParameters proxy);
+      @Nullable String userAgent, @Nullable ProxyParameters proxy, ChannelTracer subchannelTracer);
 
   /**
    * Returns an executor for scheduling provided by the transport. The service should be configured

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -196,7 +196,7 @@ public final class ManagedChannelImpl
 
   private final ManagedChannelReference phantom;
 
-  private final ChannelTracer.Factory channelTracerFactory; // new tracer for each oobchannel
+  private final ChannelTracer.Factory subchannelTracerFactory; // new tracer for each oobchannel
   private final ChannelTracer channelTracer;
 
   // Called from channelExecutor
@@ -454,7 +454,8 @@ public final class ManagedChannelImpl
       Supplier<Stopwatch> stopwatchSupplier,
       List<ClientInterceptor> interceptors,
       ProxyDetector proxyDetector,
-      ChannelTracer.Factory channelTracerFactory) {
+      ChannelTracer channelTracer,
+      ChannelTracer.Factory subchannelTracerFactory) {
     this.target = checkNotNull(builder.target, "target");
     this.nameResolverFactory = builder.getNameResolverFactory();
     this.nameResolverParams = checkNotNull(builder.getNameResolverParams(), "nameResolverParams");
@@ -487,8 +488,8 @@ public final class ManagedChannelImpl
     this.proxyDetector = proxyDetector;
 
     phantom = new ManagedChannelReference(this);
-    this.channelTracerFactory = channelTracerFactory;
-    channelTracer = channelTracerFactory.create();
+    this.channelTracer = channelTracer;
+    this.subchannelTracerFactory = subchannelTracerFactory;
     logger.log(Level.FINE, "[{0}] Created with target {1}", new Object[] {getLogId(), target});
   }
 
@@ -860,7 +861,7 @@ public final class ManagedChannelImpl
               }
             },
             proxyDetector,
-            channelTracerFactory.create());
+            subchannelTracerFactory.create());
       subchannel.subchannel = internalSubchannel;
       logger.log(Level.FINE, "[{0}] {1} created for {2}",
           new Object[] {getLogId(), internalSubchannel.getLogId(), addressGroup});
@@ -923,7 +924,7 @@ public final class ManagedChannelImpl
       checkState(!terminated, "Channel is terminated");
       final OobChannel oobChannel = new OobChannel(
           authority, oobExecutorPool, transportFactory.getScheduledExecutorService(),
-          channelExecutor, channelTracerFactory.create());
+          channelExecutor, channelTracer);
       final InternalSubchannel internalSubchannel = new InternalSubchannel(
           addressGroup, authority, userAgent, backoffPolicyProvider, transportFactory,
           transportFactory.getScheduledExecutorService(), stopwatchSupplier, channelExecutor,
@@ -943,7 +944,7 @@ public final class ManagedChannelImpl
             }
           },
           proxyDetector,
-          channelTracerFactory.create());
+          subchannelTracerFactory.create());
       oobChannel.setSubchannel(internalSubchannel);
       runSerialized(new Runnable() {
           @Override

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
@@ -245,9 +244,7 @@ final class OobChannel
 
   @Override
   public ListenableFuture<InternalChannelStats> getStats() {
-    SettableFuture<InternalChannelStats> ret = SettableFuture.create();
-    ret.set(channelTracer.getStats());
-    return ret;
+    return subchannel.getStats();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/TransportTracer.java
+++ b/core/src/main/java/io/grpc/internal/TransportTracer.java
@@ -53,7 +53,7 @@ public final class TransportTracer {
   private final ChannelTracer subchannelTracer;
 
   /**
-   * Creates a {code TransportTracer}. The {@link ChannelTracer} is null for server transports.
+   * The {@link ChannelTracer} is null for server transports.
    */
   private TransportTracer(TimeProvider timeProvider, @Nullable ChannelTracer subchannelTracer) {
     this.timeProvider = timeProvider;

--- a/core/src/main/java/io/grpc/internal/TransportTracer.java
+++ b/core/src/main/java/io/grpc/internal/TransportTracer.java
@@ -52,15 +52,12 @@ public final class TransportTracer {
   @Nullable
   private final ChannelTracer subchannelTracer;
 
-  private TransportTracer(@Nullable ChannelTracer subchannelTracer) {
-    this.timeProvider = SYSTEM_TIME_PROVIDER;
-    this.subchannelTracer = subchannelTracer;
-  }
-
+  /**
+   * Creates a {code TransportTracer}. The {@link ChannelTracer} is null for server transports.
+   */
   private TransportTracer(TimeProvider timeProvider, @Nullable ChannelTracer subchannelTracer) {
     this.timeProvider = timeProvider;
     this.subchannelTracer = subchannelTracer;
-
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/TransportTracer.java
+++ b/core/src/main/java/io/grpc/internal/TransportTracer.java
@@ -52,7 +52,7 @@ public final class TransportTracer {
   @Nullable
   private final ChannelTracer subchannelTracer;
 
-  public TransportTracer(@Nullable ChannelTracer subchannelTracer) {
+  private TransportTracer(@Nullable ChannelTracer subchannelTracer) {
     this.timeProvider = SYSTEM_TIME_PROVIDER;
     this.subchannelTracer = subchannelTracer;
   }

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -62,7 +62,10 @@ public class AbstractClientStreamTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private final StatsTraceContext statsTraceCtx = StatsTraceContext.NOOP;
-  private final TransportTracer transportTracer = new TransportTracer();
+  private final TransportTracer transportTracer =
+      TransportTracer
+          .getDefaultFactory()
+          .createClientTracer(ChannelTracer.getDefaultFactory().create());
   @Mock private ClientStreamListener mockListener;
 
   @Before

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -70,7 +70,7 @@ public class AbstractServerStreamTest {
 
   @Before
   public void setUp() {
-    transportTracer = new TransportTracer();
+    transportTracer = TransportTracer.getDefaultFactory().createServerTracer();
     stream = new AbstractServerStreamBase(
         allocator,
         sink,

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -92,6 +92,7 @@ public class CallCredentialsApplyingTest {
   private static final Metadata.Key<String> CREDS_KEY =
       Metadata.Key.of("test-creds", Metadata.ASCII_STRING_MARSHALLER);
   private static final String CREDS_VALUE = "some credentials";
+  private final ChannelTracer subchannelTracer = ChannelTracer.getDefaultFactory().create();
 
   private final Metadata origHeaders = new Metadata();
   private ForwardingConnectionClientTransport transport;
@@ -101,16 +102,18 @@ public class CallCredentialsApplyingTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     origHeaders.put(ORIG_HEADER_KEY, ORIG_HEADER_VALUE);
-    when(mockTransportFactory.newClientTransport(address, AUTHORITY, USER_AGENT, NO_PROXY))
+    when(mockTransportFactory
+        .newClientTransport(address, AUTHORITY, USER_AGENT, NO_PROXY, subchannelTracer))
         .thenReturn(mockTransport);
     when(mockTransport.newStream(same(method), any(Metadata.class), any(CallOptions.class)))
         .thenReturn(mockStream);
     ClientTransportFactory transportFactory = new CallCredentialsApplyingTransportFactory(
         mockTransportFactory, mockExecutor);
     transport = (ForwardingConnectionClientTransport) transportFactory.newClientTransport(
-        address, AUTHORITY, USER_AGENT, NO_PROXY);
+        address, AUTHORITY, USER_AGENT, NO_PROXY, subchannelTracer);
     callOptions = CallOptions.DEFAULT.withCallCredentials(mockCreds);
-    verify(mockTransportFactory).newClientTransport(address, AUTHORITY, USER_AGENT, NO_PROXY);
+    verify(mockTransportFactory)
+        .newClientTransport(address, AUTHORITY, USER_AGENT, NO_PROXY, subchannelTracer);
     assertSame(mockTransport, transport.delegate());
   }
 

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -56,7 +56,10 @@ public class Http2ClientStreamTransportStateTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    transportTracer = new TransportTracer();
+    transportTracer = 
+      TransportTracer
+          .getDefaultFactory()
+          .createClientTracer(ChannelTracer.getDefaultFactory().create());
 
     doAnswer(new Answer<Void>() {
       @Override

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -91,7 +91,10 @@ public class MessageDeframerTest {
     private Listener listener = mock(Listener.class);
     private TestBaseStreamTracer tracer = new TestBaseStreamTracer();
     private StatsTraceContext statsTraceCtx = new StatsTraceContext(new StreamTracer[]{tracer});
-    private TransportTracer transportTracer = new TransportTracer();
+    private TransportTracer transportTracer =
+        TransportTracer
+            .getDefaultFactory()
+            .createClientTracer(ChannelTracer.getDefaultFactory().create());
 
     private MessageDeframer deframer = new MessageDeframer(listener, Codec.Identity.NONE,
             DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx, transportTracer, "test");

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -90,7 +90,7 @@ final class TestUtils {
       }
     }).when(mockTransportFactory)
         .newClientTransport(any(SocketAddress.class), any(String.class), any(String.class),
-            any(ProxyParameters.class));
+            any(ProxyParameters.class), any(ChannelTracer.class));
 
     return captor;
   }

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -165,7 +165,8 @@ class NettyServer implements InternalServer, InternalWithLogId {
 
         NettyServerTransport transport =
             new NettyServerTransport(
-                ch, protocolNegotiator, streamTracerFactories, transportTracerFactory.create(),
+                ch, protocolNegotiator, streamTracerFactories,
+                transportTracerFactory.createServerTracer(),
                 maxStreamsPerConnection,
                 flowControlWindow, maxMessageSize, maxHeaderListSize,
                 keepAliveTimeInNanos, keepAliveTimeoutInNanos,

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -47,6 +47,7 @@ import io.grpc.InternalStatus;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.StatsTraceContext;
@@ -99,7 +100,10 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
       .setResponseMarshaller(marshaller)
       .build();
 
-  private final TransportTracer transportTracer = new TransportTracer();
+  private final TransportTracer transportTracer = 
+      TransportTracer
+          .getDefaultFactory()
+          .createClientTracer(ChannelTracer.getDefaultFactory().create());
 
   /** Set up for test. */
   @Before

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -47,6 +47,7 @@ import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
@@ -108,6 +109,10 @@ public class NettyClientTransportTest {
     // Throwing is useless in this method, because Netty doesn't propagate the exception
     @Override public void run() {}
   };
+  private final TransportTracer transportTracer =
+      TransportTracer
+          .getDefaultFactory()
+          .createClientTracer(ChannelTracer.getDefaultFactory().create());
 
   private ProtocolNegotiator negotiator = ProtocolNegotiators.serverTls(SSL_CONTEXT);
 
@@ -171,7 +176,7 @@ public class NettyClientTransportTest {
         address, NioSocketChannel.class, channelOptions, group, newNegotiator(),
         DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
         KEEPALIVE_TIME_NANOS_DISABLED, 1L, false, authority, null /* user agent */,
-        tooManyPingsRunnable, new TransportTracer());
+        tooManyPingsRunnable, transportTracer);
     transports.add(transport);
     callMeMaybe(transport.start(clientTransportListener));
 
@@ -375,7 +380,7 @@ public class NettyClientTransportTest {
         address, CantConstructChannel.class, new HashMap<ChannelOption<?>, Object>(), group,
         newNegotiator(), DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE,
         GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, KEEPALIVE_TIME_NANOS_DISABLED, 1, false, authority,
-        null, tooManyPingsRunnable, new TransportTracer());
+        null, tooManyPingsRunnable, transportTracer);
     transports.add(transport);
 
     // Should not throw
@@ -544,7 +549,7 @@ public class NettyClientTransportTest {
         DEFAULT_WINDOW_SIZE, maxMsgSize, maxHeaderListSize,
         keepAliveTimeNano, keepAliveTimeoutNano,
         false, authority, userAgent, tooManyPingsRunnable,
-        new TransportTracer());
+        transportTracer);
     transports.add(transport);
     return transport;
   }

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.InternalTransportStats;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.MessageFramer;
 import io.grpc.internal.StatsTraceContext;
@@ -100,7 +101,10 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
    */
   protected void manualSetUp() throws Exception {}
 
-  protected final TransportTracer transportTracer = new TransportTracer();
+  protected final TransportTracer transportTracer = 
+      TransportTracer
+          .getDefaultFactory()
+          .createClientTracer(ChannelTracer.getDefaultFactory().create());
   protected int flowControlWindow = DEFAULT_WINDOW_SIZE;
 
   private final FakeClock fakeClock = new FakeClock();

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ListMultimap;
 import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ServerStreamListener;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.StreamListener;
@@ -299,7 +300,10 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     }).when(writeQueue).enqueue(any(QueuedCommand.class), any(ChannelPromise.class), anyBoolean());
     when(writeQueue.enqueue(any(QueuedCommand.class), anyBoolean())).thenReturn(future);
     StatsTraceContext statsTraceCtx = StatsTraceContext.NOOP;
-    TransportTracer transportTracer = new TransportTracer();
+    TransportTracer transportTracer = 
+        TransportTracer
+            .getDefaultFactory()
+            .createClientTracer(ChannelTracer.getDefaultFactory().create());
     NettyServerStream.TransportState state = new NettyServerStream.TransportState(
         handler, channel.eventLoop(), http2Stream, DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx,
         transportTracer);

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -17,6 +17,7 @@
 package io.grpc.netty;
 
 import io.grpc.ServerStreamTracer;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.InternalServer;
@@ -43,6 +44,7 @@ public class NettyTransportTest extends AbstractTransportTest {
           return fakeClock.currentTimeMillis();
         }
       });
+  private final ChannelTracer subchannelTracer = ChannelTracer.getDefaultFactory().create();
   // Avoid LocalChannel for testing because LocalChannel can fail with
   // io.netty.channel.ChannelException instead of java.net.ConnectException which breaks
   // serverNotListening test.
@@ -106,7 +108,8 @@ public class NettyTransportTest extends AbstractTransportTest {
         new InetSocketAddress("localhost", port),
         testAuthority(server),
         null /* agent */,
-        null /* proxy */);
+        null /* proxy */,
+        subchannelTracer);
   }
 
   @Test

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -31,6 +31,7 @@ import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.AtomicBackoff;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
@@ -427,7 +428,8 @@ public class OkHttpChannelBuilder extends
     @Override
     public ConnectionClientTransport newClientTransport(
         SocketAddress addr, String authority, @Nullable String userAgent,
-        @Nullable ProxyParameters proxy) {
+        @Nullable ProxyParameters proxy, ChannelTracer subchannelTracer) {
+      Preconditions.checkNotNull(subchannelTracer, "subchannel tracer must not be null");
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
@@ -452,7 +454,7 @@ public class OkHttpChannelBuilder extends
           proxy == null ? null : proxy.username,
           proxy == null ? null : proxy.password,
           tooManyPingsRunnable,
-          transportTracerFactory.create());
+          transportTracerFactory.createClientTracer(subchannelTracer));
       if (enableKeepAlive) {
         transport.enableKeepAlive(
             true, keepAliveTimeNanosState.get(), keepAliveTimeoutNanos, keepAliveWithoutCalls);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNull;
 
 import com.squareup.okhttp.ConnectionSpec;
 import io.grpc.NameResolver;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.GrpcUtil;
 import java.net.InetSocketAddress;
 import org.junit.Rule;
@@ -37,6 +38,7 @@ import org.junit.runners.JUnit4;
 public class OkHttpChannelBuilderTest {
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
+  private final ChannelTracer subchannelTracer = ChannelTracer.getDefaultFactory().create();
 
   @Test
   public void authorityIsReadable() {
@@ -110,7 +112,7 @@ public class OkHttpChannelBuilderTest {
   public void usePlaintext_newClientTransportAllowed() {
     OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("host", 1234).usePlaintext(true);
     builder.buildTransportFactory().newClientTransport(new InetSocketAddress(5678),
-        "dummy_authority", "dummy_userAgent", null /* proxy */);
+        "dummy_authority", "dummy_userAgent", null /* proxy */, subchannelTracer);
   }
 
   @Test

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -30,6 +30,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.StatsTraceContext;
@@ -63,7 +64,10 @@ public class OkHttpClientStreamTest {
   @Captor private ArgumentCaptor<List<Header>> headersCaptor;
 
   private final Object lock = new Object();
-  private final TransportTracer transportTracer = new TransportTracer();
+  private final TransportTracer transportTracer = 
+      TransportTracer
+          .getDefaultFactory()
+          .createClientTracer(ChannelTracer.getDefaultFactory().create());
 
   private MethodDescriptor<?, ?> methodDescriptor;
   private OkHttpClientStream stream;

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -62,6 +62,7 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
 import io.grpc.internal.AbstractStream;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.GrpcUtil;
@@ -137,7 +138,10 @@ public class OkHttpClientTransportTest {
   private final InetSocketAddress proxyAddr = null;
   private final String proxyUser = null;
   private final String proxyPassword = null;
-  private final TransportTracer transportTracer = new TransportTracer();
+  private final TransportTracer transportTracer = 
+      TransportTracer
+          .getDefaultFactory()
+          .createClientTracer(ChannelTracer.getDefaultFactory().create());
   private OkHttpClientTransport clientTransport;
   private MockFrameReader frameReader;
   private ExecutorService executor = Executors.newCachedThreadPool();
@@ -203,7 +207,7 @@ public class OkHttpClientTransportTest {
         connectedFuture,
         maxMessageSize,
         tooManyPingsRunnable,
-        new TransportTracer());
+        transportTracer);
     clientTransport.start(transportListener);
     if (waitingForConnected) {
       connectedFuture.get(TIME_OUT_MS, TimeUnit.MILLISECONDS);
@@ -1475,7 +1479,7 @@ public class OkHttpClientTransportTest {
         proxyUser,
         proxyPassword,
         tooManyPingsRunnable,
-        new TransportTracer());
+        transportTracer);
 
     ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
     clientTransport.start(listener);

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -18,6 +18,7 @@ package io.grpc.okhttp;
 
 import io.grpc.ServerStreamTracer;
 import io.grpc.internal.AccessProtectedHack;
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.InternalServer;
@@ -45,6 +46,7 @@ public class OkHttpTransportTest extends AbstractTransportTest {
           return fakeClock.currentTimeMillis();
         }
       });
+  private final ChannelTracer subchannelTracer = ChannelTracer.getDefaultFactory().create();
   private ClientTransportFactory clientFactory = OkHttpChannelBuilder
       // Although specified here, address is ignored because we never call build.
       .forAddress("localhost", 0)
@@ -91,7 +93,8 @@ public class OkHttpTransportTest extends AbstractTransportTest {
         new InetSocketAddress("localhost", port),
         testAuthority(server),
         null /* agent */,
-        null /* proxy */);
+        null /* proxy */,
+        subchannelTracer);
   }
 
   @Override

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal.testing;
 
+import io.grpc.internal.ChannelTracer;
 import io.grpc.internal.ClientTransportFactory;
 import java.net.InetSocketAddress;
 import org.junit.Test;
@@ -24,6 +25,8 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public abstract class AbstractClientTransportFactoryTest {
+
+  private final ChannelTracer subchannelTracer = ChannelTracer.getDefaultFactory().create();
 
   protected abstract ClientTransportFactory newClientTransportFactory();
 
@@ -40,6 +43,10 @@ public abstract class AbstractClientTransportFactoryTest {
     ClientTransportFactory transportFactory = newClientTransportFactory();
     transportFactory.close();
     transportFactory.newClientTransport(
-        new InetSocketAddress("localhost", 12345), "localhost:" + 12345, "agent", null);
+        new InetSocketAddress("localhost", 12345),
+        "localhost:" + 12345,
+        "agent",
+        null,
+        subchannelTracer);
   }
 }


### PR DESCRIPTION
Today, the ChannelTracer inside ClientCall is the subchannel's
tracer.

This PR makes it so that the ClientCall ChannelTracer is the one
from the ManagedChannelImpl. The subchannels' ChannelTracers are
linked to the TransportTracer. The result is that as soon as the
ClientCall starts or finishes, the ManagedChannel stats are
updated. When the corresponding event takes place on the
transport, then the subchannel stats are updated.

The "update test class method signatures" contains mostly mechanical
changes.

