### PR TITLE
netty: make GrpcHttp2ConnectionHandler able to indicate it will no longer be used

### DIFF
--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -23,6 +23,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.getEmbeddedHttp2Except
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -46,10 +47,12 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
   private static final ByteBuf payloadBuf =
       unreleasableBuffer(directBuffer(8).writeLong(BDP_MEASUREMENT_PING));
 
-  AbstractNettyHandler(Http2ConnectionDecoder decoder,
-                       Http2ConnectionEncoder encoder,
-                       Http2Settings initialSettings) {
-    super(decoder, encoder, initialSettings);
+  AbstractNettyHandler(
+      ChannelPromise channelUnused,
+      Http2ConnectionDecoder decoder,
+      Http2ConnectionEncoder encoder,
+      Http2Settings initialSettings) {
+    super(channelUnused, decoder, encoder, initialSettings);
 
     // During a graceful shutdown, wait until all streams are closed.
     gracefulShutdownTimeoutMillis(GRACEFUL_SHUTDOWN_NO_TIMEOUT);

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
@@ -23,19 +23,25 @@ import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2Settings;
+import javax.annotation.Nullable;
 
 /**
  * gRPC wrapper for {@link Http2ConnectionHandler}.
  */
 @Internal
 public abstract class GrpcHttp2ConnectionHandler extends Http2ConnectionHandler {
-  public GrpcHttp2ConnectionHandler(Http2ConnectionDecoder decoder,
+
+  @Nullable
+  protected final ChannelPromise channelUnused;
+
+  public GrpcHttp2ConnectionHandler(
+      ChannelPromise channelUnused,
+      Http2ConnectionDecoder decoder,
       Http2ConnectionEncoder encoder,
       Http2Settings initialSettings) {
     super(decoder, encoder, initialSettings);
+    this.channelUnused = channelUnused;
   }
-
-  protected ChannelPromise channelUnused;
 
   /**
    * Triggered on protocol negotiation completion.

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
@@ -18,6 +18,7 @@ package io.grpc.netty;
 
 import io.grpc.Attributes;
 import io.grpc.Internal;
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
@@ -34,6 +35,8 @@ public abstract class GrpcHttp2ConnectionHandler extends Http2ConnectionHandler 
     super(decoder, encoder, initialSettings);
   }
 
+  protected ChannelPromise channelUnused;
+
   /**
    * Triggered on protocol negotiation completion.
    *
@@ -43,5 +46,15 @@ public abstract class GrpcHttp2ConnectionHandler extends Http2ConnectionHandler 
    * @param attrs arbitrary attributes passed after protocol negotiation (eg. SSLSession).
    */
   public void handleProtocolNegotiationCompleted(Attributes attrs) {
+  }
+
+  /**
+   * Calling this method indicates that the channel will no longer be used.  This method is roughly
+   * the same as calling {@link #close} on the channel, but leaving the channel alive.  This is
+   * useful if the channel will soon be deregistered from the executor and used in a non-Netty
+   * context.
+   */
+  public void notifyUnused() {
+    channelUnused.setSuccess(null);
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -208,7 +208,7 @@ class NettyClientHandler extends AbstractNettyHandler {
       Supplier<Stopwatch> stopwatchFactory,
       final Runnable tooManyPingsRunnable,
       TransportTracer transportTracer) {
-    super(decoder, encoder, settings);
+    super(/* channelUnused= */ null, decoder, encoder, settings);
     this.lifecycleManager = lifecycleManager;
     this.keepAliveManager = keepAliveManager;
     this.stopwatchFactory = stopwatchFactory;

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -35,6 +35,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -156,6 +157,24 @@ class NettyServer implements InternalServer, InternalWithLogId {
       @Override
       public void initChannel(Channel ch) throws Exception {
 
+        /**
+         * Releases the event loop if the channel is "done", possibly due to the channel closing.
+         */
+        final class LoopReleaser implements ChannelFutureListener {
+          boolean done;
+
+          @Override
+          public void operationComplete(ChannelFuture future) throws Exception {
+            if (!done) {
+              done = true;
+              eventLoopReferenceCounter.release();
+            }
+          }
+        }
+
+        ChannelFutureListener loopReleaser = new LoopReleaser();
+        ChannelPromise channelDone = ch.newPromise();
+
         long maxConnectionAgeInNanos = NettyServer.this.maxConnectionAgeInNanos;
         if (maxConnectionAgeInNanos != MAX_CONNECTION_AGE_NANOS_DISABLED) {
           // apply a random jitter of +/-10% to max connection age
@@ -165,13 +184,22 @@ class NettyServer implements InternalServer, InternalWithLogId {
 
         NettyServerTransport transport =
             new NettyServerTransport(
-                ch, protocolNegotiator, streamTracerFactories, transportTracerFactory.create(),
+                ch,
+                channelDone,
+                protocolNegotiator,
+                streamTracerFactories,
+                transportTracerFactory.create(),
                 maxStreamsPerConnection,
-                flowControlWindow, maxMessageSize, maxHeaderListSize,
-                keepAliveTimeInNanos, keepAliveTimeoutInNanos,
+                flowControlWindow,
+                maxMessageSize,
+                maxHeaderListSize,
+                keepAliveTimeInNanos,
+                keepAliveTimeoutInNanos,
                 maxConnectionIdleInNanos,
-                maxConnectionAgeInNanos, maxConnectionAgeGraceInNanos,
-                permitKeepAliveWithoutCalls, permitKeepAliveTimeInNanos);
+                maxConnectionAgeInNanos,
+                maxConnectionAgeGraceInNanos,
+                permitKeepAliveWithoutCalls,
+                permitKeepAliveTimeInNanos);
         ServerTransportListener transportListener;
         // This is to order callbacks on the listener, not to guard access to channel.
         synchronized (NettyServer.this) {
@@ -185,13 +213,10 @@ class NettyServer implements InternalServer, InternalWithLogId {
           eventLoopReferenceCounter.retain();
           transportListener = listener.transportCreated(transport);
         }
+
         transport.start(transportListener);
-        ch.closeFuture().addListener(new ChannelFutureListener() {
-          @Override
-          public void operationComplete(ChannelFuture future) {
-            eventLoopReferenceCounter.release();
-          }
-        });
+        channelDone.addListener(loopReleaser);
+        ch.closeFuture().addListener(loopReleaser);
       }
     });
     // Bind and start to accept incoming connections.

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -243,8 +243,7 @@ class NettyServerHandler extends AbstractNettyHandler {
       long maxConnectionAgeInNanos,
       long maxConnectionAgeGraceInNanos,
       final KeepAliveEnforcer keepAliveEnforcer) {
-    super(decoder, encoder, settings);
-    this.channelUnused = channelUnused;
+    super(channelUnused, decoder, encoder, settings);
 
     final MaxConnectionIdleManager maxConnectionIdleManager;
     if (maxConnectionIdleInNanos == MAX_CONNECTION_IDLE_NANOS_DISABLED) {

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -126,6 +126,7 @@ class NettyServerHandler extends AbstractNettyHandler {
 
   static NettyServerHandler newHandler(
       ServerTransportListener transportListener,
+      ChannelPromise channelUnused,
       List<ServerStreamTracer.Factory> streamTracerFactories,
       TransportTracer transportTracer,
       int maxStreams,
@@ -147,6 +148,7 @@ class NettyServerHandler extends AbstractNettyHandler {
     Http2FrameWriter frameWriter =
         new Http2OutboundFrameLogger(new DefaultHttp2FrameWriter(), frameLogger);
     return newHandler(
+        channelUnused,
         frameReader,
         frameWriter,
         transportListener,
@@ -167,7 +169,9 @@ class NettyServerHandler extends AbstractNettyHandler {
 
   @VisibleForTesting
   static NettyServerHandler newHandler(
-      Http2FrameReader frameReader, Http2FrameWriter frameWriter,
+      ChannelPromise channelUnused,
+      Http2FrameReader frameReader,
+      Http2FrameWriter frameWriter,
       ServerTransportListener transportListener,
       List<ServerStreamTracer.Factory> streamTracerFactories,
       TransportTracer transportTracer,
@@ -210,6 +214,7 @@ class NettyServerHandler extends AbstractNettyHandler {
     settings.maxHeaderListSize(maxHeaderListSize);
 
     return new NettyServerHandler(
+        channelUnused,
         connection,
         transportListener,
         streamTracerFactories,
@@ -223,6 +228,7 @@ class NettyServerHandler extends AbstractNettyHandler {
   }
 
   private NettyServerHandler(
+      ChannelPromise channelUnused,
       final Http2Connection connection,
       ServerTransportListener transportListener,
       List<ServerStreamTracer.Factory> streamTracerFactories,
@@ -238,6 +244,7 @@ class NettyServerHandler extends AbstractNettyHandler {
       long maxConnectionAgeGraceInNanos,
       final KeepAliveEnforcer keepAliveEnforcer) {
     super(decoder, encoder, settings);
+    this.channelUnused = channelUnused;
 
     final MaxConnectionIdleManager maxConnectionIdleManager;
     if (maxConnectionIdleInNanos == MAX_CONNECTION_IDLE_NANOS_DISABLED) {

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -117,9 +117,9 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
     frameWriter = spy(new DefaultHttp2FrameWriter());
     frameReader = new DefaultHttp2FrameReader(headersDecoder);
 
+    channel = new FakeClockSupportedChanel();
     handler = newHandler();
-
-    channel = new FakeClockSupportedChanel(handler);
+    channel.pipeline().addLast(handler);
     ctx = channel.pipeline().context(handler);
 
     writeQueue = initWriteQueue();

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -92,6 +92,8 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -108,7 +110,7 @@ import org.mockito.stubbing.Answer;
 public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHandler> {
 
   @Rule
-  public final Timeout globalTimeout = Timeout.seconds(1);
+  public final TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10));
 
   private static final int STREAM_ID = 3;
 
@@ -858,14 +860,23 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
   @Override
   protected NettyServerHandler newHandler() {
     return NettyServerHandler.newHandler(
-        frameReader(), frameWriter(), transportListener,
-        Arrays.asList(streamTracerFactory), transportTracer,
-        maxConcurrentStreams, flowControlWindow,
-        maxHeaderListSize, DEFAULT_MAX_MESSAGE_SIZE,
-        keepAliveTimeInNanos, keepAliveTimeoutInNanos,
+        /* channelUnused= */ channel().newPromise(),
+        frameReader(),
+        frameWriter(),
+        transportListener,
+        Arrays.asList(streamTracerFactory),
+        transportTracer,
+        maxConcurrentStreams,
+        flowControlWindow,
+        maxHeaderListSize,
+        DEFAULT_MAX_MESSAGE_SIZE,
+        keepAliveTimeInNanos,
+        keepAliveTimeoutInNanos,
         maxConnectionIdleInNanos,
-        maxConnectionAgeInNanos, maxConnectionAgeGraceInNanos,
-        permitKeepAliveWithoutCalls, permitKeepAliveTimeInNanos);
+        maxConnectionAgeInNanos,
+        maxConnectionAgeGraceInNanos,
+        permitKeepAliveWithoutCalls,
+        permitKeepAliveTimeInNanos);
   }
 
   @Override


### PR DESCRIPTION
This adds a method on GrpcHttp2ConnectionHandler which, when called, indicates that the channel associated with the handler is no longer needed.   

Notes:

* The handler may not be on the channel, but will either a. need to be added or will never be added.
* The channel will only be "unused" on the server side.
* It is expected that after calling `notifyUnused()`, the channel will be deregistered from the loop without being properly shut down.   This allows the channel to be handed off to a Non-netty API. 