### PR TITLE
build: run unit tests on osx, ensure proto output included

### DIFF
--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -54,6 +54,7 @@ export CXXFLAGS="-I/tmp/protobuf/include"
 ./gradlew assemble generateTestProto install $GRADLE_FLAGS
 
 if [[ -z "${SKIP_CLEAN_CHECK:-}" && ! -z $(git status --porcelain) ]]; then
+  git status
   echo "Error Working directory is not clean. Forget to commit generated files?"
   exit 1
 fi

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -53,7 +53,7 @@ export CXXFLAGS="-I/tmp/protobuf/include"
 # Ensure all *.proto changes include *.java generated code
 ./gradlew assemble generateTestProto install $GRADLE_FLAGS
 
-if [[ -z "$SKIP_CLEAN_CHECK" && ! -z $(git status --porcelain) ]]; then
+if [[ -z "${SKIP_CLEAN_CHECK:-}" && ! -z $(git status --porcelain) ]]; then
   echo "Error Working directory is not clean. Forget to commit generated files?"
   exit 1
 fi

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -50,8 +50,16 @@ export LD_LIBRARY_PATH=/tmp/protobuf/lib
 export LDFLAGS=-L/tmp/protobuf/lib
 export CXXFLAGS="-I/tmp/protobuf/include"
 
-# Run tests
+# Ensure all *.proto changes include *.java generated code
 ./gradlew assemble generateTestProto install $GRADLE_FLAGS
+
+if [[ -z "$SKIP_CLEAN_CHECK" && ! -z $(git status --porcelain) ]]; then
+  echo "Error Working directory is not clean. Forget to commit generated files?"
+  exit 1
+fi
+
+# Run tests
+./gradlew build
 pushd examples
 ./gradlew build $GRADLE_FLAGS
 # --batch-mode reduces log spam


### PR DESCRIPTION
This adds back functionality that was accidentally dropped when
porting from travis:
- make sure generating protos will not lead to any uncomitted changes
- actually run the unit tests