### PR TITLE
core: retry part I followup, refactor commit()

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -56,37 +56,69 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     this.method = method;
   }
 
-  private boolean commit(Substream winningSubstream) {
-    if (commit0(winningSubstream)) {
-      postCommit();
-      return true;
+  @GuardedBy("lock")
+  @Nullable // null if already committed
+  @CheckReturnValue
+  private Runnable commit(Substream winningSubstream) {
+    final Runnable runnable = commit0(winningSubstream);
+    if (runnable == null) {
+      return null;
     }
-    return false;
+
+    class CommitTask implements Runnable {
+      @Override
+      public void run() {
+        runnable.run();
+        postCommit();
+      }
+    }
+
+    return new CommitTask();
   }
 
-  private boolean commit0(Substream winningSubstream) {
-    Collection<Substream> savedDrainedSubstreams;
-    synchronized (lock) {
-      if (state.winningSubstream != null) {
-        return false;
+  @GuardedBy("lock")
+  @Nullable // null if already committed
+  @CheckReturnValue
+  private Runnable commit0(final Substream winningSubstream) {
+    if (state.winningSubstream != null) {
+      return null;
+    }
+    final Collection<Substream> savedDrainedSubstreams = state.drainedSubstreams;
+
+    state = state.committed(winningSubstream);
+
+    class Commit0Task implements Runnable {
+      @Override
+      public void run() {
+        // For hedging only, not needed for normal retry
+        // TODO(zdapeng): also cancel all the scheduled hedges.
+        for (Substream substream : savedDrainedSubstreams) {
+          if (substream != winningSubstream) {
+            substream.stream.cancel(CANCELLED_BECAUSE_COMMITTED);
+          }
+        }
       }
-
-      savedDrainedSubstreams = state.drainedSubstreams;
-
-      state = state.committed(winningSubstream);
     }
 
-    // For hedging only, not needed for normal retry
-    // TODO(zdapeng): also cancel all the scheduled hedges.
-    for (Substream substream : savedDrainedSubstreams) {
-      if (substream != winningSubstream) {
-        substream.stream.cancel(CANCELLED_BECAUSE_COMMITTED);
-      }
-    }
-    return true;
+    return new Commit0Task();
   }
 
   abstract void postCommit();
+
+  /**
+   * Calls commit() and if successful runs the post commit task.
+   */
+  private void commitAndRun(Substream winningSubstream) {
+    Runnable postCommitTask;
+
+    synchronized (lock) {
+      postCommitTask = commit(winningSubstream);
+    }
+
+    if (postCommitTask != null) {
+      postCommitTask.run();
+    }
+  }
 
   private void retry() {
     Substream substream = createSubstream();
@@ -199,7 +231,14 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   public final void cancel(Status reason) {
     Substream noopSubstream = new Substream();
     noopSubstream.stream = new NoopClientStream();
-    if (commit0(noopSubstream)) {
+    Runnable runnable;
+
+    synchronized (lock) {
+      runnable = commit0(noopSubstream);
+    }
+
+    if (runnable != null) {
+      runnable.run();
       masterListener.closed(reason, new Metadata());
       postCommit();
       return;
@@ -427,7 +466,8 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
     @Override
     public void headersRead(Metadata headers) {
-      if (commit(substream)) {
+      commitAndRun(substream);
+      if (state.winningSubstream == substream) {
         masterListener.headersRead(headers);
       }
     }
@@ -444,7 +484,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
         // TODO(zdapeng): backoff and schedule; retry() should run in an executor
         retry();
       } else if (!hasHedging()) {
-        commit(substream);
+        commitAndRun(substream);
         if (state.winningSubstream == substream) {
           masterListener.closed(status, trailers);
         }


### PR DESCRIPTION
Based on the comment in #3839, 

> I think it may not be useful/necessary to make this a volatile instead of using a lock. It's not used one we've committed, we likely only have 1-2 streams at a time, the critical section seems quite controlled (doesn't need to call into arbitrary code), and using a volatile is looking complicated/possibly-broken. The first 3 points are different from our other atomic usages here.

it's more reasonable and convenient to return a `Runnable` for `commit()` method because we want to execute part of the commit under a lock and run part of it out of the lock.