### PR TITLE
core: Resolve address of GRPC_PROXY_EXP hostname

### DIFF
--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -184,8 +184,7 @@ class ProxyDetectorImpl implements ProxyDetector {
             + "be removed in a future release. Use the JVM flags "
             + "\"-Dhttps.proxyHost=HOST -Dhttps.proxyPort=PORT\" to set the https proxy for "
             + "this JVM.");
-    // Return an unresolved InetSocketAddress to avoid DNS lookup
-    return InetSocketAddress.createUnresolved(parts[0], port);
+    return new InetSocketAddress(parts[0], port);
   }
 
   /**


### PR DESCRIPTION
Since this address is never resolved gRPC fails to connect with an
UnresolvedAddressException when the env variable is specified. This
should resolve the address before we attempt to proxy to it.

I know this env variable is scheduled to be removed, so if that's happening in the next version I guess this fix probably isn't necessary.

Also not sure whether there's a good reason why we don't make a DNS lookup here (c.f. comment), but I couldn't find anywhere down the pipeline where this would otherwise get resolved.