### PR TITLE
core,services: lock down visibility of BinaryLogSink

### DIFF
--- a/core/src/test/java/io/grpc/ServiceProvidersTestAbstractProvider.java
+++ b/core/src/test/java/io/grpc/ServiceProvidersTestAbstractProvider.java
@@ -21,7 +21,7 @@ package io.grpc;
  */
 // Nesting the class inside the test leads to a class name that has a '$' in it, which causes
 // issues with our build pipeline.
-public abstract class ServiceProvidersTestAbstractProvider {
+abstract class ServiceProvidersTestAbstractProvider {
   abstract boolean isAvailable();
 
   abstract int priority();

--- a/services/src/main/java/io/grpc/services/BinaryLogSink.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogSink.java
@@ -19,7 +19,7 @@ package io.grpc.services;
 import com.google.protobuf.MessageLite;
 import java.io.Closeable;
 
-public abstract class BinaryLogSink implements Closeable {
+abstract class BinaryLogSink implements Closeable {
   /**
    * Writes the {@code message} to the destination.
    */


### PR DESCRIPTION
- This class should not be a part of the public API
- Update ServiceProvidersTest to verify package private services can be
  loaded with the utility.