### PR TITLE
Update protobuf-gradle-plugin to 0.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ buildscript {
   dependencies {
     // ASSUMES GRADLE 2.12 OR HIGHER. Use plugin version 0.7.5 with earlier
     // gradle versions
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.1'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
   }
 }
 

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.1"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.3"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ subprojects {
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
                 protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",
                 protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
-                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.1',
+                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.3',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
 
                 netty: "io.netty:netty-codec-http2:[${nettyVersion}]",

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.1"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.3"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.1"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.3"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.1"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.3"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   dependencies {
     // ASSUMES GRADLE 2.12 OR HIGHER. Use plugin version 0.7.5 with earlier
     // gradle versions
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.1'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
   }
 }
 


### PR DESCRIPTION
This fixes support for newer Android Gradle Plugins.

CC @zhangkun83. This is a more complete version of #3597.