### PR TITLE
Add server and client builder customization to GrpcServerRule

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -671,6 +671,7 @@ public final class ManagedChannelImpl extends ManagedChannel implements Instrume
 
     @Override
     public String authority() {
+      checkNotNull(nameResolver, "Cannot access authority of terminated channel");
       String authority = nameResolver.getServiceAuthority();
       return checkNotNull(authority, "authority");
     }


### PR DESCRIPTION
Implements #3624

* Add `GrpcServerRule.withServerBuilderSetup()` method.
* Add `GrpcServerRule.withChannelBuilderSetup()` method.