### PR TITLE
all: drop @grpc_java from java_grpc_library.bzl

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -58,7 +58,7 @@ _gensource = rule(
             cfg = "host",
         ),
         "_java_plugin": attr.label(
-            default = Label("@grpc_java//compiler:grpc_java_plugin"),
+            default = Label("//compiler:grpc_java_plugin"),
             executable = True,
             cfg = "host",
         ),
@@ -107,9 +107,9 @@ def java_grpc_library(name, srcs, deps, flavor=None,
   )
 
   added_deps = [
-      "@grpc_java//core",
-      "@grpc_java//stub",
-      "@grpc_java//protobuf",
+      "//core",
+      "//stub",
+      "//protobuf",
       "@com_google_guava_guava//jar",
   ]
   if flavor == "normal":


### PR DESCRIPTION
These don't contribute if grpc-java is imported with name = grpc_java,
and break the build if grpc-java is imported with another name.