### PR TITLE
core: add missing separator in user-agent

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -433,6 +433,7 @@ public final class GrpcUtil {
     }
     builder.append("grpc-java-");
     builder.append(transportName);
+    builder.append('/');
     builder.append(IMPLEMENTATION_VERSION);
     return builder.toString();
   }

--- a/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/GrpcUtilTest.java
@@ -117,7 +117,7 @@ public class GrpcUtilTest {
 
   @Test
   public void grpcUserAgent() {
-    assertTrue(GrpcUtil.getGrpcUserAgent("netty", null).startsWith("grpc-java-netty"));
+    assertTrue(GrpcUtil.getGrpcUserAgent("netty", null).startsWith("grpc-java-netty/"));
     assertTrue(GrpcUtil.getGrpcUserAgent("okhttp", "libfoo/1.0")
         .startsWith("libfoo/1.0 grpc-java-okhttp"));
   }


### PR DESCRIPTION
The separator was accidentally removed in 1bbe126b4