### PR TITLE
RELEASING.md: include golden files in branch cut

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,6 +90,8 @@ would be used to create all `v1.7` tags (e.g. `v1.7.0`, `v1.7.1`).
    # Change version to next minor (and keep -SNAPSHOT)
    $ sed -i 's/[0-9]\+\.[0-9]\+\.[0-9]\+\(.*CURRENT_GRPC_VERSION\)/'$MAJOR.$((MINOR+1)).0'\1/' \
      "${VERSION_FILES[@]}"
+   $ sed -i s/$MAJOR.$MINOR.$PATCH/$MAJOR.$((MINOR+1)).0/ \
+     compiler/src/test{,Lite,Nano}/golden/TestService.java.txt
    $ ./gradlew build
    $ git commit -a -m "Start $MAJOR.$((MINOR+1)).0 development cycle"
    ```


### PR DESCRIPTION
Trying again: https://github.com/grpc/grpc-java/pull/3692 wasn't quite right, so this copies the command from https://github.com/grpc/grpc-java/commit/9c46f92b111c6a1b632024b81ef20653cc237379#diff-60cd2f42437b5cb3c2c09391a6f4c54a to the "Branching the Release" section.