### PR TITLE
Partially revert "core: Tracking NameResolverProvider being experimen…

### DIFF
--- a/core/src/main/java/io/grpc/NameResolverProvider.java
+++ b/core/src/main/java/io/grpc/NameResolverProvider.java
@@ -32,6 +32,12 @@ import java.util.List;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4159")
 public abstract class NameResolverProvider extends NameResolver.Factory {
+  /**
+   * The port number used in case the target or the underlying naming system doesn't provide a
+   * port number.
+   */
+  public static final Attributes.Key<Integer> PARAMS_DEFAULT_PORT =
+      NameResolver.Factory.PARAMS_DEFAULT_PORT;
   @VisibleForTesting
   static final Iterable<Class<?>> HARDCODED_CLASSES = new HardcodedClasses();
 


### PR DESCRIPTION
…tal"

This partially reverts commit c07ad68cbd4fd836900c166693cdaa2c7613edc0.

The PARAMS_DEFAULT_PORT in NameResorverProvider is the preferred name.
The hope is still to kill NameResolver.Factory.

CC @zpencer 