### PR TITLE
bazel: fix protobuf sha256

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -138,7 +138,7 @@ def com_google_protobuf():
   # This statement defines the @com_google_protobuf repo.
   native.http_archive(
       name = "com_google_protobuf",
-      sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
+      sha256 = "1f8b9b202e9a4e467ff0b0f25facb1642727cdf5e69092038f15b37c75b99e45",
       strip_prefix = "protobuf-3.5.1",
       urls = ["https://github.com/google/protobuf/archive/v3.5.1.zip"],
   )
@@ -148,7 +148,7 @@ def com_google_protobuf_java():
   # which is the Java proto runtime (base classes and common utilities).
   native.http_archive(
       name = "com_google_protobuf_java",
-      sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
+      sha256 = "1f8b9b202e9a4e467ff0b0f25facb1642727cdf5e69092038f15b37c75b99e45",
       strip_prefix = "protobuf-3.5.1",
       urls = ["https://github.com/google/protobuf/archive/v3.5.1.zip"],
   )


### PR DESCRIPTION
Currently, grpc-java could not build by bazel because protobuf's sha256 is incorrect.
It might need some CI (travis or kokoro(?)) checking.

```
$ bazel build //protobuf:all
....................
ERROR: /Users/jyane/workspace/repos/github.com/jyane/grpc-java/protobuf/BUILD.bazel:1:1: no such package '@com_google_protobuf_java//': Error downloading [https://github.com/google/protobuf/archive/v3.5.1.zip] to /private/var/tmp/_bazel_jyane/6860dd76b063c3142c2bc69dd88c44cb/external/com_google_protobuf_java/v3.5.1.zip: Checksum was 1f8b9b202e9a4e467ff0b0f25facb1642727cdf5e69092038f15b37c75b99e45 but wanted cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30 and referenced by '//protobuf:protobuf'
ERROR: /Users/jyane/workspace/repos/github.com/jyane/grpc-java/protobuf/BUILD.bazel:1:1: no such package '@com_google_protobuf_java//': Error downloading [https://github.com/google/protobuf/archive/v3.5.1.zip] to /private/var/tmp/_bazel_jyane/6860dd76b063c3142c2bc69dd88c44cb/external/com_google_protobuf_java/v3.5.1.zip: Checksum was 1f8b9b202e9a4e467ff0b0f25facb1642727cdf5e69092038f15b37c75b99e45 but wanted cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30 and referenced by '//protobuf:protobuf'
ERROR: Analysis of target '//protobuf:protobuf' failed; build aborted: no such package '@com_google_protobuf_java//': Error downloading [https://github.com/google/protobuf/archive/v3.5.1.zip] to /private/var/tmp/_bazel_jyane/6860dd76b063c3142c2bc69dd88c44cb/external/com_google_protobuf_java/v3.5.1.zip: Checksum was 1f8b9b202e9a4e467ff0b0f25facb1642727cdf5e69092038f15b37c75b99e45 but wanted cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30
INFO: Elapsed time: 23.761s
FAILED: Build did NOT complete successfully (13 packages loaded)
```
  
  