### PR TITLE
core: rename io.grpc.internal.ChannelTracer to CallTracer

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -337,7 +337,7 @@ public abstract class AbstractManagedChannelImplBuilder
         GrpcUtil.STOPWATCH_SUPPLIER,
         getEffectiveInterceptors(),
         GrpcUtil.getProxyDetector(),
-        ChannelTracer.getDefaultFactory());
+        CallTracer.getDefaultFactory());
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/internal/CallTracer.java
+++ b/core/src/main/java/io/grpc/internal/CallTracer.java
@@ -46,7 +46,7 @@ final class CallTracer {
     }
   }
 
-  void updateInternalChannelStatsBuilder(InternalChannelStats.Builder builder) {
+  void updateBuilder(InternalChannelStats.Builder builder) {
     builder
         .setCallsStarted(callsStarted.value())
         .setCallsSucceeded(callsSucceeded.value())

--- a/core/src/main/java/io/grpc/internal/CallTracer.java
+++ b/core/src/main/java/io/grpc/internal/CallTracer.java
@@ -20,16 +20,16 @@ import com.google.common.annotations.VisibleForTesting;
 import io.grpc.InternalChannelStats;
 
 /**
- * A collection of channel level stats for channelz.
+ * A collection of call stats for channelz.
  */
-final class ChannelTracer {
+final class CallTracer {
   private final TimeProvider timeProvider;
   private final LongCounter callsStarted = LongCounterFactory.create();
   private final LongCounter callsSucceeded = LongCounterFactory.create();
   private final LongCounter callsFailed = LongCounterFactory.create();
   private volatile long lastCallStartedMillis;
 
-  ChannelTracer(TimeProvider timeProvider) {
+  CallTracer(TimeProvider timeProvider) {
     this.timeProvider = timeProvider;
   }
 
@@ -46,8 +46,9 @@ final class ChannelTracer {
     }
   }
 
-  public void updateBuilder(InternalChannelStats.Builder builder) {
-    builder.setCallsStarted(callsStarted.value())
+  void updateInternalChannelStatsBuilder(InternalChannelStats.Builder builder) {
+    builder
+        .setCallsStarted(callsStarted.value())
         .setCallsSucceeded(callsSucceeded.value())
         .setCallsFailed(callsFailed.value())
         .setLastCallStartedMillis(lastCallStartedMillis);
@@ -60,7 +61,7 @@ final class ChannelTracer {
   }
 
   public interface Factory {
-    ChannelTracer create();
+    CallTracer create();
   }
 
   static final TimeProvider SYSTEM_TIME_PROVIDER = new TimeProvider() {
@@ -72,8 +73,8 @@ final class ChannelTracer {
 
   static final Factory DEFAULT_FACTORY = new Factory() {
     @Override
-    public ChannelTracer create() {
-      return new ChannelTracer(SYSTEM_TIME_PROVIDER);
+    public CallTracer create() {
+      return new CallTracer(SYSTEM_TIME_PROVIDER);
     }
   };
 

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -68,7 +68,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
 
   private final MethodDescriptor<ReqT, RespT> method;
   private final Executor callExecutor;
-  private final ChannelTracer channelTracer;
+  private final CallTracer channelCallsTracer;
   private final Context context;
   private volatile ScheduledFuture<?> deadlineCancellationFuture;
   private final boolean unaryRequest;
@@ -88,7 +88,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       MethodDescriptor<ReqT, RespT> method, Executor executor, CallOptions callOptions,
       ClientTransportProvider clientTransportProvider,
       ScheduledExecutorService deadlineCancellationExecutor,
-      ChannelTracer channelTracer) {
+      CallTracer channelCallsTracer) {
     this.method = method;
     // If we know that the executor is a direct executor, we don't need to wrap it with a
     // SerializingExecutor. This is purely for performance reasons.
@@ -96,7 +96,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     this.callExecutor = executor == directExecutor()
         ? new SerializeReentrantCallsDirectExecutor()
         : new SerializingExecutor(executor);
-    this.channelTracer = channelTracer;
+    this.channelCallsTracer = channelCallsTracer;
     // Propagate the context from the thread which initiated the call to all callbacks.
     this.context = Context.current();
     this.unaryRequest = method.getType() == MethodType.UNARY
@@ -261,7 +261,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     stream.setCompressor(compressor);
     stream.setFullStreamDecompression(fullStreamDecompression);
     stream.setDecompressorRegistry(decompressorRegistry);
-    channelTracer.reportCallStarted();
+    channelCallsTracer.reportCallStarted();
     stream.start(new ClientStreamListenerImpl(observer));
 
     // Delay any sources of cancellation after start(), because most of the transports are broken if
@@ -557,7 +557,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
         closeObserver(observer, status, trailers);
       } finally {
         removeContextListenerAndCancelDeadlineFuture();
-        channelTracer.reportCallEnded(status.isOk());
+        channelCallsTracer.reportCallEnded(status.isOk());
       }
     }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -273,7 +273,7 @@ public final class ManagedChannelImpl
   public ListenableFuture<InternalChannelStats> getStats() {
     SettableFuture<InternalChannelStats> ret = SettableFuture.create();
     InternalChannelStats.Builder builder = new InternalChannelStats.Builder();
-    channelCallTracer.updateInternalChannelStatsBuilder(builder);
+    channelCallTracer.updateBuilder(builder);
     builder.setTarget(target).setState(channelStateManager.getState());
     ret.set(builder.build());
     return ret;
@@ -1136,7 +1136,7 @@ public final class ManagedChannelImpl
     public ListenableFuture<InternalChannelStats> getStats() {
       SettableFuture<InternalChannelStats> ret = SettableFuture.create();
       InternalChannelStats.Builder builder = new InternalChannelStats.Builder();
-      subchannelCallTracer.updateInternalChannelStatsBuilder(builder);
+      subchannelCallTracer.updateBuilder(builder);
       builder.setTarget(target).setState(subchannel.getState());
       ret.set(builder.build());
       return ret;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -197,8 +197,8 @@ public final class ManagedChannelImpl
 
   private final ManagedChannelReference phantom;
 
-  private final ChannelTracer.Factory channelTracerFactory; // new tracer for each oobchannel
-  private final ChannelTracer channelTracer;
+  private final CallTracer.Factory callTracerFactory;
+  private final CallTracer channelCallTracer;
 
   // Called from channelExecutor
   private final ManagedClientTransport.Listener delayedTransportListener =
@@ -273,9 +273,8 @@ public final class ManagedChannelImpl
   public ListenableFuture<InternalChannelStats> getStats() {
     SettableFuture<InternalChannelStats> ret = SettableFuture.create();
     InternalChannelStats.Builder builder = new InternalChannelStats.Builder();
-    channelTracer.updateBuilder(builder);
-    builder.setTarget(target)
-        .setState(channelStateManager.getState());
+    channelCallTracer.updateInternalChannelStatsBuilder(builder);
+    builder.setTarget(target).setState(channelStateManager.getState());
     ret.set(builder.build());
     return ret;
   }
@@ -459,7 +458,7 @@ public final class ManagedChannelImpl
       Supplier<Stopwatch> stopwatchSupplier,
       List<ClientInterceptor> interceptors,
       ProxyDetector proxyDetector,
-      ChannelTracer.Factory channelTracerFactory) {
+      CallTracer.Factory callTracerFactory) {
     this.target = checkNotNull(builder.target, "target");
     this.nameResolverFactory = builder.getNameResolverFactory();
     this.nameResolverParams = checkNotNull(builder.getNameResolverParams(), "nameResolverParams");
@@ -495,8 +494,8 @@ public final class ManagedChannelImpl
     this.proxyDetector = proxyDetector;
 
     phantom = new ManagedChannelReference(this);
-    this.channelTracerFactory = channelTracerFactory;
-    channelTracer = channelTracerFactory.create();
+    this.callTracerFactory = callTracerFactory;
+    channelCallTracer = callTracerFactory.create();
     logger.log(Level.FINE, "[{0}] Created with target {1}", new Object[] {getLogId(), target});
   }
 
@@ -648,7 +647,7 @@ public final class ManagedChannelImpl
               callOptions,
               transportProvider,
               terminated ? null : transportFactory.getScheduledExecutorService(),
-          channelTracer)
+          channelCallTracer)
           .setFullStreamDecompression(fullStreamDecompression)
           .setDecompressorRegistry(decompressorRegistry)
           .setCompressorRegistry(compressorRegistry);
@@ -836,7 +835,7 @@ public final class ManagedChannelImpl
       checkNotNull(attrs, "attrs");
       // TODO(ejona): can we be even stricter? Like loadBalancer == null?
       checkState(!terminated, "Channel is terminated");
-      final SubchannelImpl subchannel = new SubchannelImpl(attrs, channelTracerFactory.create());
+      final SubchannelImpl subchannel = new SubchannelImpl(attrs, callTracerFactory.create());
       final InternalSubchannel internalSubchannel = new InternalSubchannel(
             addressGroup, authority(), userAgent, backoffPolicyProvider, transportFactory,
             transportFactory.getScheduledExecutorService(), stopwatchSupplier, channelExecutor,
@@ -930,7 +929,7 @@ public final class ManagedChannelImpl
       checkState(!terminated, "Channel is terminated");
       final OobChannel oobChannel = new OobChannel(
           authority, oobExecutorPool, transportFactory.getScheduledExecutorService(),
-          channelExecutor, channelTracerFactory);
+          channelExecutor, callTracerFactory);
       final InternalSubchannel internalSubchannel = new InternalSubchannel(
           addressGroup, authority, userAgent, backoffPolicyProvider, transportFactory,
           transportFactory.getScheduledExecutorService(), stopwatchSupplier, channelExecutor,
@@ -1055,16 +1054,16 @@ public final class ManagedChannelImpl
     InternalSubchannel subchannel;
     final Object shutdownLock = new Object();
     final Attributes attrs;
-    final ChannelTracer subchannelTracer;
+    final CallTracer subchannelCallTracer;
 
     @GuardedBy("shutdownLock")
     boolean shutdownRequested;
     @GuardedBy("shutdownLock")
     ScheduledFuture<?> delayedShutdownTask;
 
-    SubchannelImpl(Attributes attrs, ChannelTracer subchannelTracer) {
+    SubchannelImpl(Attributes attrs, CallTracer subchannelCallTracer) {
       this.attrs = checkNotNull(attrs, "attrs");
-      this.subchannelTracer = subchannelTracer;
+      this.subchannelCallTracer = subchannelCallTracer;
     }
 
     @Override
@@ -1137,9 +1136,8 @@ public final class ManagedChannelImpl
     public ListenableFuture<InternalChannelStats> getStats() {
       SettableFuture<InternalChannelStats> ret = SettableFuture.create();
       InternalChannelStats.Builder builder = new InternalChannelStats.Builder();
-      subchannelTracer.updateBuilder(builder);
-      builder.setTarget(target)
-          .setState(subchannel.getState());
+      subchannelCallTracer.updateInternalChannelStatsBuilder(builder);
+      builder.setTarget(target).setState(subchannel.getState());
       ret.set(builder.build());
       return ret;
     }

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -157,7 +157,7 @@ final class OobChannel
         public ListenableFuture<InternalChannelStats> getStats() {
           SettableFuture<InternalChannelStats> ret = SettableFuture.create();
           InternalChannelStats.Builder builder = new InternalChannelStats.Builder();
-          subchannelCallsTracer.updateInternalChannelStatsBuilder(builder);
+          subchannelCallsTracer.updateBuilder(builder);
           builder.setTarget(authority).setState(subchannel.getState());
           ret.set(builder.build());
           return ret;
@@ -259,7 +259,7 @@ final class OobChannel
   public ListenableFuture<InternalChannelStats> getStats() {
     SettableFuture<InternalChannelStats> ret = SettableFuture.create();
     InternalChannelStats.Builder builder = new InternalChannelStats.Builder();
-    channelCallsTracer.updateInternalChannelStatsBuilder(builder);
+    channelCallsTracer.updateBuilder(builder);
     builder.setTarget(authority).setState(subchannel.getState());
     ret.set(builder.build());
     return ret;

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -69,8 +69,8 @@ final class OobChannel
   private final ScheduledExecutorService deadlineCancellationExecutor;
   private final CountDownLatch terminatedLatch = new CountDownLatch(1);
   private volatile boolean shutdown;
-  private final ChannelTracer channelTracer;
-  private final ChannelTracer subchannelTracer;
+  private final CallTracer channelCallsTracer;
+  private final CallTracer subchannelCallsTracer;
 
   private final ClientTransportProvider transportProvider = new ClientTransportProvider() {
     @Override
@@ -91,7 +91,7 @@ final class OobChannel
   OobChannel(
       String authority, ObjectPool<? extends Executor> executorPool,
       ScheduledExecutorService deadlineCancellationExecutor, ChannelExecutor channelExecutor,
-      ChannelTracer.Factory channelTracerFactory) {
+      CallTracer.Factory callTracerFactory) {
     this.authority = checkNotNull(authority, "authority");
     this.executorPool = checkNotNull(executorPool, "executorPool");
     this.executor = checkNotNull(executorPool.getObject(), "executor");
@@ -119,8 +119,8 @@ final class OobChannel
           // Don't care
         }
       });
-    this.channelTracer = channelTracerFactory.create();
-    this.subchannelTracer = channelTracerFactory.create();
+    this.channelCallsTracer = callTracerFactory.create();
+    this.subchannelCallsTracer = callTracerFactory.create();
   }
 
   // Must be called only once, right after the OobChannel is created.
@@ -157,9 +157,8 @@ final class OobChannel
         public ListenableFuture<InternalChannelStats> getStats() {
           SettableFuture<InternalChannelStats> ret = SettableFuture.create();
           InternalChannelStats.Builder builder = new InternalChannelStats.Builder();
-          subchannelTracer.updateBuilder(builder);
-          builder.setTarget(authority)
-              .setState(subchannel.getState());
+          subchannelCallsTracer.updateInternalChannelStatsBuilder(builder);
+          builder.setTarget(authority).setState(subchannel.getState());
           ret.set(builder.build());
           return ret;
         }
@@ -185,7 +184,7 @@ final class OobChannel
       MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
     return new ClientCallImpl<RequestT, ResponseT>(methodDescriptor,
         callOptions.getExecutor() == null ? executor : callOptions.getExecutor(),
-        callOptions, transportProvider, deadlineCancellationExecutor, channelTracer);
+        callOptions, transportProvider, deadlineCancellationExecutor, channelCallsTracer);
   }
 
   @Override
@@ -260,9 +259,8 @@ final class OobChannel
   public ListenableFuture<InternalChannelStats> getStats() {
     SettableFuture<InternalChannelStats> ret = SettableFuture.create();
     InternalChannelStats.Builder builder = new InternalChannelStats.Builder();
-    channelTracer.updateBuilder(builder);
-    builder.setTarget(authority)
-        .setState(subchannel.getState());
+    channelCallsTracer.updateInternalChannelStatsBuilder(builder);
+    builder.setTarget(authority).setState(subchannel.getState());
     ret.set(builder.build());
     return ret;
   }

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -89,7 +89,7 @@ public class ClientCallImplTest {
   private final FakeClock fakeClock = new FakeClock();
   private final ScheduledExecutorService deadlineCancellationExecutor =
       fakeClock.getScheduledExecutorService();
-  private final ChannelTracer channelTracer = ChannelTracer.getDefaultFactory().create();
+  private final CallTracer channelCallTracer = CallTracer.getDefaultFactory().create();
   private final DecompressorRegistry decompressorRegistry =
       DecompressorRegistry.getDefaultInstance().with(new Codec.Gzip(), true);
   private final MethodDescriptor<Void, Void> method = MethodDescriptor.<Void, Void>newBuilder()
@@ -151,7 +151,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
@@ -172,7 +172,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
@@ -208,7 +208,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
@@ -242,7 +242,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
     call.start(callListener, new Metadata());
     verify(stream).start(listenerArgumentCaptor.capture());
     final ClientStreamListener streamListener = listenerArgumentCaptor.getValue();
@@ -275,7 +275,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer)
+        channelCallTracer)
             .setDecompressorRegistry(decompressorRegistry);
 
     call.start(callListener, new Metadata());
@@ -298,7 +298,7 @@ public class ClientCallImplTest {
         baseCallOptions.withAuthority("overridden-authority"),
         provider,
         deadlineCancellationExecutor,
-        channelTracer)
+        channelCallTracer)
             .setDecompressorRegistry(decompressorRegistry);
 
     call.start(callListener, new Metadata());
@@ -314,7 +314,7 @@ public class ClientCallImplTest {
         callOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer)
+        channelCallTracer)
         .setDecompressorRegistry(decompressorRegistry);
     final Metadata metadata = new Metadata();
 
@@ -332,7 +332,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer)
+        channelCallTracer)
             .setDecompressorRegistry(decompressorRegistry);
 
     call.start(callListener, new Metadata());
@@ -501,7 +501,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer)
+        channelCallTracer)
             .setDecompressorRegistry(decompressorRegistry);
 
     Context.ROOT.attach();
@@ -575,7 +575,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer)
+        channelCallTracer)
             .setDecompressorRegistry(decompressorRegistry);
 
     previous.attach();
@@ -604,7 +604,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer)
+        channelCallTracer)
         .setDecompressorRegistry(decompressorRegistry);
 
     previous.attach();
@@ -648,7 +648,7 @@ public class ClientCallImplTest {
         callOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer)
+        channelCallTracer)
             .setDecompressorRegistry(decompressorRegistry);
     call.start(callListener, new Metadata());
     verify(transport, times(0))
@@ -671,7 +671,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
 
     Metadata headers = new Metadata();
 
@@ -699,7 +699,7 @@ public class ClientCallImplTest {
         callOpts,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
 
     Metadata headers = new Metadata();
 
@@ -727,7 +727,7 @@ public class ClientCallImplTest {
         callOpts,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
 
     Metadata headers = new Metadata();
 
@@ -753,7 +753,7 @@ public class ClientCallImplTest {
         baseCallOptions.withDeadline(Deadline.after(1, TimeUnit.SECONDS)),
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
 
     call.start(callListener, new Metadata());
 
@@ -777,7 +777,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
 
     call.start(callListener, new Metadata());
 
@@ -797,7 +797,7 @@ public class ClientCallImplTest {
         baseCallOptions.withDeadline(Deadline.after(1, TimeUnit.SECONDS)),
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
     call.start(callListener, new Metadata());
     call.cancel("canceled", null);
 
@@ -821,7 +821,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
 
     Metadata headers = new Metadata();
 
@@ -838,7 +838,7 @@ public class ClientCallImplTest {
         baseCallOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer);
+        channelCallTracer);
     final Exception cause = new Exception();
     ClientCall.Listener<Void> callListener =
         new ClientCall.Listener<Void>() {
@@ -875,7 +875,7 @@ public class ClientCallImplTest {
         callOptions,
         provider,
         deadlineCancellationExecutor,
-        channelTracer)
+        channelCallTracer)
             .setDecompressorRegistry(decompressorRegistry);
 
     call.start(callListener, new Metadata());
@@ -888,7 +888,7 @@ public class ClientCallImplTest {
   public void getAttributes() {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method, MoreExecutors.directExecutor(), baseCallOptions, provider,
-        deadlineCancellationExecutor, channelTracer);
+        deadlineCancellationExecutor, channelCallTracer);
     Attributes attrs =
         Attributes.newBuilder().set(Key.<String>of("fake key"), "fake value").build();
     when(stream.getAttributes()).thenReturn(attrs);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -143,7 +143,7 @@ public class ManagedChannelImplIdlenessTest {
         builder, mockTransportFactory, new FakeBackoffPolicyProvider(),
         oobExecutorPool, timer.getStopwatchSupplier(),
         Collections.<ClientInterceptor>emptyList(),
-        GrpcUtil.NOOP_PROXY_DETECTOR, ChannelTracer.getDefaultFactory());
+        GrpcUtil.NOOP_PROXY_DETECTOR, CallTracer.getDefaultFactory());
     newTransports = TestUtils.captureTransports(mockTransportFactory);
 
     for (int i = 0; i < 2; i++) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -140,10 +140,10 @@ public class ManagedChannelImplTest {
   private final FakeClock timer = new FakeClock();
   private final FakeClock executor = new FakeClock();
   private final FakeClock oobExecutor = new FakeClock();
-  private final ChannelTracer.Factory channelStatsFactory = new ChannelTracer.Factory() {
+  private final CallTracer.Factory channelStatsFactory = new CallTracer.Factory() {
     @Override
-    public ChannelTracer create() {
-      return new ChannelTracer(new ChannelTracer.TimeProvider() {
+    public CallTracer create() {
+      return new CallTracer(new CallTracer.TimeProvider() {
         @Override
         public long currentTimeMillis() {
           return executor.currentTimeMillis();


### PR DESCRIPTION
This class will be reused to count ServerCall stats.