### PR TITLE
core: delete outboundMessage() and inboundMessage() on StreamTracer.

### DIFF
--- a/core/src/main/java/io/grpc/StreamTracer.java
+++ b/core/src/main/java/io/grpc/StreamTracer.java
@@ -37,32 +37,10 @@ public abstract class StreamTracer {
    * about the message, but doesn't have further guarantee such as whether the message is serialized
    * or not.
    *
-   * @deprecated use {@link #outboundMessage(int)}
-   */
-  @Deprecated
-  public void outboundMessage() {
-  }
-
-  /**
-   * An outbound message has been passed to the stream.  This is called as soon as the stream knows
-   * about the message, but doesn't have further guarantee such as whether the message is serialized
-   * or not.
-   *
    * @param seqNo the sequential number of the message within the stream, starting from 0.  It can
    *              be used to correlate with {@link #outboundMessageSent} for the same message.
    */
   public void outboundMessage(int seqNo) {
-  }
-
-  /**
-   * An inbound message has been received by the stream.  This is called as soon as the stream knows
-   * about the message, but doesn't have further guarantee such as whether the message is
-   * deserialized or not.
-   *
-   * @deprecated use {@link #inboundMessage(int)}
-   */
-  @Deprecated
-  public void inboundMessage() {
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -154,11 +154,9 @@ public final class StatsTraceContext {
    *
    * <p>Called from {@link io.grpc.internal.Framer}.
    */
-  @SuppressWarnings("deprecation")
   public void outboundMessage(int seqNo) {
     for (StreamTracer tracer : tracers) {
       tracer.outboundMessage(seqNo);
-      tracer.outboundMessage();
     }
   }
 
@@ -167,11 +165,9 @@ public final class StatsTraceContext {
    *
    * <p>Called from {@link io.grpc.internal.MessageDeframer}.
    */
-  @SuppressWarnings("deprecation")
   public void inboundMessage(int seqNo) {
     for (StreamTracer tracer : tracers) {
       tracer.inboundMessage(seqNo);
-      tracer.inboundMessage();
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -350,7 +350,6 @@ public class AbstractClientStreamTest {
         .writeFrame(
             any(WritableBuffer.class), any(Boolean.class), any(Boolean.class), any(Integer.class));
     assertThat(tracer.nextOutboundEvent()).isEqualTo("outboundMessage(0)");
-    assertThat(tracer.nextOutboundEvent()).isEqualTo("outboundMessage()");
     assertThat(tracer.nextOutboundEvent()).matches("outboundMessageSent\\(0, [0-9]+, [0-9]+\\)");
     assertNull(tracer.nextOutboundEvent());
     assertNull(tracer.nextInboundEvent());

--- a/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageDeframerTest.java
@@ -490,7 +490,6 @@ public class MessageDeframerTest {
     long expectedUncompressedSize = 0;
     for (int i = 0; i < count; i++) {
       assertEquals("inboundMessage(" + i + ")", tracer.nextInboundEvent());
-      assertEquals("inboundMessage()", tracer.nextInboundEvent());
       assertEquals(
           String.format("inboundMessageRead(%d, %d, -1)", i, sizes[i * 2]),
           tracer.nextInboundEvent());

--- a/core/src/test/java/io/grpc/internal/MessageFramerTest.java
+++ b/core/src/test/java/io/grpc/internal/MessageFramerTest.java
@@ -382,7 +382,6 @@ public class MessageFramerTest {
     long expectedUncompressedSize = 0;
     for (int i = 0; i < count; i++) {
       assertEquals("outboundMessage(" + i + ")", tracer.nextOutboundEvent());
-      assertEquals("outboundMessage()", tracer.nextOutboundEvent());
       assertEquals(
           String.format("outboundMessageSent(%d, %d, %d)", i, sizes[i * 2], sizes[i * 2 + 1]),
           tracer.nextOutboundEvent());

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1912,7 +1912,6 @@ public abstract class AbstractInteropTest {
     int seqNo = 0;
     for (MessageLite msg : sentMessages) {
       assertThat(tracer.nextOutboundEvent()).isEqualTo(String.format("outboundMessage(%d)", seqNo));
-      assertThat(tracer.nextOutboundEvent()).isEqualTo("outboundMessage()");
       assertThat(tracer.nextOutboundEvent()).matches(
           String.format("outboundMessageSent\\(%d, -?[0-9]+, -?[0-9]+\\)", seqNo));
       seqNo++;
@@ -1923,7 +1922,6 @@ public abstract class AbstractInteropTest {
     seqNo = 0;
     for (MessageLite msg : receivedMessages) {
       assertThat(tracer.nextInboundEvent()).isEqualTo(String.format("inboundMessage(%d)", seqNo));
-      assertThat(tracer.nextInboundEvent()).isEqualTo("inboundMessage()");
       assertThat(tracer.nextInboundEvent()).matches(
           String.format("inboundMessageRead\\(%d, -?[0-9]+, -?[0-9]+\\)", seqNo)); 
       uncompressedReceivedSize += msg.getSerializedSize();

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -685,7 +685,6 @@ public abstract class AbstractTransportTest {
     assertTrue(clientStream.isReady());
     clientStream.writeMessage(methodDescriptor.streamRequest("Hello!"));
     assertThat(clientStreamTracer1.nextOutboundEvent()).isEqualTo("outboundMessage(0)");
-    assertThat(clientStreamTracer1.nextOutboundEvent()).isEqualTo("outboundMessage()");
 
     clientStream.flush();
     InputStream message = serverStreamListener.messageQueue.poll(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -701,7 +700,6 @@ public abstract class AbstractTransportTest {
       assertThat(clientStreamTracer1.getOutboundUncompressedSize()).isEqualTo(0L);
     }
     assertThat(serverStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage(0)");
-    assertThat(serverStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage()");
     assertNull("no additional message expected", serverStreamListener.messageQueue.poll());
 
     clientStream.halfClose();
@@ -739,7 +737,6 @@ public abstract class AbstractTransportTest {
     assertTrue(serverStream.isReady());
     serverStream.writeMessage(methodDescriptor.streamResponse("Hi. Who are you?"));
     assertThat(serverStreamTracer1.nextOutboundEvent()).isEqualTo("outboundMessage(0)");
-    assertThat(serverStreamTracer1.nextOutboundEvent()).isEqualTo("outboundMessage()");
 
     serverStream.flush();
     message = clientStreamListener.messageQueue.poll(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -755,7 +752,6 @@ public abstract class AbstractTransportTest {
     }
     assertTrue(clientStreamTracer1.getInboundHeaders());
     assertThat(clientStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage(0)");
-    assertThat(clientStreamTracer1.nextInboundEvent()).isEqualTo("inboundMessage()");
     assertEquals("Hi. Who are you?", methodDescriptor.parseResponse(message));
     assertThat(clientStreamTracer1.nextInboundEvent())
         .matches("inboundMessageRead\\(0, -?[0-9]+, -?[0-9]+\\)");

--- a/testing/src/main/java/io/grpc/internal/testing/TestClientStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestClientStreamTracer.java
@@ -133,20 +133,8 @@ public class TestClientStreamTracer extends ClientStreamTracer implements TestSt
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  public void inboundMessage() {
-    delegate.inboundMessage();
-  }
-
-  @Override
   public void inboundMessage(int seqNo) {
     delegate.inboundMessage(seqNo);
-  }
-
-  @Override
-  @SuppressWarnings("deprecation")
-  public void outboundMessage() {
-    delegate.outboundMessage();
   }
 
   @Override

--- a/testing/src/main/java/io/grpc/internal/testing/TestServerStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestServerStreamTracer.java
@@ -112,20 +112,8 @@ public class TestServerStreamTracer extends ServerStreamTracer implements TestSt
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  public void inboundMessage() {
-    delegate.inboundMessage();
-  }
-
-  @Override
   public void inboundMessage(int seqNo) {
     delegate.inboundMessage(seqNo);
-  }
-
-  @Override
-  @SuppressWarnings("deprecation")
-  public void outboundMessage() {
-    delegate.outboundMessage();
   }
 
   @Override

--- a/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
@@ -164,20 +164,8 @@ public interface TestStreamTracer {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public void inboundMessage() {
-      inboundEvents.add("inboundMessage()");
-    }
-
-    @Override
     public void inboundMessage(int seqNo) {
       inboundEvents.add("inboundMessage(" + seqNo + ")");
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public void outboundMessage() {
-      outboundEvents.add("outboundMessage()");
     }
 
     @Override


### PR DESCRIPTION
They were deprecated in 1.7.0.

Resolves #3460