### PR TITLE
buildscripts: Add Kokoro-based Bazel CI

### DIFF
--- a/buildscripts/kokoro/bazel.cfg
+++ b/buildscripts/kokoro/bazel.cfg
@@ -1,0 +1,5 @@
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-java/buildscripts/kokoro/bazel.sh"
+timeout_mins: 45

--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -exu -o pipefail
+
+cd github/grpc-java
+bazel build ...


### PR DESCRIPTION
The internal change is cl/181324357

So... this was really easy (granted, completely untested). But it does have the standard problem of Kokoro of being hard to see externally. I think that's likely "okay" right now, and eventually that limitation should go away. Given there aren't even any tests being run, I hope that just the "failure" signal would be enough for most people.

I'm not against adding bazel to Travis, but it seemed to become a bit of a can of worms, as could be seen in #3925. I think we could make it reasonably clean, but I'm not sure it's worth the effort given how simple this solution is.

CC @jyane