### PR TITLE
core,services: fix binarylog unit tests

### DIFF
--- a/core/src/test/java/io/grpc/internal/BinaryLogProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/BinaryLogProviderTest.java
@@ -183,37 +183,37 @@ public class BinaryLogProviderTest {
         },
         new Metadata());
 
-    String actualRequest = "hello world";
+    String expectedRequest = "hello world";
     assertThat(binlogReq).isEmpty();
     assertThat(serializedReq).isEmpty();
     assertEquals(0, reqMarshaller.streamInvocations);
-    clientCall.sendMessage(actualRequest);
+    clientCall.sendMessage(expectedRequest);
     // it is unacceptably expensive for the binlog to double parse every logged message
     assertEquals(1, reqMarshaller.streamInvocations);
     assertEquals(0, reqMarshaller.parseInvocations);
     assertThat(binlogReq).hasSize(1);
     assertThat(serializedReq).hasSize(1);
     assertEquals(
-        actualRequest,
+        expectedRequest,
         StringMarshaller.INSTANCE.parse(new ByteArrayInputStream(binlogReq.get(0))));
     assertEquals(
-        actualRequest,
+        expectedRequest,
         StringMarshaller.INSTANCE.parse(serializedReq.get(0)));
 
-    int actualResponse = 12345;
+    int expectedResponse = 12345;
     assertThat(binlogResp).isEmpty();
     assertThat(observedResponse).isEmpty();
     assertEquals(0, respMarshaller.parseInvocations);
-    onClientMessageHelper(listener.get(), IntegerMarshaller.INSTANCE.stream(actualResponse));
+    onClientMessageHelper(listener.get(), IntegerMarshaller.INSTANCE.stream(expectedResponse));
     // it is unacceptably expensive for the binlog to double parse every logged message
     assertEquals(1, respMarshaller.parseInvocations);
     assertEquals(0, respMarshaller.streamInvocations);
     assertThat(binlogResp).hasSize(1);
     assertThat(observedResponse).hasSize(1);
     assertEquals(
-        actualResponse,
+        expectedResponse,
         (int) IntegerMarshaller.INSTANCE.parse(new ByteArrayInputStream(binlogResp.get(0))));
-    assertEquals(actualResponse, (int) observedResponse.get(0));
+    assertEquals(expectedResponse, (int) observedResponse.get(0));
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
@@ -274,35 +274,35 @@ public class BinaryLogProviderTest {
     List<Object> serializedResp = new ArrayList<Object>();
     ServerCall.Listener<?> wListener = startServerCallHelper(wDef, serializedResp);
 
-    String actualRequest = "hello world";
+    String expectedRequest = "hello world";
     assertThat(binlogReq).isEmpty();
     assertThat(observedRequest).isEmpty();
     assertEquals(0, reqMarshaller.parseInvocations);
-    onServerMessageHelper(wListener, StringMarshaller.INSTANCE.stream(actualRequest));
+    onServerMessageHelper(wListener, StringMarshaller.INSTANCE.stream(expectedRequest));
     // it is unacceptably expensive for the binlog to double parse every logged message
     assertEquals(1, reqMarshaller.parseInvocations);
     assertEquals(0, reqMarshaller.streamInvocations);
     assertThat(binlogReq).hasSize(1);
     assertThat(observedRequest).hasSize(1);
     assertEquals(
-        actualRequest,
+        expectedRequest,
         StringMarshaller.INSTANCE.parse(new ByteArrayInputStream(binlogReq.get(0))));
-    assertEquals(actualRequest, observedRequest.get(0));
+    assertEquals(expectedRequest, observedRequest.get(0));
 
-    int actualResponse = 12345;
+    int expectedResponse = 12345;
     assertThat(binlogResp).isEmpty();
     assertThat(serializedResp).isEmpty();
     assertEquals(0, respMarshaller.streamInvocations);
-    serverCall.get().sendMessage(actualResponse);
+    serverCall.get().sendMessage(expectedResponse);
     // it is unacceptably expensive for the binlog to double parse every logged message
     assertEquals(0, respMarshaller.parseInvocations);
     assertEquals(1, respMarshaller.streamInvocations);
     assertThat(binlogResp).hasSize(1);
     assertThat(serializedResp).hasSize(1);
     assertEquals(
-        actualResponse,
+        expectedResponse,
         (int) IntegerMarshaller.INSTANCE.parse(new ByteArrayInputStream(binlogResp.get(0))));
-    assertEquals(actualResponse, (int) method.parseResponse((InputStream) serializedResp.get(0)));
+    assertEquals(expectedResponse, (int) method.parseResponse((InputStream) serializedResp.get(0)));
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/services/src/test/java/io/grpc/services/BinaryLogTest.java
+++ b/services/src/test/java/io/grpc/services/BinaryLogTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.primitives.Bytes;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.UnsafeByteOperations;
 import io.grpc.Metadata;
 import io.grpc.binarylog.GrpcLogEntry;
 import io.grpc.binarylog.Message;
@@ -487,7 +486,7 @@ public final class BinaryLogTest {
     assertEquals(
         Message
             .newBuilder()
-            .setData(UnsafeByteOperations.unsafeWrap(truncatedMessage.getBytes(US_ASCII)))
+            .setData(ByteString.copyFrom(truncatedMessage.getBytes(US_ASCII)))
             .setFlags(0)
             .setLength(bytes.remaining())
             .build(),


### PR DESCRIPTION
- The unsafe operation was reverted in code, so the test should not
  use it either
- The variable naming is tripping internal linters