### PR TITLE
README.md: include supported Android API levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 gRPC-Java - An RPC library and framework
 ========================================
 
-gRPC-Java works with JDK 6. TLS usage typically requires using Java 8, or Play
-Services Dynamic Security Provider on Android. Please see the [Security
-Readme](SECURITY.md).
+gRPC-Java works with JDK 6. On Android, gRPC-Java supports Android API levels
+14 and up (Ice Cream Sandwich and later).
+
+TLS usage typically requires using Java 8, or Play Services Dynamic Security
+Provider on Android. Please see the [Security Readme](SECURITY.md).
 
 <table>
   <tr>


### PR DESCRIPTION
We can make this more nuanced (I'd have to test it out, but as far as I remember we work just fine on earlier Android levels if you don't care about TLS) but API level 14 is the minimum required by Google Play Services. Are we okay with setting that as the minimum supported version?