### PR TITLE
core: disable jndi in gae jdk7

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -312,6 +312,9 @@ final class DnsNameResolver extends NameResolver {
   @VisibleForTesting
   @SuppressWarnings("LiteralClassName")
   static boolean jndiAvailable() {
+    if (GrpcUtil.IS_RESTRICTED_APPENGINE) {
+      return false;
+    }
     try {
       Class.forName("javax.naming.directory.InitialDirContext");
       Class.forName("com.sun.jndi.dns.DnsContextFactory");


### PR DESCRIPTION
Enabling it makes the GAE interop test consistently fail with this stack trace:

```
io.grpc.internal.ManagedChannelImpl$NameResolverListenerImpl onError: [io.grpc.internal.ManagedChannelImpl-5] Failed to resolve name. status=Status{code=UNKNOWN, description=null, cause=java.lang.IllegalStateException: Cannot create new threads after request thread stops. (ManagedChannelImpl.java:1056)
	at com.google.apphosting.runtime.ApiProxyImpl$CurrentRequestThread.start(ApiProxyImpl.java:1183)
	at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:972)
	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1394)
	at io.grpc.internal.DnsNameResolver.resolve(DnsNameResolver.java:265)
	at io.grpc.internal.DnsNameResolver.start(DnsNameResolver.java:156)
	at io.grpc.internal.ManagedChannelImpl.exitIdleMode(ManagedChannelImpl.java:358)
	at io.grpc.internal.ManagedChannelImpl$4$1.run(ManagedChannelImpl.java:405)
	at io.grpc.internal.ChannelExecutor.drain(ChannelExecutor.java:73)
	at io.grpc.internal.ManagedChannelImpl$4.get(ManagedChannelImpl.java:407)
	at io.grpc.internal.ClientCallImpl.start(ClientCallImpl.java:238)
	at io.grpc.internal.CensusTracingModule$TracingClientInterceptor$1.start(CensusTracingModule.java:387)
	at io.grpc.internal.CensusStatsModule$StatsClientInterceptor$1.start(CensusStatsModule.java:679)
	at io.grpc.stub.ClientCalls.startCall(ClientCalls.java:293)
	at io.grpc.stub.ClientCalls.asyncUnaryRequestCall(ClientCalls.java:268)
	at io.grpc.stub.ClientCalls.futureUnaryCall(ClientCalls.java:177)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:119)
	at io.grpc.testing.integration.TestServiceGrpc$TestServiceBlockingStub.unaryCall(TestServiceGrpc.java:633)
	at io.grpc.testing.integration.AbstractInteropTest.largeUnary(AbstractInteropTest.java:383)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at com.google.apphosting.runtime.security.shared.intercept.java.lang.reflect.Method_$1.run(Method_.java:169)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.google.apphosting.runtime.security.shared.intercept.java.lang.reflect.Method_.privilegedInvoke(Method_.java:165)
	at com.google.apphosting.runtime.security.shared.intercept.java.lang.reflect.Method_.invoke_(Method_.java:123)
	at com.google.apphosting.runtime.security.shared.intercept.java.lang.reflect.Method_.invoke(Method_.java:42)
	at io.grpc.testing.integration.OkHttpClientInteropServlet.doGet(OkHttpClientInteropServlet.java:90)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:617)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:717)
	at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1166)
	at com.google.apphosting.utils.servlet.ParseBlobUploadFilter.doFilter(ParseBlobUploadFilter.java:125)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
	at com.google.apphosting.runtime.jetty.SaveSessionFilter.doFilter(SaveSessionFilter.java:37)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
	at com.google.apphosting.utils.servlet.JdbcMySqlConnectionCleanupFilter.doFilter(JdbcMySqlConnectionCleanupFilter.java:60)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
	at com.google.apphosting.utils.servlet.TransactionCleanupFilter.doFilter(TransactionCleanupFilter.java:48)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
	at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:388)
	at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)
	at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
	at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:765)
	at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:418)
	at com.google.apphosting.runtime.jetty.AppVersionHandlerMap.handle(AppVersionHandlerMap.java:257)
	at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
	at org.mortbay.jetty.Server.handle(Server.java:326)
	at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
	at org.mortbay.jetty.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:923)
	at com.google.apphosting.runtime.jetty.RpcRequestParser.parseAvailable(RpcRequestParser.java:76)
	at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
	at com.google.apphosting.runtime.jetty.JettyServletEngineAdapter.serviceRequest(JettyServletEngineAdapter.java:146)
	at com.google.apphosting.runtime.JavaRuntime$RequestRunnable.dispatchServletRequest(JavaRuntime.java:680)
	at com.google.apphosting.runtime.JavaRuntime$RequestRunnable.dispatchRequest(JavaRuntime.java:642)
	at com.google.apphosting.runtime.JavaRuntime$RequestRunnable.run(JavaRuntime.java:612)
	at com.google.tracing.TraceContext$TraceContextRunnable.runInContext(TraceContext.java:455)
	at com.google.tracing.TraceContext$TraceContextRunnable$1.run(TraceContext.java:462)
	at com.google.tracing.CurrentContext.runInContext(CurrentContext.java:320)
	at com.google.tracing.TraceContext$AbstractTraceContextCallback.runInInheritedContextNoUnref(TraceContext.java:321)
	at com.google.tracing.TraceContext$AbstractTraceContextCallback.runInInheritedContext(TraceContext.java:313)
	at com.google.tracing.TraceContext$TraceContextRunnable.run(TraceContext.java:459)
	at com.google.apphosting.runtime.ThreadGroupPool$PoolEntry.run(ThreadGroupPool.java:274)
	at java.lang.Thread.run(Thread.java:745)
}
```