### PR TITLE
examples: match applicationId to AndroidManifest.xml package

### DIFF
--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        applicationId "io.grpc.android.clientcacheexample"
+        applicationId "io.grpc.clientcacheexample"
         minSdkVersion 19
         targetSdkVersion 27
         multiDexEnabled true

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        applicationId "io.grpc.android.helloworldexample"
+        applicationId "io.grpc.helloworldexample"
         // API level 14+ is required for TLS since Google Play Services v10.2
         minSdkVersion 14
         targetSdkVersion 27


### PR DESCRIPTION
`applicationId` from the gradle file replaces the package value declared in `AndroidManifest.xml` when the apk is built (see https://developer.android.com/studio/build/application-id.html#change_the_package_name), which makes for confusing behavior when the values are not aligned - the package name is important for authorization/credentials with google APIs.

