### PR TITLE
Add toString for MethodDescriptor and ServiceDescriptor

### DIFF
--- a/core/src/main/java/io/grpc/MethodDescriptor.java
+++ b/core/src/main/java/io/grpc/MethodDescriptor.java
@@ -18,6 +18,7 @@ package io.grpc;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -571,5 +572,20 @@ public final class MethodDescriptor<ReqT, RespT> {
           safe,
           sampledToLocalTracing);
     }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+      .add("fullMethodName", fullMethodName)
+      .add("type", type)
+      .add("idempotent", idempotent)
+      .add("safe", safe)
+      .add("sampledToLocalTracing", sampledToLocalTracing)
+      .add("requestMarshaller", requestMarshaller)
+      .add("responseMarshaller", responseMarshaller)
+      .add("schemaDescriptor", schemaDescriptor)
+      .omitNullValues()
+      .toString();
   }
 }

--- a/core/src/main/java/io/grpc/ServiceDescriptor.java
+++ b/core/src/main/java/io/grpc/ServiceDescriptor.java
@@ -19,6 +19,7 @@ package io.grpc;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -203,5 +204,15 @@ public final class ServiceDescriptor {
     public ServiceDescriptor build() {
       return new ServiceDescriptor(this);
     }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("schemaDescriptor", schemaDescriptor)
+        .add("methods", methods)
+        .omitNullValues()
+        .toString();
   }
 }

--- a/core/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/core/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -39,10 +39,13 @@ public class MethodDescriptorTest {
 
   @Test
   public void createMethodDescriptor() {
-    @SuppressWarnings("deprecation") // MethodDescriptor.create
-    MethodDescriptor<String, String> descriptor = MethodDescriptor.<String, String>create(
-        MethodType.CLIENT_STREAMING, "package.service/method", new StringMarshaller(),
-        new StringMarshaller());
+    MethodDescriptor<String, String> descriptor = MethodDescriptor.<String, String>newBuilder()
+        .setType(MethodType.CLIENT_STREAMING)
+        .setFullMethodName("package.service/method")
+        .setRequestMarshaller(new StringMarshaller())
+        .setResponseMarshaller(new StringMarshaller())
+        .build();
+
     assertEquals(MethodType.CLIENT_STREAMING, descriptor.getType());
     assertEquals("package.service/method", descriptor.getFullMethodName());
     assertFalse(descriptor.isIdempotent());
@@ -169,5 +172,30 @@ public class MethodDescriptorTest {
     assertEquals(md1.isIdempotent(), md2.isIdempotent());
     assertEquals(md1.isSafe(), md2.isSafe());
     assertSame(md1.getSchemaDescriptor(), md2.getSchemaDescriptor());
+  }
+
+  @Test
+  public void toStringTest() {
+    MethodDescriptor<String, String> descriptor = MethodDescriptor.<String, String>newBuilder()
+        .setType(MethodType.UNARY)
+        .setFullMethodName("package.service/method")
+        .setRequestMarshaller(StringMarshaller.INSTANCE)
+        .setResponseMarshaller(StringMarshaller.INSTANCE)
+        .setSampledToLocalTracing(true)
+        .setIdempotent(true)
+        .setSafe(true)
+        .setSchemaDescriptor(new Object())
+        .build();
+
+    String toString = descriptor.toString();
+    assertTrue(toString.contains("MethodDescriptor"));
+    assertTrue(toString.contains("fullMethodName=package.service/method"));
+    assertTrue(toString.contains("type=UNARY"));
+    assertTrue(toString.contains("idempotent=true"));
+    assertTrue(toString.contains("safe=true"));
+    assertTrue(toString.contains("sampledToLocalTracing=true"));
+    assertTrue(toString.contains("requestMarshaller=io.grpc.StringMarshaller"));
+    assertTrue(toString.contains("responseMarshaller=io.grpc.StringMarshaller"));
+    assertTrue(toString.contains("schemaDescriptor=java.lang.Object"));
   }
 }

--- a/core/src/test/java/io/grpc/ServiceDescriptorTest.java
+++ b/core/src/test/java/io/grpc/ServiceDescriptorTest.java
@@ -16,6 +16,8 @@
 
 package io.grpc;
 
+import static org.junit.Assert.assertTrue;
+
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.testing.TestMethodDescriptors;
 import java.util.Arrays;
@@ -63,13 +65,13 @@ public class ServiceDescriptorTest {
 
   @Test
   public void failsOnNonMatchingNames() {
-    @SuppressWarnings("deprecation") // MethodDescriptor.create
     List<MethodDescriptor<?, ?>> descriptors = Collections.<MethodDescriptor<?, ?>>singletonList(
-        MethodDescriptor.create(
-            MethodType.UNARY,
-            MethodDescriptor.generateFullMethodName("wrongservice", "method"),
-            TestMethodDescriptors.voidMarshaller(),
-            TestMethodDescriptors.voidMarshaller()));
+        MethodDescriptor.<Void, Void>newBuilder()
+          .setType(MethodType.UNARY)
+          .setFullMethodName(MethodDescriptor.generateFullMethodName("wrongservice", "method"))
+          .setRequestMarshaller(TestMethodDescriptors.voidMarshaller())
+          .setResponseMarshaller(TestMethodDescriptors.voidMarshaller())
+          .build());
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("service names");
@@ -79,22 +81,49 @@ public class ServiceDescriptorTest {
 
   @Test
   public void failsOnNonDuplicateNames() {
-    @SuppressWarnings("deprecation") // MethodDescriptor.create
     List<MethodDescriptor<?, ?>> descriptors = Arrays.<MethodDescriptor<?, ?>>asList(
-        MethodDescriptor.create(
-            MethodType.UNARY,
-            MethodDescriptor.generateFullMethodName("name", "method"),
-            TestMethodDescriptors.voidMarshaller(),
-            TestMethodDescriptors.voidMarshaller()),
-        MethodDescriptor.create(
-            MethodType.UNARY,
-            MethodDescriptor.generateFullMethodName("name", "method"),
-            TestMethodDescriptors.voidMarshaller(),
-            TestMethodDescriptors.voidMarshaller()));
+        MethodDescriptor.<Void, Void>newBuilder()
+          .setType(MethodType.UNARY)
+          .setFullMethodName(MethodDescriptor.generateFullMethodName("name", "method"))
+          .setRequestMarshaller(TestMethodDescriptors.voidMarshaller())
+          .setResponseMarshaller(TestMethodDescriptors.voidMarshaller())
+          .build(),
+        MethodDescriptor.<Void, Void>newBuilder()
+          .setType(MethodType.UNARY)
+          .setFullMethodName(MethodDescriptor.generateFullMethodName("name", "method"))
+          .setRequestMarshaller(TestMethodDescriptors.voidMarshaller())
+          .setResponseMarshaller(TestMethodDescriptors.voidMarshaller())
+          .build());
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("duplicate");
 
     new ServiceDescriptor("name", descriptors);
+  }
+
+  @Test
+  public void toStringTest() {
+    ServiceDescriptor descriptor = new ServiceDescriptor("package.service",
+        Arrays.<MethodDescriptor<?, ?>>asList(
+        MethodDescriptor.<Void, Void>newBuilder()
+          .setType(MethodType.UNARY)
+          .setFullMethodName(MethodDescriptor.generateFullMethodName("package.service",
+            "methodOne"))
+          .setRequestMarshaller(TestMethodDescriptors.voidMarshaller())
+          .setResponseMarshaller(TestMethodDescriptors.voidMarshaller())
+          .build(),
+        MethodDescriptor.<Void, Void>newBuilder()
+          .setType(MethodType.UNARY)
+          .setFullMethodName(MethodDescriptor.generateFullMethodName("package.service",
+            "methodTwo"))
+          .setRequestMarshaller(TestMethodDescriptors.voidMarshaller())
+          .setResponseMarshaller(TestMethodDescriptors.voidMarshaller())
+          .build()));
+
+    String toString = descriptor.toString();
+    assertTrue(toString.contains("ServiceDescriptor"));
+    assertTrue(toString.contains("name=package.service"));
+    assertTrue(toString.contains("package.service/methodOne"));
+    assertTrue(toString.contains("package.service/methodTwo"));
   }
 }


### PR DESCRIPTION
Implements #2472

* Added `MethodDescriptor.toString()` method.
* Added `ServiceDescriptor.toString()` method.
* Upgraded deprecated code in unit tests.