### PR TITLE
bazel,grpclb: add a bazel build definition

### DIFF
--- a/grpclb/BUILD.bazel
+++ b/grpclb/BUILD.bazel
@@ -21,9 +21,7 @@ java_library(
 
 proto_library(
     name = "load_balancer_proto",
-    srcs = [
-        "src/main/proto/load_balancer.proto",
-    ],
+    srcs = ["src/main/proto/load_balancer.proto"],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
         "@com_google_protobuf//:duration_proto",
@@ -32,17 +30,11 @@ proto_library(
 
 java_proto_library(
     name = "load_balancer_java_proto",
-    deps = [
-        ":load_balancer_proto",
-    ],
+    deps = [":load_balancer_proto"],
 )
 
 java_grpc_library(
     name = "load_balancer_java_grpc",
-    srcs = [
-        ":load_balancer_proto",
-    ],
-    deps = [
-        ":load_balancer_java_proto",
-    ],
+    srcs = [":load_balancer_proto"],
+    deps = [":load_balancer_java_proto"],
 )

--- a/grpclb/BUILD.bazel
+++ b/grpclb/BUILD.bazel
@@ -1,0 +1,48 @@
+load("//:java_grpc_library.bzl", "java_grpc_library")
+
+java_library(
+    name = "grpclb",
+    srcs = glob([
+        "src/main/java/io/grpc/grpclb/*.java",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core",
+        "//core:internal",
+        "//core:util",
+        "//stub",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@com_google_guava_guava//jar",
+        "@com_google_code_findbugs_jsr305//jar",
+        ":load_balancer_java_proto",
+        ":load_balancer_java_grpc",
+    ],
+)
+
+proto_library(
+    name = "load_balancer_proto",
+    srcs = [
+        "src/main/proto/load_balancer.proto",
+    ],
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:duration_proto",
+    ],
+)
+
+java_proto_library(
+    name = "load_balancer_java_proto",
+    deps = [
+        ":load_balancer_proto",
+    ],
+)
+
+java_grpc_library(
+    name = "load_balancer_java_grpc",
+    srcs = [
+        ":load_balancer_proto",
+    ],
+    deps = [
+        ":load_balancer_java_proto",
+    ],
+)


### PR DESCRIPTION
add a bazel build definition to grpclb.

I think `src/generated` was created for resolving this issue https://github.com/grpc/grpc-java/issues/357 then I did not add generated files. I just use `java_grpc_library`.

But Bazel requires a full path from WORKSPACE in a proto file (https://github.com/cgrushko/proto_library/blob/04369f0d2ade8c8566727e0b6f3a53f1ba8925c0/src/person.proto#L5) for importing other proto files.
In this PR, it does not relate, but services will require a full path (https://github.com/grpc/grpc-java/compare/master...jyane:add-services-bazel#diff-afc0c0ce1aad649c36404301917e883cR21)

"Do not add generated files" or "Use generated files in Bazel" which is better for now?