### PR TITLE
buildscripts: Hard-code use of TLSv1.2 for github download (v1.6.x backport)

### DIFF
--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -22,7 +22,8 @@ if not exist "%CMAKE_NAME%" (
   call :installCmake
 )
 set PATH=%PATH%;%cd%\%CMAKE_NAME%\bin
-powershell -command "& { iwr https://github.com/google/protobuf/archive/v%PROTOBUF_VER%.zip -OutFile protobuf.zip }"
+@rem GitHub requires TLSv1.2, and for whatever reason our powershell doesn't have it enabled
+powershell -command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; iwr https://github.com/google/protobuf/archive/v%PROTOBUF_VER%.zip -OutFile protobuf.zip }"
 7za X protobuf.zip
 del protobuf.zip
 pushd protobuf-%PROTOBUF_VER%\cmake


### PR DESCRIPTION
GitHub is now requiring TLS v1.2:
https://githubengineering.com/crypto-removal-notice/

Without this configuration, we see:
```
iwr : The request was aborted: Could not create SSL/TLS secure channel.
At line:1 char:5
+ & { iwr https://github.com/google/protobuf/archive/v3.5.1.zip -OutFile
protobuf. ...
+
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:Htt
  pWebRequest) [Invoke-WebRequest], WebException
   + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShe
  ll.Commands.InvokeWebRequestCommand
```

Fixes #4120
Backports #4121 