### PR TITLE
build.gradle: bump protobuf plugin to 0.8.5

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -41,10 +41,3 @@ configureProtoCompilation()
 javadoc {
     exclude 'io/grpc/alts/internal/**'
 }
-
-idea {
-    module {
-        sourceDirs += file("${projectDir}/src/generated/main/grpc");
-        sourceDirs += file("${projectDir}/src/generated/main/java");
-    }
-}

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -91,12 +91,3 @@ applicationDistribution.into("bin") {
     from(benchmark_worker)
     fileMode = 0755
 }
-
-// Let intellij projects refer to generated code
-idea {
-    module {
-        sourceDirs += file("${projectDir}/src/generated/main/java");
-        sourceDirs += file("${projectDir}/src/generated/main/grpc");
-    }
-}
-

--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ subprojects {
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
                 protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",
                 protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
-                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.3',
+                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.4',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
                 lang: "org.apache.commons:commons-lang3:3.5",
 

--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ subprojects {
                 protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
                 protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",
                 protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
-                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.4',
+                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.5',
                 protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
                 lang: "org.apache.commons:commons-lang3:3.5",
 

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -22,10 +22,3 @@ dependencies {
 }
 
 configureProtoCompilation()
-
-idea {
-    module {
-        sourceDirs += file("${projectDir}/src/generated/main/grpc");
-        sourceDirs += file("${projectDir}/src/generated/main/java");
-    }
-}

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -101,11 +101,3 @@ applicationDistribution.into("bin") {
     from(http2_client)
     fileMode = 0755
 }
-
-// Let intellij projects refer to generated code
-idea {
-  module {
-    sourceDirs += file("${projectDir}/src/generated/main/java")
-    sourceDirs += file("${projectDir}/src/generated/main/grpc")
-  }
-}

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -59,9 +59,3 @@ protobuf {
     }
   }
 }
-
-idea {
-    module {
-        testSourceDirs += file("${projectDir}/build/generated/source/proto/test/javalite/")
-    }
-}

--- a/protobuf-nano/build.gradle
+++ b/protobuf-nano/build.gradle
@@ -36,9 +36,3 @@ if (project.hasProperty('protobuf')) {
     }
   }
 }
-
-idea {
-    module {
-        sourceDirs += file("${projectDir}/src/generated/test/javanano");
-    }
-}

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -30,13 +30,3 @@ dependencies {
 }
 
 configureProtoCompilation()
-
-// Let intellij projects refer to generated code
-idea {
-    module {
-        sourceDirs += file("${projectDir}/src/generated/main/java");
-        sourceDirs += file("${projectDir}/src/generated/main/grpc");
-        testSourceDirs += file("${projectDir}/src/generated/test/java")
-        testSourceDirs += file("${projectDir}/src/generated/test/grpc")
-    }
-}

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -20,11 +20,3 @@ dependencies {
 }
 
 configureProtoCompilation()
-
-// Let intellij projects refer to generated code
-idea {
-    module {
-        sourceDirs += file("${projectDir}/src/generated/main/java")
-        sourceDirs += file("${projectDir}/src/generated/main/grpc")
-    }
-}


### PR DESCRIPTION
This update automatically adds generated sources and proto IDLs to the
`idea` plugin, so clean up the configs.