### PR TITLE
okhttp: support Conscrypt security provider

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,11 +10,37 @@ On Android, use the [Play Services Provider](#tls-on-android). For non-Android s
 
 ## TLS on Android
 
-On Android we recommend the use of the [Play Services Dynamic Security Provider](http://appfoundry.be/blog/2014/11/18/Google-Play-Services-Dynamic-Security-Provider) to ensure your application has an up-to-date OpenSSL library with the necessary ciper-suites and a reliable ALPN implementation.
+On Android we recommend the use of the [Play Services Dynamic Security
+Provider](https://www.appfoundry.be/blog/2014/11/18/Google-Play-Services-Dynamic-Security-Provider/)
+to ensure your application has an up-to-date OpenSSL library with the necessary
+ciper-suites and a reliable ALPN implementation. This requires [updating the
+security provider at
+runtime](https://developer.android.com/training/articles/security-gms-provider.html).
 
-You may need to [update the security provider](https://developer.android.com/training/articles/security-gms-provider.html) to enable ALPN support, especially for Android versions < 5.0. If the provider fails to update, ALPN may not work.
+Although ALPN mostly works on newer Android releases (especially since 5.0),
+there are bugs and discovered security vulnerabilities that are only fixed by
+upgrading the security provider. Thus, we recommend using the Play Service
+Dynamic Security Provider for all Android versions.
 
 *Note: The Dynamic Security Provider must be installed **before** creating a gRPC OkHttp channel. gRPC's OkHttpProtocolNegotiator statically initializes the security protocol(s) available to gRPC, which means that changes to the security provider after the first channel is created will not be picked up by gRPC.*
+
+### Bundling Conscrypt
+
+If depending on Play Services is not an option for your app, then you may bundle
+[Conscrypt](https://conscrypt.org) with your application. Binaries are available
+on [Maven
+Central](https://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.conscrypt%20a%3Aconscrypt-android).
+
+Like the Play Services Dynamic Security Provider, you must still "install"
+Conscrypt before use.
+
+```java
+import org.conscrypt.Conscrypt;
+import java.security.Security;
+...
+
+Security.addProvider(Conscrypt.newProvider());
+```
 
 ## TLS with OpenSSL
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ import org.conscrypt.Conscrypt;
 import java.security.Security;
 ...
 
-Security.addProvider(Conscrypt.newProvider());
+Security.insertProviderAt(Conscrypt.newProvider(), 1);
 ```
 
 ## TLS with OpenSSL

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpProtocolNegotiator.java
@@ -25,7 +25,6 @@ import io.grpc.okhttp.internal.Protocol;
 import io.grpc.okhttp.internal.Util;
 import java.io.IOException;
 import java.net.Socket;
-import java.security.Provider;
 import java.security.Security;
 import java.util.List;
 import java.util.logging.Level;
@@ -221,14 +220,17 @@ class OkHttpProtocolNegotiator {
     static TlsExtensionType pickTlsExtensionType(ClassLoader loader) {
       // Decide which TLS Extension (APLN and NPN) we will use, follow the rules:
       // 1. If Google Play Services Security Provider is installed, use both
-      // 2. If on Android 5.0 or later, use both, else
-      // 3. If on Android 4.1 or later, use NPN, else
-      // 4. Fail.
-      // TODO(madongfly): Logging.
+      // 2. If Conscrypt is installed, use both
+      // 3. If on Android 5.0 or later, use both, else
+      // 4. If on Android 4.1 or later, use NPN, else
+      // 5. Fail.
 
       // Check if Google Play Services Security Provider is installed.
-      Provider provider = Security.getProvider("GmsCore_OpenSSL");
-      if (provider != null) {
+      if (Security.getProvider("GmsCore_OpenSSL") != null) {
+        return TlsExtensionType.ALPN_AND_NPN;
+      }
+
+      if (Security.getProvider("Conscrypt") != null) {
         return TlsExtensionType.ALPN_AND_NPN;
       }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpProtocolNegotiatorTest.java
@@ -19,7 +19,6 @@ package io.grpc.okhttp;
 import static com.google.common.base.Charsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -28,17 +27,13 @@ import static org.mockito.Mockito.when;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.grpc.okhttp.OkHttpProtocolNegotiator.AndroidNegotiator;
-import io.grpc.okhttp.OkHttpProtocolNegotiator.AndroidNegotiator.TlsExtensionType;
 import io.grpc.okhttp.internal.Platform;
+import io.grpc.okhttp.internal.Platform.TlsExtensionType;
 import io.grpc.okhttp.internal.Protocol;
 import java.io.IOException;
-import java.security.Provider;
-import java.security.Security;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -53,21 +48,8 @@ import org.mockito.Mockito;
 public class OkHttpProtocolNegotiatorTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
-  private final Provider fakeSecurityProvider = new Provider("GmsCore_OpenSSL", 1.0, "info") {};
-  private final Provider fakeConscrypt = new Provider("Conscrypt", 1.0, "info") {};
   private final SSLSocket sock = mock(SSLSocket.class);
   private final Platform platform = mock(Platform.class);
-
-  @Before
-  public void setUp() {
-    // Tests that depend on android need this to know which protocol negotiation to use.
-    Security.addProvider(fakeSecurityProvider);
-  }
-
-  @After
-  public void tearDown() {
-    Security.removeProvider(fakeSecurityProvider.getName());
-  }
 
   @Test
   public void createNegotiator_isAndroid() {
@@ -180,103 +162,11 @@ public class OkHttpProtocolNegotiatorTest {
     verify(platform).afterHandshake(sock);
   }
 
-  @Test
-  public void pickTlsExtensionType_securityProvider() throws Exception {
-    assertNotNull(Security.getProvider(fakeSecurityProvider.getName()));
-
-    AndroidNegotiator.TlsExtensionType tlsExtensionType =
-        AndroidNegotiator.pickTlsExtensionType(getClass().getClassLoader());
-
-    assertEquals(TlsExtensionType.ALPN_AND_NPN, tlsExtensionType);
-  }
-
-  @Test
-  public void pickTlsExtensionType_android50() throws Exception {
-    Security.removeProvider(fakeSecurityProvider.getName());
-    ClassLoader cl = new ClassLoader(this.getClass().getClassLoader()) {
-      @Override
-      protected Class<?> findClass(String name) throws ClassNotFoundException {
-        // Just don't throw.
-        if ("android.net.Network".equals(name)) {
-          return null;
-        }
-        return super.findClass(name);
-      }
-    };
-
-    AndroidNegotiator.TlsExtensionType tlsExtensionType =
-        AndroidNegotiator.pickTlsExtensionType(cl);
-
-    assertEquals(TlsExtensionType.ALPN_AND_NPN, tlsExtensionType);
-  }
-
-  @Test
-  public void pickTlsExtensionType_android41() throws Exception {
-    Security.removeProvider(fakeSecurityProvider.getName());
-    ClassLoader cl = new ClassLoader(this.getClass().getClassLoader()) {
-      @Override
-      protected Class<?> findClass(String name) throws ClassNotFoundException {
-        // Just don't throw.
-        if ("android.app.ActivityOptions".equals(name)) {
-          return null;
-        }
-        return super.findClass(name);
-      }
-    };
-
-    AndroidNegotiator.TlsExtensionType tlsExtensionType =
-        AndroidNegotiator.pickTlsExtensionType(cl);
-
-    assertEquals(TlsExtensionType.NPN, tlsExtensionType);
-  }
-
-  @Test
-  public void pickTlsExtensionType_android41WithConscrypt() throws Exception {
-    Security.removeProvider(fakeSecurityProvider.getName());
-    Security.addProvider(fakeConscrypt);
-    ClassLoader cl =
-        new ClassLoader(this.getClass().getClassLoader()) {
-          @Override
-          protected Class<?> findClass(String name) throws ClassNotFoundException {
-            // Just don't throw.
-            if ("android.app.ActivityOptions".equals(name)) {
-              return null;
-            }
-            return super.findClass(name);
-          }
-        };
-
-    AndroidNegotiator.TlsExtensionType tlsExtensionType =
-        AndroidNegotiator.pickTlsExtensionType(cl);
-
-    assertEquals(TlsExtensionType.ALPN_AND_NPN, tlsExtensionType);
-
-    // Clean up
-    Security.removeProvider(fakeConscrypt.getName());
-  }
-
-  @Test
-  public void pickTlsExtensionType_none() throws Exception {
-    Security.removeProvider(fakeSecurityProvider.getName());
-
-    AndroidNegotiator.TlsExtensionType tlsExtensionType =
-        AndroidNegotiator.pickTlsExtensionType(getClass().getClassLoader());
-
-    assertNull(tlsExtensionType);
-  }
-
-  @Test
-  public void androidNegotiator_failsOnNull() {
-    thrown.expect(NullPointerException.class);
-    thrown.expectMessage("Unable to pick a TLS extension");
-
-    new AndroidNegotiator(platform, null);
-  }
-
   // Checks that the super class is properly invoked.
   @Test
   public void negotiate_android_handshakeFails() throws Exception {
-    AndroidNegotiator negotiator = new AndroidNegotiator(platform, TlsExtensionType.ALPN_AND_NPN);
+    when(platform.getTlsExtensionType()).thenReturn(TlsExtensionType.ALPN_AND_NPN);
+    AndroidNegotiator negotiator = new AndroidNegotiator(platform);
 
     FakeAndroidSslSocket androidSock = new FakeAndroidSslSocket() {
       @Override
@@ -301,7 +191,8 @@ public class OkHttpProtocolNegotiatorTest {
 
   @Test
   public void getSelectedProtocol_alpn() throws Exception {
-    AndroidNegotiator negotiator = new AndroidNegotiator(platform, TlsExtensionType.ALPN_AND_NPN);
+    when(platform.getTlsExtensionType()).thenReturn(TlsExtensionType.ALPN_AND_NPN);
+    AndroidNegotiator negotiator = new AndroidNegotiator(platform);
     FakeAndroidSslSocket androidSock = new FakeAndroidSslSocketAlpn();
 
     String actual = negotiator.getSelectedProtocol(androidSock);
@@ -319,7 +210,8 @@ public class OkHttpProtocolNegotiatorTest {
 
   @Test
   public void getSelectedProtocol_npn() throws Exception {
-    AndroidNegotiator negotiator = new AndroidNegotiator(platform, TlsExtensionType.NPN);
+    when(platform.getTlsExtensionType()).thenReturn(TlsExtensionType.NPN);
+    AndroidNegotiator negotiator = new AndroidNegotiator(platform);
     FakeAndroidSslSocket androidSock = new FakeAndroidSslSocketNpn();
 
     String actual = negotiator.getSelectedProtocol(androidSock);

--- a/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Platform.java
+++ b/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/Platform.java
@@ -61,25 +61,22 @@ import okio.Buffer;
 public class Platform {
   public static final Logger logger = Logger.getLogger(Platform.class.getName());
 
+  public enum TlsExtensionType {
+    ALPN_AND_NPN,
+    NPN,
+    NONE,
+  }
+
   /**
-   * List of preferred security provider names, in order of preference. These will be used, if
-   * present, followed by {@code SECONDARY_ANDROID_SECURITY_PROVIDER_CLASSES} if these are
-   * unavailable.
+   * List of recognized security providers. The first recognized security provider according to the
+   * preference order returned by {@link Security#getProviders} will be selected.
    */
   private static final String[] ANDROID_SECURITY_PROVIDERS =
       new String[] {
         // See https://developer.android.com/training/articles/security-gms-provider.html
-        "GmsCore_OpenSSL",
-        "Conscrypt"
-      };
-  /**
-   * List of secondary security provider class names to use in order of preference, if the
-   * preferred providers are unavailable.
-   */
-  private static final String[] SECONDARY_ANDROID_SECURITY_PROVIDER_CLASSES =
-      new String[] {
-        "com.android.org.conscrypt.OpenSSLProvider",
+        "com.google.android.gms.org.conscrypt.OpenSSLProvider",
         "org.conscrypt.OpenSSLProvider",
+        "com.android.org.conscrypt.OpenSSLProvider",
         "org.apache.harmony.xnet.provider.jsse.OpenSSLProvider"
       };
 
@@ -114,6 +111,11 @@ public class Platform {
     return sslProvider;
   }
 
+  /** Returns the TLS extension type available (ALPN and NPN, NPN, or None). */
+  public TlsExtensionType getTlsExtensionType() {
+    return TlsExtensionType.NONE;
+  }
+
   /**
    * Configure TLS extensions on {@code sslSocket} for {@code route}.
    *
@@ -143,10 +145,9 @@ public class Platform {
 
   /** Attempt to match the host runtime to a capable Platform implementation. */
   private static Platform findPlatform() {
-    Provider sslProvider = GrpcUtil.IS_RESTRICTED_APPENGINE ?
-        getAppEngineProvider()
-        : getAndroidSecurityProvider();
-    if (sslProvider != null) {
+    Provider androidOrAppEngineProvider =
+        GrpcUtil.IS_RESTRICTED_APPENGINE ? getAppEngineProvider() : getAndroidSecurityProvider();
+    if (androidOrAppEngineProvider != null) {
       // Attempt to find Android 2.3+ APIs.
       OptionalMethod<Socket> setUseSessionTickets
           = new OptionalMethod<Socket>(null, "setUseSessionTickets", boolean.class);
@@ -167,9 +168,31 @@ public class Platform {
       } catch (ClassNotFoundException ignored) {
       } catch (NoSuchMethodException ignored) {
       }
-      return new Android(setUseSessionTickets, setHostname, trafficStatsTagSocket,
-          trafficStatsUntagSocket, getAlpnSelectedProtocol, setAlpnProtocols, sslProvider);
+
+      TlsExtensionType tlsExtensionType;
+      if (GrpcUtil.IS_RESTRICTED_APPENGINE) {
+        tlsExtensionType = TlsExtensionType.ALPN_AND_NPN;
+      } else if (androidOrAppEngineProvider.getName().equals("GmsCore_OpenSSL")
+          || androidOrAppEngineProvider.getName().equals("Conscrypt")) {
+        tlsExtensionType = TlsExtensionType.ALPN_AND_NPN;
+      } else if (isAtLeastAndroid5()) {
+        tlsExtensionType = TlsExtensionType.ALPN_AND_NPN;
+      } else if (isAtLeastAndroid41()) {
+        tlsExtensionType = TlsExtensionType.NPN;
+      } else {
+        tlsExtensionType = TlsExtensionType.NONE;
+      }
+      return new Android(
+          setUseSessionTickets,
+          setHostname,
+          trafficStatsTagSocket,
+          trafficStatsUntagSocket,
+          getAlpnSelectedProtocol,
+          setAlpnProtocols,
+          androidOrAppEngineProvider,
+          tlsExtensionType);
     }
+    Provider sslProvider;
     try {
       sslProvider = SSLContext.getDefault().getProvider();
     } catch (NoSuchAlgorithmException nsae) {
@@ -193,7 +216,32 @@ public class Platform {
     } catch (NoSuchMethodException ignored) {
     }
 
+    // TODO(ericgribkoff) Return null here
     return new Platform(sslProvider);
+  }
+
+  private static boolean isAtLeastAndroid5() {
+    try {
+      Platform.class
+          .getClassLoader()
+          .loadClass("android.net.Network"); // Arbitrary class added in Android 5.0.
+      return true;
+    } catch (ClassNotFoundException e) {
+      logger.log(Level.FINE, "Can't find class", e);
+    }
+    return false;
+  }
+
+  private static boolean isAtLeastAndroid41() {
+    try {
+      Platform.class
+          .getClassLoader()
+          .loadClass("android.app.ActivityOptions"); // Arbitrary class added in Android 4.1.
+      return true;
+    } catch (ClassNotFoundException e) {
+      logger.log(Level.FINE, "Can't find class", e);
+    }
+    return false;
   }
 
   /**
@@ -210,20 +258,13 @@ public class Platform {
   }
 
   /**
-   * Select from the available security providers in preference order. If a preferred provider is
-   * not found then warn but continue.
+   * Select the first recognized security provider according to the preference order returned by
+   * {@link Security#getProviders}. If a recognized provider is not found then warn but continue.
    */
   private static Provider getAndroidSecurityProvider() {
-    for (String providerName : ANDROID_SECURITY_PROVIDERS) {
-      Provider provider = Security.getProvider(providerName);
-      if (provider != null) {
-        logger.log(Level.FINE, "Found registered provider {0}", provider);
-        return provider;
-      }
-    }
-    for (String providerClassName : SECONDARY_ANDROID_SECURITY_PROVIDER_CLASSES) {
-      Provider[] providers = Security.getProviders();
-      for (Provider availableProvider : providers) {
+    Provider[] providers = Security.getProviders();
+    for (Provider availableProvider : providers) {
+      for (String providerClassName : ANDROID_SECURITY_PROVIDERS) {
         if (providerClassName.equals(availableProvider.getClass().getName())) {
           logger.log(Level.FINE, "Found registered provider {0}", providerClassName);
           return availableProvider;
@@ -234,7 +275,7 @@ public class Platform {
     return null;
   }
 
-  /** Android 2.3 or better. */
+  /** Android 2.3 or better, or AppEngine with Conscrypt. */
   private static class Android extends Platform {
 
     private final OptionalMethod<Socket> setUseSessionTickets;
@@ -248,10 +289,17 @@ public class Platform {
     private final OptionalMethod<Socket> getAlpnSelectedProtocol;
     private final OptionalMethod<Socket> setAlpnProtocols;
 
-    public Android(OptionalMethod<Socket> setUseSessionTickets, OptionalMethod<Socket> setHostname,
-        Method trafficStatsTagSocket, Method trafficStatsUntagSocket,
-        OptionalMethod<Socket> getAlpnSelectedProtocol, OptionalMethod<Socket> setAlpnProtocols,
-        Provider provider) {
+    private final TlsExtensionType tlsExtensionType;
+
+    public Android(
+        OptionalMethod<Socket> setUseSessionTickets,
+        OptionalMethod<Socket> setHostname,
+        Method trafficStatsTagSocket,
+        Method trafficStatsUntagSocket,
+        OptionalMethod<Socket> getAlpnSelectedProtocol,
+        OptionalMethod<Socket> setAlpnProtocols,
+        Provider provider,
+        TlsExtensionType tlsExtensionType) {
       super(provider);
       this.setUseSessionTickets = setUseSessionTickets;
       this.setHostname = setHostname;
@@ -259,6 +307,12 @@ public class Platform {
       this.trafficStatsUntagSocket = trafficStatsUntagSocket;
       this.getAlpnSelectedProtocol = getAlpnSelectedProtocol;
       this.setAlpnProtocols = setAlpnProtocols;
+      this.tlsExtensionType = tlsExtensionType;
+    }
+
+    @Override
+    public TlsExtensionType getTlsExtensionType() {
+      return tlsExtensionType;
     }
 
     @Override public void connectSocket(Socket socket, InetSocketAddress address,
@@ -339,6 +393,11 @@ public class Platform {
       this.removeMethod = removeMethod;
       this.clientProviderClass = clientProviderClass;
       this.serverProviderClass = serverProviderClass;
+    }
+
+    @Override
+    public TlsExtensionType getTlsExtensionType() {
+      return TlsExtensionType.ALPN_AND_NPN;
     }
 
     @Override public void configureTlsExtensions(


### PR DESCRIPTION
This addresses https://github.com/grpc/grpc-java/issues/3966 and incorporates the text changes to `SECURITY.md` from #3301. Tested with `org.conscrypt:conscrypt-android:1.0.0.RC14`, as well as Google Play's security provider.

This changes our detection of the Google Play security provider from using the class name to the provider name, `GmsCore_OpenSSL`. This would seem to be equally as stable, and recent versions of OkHttp do the [check similarly](https://github.com/square/okhttp/blob/1d9c158a96382facc3be672f6b41dc79fb5eb48b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java#L196), although I realized in testing this that OkHttp uses `GMSCore_OpenSSL`, which did not work in my tests (checking elsewhere, it should indeed be `GmsCore_OpenSSL`, and the lookup is case-sensitive).