### PR TITLE
bazel,travis: add bazel build checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,14 @@ sudo: false
 
 language: java
 
+addons:
+  apt:
+    packages:
+      - wget
+
 env:
   global:
+    - BAZEL_VERSION=0.9.0
     - GRADLE_OPTS=-Xmx512m
     - PROTOBUF_VERSION=3.5.1
     - LDFLAGS=-L/tmp/protobuf/lib
@@ -23,6 +29,9 @@ before_install:
   - echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties
   - echo "failOnWarnings=true" >> $HOME/.gradle/gradle.properties
   - echo "errorProne=true" >> $HOME/.gradle/gradle.properties
+  - mkdir -p /tmp/bazel
+  - wget -nc "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" -P /tmp/bazel
+  - sudo dpkg -i "/tmp/bazel/bazel_${BAZEL_VERSION}-linux-x86_64.deb"
 
 install:
   - ./gradlew assemble generateTestProto install
@@ -34,6 +43,7 @@ before_script:
 
 script:
   - ./gradlew check :grpc-all:jacocoTestReport
+  - bazel build //compiler:all //context:all //core:all //netty:all //okhttp:all //protobuf:all //protobuf-lite:all //protobuf-nano:all //stub:all //testing:all
 
 after_success:
   - if \[ "$TRAVIS_OS_NAME" = linux \]; then ./gradlew :grpc-all:coveralls; fi
@@ -47,6 +57,7 @@ notifications:
 
 cache:
   directories:
+    - /tmp/bazel
     - /tmp/protobuf-${PROTOBUF_VERSION}
     - /tmp/gradle-caches-modules-2
     - /tmp/gradle-wrapper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 
 language: java
 
@@ -6,6 +6,11 @@ addons:
   apt:
     packages:
       - wget
+
+matrix:
+  include:
+    - env: TARGET="bazel"
+    - env: TARGET="gradle"
 
 env:
   global:
@@ -17,37 +22,19 @@ env:
     - LD_LIBRARY_PATH=/tmp/protobuf/lib
 
 before_install:
-  - mkdir -p $HOME/.gradle/caches &&
-    ln -s /tmp/gradle-caches-modules-2 $HOME/.gradle/caches/modules-2
-  - mkdir -p $HOME/.gradle &&
-    ln -s /tmp/gradle-wrapper $HOME/.gradle/wrapper
-    # Work around https://github.com/travis-ci/travis-ci/issues/2317
-  - if \[ "$TRAVIS_OS_NAME" = linux \]; then jdk_switcher use oraclejdk8; fi
-  - buildscripts/make_dependencies.sh # build protoc into /tmp/protobuf-${PROTOBUF_VERSION}
-  - ln -s "/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)" /tmp/protobuf
-  - mkdir -p $HOME/.gradle
-  - echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties
-  - echo "failOnWarnings=true" >> $HOME/.gradle/gradle.properties
-  - echo "errorProne=true" >> $HOME/.gradle/gradle.properties
-  - mkdir -p /tmp/bazel
-  - wget -nc "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" -P /tmp/bazel
-  - sudo dpkg -i "/tmp/bazel/bazel_${BAZEL_VERSION}-linux-x86_64.deb"
+  - buildscripts/travis-before_install.sh
 
 install:
-  - ./gradlew assemble generateTestProto install
-  - pushd examples && ./gradlew build && popd
-  - pushd examples && mvn verify && popd
+  - buildscripts/travis-install.sh
 
 before_script:
   - test -z "$(git status --porcelain)" || (git status && echo Error Working directory is not clean. Forget to commit generated files? && false)
 
 script:
-  - ./gradlew check :grpc-all:jacocoTestReport
-  - bazel build //...
+  - buildscripts/travis-script.sh
 
 after_success:
-  - if \[ "$TRAVIS_OS_NAME" = linux \]; then ./gradlew :grpc-all:coveralls; fi
-  - bash <(curl -s https://codecov.io/bash)
+  - buildscripts/travis-after_success.sh
 
 os:
   - linux
@@ -63,6 +50,4 @@ cache:
     - /tmp/gradle-wrapper
 
 before_cache:
-  # The lock changes based on folder name; normally $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm /tmp/gradle-caches-modules-2/gradle-caches-modules-2.lock
-  - find $HOME/.gradle/wrapper -not -name "*-all.zip" -and -not -name "*-bin.zip" -delete
+  - buildscripts/travis-before_cache.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 
 script:
   - ./gradlew check :grpc-all:jacocoTestReport
-  - bazel build //compiler:all //context:all //core:all //netty:all //okhttp:all //protobuf:all //protobuf-lite:all //protobuf-nano:all //stub:all //testing:all
+  - bazel build //...
 
 after_success:
   - if \[ "$TRAVIS_OS_NAME" = linux \]; then ./gradlew :grpc-all:coveralls; fi

--- a/buildscripts/travis-after_success.sh
+++ b/buildscripts/travis-after_success.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -evx -o pipefail
+
+if [ "${TARGET}" = "bazel" ]; then
+  echo 'NOOP'
+fi
+
+if [ "${TARGET}" = "gradle" ]; then
+  if [ "$TRAVIS_OS_NAME" = linux ]; then 
+    ./gradlew :grpc-all:coveralls
+  fi
+  bash <(curl -s https://codecov.io/bash)
+fi

--- a/buildscripts/travis-before_cache.sh
+++ b/buildscripts/travis-before_cache.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -evx -o pipefail
+
+if [ "${TARGET}" = "bazel" ]; then
+  echo 'NOOP'
+fi
+
+if [ "${TARGET}" = "gradle" ]; then
+  # The lock changes based on folder name; normally $HOME/.gradle/caches/modules-2/modules-2.lock
+  rm /tmp/gradle-caches-modules-2/gradle-caches-modules-2.lock
+  find $HOME/.gradle/wrapper -not -name "*-all.zip" -and -not -name "*-bin.zip" -delete
+fi

--- a/buildscripts/travis-before_install.sh
+++ b/buildscripts/travis-before_install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -evx -o pipefail
+
+if [ "${TARGET}" = "bazel" ]; then
+  mkdir -p /tmp/bazel
+  wget -nc "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" -P /tmp/bazel
+  sudo dpkg -i "/tmp/bazel/bazel_${BAZEL_VERSION}-linux-x86_64.deb"
+fi
+
+if [ "${TARGET}" = "gradle" ]; then
+  mkdir -p $HOME/.gradle/caches &&
+    ln -s /tmp/gradle-caches-modules-2 $HOME/.gradle/caches/modules-2
+  mkdir -p $HOME/.gradle &&
+    ln -s /tmp/gradle-wrapper $HOME/.gradle/wrapper
+  # Work around https://github.com/travis-ci/travis-ci/issues/2317
+  if [ "${TRAVIS_OS_NAME}" = linux ]; then 
+    source /opt/jdk_switcher/jdk_switcher.sh && jdk_switcher use oraclejdk8
+  fi
+  buildscripts/make_dependencies.sh # build protoc into /tmp/protobuf-${PROTOBUF_VERSION}
+  ln -s "/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)" /tmp/protobuf
+  mkdir -p $HOME/.gradle
+  echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties
+  echo "failOnWarnings=true" >> $HOME/.gradle/gradle.properties
+  echo "errorProne=true" >> $HOME/.gradle/gradle.properties
+fi

--- a/buildscripts/travis-install.sh
+++ b/buildscripts/travis-install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -evx -o pipefail
+
+if [ "${TARGET}" = "bazel" ]; then
+  echo 'NOOP'
+fi
+
+if [ "${TARGET}" = "gradle" ]; then
+  ./gradlew assemble generateTestProto install
+  pushd examples && ./gradlew build && popd
+  pushd examples && mvn verify && popd
+fi

--- a/buildscripts/travis-script.sh
+++ b/buildscripts/travis-script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -evx -o pipefail
+
+if [ "${TARGET}" = "bazel" ]; then
+  bazel build //...
+fi
+
+if [ "${TARGET}" = "gradle" ]; then
+  ./gradlew check :grpc-all:jacocoTestReport
+fi


### PR DESCRIPTION
add bazel build checking to `.travis.yml`.

This PR's CI would be failed because protobuf's sha256 is incorrect.
When it (https://github.com/grpc/grpc-java/pull/3924) be merged, I will rebase this branch to pass CI.

This PR is partial fix for this issue: https://github.com/grpc/grpc-java/issues/3502