### PR TITLE
core: remove runDueTasks with filter

### DIFF
--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -214,33 +214,18 @@ public final class FakeClock {
    * @return the number of tasks run by this call
    */
   public int runDueTasks() {
-    return runDueTasks(ACCEPT_ALL_FILTER);
-  }
-
-  /**
-   * Run all due tasks that match the {@link TaskFilter}.
-   *
-   * @return the number of tasks run by this call
-   */
-  public int runDueTasks(TaskFilter filter) {
     int count = 0;
-    List<ScheduledTask> putBack = new ArrayList<ScheduledTask>();
     while (true) {
       ScheduledTask task = tasks.peek();
       if (task == null || task.dueTimeNanos > currentTimeNanos) {
         break;
       }
       if (tasks.remove(task)) {
-        if (filter.shouldAccept(task.command)) {
-          task.command.run();
-          task.complete();
-          count++;
-        } else {
-          putBack.add(task);
-        }
+        task.command.run();
+        task.complete();
+        count++;
       }
     }
-    tasks.addAll(putBack);
     return count;
   }
 

--- a/core/src/test/java/io/grpc/internal/FakeClockTest.java
+++ b/core/src/test/java/io/grpc/internal/FakeClockTest.java
@@ -189,9 +189,9 @@ public class FakeClockTest {
     assertEquals(2, fakeClock.getPendingTasks().size());
     assertEquals(1, fakeClock.getPendingTasks(filter).size());
     assertSame(selectedRunnable, fakeClock.getPendingTasks(filter).iterator().next().command);
-    assertEquals(1, fakeClock.runDueTasks(filter));
+    assertEquals(2, fakeClock.runDueTasks());
     assertTrue(selectedDone.get());
-    assertFalse(ignoredDone.get());
+    assertTrue(ignoredDone.get());
   }
 
   private Runnable newRunnable() {

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -920,8 +920,8 @@ public class ServerImplTest {
     assertTrue(onHalfCloseCalled.get());
 
     streamListener.closed(Status.CANCELLED);
-    assertEquals(1, executor.runDueTasks(CONTEXT_CLOSER_TASK_FITLER));
-    assertEquals(1, executor.runDueTasks());
+    assertEquals(1, executor.numPendingTasks(CONTEXT_CLOSER_TASK_FITLER));
+    assertEquals(2, executor.runDueTasks());
     assertTrue(onCancelCalled.get());
 
     // Close should never be called if asserts in listener pass.
@@ -991,11 +991,10 @@ public class ServerImplTest {
     assertFalse(callReference.get().isCancelled());
     assertFalse(context.get().isCancelled());
     streamListener.closed(Status.CANCELLED);
-    assertEquals(1, executor.runDueTasks(CONTEXT_CLOSER_TASK_FITLER));
+    assertEquals(1, executor.numPendingTasks(CONTEXT_CLOSER_TASK_FITLER));
+    assertEquals(2, executor.runDueTasks());
     assertTrue(callReference.get().isCancelled());
     assertTrue(context.get().isCancelled());
-
-    assertEquals(1, executor.runDueTasks());
     assertTrue(contextCancelled.get());
   }
 


### PR DESCRIPTION
In `FakeClock` we have `runDueTasks()` (without filter), `numPendingTasks(filter)`, and `getPendingTasks(filter)` which are useful. The `runDueTasks(filter)` method seems not a right way to test. 

This PR is low priority.