### PR TITLE
core: non mocking tests for forwarding {Server,Client}{Call, CallListener}

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingClientCallListener.java
+++ b/core/src/main/java/io/grpc/ForwardingClientCallListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, gRPC Authors All rights reserved.
+ * Copyright 2018, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/grpc/ForwardingClientCallListenerTest.java
+++ b/core/src/test/java/io/grpc/ForwardingClientCallListenerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for {@link ForwardingClientCallListener}.
+ */
+@RunWith(JUnit4.class)
+public class ForwardingClientCallListenerTest {
+  @Mock private ClientCall.Listener<Integer> mock;
+  private ForwardingClientCallListener<Integer> forwarder;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    forwarder = new SimpleForwardingClientCallListener<Integer>(mock) {};
+  }
+
+  @Test
+  public void allMethodsForwarded() throws Exception {
+    ForwardingTestUtil.testMethodsForwarded(
+        ClientCall.Listener.class,
+        mock,
+        forwarder,
+        Collections.<Method>emptyList());
+  }
+
+  @Test
+  public void testOnHeaders() {
+    Metadata headers = new Metadata();
+    forwarder.onHeaders(headers);
+    verify(mock).onHeaders(same(headers));
+  }
+
+  @Test
+  public void onMessage() {
+    forwarder.onMessage(12345);
+    verify(mock).onMessage(12345);
+  }
+
+  @Test
+  public void close() {
+    Status status = Status.INTERNAL;
+    Metadata trailers = new Metadata();
+    forwarder.onClose(status, trailers);
+    verify(mock).onClose(same(status), same(trailers));
+  }
+}

--- a/core/src/test/java/io/grpc/ForwardingClientCallTest.java
+++ b/core/src/test/java/io/grpc/ForwardingClientCallTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static junit.framework.TestCase.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.ClientCall.Listener;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.internal.NoopClientCall;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for {@link ForwardingClientCall}.
+ */
+@RunWith(JUnit4.class)
+public class ForwardingClientCallTest {
+  // do not mock subclasses of ClientCall unless you know what you're doing, see @DoNotMock usages
+  @Mock
+  private NoopClientCall<Integer, String> mock;
+  private ForwardingClientCall<Integer, String> forwarder;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    forwarder = new SimpleForwardingClientCall<Integer, String>(mock) {};
+  }
+
+  @Test
+  public void allMethodsForwarded() throws Exception {
+    ForwardingTestUtil.testMethodsForwarded(
+        ClientCall.class, mock, forwarder, Collections.<Method>emptyList());
+  }
+
+  @Test
+  public void testRequest() {
+    forwarder.request(1234);
+    verify(mock).request(1234);
+  }
+
+  @Test
+  public void testStart() {
+    Metadata headers = new Metadata();
+    Listener<String> listener = new Listener<String>() {};
+    forwarder.start(listener, headers);
+    verify(mock).start(same(listener), same(headers));
+  }
+
+  @Test
+  public void testSendMessage() {
+    int message = 3456;
+    forwarder.sendMessage(message);
+    verify(mock).sendMessage(message);
+  }
+
+  @Test
+  public void testIsReady() {
+    when(mock.isReady()).thenReturn(true);
+    assertEquals(true, forwarder.isReady());
+  }
+
+  @Test
+  public void testSetMessageCompression() {
+    forwarder.setMessageCompression(true);
+    verify(mock).setMessageCompression(true);
+  }
+
+  @Test
+  public void testGetAttributes() {
+    Attributes attributes = Attributes.newBuilder().build();
+    when(mock.getAttributes()).thenReturn(attributes);
+    assertSame(attributes, forwarder.getAttributes());
+  }
+}

--- a/core/src/test/java/io/grpc/ForwardingClientCallTest.java
+++ b/core/src/test/java/io/grpc/ForwardingClientCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, gRPC Authors All rights reserved.
+ * Copyright 2018, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/grpc/ForwardingServerCallTest.java
+++ b/core/src/test/java/io/grpc/ForwardingServerCallTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2015, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static junit.framework.TestCase.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.internal.NoopServerCall;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for {@link ForwardingServerCall}.
+ */
+@RunWith(JUnit4.class)
+public class ForwardingServerCallTest {
+  // do not mock subclasses of ServerCall unless you know what you're doing, see @DoNotMock usages
+  @Mock
+  private NoopServerCall<Integer, String> mock;
+  private ForwardingServerCall<Integer, String> forwarder;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    forwarder = new SimpleForwardingServerCall<Integer, String>(mock) {};
+  }
+
+  @Test
+  public void allMethodsForwarded() throws Exception {
+    ForwardingTestUtil.testMethodsForwarded(
+        ServerCall.class, mock, forwarder, Collections.<Method>emptyList());
+  }
+
+  @Test
+  public void testRequest() {
+    forwarder.request(1234);
+    verify(mock).request(1234);
+  }
+
+  @Test
+  public void testSendHeaders() {
+    Metadata headers = new Metadata();
+    forwarder.sendHeaders(headers);
+    verify(mock).sendHeaders(same(headers));
+  }
+
+  @Test
+  public void testSendMessage() {
+    String message = "hello";
+    forwarder.sendMessage(message);
+    verify(mock).sendMessage(message);
+  }
+
+  @Test
+  public void testIsReady() {
+    when(mock.isReady()).thenReturn(true);
+    assertEquals(true, forwarder.isReady());
+  }
+
+  @Test
+  public void testClose() {
+    Status status = Status.INTERNAL;
+    Metadata trailers = new Metadata();
+    forwarder.close(status, trailers);
+    verify(mock).close(same(status), same(trailers));
+  }
+
+  @Test
+  public void testIsCancelled() {
+    when(mock.isCancelled()).thenReturn(true);
+    assertEquals(true, forwarder.isCancelled());
+  }
+
+  @Test
+  public void testSetMessageCompression() {
+    forwarder.setMessageCompression(true);
+    verify(mock).setMessageCompression(true);
+  }
+
+  @Test
+  public void testSetCompression() {
+    forwarder.setCompression("mycompressor");
+    verify(mock).setCompression("mycompressor");
+  }
+
+  @Test
+  public void testGetAttributes() {
+    Attributes attributes = Attributes.newBuilder().build();
+    when(mock.getAttributes()).thenReturn(attributes);
+    assertSame(attributes, forwarder.getAttributes());
+  }
+
+  @Test
+  public void testGetAuthority() {
+    when(mock.getAuthority()).thenReturn("myauthority");
+    assertEquals("myauthority", forwarder.getAuthority());
+  }
+
+  @Test
+  public void testGetMethodDescriptor() {
+    MethodDescriptor<Integer, String> method = MethodDescriptor.<Integer, String>newBuilder()
+        .setFullMethodName("test/method")
+        .setType(MethodType.UNARY)
+        .setRequestMarshaller(IntegerMarshaller.INSTANCE)
+        .setResponseMarshaller(StringMarshaller.INSTANCE)
+        .build();
+    when(mock.getMethodDescriptor()).thenReturn(method);
+    assertSame(method, forwarder.getMethodDescriptor());
+  }
+}

--- a/core/src/test/java/io/grpc/ForwardingServerCallTest.java
+++ b/core/src/test/java/io/grpc/ForwardingServerCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, gRPC Authors All rights reserved.
+ * Copyright 2018, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Instead of mocking ServerCall and ClientCall this mocks
NoopServerCall and NoopClientCall.
