### PR TITLE
netty/shaded: Bump shadow plugin version to 2.0.2

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
     }
 }
 


### PR DESCRIPTION
This fixes the gradle warning:
The SimpleWorkResult type has been deprecated and is scheduled to be
removed in Gradle 5.0. Please use WorkResults.didWork() instead.