### PR TITLE
Cleaner release docker

### DIFF
--- a/buildscripts/grpc-java-releasing/Dockerfile
+++ b/buildscripts/grpc-java-releasing/Dockerfile
@@ -1,0 +1,6 @@
+FROM protoc-artifacts:latest
+
+COPY scl-enable-devtoolset.sh /
+
+# Start in devtoolset environment that uses GCC 4.7
+ENTRYPOINT ["/scl-enable-devtoolset.sh"]

--- a/buildscripts/grpc-java-releasing/scl-enable-devtoolset.sh
+++ b/buildscripts/grpc-java-releasing/scl-enable-devtoolset.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eu -o pipefail
+
+quote() {
+  local arg
+  for arg in "$@"; do
+    printf "'"
+    printf "%s" "$arg" | sed -e "s/'/'\\\\''/g"
+    printf "' "
+  done
+}
+
+exec scl enable devtoolset-1.1 "$(quote "$@")"

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -70,6 +70,7 @@ popd
 # TODO(zpencer): also build the GAE examples
 
 LOCAL_MVN_TEMP=$(mktemp -d)
+# Note that this disables parallel=true from GRADLE_FLAGS
 ./gradlew clean grpc-compiler:build grpc-compiler:uploadArchives $GRADLE_FLAGS -PtargetArch=x86_64 \
   -Dorg.gradle.parallel=false -PrepositoryDir=$LOCAL_MVN_TEMP
 

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -43,6 +43,7 @@ GRADLE_FLAGS="${GRADLE_FLAGS:-}"
 GRADLE_FLAGS+=" -Pcheckstyle.ignoreFailures=false"
 GRADLE_FLAGS+=" -PfailOnWarnings=true"
 GRADLE_FLAGS+=" -PerrorProne=true"
+GRADLE_FLAGS+=" -Dorg.gradle.parallel=true"
 export GRADLE_OPTS="-Xmx512m"
 
 # Make protobuf discoverable by :grpc-compiler
@@ -60,7 +61,7 @@ if [[ -z "${SKIP_CLEAN_CHECK:-}" && ! -z $(git status --porcelain) ]]; then
 fi
 
 # Run tests
-./gradlew build
+./gradlew build $GRADLE_FLAGS
 pushd examples
 ./gradlew build $GRADLE_FLAGS
 # --batch-mode reduces log spam
@@ -69,8 +70,8 @@ popd
 # TODO(zpencer): also build the GAE examples
 
 LOCAL_MVN_TEMP=$(mktemp -d)
-./gradlew clean grpc-compiler:build grpc-compiler:uploadArchives -PtargetArch=x86_64 \
-  -Dorg.gradle.parallel=false -PrepositoryDir=$LOCAL_MVN_TEMP $GRADLE_FLAGS
+./gradlew clean grpc-compiler:build grpc-compiler:uploadArchives $GRADLE_FLAGS -PtargetArch=x86_64 \
+  -Dorg.gradle.parallel=false -PrepositoryDir=$LOCAL_MVN_TEMP
 
 if [[ -z "${MVN_ARTIFACTS:-}" ]]; then
   exit 0

--- a/buildscripts/run_in_docker.sh
+++ b/buildscripts/run_in_docker.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+quote() {
+  for X in "$@"; do
+    printf "'"
+    printf "%s" "$X" | sed -e "s/'/'\\\\''/g"
+    printf "' "
+  done
+}
+
+if [ "$1" != "in-docker" ]; then
+  args="$(quote "$@")"
+  exec docker run -it --rm=true -v $PWD:/grpc-java grpc-java-deploy \
+    "/grpc-java/buildscripts/run_in_docker.sh in-docker $(id -u) $(id -g) $args"
+fi
+
+shift
+# In Docker
+SWAP_UID=$1
+SWAP_GID=$2
+shift 2
+# Java uses NSS to determine the user's home. If that fails it uses '?' in the
+# current directory. So we need to set up the user's home in /etc/passwd.
+groupadd thegroup -g $SWAP_GID
+useradd theuser -u $SWAP_UID -g $SWAP_GID -m
+cd /grpc-java
+args="$(quote "$@")"
+exec su theuser -c "$args"

--- a/buildscripts/run_in_docker.sh
+++ b/buildscripts/run_in_docker.sh
@@ -1,29 +1,40 @@
 #!/bin/bash
-set -e
+set -eu -o pipefail
 
 quote() {
-  for X in "$@"; do
+  local arg
+  for arg in "$@"; do
     printf "'"
-    printf "%s" "$X" | sed -e "s/'/'\\\\''/g"
+    printf "%s" "$arg" | sed -e "s/'/'\\\\''/g"
     printf "' "
   done
 }
 
-if [ "$1" != "in-docker" ]; then
-  args="$(quote "$@")"
-  exec docker run -it --rm=true -v $PWD:/grpc-java grpc-java-deploy \
-    "/grpc-java/buildscripts/run_in_docker.sh in-docker $(id -u) $(id -g) $args"
+if [[ "${1:-}" != "in-docker" ]]; then
+  readonly grpc_java_dir="$(dirname $(readlink -f "$0"))/.."
+  exec docker run -it --rm=true -v "${grpc_java_dir}:/grpc-java" -w /grpc-java \
+    grpc-java-releasing \
+    ./buildscripts/run_in_docker.sh in-docker "$(id -u)" "$(id -g)" "$@"
 fi
 
+## In Docker
+
 shift
-# In Docker
-SWAP_UID=$1
-SWAP_GID=$2
+
+readonly swap_uid="$1"
+readonly swap_gid="$2"
 shift 2
+
 # Java uses NSS to determine the user's home. If that fails it uses '?' in the
 # current directory. So we need to set up the user's home in /etc/passwd.
-groupadd thegroup -g $SWAP_GID
-useradd theuser -u $SWAP_UID -g $SWAP_GID -m
-cd /grpc-java
-args="$(quote "$@")"
-exec su theuser -c "$args"
+# If this wasn't the case, we could have passed -u to docker run and avoided
+# this script inside the container. JAVA_TOOL_OPTIONS is okay, but is noisy.
+groupadd thegroup -g "$swap_gid"
+useradd theuser -u "$swap_uid" -g "$swap_gid" -m
+if [[ "$#" -eq 0 ]]; then
+  exec su theuser
+else
+  # runuser is too old in the container to support the -u flag; if it did, we'd
+  # be able to remove the 'quote' function.
+  exec su theuser -c "$(quote "$@")"
+fi

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,4 +1,20 @@
 FROM protoc-artifacts:latest
 
+RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
+    git fetch && \
+    git checkout v3.5.1 && \
+    ./autogen.sh && \
+    CXXFLAGS=-m32 ./configure --disable-shared --prefix=/protobuf-32 && \
+    make clean && make -j$(nproc) && make -j$(nproc) install"'
+
+RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
+    CXXFLAGS=-m64 ./configure --disable-shared --prefix=/protobuf-64 && \
+    make clean && make -j$(nproc) && make -j$(nproc) install"'
+
+ENV CXXFLAGS=-I/protobuf-32/include \
+    LDFLAGS="-L/protobuf-32/lib -L/protobuf-64/lib"
+
+RUN git clone --depth 1 https://github.com/grpc/grpc-java.git
+
 # Start in devtoolset environment that uses GCC 4.7
-ENTRYPOINT ["scl", "enable", "devtoolset-1.1"]
+CMD ["scl", "enable", "devtoolset-1.1", "bash"]

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,20 +1,4 @@
 FROM protoc-artifacts:latest
 
-RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
-    git fetch && \
-    git checkout v3.5.1 && \
-    ./autogen.sh && \
-    CXXFLAGS=-m32 ./configure --disable-shared --prefix=/protobuf-32 && \
-    make clean && make -j$(nproc) && make -j$(nproc) install"'
-
-RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
-    CXXFLAGS=-m64 ./configure --disable-shared --prefix=/protobuf-64 && \
-    make clean && make -j$(nproc) && make -j$(nproc) install"'
-
-ENV CXXFLAGS=-I/protobuf-32/include \
-    LDFLAGS="-L/protobuf-32/lib -L/protobuf-64/lib"
-
-RUN git clone --depth 1 https://github.com/grpc/grpc-java.git
-
 # Start in devtoolset environment that uses GCC 4.7
-CMD ["scl", "enable", "devtoolset-1.1", "bash"]
+ENTRYPOINT ["scl", "enable", "devtoolset-1.1"]


### PR DESCRIPTION
CC @zpencer @zhangkun83 

This removes pre-compiled protoc from the docker image, since there's nothing actually tying the version in the docker image to our source. Similarly it no longer checks out grpc-java as part of the docker image because that checkout is guaranteed to be old.

Then the question is how we want to build within the docker image. You could fire it up like before, and then do a git clone and then go on your way. run_in_docker.sh ~~is a POC that~~ drops you into the docker container with your current grpc-java checkout and as your current user so that you can develop there mostly as normal. I'd imagine the release process would eventually become `./buildscripts/run_in_docker.sh env MVN_ARTIFACTS=1 ./buildscripts/kokoro/unix.sh` which would drop results to mvn-release which is available outside the docker image. You'd then sign and upload using the scripts sign-local-repo.sh and sonatype-upload.sh.

~~This can't go in now because the new release flow involving sign-local-repo.sh and sonatype-upload.sh is still in development, and until then this would break the current release process (although that could be fixed by making a new docker script here instead of modifying our existing one).~~