### PR TITLE
netty: pass full authority to SSLEngine

### DIFF
--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -181,7 +181,7 @@ public class NettyChannelBuilderTest {
     assertTrue(negotiator instanceof ProtocolNegotiators.TlsNegotiator);
     ProtocolNegotiators.TlsNegotiator n = (TlsNegotiator) negotiator;
 
-    assertEquals("authority", n.getHost());
+    assertEquals("authority", n.getPortlessAuthority());
     assertEquals(1234, n.getPort());
   }
 
@@ -196,7 +196,7 @@ public class NettyChannelBuilderTest {
     assertTrue(negotiator instanceof ProtocolNegotiators.TlsNegotiator);
     ProtocolNegotiators.TlsNegotiator n = (TlsNegotiator) negotiator;
 
-    assertEquals("bad_authority", n.getHost());
+    assertEquals("bad_authority", n.getPortlessAuthority());
     assertEquals(-1, n.getPort());
   }
 

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -75,7 +75,7 @@ public class ProtocolNegotiatorsTest {
     @Override public void run() {}
   };
 
-  @Rule public final Timeout globalTimeout = Timeout.seconds(50000);
+  @Rule public final Timeout globalTimeout = Timeout.seconds(5);
 
   @Rule
   public final ExpectedException thrown = ExpectedException.none();


### PR DESCRIPTION
Previously, attempting to call overrideAuthority with a valid
authority would drop the beginning portion of the authority if it
contained a User.  For example `TestUser@testserver`.   This would
make the SSL handshake fail because the certificate name woudl be
`TestUser@testserver`, but the name to match would be `testserver`.

This usage is uncommon, but it may not be possible to modify the
certificate being used.  The only previous recourse was to disable
hostname verification, which is less than ideal.

Instead, pass the authority through without the port, rather than
the hostname.  This also solves the problem with invalid host names
like "test_cert".   This is the same behavior as the Go gRPC
implementation.

Note: the SSL engine has called this parameter "host", but I
believe this is a historical artifact.