### PR TITLE
Add ALTS to interop tests

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -1,7 +1,7 @@
 description = "gRPC: ALTS"
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 buildscript {
     repositories {

--- a/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
@@ -150,7 +150,7 @@ public final class AltsChannelBuilder extends ForwardingChannelBuilder<AltsChann
 
     @Override
     public TransportCreationParamsFilter create(
-        SocketAddress serverAddress,
+        final SocketAddress serverAddress,
         final String authority,
         final String userAgent,
         final ProxyParameters proxy) {

--- a/alts/src/main/java/io/grpc/alts/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/AltsProtocolNegotiator.java
@@ -53,7 +53,7 @@ public abstract class AltsProtocolNegotiator implements ProtocolNegotiator {
   }
 
   /** Creates a negotiator used for ALTS. */
-  public static AltsProtocolNegotiator create(TsiHandshakerFactory handshakerFactory) {
+  public static AltsProtocolNegotiator create(final TsiHandshakerFactory handshakerFactory) {
     return new AltsProtocolNegotiator() {
       @Override
       public Handler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {

--- a/alts/src/test/java/io/grpc/alts/InternalNettyTsiHandshakerTest.java
+++ b/alts/src/test/java/io/grpc/alts/InternalNettyTsiHandshakerTest.java
@@ -181,7 +181,16 @@ public class InternalNettyTsiHandshakerTest {
   }
 
   private void doHandshake() throws GeneralSecurityException {
-    doHandshake(clientHandshaker, serverHandshaker, alloc, buf -> ref(buf));
+    doHandshake(
+        clientHandshaker,
+        serverHandshaker,
+        alloc,
+        new java.util.function.Function<ByteBuf, ByteBuf>() {
+          @Override
+          public ByteBuf apply(ByteBuf buf) {
+            return ref(buf);
+          }
+        });
   }
 
   private ByteBuf ref(ByteBuf buf) {

--- a/alts/src/test/java/io/grpc/alts/transportsecurity/AltsTsiTest.java
+++ b/alts/src/test/java/io/grpc/alts/transportsecurity/AltsTsiTest.java
@@ -22,6 +22,7 @@ import com.google.common.testing.GcFinalization;
 import io.grpc.alts.Handshaker.HandshakeProtocol;
 import io.grpc.alts.Handshaker.HandshakerReq;
 import io.grpc.alts.Handshaker.HandshakerResp;
+import io.grpc.alts.transportsecurity.ByteBufTestUtils.RegisterRef;
 import io.grpc.alts.transportsecurity.TsiTest.Handshakers;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCounted;
@@ -45,6 +46,16 @@ public class AltsTsiTest {
   private final List<ReferenceCounted> references = new ArrayList<>();
   private AltsHandshakerClient client;
   private AltsHandshakerClient server;
+  private final RegisterRef ref =
+      new RegisterRef() {
+        @Override
+        public ByteBuf register(ByteBuf buf) {
+          if (buf != null) {
+            references.add(buf);
+          }
+          return buf;
+        }
+      };
 
   @Before
   public void setUp() throws Exception {
@@ -101,47 +112,47 @@ public class AltsTsiTest {
 
   @Test
   public void pingPong() throws GeneralSecurityException {
-    TsiTest.pingPongTest(newHandshakers(), this::ref);
+    TsiTest.pingPongTest(newHandshakers(), ref);
   }
 
   @Test
   public void pingPongExactFrameSize() throws GeneralSecurityException {
-    TsiTest.pingPongExactFrameSizeTest(newHandshakers(), this::ref);
+    TsiTest.pingPongExactFrameSizeTest(newHandshakers(), ref);
   }
 
   @Test
   public void pingPongSmallBuffer() throws GeneralSecurityException {
-    TsiTest.pingPongSmallBufferTest(newHandshakers(), this::ref);
+    TsiTest.pingPongSmallBufferTest(newHandshakers(), ref);
   }
 
   @Test
   public void pingPongSmallFrame() throws GeneralSecurityException {
-    TsiTest.pingPongSmallFrameTest(OVERHEAD, newHandshakers(), this::ref);
+    TsiTest.pingPongSmallFrameTest(OVERHEAD, newHandshakers(), ref);
   }
 
   @Test
   public void pingPongSmallFrameSmallBuffer() throws GeneralSecurityException {
-    TsiTest.pingPongSmallFrameSmallBufferTest(OVERHEAD, newHandshakers(), this::ref);
+    TsiTest.pingPongSmallFrameSmallBufferTest(OVERHEAD, newHandshakers(), ref);
   }
 
   @Test
   public void corruptedCounter() throws GeneralSecurityException {
-    TsiTest.corruptedCounterTest(newHandshakers(), this::ref);
+    TsiTest.corruptedCounterTest(newHandshakers(), ref);
   }
 
   @Test
   public void corruptedCiphertext() throws GeneralSecurityException {
-    TsiTest.corruptedCiphertextTest(newHandshakers(), this::ref);
+    TsiTest.corruptedCiphertextTest(newHandshakers(), ref);
   }
 
   @Test
   public void corruptedTag() throws GeneralSecurityException {
-    TsiTest.corruptedTagTest(newHandshakers(), this::ref);
+    TsiTest.corruptedTagTest(newHandshakers(), ref);
   }
 
   @Test
   public void reflectedCiphertext() throws GeneralSecurityException {
-    TsiTest.reflectedCiphertextTest(newHandshakers(), this::ref);
+    TsiTest.reflectedCiphertextTest(newHandshakers(), ref);
   }
 
   private static class MockAltsHandshakerStub extends AltsHandshakerStub {
@@ -183,12 +194,5 @@ public class AltsTsiTest {
 
     @Override
     public void close() {}
-  }
-
-  private ByteBuf ref(ByteBuf buf) {
-    if (buf != null) {
-      references.add(buf);
-    }
-    return buf;
   }
 }

--- a/alts/src/test/java/io/grpc/alts/transportsecurity/FakeChannelCrypter.java
+++ b/alts/src/test/java/io/grpc/alts/transportsecurity/FakeChannelCrypter.java
@@ -52,9 +52,10 @@ public final class FakeChannelCrypter implements ChannelCrypterNetty {
     for (ByteBuf buf : ciphertext) {
       out.writeBytes(buf);
     }
-    boolean tagValid = tag.forEachByte((byte value) -> value == TAG_BYTE) == -1;
-    if (!tagValid) {
-      throw new AEADBadTagException("Tag mismatch!");
+    while (tag.isReadable()) {
+      if (tag.readByte() != TAG_BYTE) {
+        throw new AEADBadTagException("Tag mismatch!");
+      }
     }
   }
 

--- a/alts/src/test/java/io/grpc/alts/transportsecurity/FakeTsiHandshaker.java
+++ b/alts/src/test/java/io/grpc/alts/transportsecurity/FakeTsiHandshaker.java
@@ -19,6 +19,7 @@ package io.grpc.alts.transportsecurity;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Preconditions;
+import io.grpc.alts.transportsecurity.TsiPeer.Property;
 import io.netty.buffer.ByteBufAllocator;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
@@ -203,7 +204,7 @@ public class FakeTsiHandshaker implements TsiHandshaker {
 
   @Override
   public TsiPeer extractPeer() {
-    return new TsiPeer(Collections.emptyList());
+    return new TsiPeer(Collections.<Property<?>>emptyList());
   }
 
   @Override

--- a/alts/src/test/java/io/grpc/alts/transportsecurity/FakeTsiTest.java
+++ b/alts/src/test/java/io/grpc/alts/transportsecurity/FakeTsiTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import com.google.common.testing.GcFinalization;
+import io.grpc.alts.transportsecurity.ByteBufTestUtils.RegisterRef;
 import io.grpc.alts.transportsecurity.TsiTest.Handshakers;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCounted;
@@ -44,6 +45,16 @@ public class FakeTsiTest {
       FakeChannelCrypter.getTagBytes() + AltsTsiFrameProtector.getHeaderBytes();
 
   private final List<ReferenceCounted> references = new ArrayList<>();
+  private final RegisterRef ref =
+      new RegisterRef() {
+        @Override
+        public ByteBuf register(ByteBuf buf) {
+          if (buf != null) {
+            references.add(buf);
+          }
+          return buf;
+        }
+      };
 
   private static Handshakers newHandshakers() {
     TsiHandshaker clientHandshaker = FakeTsiHandshaker.newFakeHandshakerClient();
@@ -157,53 +168,46 @@ public class FakeTsiTest {
 
   @Test
   public void pingPong() throws GeneralSecurityException {
-    TsiTest.pingPongTest(newHandshakers(), this::ref);
+    TsiTest.pingPongTest(newHandshakers(), ref);
   }
 
   @Test
   public void pingPongExactFrameSize() throws GeneralSecurityException {
-    TsiTest.pingPongExactFrameSizeTest(newHandshakers(), this::ref);
+    TsiTest.pingPongExactFrameSizeTest(newHandshakers(), ref);
   }
 
   @Test
   public void pingPongSmallBuffer() throws GeneralSecurityException {
-    TsiTest.pingPongSmallBufferTest(newHandshakers(), this::ref);
+    TsiTest.pingPongSmallBufferTest(newHandshakers(), ref);
   }
 
   @Test
   public void pingPongSmallFrame() throws GeneralSecurityException {
-    TsiTest.pingPongSmallFrameTest(OVERHEAD, newHandshakers(), this::ref);
+    TsiTest.pingPongSmallFrameTest(OVERHEAD, newHandshakers(), ref);
   }
 
   @Test
   public void pingPongSmallFrameSmallBuffer() throws GeneralSecurityException {
-    TsiTest.pingPongSmallFrameSmallBufferTest(OVERHEAD, newHandshakers(), this::ref);
+    TsiTest.pingPongSmallFrameSmallBufferTest(OVERHEAD, newHandshakers(), ref);
   }
 
   @Test
   public void corruptedCounter() throws GeneralSecurityException {
-    TsiTest.corruptedCounterTest(newHandshakers(), this::ref);
+    TsiTest.corruptedCounterTest(newHandshakers(), ref);
   }
 
   @Test
   public void corruptedCiphertext() throws GeneralSecurityException {
-    TsiTest.corruptedCiphertextTest(newHandshakers(), this::ref);
+    TsiTest.corruptedCiphertextTest(newHandshakers(), ref);
   }
 
   @Test
   public void corruptedTag() throws GeneralSecurityException {
-    TsiTest.corruptedTagTest(newHandshakers(), this::ref);
+    TsiTest.corruptedTagTest(newHandshakers(), ref);
   }
 
   @Test
   public void reflectedCiphertext() throws GeneralSecurityException {
-    TsiTest.reflectedCiphertextTest(newHandshakers(), this::ref);
-  }
-
-  private ByteBuf ref(ByteBuf buf) {
-    if (buf != null) {
-      references.add(buf);
-    }
-    return buf;
+    TsiTest.reflectedCiphertextTest(newHandshakers(), ref);
   }
 }

--- a/alts/src/test/java/io/grpc/alts/transportsecurity/TsiTest.java
+++ b/alts/src/test/java/io/grpc/alts/transportsecurity/TsiTest.java
@@ -123,10 +123,18 @@ public final class TsiTest {
       throws GeneralSecurityException {
 
     ByteBuf plaintextBuffer = Unpooled.wrappedBuffer(message.getBytes(UTF_8));
-    List<ByteBuf> protectOut = new ArrayList<>();
+    final List<ByteBuf> protectOut = new ArrayList<>();
     List<Object> unprotectOut = new ArrayList<>();
 
-    sender.protectFlush(Collections.singletonList(plaintextBuffer), protectOut::add, alloc);
+    sender.protectFlush(
+        Collections.singletonList(plaintextBuffer),
+        new java.util.function.Consumer<ByteBuf>() {
+          @Override
+          public void accept(ByteBuf buf) {
+            protectOut.add(buf);
+          }
+        },
+        alloc);
     assertThat(protectOut.size()).isEqualTo(1);
 
     ByteBuf protect = ref.register(protectOut.get(0));
@@ -249,10 +257,18 @@ public final class TsiTest {
 
     String message = "hello world";
     ByteBuf plaintextBuffer = Unpooled.wrappedBuffer(message.getBytes(UTF_8));
-    List<ByteBuf> protectOut = new ArrayList<>();
+    final List<ByteBuf> protectOut = new ArrayList<>();
     List<Object> unprotectOut = new ArrayList<>();
 
-    sender.protectFlush(Collections.singletonList(plaintextBuffer), protectOut::add, alloc);
+    sender.protectFlush(
+        Collections.singletonList(plaintextBuffer),
+        new java.util.function.Consumer<ByteBuf>() {
+          @Override
+          public void accept(ByteBuf buf) {
+            protectOut.add(buf);
+          }
+        },
+        alloc);
     assertThat(protectOut.size()).isEqualTo(1);
 
     ByteBuf protect = ref.register(protectOut.get(0));
@@ -282,10 +298,18 @@ public final class TsiTest {
 
     String message = "hello world";
     ByteBuf plaintextBuffer = Unpooled.wrappedBuffer(message.getBytes(UTF_8));
-    List<ByteBuf> protectOut = new ArrayList<>();
+    final List<ByteBuf> protectOut = new ArrayList<>();
     List<Object> unprotectOut = new ArrayList<>();
 
-    sender.protectFlush(Collections.singletonList(plaintextBuffer), protectOut::add, alloc);
+    sender.protectFlush(
+        Collections.singletonList(plaintextBuffer),
+        new java.util.function.Consumer<ByteBuf>() {
+          @Override
+          public void accept(ByteBuf buf) {
+            protectOut.add(buf);
+          }
+        },
+        alloc);
     assertThat(protectOut.size()).isEqualTo(1);
 
     ByteBuf protect = ref.register(protectOut.get(0));
@@ -313,10 +337,18 @@ public final class TsiTest {
 
     String message = "hello world";
     ByteBuf plaintextBuffer = Unpooled.wrappedBuffer(message.getBytes(UTF_8));
-    List<ByteBuf> protectOut = new ArrayList<>();
+    final List<ByteBuf> protectOut = new ArrayList<>();
     List<Object> unprotectOut = new ArrayList<>();
 
-    sender.protectFlush(Collections.singletonList(plaintextBuffer), protectOut::add, alloc);
+    sender.protectFlush(
+        Collections.singletonList(plaintextBuffer),
+        new java.util.function.Consumer<ByteBuf>() {
+          @Override
+          public void accept(ByteBuf buf) {
+            protectOut.add(buf);
+          }
+        },
+        alloc);
     assertThat(protectOut.size()).isEqualTo(1);
 
     ByteBuf protect = ref.register(protectOut.get(0));
@@ -344,10 +376,18 @@ public final class TsiTest {
 
     String message = "hello world";
     ByteBuf plaintextBuffer = Unpooled.wrappedBuffer(message.getBytes(UTF_8));
-    List<ByteBuf> protectOut = new ArrayList<>();
+    final List<ByteBuf> protectOut = new ArrayList<>();
     List<Object> unprotectOut = new ArrayList<>();
 
-    sender.protectFlush(Collections.singletonList(plaintextBuffer), protectOut::add, alloc);
+    sender.protectFlush(
+        Collections.singletonList(plaintextBuffer),
+        new java.util.function.Consumer<ByteBuf>() {
+          @Override
+          public void accept(ByteBuf buf) {
+            protectOut.add(buf);
+          }
+        },
+        alloc);
     assertThat(protectOut.size()).isEqualTo(1);
 
     ByteBuf protect = ref.register(protectOut.get(0));

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -14,7 +14,8 @@ buildscript {
 }
 
 dependencies {
-    compile project(':grpc-auth'),
+    compile project(':grpc-alts'),
+            project(':grpc-auth'),
             project(':grpc-core'),
             project(':grpc-netty'),
             project(':grpc-okhttp'),

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Server;
 import io.grpc.ServerInterceptors;
+import io.grpc.alts.AltsServerBuilder;
 import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
@@ -28,34 +29,32 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Server that manages startup/shutdown of a single {@code TestService}.
- */
+/** Server that manages startup/shutdown of a single {@code TestService}. */
 public class TestServiceServer {
-  /**
-   * The main application allowing this server to be launched from the command line.
-   */
+  /** The main application allowing this server to be launched from the command line. */
   public static void main(String[] args) throws Exception {
     final TestServiceServer server = new TestServiceServer();
     server.parseArgs(args);
     if (server.useTls) {
       System.out.println(
           "\nUsing fake CA for TLS certificate. Test clients should expect host\n"
-          + "*.test.google.fr and our test CA. For the Java test client binary, use:\n"
-          + "--server_host_override=foo.test.google.fr --use_test_ca=true\n");
+              + "*.test.google.fr and our test CA. For the Java test client binary, use:\n"
+              + "--server_host_override=foo.test.google.fr --use_test_ca=true\n");
     }
 
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      @Override
-      public void run() {
-        try {
-          System.out.println("Shutting down");
-          server.stop();
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-      }
-    });
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread() {
+              @Override
+              public void run() {
+                try {
+                  System.out.println("Shutting down");
+                  server.stop();
+                } catch (Exception e) {
+                  e.printStackTrace();
+                }
+              }
+            });
     server.start();
     System.out.println("Server started on port " + server.port);
     server.blockUntilShutdown();
@@ -63,6 +62,7 @@ public class TestServiceServer {
 
   private int port = 8080;
   private boolean useTls = true;
+  private boolean useAlts = false;
 
   private ScheduledExecutorService executor;
   private Server server;
@@ -92,6 +92,8 @@ public class TestServiceServer {
         port = Integer.parseInt(value);
       } else if ("use_tls".equals(key)) {
         useTls = Boolean.parseBoolean(value);
+      } else if ("use_alts".equals(key)) {
+        useAlts = Boolean.parseBoolean(value);
       } else if ("grpc_version".equals(key)) {
         if (!"2".equals(value)) {
           System.err.println("Only grpc version 2 is supported");
@@ -104,13 +106,18 @@ public class TestServiceServer {
         break;
       }
     }
+    if (useAlts) {
+      useTls = false;
+    }
     if (usage) {
       TestServiceServer s = new TestServiceServer();
       System.out.println(
           "Usage: [ARGS...]"
-          + "\n"
-          + "\n  --port=PORT           Port to connect to. Default " + s.port
-          + "\n  --use_tls=true|false  Whether to use TLS. Default " + s.useTls
+              + "\n"
+              + "\n  --port=PORT           Port to connect to. Default " + s.port
+              + "\n  --use_tls=true|false  Whether to use TLS. Default " + s.useTls
+              + "\n  --use_alts=true|false Whether to use ALTS. Enable ALTS will disable TLS."
+              + "\n                        Default " + s.useAlts
       );
       System.exit(1);
     }
@@ -120,17 +127,31 @@ public class TestServiceServer {
   void start() throws Exception {
     executor = Executors.newSingleThreadScheduledExecutor();
     SslContext sslContext = null;
-    if (useTls) {
-      sslContext = GrpcSslContexts.forServer(
-              TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key")).build();
+    if (useAlts) {
+      server =
+          AltsServerBuilder.forPort(port)
+              .addService(
+                  ServerInterceptors.intercept(
+                      new TestServiceImpl(executor), TestServiceImpl.interceptors()))
+              .build()
+              .start();
+    } else {
+      if (useTls) {
+        sslContext =
+            GrpcSslContexts.forServer(
+                    TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"))
+                .build();
+      }
+      server =
+          NettyServerBuilder.forPort(port)
+              .sslContext(sslContext)
+              .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+              .addService(
+                  ServerInterceptors.intercept(
+                      new TestServiceImpl(executor), TestServiceImpl.interceptors()))
+              .build()
+              .start();
     }
-    server = NettyServerBuilder.forPort(port)
-        .sslContext(sslContext)
-        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
-        .addService(ServerInterceptors.intercept(
-            new TestServiceImpl(executor),
-            TestServiceImpl.interceptors()))
-        .build().start();
   }
 
   @VisibleForTesting
@@ -147,9 +168,7 @@ public class TestServiceServer {
     return server.getPort();
   }
 
-  /**
-   * Await termination on the main thread since the grpc library uses daemon threads.
-   */
+  /** Await termination on the main thread since the grpc library uses daemon threads. */
   private void blockUntilShutdown() throws InterruptedException {
     if (server != null) {
       server.awaitTermination();


### PR DESCRIPTION
In order to prepare ALTS kokoro interop test, we add '--use_alts' option to test_client and test_server.