### PR TITLE
kokoro: Use --include-build in cronet

### DIFF
--- a/buildscripts/kokoro/cronet.sh
+++ b/buildscripts/kokoro/cronet.sh
@@ -2,9 +2,6 @@
 
 set -exu -o pipefail
 
-cd ./github/grpc-java
-./gradlew -PskipCodegen=true install
-
-cd cronet
+cd ./github/grpc-java/cronet
 ./cronet_deps.sh
-../gradlew build
+../gradlew --include-build .. build


### PR DESCRIPTION
This avoids needing to build all of grpc as well as avoids having to
manually track which dependencies are necessary.

This cuts 1.5 minutes off the Cronet build time (to 3.5 minutes). But it
also reduces the amount being downloaded which should help with #3284.