### PR TITLE
core: support full stream compression

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -116,6 +116,12 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
+  public T enableFullStreamCompression() {
+    delegate().enableFullStreamCompression();
+    return thisT();
+  }
+
+  @Override
   public T enableFullStreamDecompression() {
     delegate().enableFullStreamDecompression();
     return thisT();

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -205,6 +205,21 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   public abstract T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory);
 
   /**
+   * Enables full-stream compression of outbound streams. This requires server support for
+   * full-stream compression.
+   *
+   * <p>EXPERIMENTAL: This method is here to enable an experimental feature, and may be changed or
+   * removed once the feature is stable.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @since 1.10.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3399")
+  public T enableFullStreamCompression() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Enables full-stream decompression of inbound streams. This will cause the channel's outbound
    * headers to advertise support for GZIP compressed streams, and gRPC servers which support the
    * feature may respond with a GZIP compressed stream.

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -173,6 +173,35 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   public abstract T compressorRegistry(@Nullable CompressorRegistry registry);
 
   /**
+   * Enables full-stream compression of outbound RPCs, if the client advertises support for this
+   * feature.
+   *
+   * <p>EXPERIMENTAL: This method is here to enable an experimental feature, and may be changed or
+   * removed once the feature is stable.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @since 1.10.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3399")
+  public T enableFullStreamCompression() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * /** Enables full-stream decompression of inbound GZIP compressed streams.
+   *
+   * <p>EXPERIMENTAL: This method is here to enable an experimental feature, and may be changed or
+   * removed once the feature is stable.
+   *
+   * @throws UnsupportedOperationException if unsupported
+   * @since 1.10.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3399")
+  public T enableFullStreamDecompression() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Sets the permitted time for new connections to complete negotiation handshakes before being
    * killed.
    *

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -463,10 +463,23 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       }
 
       @Override
+      public void setFullStreamCompression(boolean enable) {
+        // noop
+      }
+
+      @Override
+      public void setFullStreamDecompression(boolean enable) {
+        // noop
+      }
+
+      @Override
       public void setCompressor(Compressor compressor) {}
 
       @Override
       public void setDecompressor(Decompressor decompressor) {}
+
+      @Override
+      public void setFullStreamDecompressor() {}
 
       @Override public Attributes getAttributes() {
         return serverStreamAttributes;
@@ -653,6 +666,9 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
       @Override
       public void setCompressor(Compressor compressor) {}
+
+      @Override
+      public void setFullStreamCompression(boolean enable) {}
 
       @Override
       public void setFullStreamDecompression(boolean fullStreamDecompression) {}

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -116,6 +116,7 @@ public abstract class AbstractManagedChannelImplBuilder
 
   LoadBalancer.Factory loadBalancerFactory = DEFAULT_LOAD_BALANCER_FACTORY;
 
+  boolean fullStreamCompression;
   boolean fullStreamDecompression;
 
   DecompressorRegistry decompressorRegistry = DEFAULT_DECOMPRESSOR_REGISTRY;
@@ -228,6 +229,12 @@ public abstract class AbstractManagedChannelImplBuilder
     } else {
       this.loadBalancerFactory = DEFAULT_LOAD_BALANCER_FACTORY;
     }
+    return thisT();
+  }
+
+  @Override
+  public final T enableFullStreamCompression() {
+    this.fullStreamCompression = true;
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -97,6 +97,9 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
 
   CompressorRegistry compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
 
+  boolean fullStreamCompression;
+  boolean fullStreamDecompression;
+
   long handshakeTimeoutMillis = DEFAULT_HANDSHAKE_TIMEOUT_MILLIS;
 
   @Nullable
@@ -183,6 +186,18 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
     } else {
       compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
     }
+    return thisT();
+  }
+
+  @Override
+  public T enableFullStreamCompression() {
+    this.fullStreamCompression = true;
+    return thisT();
+  }
+
+  @Override
+  public T enableFullStreamDecompression() {
+    this.fullStreamDecompression = true;
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -163,6 +163,11 @@ public abstract class AbstractServerStream extends AbstractStream
     transportState().setDecompressor(Preconditions.checkNotNull(decompressor, "decompressor"));
   }
 
+  @Override
+  public final void setFullStreamDecompressor() {
+    transportState().enableFullStreamDecompressor();
+  }
+
   @Override public Attributes getAttributes() {
     return Attributes.EMPTY;
   }

--- a/core/src/main/java/io/grpc/internal/AbstractStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractStream.java
@@ -46,6 +46,16 @@ public abstract class AbstractStream implements Stream {
   }
 
   @Override
+  public final void setFullStreamCompression(boolean enable) {
+    framer().setStreamCompression(enable);
+  }
+
+  @Override
+  public final void setFullStreamDecompression(boolean enable) {
+    transportState().setFullStreamDecompression(enable);
+  }
+
+  @Override
   public final void writeMessage(InputStream message) {
     checkNotNull(message, "message");
     if (!framer().isClosed()) {
@@ -104,6 +114,8 @@ public abstract class AbstractStream implements Stream {
     @VisibleForTesting
     public static final int DEFAULT_ONREADY_THRESHOLD = 32 * 1024;
 
+    protected boolean fullStreamDecompression;
+
     private Deframer deframer;
     private final Object onReadyLock = new Object();
     private final StatsTraceContext statsTraceCtx;
@@ -143,8 +155,8 @@ public abstract class AbstractStream implements Stream {
           getClass().getName());
     }
 
-    protected void setFullStreamDecompressor(GzipInflatingBuffer fullStreamDecompressor) {
-      deframer.setFullStreamDecompressor(fullStreamDecompressor);
+    protected void enableFullStreamDecompressor() {
+      deframer.enableFullStreamDecompression();
       deframer = new ApplicationThreadDeframer(this, this, (MessageDeframer) deframer);
     }
 
@@ -211,6 +223,10 @@ public abstract class AbstractStream implements Stream {
 
     protected final void setDecompressor(Decompressor decompressor) {
       deframer.setDecompressor(decompressor);
+    }
+
+    private void setFullStreamDecompression(boolean fullStreamDecompression) {
+      this.fullStreamDecompression = fullStreamDecompression;
     }
 
     private boolean isReady() {

--- a/core/src/main/java/io/grpc/internal/ApplicationThreadDeframer.java
+++ b/core/src/main/java/io/grpc/internal/ApplicationThreadDeframer.java
@@ -64,8 +64,8 @@ public class ApplicationThreadDeframer implements Deframer, MessageDeframer.List
   }
 
   @Override
-  public void setFullStreamDecompressor(GzipInflatingBuffer fullStreamDecompressor) {
-    deframer.setFullStreamDecompressor(fullStreamDecompressor);
+  public void enableFullStreamDecompression() {
+    deframer.enableFullStreamDecompression();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ClientStream.java
@@ -53,12 +53,6 @@ public interface ClientStream extends Stream {
   void setAuthority(String authority);
 
   /**
-   * Enables full-stream decompression, allowing the client stream to use {@link
-   * GzipInflatingBuffer} to decode inbound GZIP compressed streams.
-   */
-  void setFullStreamDecompression(boolean fullStreamDecompression);
-
-  /**
    * Sets the registry to find a decompressor for the framer. May only be called before {@link
    * #start}. If the transport does not support compression, this may do nothing.
    *

--- a/core/src/main/java/io/grpc/internal/Deframer.java
+++ b/core/src/main/java/io/grpc/internal/Deframer.java
@@ -33,12 +33,10 @@ public interface Deframer {
   void setDecompressor(Decompressor decompressor);
 
   /**
-   * Sets the decompressor used for full-stream decompression. Full-stream decompression disables
-   * any per-message decompressor set by {@link #setDecompressor}.
-   *
-   * @param fullStreamDecompressor the decompressing wrapper
+   * Enable full-stream decompression. This should only be set once, and is incompatible with also
+   * setting a per-message decompressor via {@link #setDecompressor}.
    */
-  void setFullStreamDecompressor(GzipInflatingBuffer fullStreamDecompressor);
+  void enableFullStreamDecompression();
 
   /**
    * Requests up to the given number of messages from the call. No additional messages will be

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -347,6 +347,21 @@ class DelayedStream implements ClientStream {
     }
   }
 
+  @Override
+  public void setFullStreamCompression(final boolean enable) {
+    if (passThrough) {
+      realStream.setFullStreamCompression(enable);
+    } else {
+      delayOrExecute(
+          new Runnable() {
+            @Override
+            public void run() {
+              realStream.setFullStreamCompression(enable);
+            }
+          });
+    }
+  }
+
   @VisibleForTesting
   ClientStream getRealStream() {
     return realStream;

--- a/core/src/main/java/io/grpc/internal/Framer.java
+++ b/core/src/main/java/io/grpc/internal/Framer.java
@@ -46,6 +46,9 @@ public interface Framer {
   /** Set the compressor used for compression. */
   Framer setCompressor(Compressor compressor);
 
+  /** Enable or disable full-stream compression. */
+  Framer setStreamCompression(boolean enable);
+
   /** Set a size limit for each outbound message. */ 
   void setMaxOutboundMessageSize(int maxSize);
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -120,6 +120,7 @@ public final class ManagedChannelImpl
 
   private final ChannelExecutor channelExecutor = new ChannelExecutor();
 
+  private boolean fullStreamCompression;
   private boolean fullStreamDecompression;
 
   private final DecompressorRegistry decompressorRegistry;
@@ -480,6 +481,7 @@ public final class ManagedChannelImpl
           "invalid idleTimeoutMillis %s", builder.idleTimeoutMillis);
       this.idleTimeoutMillis = builder.idleTimeoutMillis;
     }
+    this.fullStreamCompression = builder.fullStreamCompression;
     this.fullStreamDecompression = builder.fullStreamDecompression;
     this.decompressorRegistry = checkNotNull(builder.decompressorRegistry, "decompressorRegistry");
     this.compressorRegistry = checkNotNull(builder.compressorRegistry, "compressorRegistry");
@@ -640,7 +642,8 @@ public final class ManagedChannelImpl
               callOptions,
               transportProvider,
               terminated ? null : transportFactory.getScheduledExecutorService(),
-          channelTracer)
+              channelTracer)
+          .setFullStreamCompression(fullStreamCompression)
           .setFullStreamDecompression(fullStreamDecompression)
           .setDecompressorRegistry(decompressorRegistry)
           .setCompressorRegistry(compressorRegistry);

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -147,7 +147,12 @@ public class MessageDeframer implements Closeable, Deframer {
   }
 
   @Override
-  public void setFullStreamDecompressor(GzipInflatingBuffer fullStreamDecompressor) {
+  public void enableFullStreamDecompression() {
+    setFullStreamDecompressor(new GzipInflatingBuffer());
+  }
+
+  @VisibleForTesting
+  void setFullStreamDecompressor(GzipInflatingBuffer fullStreamDecompressor) {
     checkState(decompressor == Codec.Identity.NONE, "per-message decompressor already set");
     checkState(this.fullStreamDecompressor == null, "full stream decompressor already set");
     this.fullStreamDecompressor =

--- a/core/src/main/java/io/grpc/internal/NoopClientStream.java
+++ b/core/src/main/java/io/grpc/internal/NoopClientStream.java
@@ -68,6 +68,9 @@ public class NoopClientStream implements ClientStream {
   public void setCompressor(Compressor compressor) {}
 
   @Override
+  public void setFullStreamCompression(boolean enable) {}
+
+  @Override
   public void setFullStreamDecompression(boolean fullStreamDecompression) {}
 
   @Override

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -311,18 +311,6 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   }
 
   @Override
-  public final void setFullStreamDecompression(final boolean fullStreamDecompression) {
-    class FullStreamDecompressionEntry implements BufferEntry {
-      @Override
-      public void runWith(Substream substream) {
-        substream.stream.setFullStreamDecompression(fullStreamDecompression);
-      }
-    }
-
-    delayOrExecute(new FullStreamDecompressionEntry());
-  }
-
-  @Override
   public final void setMessageCompression(final boolean enable) {
     class MessageCompressionEntry implements BufferEntry {
       @Override
@@ -332,6 +320,30 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     }
 
     delayOrExecute(new MessageCompressionEntry());
+  }
+
+  @Override
+  public final void setFullStreamCompression(final boolean enable) {
+    class StreamCompressionEntry implements BufferEntry {
+      @Override
+      public void runWith(Substream substream) {
+        substream.stream.setFullStreamCompression(enable);
+      }
+    }
+
+    delayOrExecute(new StreamCompressionEntry());
+  }
+
+  @Override
+  public final void setFullStreamDecompression(final boolean fullStreamDecompression) {
+    class FullStreamDecompressionEntry implements BufferEntry {
+      @Override
+      public void runWith(Substream substream) {
+        substream.stream.setFullStreamDecompression(fullStreamDecompression);
+      }
+    }
+
+    delayOrExecute(new FullStreamDecompressionEntry());
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -67,6 +67,9 @@ public interface ServerStream extends Stream {
    */
   void setDecompressor(Decompressor decompressor);
 
+  /** Enables the decompressor for compressed streams on the deframer. */
+  void setFullStreamDecompressor();
+
   /**
    * Attributes describing stream.  This is inherited from the transport attributes, and used
    * as the basis of {@link io.grpc.ServerCall#getAttributes}.

--- a/core/src/main/java/io/grpc/internal/Stream.java
+++ b/core/src/main/java/io/grpc/internal/Stream.java
@@ -77,4 +77,15 @@ public interface Stream {
    * but may not have any effect if compression is not enabled on the call.
    */
   void setMessageCompression(boolean enable);
+
+  /**
+   * Enables full-stream GZIP compression for outbound RPCs.
+   */
+  void setFullStreamCompression(boolean enable);
+
+  /**
+   * Enables full-stream decompression, using {@link GzipInflatingBuffer} to decode inbound GZIP
+   * compressed streams.
+   */
+  void setFullStreamDecompression(boolean enable);
 }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -141,6 +141,17 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
+  public void fullStreamCompression_default() {
+    assertFalse(builder.fullStreamCompression);
+  }
+
+  @Test
+  public void fullStreamCompression_enabled() {
+    assertEquals(builder, builder.enableFullStreamCompression());
+    assertTrue(builder.fullStreamCompression);
+  }
+
+  @Test
   public void fullStreamDecompression_default() {
     assertFalse(builder.fullStreamDecompression);
   }

--- a/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
@@ -18,6 +18,8 @@ package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import io.grpc.Metadata;
 import io.grpc.ServerStreamTracer;
@@ -81,6 +83,28 @@ public class AbstractServerImplBuilderTest {
     builder.setStatsEnabled(false);
     List<ServerStreamTracer.Factory> factories = builder.getTracerFactories();
     assertThat(factories).containsExactly(DUMMY_USER_TRACER);
+  }
+
+  @Test
+  public void fullStreamCompression_default() {
+    assertFalse(builder.fullStreamCompression);
+  }
+
+  @Test
+  public void fullStreamCompression_enabled() {
+    assertEquals(builder, builder.enableFullStreamCompression());
+    assertTrue(builder.fullStreamCompression);
+  }
+
+  @Test
+  public void fullStreamDecompression_default() {
+    assertFalse(builder.fullStreamDecompression);
+  }
+
+  @Test
+  public void fullStreamDecompression_enabled() {
+    assertEquals(builder, builder.enableFullStreamDecompression());
+    assertTrue(builder.fullStreamDecompression);
   }
 
   static class Builder extends AbstractServerImplBuilder<Builder> {

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -343,7 +343,7 @@ public class ClientCallImplTest {
   public void prepareHeaders_userAgentIgnored() {
     Metadata m = new Metadata();
     m.put(GrpcUtil.USER_AGENT_KEY, "batmobile");
-    ClientCallImpl.prepareHeaders(m, decompressorRegistry, Codec.Identity.NONE, false);
+    ClientCallImpl.prepareHeaders(m, decompressorRegistry, Codec.Identity.NONE, false, false);
 
     // User Agent is removed and set by the transport
     assertThat(m.get(GrpcUtil.USER_AGENT_KEY)).isNotNull();
@@ -352,7 +352,7 @@ public class ClientCallImplTest {
   @Test
   public void prepareHeaders_ignoreIdentityEncoding() {
     Metadata m = new Metadata();
-    ClientCallImpl.prepareHeaders(m, decompressorRegistry, Codec.Identity.NONE, false);
+    ClientCallImpl.prepareHeaders(m, decompressorRegistry, Codec.Identity.NONE, false, false);
 
     assertNull(m.get(GrpcUtil.MESSAGE_ENCODING_KEY));
   }
@@ -395,7 +395,7 @@ public class ClientCallImplTest {
           }
         }, false); // not advertised
 
-    ClientCallImpl.prepareHeaders(m, customRegistry, Codec.Identity.NONE, false);
+    ClientCallImpl.prepareHeaders(m, customRegistry, Codec.Identity.NONE, false, false);
 
     Iterable<String> acceptedEncodings = ACCEPT_ENCODING_SPLITTER.split(
         new String(m.get(GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY), GrpcUtil.US_ASCII));
@@ -407,7 +407,7 @@ public class ClientCallImplTest {
   @Test
   public void prepareHeaders_noAcceptedContentEncodingsWithoutFullStreamDecompressionEnabled() {
     Metadata m = new Metadata();
-    ClientCallImpl.prepareHeaders(m, decompressorRegistry, Codec.Identity.NONE, false);
+    ClientCallImpl.prepareHeaders(m, decompressorRegistry, Codec.Identity.NONE, false, false);
 
     assertNull(m.get(GrpcUtil.CONTENT_ACCEPT_ENCODING_KEY));
   }
@@ -457,7 +457,7 @@ public class ClientCallImplTest {
                 },
                 false); // not advertised
 
-    ClientCallImpl.prepareHeaders(m, customRegistry, Codec.Identity.NONE, true);
+    ClientCallImpl.prepareHeaders(m, customRegistry, Codec.Identity.NONE, false, true);
 
     Iterable<String> acceptedMessageEncodings =
         ACCEPT_ENCODING_SPLITTER.split(
@@ -481,12 +481,21 @@ public class ClientCallImplTest {
     m.put(GrpcUtil.CONTENT_ACCEPT_ENCODING_KEY, "gzip".getBytes(GrpcUtil.US_ASCII));
 
     ClientCallImpl.prepareHeaders(
-        m, DecompressorRegistry.emptyInstance(), Codec.Identity.NONE, false);
+        m, DecompressorRegistry.emptyInstance(), Codec.Identity.NONE, false, false);
 
     assertNull(m.get(GrpcUtil.MESSAGE_ENCODING_KEY));
     assertNull(m.get(GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY));
     assertNull(m.get(GrpcUtil.CONTENT_ENCODING_KEY));
     assertNull(m.get(GrpcUtil.CONTENT_ACCEPT_ENCODING_KEY));
+  }
+
+  @Test
+  public void prepareHeaders_contentEncodingAdded() {
+    Metadata m = new Metadata();
+    ClientCallImpl.prepareHeaders(m, decompressorRegistry, Codec.Identity.NONE, true, false);
+
+    // User Agent is removed and set by the transport
+    assertThat(m.get(GrpcUtil.CONTENT_ENCODING_KEY)).isEqualTo("gzip");
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -102,21 +102,21 @@ public class MessageDeframerTest {
     @Before
     public void setUp() {
       if (useGzipInflatingBuffer) {
-        deframer.setFullStreamDecompressor(new GzipInflatingBuffer() {
-          @Override
-          public void addGzippedBytes(ReadableBuffer buffer) {
-            try {
-              ByteArrayOutputStream gzippedOutputStream = new ByteArrayOutputStream();
-              OutputStream gzipCompressingStream = new GZIPOutputStream(
-                      gzippedOutputStream);
-              buffer.readBytes(gzipCompressingStream, buffer.readableBytes());
-              gzipCompressingStream.close();
-              super.addGzippedBytes(ReadableBuffers.wrap(gzippedOutputStream.toByteArray()));
-            } catch (IOException e) {
-              throw new RuntimeException(e);
-            }
-          }
-        });
+        deframer.setFullStreamDecompressor(
+            new GzipInflatingBuffer() {
+              @Override
+              void addGzippedBytes(ReadableBuffer buffer) {
+                try {
+                  ByteArrayOutputStream gzippedOutputStream = new ByteArrayOutputStream();
+                  OutputStream gzipCompressingStream = new GZIPOutputStream(gzippedOutputStream);
+                  buffer.readBytes(gzipCompressingStream, buffer.readableBytes());
+                  gzipCompressingStream.close();
+                  super.addGzippedBytes(ReadableBuffers.wrap(gzippedOutputStream.toByteArray()));
+                } catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+            });
       }
     }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -81,6 +81,7 @@ public class TestServiceClient {
   private String defaultServiceAccount;
   private String serviceAccountKeyFile;
   private String oauthScope;
+  private boolean fullStreamCompression;
   private boolean fullStreamDecompression;
 
   private Tester tester = new Tester();
@@ -132,6 +133,8 @@ public class TestServiceClient {
         serviceAccountKeyFile = value;
       } else if ("oauth_scope".equals(key)) {
         oauthScope = value;
+      } else if ("full_stream_compression".equals(key)) {
+        fullStreamCompression = Boolean.parseBoolean(value);
       } else if ("full_stream_decompression".equals(key)) {
         fullStreamDecompression = Boolean.parseBoolean(value);
       } else {
@@ -162,6 +165,8 @@ public class TestServiceClient {
           + "\n  --service_account_key_file  Path to service account json key file."
             + c.serviceAccountKeyFile
           + "\n  --oauth_scope               Scope for OAuth tokens. Default " + c.oauthScope
+          + "\n  --full_stream_compression Enable full-stream compression. Default "
+            + c.fullStreamCompression
           + "\n  --full_stream_decompression Enable full-stream decompression. Default "
             + c.fullStreamDecompression
       );
@@ -336,6 +341,9 @@ public class TestServiceClient {
         if (serverHostOverride != null) {
           nettyBuilder.overrideAuthority(serverHostOverride);
         }
+        if (fullStreamCompression) {
+          nettyBuilder.enableFullStreamCompression();
+        }
         if (fullStreamDecompression) {
           nettyBuilder.enableFullStreamDecompression();
         }
@@ -359,6 +367,9 @@ public class TestServiceClient {
           }
         } else {
           okBuilder.usePlaintext(true);
+        }
+        if (fullStreamCompression) {
+          okBuilder.enableFullStreamCompression();
         }
         if (fullStreamDecompression) {
           okBuilder.enableFullStreamDecompression();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -124,13 +124,17 @@ public class TestServiceServer {
       sslContext = GrpcSslContexts.forServer(
               TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key")).build();
     }
-    server = NettyServerBuilder.forPort(port)
-        .sslContext(sslContext)
-        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
-        .addService(ServerInterceptors.intercept(
-            new TestServiceImpl(executor),
-            TestServiceImpl.interceptors()))
-        .build().start();
+    server =
+        NettyServerBuilder.forPort(port)
+            .sslContext(sslContext)
+            .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+            .enableFullStreamCompression()
+            .enableFullStreamDecompression()
+            .addService(
+                ServerInterceptors.intercept(
+                    new TestServiceImpl(executor), TestServiceImpl.interceptors()))
+            .build()
+            .start();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This adds support for compressing outbound streams, and also adds the API methods to enable decompressing inbound streams on the server side. The main changes are in `MessageFramer`; the bulk of the rest of the file modifications are just API glue to support enabling full stream (de)compression. This is a follow-up to https://github.com/grpc/grpc-java/pull/3403

Without enabling any of the new options, this PR does still add `content-encoding: identity` to the server's outbound headers. This is in line with current behavior with `grpc-encoding` (see `ServerCallImpl#sendHeaders`), but can be suppressed if this might pose an integration risk while this feature is still experimental.

edit: https://github.com/grpc/grpc-java/issues/1944 can be closed once this is in