### PR TITLE
netty: Include more details for closure of unknown reason

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -355,7 +355,8 @@ class NettyClientTransport implements ConnectionClientTransport {
         || t instanceof Http2ChannelClosedException) {
       Status shutdownStatus = lifecycleManager.getShutdownStatus();
       if (shutdownStatus == null) {
-        return Status.UNKNOWN.withDescription("Channel closed but for unknown reason");
+        return Status.UNKNOWN.withDescription("Channel closed but for unknown reason")
+            .withCause(new ClosedChannelException().initCause(t));
       }
       return shutdownStatus;
     }


### PR DESCRIPTION
Some users have reported "Channel closed but for unknown reason".
Adding this information doesn't tell us where the bug is, but may help
us narrow down why getShutdownStatus() is null.