### PR TITLE
core: prefer getHostString() to getHostName() in ProxyDetectorImpl

### DIFF
--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -120,15 +120,24 @@ class ProxyDetectorImpl implements ProxyDetector {
 
   private ProxyParameters detectProxy(InetSocketAddress targetAddr) {
     URI uri;
+    String host;
     try {
-      uri = new URI(
-          PROXY_SCHEME,
-          null, /* userInfo */
-          targetAddr.getHostName(),
-          targetAddr.getPort(),
-          null, /* path */
-          null, /* query */
-          null /* fragment */);
+      host = GrpcUtil.getHost(targetAddr);
+    } catch (Throwable t) {
+      // Workaround for Android API levels < 19 if getHostName causes a NetworkOnMainThreadException
+      log.log(Level.WARNING, "Failed to get host for proxy lookup, proceeding without proxy", t);
+      return null;
+    }
+    try {
+      uri =
+          new URI(
+              PROXY_SCHEME,
+              null, /* userInfo */
+              host,
+              targetAddr.getPort(),
+              null, /* path */
+              null, /* query */
+              null /* fragment */);
     } catch (final URISyntaxException e) {
       log.log(
           Level.WARNING,


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-java/issues/4154 by using `getHostString()` instead of `getHostName()` when its available, to avoid a potential reverse lookup that can execute on the user's calling thread.

For non-Android users, this will avoid the network I/O for anyone using Java 7+. But for Android, `getHostString()` is only available for Android API levels >= 19 and the fallback to `getHostName()` can still trigger a `NetworkOnMainException`.

@ejona86 From a preliminary look, https://github.com/grpc/grpc-java/pull/4137 will address the root cause of #4154, and will apply to all supported Android API levels. If #4137 makes it in the next release, we probably won't need this PR - unless we want to backport a light-weight fix for #4145 to existing releases.