### PR TITLE
core: temporarily disable retry when stats or tracing is enabled

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -254,7 +254,7 @@ public abstract class AbstractManagedChannelImplBuilder
       this.decompressorRegistry = registry;
     } else {
       this.decompressorRegistry = DEFAULT_DECOMPRESSOR_REGISTRY;
-    } 
+    }
     return thisT();
   }
 
@@ -398,11 +398,15 @@ public abstract class AbstractManagedChannelImplBuilder
         CallTracer.getDefaultFactory());
   }
 
+  // Temporarily disable retry when stats or tracing is enabled to avoid breakage, until we know
+  // what should be the desired behavior for retry + stats/tracing.
+  // TODO(zdapeng): FIX IT
   @VisibleForTesting
   final List<ClientInterceptor> getEffectiveInterceptors() {
     List<ClientInterceptor> effectiveInterceptors =
         new ArrayList<ClientInterceptor>(this.interceptors);
     if (statsEnabled) {
+      retryDisabled = true;
       CensusStatsModule censusStats = this.censusStatsOverride;
       if (censusStats == null) {
         censusStats = new CensusStatsModule(GrpcUtil.STOPWATCH_SUPPLIER, true);
@@ -413,6 +417,7 @@ public abstract class AbstractManagedChannelImplBuilder
           0, censusStats.getClientInterceptor(recordStartedRpcs, recordFinishedRpcs));
     }
     if (tracingEnabled) {
+      retryDisabled = true;
       CensusTracingModule censusTracing =
           new CensusTracingModule(Tracing.getTracer(),
               Tracing.getPropagationComponent().getBinaryFormat());


### PR DESCRIPTION
To avoid breakage, temporarily disable retry when stats or tracing is enabled.

This still agrees with the description of the javadoc of `ManagedChannelBuilder.enableRetry()`

```java
/**
   * Enables the retry mechanism provided by the gRPC library.
   *
   * <p>This method may not work as expected for the current release because retry is not fully
   * implemented yet.
   *
   * @return this
   * @since 1.11.0
   */
  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/3982")
  public T enableRetry()
```