### PR TITLE
alts: Remove Java 8 library usages

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -23,6 +23,7 @@ dependencies {
                 libraries.junit,
                 libraries.mockito,
                 libraries.truth
+    signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 
 configureProtoCompilation()

--- a/alts/src/main/java/io/grpc/alts/InternalTsiFrameHandler.java
+++ b/alts/src/main/java/io/grpc/alts/InternalTsiFrameHandler.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Internal;
 import io.grpc.alts.InternalTsiHandshakeHandler.TsiHandshakeCompletionEvent;
 import io.grpc.alts.transportsecurity.TsiFrameProtector;
+import io.grpc.alts.transportsecurity.TsiFrameProtector.Consumer;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelHandlerContext;
@@ -169,7 +170,7 @@ public final class InternalTsiFrameHandler extends ByteToMessageDecoder
 
     protector.protectFlush(
         bufs,
-        new java.util.function.Consumer<ByteBuf>() {
+        new Consumer<ByteBuf>() {
           @Override
           public void accept(ByteBuf b) {
             ctx.writeAndFlush(b, aggregatePromise.newPromise());

--- a/alts/src/main/java/io/grpc/alts/transportsecurity/AltsTsiFrameProtector.java
+++ b/alts/src/main/java/io/grpc/alts/transportsecurity/AltsTsiFrameProtector.java
@@ -20,12 +20,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 
+import com.google.common.primitives.Ints;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 /** Frame protector that uses the ALTS framing. */
 public final class AltsTsiFrameProtector implements TsiFrameProtector {
@@ -147,7 +147,7 @@ public final class AltsTsiFrameProtector implements TsiFrameProtector {
       }
       long protectedBytes = frameNum * (HEADER_BYTES + suffixBytes) + unprotectedBytes;
 
-      ByteBuf protectedBuf = alloc.directBuffer(Math.toIntExact(protectedBytes));
+      ByteBuf protectedBuf = alloc.directBuffer(Ints.checkedCast(protectedBytes));
       try {
         int bufferIdx = 0;
         for (int frameIdx = 0; frameIdx < frameNum; ++frameIdx) {
@@ -332,8 +332,8 @@ public final class AltsTsiFrameProtector implements TsiFrameProtector {
 
       // We leave space for suffixBytes to allow for in-place encryption. This allows for calling
       // doFinal in the JCE implementation which can be optimized better than update and doFinal.
-      ByteBuf unprotectedBuf =
-          alloc.directBuffer(Math.toIntExact(requiredUnprotectedBytesCompleteFrames + suffixBytes));
+      ByteBuf unprotectedBuf = alloc.directBuffer(
+          Ints.checkedCast(requiredUnprotectedBytesCompleteFrames + suffixBytes));
       try {
 
         ByteBuf out = writeSlice(unprotectedBuf, firstFrameUnprotectedLen + suffixBytes);

--- a/alts/src/main/java/io/grpc/alts/transportsecurity/TsiFrameProtector.java
+++ b/alts/src/main/java/io/grpc/alts/transportsecurity/TsiFrameProtector.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import java.security.GeneralSecurityException;
 import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * This object protects and unprotects netty buffers once the handshake is done.
@@ -53,4 +52,9 @@ public interface TsiFrameProtector {
 
   /** Must be called to release all associated resources (instance cannot be used afterwards). */
   void destroy();
+
+  /** A mirror of java.util.function.Consumer without the Java 8 dependency. */
+  interface Consumer<T> {
+    void accept(T t);
+  }
 }

--- a/alts/src/test/java/io/grpc/alts/AltsProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/AltsProtocolNegotiatorTest.java
@@ -29,6 +29,7 @@ import io.grpc.alts.Handshaker.HandshakerResult;
 import io.grpc.alts.transportsecurity.AltsAuthContext;
 import io.grpc.alts.transportsecurity.FakeTsiHandshaker;
 import io.grpc.alts.transportsecurity.TsiFrameProtector;
+import io.grpc.alts.transportsecurity.TsiFrameProtector.Consumer;
 import io.grpc.alts.transportsecurity.TsiHandshaker;
 import io.grpc.alts.transportsecurity.TsiHandshakerFactory;
 import io.grpc.alts.transportsecurity.TsiPeer;
@@ -69,7 +70,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -224,7 +224,7 @@ public class AltsProtocolNegotiatorTest {
     final AtomicReference<ByteBuf> newlyProtectedData = new AtomicReference<>();
     serverProtector.protectFlush(
         Collections.singletonList(unprotectedData),
-        new java.util.function.Consumer<ByteBuf>() {
+        new Consumer<ByteBuf>() {
           @Override
           public void accept(ByteBuf buf) {
             newlyProtectedData.set(buf);
@@ -257,7 +257,7 @@ public class AltsProtocolNegotiatorTest {
         serverHandshaker.createFrameProtector(serverFrameSize, channel.alloc());
     serverProtector.protectFlush(
         Collections.singletonList(unprotectedData),
-        new java.util.function.Consumer<ByteBuf>() {
+        new Consumer<ByteBuf>() {
           @Override
           public void accept(ByteBuf buf) {
             channel.writeInbound(buf);

--- a/alts/src/test/java/io/grpc/alts/InternalNettyTsiHandshakerTest.java
+++ b/alts/src/test/java/io/grpc/alts/InternalNettyTsiHandshakerTest.java
@@ -185,7 +185,7 @@ public class InternalNettyTsiHandshakerTest {
         clientHandshaker,
         serverHandshaker,
         alloc,
-        new java.util.function.Function<ByteBuf, ByteBuf>() {
+        new Function<ByteBuf, ByteBuf>() {
           @Override
           public ByteBuf apply(ByteBuf buf) {
             return ref(buf);
@@ -198,5 +198,10 @@ public class InternalNettyTsiHandshakerTest {
       references.add(buf);
     }
     return buf;
+  }
+
+  /** A mirror of java.util.function.Function without the Java 8 dependency. */
+  private interface Function<T,R> {
+    R apply(T t);
   }
 }

--- a/alts/src/test/java/io/grpc/alts/transportsecurity/TsiTest.java
+++ b/alts/src/test/java/io/grpc/alts/transportsecurity/TsiTest.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 
 import io.grpc.alts.transportsecurity.ByteBufTestUtils.RegisterRef;
+import io.grpc.alts.transportsecurity.TsiFrameProtector.Consumer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -128,7 +129,7 @@ public final class TsiTest {
 
     sender.protectFlush(
         Collections.singletonList(plaintextBuffer),
-        new java.util.function.Consumer<ByteBuf>() {
+        new Consumer<ByteBuf>() {
           @Override
           public void accept(ByteBuf buf) {
             protectOut.add(buf);
@@ -262,7 +263,7 @@ public final class TsiTest {
 
     sender.protectFlush(
         Collections.singletonList(plaintextBuffer),
-        new java.util.function.Consumer<ByteBuf>() {
+        new Consumer<ByteBuf>() {
           @Override
           public void accept(ByteBuf buf) {
             protectOut.add(buf);
@@ -303,7 +304,7 @@ public final class TsiTest {
 
     sender.protectFlush(
         Collections.singletonList(plaintextBuffer),
-        new java.util.function.Consumer<ByteBuf>() {
+        new Consumer<ByteBuf>() {
           @Override
           public void accept(ByteBuf buf) {
             protectOut.add(buf);
@@ -342,7 +343,7 @@ public final class TsiTest {
 
     sender.protectFlush(
         Collections.singletonList(plaintextBuffer),
-        new java.util.function.Consumer<ByteBuf>() {
+        new Consumer<ByteBuf>() {
           @Override
           public void accept(ByteBuf buf) {
             protectOut.add(buf);
@@ -381,7 +382,7 @@ public final class TsiTest {
 
     sender.protectFlush(
         Collections.singletonList(plaintextBuffer),
-        new java.util.function.Consumer<ByteBuf>() {
+        new Consumer<ByteBuf>() {
           @Override
           public void accept(ByteBuf buf) {
             protectOut.add(buf);


### PR DESCRIPTION
This doesn't seem that much worse than avoiding Java 8 language features. ~~Is this acceptable, or should I split up the interop-test Blaze target?~~ Discussed elsewhere; this seems good.