### PR TITLE
(backport) compiler: avoid invoking experimental method in generated code

### DIFF
--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/BenchmarkServiceGrpc.java
@@ -30,7 +30,7 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getUnaryCallMethod;
@@ -38,6 +38,11 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getUnaryCallMethod() {
+    return getUnaryCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getUnaryCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getUnaryCallMethod;
     if ((getUnaryCallMethod = BenchmarkServiceGrpc.getUnaryCallMethod) == null) {
       synchronized (BenchmarkServiceGrpc.class) {
@@ -62,7 +67,7 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_CALL = getStreamingCallMethod();
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_CALL = getStreamingCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingCallMethod;
@@ -70,6 +75,11 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingCallMethod() {
+    return getStreamingCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingCallMethod;
     if ((getStreamingCallMethod = BenchmarkServiceGrpc.getStreamingCallMethod) == null) {
       synchronized (BenchmarkServiceGrpc.class) {
@@ -94,7 +104,7 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingFromClientMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_FROM_CLIENT = getStreamingFromClientMethod();
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_FROM_CLIENT = getStreamingFromClientMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromClientMethod;
@@ -102,6 +112,11 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromClientMethod() {
+    return getStreamingFromClientMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromClientMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromClientMethod;
     if ((getStreamingFromClientMethod = BenchmarkServiceGrpc.getStreamingFromClientMethod) == null) {
       synchronized (BenchmarkServiceGrpc.class) {
@@ -126,7 +141,7 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingFromServerMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_FROM_SERVER = getStreamingFromServerMethod();
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_FROM_SERVER = getStreamingFromServerMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromServerMethod;
@@ -134,6 +149,11 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromServerMethod() {
+    return getStreamingFromServerMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromServerMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingFromServerMethod;
     if ((getStreamingFromServerMethod = BenchmarkServiceGrpc.getStreamingFromServerMethod) == null) {
       synchronized (BenchmarkServiceGrpc.class) {
@@ -158,7 +178,7 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingBothWaysMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
-      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_BOTH_WAYS = getStreamingBothWaysMethod();
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> METHOD_STREAMING_BOTH_WAYS = getStreamingBothWaysMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingBothWaysMethod;
@@ -166,6 +186,11 @@ public final class BenchmarkServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
       io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingBothWaysMethod() {
+    return getStreamingBothWaysMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest,
+      io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingBothWaysMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Messages.SimpleRequest, io.grpc.benchmarks.proto.Messages.SimpleResponse> getStreamingBothWaysMethod;
     if ((getStreamingBothWaysMethod = BenchmarkServiceGrpc.getStreamingBothWaysMethod) == null) {
       synchronized (BenchmarkServiceGrpc.class) {
@@ -223,7 +248,7 @@ public final class BenchmarkServiceGrpc {
      */
     public void unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -235,7 +260,7 @@ public final class BenchmarkServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingCall(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getStreamingCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -246,7 +271,7 @@ public final class BenchmarkServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingFromClient(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getStreamingFromClientMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingFromClientMethodHelper(), responseObserver);
     }
 
     /**
@@ -257,7 +282,7 @@ public final class BenchmarkServiceGrpc {
      */
     public void streamingFromServer(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getStreamingFromServerMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingFromServerMethodHelper(), responseObserver);
     }
 
     /**
@@ -268,41 +293,41 @@ public final class BenchmarkServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingBothWays(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getStreamingBothWaysMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingBothWaysMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getUnaryCallMethod(),
+            getUnaryCallMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Messages.SimpleRequest,
                 io.grpc.benchmarks.proto.Messages.SimpleResponse>(
                   this, METHODID_UNARY_CALL)))
           .addMethod(
-            getStreamingCallMethod(),
+            getStreamingCallMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Messages.SimpleRequest,
                 io.grpc.benchmarks.proto.Messages.SimpleResponse>(
                   this, METHODID_STREAMING_CALL)))
           .addMethod(
-            getStreamingFromClientMethod(),
+            getStreamingFromClientMethodHelper(),
             asyncClientStreamingCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Messages.SimpleRequest,
                 io.grpc.benchmarks.proto.Messages.SimpleResponse>(
                   this, METHODID_STREAMING_FROM_CLIENT)))
           .addMethod(
-            getStreamingFromServerMethod(),
+            getStreamingFromServerMethodHelper(),
             asyncServerStreamingCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Messages.SimpleRequest,
                 io.grpc.benchmarks.proto.Messages.SimpleResponse>(
                   this, METHODID_STREAMING_FROM_SERVER)))
           .addMethod(
-            getStreamingBothWaysMethod(),
+            getStreamingBothWaysMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Messages.SimpleRequest,
@@ -339,7 +364,7 @@ public final class BenchmarkServiceGrpc {
     public void unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -352,7 +377,7 @@ public final class BenchmarkServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingCall(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getStreamingCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -364,7 +389,7 @@ public final class BenchmarkServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingFromClient(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(getStreamingFromClientMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingFromClientMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -376,7 +401,7 @@ public final class BenchmarkServiceGrpc {
     public void streamingFromServer(io.grpc.benchmarks.proto.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(getStreamingFromServerMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingFromServerMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -388,7 +413,7 @@ public final class BenchmarkServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleRequest> streamingBothWays(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Messages.SimpleResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getStreamingBothWaysMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingBothWaysMethodHelper(), getCallOptions()), responseObserver);
     }
   }
 
@@ -418,7 +443,7 @@ public final class BenchmarkServiceGrpc {
      */
     public io.grpc.benchmarks.proto.Messages.SimpleResponse unaryCall(io.grpc.benchmarks.proto.Messages.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
+          getChannel(), getUnaryCallMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -430,7 +455,7 @@ public final class BenchmarkServiceGrpc {
     public java.util.Iterator<io.grpc.benchmarks.proto.Messages.SimpleResponse> streamingFromServer(
         io.grpc.benchmarks.proto.Messages.SimpleRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), getStreamingFromServerMethod(), getCallOptions(), request);
+          getChannel(), getStreamingFromServerMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -461,7 +486,7 @@ public final class BenchmarkServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Messages.SimpleResponse> unaryCall(
         io.grpc.benchmarks.proto.Messages.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -566,11 +591,11 @@ public final class BenchmarkServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new BenchmarkServiceFileDescriptorSupplier())
-              .addMethod(getUnaryCallMethod())
-              .addMethod(getStreamingCallMethod())
-              .addMethod(getStreamingFromClientMethod())
-              .addMethod(getStreamingFromServerMethod())
-              .addMethod(getStreamingBothWaysMethod())
+              .addMethod(getUnaryCallMethodHelper())
+              .addMethod(getStreamingCallMethodHelper())
+              .addMethod(getStreamingFromClientMethodHelper())
+              .addMethod(getStreamingFromServerMethodHelper())
+              .addMethod(getStreamingBothWaysMethodHelper())
               .build();
         }
       }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/ReportQpsScenarioServiceGrpc.java
@@ -30,7 +30,7 @@ public final class ReportQpsScenarioServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getReportScenarioMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult,
-      io.grpc.benchmarks.proto.Control.Void> METHOD_REPORT_SCENARIO = getReportScenarioMethod();
+      io.grpc.benchmarks.proto.Control.Void> METHOD_REPORT_SCENARIO = getReportScenarioMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult,
       io.grpc.benchmarks.proto.Control.Void> getReportScenarioMethod;
@@ -38,6 +38,11 @@ public final class ReportQpsScenarioServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult,
       io.grpc.benchmarks.proto.Control.Void> getReportScenarioMethod() {
+    return getReportScenarioMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult,
+      io.grpc.benchmarks.proto.Control.Void> getReportScenarioMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ScenarioResult, io.grpc.benchmarks.proto.Control.Void> getReportScenarioMethod;
     if ((getReportScenarioMethod = ReportQpsScenarioServiceGrpc.getReportScenarioMethod) == null) {
       synchronized (ReportQpsScenarioServiceGrpc.class) {
@@ -94,13 +99,13 @@ public final class ReportQpsScenarioServiceGrpc {
      */
     public void reportScenario(io.grpc.benchmarks.proto.Control.ScenarioResult request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
-      asyncUnimplementedUnaryCall(getReportScenarioMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getReportScenarioMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getReportScenarioMethod(),
+            getReportScenarioMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Control.ScenarioResult,
@@ -136,7 +141,7 @@ public final class ReportQpsScenarioServiceGrpc {
     public void reportScenario(io.grpc.benchmarks.proto.Control.ScenarioResult request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getReportScenarioMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getReportScenarioMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -165,7 +170,7 @@ public final class ReportQpsScenarioServiceGrpc {
      */
     public io.grpc.benchmarks.proto.Control.Void reportScenario(io.grpc.benchmarks.proto.Control.ScenarioResult request) {
       return blockingUnaryCall(
-          getChannel(), getReportScenarioMethod(), getCallOptions(), request);
+          getChannel(), getReportScenarioMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -195,7 +200,7 @@ public final class ReportQpsScenarioServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.Void> reportScenario(
         io.grpc.benchmarks.proto.Control.ScenarioResult request) {
       return futureUnaryCall(
-          getChannel().newCall(getReportScenarioMethod(), getCallOptions()), request);
+          getChannel().newCall(getReportScenarioMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -283,7 +288,7 @@ public final class ReportQpsScenarioServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new ReportQpsScenarioServiceFileDescriptorSupplier())
-              .addMethod(getReportScenarioMethod())
+              .addMethod(getReportScenarioMethodHelper())
               .build();
         }
       }

--- a/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
+++ b/benchmarks/src/generated/main/grpc/io/grpc/benchmarks/proto/WorkerServiceGrpc.java
@@ -30,7 +30,7 @@ public final class WorkerServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getRunServerMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs,
-      io.grpc.benchmarks.proto.Control.ServerStatus> METHOD_RUN_SERVER = getRunServerMethod();
+      io.grpc.benchmarks.proto.Control.ServerStatus> METHOD_RUN_SERVER = getRunServerMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs,
       io.grpc.benchmarks.proto.Control.ServerStatus> getRunServerMethod;
@@ -38,6 +38,11 @@ public final class WorkerServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs,
       io.grpc.benchmarks.proto.Control.ServerStatus> getRunServerMethod() {
+    return getRunServerMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs,
+      io.grpc.benchmarks.proto.Control.ServerStatus> getRunServerMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ServerArgs, io.grpc.benchmarks.proto.Control.ServerStatus> getRunServerMethod;
     if ((getRunServerMethod = WorkerServiceGrpc.getRunServerMethod) == null) {
       synchronized (WorkerServiceGrpc.class) {
@@ -62,7 +67,7 @@ public final class WorkerServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getRunClientMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs,
-      io.grpc.benchmarks.proto.Control.ClientStatus> METHOD_RUN_CLIENT = getRunClientMethod();
+      io.grpc.benchmarks.proto.Control.ClientStatus> METHOD_RUN_CLIENT = getRunClientMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs,
       io.grpc.benchmarks.proto.Control.ClientStatus> getRunClientMethod;
@@ -70,6 +75,11 @@ public final class WorkerServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs,
       io.grpc.benchmarks.proto.Control.ClientStatus> getRunClientMethod() {
+    return getRunClientMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs,
+      io.grpc.benchmarks.proto.Control.ClientStatus> getRunClientMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.ClientArgs, io.grpc.benchmarks.proto.Control.ClientStatus> getRunClientMethod;
     if ((getRunClientMethod = WorkerServiceGrpc.getRunClientMethod) == null) {
       synchronized (WorkerServiceGrpc.class) {
@@ -94,7 +104,7 @@ public final class WorkerServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getCoreCountMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest,
-      io.grpc.benchmarks.proto.Control.CoreResponse> METHOD_CORE_COUNT = getCoreCountMethod();
+      io.grpc.benchmarks.proto.Control.CoreResponse> METHOD_CORE_COUNT = getCoreCountMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest,
       io.grpc.benchmarks.proto.Control.CoreResponse> getCoreCountMethod;
@@ -102,6 +112,11 @@ public final class WorkerServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest,
       io.grpc.benchmarks.proto.Control.CoreResponse> getCoreCountMethod() {
+    return getCoreCountMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest,
+      io.grpc.benchmarks.proto.Control.CoreResponse> getCoreCountMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.CoreRequest, io.grpc.benchmarks.proto.Control.CoreResponse> getCoreCountMethod;
     if ((getCoreCountMethod = WorkerServiceGrpc.getCoreCountMethod) == null) {
       synchronized (WorkerServiceGrpc.class) {
@@ -126,7 +141,7 @@ public final class WorkerServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getQuitWorkerMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void,
-      io.grpc.benchmarks.proto.Control.Void> METHOD_QUIT_WORKER = getQuitWorkerMethod();
+      io.grpc.benchmarks.proto.Control.Void> METHOD_QUIT_WORKER = getQuitWorkerMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void,
       io.grpc.benchmarks.proto.Control.Void> getQuitWorkerMethod;
@@ -134,6 +149,11 @@ public final class WorkerServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void,
       io.grpc.benchmarks.proto.Control.Void> getQuitWorkerMethod() {
+    return getQuitWorkerMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void,
+      io.grpc.benchmarks.proto.Control.Void> getQuitWorkerMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.benchmarks.proto.Control.Void, io.grpc.benchmarks.proto.Control.Void> getQuitWorkerMethod;
     if ((getQuitWorkerMethod = WorkerServiceGrpc.getQuitWorkerMethod) == null) {
       synchronized (WorkerServiceGrpc.class) {
@@ -195,7 +215,7 @@ public final class WorkerServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerArgs> runServer(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerStatus> responseObserver) {
-      return asyncUnimplementedStreamingCall(getRunServerMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getRunServerMethodHelper(), responseObserver);
     }
 
     /**
@@ -210,7 +230,7 @@ public final class WorkerServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientArgs> runClient(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientStatus> responseObserver) {
-      return asyncUnimplementedStreamingCall(getRunClientMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getRunClientMethodHelper(), responseObserver);
     }
 
     /**
@@ -220,7 +240,7 @@ public final class WorkerServiceGrpc {
      */
     public void coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.CoreResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getCoreCountMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getCoreCountMethodHelper(), responseObserver);
     }
 
     /**
@@ -230,34 +250,34 @@ public final class WorkerServiceGrpc {
      */
     public void quitWorker(io.grpc.benchmarks.proto.Control.Void request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
-      asyncUnimplementedUnaryCall(getQuitWorkerMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getQuitWorkerMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getRunServerMethod(),
+            getRunServerMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Control.ServerArgs,
                 io.grpc.benchmarks.proto.Control.ServerStatus>(
                   this, METHODID_RUN_SERVER)))
           .addMethod(
-            getRunClientMethod(),
+            getRunClientMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Control.ClientArgs,
                 io.grpc.benchmarks.proto.Control.ClientStatus>(
                   this, METHODID_RUN_CLIENT)))
           .addMethod(
-            getCoreCountMethod(),
+            getCoreCountMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Control.CoreRequest,
                 io.grpc.benchmarks.proto.Control.CoreResponse>(
                   this, METHODID_CORE_COUNT)))
           .addMethod(
-            getQuitWorkerMethod(),
+            getQuitWorkerMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.benchmarks.proto.Control.Void,
@@ -298,7 +318,7 @@ public final class WorkerServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerArgs> runServer(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ServerStatus> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getRunServerMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getRunServerMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -314,7 +334,7 @@ public final class WorkerServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientArgs> runClient(
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.ClientStatus> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getRunClientMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getRunClientMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -325,7 +345,7 @@ public final class WorkerServiceGrpc {
     public void coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.CoreResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCoreCountMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getCoreCountMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -336,7 +356,7 @@ public final class WorkerServiceGrpc {
     public void quitWorker(io.grpc.benchmarks.proto.Control.Void request,
         io.grpc.stub.StreamObserver<io.grpc.benchmarks.proto.Control.Void> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getQuitWorkerMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getQuitWorkerMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -365,7 +385,7 @@ public final class WorkerServiceGrpc {
      */
     public io.grpc.benchmarks.proto.Control.CoreResponse coreCount(io.grpc.benchmarks.proto.Control.CoreRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCoreCountMethod(), getCallOptions(), request);
+          getChannel(), getCoreCountMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -375,7 +395,7 @@ public final class WorkerServiceGrpc {
      */
     public io.grpc.benchmarks.proto.Control.Void quitWorker(io.grpc.benchmarks.proto.Control.Void request) {
       return blockingUnaryCall(
-          getChannel(), getQuitWorkerMethod(), getCallOptions(), request);
+          getChannel(), getQuitWorkerMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -405,7 +425,7 @@ public final class WorkerServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.CoreResponse> coreCount(
         io.grpc.benchmarks.proto.Control.CoreRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCoreCountMethod(), getCallOptions()), request);
+          getChannel().newCall(getCoreCountMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -416,7 +436,7 @@ public final class WorkerServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.benchmarks.proto.Control.Void> quitWorker(
         io.grpc.benchmarks.proto.Control.Void request) {
       return futureUnaryCall(
-          getChannel().newCall(getQuitWorkerMethod(), getCallOptions()), request);
+          getChannel().newCall(getQuitWorkerMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -517,10 +537,10 @@ public final class WorkerServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new WorkerServiceFileDescriptorSupplier())
-              .addMethod(getRunServerMethod())
-              .addMethod(getRunClientMethod())
-              .addMethod(getCoreCountMethod())
-              .addMethod(getQuitWorkerMethod())
+              .addMethod(getRunServerMethodHelper())
+              .addMethod(getRunClientMethodHelper())
+              .addMethod(getCoreCountMethodHelper())
+              .addMethod(getQuitWorkerMethodHelper())
               .build();
         }
       }

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -78,6 +78,10 @@ static inline string MethodPropertiesGetterName(const MethodDescriptor* method) 
   return MixedLower("get_" + method->name() + "_method");
 }
 
+static inline string MethodPropertiesGetterHelperName(const MethodDescriptor* method) {
+  return MixedLower("get_" + method->name() + "_method_helper");
+}
+
 static inline string MethodIdFieldName(const MethodDescriptor* method) {
   return "METHODID_" + ToAllUpperCase(method->name());
 }
@@ -319,6 +323,7 @@ static void PrintMethodFields(
     (*vars)["method_field_name"] = MethodPropertiesFieldName(method);
     (*vars)["method_new_field_name"] = MethodPropertiesGetterName(method);
     (*vars)["method_method_name"] = MethodPropertiesGetterName(method);
+    (*vars)["method_method_name_helper"] = MethodPropertiesGetterHelperName(method);
     bool client_streaming = method->client_streaming();
     bool server_streaming = method->server_streaming();
     if (client_streaming) {
@@ -346,7 +351,7 @@ static void PrintMethodFields(
           "@$ExperimentalApi$(\"https://github.com/grpc/grpc-java/issues/1901\")\n"
           "@$Deprecated$ // Use {@link #$method_method_name$()} instead. \n"
           "public static final $MethodDescriptor$<$input_type$,\n"
-          "    $output_type$> $method_field_name$ = $method_method_name$();\n"
+          "    $output_type$> $method_field_name$ = $method_method_name_helper$();\n"
           "\n"
           "private static volatile $MethodDescriptor$<$input_type$,\n"
           "    $output_type$> $method_new_field_name$;\n"
@@ -354,6 +359,11 @@ static void PrintMethodFields(
           "@$ExperimentalApi$(\"https://github.com/grpc/grpc-java/issues/1901\")\n"
           "public static $MethodDescriptor$<$input_type$,\n"
           "    $output_type$> $method_method_name$() {\n"
+          "  return $method_method_name_helper$();\n"
+          "}\n"
+          "\n"
+          "private static $MethodDescriptor$<$input_type$,\n"
+          "    $output_type$> $method_method_name_helper$() {\n"
           "  $MethodDescriptor$<$input_type$, $output_type$> $method_new_field_name$;\n"
           "  if (($method_new_field_name$ = $service_class_name$.$method_new_field_name$) == null) {\n"
           "    synchronized ($service_class_name$.class) {\n"
@@ -385,7 +395,7 @@ static void PrintMethodFields(
           "@$ExperimentalApi$(\"https://github.com/grpc/grpc-java/issues/1901\")\n"
           "@$Deprecated$ // Use {@link #$method_method_name$()} instead. \n"
           "public static final $MethodDescriptor$<$input_type$,\n"
-          "    $output_type$> $method_field_name$ = $method_method_name$();\n"
+          "    $output_type$> $method_field_name$ = $method_method_name_helper$();\n"
           "\n"
           "private static volatile $MethodDescriptor$<$input_type$,\n"
           "    $output_type$> $method_new_field_name$;\n"
@@ -393,6 +403,11 @@ static void PrintMethodFields(
           "@$ExperimentalApi$(\"https://github.com/grpc/grpc-java/issues/1901\")\n"
           "public static $MethodDescriptor$<$input_type$,\n"
           "    $output_type$> $method_method_name$() {\n"
+          "  return $method_method_name_helper$();\n"
+          "}\n"
+          "\n"
+          "private static $MethodDescriptor$<$input_type$,\n"
+          "    $output_type$> $method_method_name_helper$() {\n"
           "  $MethodDescriptor$<$input_type$, $output_type$> $method_new_field_name$;\n"
           "  if (($method_new_field_name$ = $service_class_name$.$method_new_field_name$) == null) {\n"
           "    synchronized ($service_class_name$.class) {\n"
@@ -597,7 +612,7 @@ static void PrintStub(
     (*vars)["output_type"] = MessageFullJavaName(generate_nano,
                                                  method->output_type());
     (*vars)["lower_method_name"] = LowerMethodName(method);
-    (*vars)["method_method_name"] = MethodPropertiesGetterName(method);
+    (*vars)["method_method_name_helper"] = MethodPropertiesGetterHelperName(method);
     bool client_streaming = method->client_streaming();
     bool server_streaming = method->server_streaming();
 
@@ -677,11 +692,11 @@ static void PrintStub(
           if (client_streaming) {
             p->Print(
                 *vars,
-                "return asyncUnimplementedStreamingCall($method_method_name$(), responseObserver);\n");
+                "return asyncUnimplementedStreamingCall($method_method_name_helper$(), responseObserver);\n");
           } else {
             p->Print(
                 *vars,
-                "asyncUnimplementedUnaryCall($method_method_name$(), responseObserver);\n");
+                "asyncUnimplementedUnaryCall($method_method_name_helper$(), responseObserver);\n");
           }
           break;
         default:
@@ -702,7 +717,7 @@ static void PrintStub(
           p->Print(
               *vars,
               "return $calls_method$(\n"
-              "    getChannel(), $method_method_name$(), getCallOptions(), $params$);\n");
+              "    getChannel(), $method_method_name_helper$(), getCallOptions(), $params$);\n");
           break;
         case ASYNC_CALL:
           if (server_streaming) {
@@ -726,7 +741,7 @@ static void PrintStub(
           p->Print(
               *vars,
               "$last_line_prefix$$calls_method$(\n"
-              "    getChannel().newCall($method_method_name$(), getCallOptions()), $params$);\n");
+              "    getChannel().newCall($method_method_name_helper$(), getCallOptions()), $params$);\n");
           break;
         case FUTURE_CALL:
           GRPC_CODEGEN_CHECK(!client_streaming && !server_streaming)
@@ -737,7 +752,7 @@ static void PrintStub(
           p->Print(
               *vars,
               "return $calls_method$(\n"
-              "    getChannel().newCall($method_method_name$(), getCallOptions()), request);\n");
+              "    getChannel().newCall($method_method_name_helper$(), getCallOptions()), request);\n");
           break;
       }
     }
@@ -961,8 +976,8 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
   }
   for (int i = 0; i < service->method_count(); ++i) {
     const MethodDescriptor* method = service->method(i);
-    (*vars)["method_method_name"] = MethodPropertiesGetterName(method);
-    p->Print(*vars, "\n.addMethod($method_method_name$())");
+    (*vars)["method_method_name_helper"] = MethodPropertiesGetterHelperName(method);
+    p->Print(*vars, "\n.addMethod($method_method_name_helper$())");
   }
   p->Print("\n.build();\n");
   p->Outdent();
@@ -993,7 +1008,7 @@ static void PrintBindServiceMethodBody(const ServiceDescriptor* service,
   for (int i = 0; i < service->method_count(); ++i) {
     const MethodDescriptor* method = service->method(i);
     (*vars)["lower_method_name"] = LowerMethodName(method);
-    (*vars)["method_method_name"] = MethodPropertiesGetterName(method);
+    (*vars)["method_method_name_helper"] = MethodPropertiesGetterHelperName(method);
     (*vars)["input_type"] = MessageFullJavaName(generate_nano,
                                                 method->input_type());
     (*vars)["output_type"] = MessageFullJavaName(generate_nano,
@@ -1018,7 +1033,7 @@ static void PrintBindServiceMethodBody(const ServiceDescriptor* service,
     p->Indent();
     p->Print(
         *vars,
-        "$method_method_name$(),\n"
+        "$method_method_name_helper$(),\n"
         "$calls_method$(\n");
     p->Indent();
     p->Print(

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -33,7 +33,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
-      io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+      io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
       io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod;
@@ -41,6 +41,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
       io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod() {
+    return getUnaryCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
+      io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest, io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod;
     if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -65,7 +70,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingOutputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethod();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
@@ -73,6 +78,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod() {
+    return getStreamingOutputCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
     if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -97,7 +107,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingInputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
-      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethod();
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
@@ -105,6 +115,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod() {
+    return getStreamingInputCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
     if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -129,7 +144,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getFullBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL = getFullBidiCallMethod();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL = getFullBidiCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
@@ -137,6 +152,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod() {
+    return getFullBidiCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
     if ((getFullBidiCallMethod = TestServiceGrpc.getFullBidiCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -161,7 +181,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getHalfBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL = getHalfBidiCallMethod();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL = getHalfBidiCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
@@ -169,6 +189,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod() {
+    return getHalfBidiCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
     if ((getHalfBidiCallMethod = TestServiceGrpc.getHalfBidiCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -229,7 +254,7 @@ public final class TestServiceGrpc {
      */
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -240,7 +265,7 @@ public final class TestServiceGrpc {
      */
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getStreamingOutputCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingOutputCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -251,7 +276,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getStreamingInputCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingInputCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -263,7 +288,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getFullBidiCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getFullBidiCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -276,41 +301,41 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getHalfBidiCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getHalfBidiCallMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getUnaryCallMethod(),
+            getUnaryCallMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.SimpleRequest,
                 io.grpc.testing.integration.Test.SimpleResponse>(
                   this, METHODID_UNARY_CALL)))
           .addMethod(
-            getStreamingOutputCallMethod(),
+            getStreamingOutputCallMethodHelper(),
             asyncServerStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
                   this, METHODID_STREAMING_OUTPUT_CALL)))
           .addMethod(
-            getStreamingInputCallMethod(),
+            getStreamingInputCallMethodHelper(),
             asyncClientStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.StreamingInputCallRequest,
                 io.grpc.testing.integration.Test.StreamingInputCallResponse>(
                   this, METHODID_STREAMING_INPUT_CALL)))
           .addMethod(
-            getFullBidiCallMethod(),
+            getFullBidiCallMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
                   this, METHODID_FULL_BIDI_CALL)))
           .addMethod(
-            getHalfBidiCallMethod(),
+            getHalfBidiCallMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.StreamingOutputCallRequest,
@@ -350,7 +375,7 @@ public final class TestServiceGrpc {
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -362,7 +387,7 @@ public final class TestServiceGrpc {
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(getStreamingOutputCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingOutputCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -374,7 +399,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(getStreamingInputCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingInputCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -387,7 +412,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getFullBidiCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getFullBidiCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -401,7 +426,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getHalfBidiCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getHalfBidiCallMethodHelper(), getCallOptions()), responseObserver);
     }
   }
 
@@ -434,7 +459,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
+          getChannel(), getUnaryCallMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -446,7 +471,7 @@ public final class TestServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
+          getChannel(), getStreamingOutputCallMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -480,7 +505,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -585,11 +610,11 @@ public final class TestServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new TestServiceFileDescriptorSupplier())
-              .addMethod(getUnaryCallMethod())
-              .addMethod(getStreamingOutputCallMethod())
-              .addMethod(getStreamingInputCallMethod())
-              .addMethod(getFullBidiCallMethod())
-              .addMethod(getHalfBidiCallMethod())
+              .addMethod(getUnaryCallMethodHelper())
+              .addMethod(getStreamingOutputCallMethodHelper())
+              .addMethod(getStreamingInputCallMethodHelper())
+              .addMethod(getFullBidiCallMethodHelper())
+              .addMethod(getHalfBidiCallMethodHelper())
               .build();
         }
       }

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -33,7 +33,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
-      io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+      io.grpc.testing.integration.Test.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
       io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod;
@@ -41,6 +41,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
       io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod() {
+    return getUnaryCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest,
+      io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.SimpleRequest, io.grpc.testing.integration.Test.SimpleResponse> getUnaryCallMethod;
     if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -64,7 +69,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingOutputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethod();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
@@ -72,6 +77,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod() {
+    return getStreamingOutputCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
     if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -95,7 +105,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingInputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
-      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethod();
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
@@ -103,6 +113,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod() {
+    return getStreamingInputCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
     if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -126,7 +141,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getFullBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL = getFullBidiCallMethod();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL = getFullBidiCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
@@ -134,6 +149,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod() {
+    return getFullBidiCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
     if ((getFullBidiCallMethod = TestServiceGrpc.getFullBidiCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -157,7 +177,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getHalfBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL = getHalfBidiCallMethod();
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL = getHalfBidiCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
@@ -165,6 +185,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod() {
+    return getHalfBidiCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingOutputCallRequest, io.grpc.testing.integration.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
     if ((getHalfBidiCallMethod = TestServiceGrpc.getHalfBidiCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -224,7 +249,7 @@ public final class TestServiceGrpc {
      */
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -235,7 +260,7 @@ public final class TestServiceGrpc {
      */
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getStreamingOutputCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingOutputCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -246,7 +271,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getStreamingInputCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingInputCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -258,7 +283,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getFullBidiCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getFullBidiCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -271,41 +296,41 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getHalfBidiCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getHalfBidiCallMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getUnaryCallMethod(),
+            getUnaryCallMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.SimpleRequest,
                 io.grpc.testing.integration.Test.SimpleResponse>(
                   this, METHODID_UNARY_CALL)))
           .addMethod(
-            getStreamingOutputCallMethod(),
+            getStreamingOutputCallMethodHelper(),
             asyncServerStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
                   this, METHODID_STREAMING_OUTPUT_CALL)))
           .addMethod(
-            getStreamingInputCallMethod(),
+            getStreamingInputCallMethodHelper(),
             asyncClientStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.StreamingInputCallRequest,
                 io.grpc.testing.integration.Test.StreamingInputCallResponse>(
                   this, METHODID_STREAMING_INPUT_CALL)))
           .addMethod(
-            getFullBidiCallMethod(),
+            getFullBidiCallMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
                   this, METHODID_FULL_BIDI_CALL)))
           .addMethod(
-            getHalfBidiCallMethod(),
+            getHalfBidiCallMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Test.StreamingOutputCallRequest,
@@ -345,7 +370,7 @@ public final class TestServiceGrpc {
     public void unaryCall(io.grpc.testing.integration.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -357,7 +382,7 @@ public final class TestServiceGrpc {
     public void streamingOutputCall(io.grpc.testing.integration.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(getStreamingOutputCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingOutputCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -369,7 +394,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(getStreamingInputCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingInputCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -382,7 +407,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getFullBidiCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getFullBidiCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -396,7 +421,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getHalfBidiCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getHalfBidiCallMethodHelper(), getCallOptions()), responseObserver);
     }
   }
 
@@ -429,7 +454,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.Test.SimpleResponse unaryCall(io.grpc.testing.integration.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
+          getChannel(), getUnaryCallMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -441,7 +466,7 @@ public final class TestServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
+          getChannel(), getStreamingOutputCallMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -475,7 +500,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Test.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -544,11 +569,11 @@ public final class TestServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .addMethod(getUnaryCallMethod())
-              .addMethod(getStreamingOutputCallMethod())
-              .addMethod(getStreamingInputCallMethod())
-              .addMethod(getFullBidiCallMethod())
-              .addMethod(getHalfBidiCallMethod())
+              .addMethod(getUnaryCallMethodHelper())
+              .addMethod(getStreamingOutputCallMethodHelper())
+              .addMethod(getStreamingInputCallMethodHelper())
+              .addMethod(getFullBidiCallMethodHelper())
+              .addMethod(getHalfBidiCallMethodHelper())
               .build();
         }
       }

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -37,7 +37,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.SimpleRequest,
-      io.grpc.testing.integration.nano.Test.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+      io.grpc.testing.integration.nano.Test.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.SimpleRequest,
       io.grpc.testing.integration.nano.Test.SimpleResponse> getUnaryCallMethod;
@@ -45,6 +45,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.SimpleRequest,
       io.grpc.testing.integration.nano.Test.SimpleResponse> getUnaryCallMethod() {
+    return getUnaryCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.SimpleRequest,
+      io.grpc.testing.integration.nano.Test.SimpleResponse> getUnaryCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.SimpleRequest, io.grpc.testing.integration.nano.Test.SimpleResponse> getUnaryCallMethod;
     if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -70,7 +75,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingOutputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethod();
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
@@ -78,6 +83,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod() {
+    return getStreamingOutputCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getStreamingOutputCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getStreamingOutputCallMethod;
     if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -103,7 +113,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingInputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
-      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethod();
+      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
@@ -111,6 +121,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
       io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getStreamingInputCallMethod() {
+    return getStreamingInputCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getStreamingInputCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest, io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getStreamingInputCallMethod;
     if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -136,7 +151,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getFullBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL = getFullBidiCallMethod();
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_FULL_BIDI_CALL = getFullBidiCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
@@ -144,6 +159,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getFullBidiCallMethod() {
+    return getFullBidiCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getFullBidiCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getFullBidiCallMethod;
     if ((getFullBidiCallMethod = TestServiceGrpc.getFullBidiCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -169,7 +189,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getHalfBidiCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
-      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL = getHalfBidiCallMethod();
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> METHOD_HALF_BIDI_CALL = getHalfBidiCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
@@ -177,6 +197,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
       io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getHalfBidiCallMethod() {
+    return getHalfBidiCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getHalfBidiCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest, io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> getHalfBidiCallMethod;
     if ((getHalfBidiCallMethod = TestServiceGrpc.getHalfBidiCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -287,7 +312,7 @@ public final class TestServiceGrpc {
      */
     public void unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -298,7 +323,7 @@ public final class TestServiceGrpc {
      */
     public void streamingOutputCall(io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getStreamingOutputCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingOutputCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -309,7 +334,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getStreamingInputCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingInputCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -321,7 +346,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getFullBidiCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getFullBidiCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -334,41 +359,41 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getHalfBidiCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getHalfBidiCallMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getUnaryCallMethod(),
+            getUnaryCallMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.testing.integration.nano.Test.SimpleRequest,
                 io.grpc.testing.integration.nano.Test.SimpleResponse>(
                   this, METHODID_UNARY_CALL)))
           .addMethod(
-            getStreamingOutputCallMethod(),
+            getStreamingOutputCallMethodHelper(),
             asyncServerStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
                 io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(
                   this, METHODID_STREAMING_OUTPUT_CALL)))
           .addMethod(
-            getStreamingInputCallMethod(),
+            getStreamingInputCallMethodHelper(),
             asyncClientStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
                 io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>(
                   this, METHODID_STREAMING_INPUT_CALL)))
           .addMethod(
-            getFullBidiCallMethod(),
+            getFullBidiCallMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
                 io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(
                   this, METHODID_FULL_BIDI_CALL)))
           .addMethod(
-            getHalfBidiCallMethod(),
+            getHalfBidiCallMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
@@ -408,7 +433,7 @@ public final class TestServiceGrpc {
     public void unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -420,7 +445,7 @@ public final class TestServiceGrpc {
     public void streamingOutputCall(io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(getStreamingOutputCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingOutputCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -432,7 +457,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(getStreamingInputCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingInputCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -445,7 +470,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> fullBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getFullBidiCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getFullBidiCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -459,7 +484,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest> halfBidiCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getHalfBidiCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getHalfBidiCallMethodHelper(), getCallOptions()), responseObserver);
     }
   }
 
@@ -492,7 +517,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.nano.Test.SimpleResponse unaryCall(io.grpc.testing.integration.nano.Test.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
+          getChannel(), getUnaryCallMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -504,7 +529,7 @@ public final class TestServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
+          getChannel(), getStreamingOutputCallMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -538,7 +563,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.nano.Test.SimpleResponse> unaryCall(
         io.grpc.testing.integration.nano.Test.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -607,11 +632,11 @@ public final class TestServiceGrpc {
         result = serviceDescriptor;
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .addMethod(getUnaryCallMethod())
-              .addMethod(getStreamingOutputCallMethod())
-              .addMethod(getStreamingInputCallMethod())
-              .addMethod(getFullBidiCallMethod())
-              .addMethod(getHalfBidiCallMethod())
+              .addMethod(getUnaryCallMethodHelper())
+              .addMethod(getStreamingOutputCallMethodHelper())
+              .addMethod(getStreamingInputCallMethodHelper())
+              .addMethod(getFullBidiCallMethodHelper())
+              .addMethod(getHalfBidiCallMethodHelper())
               .build();
         }
       }

--- a/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
+++ b/grpclb/src/generated/main/grpc/io/grpc/grpclb/LoadBalancerGrpc.java
@@ -30,7 +30,7 @@ public final class LoadBalancerGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getBalanceLoadMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest,
-      io.grpc.grpclb.LoadBalanceResponse> METHOD_BALANCE_LOAD = getBalanceLoadMethod();
+      io.grpc.grpclb.LoadBalanceResponse> METHOD_BALANCE_LOAD = getBalanceLoadMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest,
       io.grpc.grpclb.LoadBalanceResponse> getBalanceLoadMethod;
@@ -38,6 +38,11 @@ public final class LoadBalancerGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest,
       io.grpc.grpclb.LoadBalanceResponse> getBalanceLoadMethod() {
+    return getBalanceLoadMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest,
+      io.grpc.grpclb.LoadBalanceResponse> getBalanceLoadMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.grpclb.LoadBalanceRequest, io.grpc.grpclb.LoadBalanceResponse> getBalanceLoadMethod;
     if ((getBalanceLoadMethod = LoadBalancerGrpc.getBalanceLoadMethod) == null) {
       synchronized (LoadBalancerGrpc.class) {
@@ -94,13 +99,13 @@ public final class LoadBalancerGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceRequest> balanceLoad(
         io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getBalanceLoadMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getBalanceLoadMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getBalanceLoadMethod(),
+            getBalanceLoadMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.grpclb.LoadBalanceRequest,
@@ -136,7 +141,7 @@ public final class LoadBalancerGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceRequest> balanceLoad(
         io.grpc.stub.StreamObserver<io.grpc.grpclb.LoadBalanceResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getBalanceLoadMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getBalanceLoadMethodHelper(), getCallOptions()), responseObserver);
     }
   }
 
@@ -261,7 +266,7 @@ public final class LoadBalancerGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new LoadBalancerFileDescriptorSupplier())
-              .addMethod(getBalanceLoadMethod())
+              .addMethod(getBalanceLoadMethodHelper())
               .build();
         }
       }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/MetricsServiceGrpc.java
@@ -30,7 +30,7 @@ public final class MetricsServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGetAllGaugesMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,
-      io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_ALL_GAUGES = getGetAllGaugesMethod();
+      io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_ALL_GAUGES = getGetAllGaugesMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,
       io.grpc.testing.integration.Metrics.GaugeResponse> getGetAllGaugesMethod;
@@ -38,6 +38,11 @@ public final class MetricsServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,
       io.grpc.testing.integration.Metrics.GaugeResponse> getGetAllGaugesMethod() {
+    return getGetAllGaugesMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage,
+      io.grpc.testing.integration.Metrics.GaugeResponse> getGetAllGaugesMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.EmptyMessage, io.grpc.testing.integration.Metrics.GaugeResponse> getGetAllGaugesMethod;
     if ((getGetAllGaugesMethod = MetricsServiceGrpc.getGetAllGaugesMethod) == null) {
       synchronized (MetricsServiceGrpc.class) {
@@ -62,7 +67,7 @@ public final class MetricsServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGetGaugeMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest,
-      io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_GAUGE = getGetGaugeMethod();
+      io.grpc.testing.integration.Metrics.GaugeResponse> METHOD_GET_GAUGE = getGetGaugeMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest,
       io.grpc.testing.integration.Metrics.GaugeResponse> getGetGaugeMethod;
@@ -70,6 +75,11 @@ public final class MetricsServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest,
       io.grpc.testing.integration.Metrics.GaugeResponse> getGetGaugeMethod() {
+    return getGetGaugeMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest,
+      io.grpc.testing.integration.Metrics.GaugeResponse> getGetGaugeMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Metrics.GaugeRequest, io.grpc.testing.integration.Metrics.GaugeResponse> getGetGaugeMethod;
     if ((getGetGaugeMethod = MetricsServiceGrpc.getGetGaugeMethod) == null) {
       synchronized (MetricsServiceGrpc.class) {
@@ -127,7 +137,7 @@ public final class MetricsServiceGrpc {
      */
     public void getAllGauges(io.grpc.testing.integration.Metrics.EmptyMessage request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetAllGaugesMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetAllGaugesMethodHelper(), responseObserver);
     }
 
     /**
@@ -137,20 +147,20 @@ public final class MetricsServiceGrpc {
      */
     public void getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetGaugeMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetGaugeMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getGetAllGaugesMethod(),
+            getGetAllGaugesMethodHelper(),
             asyncServerStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Metrics.EmptyMessage,
                 io.grpc.testing.integration.Metrics.GaugeResponse>(
                   this, METHODID_GET_ALL_GAUGES)))
           .addMethod(
-            getGetGaugeMethod(),
+            getGetGaugeMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Metrics.GaugeRequest,
@@ -187,7 +197,7 @@ public final class MetricsServiceGrpc {
     public void getAllGauges(io.grpc.testing.integration.Metrics.EmptyMessage request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(getGetAllGaugesMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetAllGaugesMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -198,7 +208,7 @@ public final class MetricsServiceGrpc {
     public void getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Metrics.GaugeResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetGaugeMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetGaugeMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -229,7 +239,7 @@ public final class MetricsServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.Metrics.GaugeResponse> getAllGauges(
         io.grpc.testing.integration.Metrics.EmptyMessage request) {
       return blockingServerStreamingCall(
-          getChannel(), getGetAllGaugesMethod(), getCallOptions(), request);
+          getChannel(), getGetAllGaugesMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -239,7 +249,7 @@ public final class MetricsServiceGrpc {
      */
     public io.grpc.testing.integration.Metrics.GaugeResponse getGauge(io.grpc.testing.integration.Metrics.GaugeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetGaugeMethod(), getCallOptions(), request);
+          getChannel(), getGetGaugeMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -269,7 +279,7 @@ public final class MetricsServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Metrics.GaugeResponse> getGauge(
         io.grpc.testing.integration.Metrics.GaugeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetGaugeMethod(), getCallOptions()), request);
+          getChannel().newCall(getGetGaugeMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -362,8 +372,8 @@ public final class MetricsServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new MetricsServiceFileDescriptorSupplier())
-              .addMethod(getGetAllGaugesMethod())
-              .addMethod(getGetGaugeMethod())
+              .addMethod(getGetAllGaugesMethodHelper())
+              .addMethod(getGetGaugeMethodHelper())
               .build();
         }
       }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/ReconnectServiceGrpc.java
@@ -33,7 +33,7 @@ public final class ReconnectServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStartMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      com.google.protobuf.EmptyProtos.Empty> METHOD_START = getStartMethod();
+      com.google.protobuf.EmptyProtos.Empty> METHOD_START = getStartMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> getStartMethod;
@@ -41,6 +41,11 @@ public final class ReconnectServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> getStartMethod() {
+    return getStartMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getStartMethodHelper() {
     io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty> getStartMethod;
     if ((getStartMethod = ReconnectServiceGrpc.getStartMethod) == null) {
       synchronized (ReconnectServiceGrpc.class) {
@@ -65,7 +70,7 @@ public final class ReconnectServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStopMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      io.grpc.testing.integration.Messages.ReconnectInfo> METHOD_STOP = getStopMethod();
+      io.grpc.testing.integration.Messages.ReconnectInfo> METHOD_STOP = getStopMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       io.grpc.testing.integration.Messages.ReconnectInfo> getStopMethod;
@@ -73,6 +78,11 @@ public final class ReconnectServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       io.grpc.testing.integration.Messages.ReconnectInfo> getStopMethod() {
+    return getStopMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      io.grpc.testing.integration.Messages.ReconnectInfo> getStopMethodHelper() {
     io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, io.grpc.testing.integration.Messages.ReconnectInfo> getStopMethod;
     if ((getStopMethod = ReconnectServiceGrpc.getStopMethod) == null) {
       synchronized (ReconnectServiceGrpc.class) {
@@ -129,27 +139,27 @@ public final class ReconnectServiceGrpc {
      */
     public void start(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getStartMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getStartMethodHelper(), responseObserver);
     }
 
     /**
      */
     public void stop(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.ReconnectInfo> responseObserver) {
-      asyncUnimplementedUnaryCall(getStopMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getStopMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getStartMethod(),
+            getStartMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 com.google.protobuf.EmptyProtos.Empty,
                 com.google.protobuf.EmptyProtos.Empty>(
                   this, METHODID_START)))
           .addMethod(
-            getStopMethod(),
+            getStopMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 com.google.protobuf.EmptyProtos.Empty,
@@ -185,7 +195,7 @@ public final class ReconnectServiceGrpc {
     public void start(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getStartMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStartMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -193,7 +203,7 @@ public final class ReconnectServiceGrpc {
     public void stop(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.ReconnectInfo> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getStopMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStopMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -222,14 +232,14 @@ public final class ReconnectServiceGrpc {
      */
     public com.google.protobuf.EmptyProtos.Empty start(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), getStartMethod(), getCallOptions(), request);
+          getChannel(), getStartMethodHelper(), getCallOptions(), request);
     }
 
     /**
      */
     public io.grpc.testing.integration.Messages.ReconnectInfo stop(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), getStopMethod(), getCallOptions(), request);
+          getChannel(), getStopMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -259,7 +269,7 @@ public final class ReconnectServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> start(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(getStartMethod(), getCallOptions()), request);
+          getChannel().newCall(getStartMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -267,7 +277,7 @@ public final class ReconnectServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.ReconnectInfo> stop(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(getStopMethod(), getCallOptions()), request);
+          getChannel().newCall(getStopMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -360,8 +370,8 @@ public final class ReconnectServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new ReconnectServiceFileDescriptorSupplier())
-              .addMethod(getStartMethod())
-              .addMethod(getStopMethod())
+              .addMethod(getStartMethodHelper())
+              .addMethod(getStopMethodHelper())
               .build();
         }
       }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/TestServiceGrpc.java
@@ -34,7 +34,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getEmptyCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      com.google.protobuf.EmptyProtos.Empty> METHOD_EMPTY_CALL = getEmptyCallMethod();
+      com.google.protobuf.EmptyProtos.Empty> METHOD_EMPTY_CALL = getEmptyCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> getEmptyCallMethod;
@@ -42,6 +42,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> getEmptyCallMethod() {
+    return getEmptyCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getEmptyCallMethodHelper() {
     io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty> getEmptyCallMethod;
     if ((getEmptyCallMethod = TestServiceGrpc.getEmptyCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -66,7 +71,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
-      io.grpc.testing.integration.Messages.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethod();
+      io.grpc.testing.integration.Messages.SimpleResponse> METHOD_UNARY_CALL = getUnaryCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
       io.grpc.testing.integration.Messages.SimpleResponse> getUnaryCallMethod;
@@ -74,6 +79,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
       io.grpc.testing.integration.Messages.SimpleResponse> getUnaryCallMethod() {
+    return getUnaryCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
+      io.grpc.testing.integration.Messages.SimpleResponse> getUnaryCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest, io.grpc.testing.integration.Messages.SimpleResponse> getUnaryCallMethod;
     if ((getUnaryCallMethod = TestServiceGrpc.getUnaryCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -98,7 +108,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getCacheableUnaryCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
-      io.grpc.testing.integration.Messages.SimpleResponse> METHOD_CACHEABLE_UNARY_CALL = getCacheableUnaryCallMethod();
+      io.grpc.testing.integration.Messages.SimpleResponse> METHOD_CACHEABLE_UNARY_CALL = getCacheableUnaryCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
       io.grpc.testing.integration.Messages.SimpleResponse> getCacheableUnaryCallMethod;
@@ -106,6 +116,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
       io.grpc.testing.integration.Messages.SimpleResponse> getCacheableUnaryCallMethod() {
+    return getCacheableUnaryCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest,
+      io.grpc.testing.integration.Messages.SimpleResponse> getCacheableUnaryCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.SimpleRequest, io.grpc.testing.integration.Messages.SimpleResponse> getCacheableUnaryCallMethod;
     if ((getCacheableUnaryCallMethod = TestServiceGrpc.getCacheableUnaryCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -130,7 +145,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingOutputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethod();
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_STREAMING_OUTPUT_CALL = getStreamingOutputCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getStreamingOutputCallMethod;
@@ -138,6 +153,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getStreamingOutputCallMethod() {
+    return getStreamingOutputCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getStreamingOutputCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getStreamingOutputCallMethod;
     if ((getStreamingOutputCallMethod = TestServiceGrpc.getStreamingOutputCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -162,7 +182,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getStreamingInputCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
-      io.grpc.testing.integration.Messages.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethod();
+      io.grpc.testing.integration.Messages.StreamingInputCallResponse> METHOD_STREAMING_INPUT_CALL = getStreamingInputCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
       io.grpc.testing.integration.Messages.StreamingInputCallResponse> getStreamingInputCallMethod;
@@ -170,6 +190,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
       io.grpc.testing.integration.Messages.StreamingInputCallResponse> getStreamingInputCallMethod() {
+    return getStreamingInputCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingInputCallResponse> getStreamingInputCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingInputCallRequest, io.grpc.testing.integration.Messages.StreamingInputCallResponse> getStreamingInputCallMethod;
     if ((getStreamingInputCallMethod = TestServiceGrpc.getStreamingInputCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -194,7 +219,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getFullDuplexCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL = getFullDuplexCallMethod();
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_FULL_DUPLEX_CALL = getFullDuplexCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getFullDuplexCallMethod;
@@ -202,6 +227,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getFullDuplexCallMethod() {
+    return getFullDuplexCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getFullDuplexCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getFullDuplexCallMethod;
     if ((getFullDuplexCallMethod = TestServiceGrpc.getFullDuplexCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -226,7 +256,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getHalfDuplexCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
-      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL = getHalfDuplexCallMethod();
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> METHOD_HALF_DUPLEX_CALL = getHalfDuplexCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getHalfDuplexCallMethod;
@@ -234,6 +264,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
       io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getHalfDuplexCallMethod() {
+    return getHalfDuplexCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
+      io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getHalfDuplexCallMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.integration.Messages.StreamingOutputCallRequest, io.grpc.testing.integration.Messages.StreamingOutputCallResponse> getHalfDuplexCallMethod;
     if ((getHalfDuplexCallMethod = TestServiceGrpc.getHalfDuplexCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -258,7 +293,7 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getUnimplementedCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL = getUnimplementedCallMethod();
+      com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL = getUnimplementedCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod;
@@ -266,6 +301,11 @@ public final class TestServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod() {
+    return getUnimplementedCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethodHelper() {
     io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod;
     if ((getUnimplementedCallMethod = TestServiceGrpc.getUnimplementedCallMethod) == null) {
       synchronized (TestServiceGrpc.class) {
@@ -326,7 +366,7 @@ public final class TestServiceGrpc {
      */
     public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getEmptyCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getEmptyCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -336,7 +376,7 @@ public final class TestServiceGrpc {
      */
     public void unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getUnaryCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -348,7 +388,7 @@ public final class TestServiceGrpc {
      */
     public void cacheableUnaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getCacheableUnaryCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getCacheableUnaryCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -359,7 +399,7 @@ public final class TestServiceGrpc {
      */
     public void streamingOutputCall(io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getStreamingOutputCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getStreamingOutputCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -370,7 +410,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getStreamingInputCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingInputCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -382,7 +422,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getFullDuplexCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getFullDuplexCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -395,7 +435,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getHalfDuplexCallMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getHalfDuplexCallMethodHelper(), responseObserver);
     }
 
     /**
@@ -406,62 +446,62 @@ public final class TestServiceGrpc {
      */
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getUnimplementedCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getUnimplementedCallMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getEmptyCallMethod(),
+            getEmptyCallMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 com.google.protobuf.EmptyProtos.Empty,
                 com.google.protobuf.EmptyProtos.Empty>(
                   this, METHODID_EMPTY_CALL)))
           .addMethod(
-            getUnaryCallMethod(),
+            getUnaryCallMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Messages.SimpleRequest,
                 io.grpc.testing.integration.Messages.SimpleResponse>(
                   this, METHODID_UNARY_CALL)))
           .addMethod(
-            getCacheableUnaryCallMethod(),
+            getCacheableUnaryCallMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Messages.SimpleRequest,
                 io.grpc.testing.integration.Messages.SimpleResponse>(
                   this, METHODID_CACHEABLE_UNARY_CALL)))
           .addMethod(
-            getStreamingOutputCallMethod(),
+            getStreamingOutputCallMethodHelper(),
             asyncServerStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
                   this, METHODID_STREAMING_OUTPUT_CALL)))
           .addMethod(
-            getStreamingInputCallMethod(),
+            getStreamingInputCallMethodHelper(),
             asyncClientStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Messages.StreamingInputCallRequest,
                 io.grpc.testing.integration.Messages.StreamingInputCallResponse>(
                   this, METHODID_STREAMING_INPUT_CALL)))
           .addMethod(
-            getFullDuplexCallMethod(),
+            getFullDuplexCallMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
                   this, METHODID_FULL_DUPLEX_CALL)))
           .addMethod(
-            getHalfDuplexCallMethod(),
+            getHalfDuplexCallMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.integration.Messages.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Messages.StreamingOutputCallResponse>(
                   this, METHODID_HALF_DUPLEX_CALL)))
           .addMethod(
-            getUnimplementedCallMethod(),
+            getUnimplementedCallMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 com.google.protobuf.EmptyProtos.Empty,
@@ -501,7 +541,7 @@ public final class TestServiceGrpc {
     public void emptyCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getEmptyCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getEmptyCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -512,7 +552,7 @@ public final class TestServiceGrpc {
     public void unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -525,7 +565,7 @@ public final class TestServiceGrpc {
     public void cacheableUnaryCall(io.grpc.testing.integration.Messages.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCacheableUnaryCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getCacheableUnaryCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -537,7 +577,7 @@ public final class TestServiceGrpc {
     public void streamingOutputCall(io.grpc.testing.integration.Messages.StreamingOutputCallRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(getStreamingOutputCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getStreamingOutputCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -549,7 +589,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallRequest> streamingInputCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingInputCallResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(getStreamingInputCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingInputCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -562,7 +602,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> fullDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getFullDuplexCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getFullDuplexCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -576,7 +616,7 @@ public final class TestServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallRequest> halfDuplexCall(
         io.grpc.stub.StreamObserver<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getHalfDuplexCallMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getHalfDuplexCallMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -588,7 +628,7 @@ public final class TestServiceGrpc {
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUnimplementedCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnimplementedCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -621,7 +661,7 @@ public final class TestServiceGrpc {
      */
     public com.google.protobuf.EmptyProtos.Empty emptyCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), getEmptyCallMethod(), getCallOptions(), request);
+          getChannel(), getEmptyCallMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -631,7 +671,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.Messages.SimpleResponse unaryCall(io.grpc.testing.integration.Messages.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUnaryCallMethod(), getCallOptions(), request);
+          getChannel(), getUnaryCallMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -643,7 +683,7 @@ public final class TestServiceGrpc {
      */
     public io.grpc.testing.integration.Messages.SimpleResponse cacheableUnaryCall(io.grpc.testing.integration.Messages.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCacheableUnaryCallMethod(), getCallOptions(), request);
+          getChannel(), getCacheableUnaryCallMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -655,7 +695,7 @@ public final class TestServiceGrpc {
     public java.util.Iterator<io.grpc.testing.integration.Messages.StreamingOutputCallResponse> streamingOutputCall(
         io.grpc.testing.integration.Messages.StreamingOutputCallRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), getStreamingOutputCallMethod(), getCallOptions(), request);
+          getChannel(), getStreamingOutputCallMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -666,7 +706,7 @@ public final class TestServiceGrpc {
      */
     public com.google.protobuf.EmptyProtos.Empty unimplementedCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), getUnimplementedCallMethod(), getCallOptions(), request);
+          getChannel(), getUnimplementedCallMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -700,7 +740,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> emptyCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(getEmptyCallMethod(), getCallOptions()), request);
+          getChannel().newCall(getEmptyCallMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -711,7 +751,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> unaryCall(
         io.grpc.testing.integration.Messages.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUnaryCallMethod(), getCallOptions()), request);
+          getChannel().newCall(getUnaryCallMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -724,7 +764,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.integration.Messages.SimpleResponse> cacheableUnaryCall(
         io.grpc.testing.integration.Messages.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCacheableUnaryCallMethod(), getCallOptions()), request);
+          getChannel().newCall(getCacheableUnaryCallMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -736,7 +776,7 @@ public final class TestServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> unimplementedCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(getUnimplementedCallMethod(), getCallOptions()), request);
+          getChannel().newCall(getUnimplementedCallMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -856,14 +896,14 @@ public final class TestServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new TestServiceFileDescriptorSupplier())
-              .addMethod(getEmptyCallMethod())
-              .addMethod(getUnaryCallMethod())
-              .addMethod(getCacheableUnaryCallMethod())
-              .addMethod(getStreamingOutputCallMethod())
-              .addMethod(getStreamingInputCallMethod())
-              .addMethod(getFullDuplexCallMethod())
-              .addMethod(getHalfDuplexCallMethod())
-              .addMethod(getUnimplementedCallMethod())
+              .addMethod(getEmptyCallMethodHelper())
+              .addMethod(getUnaryCallMethodHelper())
+              .addMethod(getCacheableUnaryCallMethodHelper())
+              .addMethod(getStreamingOutputCallMethodHelper())
+              .addMethod(getStreamingInputCallMethodHelper())
+              .addMethod(getFullDuplexCallMethodHelper())
+              .addMethod(getHalfDuplexCallMethodHelper())
+              .addMethod(getUnimplementedCallMethodHelper())
               .build();
         }
       }

--- a/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
+++ b/interop-testing/src/generated/main/grpc/io/grpc/testing/integration/UnimplementedServiceGrpc.java
@@ -34,7 +34,7 @@ public final class UnimplementedServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getUnimplementedCallMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
-      com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL = getUnimplementedCallMethod();
+      com.google.protobuf.EmptyProtos.Empty> METHOD_UNIMPLEMENTED_CALL = getUnimplementedCallMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod;
@@ -42,6 +42,11 @@ public final class UnimplementedServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
       com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod() {
+    return getUnimplementedCallMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty,
+      com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethodHelper() {
     io.grpc.MethodDescriptor<com.google.protobuf.EmptyProtos.Empty, com.google.protobuf.EmptyProtos.Empty> getUnimplementedCallMethod;
     if ((getUnimplementedCallMethod = UnimplementedServiceGrpc.getUnimplementedCallMethod) == null) {
       synchronized (UnimplementedServiceGrpc.class) {
@@ -102,13 +107,13 @@ public final class UnimplementedServiceGrpc {
      */
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getUnimplementedCallMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getUnimplementedCallMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getUnimplementedCallMethod(),
+            getUnimplementedCallMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 com.google.protobuf.EmptyProtos.Empty,
@@ -148,7 +153,7 @@ public final class UnimplementedServiceGrpc {
     public void unimplementedCall(com.google.protobuf.EmptyProtos.Empty request,
         io.grpc.stub.StreamObserver<com.google.protobuf.EmptyProtos.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUnimplementedCallMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnimplementedCallMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -181,7 +186,7 @@ public final class UnimplementedServiceGrpc {
      */
     public com.google.protobuf.EmptyProtos.Empty unimplementedCall(com.google.protobuf.EmptyProtos.Empty request) {
       return blockingUnaryCall(
-          getChannel(), getUnimplementedCallMethod(), getCallOptions(), request);
+          getChannel(), getUnimplementedCallMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -215,7 +220,7 @@ public final class UnimplementedServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.EmptyProtos.Empty> unimplementedCall(
         com.google.protobuf.EmptyProtos.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(getUnimplementedCallMethod(), getCallOptions()), request);
+          getChannel().newCall(getUnimplementedCallMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -303,7 +308,7 @@ public final class UnimplementedServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new UnimplementedServiceFileDescriptorSupplier())
-              .addMethod(getUnimplementedCallMethod())
+              .addMethod(getUnimplementedCallMethodHelper())
               .build();
         }
       }

--- a/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/health/v1/HealthGrpc.java
@@ -30,7 +30,7 @@ public final class HealthGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getCheckMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest,
-      io.grpc.health.v1.HealthCheckResponse> METHOD_CHECK = getCheckMethod();
+      io.grpc.health.v1.HealthCheckResponse> METHOD_CHECK = getCheckMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest,
       io.grpc.health.v1.HealthCheckResponse> getCheckMethod;
@@ -38,6 +38,11 @@ public final class HealthGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest,
       io.grpc.health.v1.HealthCheckResponse> getCheckMethod() {
+    return getCheckMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest,
+      io.grpc.health.v1.HealthCheckResponse> getCheckMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.health.v1.HealthCheckRequest, io.grpc.health.v1.HealthCheckResponse> getCheckMethod;
     if ((getCheckMethod = HealthGrpc.getCheckMethod) == null) {
       synchronized (HealthGrpc.class) {
@@ -91,13 +96,13 @@ public final class HealthGrpc {
      */
     public void check(io.grpc.health.v1.HealthCheckRequest request,
         io.grpc.stub.StreamObserver<io.grpc.health.v1.HealthCheckResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getCheckMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getCheckMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getCheckMethod(),
+            getCheckMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.health.v1.HealthCheckRequest,
@@ -130,7 +135,7 @@ public final class HealthGrpc {
     public void check(io.grpc.health.v1.HealthCheckRequest request,
         io.grpc.stub.StreamObserver<io.grpc.health.v1.HealthCheckResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCheckMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getCheckMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -156,7 +161,7 @@ public final class HealthGrpc {
      */
     public io.grpc.health.v1.HealthCheckResponse check(io.grpc.health.v1.HealthCheckRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCheckMethod(), getCallOptions(), request);
+          getChannel(), getCheckMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -183,7 +188,7 @@ public final class HealthGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.health.v1.HealthCheckResponse> check(
         io.grpc.health.v1.HealthCheckRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCheckMethod(), getCallOptions()), request);
+          getChannel().newCall(getCheckMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -271,7 +276,7 @@ public final class HealthGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new HealthFileDescriptorSupplier())
-              .addMethod(getCheckMethod())
+              .addMethod(getCheckMethodHelper())
               .build();
         }
       }

--- a/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/instrumentation/v1alpha/MonitoringGrpc.java
@@ -30,7 +30,7 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGetCanonicalRpcStatsMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.google.protobuf.Empty,
-      io.grpc.instrumentation.v1alpha.CanonicalRpcStats> METHOD_GET_CANONICAL_RPC_STATS = getGetCanonicalRpcStatsMethod();
+      io.grpc.instrumentation.v1alpha.CanonicalRpcStats> METHOD_GET_CANONICAL_RPC_STATS = getGetCanonicalRpcStatsMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<com.google.protobuf.Empty,
       io.grpc.instrumentation.v1alpha.CanonicalRpcStats> getGetCanonicalRpcStatsMethod;
@@ -38,6 +38,11 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<com.google.protobuf.Empty,
       io.grpc.instrumentation.v1alpha.CanonicalRpcStats> getGetCanonicalRpcStatsMethod() {
+    return getGetCanonicalRpcStatsMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.google.protobuf.Empty,
+      io.grpc.instrumentation.v1alpha.CanonicalRpcStats> getGetCanonicalRpcStatsMethodHelper() {
     io.grpc.MethodDescriptor<com.google.protobuf.Empty, io.grpc.instrumentation.v1alpha.CanonicalRpcStats> getGetCanonicalRpcStatsMethod;
     if ((getGetCanonicalRpcStatsMethod = MonitoringGrpc.getGetCanonicalRpcStatsMethod) == null) {
       synchronized (MonitoringGrpc.class) {
@@ -62,7 +67,7 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGetStatsMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
-      io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_GET_STATS = getGetStatsMethod();
+      io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_GET_STATS = getGetStatsMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
       io.grpc.instrumentation.v1alpha.StatsResponse> getGetStatsMethod;
@@ -70,6 +75,11 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
       io.grpc.instrumentation.v1alpha.StatsResponse> getGetStatsMethod() {
+    return getGetStatsMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
+      io.grpc.instrumentation.v1alpha.StatsResponse> getGetStatsMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest, io.grpc.instrumentation.v1alpha.StatsResponse> getGetStatsMethod;
     if ((getGetStatsMethod = MonitoringGrpc.getGetStatsMethod) == null) {
       synchronized (MonitoringGrpc.class) {
@@ -94,7 +104,7 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getWatchStatsMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
-      io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_WATCH_STATS = getWatchStatsMethod();
+      io.grpc.instrumentation.v1alpha.StatsResponse> METHOD_WATCH_STATS = getWatchStatsMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
       io.grpc.instrumentation.v1alpha.StatsResponse> getWatchStatsMethod;
@@ -102,6 +112,11 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
       io.grpc.instrumentation.v1alpha.StatsResponse> getWatchStatsMethod() {
+    return getWatchStatsMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest,
+      io.grpc.instrumentation.v1alpha.StatsResponse> getWatchStatsMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.StatsRequest, io.grpc.instrumentation.v1alpha.StatsResponse> getWatchStatsMethod;
     if ((getWatchStatsMethod = MonitoringGrpc.getWatchStatsMethod) == null) {
       synchronized (MonitoringGrpc.class) {
@@ -126,7 +141,7 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGetRequestTracesMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest,
-      io.grpc.instrumentation.v1alpha.TraceResponse> METHOD_GET_REQUEST_TRACES = getGetRequestTracesMethod();
+      io.grpc.instrumentation.v1alpha.TraceResponse> METHOD_GET_REQUEST_TRACES = getGetRequestTracesMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest,
       io.grpc.instrumentation.v1alpha.TraceResponse> getGetRequestTracesMethod;
@@ -134,6 +149,11 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest,
       io.grpc.instrumentation.v1alpha.TraceResponse> getGetRequestTracesMethod() {
+    return getGetRequestTracesMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest,
+      io.grpc.instrumentation.v1alpha.TraceResponse> getGetRequestTracesMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.TraceRequest, io.grpc.instrumentation.v1alpha.TraceResponse> getGetRequestTracesMethod;
     if ((getGetRequestTracesMethod = MonitoringGrpc.getGetRequestTracesMethod) == null) {
       synchronized (MonitoringGrpc.class) {
@@ -158,7 +178,7 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGetCustomMonitoringDataMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
-      io.grpc.instrumentation.v1alpha.CustomMonitoringData> METHOD_GET_CUSTOM_MONITORING_DATA = getGetCustomMonitoringDataMethod();
+      io.grpc.instrumentation.v1alpha.CustomMonitoringData> METHOD_GET_CUSTOM_MONITORING_DATA = getGetCustomMonitoringDataMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
       io.grpc.instrumentation.v1alpha.CustomMonitoringData> getGetCustomMonitoringDataMethod;
@@ -166,6 +186,11 @@ public final class MonitoringGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
       io.grpc.instrumentation.v1alpha.CustomMonitoringData> getGetCustomMonitoringDataMethod() {
+    return getGetCustomMonitoringDataMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
+      io.grpc.instrumentation.v1alpha.CustomMonitoringData> getGetCustomMonitoringDataMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.instrumentation.v1alpha.MonitoringDataGroup, io.grpc.instrumentation.v1alpha.CustomMonitoringData> getGetCustomMonitoringDataMethod;
     if ((getGetCustomMonitoringDataMethod = MonitoringGrpc.getGetCustomMonitoringDataMethod) == null) {
       synchronized (MonitoringGrpc.class) {
@@ -222,7 +247,7 @@ public final class MonitoringGrpc {
      */
     public void getCanonicalRpcStats(com.google.protobuf.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.CanonicalRpcStats> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetCanonicalRpcStatsMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetCanonicalRpcStatsMethodHelper(), responseObserver);
     }
 
     /**
@@ -232,7 +257,7 @@ public final class MonitoringGrpc {
      */
     public void getStats(io.grpc.instrumentation.v1alpha.StatsRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.StatsResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetStatsMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetStatsMethodHelper(), responseObserver);
     }
 
     /**
@@ -242,7 +267,7 @@ public final class MonitoringGrpc {
      */
     public void watchStats(io.grpc.instrumentation.v1alpha.StatsRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.StatsResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getWatchStatsMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getWatchStatsMethodHelper(), responseObserver);
     }
 
     /**
@@ -252,7 +277,7 @@ public final class MonitoringGrpc {
      */
     public void getRequestTraces(io.grpc.instrumentation.v1alpha.TraceRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.TraceResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetRequestTracesMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetRequestTracesMethodHelper(), responseObserver);
     }
 
     /**
@@ -265,41 +290,41 @@ public final class MonitoringGrpc {
      */
     public void getCustomMonitoringData(io.grpc.instrumentation.v1alpha.MonitoringDataGroup request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.CustomMonitoringData> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetCustomMonitoringDataMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetCustomMonitoringDataMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getGetCanonicalRpcStatsMethod(),
+            getGetCanonicalRpcStatsMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 com.google.protobuf.Empty,
                 io.grpc.instrumentation.v1alpha.CanonicalRpcStats>(
                   this, METHODID_GET_CANONICAL_RPC_STATS)))
           .addMethod(
-            getGetStatsMethod(),
+            getGetStatsMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.instrumentation.v1alpha.StatsRequest,
                 io.grpc.instrumentation.v1alpha.StatsResponse>(
                   this, METHODID_GET_STATS)))
           .addMethod(
-            getWatchStatsMethod(),
+            getWatchStatsMethodHelper(),
             asyncServerStreamingCall(
               new MethodHandlers<
                 io.grpc.instrumentation.v1alpha.StatsRequest,
                 io.grpc.instrumentation.v1alpha.StatsResponse>(
                   this, METHODID_WATCH_STATS)))
           .addMethod(
-            getGetRequestTracesMethod(),
+            getGetRequestTracesMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.instrumentation.v1alpha.TraceRequest,
                 io.grpc.instrumentation.v1alpha.TraceResponse>(
                   this, METHODID_GET_REQUEST_TRACES)))
           .addMethod(
-            getGetCustomMonitoringDataMethod(),
+            getGetCustomMonitoringDataMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.instrumentation.v1alpha.MonitoringDataGroup,
@@ -335,7 +360,7 @@ public final class MonitoringGrpc {
     public void getCanonicalRpcStats(com.google.protobuf.Empty request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.CanonicalRpcStats> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetCanonicalRpcStatsMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetCanonicalRpcStatsMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -346,7 +371,7 @@ public final class MonitoringGrpc {
     public void getStats(io.grpc.instrumentation.v1alpha.StatsRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.StatsResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetStatsMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetStatsMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -357,7 +382,7 @@ public final class MonitoringGrpc {
     public void watchStats(io.grpc.instrumentation.v1alpha.StatsRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.StatsResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(getWatchStatsMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getWatchStatsMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -368,7 +393,7 @@ public final class MonitoringGrpc {
     public void getRequestTraces(io.grpc.instrumentation.v1alpha.TraceRequest request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.TraceResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetRequestTracesMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetRequestTracesMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -382,7 +407,7 @@ public final class MonitoringGrpc {
     public void getCustomMonitoringData(io.grpc.instrumentation.v1alpha.MonitoringDataGroup request,
         io.grpc.stub.StreamObserver<io.grpc.instrumentation.v1alpha.CustomMonitoringData> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetCustomMonitoringDataMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetCustomMonitoringDataMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -411,7 +436,7 @@ public final class MonitoringGrpc {
      */
     public io.grpc.instrumentation.v1alpha.CanonicalRpcStats getCanonicalRpcStats(com.google.protobuf.Empty request) {
       return blockingUnaryCall(
-          getChannel(), getGetCanonicalRpcStatsMethod(), getCallOptions(), request);
+          getChannel(), getGetCanonicalRpcStatsMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -421,7 +446,7 @@ public final class MonitoringGrpc {
      */
     public io.grpc.instrumentation.v1alpha.StatsResponse getStats(io.grpc.instrumentation.v1alpha.StatsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetStatsMethod(), getCallOptions(), request);
+          getChannel(), getGetStatsMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -432,7 +457,7 @@ public final class MonitoringGrpc {
     public java.util.Iterator<io.grpc.instrumentation.v1alpha.StatsResponse> watchStats(
         io.grpc.instrumentation.v1alpha.StatsRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), getWatchStatsMethod(), getCallOptions(), request);
+          getChannel(), getWatchStatsMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -442,7 +467,7 @@ public final class MonitoringGrpc {
      */
     public io.grpc.instrumentation.v1alpha.TraceResponse getRequestTraces(io.grpc.instrumentation.v1alpha.TraceRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetRequestTracesMethod(), getCallOptions(), request);
+          getChannel(), getGetRequestTracesMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -455,7 +480,7 @@ public final class MonitoringGrpc {
      */
     public io.grpc.instrumentation.v1alpha.CustomMonitoringData getCustomMonitoringData(io.grpc.instrumentation.v1alpha.MonitoringDataGroup request) {
       return blockingUnaryCall(
-          getChannel(), getGetCustomMonitoringDataMethod(), getCallOptions(), request);
+          getChannel(), getGetCustomMonitoringDataMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -485,7 +510,7 @@ public final class MonitoringGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.instrumentation.v1alpha.CanonicalRpcStats> getCanonicalRpcStats(
         com.google.protobuf.Empty request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetCanonicalRpcStatsMethod(), getCallOptions()), request);
+          getChannel().newCall(getGetCanonicalRpcStatsMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -496,7 +521,7 @@ public final class MonitoringGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.instrumentation.v1alpha.StatsResponse> getStats(
         io.grpc.instrumentation.v1alpha.StatsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetStatsMethod(), getCallOptions()), request);
+          getChannel().newCall(getGetStatsMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -507,7 +532,7 @@ public final class MonitoringGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.instrumentation.v1alpha.TraceResponse> getRequestTraces(
         io.grpc.instrumentation.v1alpha.TraceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetRequestTracesMethod(), getCallOptions()), request);
+          getChannel().newCall(getGetRequestTracesMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -521,7 +546,7 @@ public final class MonitoringGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.instrumentation.v1alpha.CustomMonitoringData> getCustomMonitoringData(
         io.grpc.instrumentation.v1alpha.MonitoringDataGroup request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetCustomMonitoringDataMethod(), getCallOptions()), request);
+          getChannel().newCall(getGetCustomMonitoringDataMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -629,11 +654,11 @@ public final class MonitoringGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new MonitoringFileDescriptorSupplier())
-              .addMethod(getGetCanonicalRpcStatsMethod())
-              .addMethod(getGetStatsMethod())
-              .addMethod(getWatchStatsMethod())
-              .addMethod(getGetRequestTracesMethod())
-              .addMethod(getGetCustomMonitoringDataMethod())
+              .addMethod(getGetCanonicalRpcStatsMethodHelper())
+              .addMethod(getGetStatsMethodHelper())
+              .addMethod(getWatchStatsMethodHelper())
+              .addMethod(getGetRequestTracesMethodHelper())
+              .addMethod(getGetCustomMonitoringDataMethodHelper())
               .build();
         }
       }

--- a/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
+++ b/services/src/generated/main/grpc/io/grpc/reflection/v1alpha/ServerReflectionGrpc.java
@@ -30,7 +30,7 @@ public final class ServerReflectionGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getServerReflectionInfoMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest,
-      io.grpc.reflection.v1alpha.ServerReflectionResponse> METHOD_SERVER_REFLECTION_INFO = getServerReflectionInfoMethod();
+      io.grpc.reflection.v1alpha.ServerReflectionResponse> METHOD_SERVER_REFLECTION_INFO = getServerReflectionInfoMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest,
       io.grpc.reflection.v1alpha.ServerReflectionResponse> getServerReflectionInfoMethod;
@@ -38,6 +38,11 @@ public final class ServerReflectionGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest,
       io.grpc.reflection.v1alpha.ServerReflectionResponse> getServerReflectionInfoMethod() {
+    return getServerReflectionInfoMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest,
+      io.grpc.reflection.v1alpha.ServerReflectionResponse> getServerReflectionInfoMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.reflection.v1alpha.ServerReflectionRequest, io.grpc.reflection.v1alpha.ServerReflectionResponse> getServerReflectionInfoMethod;
     if ((getServerReflectionInfoMethod = ServerReflectionGrpc.getServerReflectionInfoMethod) == null) {
       synchronized (ServerReflectionGrpc.class) {
@@ -95,13 +100,13 @@ public final class ServerReflectionGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.reflection.v1alpha.ServerReflectionRequest> serverReflectionInfo(
         io.grpc.stub.StreamObserver<io.grpc.reflection.v1alpha.ServerReflectionResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getServerReflectionInfoMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getServerReflectionInfoMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getServerReflectionInfoMethod(),
+            getServerReflectionInfoMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.reflection.v1alpha.ServerReflectionRequest,
@@ -138,7 +143,7 @@ public final class ServerReflectionGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.reflection.v1alpha.ServerReflectionRequest> serverReflectionInfo(
         io.grpc.stub.StreamObserver<io.grpc.reflection.v1alpha.ServerReflectionResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getServerReflectionInfoMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getServerReflectionInfoMethodHelper(), getCallOptions()), responseObserver);
     }
   }
 
@@ -263,7 +268,7 @@ public final class ServerReflectionGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new ServerReflectionFileDescriptorSupplier())
-              .addMethod(getServerReflectionInfoMethod())
+              .addMethod(getServerReflectionInfoMethodHelper())
               .build();
         }
       }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/AnotherDynamicServiceGrpc.java
@@ -33,7 +33,7 @@ public final class AnotherDynamicServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getMethodMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
-      io.grpc.reflection.testing.DynamicReply> METHOD_METHOD = getMethodMethod();
+      io.grpc.reflection.testing.DynamicReply> METHOD_METHOD = getMethodMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
       io.grpc.reflection.testing.DynamicReply> getMethodMethod;
@@ -41,6 +41,11 @@ public final class AnotherDynamicServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
       io.grpc.reflection.testing.DynamicReply> getMethodMethod() {
+    return getMethodMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
+      io.grpc.reflection.testing.DynamicReply> getMethodMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest, io.grpc.reflection.testing.DynamicReply> getMethodMethod;
     if ((getMethodMethod = AnotherDynamicServiceGrpc.getMethodMethod) == null) {
       synchronized (AnotherDynamicServiceGrpc.class) {
@@ -100,13 +105,13 @@ public final class AnotherDynamicServiceGrpc {
      */
     public void method(io.grpc.reflection.testing.DynamicRequest request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.DynamicReply> responseObserver) {
-      asyncUnimplementedUnaryCall(getMethodMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getMethodMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getMethodMethod(),
+            getMethodMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.reflection.testing.DynamicRequest,
@@ -145,7 +150,7 @@ public final class AnotherDynamicServiceGrpc {
     public void method(io.grpc.reflection.testing.DynamicRequest request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.DynamicReply> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getMethodMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getMethodMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -177,7 +182,7 @@ public final class AnotherDynamicServiceGrpc {
      */
     public io.grpc.reflection.testing.DynamicReply method(io.grpc.reflection.testing.DynamicRequest request) {
       return blockingUnaryCall(
-          getChannel(), getMethodMethod(), getCallOptions(), request);
+          getChannel(), getMethodMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -210,7 +215,7 @@ public final class AnotherDynamicServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.reflection.testing.DynamicReply> method(
         io.grpc.reflection.testing.DynamicRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getMethodMethod(), getCallOptions()), request);
+          getChannel().newCall(getMethodMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -298,7 +303,7 @@ public final class AnotherDynamicServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new AnotherDynamicServiceFileDescriptorSupplier())
-              .addMethod(getMethodMethod())
+              .addMethod(getMethodMethodHelper())
               .build();
         }
       }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/DynamicServiceGrpc.java
@@ -33,7 +33,7 @@ public final class DynamicServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getMethodMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
-      io.grpc.reflection.testing.DynamicReply> METHOD_METHOD = getMethodMethod();
+      io.grpc.reflection.testing.DynamicReply> METHOD_METHOD = getMethodMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
       io.grpc.reflection.testing.DynamicReply> getMethodMethod;
@@ -41,6 +41,11 @@ public final class DynamicServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
       io.grpc.reflection.testing.DynamicReply> getMethodMethod() {
+    return getMethodMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest,
+      io.grpc.reflection.testing.DynamicReply> getMethodMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.reflection.testing.DynamicRequest, io.grpc.reflection.testing.DynamicReply> getMethodMethod;
     if ((getMethodMethod = DynamicServiceGrpc.getMethodMethod) == null) {
       synchronized (DynamicServiceGrpc.class) {
@@ -100,13 +105,13 @@ public final class DynamicServiceGrpc {
      */
     public void method(io.grpc.reflection.testing.DynamicRequest request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.DynamicReply> responseObserver) {
-      asyncUnimplementedUnaryCall(getMethodMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getMethodMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getMethodMethod(),
+            getMethodMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.reflection.testing.DynamicRequest,
@@ -145,7 +150,7 @@ public final class DynamicServiceGrpc {
     public void method(io.grpc.reflection.testing.DynamicRequest request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.DynamicReply> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getMethodMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getMethodMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -177,7 +182,7 @@ public final class DynamicServiceGrpc {
      */
     public io.grpc.reflection.testing.DynamicReply method(io.grpc.reflection.testing.DynamicRequest request) {
       return blockingUnaryCall(
-          getChannel(), getMethodMethod(), getCallOptions(), request);
+          getChannel(), getMethodMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -210,7 +215,7 @@ public final class DynamicServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.reflection.testing.DynamicReply> method(
         io.grpc.reflection.testing.DynamicRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getMethodMethod(), getCallOptions()), request);
+          getChannel().newCall(getMethodMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -298,7 +303,7 @@ public final class DynamicServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new DynamicServiceFileDescriptorSupplier())
-              .addMethod(getMethodMethod())
+              .addMethod(getMethodMethodHelper())
               .build();
         }
       }

--- a/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
+++ b/services/src/generated/test/grpc/io/grpc/reflection/testing/ReflectableServiceGrpc.java
@@ -30,7 +30,7 @@ public final class ReflectableServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getMethodMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request,
-      io.grpc.reflection.testing.Reply> METHOD_METHOD = getMethodMethod();
+      io.grpc.reflection.testing.Reply> METHOD_METHOD = getMethodMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request,
       io.grpc.reflection.testing.Reply> getMethodMethod;
@@ -38,6 +38,11 @@ public final class ReflectableServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request,
       io.grpc.reflection.testing.Reply> getMethodMethod() {
+    return getMethodMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request,
+      io.grpc.reflection.testing.Reply> getMethodMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.reflection.testing.Request, io.grpc.reflection.testing.Reply> getMethodMethod;
     if ((getMethodMethod = ReflectableServiceGrpc.getMethodMethod) == null) {
       synchronized (ReflectableServiceGrpc.class) {
@@ -91,13 +96,13 @@ public final class ReflectableServiceGrpc {
      */
     public void method(io.grpc.reflection.testing.Request request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.Reply> responseObserver) {
-      asyncUnimplementedUnaryCall(getMethodMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getMethodMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getMethodMethod(),
+            getMethodMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.reflection.testing.Request,
@@ -130,7 +135,7 @@ public final class ReflectableServiceGrpc {
     public void method(io.grpc.reflection.testing.Request request,
         io.grpc.stub.StreamObserver<io.grpc.reflection.testing.Reply> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getMethodMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getMethodMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -156,7 +161,7 @@ public final class ReflectableServiceGrpc {
      */
     public io.grpc.reflection.testing.Reply method(io.grpc.reflection.testing.Request request) {
       return blockingUnaryCall(
-          getChannel(), getMethodMethod(), getCallOptions(), request);
+          getChannel(), getMethodMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -183,7 +188,7 @@ public final class ReflectableServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.reflection.testing.Reply> method(
         io.grpc.reflection.testing.Request request) {
       return futureUnaryCall(
-          getChannel().newCall(getMethodMethod(), getCallOptions()), request);
+          getChannel().newCall(getMethodMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -271,7 +276,7 @@ public final class ReflectableServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new ReflectableServiceFileDescriptorSupplier())
-              .addMethod(getMethodMethod())
+              .addMethod(getMethodMethodHelper())
               .build();
         }
       }

--- a/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
+++ b/testing-proto/src/generated/main/grpc/io/grpc/testing/protobuf/SimpleServiceGrpc.java
@@ -33,7 +33,7 @@ public final class SimpleServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getUnaryRpcMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
-      io.grpc.testing.protobuf.SimpleResponse> METHOD_UNARY_RPC = getUnaryRpcMethod();
+      io.grpc.testing.protobuf.SimpleResponse> METHOD_UNARY_RPC = getUnaryRpcMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
       io.grpc.testing.protobuf.SimpleResponse> getUnaryRpcMethod;
@@ -41,6 +41,11 @@ public final class SimpleServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
       io.grpc.testing.protobuf.SimpleResponse> getUnaryRpcMethod() {
+    return getUnaryRpcMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getUnaryRpcMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse> getUnaryRpcMethod;
     if ((getUnaryRpcMethod = SimpleServiceGrpc.getUnaryRpcMethod) == null) {
       synchronized (SimpleServiceGrpc.class) {
@@ -65,7 +70,7 @@ public final class SimpleServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getClientStreamingRpcMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
-      io.grpc.testing.protobuf.SimpleResponse> METHOD_CLIENT_STREAMING_RPC = getClientStreamingRpcMethod();
+      io.grpc.testing.protobuf.SimpleResponse> METHOD_CLIENT_STREAMING_RPC = getClientStreamingRpcMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
       io.grpc.testing.protobuf.SimpleResponse> getClientStreamingRpcMethod;
@@ -73,6 +78,11 @@ public final class SimpleServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
       io.grpc.testing.protobuf.SimpleResponse> getClientStreamingRpcMethod() {
+    return getClientStreamingRpcMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getClientStreamingRpcMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse> getClientStreamingRpcMethod;
     if ((getClientStreamingRpcMethod = SimpleServiceGrpc.getClientStreamingRpcMethod) == null) {
       synchronized (SimpleServiceGrpc.class) {
@@ -97,7 +107,7 @@ public final class SimpleServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getServerStreamingRpcMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
-      io.grpc.testing.protobuf.SimpleResponse> METHOD_SERVER_STREAMING_RPC = getServerStreamingRpcMethod();
+      io.grpc.testing.protobuf.SimpleResponse> METHOD_SERVER_STREAMING_RPC = getServerStreamingRpcMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
       io.grpc.testing.protobuf.SimpleResponse> getServerStreamingRpcMethod;
@@ -105,6 +115,11 @@ public final class SimpleServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
       io.grpc.testing.protobuf.SimpleResponse> getServerStreamingRpcMethod() {
+    return getServerStreamingRpcMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getServerStreamingRpcMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse> getServerStreamingRpcMethod;
     if ((getServerStreamingRpcMethod = SimpleServiceGrpc.getServerStreamingRpcMethod) == null) {
       synchronized (SimpleServiceGrpc.class) {
@@ -129,7 +144,7 @@ public final class SimpleServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getBidiStreamingRpcMethod()} instead. 
   public static final io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
-      io.grpc.testing.protobuf.SimpleResponse> METHOD_BIDI_STREAMING_RPC = getBidiStreamingRpcMethod();
+      io.grpc.testing.protobuf.SimpleResponse> METHOD_BIDI_STREAMING_RPC = getBidiStreamingRpcMethodHelper();
 
   private static volatile io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
       io.grpc.testing.protobuf.SimpleResponse> getBidiStreamingRpcMethod;
@@ -137,6 +152,11 @@ public final class SimpleServiceGrpc {
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
       io.grpc.testing.protobuf.SimpleResponse> getBidiStreamingRpcMethod() {
+    return getBidiStreamingRpcMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest,
+      io.grpc.testing.protobuf.SimpleResponse> getBidiStreamingRpcMethodHelper() {
     io.grpc.MethodDescriptor<io.grpc.testing.protobuf.SimpleRequest, io.grpc.testing.protobuf.SimpleResponse> getBidiStreamingRpcMethod;
     if ((getBidiStreamingRpcMethod = SimpleServiceGrpc.getBidiStreamingRpcMethod) == null) {
       synchronized (SimpleServiceGrpc.class) {
@@ -196,7 +216,7 @@ public final class SimpleServiceGrpc {
      */
     public void unaryRpc(io.grpc.testing.protobuf.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getUnaryRpcMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getUnaryRpcMethodHelper(), responseObserver);
     }
 
     /**
@@ -206,7 +226,7 @@ public final class SimpleServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleRequest> clientStreamingRpc(
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getClientStreamingRpcMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getClientStreamingRpcMethodHelper(), responseObserver);
     }
 
     /**
@@ -216,7 +236,7 @@ public final class SimpleServiceGrpc {
      */
     public void serverStreamingRpc(io.grpc.testing.protobuf.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getServerStreamingRpcMethod(), responseObserver);
+      asyncUnimplementedUnaryCall(getServerStreamingRpcMethodHelper(), responseObserver);
     }
 
     /**
@@ -226,34 +246,34 @@ public final class SimpleServiceGrpc {
      */
     public io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleRequest> bidiStreamingRpc(
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getBidiStreamingRpcMethod(), responseObserver);
+      return asyncUnimplementedStreamingCall(getBidiStreamingRpcMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getUnaryRpcMethod(),
+            getUnaryRpcMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 io.grpc.testing.protobuf.SimpleRequest,
                 io.grpc.testing.protobuf.SimpleResponse>(
                   this, METHODID_UNARY_RPC)))
           .addMethod(
-            getClientStreamingRpcMethod(),
+            getClientStreamingRpcMethodHelper(),
             asyncClientStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.protobuf.SimpleRequest,
                 io.grpc.testing.protobuf.SimpleResponse>(
                   this, METHODID_CLIENT_STREAMING_RPC)))
           .addMethod(
-            getServerStreamingRpcMethod(),
+            getServerStreamingRpcMethodHelper(),
             asyncServerStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.protobuf.SimpleRequest,
                 io.grpc.testing.protobuf.SimpleResponse>(
                   this, METHODID_SERVER_STREAMING_RPC)))
           .addMethod(
-            getBidiStreamingRpcMethod(),
+            getBidiStreamingRpcMethodHelper(),
             asyncBidiStreamingCall(
               new MethodHandlers<
                 io.grpc.testing.protobuf.SimpleRequest,
@@ -292,7 +312,7 @@ public final class SimpleServiceGrpc {
     public void unaryRpc(io.grpc.testing.protobuf.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUnaryRpcMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUnaryRpcMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -303,7 +323,7 @@ public final class SimpleServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleRequest> clientStreamingRpc(
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
       return asyncClientStreamingCall(
-          getChannel().newCall(getClientStreamingRpcMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getClientStreamingRpcMethodHelper(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -314,7 +334,7 @@ public final class SimpleServiceGrpc {
     public void serverStreamingRpc(io.grpc.testing.protobuf.SimpleRequest request,
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
       asyncServerStreamingCall(
-          getChannel().newCall(getServerStreamingRpcMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getServerStreamingRpcMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -325,7 +345,7 @@ public final class SimpleServiceGrpc {
     public io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleRequest> bidiStreamingRpc(
         io.grpc.stub.StreamObserver<io.grpc.testing.protobuf.SimpleResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getBidiStreamingRpcMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getBidiStreamingRpcMethodHelper(), getCallOptions()), responseObserver);
     }
   }
 
@@ -357,7 +377,7 @@ public final class SimpleServiceGrpc {
      */
     public io.grpc.testing.protobuf.SimpleResponse unaryRpc(io.grpc.testing.protobuf.SimpleRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUnaryRpcMethod(), getCallOptions(), request);
+          getChannel(), getUnaryRpcMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -368,7 +388,7 @@ public final class SimpleServiceGrpc {
     public java.util.Iterator<io.grpc.testing.protobuf.SimpleResponse> serverStreamingRpc(
         io.grpc.testing.protobuf.SimpleRequest request) {
       return blockingServerStreamingCall(
-          getChannel(), getServerStreamingRpcMethod(), getCallOptions(), request);
+          getChannel(), getServerStreamingRpcMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -401,7 +421,7 @@ public final class SimpleServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grpc.testing.protobuf.SimpleResponse> unaryRpc(
         io.grpc.testing.protobuf.SimpleRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUnaryRpcMethod(), getCallOptions()), request);
+          getChannel().newCall(getUnaryRpcMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -502,10 +522,10 @@ public final class SimpleServiceGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new SimpleServiceFileDescriptorSupplier())
-              .addMethod(getUnaryRpcMethod())
-              .addMethod(getClientStreamingRpcMethod())
-              .addMethod(getServerStreamingRpcMethod())
-              .addMethod(getBidiStreamingRpcMethod())
+              .addMethod(getUnaryRpcMethodHelper())
+              .addMethod(getClientStreamingRpcMethodHelper())
+              .addMethod(getServerStreamingRpcMethodHelper())
+              .addMethod(getBidiStreamingRpcMethodHelper())
               .build();
         }
       }


### PR DESCRIPTION
Backport of https://github.com/grpc/grpc-java/pull/4039. Backporting so that the grpc-java-api-checker tool can work starting with release 1.10.0