### PR TITLE
services: introduce BinaryLogSinkProvider

### DIFF
--- a/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
@@ -30,6 +30,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerMethodDefinition;
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -159,6 +160,12 @@ public abstract class BinaryLogProvider implements Closeable {
   @Nullable
   public abstract ClientInterceptor getClientInterceptor(String fullMethodName);
 
+  @Override
+  public void close() throws IOException {
+    // default impl: noop
+    // TODO(zpencer): make BinaryLogProvider provide a BinaryLog, and this method belongs there
+  }
+
   /**
    * A priority, from 0 to 10 that this provider should be used, taking the current environment into
    * consideration. 5 should be considered the default, and then tweaked based on environment
@@ -186,11 +193,6 @@ public abstract class BinaryLogProvider implements Closeable {
     @Override
     protected int priority() {
       return 0;
-    }
-
-    @Override
-    public void close() {
-      // noop
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
@@ -29,7 +29,9 @@ import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerMethodDefinition;
+import java.io.Closeable;
 import java.io.InputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -41,7 +43,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
-public abstract class BinaryLogProvider {
+public abstract class BinaryLogProvider implements Closeable {
   private static final Logger logger = Logger.getLogger(BinaryLogProvider.class.getName());
   private static final BinaryLogProvider PROVIDER = load(BinaryLogProvider.class.getClassLoader());
   @VisibleForTesting
@@ -185,6 +187,11 @@ public abstract class BinaryLogProvider {
     @Override
     protected int priority() {
       return 0;
+    }
+
+    @Override
+    public void close() throws IOException {
+      // noop
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
@@ -31,7 +31,6 @@ import io.grpc.ServerInterceptor;
 import io.grpc.ServerMethodDefinition;
 import java.io.Closeable;
 import java.io.InputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -190,7 +189,7 @@ public abstract class BinaryLogProvider implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
       // noop
     }
   }

--- a/core/src/test/java/io/grpc/internal/BinaryLogProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/BinaryLogProviderTest.java
@@ -83,21 +83,24 @@ public class BinaryLogProviderTest {
   private final List<byte[]> binlogReq = new ArrayList<byte[]>();
   private final List<byte[]> binlogResp = new ArrayList<byte[]>();
   private final BinaryLogProvider binlogProvider = new BinaryLogProvider() {
-      @Override
-      public ServerInterceptor getServerInterceptor(String fullMethodName) {
-        return new TestBinaryLogServerInterceptor();
-      }
+    @Override
+    public ServerInterceptor getServerInterceptor(String fullMethodName) {
+      return new TestBinaryLogServerInterceptor();
+    }
 
-      @Override
-      public ClientInterceptor getClientInterceptor(String fullMethodName) {
-        return new TestBinaryLogClientInterceptor();
-      }
+    @Override
+    public ClientInterceptor getClientInterceptor(String fullMethodName) {
+      return new TestBinaryLogClientInterceptor();
+    }
+    @Override
+    public void close() { }
 
-      @Override
-      protected int priority() {
-        return 0;
-      }
-    };
+
+    @Override
+    protected int priority() {
+      return 0;
+    }
+  };
 
   @Test
   public void noProvider() {
@@ -363,6 +366,11 @@ public class BinaryLogProviderTest {
     @Override
     protected int priority() {
       return priority;
+    }
+
+    @Override
+    public void close() throws IOException {
+      // noop
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/BinaryLogProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/BinaryLogProviderTest.java
@@ -367,11 +367,6 @@ public class BinaryLogProviderTest {
     protected int priority() {
       return priority;
     }
-
-    @Override
-    public void close() throws IOException {
-      // noop
-    }
   }
 
   private final class TestBinaryLogClientInterceptor implements ClientInterceptor {

--- a/core/src/test/java/io/grpc/internal/BinaryLogProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/BinaryLogProviderTest.java
@@ -92,6 +92,7 @@ public class BinaryLogProviderTest {
     public ClientInterceptor getClientInterceptor(String fullMethodName) {
       return new TestBinaryLogClientInterceptor();
     }
+
     @Override
     public void close() { }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -2027,9 +2027,6 @@ public class ManagedChannelImplTest {
 
     TracingClientInterceptor userInterceptor = new TracingClientInterceptor();
     binlogProvider = new BinaryLogProvider() {
-      @Override
-      public void close() { }
-
       @Nullable
       @Override
       public ServerInterceptor getServerInterceptor(String fullMethodName) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -2027,6 +2027,9 @@ public class ManagedChannelImplTest {
 
     TracingClientInterceptor userInterceptor = new TracingClientInterceptor();
     binlogProvider = new BinaryLogProvider() {
+      @Override
+      public void close() { }
+
       @Nullable
       @Override
       public ServerInterceptor getServerInterceptor(String fullMethodName) {

--- a/services/src/main/java/io/grpc/services/BinaryLog.java
+++ b/services/src/main/java/io/grpc/services/BinaryLog.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.primitives.Bytes;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.UnsafeByteOperations;
 import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -450,7 +449,7 @@ final class BinaryLog {
       int desiredRemaining = Math.min(maxMessageBytes, messageSize);
       ByteBuffer dup = message.duplicate();
       dup.limit(dup.position() + desiredRemaining);
-      builder.setData(UnsafeByteOperations.unsafeWrap(dup));
+      builder.setData(ByteString.copyFrom(dup));
     }
     return builder.build();
   }

--- a/services/src/main/java/io/grpc/services/BinaryLog.java
+++ b/services/src/main/java/io/grpc/services/BinaryLog.java
@@ -153,7 +153,7 @@ final class BinaryLog {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(maxHeaderBytes, maxMessageBytes, sink);
+    return Objects.hashCode(maxHeaderBytes, maxMessageBytes);
   }
 
   @Override

--- a/services/src/main/java/io/grpc/services/BinaryLog.java
+++ b/services/src/main/java/io/grpc/services/BinaryLog.java
@@ -76,14 +76,31 @@ final class BinaryLog {
   }
 
   /**
-   * Logs the initial metadata. This method logs the appropriate number of bytes
+   * Logs the sending of initial metadata. This method logs the appropriate number of bytes
    * as determined by the binary logging configuration.
    */
-  public void logInitialMetadata(
+  public void logSendInitialMetadata(
       Metadata metadata, boolean isServer, byte[] callId, SocketAddress peerSocket) {
     GrpcLogEntry entry = GrpcLogEntry
         .newBuilder()
         .setType(Type.SEND_INITIAL_METADATA)
+        .setLogger(isServer ? GrpcLogEntry.Logger.SERVER : GrpcLogEntry.Logger.CLIENT)
+        .setCallId(callIdToProto(callId))
+        .setPeer(socketToProto(peerSocket))
+        .setMetadata(metadataToProto(metadata, maxHeaderBytes))
+        .build();
+    sink.write(entry);
+  }
+
+  /**
+   * Logs the receiving of initial metadata. This method logs the appropriate number of bytes
+   * as determined by the binary logging configuration.
+   */
+  public void logRecvInitialMetadata(
+      Metadata metadata, boolean isServer, byte[] callId, SocketAddress peerSocket) {
+    GrpcLogEntry entry = GrpcLogEntry
+        .newBuilder()
+        .setType(Type.RECV_INITIAL_METADATA)
         .setLogger(isServer ? GrpcLogEntry.Logger.SERVER : GrpcLogEntry.Logger.CLIENT)
         .setCallId(callIdToProto(callId))
         .setPeer(socketToProto(peerSocket))
@@ -99,7 +116,7 @@ final class BinaryLog {
   public void logTrailingMetadata(Metadata metadata, boolean isServer, byte[] callId) {
     GrpcLogEntry entry = GrpcLogEntry
         .newBuilder()
-        .setType(Type.SEND_TRAILING_METADATA)
+        .setType(isServer ? Type.SEND_TRAILING_METADATA : Type.RECV_TRAILING_METADATA)
         .setLogger(isServer ? GrpcLogEntry.Logger.SERVER : GrpcLogEntry.Logger.CLIENT)
         .setCallId(callIdToProto(callId))
         .setMetadata(metadataToProto(metadata, maxHeaderBytes))

--- a/services/src/main/java/io/grpc/services/BinaryLogSink.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogSink.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.services;
+
+import com.google.protobuf.MessageLite;
+import java.io.Closeable;
+
+public abstract class BinaryLogSink implements Closeable {
+  /**
+   * Writes the {@code message} to the destination.
+   */
+  public abstract void write(MessageLite message);
+
+  /**
+   * Whether this provider is available for use, taking the current environment into consideration.
+   * If {@code false}, no other methods are safe to be called.
+   */
+  protected abstract boolean isAvailable();
+
+  /**
+   * A priority, from 0 to 10 that this provider should be used, taking the current environment into
+   * consideration. 5 should be considered the default, and then tweaked based on environment
+   * detection. A priority of 0 does not imply that the provider wouldn't work; just that it should
+   * be last in line.
+   */
+  protected abstract int priority();
+}

--- a/services/src/main/java/io/grpc/services/BinaryLogSinkProvider.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogSinkProvider.java
@@ -27,7 +27,12 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public abstract class BinaryLogSinkProvider implements Closeable {
 
+  /**
+   * Returns the {@code BinaryLogSinkProvider} that should be used.
+   */
   public static BinaryLogSinkProvider provider() {
+    // TODO(zpencer): either implement the service provider here, or use a generic helper
+    // See: https://github.com/grpc/grpc-java/pull/3886
     return null;
   }
 

--- a/services/src/main/java/io/grpc/services/BinaryLogSinkProvider.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogSinkProvider.java
@@ -17,7 +17,6 @@
 package io.grpc.services;
 
 import io.grpc.InternalServiceProviders;
-import io.grpc.internal.BinaryLogProvider;
 import java.util.Collections;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -31,7 +30,7 @@ final class BinaryLogSinkProvider {
   private static final BinaryLogSink INSTANCE = InternalServiceProviders.load(
       BinaryLogSink.class,
       Collections.<Class<?>>emptyList(),
-      BinaryLogProvider.class.getClassLoader(),
+      BinaryLogSinkProvider.class.getClassLoader(),
       new InternalServiceProviders.PriorityAccessor<BinaryLogSink>() {
         @Override
         public boolean isAvailable(BinaryLogSink provider) {

--- a/services/src/main/java/io/grpc/services/BinaryLogSinkProvider.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogSinkProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.services;
+
+import com.google.protobuf.MessageLite;
+import java.io.Closeable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Subclasses must be thread safe, and are responsible for writing the binary log message to
+ * the appropriate destination.
+ */
+@ThreadSafe
+public abstract class BinaryLogSinkProvider implements Closeable {
+
+  public static BinaryLogSinkProvider provider() {
+    return null;
+  }
+
+  /**
+   * Writes the {@code message} to the destination.
+   */
+  public abstract void write(MessageLite message);
+
+  /**
+   * Whether this provider is available for use, taking the current environment into consideration.
+   * If {@code false}, no other methods are safe to be called.
+   */
+  protected abstract boolean isAvailable();
+
+  /**
+   * A priority, from 0 to 10 that this provider should be used, taking the current environment into
+   * consideration. 5 should be considered the default, and then tweaked based on environment
+   * detection. A priority of 0 does not imply that the provider wouldn't work; just that it should
+   * be last in line.
+   */
+  protected abstract int priority();
+}

--- a/services/src/test/java/io/grpc/services/BinaryLogTest.java
+++ b/services/src/test/java/io/grpc/services/BinaryLogTest.java
@@ -50,7 +50,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class BinaryLogTest {
   private static final Charset US_ASCII = Charset.forName("US-ASCII");
-  private static final BinaryLogSinkProvider DUMMY_SINK = mock(BinaryLogSinkProvider.class);
   private static final BinaryLog HEADER_FULL = new Builder().header(Integer.MAX_VALUE).build();
   private static final BinaryLog HEADER_256 = new Builder().header(256).build();
   private static final BinaryLog MSG_FULL = new Builder().msg(Integer.MAX_VALUE).build();
@@ -97,7 +96,7 @@ public final class BinaryLogTest {
   private static final int MESSAGE_LIMIT = Integer.MAX_VALUE;
 
   private final Metadata metadata = new Metadata();
-  private final BinaryLogSinkProvider sink = mock(BinaryLogSinkProvider.class);
+  private final BinaryLogSink sink = mock(BinaryLogSink.class);
   private final BinaryLog binaryLog = new BinaryLog(sink, HEADER_LIMIT, MESSAGE_LIMIT);
   private final byte[] message = new byte[100];
 
@@ -110,98 +109,98 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_global() throws Exception {
-    assertSameLimits(BOTH_FULL, new FactoryImpl("*").getLog("p.s/m"));
-    assertSameLimits(BOTH_FULL, new FactoryImpl("*{h;m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_FULL, new FactoryImpl("*{h}").getLog("p.s/m"));
-    assertSameLimits(MSG_FULL, new FactoryImpl("*{m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_256, new FactoryImpl("*{h:256}").getLog("p.s/m"));
-    assertSameLimits(MSG_256, new FactoryImpl("*{m:256}").getLog("p.s/m"));
-    assertSameLimits(BOTH_256, new FactoryImpl("*{h:256;m:256}").getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeFactory("*").getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeFactory("*{h;m}").getLog("p.s/m"));
+    assertSameLimits(HEADER_FULL, makeFactory("*{h}").getLog("p.s/m"));
+    assertSameLimits(MSG_FULL, makeFactory("*{m}").getLog("p.s/m"));
+    assertSameLimits(HEADER_256, makeFactory("*{h:256}").getLog("p.s/m"));
+    assertSameLimits(MSG_256, makeFactory("*{m:256}").getLog("p.s/m"));
+    assertSameLimits(BOTH_256, makeFactory("*{h:256;m:256}").getLog("p.s/m"));
     assertSameLimits(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        new FactoryImpl("*{h;m:256}").getLog("p.s/m"));
+        makeFactory("*{h;m:256}").getLog("p.s/m"));
     assertSameLimits(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        new FactoryImpl("*{h:256;m}").getLog("p.s/m"));
+        makeFactory("*{h:256;m}").getLog("p.s/m"));
   }
 
   @Test
   public void configBinLog_method() throws Exception {
-    assertSameLimits(BOTH_FULL, new FactoryImpl("p.s/m").getLog("p.s/m"));
-    assertSameLimits(BOTH_FULL, new FactoryImpl("p.s/m{h;m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_FULL, new FactoryImpl("p.s/m{h}").getLog("p.s/m"));
-    assertSameLimits(MSG_FULL, new FactoryImpl("p.s/m{m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_256, new FactoryImpl("p.s/m{h:256}").getLog("p.s/m"));
-    assertSameLimits(MSG_256, new FactoryImpl("p.s/m{m:256}").getLog("p.s/m"));
-    assertSameLimits(BOTH_256, new FactoryImpl("p.s/m{h:256;m:256}").getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeFactory("p.s/m").getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeFactory("p.s/m{h;m}").getLog("p.s/m"));
+    assertSameLimits(HEADER_FULL, makeFactory("p.s/m{h}").getLog("p.s/m"));
+    assertSameLimits(MSG_FULL, makeFactory("p.s/m{m}").getLog("p.s/m"));
+    assertSameLimits(HEADER_256, makeFactory("p.s/m{h:256}").getLog("p.s/m"));
+    assertSameLimits(MSG_256, makeFactory("p.s/m{m:256}").getLog("p.s/m"));
+    assertSameLimits(BOTH_256, makeFactory("p.s/m{h:256;m:256}").getLog("p.s/m"));
     assertSameLimits(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        new FactoryImpl("p.s/m{h;m:256}").getLog("p.s/m"));
+        makeFactory("p.s/m{h;m:256}").getLog("p.s/m"));
     assertSameLimits(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        new FactoryImpl("p.s/m{h:256;m}").getLog("p.s/m"));
+        makeFactory("p.s/m{h:256;m}").getLog("p.s/m"));
   }
 
   @Test
   public void configBinLog_method_absent() throws Exception {
-    assertNull(new FactoryImpl("p.s/m").getLog("p.s/absent"));
+    assertNull(makeFactory("p.s/m").getLog("p.s/absent"));
   }
 
   @Test
   public void configBinLog_service() throws Exception {
-    assertSameLimits(BOTH_FULL, new FactoryImpl("p.s/*").getLog("p.s/m"));
-    assertSameLimits(BOTH_FULL, new FactoryImpl("p.s/*{h;m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_FULL, new FactoryImpl("p.s/*{h}").getLog("p.s/m"));
-    assertSameLimits(MSG_FULL, new FactoryImpl("p.s/*{m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_256, new FactoryImpl("p.s/*{h:256}").getLog("p.s/m"));
-    assertSameLimits(MSG_256, new FactoryImpl("p.s/*{m:256}").getLog("p.s/m"));
-    assertSameLimits(BOTH_256, new FactoryImpl("p.s/*{h:256;m:256}").getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeFactory("p.s/*").getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeFactory("p.s/*{h;m}").getLog("p.s/m"));
+    assertSameLimits(HEADER_FULL, makeFactory("p.s/*{h}").getLog("p.s/m"));
+    assertSameLimits(MSG_FULL, makeFactory("p.s/*{m}").getLog("p.s/m"));
+    assertSameLimits(HEADER_256, makeFactory("p.s/*{h:256}").getLog("p.s/m"));
+    assertSameLimits(MSG_256, makeFactory("p.s/*{m:256}").getLog("p.s/m"));
+    assertSameLimits(BOTH_256, makeFactory("p.s/*{h:256;m:256}").getLog("p.s/m"));
     assertSameLimits(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        new FactoryImpl("p.s/*{h;m:256}").getLog("p.s/m"));
+        makeFactory("p.s/*{h;m:256}").getLog("p.s/m"));
     assertSameLimits(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        new FactoryImpl("p.s/*{h:256;m}").getLog("p.s/m"));
+        makeFactory("p.s/*{h:256;m}").getLog("p.s/m"));
   }
 
   @Test
   public void configBinLog_service_absent() throws Exception {
-    assertNull(new FactoryImpl("p.s/*").getLog("p.other/m"));
+    assertNull(makeFactory("p.s/*").getLog("p.other/m"));
   }
 
   @Test
   public void createLogFromOptionString() throws Exception {
-    assertSameLimits(BOTH_FULL, FactoryImpl.createBinaryLog(/*logConfig=*/ null));
-    assertSameLimits(HEADER_FULL, FactoryImpl.createBinaryLog("{h}"));
-    assertSameLimits(MSG_FULL, FactoryImpl.createBinaryLog("{m}"));
-    assertSameLimits(HEADER_256, FactoryImpl.createBinaryLog("{h:256}"));
-    assertSameLimits(MSG_256, FactoryImpl.createBinaryLog("{m:256}"));
-    assertSameLimits(BOTH_256, FactoryImpl.createBinaryLog("{h:256;m:256}"));
+    assertSameLimits(BOTH_FULL, FactoryImpl.createBinaryLog(sink, /*logConfig=*/ null));
+    assertSameLimits(HEADER_FULL, FactoryImpl.createBinaryLog(sink, "{h}"));
+    assertSameLimits(MSG_FULL, FactoryImpl.createBinaryLog(sink, "{m}"));
+    assertSameLimits(HEADER_256, FactoryImpl.createBinaryLog(sink, "{h:256}"));
+    assertSameLimits(MSG_256, FactoryImpl.createBinaryLog(sink, "{m:256}"));
+    assertSameLimits(BOTH_256, FactoryImpl.createBinaryLog(sink, "{h:256;m:256}"));
     assertSameLimits(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        FactoryImpl.createBinaryLog("{h;m:256}"));
+        FactoryImpl.createBinaryLog(sink, "{h;m:256}"));
     assertSameLimits(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        FactoryImpl.createBinaryLog("{h:256;m}"));
+        FactoryImpl.createBinaryLog(sink, "{h:256;m}"));
   }
 
   @Test
   public void createLogFromOptionString_malformed() throws Exception {
-    assertNull(FactoryImpl.createBinaryLog("bad"));
-    assertNull(FactoryImpl.createBinaryLog("{bad}"));
-    assertNull(FactoryImpl.createBinaryLog("{x;y}"));
-    assertNull(FactoryImpl.createBinaryLog("{h:abc}"));
-    assertNull(FactoryImpl.createBinaryLog("{2}"));
-    assertNull(FactoryImpl.createBinaryLog("{2;2}"));
+    assertNull(FactoryImpl.createBinaryLog(sink, "bad"));
+    assertNull(FactoryImpl.createBinaryLog(sink, "{bad}"));
+    assertNull(FactoryImpl.createBinaryLog(sink, "{x;y}"));
+    assertNull(FactoryImpl.createBinaryLog(sink, "{h:abc}"));
+    assertNull(FactoryImpl.createBinaryLog(sink, "{2}"));
+    assertNull(FactoryImpl.createBinaryLog(sink, "{2;2}"));
     // The grammar specifies that if both h and m are present, h comes before m
-    assertNull(FactoryImpl.createBinaryLog("{m:123;h:123}"));
+    assertNull(FactoryImpl.createBinaryLog(sink, "{m:123;h:123}"));
     // NumberFormatException
-    assertNull(FactoryImpl.createBinaryLog("{h:99999999999999}"));
+    assertNull(FactoryImpl.createBinaryLog(sink, "{h:99999999999999}"));
   }
 
   @Test
   public void configBinLog_multiConfig_withGlobal() throws Exception {
-    FactoryImpl factory = new FactoryImpl(
+    FactoryImpl factory = makeFactory(
         "*{h},"
         + "package.both256/*{h:256;m:256},"
         + "package.service1/both128{h:128;m:128},"
@@ -224,7 +223,7 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_multiConfig_noGlobal() throws Exception {
-    FactoryImpl factory = new FactoryImpl(
+    FactoryImpl factory = makeFactory(
         "package.both256/*{h:256;m:256},"
         + "package.service1/both128{h:128;m:128},"
         + "package.service2/method_messageOnly{m}");
@@ -246,7 +245,7 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_ignoreDuplicates_global() throws Exception {
-    FactoryImpl factory = new FactoryImpl("*{h},p.s/m,*{h:256}");
+    FactoryImpl factory = makeFactory("*{h},p.s/m,*{h:256}");
     // The duplicate
     assertSameLimits(HEADER_FULL, factory.getLog("p.other1/m"));
     assertSameLimits(HEADER_FULL, factory.getLog("p.other2/m"));
@@ -256,7 +255,7 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_ignoreDuplicates_service() throws Exception {
-    FactoryImpl factory = new FactoryImpl("p.s/*,*{h:256},p.s/*{h}");
+    FactoryImpl factory = makeFactory("p.s/*,*{h:256},p.s/*{h}");
     // The duplicate
     assertSameLimits(BOTH_FULL, factory.getLog("p.s/m1"));
     assertSameLimits(BOTH_FULL, factory.getLog("p.s/m2"));
@@ -267,7 +266,7 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_ignoreDuplicates_method() throws Exception {
-    FactoryImpl factory = new FactoryImpl("p.s/m,*{h:256},p.s/m{h}");
+    FactoryImpl factory = makeFactory("p.s/m,*{h:256},p.s/m{h}");
     // The duplicate
     assertSameLimits(BOTH_FULL, factory.getLog("p.s/m"));
     // Other
@@ -632,6 +631,10 @@ public final class BinaryLogTest {
     verifyNoMoreInteractions(sink);
   }
 
+  private BinaryLog.FactoryImpl makeFactory(String configStr) {
+    return new BinaryLog.FactoryImpl(sink, configStr);
+  } 
+
   /** A builder class to make unit test code more readable. */
   private static final class Builder {
     int maxHeaderBytes = 0;
@@ -648,7 +651,7 @@ public final class BinaryLogTest {
     }
 
     BinaryLog build() {
-      return new BinaryLog(DUMMY_SINK, maxHeaderBytes, maxMessageBytes);
+      return new BinaryLog(mock(BinaryLogSink.class), maxHeaderBytes, maxMessageBytes);
     }
   }
 

--- a/services/src/test/java/io/grpc/services/BinaryLogTest.java
+++ b/services/src/test/java/io/grpc/services/BinaryLogTest.java
@@ -109,169 +109,169 @@ public final class BinaryLogTest {
 
   @Test
   public void configBinLog_global() throws Exception {
-    assertSameLimits(BOTH_FULL, makeFactory("*").getLog("p.s/m"));
-    assertSameLimits(BOTH_FULL, makeFactory("*{h;m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_FULL, makeFactory("*{h}").getLog("p.s/m"));
-    assertSameLimits(MSG_FULL, makeFactory("*{m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_256, makeFactory("*{h:256}").getLog("p.s/m"));
-    assertSameLimits(MSG_256, makeFactory("*{m:256}").getLog("p.s/m"));
-    assertSameLimits(BOTH_256, makeFactory("*{h:256;m:256}").getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeLog("*", "p.s/m"));
+    assertSameLimits(BOTH_FULL, makeLog("*{h;m}", "p.s/m"));
+    assertSameLimits(HEADER_FULL, makeLog("*{h}", "p.s/m"));
+    assertSameLimits(MSG_FULL, makeLog("*{m}", "p.s/m"));
+    assertSameLimits(HEADER_256, makeLog("*{h:256}", "p.s/m"));
+    assertSameLimits(MSG_256, makeLog("*{m:256}", "p.s/m"));
+    assertSameLimits(BOTH_256, makeLog("*{h:256;m:256}", "p.s/m"));
     assertSameLimits(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        makeFactory("*{h;m:256}").getLog("p.s/m"));
+        makeLog("*{h;m:256}", "p.s/m"));
     assertSameLimits(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        makeFactory("*{h:256;m}").getLog("p.s/m"));
+        makeLog("*{h:256;m}", "p.s/m"));
   }
 
   @Test
   public void configBinLog_method() throws Exception {
-    assertSameLimits(BOTH_FULL, makeFactory("p.s/m").getLog("p.s/m"));
-    assertSameLimits(BOTH_FULL, makeFactory("p.s/m{h;m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_FULL, makeFactory("p.s/m{h}").getLog("p.s/m"));
-    assertSameLimits(MSG_FULL, makeFactory("p.s/m{m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_256, makeFactory("p.s/m{h:256}").getLog("p.s/m"));
-    assertSameLimits(MSG_256, makeFactory("p.s/m{m:256}").getLog("p.s/m"));
-    assertSameLimits(BOTH_256, makeFactory("p.s/m{h:256;m:256}").getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeLog("p.s/m", "p.s/m"));
+    assertSameLimits(BOTH_FULL, makeLog("p.s/m{h;m}", "p.s/m"));
+    assertSameLimits(HEADER_FULL, makeLog("p.s/m{h}", "p.s/m"));
+    assertSameLimits(MSG_FULL, makeLog("p.s/m{m}", "p.s/m"));
+    assertSameLimits(HEADER_256, makeLog("p.s/m{h:256}", "p.s/m"));
+    assertSameLimits(MSG_256, makeLog("p.s/m{m:256}", "p.s/m"));
+    assertSameLimits(BOTH_256, makeLog("p.s/m{h:256;m:256}", "p.s/m"));
     assertSameLimits(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        makeFactory("p.s/m{h;m:256}").getLog("p.s/m"));
+        makeLog("p.s/m{h;m:256}", "p.s/m"));
     assertSameLimits(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        makeFactory("p.s/m{h:256;m}").getLog("p.s/m"));
+        makeLog("p.s/m{h:256;m}", "p.s/m"));
   }
 
   @Test
   public void configBinLog_method_absent() throws Exception {
-    assertNull(makeFactory("p.s/m").getLog("p.s/absent"));
+    assertNull(makeLog("p.s/m", "p.s/absent"));
   }
 
   @Test
   public void configBinLog_service() throws Exception {
-    assertSameLimits(BOTH_FULL, makeFactory("p.s/*").getLog("p.s/m"));
-    assertSameLimits(BOTH_FULL, makeFactory("p.s/*{h;m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_FULL, makeFactory("p.s/*{h}").getLog("p.s/m"));
-    assertSameLimits(MSG_FULL, makeFactory("p.s/*{m}").getLog("p.s/m"));
-    assertSameLimits(HEADER_256, makeFactory("p.s/*{h:256}").getLog("p.s/m"));
-    assertSameLimits(MSG_256, makeFactory("p.s/*{m:256}").getLog("p.s/m"));
-    assertSameLimits(BOTH_256, makeFactory("p.s/*{h:256;m:256}").getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeLog("p.s/*", "p.s/m"));
+    assertSameLimits(BOTH_FULL, makeLog("p.s/*{h;m}", "p.s/m"));
+    assertSameLimits(HEADER_FULL, makeLog("p.s/*{h}", "p.s/m"));
+    assertSameLimits(MSG_FULL, makeLog("p.s/*{m}", "p.s/m"));
+    assertSameLimits(HEADER_256, makeLog("p.s/*{h:256}", "p.s/m"));
+    assertSameLimits(MSG_256, makeLog("p.s/*{m:256}", "p.s/m"));
+    assertSameLimits(BOTH_256, makeLog("p.s/*{h:256;m:256}", "p.s/m"));
     assertSameLimits(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        makeFactory("p.s/*{h;m:256}").getLog("p.s/m"));
+        makeLog("p.s/*{h;m:256}", "p.s/m"));
     assertSameLimits(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        makeFactory("p.s/*{h:256;m}").getLog("p.s/m"));
+        makeLog("p.s/*{h:256;m}", "p.s/m"));
   }
 
   @Test
   public void configBinLog_service_absent() throws Exception {
-    assertNull(makeFactory("p.s/*").getLog("p.other/m"));
+    assertNull(makeLog("p.s/*", "p.other/m"));
   }
 
   @Test
   public void createLogFromOptionString() throws Exception {
-    assertSameLimits(BOTH_FULL, FactoryImpl.createBinaryLog(sink, /*logConfig=*/ null));
-    assertSameLimits(HEADER_FULL, FactoryImpl.createBinaryLog(sink, "{h}"));
-    assertSameLimits(MSG_FULL, FactoryImpl.createBinaryLog(sink, "{m}"));
-    assertSameLimits(HEADER_256, FactoryImpl.createBinaryLog(sink, "{h:256}"));
-    assertSameLimits(MSG_256, FactoryImpl.createBinaryLog(sink, "{m:256}"));
-    assertSameLimits(BOTH_256, FactoryImpl.createBinaryLog(sink, "{h:256;m:256}"));
+    assertSameLimits(BOTH_FULL, makeLog(null));
+    assertSameLimits(HEADER_FULL, makeLog("{h}"));
+    assertSameLimits(MSG_FULL, makeLog("{m}"));
+    assertSameLimits(HEADER_256, makeLog("{h:256}"));
+    assertSameLimits(MSG_256, makeLog("{m:256}"));
+    assertSameLimits(BOTH_256, makeLog("{h:256;m:256}"));
     assertSameLimits(
         new Builder().header(Integer.MAX_VALUE).msg(256).build(),
-        FactoryImpl.createBinaryLog(sink, "{h;m:256}"));
+        makeLog("{h;m:256}"));
     assertSameLimits(
         new Builder().header(256).msg(Integer.MAX_VALUE).build(),
-        FactoryImpl.createBinaryLog(sink, "{h:256;m}"));
+        makeLog("{h:256;m}"));
   }
 
   @Test
   public void createLogFromOptionString_malformed() throws Exception {
-    assertNull(FactoryImpl.createBinaryLog(sink, "bad"));
-    assertNull(FactoryImpl.createBinaryLog(sink, "{bad}"));
-    assertNull(FactoryImpl.createBinaryLog(sink, "{x;y}"));
-    assertNull(FactoryImpl.createBinaryLog(sink, "{h:abc}"));
-    assertNull(FactoryImpl.createBinaryLog(sink, "{2}"));
-    assertNull(FactoryImpl.createBinaryLog(sink, "{2;2}"));
+    assertNull(makeLog("bad"));
+    assertNull(makeLog("{bad}"));
+    assertNull(makeLog("{x;y}"));
+    assertNull(makeLog("{h:abc}"));
+    assertNull(makeLog("{2}"));
+    assertNull(makeLog("{2;2}"));
     // The grammar specifies that if both h and m are present, h comes before m
-    assertNull(FactoryImpl.createBinaryLog(sink, "{m:123;h:123}"));
+    assertNull(makeLog("{m:123;h:123}"));
     // NumberFormatException
-    assertNull(FactoryImpl.createBinaryLog(sink, "{h:99999999999999}"));
+    assertNull(makeLog("{h:99999999999999}"));
   }
 
   @Test
   public void configBinLog_multiConfig_withGlobal() throws Exception {
-    FactoryImpl factory = makeFactory(
+    String configStr =
         "*{h},"
         + "package.both256/*{h:256;m:256},"
         + "package.service1/both128{h:128;m:128},"
-        + "package.service2/method_messageOnly{m}");
-    assertSameLimits(HEADER_FULL, factory.getLog("otherpackage.service/method"));
+        + "package.service2/method_messageOnly{m}";
+    assertSameLimits(HEADER_FULL, makeLog(configStr, "otherpackage.service/method"));
 
-    assertSameLimits(BOTH_256, factory.getLog("package.both256/method1"));
-    assertSameLimits(BOTH_256, factory.getLog("package.both256/method2"));
-    assertSameLimits(BOTH_256, factory.getLog("package.both256/method3"));
+    assertSameLimits(BOTH_256, makeLog(configStr, "package.both256/method1"));
+    assertSameLimits(BOTH_256, makeLog(configStr, "package.both256/method2"));
+    assertSameLimits(BOTH_256, makeLog(configStr, "package.both256/method3"));
 
     assertSameLimits(
-        new Builder().header(128).msg(128).build(), factory.getLog("package.service1/both128"));
+        new Builder().header(128).msg(128).build(), makeLog(configStr, "package.service1/both128"));
     // the global config is in effect
-    assertSameLimits(HEADER_FULL, factory.getLog("package.service1/absent"));
+    assertSameLimits(HEADER_FULL, makeLog(configStr, "package.service1/absent"));
 
-    assertSameLimits(MSG_FULL, factory.getLog("package.service2/method_messageOnly"));
+    assertSameLimits(MSG_FULL, makeLog(configStr, "package.service2/method_messageOnly"));
     // the global config is in effect
-    assertSameLimits(HEADER_FULL, factory.getLog("package.service2/absent"));
+    assertSameLimits(HEADER_FULL, makeLog(configStr, "package.service2/absent"));
   }
 
   @Test
   public void configBinLog_multiConfig_noGlobal() throws Exception {
-    FactoryImpl factory = makeFactory(
+    String configStr =
         "package.both256/*{h:256;m:256},"
         + "package.service1/both128{h:128;m:128},"
-        + "package.service2/method_messageOnly{m}");
-    assertNull(factory.getLog("otherpackage.service/method"));
+        + "package.service2/method_messageOnly{m}";
+    assertNull(makeLog(configStr, "otherpackage.service/method"));
 
-    assertSameLimits(BOTH_256, factory.getLog("package.both256/method1"));
-    assertSameLimits(BOTH_256, factory.getLog("package.both256/method2"));
-    assertSameLimits(BOTH_256, factory.getLog("package.both256/method3"));
+    assertSameLimits(BOTH_256, makeLog(configStr, "package.both256/method1"));
+    assertSameLimits(BOTH_256, makeLog(configStr, "package.both256/method2"));
+    assertSameLimits(BOTH_256, makeLog(configStr, "package.both256/method3"));
 
     assertSameLimits(
-        new Builder().header(128).msg(128).build(), factory.getLog("package.service1/both128"));
+        new Builder().header(128).msg(128).build(), makeLog(configStr, "package.service1/both128"));
     // no global config in effect
-    assertNull(factory.getLog("package.service1/absent"));
+    assertNull(makeLog(configStr, "package.service1/absent"));
 
-    assertSameLimits(MSG_FULL, factory.getLog("package.service2/method_messageOnly"));
+    assertSameLimits(MSG_FULL, makeLog(configStr, "package.service2/method_messageOnly"));
     // no global config in effect
-    assertNull(factory.getLog("package.service2/absent"));
+    assertNull(makeLog(configStr, "package.service2/absent"));
   }
 
   @Test
   public void configBinLog_ignoreDuplicates_global() throws Exception {
-    FactoryImpl factory = makeFactory("*{h},p.s/m,*{h:256}");
+    String configStr = "*{h},p.s/m,*{h:256}";
     // The duplicate
-    assertSameLimits(HEADER_FULL, factory.getLog("p.other1/m"));
-    assertSameLimits(HEADER_FULL, factory.getLog("p.other2/m"));
+    assertSameLimits(HEADER_FULL, makeLog(configStr, "p.other1/m"));
+    assertSameLimits(HEADER_FULL, makeLog(configStr, "p.other2/m"));
     // Other
-    assertSameLimits(BOTH_FULL, factory.getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeLog(configStr, "p.s/m"));
   }
 
   @Test
   public void configBinLog_ignoreDuplicates_service() throws Exception {
-    FactoryImpl factory = makeFactory("p.s/*,*{h:256},p.s/*{h}");
+    String configStr = "p.s/*,*{h:256},p.s/*{h}";
     // The duplicate
-    assertSameLimits(BOTH_FULL, factory.getLog("p.s/m1"));
-    assertSameLimits(BOTH_FULL, factory.getLog("p.s/m2"));
+    assertSameLimits(BOTH_FULL, makeLog(configStr, "p.s/m1"));
+    assertSameLimits(BOTH_FULL, makeLog(configStr, "p.s/m2"));
     // Other
-    assertSameLimits(HEADER_256, factory.getLog("p.other1/m"));
-    assertSameLimits(HEADER_256, factory.getLog("p.other2/m"));
+    assertSameLimits(HEADER_256, makeLog(configStr, "p.other1/m"));
+    assertSameLimits(HEADER_256, makeLog(configStr, "p.other2/m"));
   }
 
   @Test
   public void configBinLog_ignoreDuplicates_method() throws Exception {
-    FactoryImpl factory = makeFactory("p.s/m,*{h:256},p.s/m{h}");
+    String configStr = "p.s/m,*{h:256},p.s/m{h}";
     // The duplicate
-    assertSameLimits(BOTH_FULL, factory.getLog("p.s/m"));
+    assertSameLimits(BOTH_FULL, makeLog(configStr, "p.s/m"));
     // Other
-    assertSameLimits(HEADER_256, factory.getLog("p.other1/m"));
-    assertSameLimits(HEADER_256, factory.getLog("p.other2/m"));
+    assertSameLimits(HEADER_256, makeLog(configStr, "p.other1/m"));
+    assertSameLimits(HEADER_256, makeLog(configStr, "p.other2/m"));
   }
 
   @Test
@@ -476,11 +476,11 @@ public final class BinaryLogTest {
   }
 
   @Test
-  public void logInitialMetadata_server() throws Exception {
+  public void logSendInitialMetadata_server() throws Exception {
     InetAddress address = InetAddress.getByName("127.0.0.1");
     int port = 12345;
     InetSocketAddress socketAddress = new InetSocketAddress(address, port);
-    binaryLog.logInitialMetadata(metadata, IS_SERVER, CALL_ID, socketAddress);
+    binaryLog.logSendInitialMetadata(metadata, IS_SERVER, CALL_ID, socketAddress);
     verify(sink).write(
         GrpcLogEntry
             .newBuilder()
@@ -493,15 +493,49 @@ public final class BinaryLogTest {
   }
 
   @Test
-  public void logInitialMetadata_client() throws Exception {
+  public void logSendInitialMetadata_client() throws Exception {
     InetAddress address = InetAddress.getByName("127.0.0.1");
     int port = 12345;
     InetSocketAddress socketAddress = new InetSocketAddress(address, port);
-    binaryLog.logInitialMetadata(metadata, IS_CLIENT, CALL_ID, socketAddress);
+    binaryLog.logSendInitialMetadata(metadata, IS_CLIENT, CALL_ID, socketAddress);
     verify(sink).write(
         GrpcLogEntry
             .newBuilder()
             .setType(GrpcLogEntry.Type.SEND_INITIAL_METADATA)
+            .setLogger(GrpcLogEntry.Logger.CLIENT)
+            .setCallId(BinaryLog.callIdToProto(CALL_ID))
+            .setPeer(BinaryLog.socketToProto(socketAddress))
+            .setMetadata(BinaryLog.metadataToProto(metadata, 10))
+            .build());
+  }
+
+  @Test
+  public void logRecvInitialMetadata_server() throws Exception {
+    InetAddress address = InetAddress.getByName("127.0.0.1");
+    int port = 12345;
+    InetSocketAddress socketAddress = new InetSocketAddress(address, port);
+    binaryLog.logRecvInitialMetadata(metadata, IS_SERVER, CALL_ID, socketAddress);
+    verify(sink).write(
+        GrpcLogEntry
+            .newBuilder()
+            .setType(GrpcLogEntry.Type.RECV_INITIAL_METADATA)
+            .setLogger(GrpcLogEntry.Logger.SERVER)
+            .setCallId(BinaryLog.callIdToProto(CALL_ID))
+            .setPeer(BinaryLog.socketToProto(socketAddress))
+            .setMetadata(BinaryLog.metadataToProto(metadata, 10))
+            .build());
+  }
+
+  @Test
+  public void logRecvInitialMetadata_client() throws Exception {
+    InetAddress address = InetAddress.getByName("127.0.0.1");
+    int port = 12345;
+    InetSocketAddress socketAddress = new InetSocketAddress(address, port);
+    binaryLog.logRecvInitialMetadata(metadata, IS_CLIENT, CALL_ID, socketAddress);
+    verify(sink).write(
+        GrpcLogEntry
+            .newBuilder()
+            .setType(GrpcLogEntry.Type.RECV_INITIAL_METADATA)
             .setLogger(GrpcLogEntry.Logger.CLIENT)
             .setCallId(BinaryLog.callIdToProto(CALL_ID))
             .setPeer(BinaryLog.socketToProto(socketAddress))
@@ -528,7 +562,7 @@ public final class BinaryLogTest {
     verify(sink).write(
         GrpcLogEntry
             .newBuilder()
-            .setType(GrpcLogEntry.Type.SEND_TRAILING_METADATA)
+            .setType(GrpcLogEntry.Type.RECV_TRAILING_METADATA)
             .setLogger(GrpcLogEntry.Logger.CLIENT)
             .setCallId(BinaryLog.callIdToProto(CALL_ID))
             .setMetadata(BinaryLog.metadataToProto(metadata, 10))
@@ -631,10 +665,6 @@ public final class BinaryLogTest {
     verifyNoMoreInteractions(sink);
   }
 
-  private BinaryLog.FactoryImpl makeFactory(String configStr) {
-    return new BinaryLog.FactoryImpl(sink, configStr);
-  } 
-
   /** A builder class to make unit test code more readable. */
   private static final class Builder {
     int maxHeaderBytes = 0;
@@ -658,5 +688,13 @@ public final class BinaryLogTest {
   private static void assertSameLimits(BinaryLog a, BinaryLog b) {
     assertEquals(a.maxMessageBytes, b.maxMessageBytes);
     assertEquals(a.maxHeaderBytes, b.maxHeaderBytes);
+  }
+
+  private BinaryLog makeLog(String factoryConfigStr, String lookup) {
+    return new BinaryLog.FactoryImpl(sink, factoryConfigStr).getLog(lookup);
+  }
+
+  private BinaryLog makeLog(String logConfigStr) {
+    return FactoryImpl.createBinaryLog(sink, logConfigStr);
   }
 }


### PR DESCRIPTION
The `BinaryLog` will write `GrpcLogEntry` objects to the sink.