### PR TITLE
Upgrade to Protobuf 3.5.1 and Protoc 3.5.1-1. (backport #3921)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: java
 env:
   global:
     - GRADLE_OPTS=-Xmx512m
-    - PROTOBUF_VERSION=3.5.0
+    - PROTOBUF_VERSION=3.5.1
     - LDFLAGS=-L/tmp/protobuf/lib
     - CXXFLAGS=-I/tmp/protobuf/include
     - LD_LIBRARY_PATH=/tmp/protobuf/lib

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -33,7 +33,7 @@ For Linux, Mac and MinGW:
 ```
 $ git clone https://github.com/google/protobuf.git
 $ cd protobuf
-$ git checkout v3.5.0
+$ git checkout v3.5.1
 $ ./autogen.sh
 $ ./configure
 $ make
@@ -72,16 +72,16 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew install ^
-    -PvcProtobufInclude=C:\path\to\protobuf-3.5.0\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.5.0\vsprojects\Release ^
+    -PvcProtobufInclude=C:\path\to\protobuf-3.5.1\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf-3.5.1\vsprojects\Release ^
     -PtargetArch=x86_32
 ```
 
 Since specifying those properties every build is bothersome, you can instead
 create ``<project-root>\gradle.properties`` with contents like:
 ```
-vcProtobufInclude=C:\\path\\to\\protobuf-3.5.0\\src
-vcProtobufLibs=C:\\path\\to\\protobuf-3.5.0\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf-3.5.1\\src
+vcProtobufLibs=C:\\path\\to\\protobuf-3.5.1\\vsprojects\\Release
 targetArch=x86_32
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <artifactId>protobuf-maven-plugin</artifactId>
       <version>0.5.0</version>
       <configuration>
-        <protocArtifact>com.google.protobuf:protoc:3.5.0:exe:${os.detected.classifier}</protocArtifact>
+        <protocArtifact>com.google.protobuf:protoc:3.5.1-1:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
         <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.8.0:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
@@ -123,7 +123,7 @@ buildscript {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.5.0"
+    artifact = "com.google.protobuf:protoc:3.5.1-1"
   }
   plugins {
     grpc {

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -30,7 +30,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.5.0'
+        artifact = 'com.google.protobuf:protoc:3.5.1-1'
     }
     plugins {
         grpc {

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ subprojects {
 
         nettyVersion = '4.1.17.Final'
         guavaVersion = '19.0'
-        protobufVersion = '3.5.0'
-        protocVersion = protobufVersion
+        protobufVersion = '3.5.1'
+        protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
 
         configureProtoCompilation = {

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -7,7 +7,7 @@
 set -exu -o pipefail
 
 export GRADLE_OPTS=-Xmx512m
-export PROTOBUF_VERSION=3.5.0
+export PROTOBUF_VERSION=3.5.1
 export LDFLAGS=-L/tmp/protobuf/lib
 export CXXFLAGS=-I/tmp/protobuf/include
 export LD_LIBRARY_PATH=/tmp/protobuf/lib

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-set PROTOBUF_VER=3.5.0
+set PROTOBUF_VER=3.5.1
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -2,7 +2,7 @@ FROM protoc-artifacts:latest
 
 RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
     git fetch && \
-    git checkout v3.5.0 && \
+    git checkout v3.5.1 && \
     ./autogen.sh && \
     CXXFLAGS=-m32 ./configure --disable-shared --prefix=/protobuf-32 && \
     make clean && make -j$(nproc) && make -j$(nproc) install"'

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -28,7 +28,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.5.0'
+        artifact = 'com.google.protobuf:protoc:3.5.1-1'
     }
     plugins {
         javalite {

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.5.0'
+        artifact = 'com.google.protobuf:protoc:3.5.1-1'
     }
     plugins {
         javalite {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
 protobuf {
   protoc {
-    artifact = 'com.google.protobuf:protoc:3.5.0'
+    artifact = 'com.google.protobuf:protoc:3.5.1-1'
   }
   plugins {
     grpc {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -67,7 +67,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.5.0</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:3.5.0:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:3.5.1-1:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -139,8 +139,8 @@ def com_google_protobuf():
   native.http_archive(
       name = "com_google_protobuf",
       sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
-      strip_prefix = "protobuf-3.5.0",
-      urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
+      strip_prefix = "protobuf-3.5.1",
+      urls = ["https://github.com/google/protobuf/archive/v3.5.1.zip"],
   )
 
 def com_google_protobuf_java():
@@ -149,8 +149,8 @@ def com_google_protobuf_java():
   native.http_archive(
       name = "com_google_protobuf_java",
       sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
-      strip_prefix = "protobuf-3.5.0",
-      urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
+      strip_prefix = "protobuf-3.5.1",
+      urls = ["https://github.com/google/protobuf/archive/v3.5.1.zip"],
   )
 
 def com_google_protobuf_nano_protobuf_javanano():


### PR DESCRIPTION
protoc-3.5.0-linux-x86_64 introduced GLIBC_2.14 dependency and broke
gRPC release process (https://github.com/google/protobuf/issues/4138).
3.5.1-1 is the proper re-build.