### PR TITLE
(backport) core: remove @Internal annotation on @Internal and @ExperimentalApi

### DIFF
--- a/core/src/main/java/io/grpc/ExperimentalApi.java
+++ b/core/src/main/java/io/grpc/ExperimentalApi.java
@@ -33,8 +33,10 @@ import java.lang.annotation.Target;
  * to an existing API is considered API-breaking.</li>
  * <li>Removing this annotation from an API gives it stable status.</li>
  * </ol>
+ *
+ * <p>Note: This annotation is intended only for gRPC library code. Users should not attach this
+ * annotation to their own code.
  */
-@Internal
 @Retention(RetentionPolicy.CLASS)
 @Target({
     ElementType.ANNOTATION_TYPE,

--- a/core/src/main/java/io/grpc/Internal.java
+++ b/core/src/main/java/io/grpc/Internal.java
@@ -30,8 +30,10 @@ import java.lang.annotation.Target;
  * anything else that will be wired into gRPC library, you may use the internal parts.  Please
  * consult the gRPC team first, because internal APIs don't have the same API stability guarantee as
  * the public APIs do.
+ *
+ * <p>Note: This annotation is intended only for gRPC library code. Users should not attach this
+ * annotation to their own code.
  */
-@Internal
 @Retention(RetentionPolicy.CLASS)
 @Target({
     ElementType.ANNOTATION_TYPE,


### PR DESCRIPTION
Backport of https://github.com/grpc/grpc-java/pull/4051. Backporting so that the grpc-java-api-checker tool can work starting with release 1.10.0