### PR TITLE
Partially revert "core: change serverimpl,servercallimpl's internalcl…

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -655,7 +655,8 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
      * Like {@link ServerCall#close(Status, Metadata)}, but thread-safe for internal use.
      */
     private void internalClose() {
-      stream.cancel(Status.INTERNAL);
+      // TODO(ejona86): this is not thread-safe :)
+      stream.close(Status.UNKNOWN, new Metadata());
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1110,7 +1110,7 @@ public class ServerImplTest {
       fail("Expected exception");
     } catch (TestError t) {
       assertSame(expectedT, t);
-      ensureServerStateIsCancelled();
+      ensureServerStateNotLeaked();
     }
   }
 
@@ -1135,7 +1135,7 @@ public class ServerImplTest {
       fail("Expected exception");
     } catch (RuntimeException t) {
       assertSame(expectedT, t);
-      ensureServerStateIsCancelled();
+      ensureServerStateNotLeaked();
     }
   }
 
@@ -1158,7 +1158,7 @@ public class ServerImplTest {
       fail("Expected exception");
     } catch (TestError t) {
       assertSame(expectedT, t);
-      ensureServerStateIsCancelled();
+      ensureServerStateNotLeaked();
     }
   }
 
@@ -1181,7 +1181,7 @@ public class ServerImplTest {
       fail("Expected exception");
     } catch (RuntimeException t) {
       assertSame(expectedT, t);
-      ensureServerStateIsCancelled();
+      ensureServerStateNotLeaked();
     }
   }
 
@@ -1204,7 +1204,7 @@ public class ServerImplTest {
       fail("Expected exception");
     } catch (TestError t) {
       assertSame(expectedT, t);
-      ensureServerStateIsCancelled();
+      ensureServerStateNotLeaked();
     }
   }
 
@@ -1227,7 +1227,7 @@ public class ServerImplTest {
       fail("Expected exception");
     } catch (RuntimeException t) {
       assertSame(expectedT, t);
-      ensureServerStateIsCancelled();
+      ensureServerStateNotLeaked();
     }
   }
 
@@ -1430,10 +1430,11 @@ public class ServerImplTest {
     verifyNoMoreInteractions(executorPool);
   }
 
-  private void ensureServerStateIsCancelled() {
-    verify(stream).cancel(statusCaptor.capture());
-    assertEquals(Status.INTERNAL, statusCaptor.getValue());
+  private void ensureServerStateNotLeaked() {
+    verify(stream).close(statusCaptor.capture(), metadataCaptor.capture());
+    assertEquals(Status.UNKNOWN, statusCaptor.getValue());
     assertNull(statusCaptor.getValue().getCause());
+    assertTrue(metadataCaptor.getValue().keys().isEmpty());
   }
 
   private static class SimpleServer implements io.grpc.internal.InternalServer {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/MoreInProcessTest.java
@@ -247,7 +247,7 @@ public class MoreInProcessTest {
         .onNext(StreamingInputCallRequest.getDefaultInstance());
 
     assertTrue(finishLatch.await(900, TimeUnit.MILLISECONDS));
-    assertEquals(Status.CANCELLED.getCode(), Status.fromThrowable(throwableRef.get()).getCode());
+    assertEquals(Status.UNKNOWN, Status.fromThrowable(throwableRef.get()));
     assertNull(responseRef.get());
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -651,13 +651,8 @@ class NettyServerHandler extends AbstractNettyHandler {
       ChannelPromise promise) {
     // Notify the listener if we haven't already.
     cmd.stream().transportReportStatus(cmd.reason());
-    Http2Error http2Error = Http2Error.INTERNAL_ERROR;
-    if (Status.DEADLINE_EXCEEDED.getCode().equals(cmd.reason().getCode()) || Status.CANCELLED
-        .getCode().equals(cmd.reason().getCode())) {
-      http2Error = Http2Error.CANCEL;
-    }
     // Terminate the stream.
-    encoder().writeRstStream(ctx, cmd.stream().id(), http2Error.code(), promise);
+    encoder().writeRstStream(ctx, cmd.stream().id(), Http2Error.CANCEL.code(), promise);
   }
 
   private void forcefulClose(final ChannelHandlerContext ctx, final ForcefulCloseCommand msg,


### PR DESCRIPTION
…ose to cancel stream (#4038)"

This partially reverts commit 48ca4527c14a95914f9cb7f58ec72997cb96899a.
It leaves the changes to ServerCallImpl and test.

This also partially reverts "Lint fixes" commit
3002a23a0ff9f72cc29c81b3be456d2ee1fa6bc4 which removed unused variables
which are now necessary again.

This is reverted for the combined result of two issues:
* Some users are testing that they get UNKNOWN when the service throws.
  That's not unreasonable given the behavior was well-publicised when it
  changed in v1.5. We should probably keep the UNKNOWN in some common
  cases (like the service threw immediately, before sending anything).
* The client could see CANCELLED instead of INTERNAL as had been
  intended. It's unclear as to why (I didn't investigate heavily). This
  behavior is visible in MoreInProcessTest and was overlooked during
  review.

CC @ramaraochavali

This unfixes #3746, but since it hadn't been closed it doesn't need to be reopened.