### PR TITLE
core: Don't re-wrap SerializingExecutors in ClientCallImpl and ServerImpl

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -95,7 +95,8 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     // See https://github.com/grpc/grpc-java/issues/368
     this.callExecutor = executor == directExecutor()
         ? new SerializeReentrantCallsDirectExecutor()
-        : new SerializingExecutor(executor);
+        : (executor instanceof SerializingExecutor
+          ? executor : new SerializingExecutor(executor));
     this.channelTracer = channelTracer;
     // Propagate the context from the thread which initiated the call to all callbacks.
     this.context = Context.current();

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -421,6 +421,8 @@ public final class ServerImpl extends io.grpc.Server implements InternalWithLogI
       // that comes with SerializingExecutor.
       if (executor == directExecutor()) {
         wrappedExecutor = new SerializeReentrantCallsDirectExecutor();
+      } else if (executor instanceof SerializingExecutor) {
+        wrappedExecutor = executor;
       } else {
         wrappedExecutor = new SerializingExecutor(executor);
       }


### PR DESCRIPTION
If the user provides a `SerializingExecutor`, there's an unnecessary performance overhead in wrapping it in another `SerializingExecutor` (see older related PR https://github.com/grpc/grpc-java/issues/368).

This is useful in particular for cases where users manage their own `SerializingExecutor`-based event loops and want RPC callbacks to run in the same context.
  