### PR TITLE
Allow specifying a ProxyDetector per ManagedChannel

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import io.grpc.internal.ProxyDetector;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -142,6 +143,11 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   @Override
   public T maxInboundMessageSize(int max) {
     delegate().maxInboundMessageSize(max);
+    return thisT();
+  }
+
+  @Override public T proxyDetector(ProxyDetector proxyDetector) {
+    delegate().proxyDetector(proxyDetector);
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -16,7 +16,7 @@
 
 package io.grpc;
 
-import io.grpc.internal.ProxyDetector;
+import java.net.Proxy;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -146,8 +146,8 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
     return thisT();
   }
 
-  @Override public T proxyDetector(ProxyDetector proxyDetector) {
-    delegate().proxyDetector(proxyDetector);
+  @Override public T proxy(Proxy proxy) {
+    delegate().proxy(proxy);
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -16,7 +16,7 @@
 
 package io.grpc;
 
-import io.grpc.internal.ProxyDetector;
+import java.net.Proxy;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -281,13 +281,13 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
-   * Sets the {@link ProxyDetector} to use when resolving proxy parameters for outgoing
+   * Sets the {@link Proxy} to use when resolving proxy parameters for outgoing
    * connections.
    *
-   * @param proxyDetector the proxy detector to use
+   * @param proxy the proxy to use
    * @return this
    */
-  public T proxyDetector(ProxyDetector proxyDetector) {
+  public T proxy(Proxy proxy) {
     // intentional nop
     return thisT();
   }

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import io.grpc.internal.ProxyDetector;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -275,6 +276,18 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2307")
   public T maxInboundMessageSize(int max) {
+    // intentional nop
+    return thisT();
+  }
+
+  /**
+   * Sets the {@link ProxyDetector} to use when resolving proxy parameters for outgoing
+   * connections.
+   *
+   * @param proxyDetector the proxy detector to use
+   * @return this
+   */
+  public T proxyDetector(ProxyDetector proxyDetector) {
     // intentional nop
     return thisT();
   }

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -16,7 +16,6 @@
 
 package io.grpc;
 
-import io.grpc.internal.ProxyDetector;
 import java.net.URI;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -107,8 +106,7 @@ public abstract class NameResolver {
     public abstract NameResolver newNameResolver(URI targetUri, Attributes params);
 
     @Nullable
-    public NameResolver newNameResolver(URI targetUri, Attributes params,
-        ProxyDetector proxyDetector) {
+    public NameResolver newNameResolver(URI targetUri, Attributes params, boolean usingProxy) {
       return newNameResolver(targetUri, params);
     }
 

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import io.grpc.internal.ProxyDetector;
 import java.net.URI;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -104,6 +105,12 @@ public abstract class NameResolver {
      */
     @Nullable
     public abstract NameResolver newNameResolver(URI targetUri, Attributes params);
+
+    @Nullable
+    public NameResolver newNameResolver(URI targetUri, Attributes params,
+        ProxyDetector proxyDetector) {
+      return newNameResolver(targetUri, params);
+    }
 
     /**
      * Returns the default scheme, which will be used to construct a URI when {@link

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -34,6 +34,7 @@ import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
 import io.grpc.PickFirstBalancerFactory;
 import io.opencensus.trace.Tracing;
+import java.net.Proxy;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -151,9 +152,9 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   @Override
-  public T proxyDetector(ProxyDetector proxyDetector) {
-    checkNotNull(proxyDetector, "proxy detector cannot be null");
-    this.proxyDetector = proxyDetector;
+  public T proxy(final Proxy proxy) {
+    checkNotNull(proxy, "proxy cannot be null");
+    this.proxyDetector = new ProxyDetectorImpl(proxy);
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+
 
 /**
  * The base class for channel builders.
@@ -128,6 +130,9 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private int maxInboundMessageSize = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
+  @VisibleForTesting
+  ProxyDetector proxyDetector = GrpcUtil.getProxyDetector();
+
   /**
    * Sets the maximum message size allowed for a single gRPC frame. If an inbound messages
    * larger than this limit is received it will not be processed and the RPC will fail with
@@ -143,6 +148,13 @@ public abstract class AbstractManagedChannelImplBuilder
 
   protected final int maxInboundMessageSize() {
     return maxInboundMessageSize;
+  }
+
+  @Override
+  public T proxyDetector(ProxyDetector proxyDetector) {
+    checkNotNull(proxyDetector, "proxy detector cannot be null");
+    this.proxyDetector = proxyDetector;
+    return thisT();
   }
 
   private boolean statsEnabled = true;
@@ -243,7 +255,7 @@ public abstract class AbstractManagedChannelImplBuilder
       this.decompressorRegistry = registry;
     } else {
       this.decompressorRegistry = DEFAULT_DECOMPRESSOR_REGISTRY;
-    } 
+    }
     return thisT();
   }
 
@@ -345,7 +357,7 @@ public abstract class AbstractManagedChannelImplBuilder
         SharedResourcePool.forResource(GrpcUtil.SHARED_CHANNEL_EXECUTOR),
         GrpcUtil.STOPWATCH_SUPPLIER,
         getEffectiveInterceptors(),
-        GrpcUtil.getProxyDetector(),
+        proxyDetector,
         ChannelTracer.getDefaultFactory());
   }
 

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
 import io.grpc.NameResolverProvider;
 import java.net.URI;
+import javax.annotation.Nullable;
 
 /**
  * A provider for {@link DnsNameResolver}.
@@ -42,13 +43,20 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
 
   @Override
   public DnsNameResolver newNameResolver(URI targetUri, Attributes params) {
+    return newNameResolver(targetUri, params, GrpcUtil.getProxyDetector());
+  }
+
+  @Nullable
+  @Override
+  public DnsNameResolver newNameResolver(URI targetUri, Attributes params,
+      ProxyDetector proxyDetector) {
     if (SCHEME.equals(targetUri.getScheme())) {
       String targetPath = Preconditions.checkNotNull(targetUri.getPath(), "targetPath");
       Preconditions.checkArgument(targetPath.startsWith("/"),
           "the path component (%s) of the target (%s) must start with '/'", targetPath, targetUri);
       String name = targetPath.substring(1);
       return new DnsNameResolver(targetUri.getAuthority(), name, params, GrpcUtil.TIMER_SERVICE,
-          GrpcUtil.SHARED_CHANNEL_EXECUTOR, GrpcUtil.getProxyDetector());
+          GrpcUtil.SHARED_CHANNEL_EXECUTOR, proxyDetector);
     } else {
       return null;
     }

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -16,7 +16,6 @@
 
 package io.grpc.internal;
 
-import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
 import io.grpc.NameResolverProvider;
 import java.net.URI;
@@ -43,20 +42,15 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
 
   @Override
   public DnsNameResolver newNameResolver(URI targetUri, Attributes params) {
-    return newNameResolver(targetUri, params, GrpcUtil.getProxyDetector());
+    return newNameResolver(targetUri, params, false);
   }
 
   @Nullable
   @Override
-  public DnsNameResolver newNameResolver(URI targetUri, Attributes params,
-      ProxyDetector proxyDetector) {
+  public DnsNameResolver newNameResolver(URI targetUri, Attributes params, boolean usingProxy) {
     if (SCHEME.equals(targetUri.getScheme())) {
-      String targetPath = Preconditions.checkNotNull(targetUri.getPath(), "targetPath");
-      Preconditions.checkArgument(targetPath.startsWith("/"),
-          "the path component (%s) of the target (%s) must start with '/'", targetPath, targetUri);
-      String name = targetPath.substring(1);
-      return new DnsNameResolver(targetUri.getAuthority(), name, params, GrpcUtil.TIMER_SERVICE,
-          GrpcUtil.SHARED_CHANNEL_EXECUTOR, proxyDetector);
+      return new DnsNameResolver(targetUri.getAuthority(), targetUri, params,
+          GrpcUtil.TIMER_SERVICE, GrpcUtil.SHARED_CHANNEL_EXECUTOR, usingProxy);
     } else {
       return null;
     }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -298,7 +298,8 @@ public final class ManagedChannelImpl
       // did not cancel idleModeTimer, both of which are bugs.
       nameResolver.shutdown();
       nameResolverStarted = false;
-      nameResolver = getNameResolver(target, nameResolverFactory, nameResolverParams);
+      nameResolver =
+          getNameResolver(target, nameResolverFactory, nameResolverParams, proxyDetector);
       lbHelper.lb.shutdown();
       lbHelper = null;
       subchannelPicker = null;
@@ -458,7 +459,8 @@ public final class ManagedChannelImpl
     this.target = checkNotNull(builder.target, "target");
     this.nameResolverFactory = builder.getNameResolverFactory();
     this.nameResolverParams = checkNotNull(builder.getNameResolverParams(), "nameResolverParams");
-    this.nameResolver = getNameResolver(target, nameResolverFactory, nameResolverParams);
+    this.nameResolver =
+        getNameResolver(target, nameResolverFactory, nameResolverParams, proxyDetector);
     this.loadBalancerFactory =
         checkNotNull(builder.loadBalancerFactory, "loadBalancerFactory");
     this.executorPool = checkNotNull(builder.executorPool, "executorPool");
@@ -494,7 +496,7 @@ public final class ManagedChannelImpl
 
   @VisibleForTesting
   static NameResolver getNameResolver(String target, NameResolver.Factory nameResolverFactory,
-      Attributes nameResolverParams) {
+      Attributes nameResolverParams, ProxyDetector proxyDetector) {
     // Finding a NameResolver. Try using the target string as the URI. If that fails, try prepending
     // "dns:///".
     URI targetUri = null;
@@ -509,7 +511,8 @@ public final class ManagedChannelImpl
       uriSyntaxErrors.append(e.getMessage());
     }
     if (targetUri != null) {
-      NameResolver resolver = nameResolverFactory.newNameResolver(targetUri, nameResolverParams);
+      NameResolver resolver = nameResolverFactory.newNameResolver(
+          targetUri, nameResolverParams, proxyDetector);
       if (resolver != null) {
         return resolver;
       }
@@ -527,7 +530,8 @@ public final class ManagedChannelImpl
         // Should not be possible.
         throw new IllegalArgumentException(e);
       }
-      NameResolver resolver = nameResolverFactory.newNameResolver(targetUri, nameResolverParams);
+      NameResolver resolver = nameResolverFactory.newNameResolver(
+          targetUri, nameResolverParams, proxyDetector);
       if (resolver != null) {
         return resolver;
       }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -501,6 +501,7 @@ public final class ManagedChannelImpl
     // "dns:///".
     URI targetUri = null;
     StringBuilder uriSyntaxErrors = new StringBuilder();
+    Integer defaultPort = nameResolverParams.get(NameResolver.Factory.PARAMS_DEFAULT_PORT);
     try {
       targetUri = new URI(target);
       // For "localhost:8080" this would likely cause newNameResolver to return null, because
@@ -511,8 +512,8 @@ public final class ManagedChannelImpl
       uriSyntaxErrors.append(e.getMessage());
     }
     if (targetUri != null) {
-      NameResolver resolver = nameResolverFactory.newNameResolver(
-          targetUri, nameResolverParams, proxyDetector);
+      NameResolver resolver = null;
+      resolver = nameResolverFactory.newNameResolver(targetUri, nameResolverParams);
       if (resolver != null) {
         return resolver;
       }
@@ -531,7 +532,8 @@ public final class ManagedChannelImpl
         throw new IllegalArgumentException(e);
       }
       NameResolver resolver = nameResolverFactory.newNameResolver(
-          targetUri, nameResolverParams, proxyDetector);
+          targetUri, nameResolverParams,
+          proxyDetector.proxyFor(GrpcUtil.unresolvedAddress(targetUri, defaultPort)) != null);
       if (resolver != null) {
         return resolver;
       }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -40,6 +40,7 @@ import io.grpc.internal.testing.StatsTestUtils.FakeStatsRecorder;
 import io.grpc.internal.testing.StatsTestUtils.FakeTagContextBinarySerializer;
 import io.grpc.internal.testing.StatsTestUtils.FakeTagger;
 import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.List;
@@ -62,7 +63,8 @@ public class AbstractManagedChannelImplBuilderTest {
       };
 
   private Builder builder = new Builder("fake");
-  private Builder directAddressBuilder = new Builder(new SocketAddress(){}, "fake");
+  private Builder directAddressBuilder = new Builder(new SocketAddress() {
+  }, "fake");
 
   @Test
   public void executor_default() {
@@ -198,14 +200,16 @@ public class AbstractManagedChannelImplBuilderTest {
   @Test
   public void proxyDetector_normal() {
     ProxyDetector defaultValue = builder.proxyDetector;
-    builder.proxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR);
+    Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("some.host", 100));
+    builder.proxy(proxy);
     assertNotEquals(defaultValue, builder.proxyDetector);
-    assertEquals(GrpcUtil.NOOP_PROXY_DETECTOR, builder.proxyDetector);
+    assertEquals(proxy.address(),
+        builder.proxyDetector.proxyFor(new InetSocketAddress("some.other.host", 200)).proxyAddress);
   }
 
   @Test(expected = NullPointerException.class)
   public void proxyDetector_null() {
-    builder.proxyDetector(null);
+    builder.proxy(null);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -196,6 +196,19 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
+  public void proxyDetector_normal() {
+    ProxyDetector defaultValue = builder.proxyDetector;
+    builder.proxyDetector(GrpcUtil.NOOP_PROXY_DETECTOR);
+    assertNotEquals(defaultValue, builder.proxyDetector);
+    assertEquals(GrpcUtil.NOOP_PROXY_DETECTOR, builder.proxyDetector);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void proxyDetector_null() {
+    builder.proxyDetector(null);
+  }
+
+  @Test
   public void userAgent_default() {
     assertNull(builder.userAgent);
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -107,7 +107,8 @@ public class ManagedChannelImplGetNameResolverTest {
     };
     try {
       ManagedChannelImpl.getNameResolver(
-          "foo.googleapis.com:8080", nameResolverFactory, NAME_RESOLVER_PARAMS);
+          "foo.googleapis.com:8080", nameResolverFactory,
+          NAME_RESOLVER_PARAMS, GrpcUtil.NOOP_PROXY_DETECTOR);
       fail("Should fail");
     } catch (IllegalArgumentException e) {
       // expected
@@ -117,7 +118,7 @@ public class ManagedChannelImplGetNameResolverTest {
   private void testValidTarget(String target, String expectedUriString, URI expectedUri) {
     Factory nameResolverFactory = new FakeNameResolverFactory(expectedUri.getScheme());
     FakeNameResolver nameResolver = (FakeNameResolver) ManagedChannelImpl.getNameResolver(
-        target, nameResolverFactory, NAME_RESOLVER_PARAMS);
+        target, nameResolverFactory, NAME_RESOLVER_PARAMS, GrpcUtil.NOOP_PROXY_DETECTOR);
     assertNotNull(nameResolver);
     assertEquals(expectedUri, nameResolver.uri);
     assertEquals(expectedUriString, nameResolver.uri.toString());
@@ -128,7 +129,7 @@ public class ManagedChannelImplGetNameResolverTest {
 
     try {
       FakeNameResolver nameResolver = (FakeNameResolver) ManagedChannelImpl.getNameResolver(
-          target, nameResolverFactory, NAME_RESOLVER_PARAMS);
+          target, nameResolverFactory, NAME_RESOLVER_PARAMS, GrpcUtil.NOOP_PROXY_DETECTOR);
       fail("Should have failed, but got resolver with " + nameResolver.uri);
     } catch (IllegalArgumentException e) {
       // expected

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -114,7 +114,7 @@ public class ManagedChannelImplIdlenessTest {
     when(mockLoadBalancerFactory.newLoadBalancer(any(Helper.class))).thenReturn(mockLoadBalancer);
     when(mockNameResolver.getServiceAuthority()).thenReturn(AUTHORITY);
     when(mockNameResolverFactory
-        .newNameResolver(any(URI.class), any(Attributes.class)))
+        .newNameResolver(any(URI.class), any(Attributes.class), any(ProxyDetector.class)))
         .thenReturn(mockNameResolver);
     when(mockTransportFactory.getScheduledExecutorService())
         .thenReturn(timer.getScheduledExecutorService());
@@ -153,7 +153,8 @@ public class ManagedChannelImplIdlenessTest {
       }
       servers.add(new EquivalentAddressGroup(addrs));
     }
-    verify(mockNameResolverFactory).newNameResolver(any(URI.class), any(Attributes.class));
+    verify(mockNameResolverFactory).newNameResolver(
+        any(URI.class), any(Attributes.class), any(ProxyDetector.class));
     // Verify the initial idleness
     verify(mockLoadBalancerFactory, never()).newLoadBalancer(any(Helper.class));
     verify(mockTransportFactory, never()).newClientTransport(

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -114,7 +114,7 @@ public class ManagedChannelImplIdlenessTest {
     when(mockLoadBalancerFactory.newLoadBalancer(any(Helper.class))).thenReturn(mockLoadBalancer);
     when(mockNameResolver.getServiceAuthority()).thenReturn(AUTHORITY);
     when(mockNameResolverFactory
-        .newNameResolver(any(URI.class), any(Attributes.class), any(ProxyDetector.class)))
+        .newNameResolver(any(URI.class), any(Attributes.class)))
         .thenReturn(mockNameResolver);
     when(mockTransportFactory.getScheduledExecutorService())
         .thenReturn(timer.getScheduledExecutorService());
@@ -153,8 +153,7 @@ public class ManagedChannelImplIdlenessTest {
       }
       servers.add(new EquivalentAddressGroup(addrs));
     }
-    verify(mockNameResolverFactory).newNameResolver(
-        any(URI.class), any(Attributes.class), any(ProxyDetector.class));
+    verify(mockNameResolverFactory).newNameResolver(any(URI.class), any(Attributes.class));
     // Verify the initial idleness
     verify(mockLoadBalancerFactory, never()).newLoadBalancer(any(Helper.class));
     verify(mockTransportFactory, never()).newClientTransport(

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1169,7 +1169,7 @@ public class ManagedChannelImplTest {
       Subchannel subchannel = helper.createSubchannel(addressGroup, Attributes.EMPTY);
       subchannel.requestConnection();
     }
-    
+
     MockClientTransportInfo transportInfo = transports.poll();
     assertNotNull(transportInfo);
 


### PR DESCRIPTION
Problem: In our current setup we use grpc to communicate between apps within our datacenters, and company policy is to route all external traffic through a web proxy (for security reasons we want to whitelist who we talk to externally). However, due to how grpc handles proxies (through the env variable or java proxy settings) there is no way for us to specify a different proxy behavior between external grpc clients (e.g. for calling out to GCP) and internal grpc clients (which we don't want going through our webproxy). 

This PR allows specifying what `ProxyDetector` you want to use when building a `ManagedChannel`. In order to do so I also had to update the `NameResolver` abstract class as currently the `DNSNameResolver` requires knowledge about whether we're using a proxy or not. 

As a follow up to this I can imagine us removing the special casing for App Engine in selecting a default `ProxyDetector` in favor of using this new API, but that can follow in a later PR. 

cc @lukaszx0 @ejona86 @carl-mastrangelo 