### PR TITLE
alts: change visibility of `NettyServerBuilder`

### DIFF
--- a/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
  */
 public final class AltsServerBuilder extends ServerBuilder<AltsServerBuilder> {
 
-  final NettyServerBuilder delegate;
+  private final NettyServerBuilder delegate;
   private boolean enableUntrustedAlts;
 
   private AltsServerBuilder(NettyServerBuilder nettyDelegate) {


### PR DESCRIPTION
I think `AltsServerBuilder` wraps `NettyServerBuilder` and delegate could be private.
Changing delegate (intended / not intended) would break the builder pattern.