### PR TITLE
core: remove unused test resouce files from NameResolverProviderTest

### DIFF
--- a/core/src/test/resources/io/grpc/NameResolverProviderTest-multipleProvider.txt
+++ b/core/src/test/resources/io/grpc/NameResolverProviderTest-multipleProvider.txt
@@ -1,3 +1,0 @@
-io.grpc.NameResolverProviderTest$Available5Provider
-io.grpc.NameResolverProviderTest$Available7Provider
-io.grpc.NameResolverProviderTest$Available0Provider

--- a/core/src/test/resources/io/grpc/NameResolverProviderTest-unavailableProvider.txt
+++ b/core/src/test/resources/io/grpc/NameResolverProviderTest-unavailableProvider.txt
@@ -1,1 +1,0 @@
-io.grpc.NameResolverProviderTest$UnavailableProvider


### PR DESCRIPTION
These should have been removed in the previous PR.