### PR TITLE
core: BinaryLogProvider should only provide a BinaryLog

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -139,7 +139,7 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private int maxInboundMessageSize = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
-  BinaryLogProvider binlogProvider = BinaryLogProvider.provider();
+  BinaryLog binlog = BinaryLogProvider.getInstance();
 
   /**
    * Sets the maximum message size allowed for a single gRPC frame. If an inbound messages

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -139,7 +139,7 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private int maxInboundMessageSize = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
-  BinaryLog binlog = BinaryLogProvider.getInstance();
+  BinaryLog binarylog = BinaryLogProvider.getInstance();
 
   /**
    * Sets the maximum message size allowed for a single gRPC frame. If an inbound messages

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -107,7 +107,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   private boolean recordFinishedRpcs = true;
   private boolean tracingEnabled = true;
 
-  protected BinaryLogProvider binlogProvider = BinaryLogProvider.provider();
+  protected BinaryLog binaryLog = BinaryLogProvider.getInstance();
   protected TransportTracer.Factory transportTracerFactory = TransportTracer.getDefaultFactory();
 
   protected Channelz channelz = Channelz.instance();

--- a/core/src/main/java/io/grpc/internal/BinaryLog.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLog.java
@@ -35,6 +35,10 @@ import java.io.InputStream;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
+/**
+ * An abstract class representing a BinaryLog. Implementations should provide
+ * {@link ServerInterceptor} and {@link ClientInterceptor} objects for each RPC method.
+ */
 public abstract class BinaryLog implements Closeable {
   private static final Logger logger = Logger.getLogger(BinaryLog.class.getName());
   @VisibleForTesting
@@ -97,16 +101,16 @@ public abstract class BinaryLog implements Closeable {
    * Wraps a {@link ServerMethodDefinition} such that it performs binary logging if needed.
    */
   final <ReqT, RespT> ServerMethodDefinition<?, ?> wrapMethodDefinition(
-      ServerMethodDefinition<ReqT, RespT> oMethodDef) {
+      ServerMethodDefinition<ReqT, RespT> originalMethodDef) {
     ServerInterceptor binlogInterceptor =
-        getServerInterceptor(oMethodDef.getMethodDescriptor().getFullMethodName());
+        getServerInterceptor(originalMethodDef.getMethodDescriptor().getFullMethodName());
     if (binlogInterceptor == null) {
-      return oMethodDef;
+      return originalMethodDef;
     }
     MethodDescriptor<InputStream, InputStream> binMethod =
-        toInputStreamMethod(oMethodDef.getMethodDescriptor());
+        toInputStreamMethod(originalMethodDef.getMethodDescriptor());
     ServerMethodDefinition<InputStream, InputStream> binDef = InternalServerInterceptors
-        .wrapMethod(oMethodDef, binMethod);
+        .wrapMethod(originalMethodDef, binMethod);
     ServerCallHandler<InputStream, InputStream> binlogHandler = InternalServerInterceptors
         .interceptCallHandler(binlogInterceptor, binDef.getServerCallHandler());
     return ServerMethodDefinition.create(binMethod, binlogHandler);

--- a/core/src/main/java/io/grpc/internal/BinaryLog.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLog.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.InternalClientInterceptors;
+import io.grpc.InternalServerInterceptors;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerMethodDefinition;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+public abstract class BinaryLog implements Closeable {
+  private static final Logger logger = Logger.getLogger(BinaryLog.class.getName());
+  @VisibleForTesting
+  static final Marshaller<InputStream> IDENTITY_MARSHALLER = new IdentityMarshaller();
+
+  private final ClientInterceptor binaryLogShim = new BinaryLogShim();
+
+  /**
+   * Returns a {@link ServerInterceptor} for binary logging. gRPC is free to cache the interceptor,
+   * so the interceptor must be reusable across calls. At runtime, the request and response
+   * marshallers are always {@code Marshaller<InputStream>}.
+   * Returns {@code null} if this method is not binary logged.
+   */
+  // TODO(zpencer): ensure the interceptor properly handles retries and hedging
+  @Nullable
+  public abstract ServerInterceptor getServerInterceptor(String fullMethodName);
+
+  /**
+   * Returns a {@link ClientInterceptor} for binary logging. gRPC is free to cache the interceptor,
+   * so the interceptor must be reusable across calls. At runtime, the request and response
+   * marshallers are always {@code Marshaller<InputStream>}.
+   * Returns {@code null} if this method is not binary logged.
+   */
+  // TODO(zpencer): ensure the interceptor properly handles retries and hedging
+  @Nullable
+  public abstract ClientInterceptor getClientInterceptor(String fullMethodName);
+
+  @Override
+  public void close() throws IOException {
+    // default impl: noop
+  }
+
+  /**
+   * A priority, from 0 to 10 that this provider should be used, taking the current environment into
+   * consideration. 5 should be considered the default, and then tweaked based on environment
+   * detection. A priority of 0 does not imply that the provider wouldn't work; just that it should
+   * be last in line.
+   */
+  protected abstract int priority();
+
+  /**
+   * Whether this provider is available for use, taking the current environment into consideration.
+   * If {@code false}, no other methods are safe to be called.
+   */
+  protected abstract boolean isAvailable();
+
+  /**
+   * Wraps a channel to provide binary logging on {@link ClientCall}s as needed.
+   */
+  Channel wrapChannel(Channel channel) {
+    return ClientInterceptors.intercept(channel, binaryLogShim);
+  }
+
+  private static MethodDescriptor<InputStream, InputStream> toInputStreamMethod(
+      MethodDescriptor<?, ?> method) {
+    return method.toBuilder(IDENTITY_MARSHALLER, IDENTITY_MARSHALLER).build();
+  }
+
+  /**
+   * Wraps a {@link ServerMethodDefinition} such that it performs binary logging if needed.
+   */
+  final <ReqT, RespT> ServerMethodDefinition<?, ?> wrapMethodDefinition(
+      ServerMethodDefinition<ReqT, RespT> oMethodDef) {
+    ServerInterceptor binlogInterceptor =
+        getServerInterceptor(oMethodDef.getMethodDescriptor().getFullMethodName());
+    if (binlogInterceptor == null) {
+      return oMethodDef;
+    }
+    MethodDescriptor<InputStream, InputStream> binMethod =
+        toInputStreamMethod(oMethodDef.getMethodDescriptor());
+    ServerMethodDefinition<InputStream, InputStream> binDef = InternalServerInterceptors
+        .wrapMethod(oMethodDef, binMethod);
+    ServerCallHandler<InputStream, InputStream> binlogHandler = InternalServerInterceptors
+        .interceptCallHandler(binlogInterceptor, binDef.getServerCallHandler());
+    return ServerMethodDefinition.create(binMethod, binlogHandler);
+  }
+
+  // Creating a named class makes debugging easier
+  private static final class IdentityMarshaller implements Marshaller<InputStream> {
+    @Override
+    public InputStream stream(InputStream value) {
+      return value;
+    }
+
+    @Override
+    public InputStream parse(InputStream stream) {
+      return stream;
+    }
+  }
+
+  /**
+   * The pipeline of interceptors is hard coded when the {@link ManagedChannelImpl} is created.
+   * This shim interceptor should always be installed as a placeholder. When a call starts,
+   * this interceptor checks with the {@link BinaryLogProvider} to see if logging should happen
+   * for this particular {@link ClientCall}'s method.
+   */
+  private final class BinaryLogShim implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method,
+        CallOptions callOptions,
+        Channel next) {
+      ClientInterceptor binlogInterceptor = getClientInterceptor(method.getFullMethodName());
+      if (binlogInterceptor == null) {
+        return next.newCall(method, callOptions);
+      } else {
+        return InternalClientInterceptors
+            .wrapClientInterceptor(
+                binlogInterceptor,
+                IDENTITY_MARSHALLER,
+                IDENTITY_MARSHALLER)
+            .interceptCall(method, callOptions, next);
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
@@ -16,237 +16,33 @@
 
 package io.grpc.internal;
 
-import com.google.common.annotations.VisibleForTesting;
-import io.grpc.CallOptions;
-import io.grpc.Channel;
-import io.grpc.ClientCall;
-import io.grpc.ClientInterceptor;
-import io.grpc.ClientInterceptors;
-import io.grpc.InternalClientInterceptors;
-import io.grpc.InternalServerInterceptors;
-import io.grpc.MethodDescriptor;
-import io.grpc.MethodDescriptor.Marshaller;
-import io.grpc.ServerCallHandler;
-import io.grpc.ServerInterceptor;
-import io.grpc.ServerMethodDefinition;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
+import io.grpc.InternalServiceProviders;
+import io.grpc.InternalServiceProviders.PriorityAccessor;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
-public abstract class BinaryLogProvider implements Closeable {
-  private static final Logger logger = Logger.getLogger(BinaryLogProvider.class.getName());
-  private static final BinaryLogProvider PROVIDER = load(BinaryLogProvider.class.getClassLoader());
-  @VisibleForTesting
-  static final Marshaller<InputStream> IDENTITY_MARSHALLER = new IdentityMarshaller();
-
-  private final ClientInterceptor binaryLogShim = new BinaryLogShim();
-
-  /**
-   * Returns a {@code BinaryLogProvider}, or {@code null} if there is no provider.
-   */
-  @Nullable
-  public static BinaryLogProvider provider() {
-    return PROVIDER;
-  }
-
-  /**
-   * Wraps a channel to provide binary logging on {@link ClientCall}s as needed.
-   */
-  Channel wrapChannel(Channel channel) {
-    return ClientInterceptors.intercept(channel, binaryLogShim);
-  }
-
-  private static MethodDescriptor<InputStream, InputStream> toInputStreamMethod(
-      MethodDescriptor<?, ?> method) {
-    return method.toBuilder(IDENTITY_MARSHALLER, IDENTITY_MARSHALLER).build();
-  }
-
-  /**
-   * Wraps a {@link ServerMethodDefinition} such that it performs binary logging if needed.
-   */
-  final <ReqT, RespT> ServerMethodDefinition<?, ?> wrapMethodDefinition(
-      ServerMethodDefinition<ReqT, RespT> oMethodDef) {
-    ServerInterceptor binlogInterceptor =
-        getServerInterceptor(oMethodDef.getMethodDescriptor().getFullMethodName());
-    if (binlogInterceptor == null) {
-      return oMethodDef;
-    }
-    MethodDescriptor<InputStream, InputStream> binMethod =
-        BinaryLogProvider.toInputStreamMethod(oMethodDef.getMethodDescriptor());
-    ServerMethodDefinition<InputStream, InputStream> binDef = InternalServerInterceptors
-        .wrapMethod(oMethodDef, binMethod);
-    ServerCallHandler<InputStream, InputStream> binlogHandler = InternalServerInterceptors
-        .interceptCallHandler(binlogInterceptor, binDef.getServerCallHandler());
-    return ServerMethodDefinition.create(binMethod, binlogHandler);
-  }
-
-
-  @VisibleForTesting
-  static BinaryLogProvider load(ClassLoader classLoader) {
-    try {
-      return loadHelper(classLoader);
-    } catch (Throwable t) {
-      logger.log(
-          Level.SEVERE, "caught exception loading BinaryLogProvider, will disable binary log", t);
-      return null;
-    }
-  }
-
-  private static BinaryLogProvider loadHelper(ClassLoader classLoader) {
-    if (isAndroid()) {
-      return null;
-    }
-
-    Iterator<BinaryLogProvider> iter = getCandidatesViaServiceLoader(classLoader).iterator();
-    List<BinaryLogProvider> list = new ArrayList<BinaryLogProvider>();
-    while (iter.hasNext()) {
-      // The iterator comes from ServiceLoader and may throw when next() is called
-      try {
-        list.add(iter.next());
-      } catch (ServiceConfigurationError e) {
-        logger.log(Level.SEVERE, "caught exception creating an instance of BinaryLogProvider", e);
-      }
-    }
-    if (list.isEmpty()) {
-      return null;
-    } else {
-      return Collections.max(list, new Comparator<BinaryLogProvider>() {
+public abstract class BinaryLogProvider {
+  private static final BinaryLog INSTANCE = InternalServiceProviders.load(
+      BinaryLog.class,
+      Collections.<Class<?>>emptyList(),
+      BinaryLog.class.getClassLoader(),
+      new PriorityAccessor<BinaryLog>() {
         @Override
-        public int compare(BinaryLogProvider f1, BinaryLogProvider f2) {
-          return f1.priority() - f2.priority();
+        public boolean isAvailable(BinaryLog binaryLog) {
+          return binaryLog.isAvailable();
+        }
+
+        @Override
+        public int getPriority(BinaryLog binaryLog) {
+          return binaryLog.priority();
         }
       });
-    }
-  }
-
-  private static ServiceLoader<BinaryLogProvider> getCandidatesViaServiceLoader(
-      ClassLoader classLoader) {
-    ServiceLoader<BinaryLogProvider> i = ServiceLoader.load(BinaryLogProvider.class, classLoader);
-    // Attempt to load using the context class loader and ServiceLoader.
-    // This allows frameworks like http://aries.apache.org/modules/spi-fly.html to plug in.
-    if (!i.iterator().hasNext()) {
-      i = ServiceLoader.load(BinaryLogProvider.class);
-    }
-    return i;
-  }
 
   /**
-   * Returns a {@link ServerInterceptor} for binary logging. gRPC is free to cache the interceptor,
-   * so the interceptor must be reusable across calls. At runtime, the request and response
-   * marshallers are always {@code Marshaller<InputStream>}.
-   * Returns {@code null} if this method is not binary logged.
+   * Returns a {@code BinaryLog}, or {@code null} if there none is available.
    */
-  // TODO(zpencer): ensure the interceptor properly handles retries and hedging
   @Nullable
-  public abstract ServerInterceptor getServerInterceptor(String fullMethodName);
-
-  /**
-   * Returns a {@link ClientInterceptor} for binary logging. gRPC is free to cache the interceptor,
-   * so the interceptor must be reusable across calls. At runtime, the request and response
-   * marshallers are always {@code Marshaller<InputStream>}.
-   * Returns {@code null} if this method is not binary logged.
-   */
-  // TODO(zpencer): ensure the interceptor properly handles retries and hedging
-  @Nullable
-  public abstract ClientInterceptor getClientInterceptor(String fullMethodName);
-
-  @Override
-  public void close() throws IOException {
-    // default impl: noop
-    // TODO(zpencer): make BinaryLogProvider provide a BinaryLog, and this method belongs there
-  }
-
-  /**
-   * A priority, from 0 to 10 that this provider should be used, taking the current environment into
-   * consideration. 5 should be considered the default, and then tweaked based on environment
-   * detection. A priority of 0 does not imply that the provider wouldn't work; just that it should
-   * be last in line.
-   */
-  protected abstract int priority();
-
-  /**
-   * A provider that always returns null interceptors.
-   */
-  @VisibleForTesting
-  static final class NullProvider extends BinaryLogProvider {
-    @Nullable
-    @Override
-    public ServerInterceptor getServerInterceptor(String fullMethodName) {
-      return null;
-    }
-
-    @Override
-    public ClientInterceptor getClientInterceptor(String fullMethodName) {
-      return null;
-    }
-
-    @Override
-    protected int priority() {
-      return 0;
-    }
-  }
-
-  /**
-   * Returns whether current platform is Android.
-   */
-  protected static boolean isAndroid() {
-    try {
-      // Specify a class loader instead of null because we may be running under Robolectric
-      Class.forName("android.app.Application", /*initialize=*/ false,
-          BinaryLogProvider.class.getClassLoader());
-      return true;
-    } catch (Exception e) {
-      // If Application isn't loaded, it might as well not be Android.
-      return false;
-    }
-  }
-
-  // Creating a named class makes debugging easier
-  private static final class IdentityMarshaller implements Marshaller<InputStream> {
-    @Override
-    public InputStream stream(InputStream value) {
-      return value;
-    }
-
-    @Override
-    public InputStream parse(InputStream stream) {
-      return stream;
-    }
-  }
-
-  /**
-   * The pipeline of interceptors is hard coded when the {@link ManagedChannelImpl} is created.
-   * This shim interceptor should always be installed as a placeholder. When a call starts,
-   * this interceptor checks with the {@link BinaryLogProvider} to see if logging should happen
-   * for this particular {@link ClientCall}'s method.
-   */
-  private final class BinaryLogShim implements ClientInterceptor {
-    @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-        MethodDescriptor<ReqT, RespT> method,
-        CallOptions callOptions,
-        Channel next) {
-      ClientInterceptor binlogInterceptor = getClientInterceptor(method.getFullMethodName());
-      if (binlogInterceptor == null) {
-        return next.newCall(method, callOptions);
-      } else {
-        return InternalClientInterceptors
-            .wrapClientInterceptor(
-                binlogInterceptor,
-                IDENTITY_MARSHALLER,
-                IDENTITY_MARSHALLER)
-            .interceptCall(method, callOptions, next);
-      }
-    }
+  public static BinaryLog getInstance() {
+    return INSTANCE;
   }
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -524,8 +524,8 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
     this.transportFactory =
         new CallCredentialsApplyingTransportFactory(clientTransportFactory, this.executor);
     Channel channel = new RealChannel();
-    if (builder.binlog != null) {
-      channel = builder.binlog.wrapChannel(channel);
+    if (builder.binarylog != null) {
+      channel = builder.binarylog.wrapChannel(channel);
     }
     this.interceptorChannel = ClientInterceptors.intercept(channel, interceptors);
     this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -524,8 +524,8 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
     this.transportFactory =
         new CallCredentialsApplyingTransportFactory(clientTransportFactory, this.executor);
     Channel channel = new RealChannel();
-    if (builder.binlogProvider != null) {
-      channel = builder.binlogProvider.wrapChannel(channel);
+    if (builder.binlog != null) {
+      channel = builder.binlog.wrapChannel(channel);
     }
     this.interceptorChannel = ClientInterceptors.intercept(channel, interceptors);
     this.stopwatchSupplier = checkNotNull(stopwatchSupplier, "stopwatchSupplier");

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -107,7 +107,7 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
 
   private final DecompressorRegistry decompressorRegistry;
   private final CompressorRegistry compressorRegistry;
-  private final BinaryLogProvider binlogProvider;
+  private final BinaryLog binaryLog;
 
   private final Channelz channelz;
   private final CallTracer serverCallTracer;
@@ -138,7 +138,7 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
     this.interceptors =
         builder.interceptors.toArray(new ServerInterceptor[builder.interceptors.size()]);
     this.handshakeTimeoutMillis = builder.handshakeTimeoutMillis;
-    this.binlogProvider = builder.binlogProvider;
+    this.binaryLog = builder.binaryLog;
     this.channelz = builder.channelz;
     this.serverCallTracer = builder.callTracerFactory.create();
 
@@ -532,8 +532,8 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
         handler = InternalServerInterceptors.interceptCallHandler(interceptor, handler);
       }
       ServerMethodDefinition<ReqT, RespT> interceptedDef = methodDef.withServerCallHandler(handler);
-      ServerMethodDefinition<?, ?> wMethodDef = binlogProvider == null
-          ? interceptedDef : binlogProvider.wrapMethodDefinition(interceptedDef);
+      ServerMethodDefinition<?, ?> wMethodDef = binaryLog == null
+          ? interceptedDef : binaryLog.wrapMethodDefinition(interceptedDef);
       return startWrappedCall(fullMethodName, wMethodDef, stream, headers, context);
     }
 

--- a/core/src/test/java/io/grpc/internal/BinaryLogTest.java
+++ b/core/src/test/java/io/grpc/internal/BinaryLogTest.java
@@ -45,6 +45,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -79,13 +80,15 @@ public class BinaryLogTest {
   private final List<byte[]> binlogReq = new ArrayList<byte[]>();
   private final List<byte[]> binlogResp = new ArrayList<byte[]>();
   private final BinaryLog binlogProvider = new BinaryLog() {
+    @Nullable
     @Override
-    public ServerInterceptor getServerInterceptor(String fullMethodName) {
+    public ServerInterceptor getServerInterceptor(MethodDescriptor<?, ?> method) {
       return new TestBinaryLogServerInterceptor();
     }
 
+    @Nullable
     @Override
-    public ClientInterceptor getClientInterceptor(String fullMethodName) {
+    public ClientInterceptor getClientInterceptor(MethodDescriptor<?, ?> method) {
       return new TestBinaryLogClientInterceptor();
     }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -228,7 +228,7 @@ public class ManagedChannelImplTest {
         .userAgent(userAgent);
     builder.executorPool = executorPool;
     builder.idleTimeoutMillis = idleTimeoutMillis;
-    builder.binlog = binlog;
+    builder.binarylog = binlog;
     builder.channelz = channelz;
     checkState(channel == null);
     channel = new ManagedChannelImpl(
@@ -2119,12 +2119,13 @@ public class ManagedChannelImplTest {
     binlog = new BinaryLog() {
       @Nullable
       @Override
-      public ServerInterceptor getServerInterceptor(String fullMethodName) {
+      public ServerInterceptor getServerInterceptor(MethodDescriptor<?, ?> method) {
         return null;
       }
 
+      @Nullable
       @Override
-      public ClientInterceptor getClientInterceptor(String fullMethodName) {
+      public ClientInterceptor getClientInterceptor(MethodDescriptor<?, ?> method) {
         return binlogInterceptor;
       }
 
@@ -2206,12 +2207,13 @@ public class ManagedChannelImplTest {
     binlog = new BinaryLog() {
       @Nullable
       @Override
-      public ServerInterceptor getServerInterceptor(String fullMethodName) {
+      public ServerInterceptor getServerInterceptor(MethodDescriptor<?, ?> method) {
         return null;
       }
 
+      @Nullable
       @Override
-      public ClientInterceptor getClientInterceptor(String fullMethodName) {
+      public ClientInterceptor getClientInterceptor(MethodDescriptor<?, ?> method) {
         return new TracingClientInterceptor();
       }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -188,7 +188,7 @@ public class ManagedChannelImplTest {
   private ObjectPool<Executor> oobExecutorPool;
   @Mock
   private CallCredentials creds;
-  private BinaryLogProvider binlogProvider = null;
+  private BinaryLog binlog = null;
   private BlockingQueue<MockClientTransportInfo> transports;
 
   private ArgumentCaptor<ClientStreamListener> streamListenerCaptor =
@@ -228,7 +228,7 @@ public class ManagedChannelImplTest {
         .userAgent(userAgent);
     builder.executorPool = executorPool;
     builder.idleTimeoutMillis = idleTimeoutMillis;
-    builder.binlogProvider = binlogProvider;
+    builder.binlog = binlog;
     builder.channelz = channelz;
     checkState(channel == null);
     channel = new ManagedChannelImpl(
@@ -2116,7 +2116,7 @@ public class ManagedChannelImplTest {
 
     TracingClientInterceptor userInterceptor = new TracingClientInterceptor();
     final TracingClientInterceptor binlogInterceptor = new TracingClientInterceptor();
-    binlogProvider = new BinaryLogProvider() {
+    binlog = new BinaryLog() {
       @Nullable
       @Override
       public ServerInterceptor getServerInterceptor(String fullMethodName) {
@@ -2131,6 +2131,11 @@ public class ManagedChannelImplTest {
       @Override
       protected int priority() {
         return 0;
+      }
+
+      @Override
+      protected boolean isAvailable() {
+        return true;
       }
     };
 
@@ -2198,7 +2203,7 @@ public class ManagedChannelImplTest {
     }
 
     TracingClientInterceptor userInterceptor = new TracingClientInterceptor();
-    binlogProvider = new BinaryLogProvider() {
+    binlog = new BinaryLog() {
       @Nullable
       @Override
       public ServerInterceptor getServerInterceptor(String fullMethodName) {
@@ -2213,6 +2218,11 @@ public class ManagedChannelImplTest {
       @Override
       protected int priority() {
         return 0;
+      }
+
+      @Override
+      protected boolean isAvailable() {
+        return true;
       }
     };
     createChannel(

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1279,15 +1279,16 @@ public class ServerImplTest {
     TracingServerInterceptor userInterceptor = new TracingServerInterceptor();
     final TracingServerInterceptor binlogInterceptor = new TracingServerInterceptor();
     builder.intercept(userInterceptor);
-    builder.binlog = new BinaryLog() {
+    builder.binaryLog = new BinaryLog() {
+      @Nullable
       @Override
-      public ServerInterceptor getServerInterceptor(String fullMethodName) {
+      public ServerInterceptor getServerInterceptor(MethodDescriptor<?, ?> method) {
         return binlogInterceptor;
       }
 
       @Nullable
       @Override
-      public ClientInterceptor getClientInterceptor(String fullMethodName) {
+      public ClientInterceptor getClientInterceptor(MethodDescriptor<?, ?> method) {
         return null;
       }
 
@@ -1334,15 +1335,16 @@ public class ServerImplTest {
 
     TestInterceptor userInterceptor = new TestInterceptor();
     builder.intercept(userInterceptor);
-    builder.binlog = new BinaryLog() {
+    builder.binaryLog = new BinaryLog() {
+      @Nullable
       @Override
-      public ServerInterceptor getServerInterceptor(String fullMethodName) {
+      public ServerInterceptor getServerInterceptor(MethodDescriptor<?, ?> method) {
         return new TestInterceptor();
       }
 
       @Nullable
       @Override
-      public ClientInterceptor getClientInterceptor(String fullMethodName) {
+      public ClientInterceptor getClientInterceptor(MethodDescriptor<?, ?> method) {
         return null;
       }
 

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1279,7 +1279,7 @@ public class ServerImplTest {
     TracingServerInterceptor userInterceptor = new TracingServerInterceptor();
     final TracingServerInterceptor binlogInterceptor = new TracingServerInterceptor();
     builder.intercept(userInterceptor);
-    builder.binlogProvider = new BinaryLogProvider() {
+    builder.binlog = new BinaryLog() {
       @Override
       public ServerInterceptor getServerInterceptor(String fullMethodName) {
         return binlogInterceptor;
@@ -1294,6 +1294,11 @@ public class ServerImplTest {
       @Override
       protected int priority() {
         return 0;
+      }
+
+      @Override
+      protected boolean isAvailable() {
+        return true;
       }
     };
     createAndStartServer();
@@ -1329,7 +1334,7 @@ public class ServerImplTest {
 
     TestInterceptor userInterceptor = new TestInterceptor();
     builder.intercept(userInterceptor);
-    builder.binlogProvider = new BinaryLogProvider() {
+    builder.binlog = new BinaryLog() {
       @Override
       public ServerInterceptor getServerInterceptor(String fullMethodName) {
         return new TestInterceptor();
@@ -1344,6 +1349,11 @@ public class ServerImplTest {
       @Override
       protected int priority() {
         return 0;
+      }
+
+      @Override
+      protected boolean isAvailable() {
+        return true;
       }
     };
     createAndStartServer();


### PR DESCRIPTION
No behavioral changes in this PR
- Move the actual logic into BinaryLog.java, so that BinaryLogProvider
  only provides the BinaryLog
- the loading is now done via ServiceProvider util instead of rolling
  our own in BinaryLogProvider