### PR TITLE
netty: upgrade to 4.1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ subprojects {
         protocPluginBaseName = 'protoc-gen-grpc-java'
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
-        nettyVersion = '4.1.17.Final'
+        nettyVersion = '4.1.21.Final'
         guavaVersion = '19.0'
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'

--- a/netty/src/main/java/io/grpc/netty/AbstractHttp2Headers.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractHttp2Headers.java
@@ -266,6 +266,11 @@ abstract class AbstractHttp2Headers implements Http2Headers {
   }
 
   @Override
+  public boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public boolean containsObject(CharSequence name, Object value) {
     throw new UnsupportedOperationException();
   }

--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -83,7 +83,7 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
     if (embedded == null) {
       // There was no embedded Http2Exception, assume it's a connection error. Subclasses are
       // responsible for storing the appropriate status and shutting down the connection.
-      onError(ctx, cause);
+      onError(ctx, /* outbound= */ false, cause);
     } else {
       super.exceptionCaught(ctx, cause);
     }

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -406,17 +406,18 @@ class NettyClientHandler extends AbstractNettyHandler {
     super.handleProtocolNegotiationCompleted(attributes);
   }
 
+
   @Override
-  protected void onConnectionError(ChannelHandlerContext ctx, Throwable cause,
+  protected void onConnectionError(ChannelHandlerContext ctx,  boolean outbound, Throwable cause,
       Http2Exception http2Ex) {
     logger.log(Level.FINE, "Caught a connection error", cause);
     lifecycleManager.notifyShutdown(Utils.statusFromThrowable(cause));
     // Parent class will shut down the Channel
-    super.onConnectionError(ctx, cause, http2Ex);
+    super.onConnectionError(ctx, outbound, cause, http2Ex);
   }
 
   @Override
-  protected void onStreamError(ChannelHandlerContext ctx, Throwable cause,
+  protected void onStreamError(ChannelHandlerContext ctx, boolean outbound, Throwable cause,
       Http2Exception.StreamException http2Ex) {
     // Close the stream with a status that contains the cause.
     NettyClientStream.TransportState stream = clientStream(connection().stream(http2Ex.streamId()));
@@ -427,7 +428,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     }
 
     // Delegate to the base class to send a RST_STREAM.
-    super.onStreamError(ctx, cause, http2Ex);
+    super.onStreamError(ctx, outbound, cause, http2Ex);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -217,8 +217,8 @@ class NettyClientTransport implements ConnectionClientTransport {
      */
     b.handler(negotiationHandler);
     ChannelFuture regFuture = b.register();
-    channel = regFuture.channel();
-    if (channel == null) {
+    if (regFuture.isDone() && !regFuture.isSuccess()) {
+      channel = null;
       // Initialization has failed badly. All new streams should be made to fail.
       Throwable t = regFuture.cause();
       if (t == null) {
@@ -238,6 +238,7 @@ class NettyClientTransport implements ConnectionClientTransport {
         }
       };
     }
+    channel = regFuture.channel();
     // Start the write queue as soon as the channel is constructed
     handler.startWriteQueue(channel);
     // This write will have no effect, yet it will only complete once the negotiationHandler

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -263,7 +263,7 @@ class NettyServerHandler extends AbstractNettyHandler {
           try {
             NettyServerHandler.this.close(ctx, ctx.newPromise());
           } catch (Exception e) {
-            onError(ctx, e);
+            onError(ctx, /* outbound= */ true, e);
           }
         }
       };
@@ -340,7 +340,7 @@ class NettyServerHandler extends AbstractNettyHandler {
                     TimeUnit.NANOSECONDS.toMillis(maxConnectionAgeGraceInNanos));
                 close(ctx, ctx.newPromise());
               } catch (Exception e) {
-                onError(ctx, e);
+                onError(ctx, /* outbound= */ true, e);
               } finally {
                 gracefulShutdownTimeoutMillis(savedGracefulShutdownTime);
               }
@@ -502,15 +502,15 @@ class NettyServerHandler extends AbstractNettyHandler {
   }
 
   @Override
-  protected void onConnectionError(ChannelHandlerContext ctx, Throwable cause,
+  protected void onConnectionError(ChannelHandlerContext ctx, boolean outbound, Throwable cause,
       Http2Exception http2Ex) {
     logger.log(Level.FINE, "Connection Error", cause);
     connectionError = cause;
-    super.onConnectionError(ctx, cause, http2Ex);
+    super.onConnectionError(ctx, outbound, cause, http2Ex);
   }
 
   @Override
-  protected void onStreamError(ChannelHandlerContext ctx, Throwable cause,
+  protected void onStreamError(ChannelHandlerContext ctx, boolean outbound, Throwable cause,
       StreamException http2Ex) {
     logger.log(Level.WARNING, "Stream Error", cause);
     NettyServerStream.TransportState serverStream = serverStream(
@@ -520,7 +520,7 @@ class NettyServerHandler extends AbstractNettyHandler {
     }
     // TODO(ejona): Abort the stream by sending headers to help the client with debugging.
     // Delegate to the base class to send a RST_STREAM.
-    super.onStreamError(ctx, cause, http2Ex);
+    super.onStreamError(ctx, outbound, cause, http2Ex);
   }
 
   @Override
@@ -774,7 +774,7 @@ class NettyServerHandler extends AbstractNettyHandler {
         try {
           forcefulClose(ctx, new ForcefulCloseCommand(status), ctx.newPromise());
         } catch (Exception ex) {
-          onError(ctx, ex);
+          onError(ctx, /* outbound= */ true, ex);
         }
       }
     }

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -339,6 +339,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
     when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
     EventLoop eventLoop = mock(EventLoop.class);
     when(ctx.executor()).thenReturn(eventLoop);
+    when(ctx.channel()).thenReturn(channel);
     return ctx;
   }
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -174,71 +174,71 @@ def com_squareup_okio():
 def io_netty_codec_http2():
   native.maven_jar(
       name = "io_netty_netty_codec_http2",
-      artifact = "io.netty:netty-codec-http2:4.1.17.Final",
-      sha1 = "f9844005869c6d9049f4b677228a89fee4c6eab3",
+      artifact = "io.netty:netty-codec-http2:4.1.21.Final",
+      sha1 = "06e045c3970f9ccff7a7064375c96dcabe120e6e",
   )
 
 def io_netty_buffer():
   native.maven_jar(
       name = "io_netty_netty_buffer",
-      artifact = "io.netty:netty-buffer:4.1.17.Final",
-      sha1 = "fdd68fb3defd7059a7392b9395ee941ef9bacc25",
+      artifact = "io.netty:netty-buffer:4.1.21.Final",
+      sha1 = "67670d3d8f8e4564a096269065ced85e3945b830",
   )
 
 def io_netty_common():
   native.maven_jar(
       name = "io_netty_netty_common",
-      artifact = "io.netty:netty-common:4.1.17.Final",
-      sha1 = "581c8ee239e4dc0976c2405d155f475538325098",
+      artifact = "io.netty:netty-common:4.1.21.Final",
+      sha1 = "d37b6cbc80774047fdb78fd4319612017ab5403e",
   )
 
 def io_netty_transport():
   native.maven_jar(
       name = "io_netty_netty_transport",
-      artifact = "io.netty:netty-transport:4.1.17.Final",
-      sha1 = "9585776b0a8153182412b5d5366061ff486914c1",
+      artifact = "io.netty:netty-transport:4.1.21.Final",
+      sha1 = "c380cceb380008e345ade08fb855a0a84fe0d2aa",
   )
 
 def io_netty_codec():
   native.maven_jar(
       name = "io_netty_netty_codec",
-      artifact = "io.netty:netty-codec:4.1.17.Final",
-      sha1 = "1d00f56dc9e55203a4bde5aae3d0828fdeb818e7",
+      artifact = "io.netty:netty-codec:4.1.21.Final",
+      sha1 = "f9ebc7d8b47348e0dabced5b175b2b7c4211aa13",
   )
 
 def io_netty_codec_socks():
   native.maven_jar(
       name = "io_netty_netty_codec_socks",
-      artifact = "io.netty:netty-codec-socks:4.1.17.Final",
-      sha1 = "a159bf1f3d5019e0d561c92fbbec8400967471fa",
+      artifact = "io.netty:netty-codec-socks:4.1.21.Final",
+      sha1 = "40c89bc61d0d998b0c137cee94338981b7b44758",
   )
 
 def io_netty_codec_http():
   native.maven_jar(
       name = "io_netty_netty_codec_http",
-      artifact = "io.netty:netty-codec-http:4.1.17.Final",
-      sha1 = "251d7edcb897122b9b23f24ff793cd0739056b9e",
+      artifact = "io.netty:netty-codec-http:4.1.21.Final",
+      sha1 = "4a67ff36dc9c6dfc4ca374441dcd8117001995df",
   )
 
 def io_netty_handler():
   native.maven_jar(
       name = "io_netty_netty_handler",
-      artifact = "io.netty:netty-handler:4.1.17.Final",
-      sha1 = "18c40ffb61a1d1979eca024087070762fdc4664a",
+      artifact = "io.netty:netty-handler:4.1.21.Final",
+      sha1 = "7d3d36d616cacfdafb946555a22c6aea513c6713",
   )
 
 def io_netty_handler_proxy():
   native.maven_jar(
       name = "io_netty_netty_handler_proxy",
-      artifact = "io.netty:netty-handler-proxy:4.1.17.Final",
-      sha1 = "9330ee60c4e48ca60aac89b7bc5ec2567e84f28e",
+      artifact = "io.netty:netty-handler-proxy:4.1.21.Final",
+      sha1 = "c914a01d61b4ab42031c4336140b8bfee1b6ba5c",
   )
 
 def io_netty_resolver():
   native.maven_jar(
       name = "io_netty_netty_resolver",
-      artifact = "io.netty:netty-resolver:4.1.17.Final",
-      sha1 = "8f386c80821e200f542da282ae1d3cde5cad8368",
+      artifact = "io.netty:netty-resolver:4.1.21.Final",
+      sha1 = "1e786ae83c8aa8f6980f7152f3a312c1ea3009ed",
   )
 
 def io_netty_tcnative_boringssl_static():


### PR DESCRIPTION
In newer netty, bootstrap can return a non-null Channel (called a FailedChannel), even if the promise was also a failure.  