### PR TITLE
buildscripts: Avoid Java 9 for Windows CI

### DIFF
--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -14,6 +14,7 @@ mkdir grpc-java-helper
 
 cd grpc-java-helper
 
+set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
 call "%VS120COMNTOOLS%\vsvars32.bat"
 call "%WORKSPACE%\buildscripts\make_dependencies.bat"
 

--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -14,6 +14,8 @@ mkdir grpc-java-helper
 
 cd grpc-java-helper
 
+@rem Clear JAVA_HOME to prevent a different Java version from being used
+set JAVA_HOME=
 set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
 call "%VS120COMNTOOLS%\vsvars32.bat"
 call "%WORKSPACE%\buildscripts\make_dependencies.bat"


### PR DESCRIPTION
Our build isn't happy on Java 9 yet.