### PR TITLE
core: split binlog tests into two in ManagedChannelImplTest

### DIFF
--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -60,6 +60,7 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.IntegerMarshaller;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -80,7 +81,7 @@ import io.grpc.internal.Channelz.ChannelStats;
 import io.grpc.internal.ManagedChannelImpl.ManagedChannelReference;
 import io.grpc.internal.NoopClientCall.NoopClientCallListener;
 import io.grpc.internal.TestUtils.MockClientTransportInfo;
-import java.io.InputStream;
+import io.grpc.internal.testing.SingleMessageProducer;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -1878,8 +1879,126 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void binaryLogTest() throws Exception {
-    final List<Object> capturedReqs = new ArrayList<Object>();
+  public void binaryLogInterceptor_eventOrdering() throws Exception {
+    final List<ClientInterceptor> recvInitialMetadata = new ArrayList<ClientInterceptor>();
+    final List<ClientInterceptor> sendInitialMetadata = new ArrayList<ClientInterceptor>();
+    final List<ClientInterceptor> sendReq = new ArrayList<ClientInterceptor>();
+    final List<ClientInterceptor> recvResp = new ArrayList<ClientInterceptor>();
+    final List<ClientInterceptor> recvTrailingMetadata = new ArrayList<ClientInterceptor>();
+    final class TracingClientInterceptor implements ClientInterceptor {
+      @Override
+      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+          MethodDescriptor<ReqT, RespT> method,
+          CallOptions callOptions,
+          Channel next) {
+        final ClientInterceptor ref = this;
+        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+          @Override
+          public void start(Listener<RespT> responseListener, Metadata headers) {
+            sendInitialMetadata.add(ref);
+            ClientCall.Listener<RespT> wListener =
+                new SimpleForwardingClientCallListener<RespT>(responseListener) {
+                  @Override
+                  public void onMessage(RespT message) {
+                    recvResp.add(ref);
+                    super.onMessage(message);
+                  }
+
+                  @Override
+                  public void onHeaders(Metadata headers) {
+                    recvInitialMetadata.add(ref);
+                    super.onHeaders(headers);
+                  }
+
+                  @Override
+                  public void onClose(Status status, Metadata trailers) {
+                    recvTrailingMetadata.add(ref);
+                    super.onClose(status, trailers);
+                  }
+                };
+            super.start(wListener, headers);
+          }
+
+          @Override
+          public void sendMessage(ReqT message) {
+            sendReq.add(ref);
+            super.sendMessage(message);
+          }
+        };
+      }
+    }
+
+    TracingClientInterceptor userInterceptor = new TracingClientInterceptor();
+    final TracingClientInterceptor binlogInterceptor = new TracingClientInterceptor();
+    binlogProvider = new BinaryLogProvider() {
+      @Nullable
+      @Override
+      public ServerInterceptor getServerInterceptor(String fullMethodName) {
+        return null;
+      }
+
+      @Override
+      public ClientInterceptor getClientInterceptor(String fullMethodName) {
+        return binlogInterceptor;
+      }
+
+      @Override
+      protected int priority() {
+        return 0;
+      }
+    };
+
+    // perform an RPC
+    Metadata headers = new Metadata();
+    ClientStream mockStream = mock(ClientStream.class);
+    createChannel(
+        new FakeNameResolverFactory(true),
+        ImmutableList.<ClientInterceptor>of(userInterceptor));
+    CallOptions options =
+        CallOptions.DEFAULT.withExecutor(executor.getScheduledExecutorService());
+    ClientCall<String, Integer> call = channel.newCall(method, options);
+    call.start(mockCallListener, headers);
+
+    Subchannel subchannel = helper.createSubchannel(addressGroup, Attributes.EMPTY);
+    subchannel.requestConnection();
+    MockClientTransportInfo transportInfo = transports.poll();
+    ConnectionClientTransport mockTransport = transportInfo.transport;
+    ManagedClientTransport.Listener transportListener = transportInfo.listener;
+    // binlog modifies the MethodDescriptor, so we can not use the same() matcher
+    when(mockTransport.newStream(
+        any(MethodDescriptor.class),
+        same(headers),
+        any(CallOptions.class)))
+        .thenReturn(mockStream);
+    transportListener.transportReady();
+    when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class)))
+        .thenReturn(PickResult.withSubchannel(subchannel));
+    helper.updateBalancingState(READY, mockPicker);
+
+    executor.runDueTasks();
+    verify(mockStream).start(streamListenerCaptor.capture());
+
+    ClientStreamListener streamListener = streamListenerCaptor.getValue();
+    streamListener.headersRead(new Metadata());
+    assertEquals(1, executor.runDueTasks());
+    String actualRequest = "hello world";
+    call.sendMessage(actualRequest);
+    streamListener.messagesAvailable(new SingleMessageProducer(method.streamResponse(1234)));
+    assertEquals(1, executor.runDueTasks());
+    call.halfClose();
+    streamListener.closed(Status.OK, new Metadata());
+    assertEquals(1, executor.runDueTasks());
+    // end: perform an RPC
+
+    assertThat(recvInitialMetadata).containsExactly(binlogInterceptor, userInterceptor).inOrder();
+    assertThat(sendInitialMetadata).containsExactly(userInterceptor, binlogInterceptor).inOrder();
+    assertThat(sendReq).containsExactly(userInterceptor, binlogInterceptor).inOrder();
+    assertThat(recvResp).containsExactly(binlogInterceptor, userInterceptor).inOrder();
+    assertThat(recvTrailingMetadata).containsExactly(binlogInterceptor, userInterceptor);
+  }
+
+  @Test
+  public void binaryLogInterceptor_intercept_reqResp() throws Exception {
     final class TracingClientInterceptor implements ClientInterceptor {
       private final List<MethodDescriptor<?, ?>> interceptedMethods =
           new ArrayList<MethodDescriptor<?, ?>>();
@@ -1888,13 +2007,7 @@ public class ManagedChannelImplTest {
       public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
           MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
         interceptedMethods.add(method);
-        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
-          @Override
-          public void sendMessage(ReqT message) {
-            capturedReqs.add(message);
-            super.sendMessage(message);
-          }
-        };
+        return next.newCall(method, callOptions);
       }
     }
 
@@ -1936,12 +2049,6 @@ public class ManagedChannelImplTest {
     assertSame(
         method.getResponseMarshaller(),
         userInterceptor.interceptedMethods.get(0).getResponseMarshaller());
-
-    // The binlog interceptor must be closest to the transport
-    assertThat(capturedReqs).hasSize(2);
-    // The InputStream is already spent, so just check its type rather than contents
-    assertEquals(actualRequest, capturedReqs.get(0));
-    assertThat(capturedReqs.get(1)).isInstanceOf(InputStream.class);
   }
 
   private static class FakeBackoffPolicyProvider implements BackoffPolicy.Provider {


### PR DESCRIPTION
The previous test was really testing two things at once, let's split
it up:
- checking that user interceptors' `MethodDescriptor`s are unchanged
- checking that the binlog interceptor runs first for incoming events
  and runs last for outgoing events