### PR TITLE
core,netty,okhttp: Transparent retry

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -559,6 +559,11 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
 
     @Override
     public void closed(Status status, Metadata trailers) {
+      closed(status, RpcProgress.PROCESSED, trailers);
+    }
+
+    @Override
+    public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
       Deadline deadline = effectiveDeadline();
       if (status.getCode() == Status.Code.CANCELLED && deadline != null) {
         // When the server's deadline expires, it can only reset the stream with CANCEL and no

--- a/core/src/main/java/io/grpc/internal/ClientStreamListener.java
+++ b/core/src/main/java/io/grpc/internal/ClientStreamListener.java
@@ -45,5 +45,39 @@ public interface ClientStreamListener extends StreamListener {
    * @param status details about the remote closure
    * @param trailers trailing metadata
    */
+  // TODO(zdapeng): remove this method in favor of the 3-arg one.
   void closed(Status status, Metadata trailers);
+
+  /**
+   * Called when the stream is fully closed. {@link
+   * io.grpc.Status.Code#OK} is the only status code that is guaranteed
+   * to have been sent from the remote server. Any other status code may have been caused by
+   * abnormal stream termination. This is guaranteed to always be the final call on a listener. No
+   * further callbacks will be issued.
+   *
+   * <p>This method should return quickly, as the same thread may be used to process other streams.
+   *
+   * @param status details about the remote closure
+   * @param rpcProgress RPC progress when client stream listener is closed
+   * @param trailers trailing metadata
+   */
+  void closed(Status status, RpcProgress rpcProgress, Metadata trailers);
+
+  /**
+   * The progress of the RPC when client stream listener is closed.
+   */
+  enum RpcProgress {
+    /**
+     * The RPC is processed by the server normally.
+     */
+    PROCESSED,
+    /**
+     * The RPC is not processed by the server's application logic.
+     */
+    REFUSED,
+    /**
+     * The RPC is dropped (by load balancer).
+     */
+    DROPPED
+  }
 }

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -420,6 +420,18 @@ class DelayedStream implements ClientStream {
       });
     }
 
+    @Override
+    public void closed(
+        final Status status, final RpcProgress rpcProgress,
+        final Metadata trailers) {
+      delayOrExecute(new Runnable() {
+        @Override
+        public void run() {
+          realListener.closed(status, rpcProgress, trailers);
+        }
+      });
+    }
+
     public void drainPendingCallbacks() {
       assert !passThrough;
       List<Runnable> toRun = new ArrayList<Runnable>();

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStreamListener.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStreamListener.java
@@ -34,6 +34,11 @@ abstract class ForwardingClientStreamListener implements ClientStreamListener {
   }
 
   @Override
+  public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
+    delegate().closed(status, rpcProgress, trailers);
+  }
+
+  @Override
   public void messagesAvailable(MessageProducer producer) {
     delegate().messagesAvailable(producer);
   }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -628,7 +628,7 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
 
     @Override
     public ClientStream newStream(
-        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+        MethodDescriptor<?, ?> method, Metadata headers, final CallOptions callOptions) {
       final ClientStream streamDelegate = super.newStream(method, headers, callOptions);
       return new ForwardingClientStream() {
         @Override
@@ -649,6 +649,13 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
             public void closed(Status status, Metadata trailers) {
               callTracer.reportCallEnded(status.isOk());
               super.closed(status, trailers);
+            }
+
+            @Override
+            public void closed(
+                Status status, RpcProgress rpcProgress, Metadata trailers) {
+              callTracer.reportCallEnded(status.isOk());
+              super.closed(status, rpcProgress, trailers);
             }
           });
         }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -628,7 +628,7 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
 
     @Override
     public ClientStream newStream(
-        MethodDescriptor<?, ?> method, Metadata headers, final CallOptions callOptions) {
+        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
       final ClientStream streamDelegate = super.newStream(method, headers, callOptions);
       return new ForwardingClientStream() {
         @Override

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -186,17 +186,12 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   @VisibleForTesting
   final Metadata updateHeaders(
       Metadata originalHeaders, int previousAttempts, int transparentRetryAttempts) {
-    Metadata newHeaders = originalHeaders;
+    Metadata newHeaders = new Metadata();
+    newHeaders.merge(originalHeaders);
     if (previousAttempts > 0) {
-      newHeaders = new Metadata();
-      newHeaders.merge(originalHeaders);
       newHeaders.put(GRPC_PREVIOUS_RPC_ATTEMPTS, String.valueOf(previousAttempts));
     }
     if (transparentRetryAttempts > 0) {
-      if (newHeaders == originalHeaders) {
-        newHeaders = new Metadata();
-        newHeaders.merge(originalHeaders);
-      }
       newHeaders.put(GRPC_TRANSPARENT_RETRY_ATTEMPTS, String.valueOf(transparentRetryAttempts));
     }
     return newHeaders;

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -24,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -136,7 +138,7 @@ public class AbstractClientStreamTest {
     stream.cancel(Status.DEADLINE_EXCEEDED);
     stream.cancel(Status.DEADLINE_EXCEEDED);
 
-    verify(mockListener).closed(any(Status.class), any(Metadata.class));
+    verify(mockListener).closed(any(Status.class), same(PROCESSED), any(Metadata.class));
   }
 
   @Test
@@ -324,7 +326,7 @@ public class AbstractClientStreamTest {
     // Simulate getting a reset
     stream.transportState().transportReportStatus(status, false /*stop delivery*/, new Metadata());
 
-    verify(mockListener).closed(any(Status.class), any(Metadata.class));
+    verify(mockListener).closed(any(Status.class), same(PROCESSED), any(Metadata.class));
   }
   
   @Test

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import static com.google.common.base.Charsets.US_ASCII;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -79,7 +80,7 @@ public class Http2ClientStreamTransportStateTest {
         "application/grpc");
     state.transportHeadersReceived(headers);
 
-    verify(mockListener, never()).closed(any(Status.class), any(Metadata.class));
+    verify(mockListener, never()).closed(any(Status.class), same(PROCESSED), any(Metadata.class));
     verify(mockListener).headersRead(headers);
   }
 
@@ -93,7 +94,7 @@ public class Http2ClientStreamTransportStateTest {
         "application/grpc");
     state.transportHeadersReceived(headers);
 
-    verify(mockListener, never()).closed(any(Status.class), any(Metadata.class));
+    verify(mockListener, never()).closed(any(Status.class), same(PROCESSED), any(Metadata.class));
     verify(mockListener).headersRead(headers);
   }
 
@@ -108,7 +109,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportDataReceived(ReadableBuffers.empty(), true);
 
     verify(mockListener, never()).headersRead(any(Metadata.class));
-    verify(mockListener).closed(statusCaptor.capture(), same(headers));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(headers));
     assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
   }
 
@@ -123,7 +124,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportDataReceived(ReadableBuffers.empty(), true);
 
     verify(mockListener, never()).headersRead(any(Metadata.class));
-    verify(mockListener).closed(statusCaptor.capture(), same(headers));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(headers));
     assertEquals(Code.UNKNOWN, statusCaptor.getValue().getCode());
     assertTrue(statusCaptor.getValue().getDescription().contains("200"));
   }
@@ -139,7 +140,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportDataReceived(ReadableBuffers.empty(), true);
 
     verify(mockListener, never()).headersRead(any(Metadata.class));
-    verify(mockListener).closed(statusCaptor.capture(), same(headers));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(headers));
     assertEquals(Code.UNAUTHENTICATED, statusCaptor.getValue().getCode());
     assertTrue(statusCaptor.getValue().getDescription().contains("401"));
     assertTrue(statusCaptor.getValue().getDescription().contains("text/html"));
@@ -163,7 +164,7 @@ public class Http2ClientStreamTransportStateTest {
         "application/grpc");
     state.transportHeadersReceived(headers);
 
-    verify(mockListener, never()).closed(any(Status.class), any(Metadata.class));
+    verify(mockListener, never()).closed(any(Status.class), same(PROCESSED), any(Metadata.class));
     verify(mockListener).headersRead(headers);
   }
 
@@ -181,7 +182,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportDataReceived(ReadableBuffers.empty(), true);
 
     verify(mockListener).headersRead(headers);
-    verify(mockListener).closed(statusCaptor.capture(), same(headersAgain));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(headersAgain));
     assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
     assertTrue(statusCaptor.getValue().getDescription().contains("twice"));
   }
@@ -201,7 +202,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportDataReceived(ReadableBuffers.empty(), true);
 
     verify(mockListener, never()).headersRead(any(Metadata.class));
-    verify(mockListener).closed(statusCaptor.capture(), same(headers));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(headers));
     assertEquals(Code.UNKNOWN, statusCaptor.getValue().getCode());
     assertTrue(statusCaptor.getValue().getDescription().contains(testString));
   }
@@ -213,7 +214,7 @@ public class Http2ClientStreamTransportStateTest {
     String testString = "This is a test";
     state.transportDataReceived(ReadableBuffers.wrap(testString.getBytes(US_ASCII)), true);
 
-    verify(mockListener).closed(statusCaptor.capture(), any(Metadata.class));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), any(Metadata.class));
     assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
   }
 
@@ -228,7 +229,7 @@ public class Http2ClientStreamTransportStateTest {
     String testString = "This is a test";
     state.transportDataReceived(ReadableBuffers.wrap(testString.getBytes(US_ASCII)), true);
 
-    verify(mockListener).closed(statusCaptor.capture(), same(headers));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(headers));
     assertTrue(statusCaptor.getValue().getDescription().contains(testString));
   }
 
@@ -244,7 +245,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportTrailersReceived(trailers);
 
     verify(mockListener, never()).headersRead(any(Metadata.class));
-    verify(mockListener).closed(Status.OK, trailers);
+    verify(mockListener).closed(Status.OK, PROCESSED, trailers);
   }
 
   @Test
@@ -261,7 +262,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportTrailersReceived(trailers);
 
     verify(mockListener).headersRead(headers);
-    verify(mockListener).closed(Status.OK, trailers);
+    verify(mockListener).closed(Status.OK, PROCESSED, trailers);
   }
 
   @Test
@@ -276,7 +277,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportTrailersReceived(trailers);
 
     verify(mockListener, never()).headersRead(any(Metadata.class));
-    verify(mockListener).closed(Status.CANCELLED, trailers);
+    verify(mockListener).closed(Status.CANCELLED, PROCESSED, trailers);
   }
 
   @Test
@@ -290,7 +291,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportTrailersReceived(trailers);
 
     verify(mockListener, never()).headersRead(any(Metadata.class));
-    verify(mockListener).closed(statusCaptor.capture(), same(trailers));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(trailers));
     assertEquals(Code.UNAUTHENTICATED, statusCaptor.getValue().getCode());
     assertTrue(statusCaptor.getValue().getDescription().contains("401"));
   }
@@ -306,7 +307,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportTrailersReceived(trailers);
 
     verify(mockListener, never()).headersRead(any(Metadata.class));
-    verify(mockListener).closed(statusCaptor.capture(), same(trailers));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(trailers));
     assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
   }
 
@@ -320,7 +321,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportTrailersReceived(trailers);
 
     verify(mockListener, never()).headersRead(any(Metadata.class));
-    verify(mockListener).closed(statusCaptor.capture(), same(trailers));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(trailers));
     assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
   }
 
@@ -338,7 +339,7 @@ public class Http2ClientStreamTransportStateTest {
     state.transportTrailersReceived(trailers);
 
     verify(mockListener).headersRead(headers);
-    verify(mockListener).closed(statusCaptor.capture(), same(trailers));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(trailers));
     assertEquals(Code.UNKNOWN, statusCaptor.getValue().getCode());
   }
 

--- a/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
+++ b/core/src/test/java/io/grpc/internal/NoopClientStreamListener.java
@@ -22,7 +22,7 @@ import io.grpc.Status;
 /**
  * No-op base class for testing.
  */
-class NoopClientStreamListener implements ClientStreamListener {
+public class NoopClientStreamListener implements ClientStreamListener {
   @Override
   public void messagesAvailable(MessageProducer producer) {}
 
@@ -34,4 +34,7 @@ class NoopClientStreamListener implements ClientStreamListener {
 
   @Override
   public void closed(Status status, Metadata trailers) {}
+
+  @Override
+  public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {}
 }

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -926,10 +926,10 @@ public class RetriableStreamTest {
   @Test
   public void updateHeaders() {
     Metadata originalHeaders = new Metadata();
-    Metadata headers = retriableStream.updateHeaders(originalHeaders, 0);
+    Metadata headers = retriableStream.updateHeaders(originalHeaders, 0, 0);
     assertSame(originalHeaders, headers);
 
-    headers = retriableStream.updateHeaders(originalHeaders, 345);
+    headers = retriableStream.updateHeaders(originalHeaders, 345, 0);
     assertEquals("345", headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
     assertNull(originalHeaders.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
   }

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -20,10 +20,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.REFUSED;
 import static io.grpc.internal.RetriableStream.GRPC_PREVIOUS_RPC_ATTEMPTS;
+import static io.grpc.internal.RetriableStream.GRPC_TRANSPARENT_RETRY_ATTEMPTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Matchers.any;
@@ -935,11 +936,20 @@ public class RetriableStreamTest {
   public void updateHeaders() {
     Metadata originalHeaders = new Metadata();
     Metadata headers = retriableStream.updateHeaders(originalHeaders, 0, 0);
-    assertSame(originalHeaders, headers);
+    assertNotSame(originalHeaders, headers);
+    assertNull(headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
+    assertNull(headers.get(GRPC_TRANSPARENT_RETRY_ATTEMPTS));
 
     headers = retriableStream.updateHeaders(originalHeaders, 345, 0);
     assertEquals("345", headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
     assertNull(originalHeaders.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
+    assertNull(headers.get(GRPC_TRANSPARENT_RETRY_ATTEMPTS));
+
+    headers = retriableStream.updateHeaders(originalHeaders, 123, 456);
+    assertEquals("123", headers.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
+    assertEquals("456", headers.get(GRPC_TRANSPARENT_RETRY_ATTEMPTS));
+    assertNull(originalHeaders.get(GRPC_PREVIOUS_RPC_ATTEMPTS));
+    assertNull(originalHeaders.get(GRPC_TRANSPARENT_RETRY_ATTEMPTS));
   }
 
   @Test

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientStreamTest.java
@@ -35,6 +35,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.cronet.CronetChannelBuilder.StreamBuilderFactory;
 import io.grpc.internal.ClientStreamListener;
+import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.StreamListener.MessageProducer;
@@ -322,7 +323,8 @@ public final class CronetClientStreamTest {
     // Verify trailer
     ArgumentCaptor<Metadata> trailerCaptor = ArgumentCaptor.forClass(Metadata.class);
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(clientListener).closed(statusCaptor.capture(), trailerCaptor.capture());
+    verify(clientListener)
+        .closed(statusCaptor.capture(), isA(RpcProgress.class), trailerCaptor.capture());
     // Verify recevied headers.
     Metadata trailers = trailerCaptor.getValue();
     Status status = statusCaptor.getValue();
@@ -365,7 +367,8 @@ public final class CronetClientStreamTest {
     callback.onSucceeded(cronetStream, info);
 
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(clientListener).closed(statusCaptor.capture(), isA(Metadata.class));
+    verify(clientListener)
+        .closed(statusCaptor.capture(), isA(RpcProgress.class), isA(Metadata.class));
     // Verify error status.
     Status status = statusCaptor.getValue();
     assertFalse(status.isOk());
@@ -390,7 +393,8 @@ public final class CronetClientStreamTest {
     clientStream.transportState().transportReportStatus(Status.UNAVAILABLE, false, new Metadata());
 
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(clientListener).closed(statusCaptor.capture(), isA(Metadata.class));
+    verify(clientListener)
+        .closed(statusCaptor.capture(), isA(RpcProgress.class), isA(Metadata.class));
     Status status = statusCaptor.getValue();
     assertEquals(Status.UNAVAILABLE.getCode(), status.getCode());
   }
@@ -417,7 +421,8 @@ public final class CronetClientStreamTest {
     clientStream.transportState().transportReportStatus(Status.UNAVAILABLE, false, new Metadata());
 
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(clientListener).closed(statusCaptor.capture(), isA(Metadata.class));
+    verify(clientListener)
+        .closed(statusCaptor.capture(), isA(RpcProgress.class), isA(Metadata.class));
     Status status = statusCaptor.getValue();
     assertEquals(Status.UNAVAILABLE.getCode(), status.getCode());
   }
@@ -447,7 +452,8 @@ public final class CronetClientStreamTest {
     clientStream.transportState().transportReportStatus(Status.UNAVAILABLE, false, new Metadata());
 
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(clientListener).closed(statusCaptor.capture(), isA(Metadata.class));
+    verify(clientListener)
+        .closed(statusCaptor.capture(), isA(RpcProgress.class), isA(Metadata.class));
     Status status = statusCaptor.getValue();
     // Stream has already finished so OK status should be reported.
     assertEquals(Status.UNAVAILABLE.getCode(), status.getCode());
@@ -479,7 +485,8 @@ public final class CronetClientStreamTest {
     clientStream.transportState().transportReportStatus(Status.UNAVAILABLE, false, new Metadata());
 
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(clientListener).closed(statusCaptor.capture(), isA(Metadata.class));
+    verify(clientListener)
+        .closed(statusCaptor.capture(), isA(RpcProgress.class), isA(Metadata.class));
     Status status = statusCaptor.getValue();
     // Stream has already finished so OK status should be reported.
     assertEquals(Status.OK.getCode(), status.getCode());
@@ -522,12 +529,14 @@ public final class CronetClientStreamTest {
     // Receive trailer first
     ((CronetClientStream.BidirectionalStreamCallback) callback)
         .processTrailers(trailers(Status.UNAUTHENTICATED.getCode().value()));
-    verify(clientListener, times(0)).closed(isA(Status.class), isA(Metadata.class));
+    verify(clientListener, times(0))
+        .closed(isA(Status.class), isA(RpcProgress.class), isA(Metadata.class));
 
     // Receive cronet's endOfStream
     callback.onReadCompleted(cronetStream, null, ByteBuffer.allocate(0), true);
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(clientListener, times(1)).closed(statusCaptor.capture(), isA(Metadata.class));
+    verify(clientListener, times(1))
+        .closed(statusCaptor.capture(), isA(RpcProgress.class), isA(Metadata.class));
     Status status = statusCaptor.getValue();
     assertEquals(Status.UNAUTHENTICATED.getCode(), status.getCode());
   }
@@ -548,13 +557,15 @@ public final class CronetClientStreamTest {
     callback.onResponseHeadersReceived(cronetStream, info);
     // Receive cronet's endOfStream
     callback.onReadCompleted(cronetStream, null, ByteBuffer.allocate(0), true);
-    verify(clientListener, times(0)).closed(isA(Status.class), isA(Metadata.class));
+    verify(clientListener, times(0))
+        .closed(isA(Status.class), isA(RpcProgress.class), isA(Metadata.class));
 
     // Receive trailer
     ((CronetClientStream.BidirectionalStreamCallback) callback)
         .processTrailers(trailers(Status.UNAUTHENTICATED.getCode().value()));
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(clientListener, times(1)).closed(statusCaptor.capture(), isA(Metadata.class));
+    verify(clientListener, times(1))
+        .closed(statusCaptor.capture(), isA(RpcProgress.class), isA(Metadata.class));
     Status status = statusCaptor.getValue();
     assertEquals(Status.UNAUTHENTICATED.getCode(), status.getCode());
   }

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -16,8 +16,6 @@
 
 package io.grpc.netty;
 
-import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
-import static io.grpc.internal.ClientStreamListener.RpcProgress.REFUSED;
 import static io.netty.handler.codec.http2.DefaultHttp2LocalFlowController.DEFAULT_WINDOW_UPDATE_RATIO;
 import static io.netty.util.CharsetUtil.UTF_8;
 
@@ -29,6 +27,7 @@ import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusException;
+import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.ClientTransport.PingCallback;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
@@ -352,7 +351,8 @@ class NettyClientHandler extends AbstractNettyHandler {
           .augmentDescription("Received Rst Stream");
       stream.transportReportStatus(
           status,
-          errorCode == Http2Error.REFUSED_STREAM.code() ? REFUSED : PROCESSED,
+          errorCode == Http2Error.REFUSED_STREAM.code()
+              ? RpcProgress.REFUSED : RpcProgress.PROCESSED,
           false /*stop delivery*/,
           new Metadata());
       if (keepAliveManager != null) {
@@ -638,7 +638,7 @@ class NettyClientHandler extends AbstractNettyHandler {
             NettyClientStream.TransportState clientStream = clientStream(stream);
             if (clientStream != null) {
               clientStream.transportReportStatus(
-                  goAwayStatus, REFUSED, false, new Metadata());
+                  goAwayStatus, RpcProgress.REFUSED, false, new Metadata());
             }
             stream.close();
           }

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -338,7 +338,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
 
   @Test
   public void receivedGoAwayShouldRefuseLaterStreamId() throws Exception {
-    // Force the stream to be buffered.
     ChannelFuture future = enqueue(new CreateStreamCommand(grpcHeaders, streamTransportState));
     channelRead(goAwayFrame(streamId - 1));
     verify(streamListener).closed(any(Status.class), eq(REFUSED), any(Metadata.class));
@@ -347,18 +346,17 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
 
   @Test
   public void receivedGoAwayShouldNotAffectEarlyStreamId() throws Exception {
-    // Force the stream to be buffered.
     ChannelFuture future = enqueue(new CreateStreamCommand(grpcHeaders, streamTransportState));
     channelRead(goAwayFrame(streamId));
     verify(streamListener, never())
         .closed(any(Status.class), any(Metadata.class));
     verify(streamListener, never())
         .closed(any(Status.class), any(RpcProgress.class), any(Metadata.class));
+    assertTrue(future.isDone());
   }
 
   @Test
   public void receivedResetWithRefuseCode() throws Exception {
-    // Force the stream to be buffered.
     ChannelFuture future = enqueue(new CreateStreamCommand(grpcHeaders, streamTransportState));
     channelRead(rstStreamFrame(streamId, (int) Http2Error.REFUSED_STREAM.code() ));
     verify(streamListener).closed(any(Status.class), eq(REFUSED), any(Metadata.class));
@@ -367,7 +365,6 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
 
   @Test
   public void receivedResetWithCanceCode() throws Exception {
-    // Force the stream to be buffered.
     ChannelFuture future = enqueue(new CreateStreamCommand(grpcHeaders, streamTransportState));
     channelRead(rstStreamFrame(streamId, (int) Http2Error.CANCEL.code()));
     verify(streamListener).closed(any(Status.class), eq(PROCESSED), any(Metadata.class));

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -17,6 +17,8 @@
 package io.grpc.netty;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.REFUSED;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.grpc.netty.Utils.CONTENT_TYPE_GRPC;
 import static io.grpc.netty.Utils.CONTENT_TYPE_HEADER;
@@ -35,6 +37,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -193,7 +196,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     cancelStream(Status.CANCELLED);
 
     assertTrue(createFuture.isSuccess());
-    verify(streamListener).closed(eq(Status.CANCELLED), any(Metadata.class));
+    verify(streamListener).closed(eq(Status.CANCELLED), same(PROCESSED), any(Metadata.class));
   }
 
   @Test
@@ -338,7 +341,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     // Read a GOAWAY that indicates our stream was never processed by the server.
     channelRead(goAwayFrame(0, 8 /* Cancel */, Unpooled.copiedBuffer("this is a test", UTF_8)));
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
-    verify(streamListener).closed(captor.capture(), notNull(Metadata.class));
+    verify(streamListener).closed(captor.capture(), same(REFUSED), notNull(Metadata.class));
     assertEquals(Status.CANCELLED.getCode(), captor.getValue().getCode());
     assertEquals("HTTP/2 error code: CANCEL\nReceived Goaway\nthis is a test",
         captor.getValue().getDescription());
@@ -423,7 +426,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     enqueue(new CreateStreamCommand(grpcHeaders, streamTransportState));
     assertEquals(3, streamTransportState.id());
     cancelStream(Status.CANCELLED);
-    verify(streamListener).closed(eq(Status.CANCELLED), any(Metadata.class));
+    verify(streamListener).closed(eq(Status.CANCELLED), same(PROCESSED), any(Metadata.class));
   }
 
   @Test
@@ -445,7 +448,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
 
     handler().channelInactive(ctx());
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
-    verify(streamListener).closed(captor.capture(), notNull(Metadata.class));
+    verify(streamListener).closed(captor.capture(), same(PROCESSED), notNull(Metadata.class));
     assertEquals(Status.UNAVAILABLE.getCode(), captor.getValue().getCode());
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -676,6 +676,11 @@ public class NettyClientTransportTest {
 
     @Override
     public void closed(Status status, Metadata trailers) {
+      closed(status, RpcProgress.PROCESSED, trailers);
+    }
+
+    @Override
+    public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
       if (status.isOk()) {
         closedFuture.set(null);
       } else {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -18,6 +18,7 @@ package io.grpc.okhttp;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 
 import com.google.common.io.BaseEncoding;
 import io.grpc.Attributes;
@@ -307,8 +308,11 @@ class OkHttpClientStream extends AbstractClientStream {
       window -= length;
       if (window < 0) {
         frameWriter.rstStream(id(), ErrorCode.FLOW_CONTROL_ERROR);
-        transport.finishStream(id(), Status.INTERNAL.withDescription(
-            "Received data size exceeded our receiving window size"), false, null, null);
+        transport.finishStream(
+            id(),
+            Status.INTERNAL.withDescription(
+                "Received data size exceeded our receiving window size"),
+            PROCESSED, false, null, null);
         return;
       }
       super.transportDataReceived(new OkHttpReadableBuffer(frame), endOfStream);
@@ -319,9 +323,9 @@ class OkHttpClientStream extends AbstractClientStream {
       if (!framer().isClosed()) {
         // If server's end-of-stream is received before client sends end-of-stream, we just send a
         // reset to server to fully close the server side stream.
-        transport.finishStream(id(), null, false, ErrorCode.CANCEL, null);
+        transport.finishStream(id(),null, PROCESSED, false, ErrorCode.CANCEL, null);
       } else {
-        transport.finishStream(id(), null, false, null, null);
+        transport.finishStream(id(), null, PROCESSED, false, null, null);
       }
     }
 
@@ -344,7 +348,8 @@ class OkHttpClientStream extends AbstractClientStream {
       } else {
         // If pendingData is null, start must have already been called, which means synStream has
         // been called as well.
-        transport.finishStream(id(), reason, stopDelivery, ErrorCode.CANCEL, trailers);
+        transport.finishStream(
+            id(), reason, PROCESSED, stopDelivery, ErrorCode.CANCEL, trailers);
       }
     }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -1838,6 +1838,11 @@ public class OkHttpClientTransportTest {
 
     @Override
     public void closed(Status status, Metadata trailers) {
+      closed(status, RpcProgress.PROCESSED, trailers);
+    }
+
+    @Override
+    public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
       this.status = status;
       this.trailers = trailers;
       closed.countDown();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -18,6 +18,8 @@ package io.grpc.okhttp;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
+import static io.grpc.internal.ClientStreamListener.RpcProgress.REFUSED;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.grpc.okhttp.Headers.CONTENT_TYPE_HEADER;
 import static io.grpc.okhttp.Headers.METHOD_HEADER;
@@ -128,6 +130,7 @@ public class OkHttpClientTransportTest {
   private static final ProxyParameters NO_PROXY = null;
   private static final String NO_USER = null;
   private static final String NO_PW = null;
+  private static final int DEFAULT_START_STREAM_ID = 3;
 
   @Rule public final Timeout globalTimeout = Timeout.seconds(10);
 
@@ -168,7 +171,7 @@ public class OkHttpClientTransportTest {
   }
 
   private void initTransport() throws Exception {
-    startTransport(3, null, true, DEFAULT_MAX_MESSAGE_SIZE, null);
+    startTransport(DEFAULT_START_STREAM_ID, null, true, DEFAULT_MAX_MESSAGE_SIZE, null);
   }
 
   private void initTransport(int startId) throws Exception {
@@ -177,7 +180,8 @@ public class OkHttpClientTransportTest {
 
   private void initTransportAndDelayConnected() throws Exception {
     delayConnectedCallback = new DelayConnectedCallback();
-    startTransport(3, delayConnectedCallback, false, DEFAULT_MAX_MESSAGE_SIZE, null);
+    startTransport(
+        DEFAULT_START_STREAM_ID, delayConnectedCallback, false, DEFAULT_MAX_MESSAGE_SIZE, null);
   }
 
   private void startTransport(int startId, @Nullable Runnable connectingCallback,
@@ -1663,6 +1667,88 @@ public class OkHttpClientTransportTest {
     shutdownAndVerify();
   }
 
+  @Test
+  public void goAway_streamListenerRpcProgress() throws Exception {
+    initTransport();
+    setMaxConcurrentStreams(2);
+    MockStreamListener listener1 = new MockStreamListener();
+    MockStreamListener listener2 = new MockStreamListener();
+    MockStreamListener listener3 = new MockStreamListener();
+    OkHttpClientStream stream1 =
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    stream1.start(listener1);
+    OkHttpClientStream stream2 =
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    stream2.start(listener2);
+    OkHttpClientStream stream3 =
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    stream3.start(listener3);
+    waitForStreamPending(1);
+
+    assertEquals(2, activeStreamCount());
+    assertContainStream(DEFAULT_START_STREAM_ID);
+    assertContainStream(DEFAULT_START_STREAM_ID + 2);
+
+    frameHandler()
+        .goAway(DEFAULT_START_STREAM_ID, ErrorCode.CANCEL, ByteString.encodeUtf8("blablabla"));
+
+    listener2.waitUntilStreamClosed();
+    listener3.waitUntilStreamClosed();
+    assertNull(listener1.rpcProgress);
+    assertEquals(REFUSED, listener2.rpcProgress);
+    assertEquals(REFUSED, listener3.rpcProgress);
+    assertEquals(1, activeStreamCount());
+    assertContainStream(DEFAULT_START_STREAM_ID);
+
+    getStream(DEFAULT_START_STREAM_ID).cancel(Status.CANCELLED);
+
+    listener1.waitUntilStreamClosed();
+    assertEquals(PROCESSED, listener1.rpcProgress);
+
+    shutdownAndVerify();
+  }
+
+  @Test
+  public void reset_streamListenerRpcProgress() throws Exception {
+    initTransport();
+    MockStreamListener listener1 = new MockStreamListener();
+    MockStreamListener listener2 = new MockStreamListener();
+    MockStreamListener listener3 = new MockStreamListener();
+    OkHttpClientStream stream1 =
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    stream1.start(listener1);
+    OkHttpClientStream stream2 =
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    stream2.start(listener2);
+    OkHttpClientStream stream3 =
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    stream3.start(listener3);
+
+    assertEquals(3, activeStreamCount());
+    assertContainStream(DEFAULT_START_STREAM_ID);
+    assertContainStream(DEFAULT_START_STREAM_ID + 2);
+    assertContainStream(DEFAULT_START_STREAM_ID + 4);
+
+    frameHandler().rstStream(DEFAULT_START_STREAM_ID + 2, ErrorCode.REFUSED_STREAM);
+
+    listener2.waitUntilStreamClosed();
+    assertNull(listener1.rpcProgress);
+    assertEquals(REFUSED, listener2.rpcProgress);
+    assertNull(listener3.rpcProgress);
+
+    frameHandler().rstStream(DEFAULT_START_STREAM_ID, ErrorCode.CANCEL);
+    listener1.waitUntilStreamClosed();
+    assertEquals(PROCESSED, listener1.rpcProgress);
+    assertNull(listener3.rpcProgress);
+
+    getStream(DEFAULT_START_STREAM_ID + 4).cancel(Status.CANCELLED);
+
+    listener3.waitUntilStreamClosed();
+    assertEquals(PROCESSED, listener3.rpcProgress);
+
+    shutdownAndVerify();
+  }
+
   private int activeStreamCount() {
     return clientTransport.getActiveStreams().length;
   }
@@ -1813,6 +1899,7 @@ public class OkHttpClientTransportTest {
     Status status;
     Metadata headers;
     Metadata trailers;
+    RpcProgress rpcProgress;
     CountDownLatch closed = new CountDownLatch(1);
     ArrayList<String> messages = new ArrayList<String>();
     boolean onReadyCalled;
@@ -1838,13 +1925,14 @@ public class OkHttpClientTransportTest {
 
     @Override
     public void closed(Status status, Metadata trailers) {
-      closed(status, RpcProgress.PROCESSED, trailers);
+      closed(status, PROCESSED, trailers);
     }
 
     @Override
     public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
       this.status = status;
       this.trailers = trailers;
+      this.rpcProgress = rpcProgress;
       closed.countDown();
     }
 

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -982,6 +982,14 @@ public abstract class AbstractTransportTest {
         // This simulates the blocking calls which can trigger clientStream.cancel().
         clientStream.cancel(Status.CANCELLED.withCause(status.asRuntimeException()));
       }
+
+      @Override
+      public void closed(
+          Status status, RpcProgress rpcProgress, Metadata trailers) {
+        super.closed(status, rpcProgress, trailers);
+        // This simulates the blocking calls which can trigger clientStream.cancel().
+        clientStream.cancel(Status.CANCELLED.withCause(status.asRuntimeException()));
+      }
     };
     clientStream.start(clientStreamListener);
     StreamCreation serverStreamCreation
@@ -1056,6 +1064,12 @@ public abstract class AbstractTransportTest {
 
       @Override
       public void closed(Status status, Metadata trailers) {
+        closed(status, RpcProgress.PROCESSED, trailers);
+      }
+
+      @Override
+      public void closed(
+          Status status, RpcProgress rpcProgress, Metadata trailers) {
         assertEquals(Status.CANCELLED.getCode(), status.getCode());
         assertEquals("nevermind", status.getDescription());
         closedCalled.set(true);
@@ -1950,6 +1964,11 @@ public abstract class AbstractTransportTest {
 
     @Override
     public void closed(Status status, Metadata trailers) {
+      closed(status, RpcProgress.PROCESSED, trailers);
+    }
+
+    @Override
+    public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
       if (this.status.isDone()) {
         fail("headersRead invoked after closed");
       }


### PR DESCRIPTION
Changes:

- `ClientStreamListener.onClose(Status status, RpcProgress rpcProgress, Metadata trailers)` added.

- `AbstractClientStream.transportReportStatus(Status status, RpcProgress rpcProgress, boolean stopDelivery, Metadata trailers)` added

- `ClientCallImpl.ClientStreamListenerImpl` will ignore the arg `rpcProgress` (non retry)

- `RetriableStream.SubListener` will handle `rpcProgress` and decide if transparent retry.

- `NettyClientHandler` and `OkHttpClientTransport` will pass `RpcProgress.REFUSED` to client stream listener for later stream ids when received GOAWAY, or for stream received a RST_STREAM frame with REFUSED code.

- All other files are just a result of refactoring.