### PR TITLE
kokoro: Avoid getting cmake if it's installed

### DIFF
--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -12,10 +12,13 @@ goto :eof
 
 :installProto
 
+where /q cmake
+if not ERRORLEVEL 1 goto :hasCmake
 if not exist "%CMAKE_NAME%" (
   call :installCmake
 )
 set PATH=%PATH%;%cd%\%CMAKE_NAME%\bin
+:hasCmake
 powershell -command "& { iwr https://github.com/google/protobuf/archive/v%PROTOBUF_VER%.zip -OutFile protobuf.zip }"
 powershell -command "& { Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('protobuf.zip', '.') }"
 del protobuf.zip


### PR DESCRIPTION
Kokoro already has cmake installed, so it's not necessary in that
environment. We still keep the old code around because it's helpful for
setting up new Windows environments in general.