### PR TITLE
enable lite flavor bazel rules

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -45,7 +45,7 @@ _gensource = rule(
         "flavor": attr.string(
             values = [
                 "normal",
-                "lite",  # Not currently supported
+                "lite",
             ],
             default = "normal",
         ),
@@ -109,14 +109,18 @@ def java_grpc_library(name, srcs, deps, flavor=None,
   added_deps = [
       "@grpc_java//core",
       "@grpc_java//stub",
-      "@grpc_java//protobuf",
       "@com_google_guava_guava//jar",
   ]
   if flavor == "normal":
-    added_deps += ["@com_google_protobuf//:protobuf_java"]
+    added_deps += [
+        "@com_google_protobuf//:protobuf_java",
+        "@grpc_java//protobuf",
+    ]
   elif flavor == "lite":
-    # TODO: This is currently blocked on https://github.com/google/protobuf/issues/2762
-    added_deps += ["@com_google_protobuf_java_lite//:protobuf_java_lite"]
+    added_deps += [
+        "@com_google_protobuf_javalite//:protobuf_java_lite",
+        "@grpc_java//protobuf-lite:protobuf_lite",
+    ]
   else:
     fail("Unknown flavor type", "flavor")
 

--- a/protobuf-lite/BUILD.bazel
+++ b/protobuf-lite/BUILD.bazel
@@ -3,12 +3,11 @@ java_library(
     srcs = glob([
         "src/main/java/**/*.java",
     ]),
-    # TOOD(zdapeng): fix visibility and deps (https://github.com/google/protobuf/issues/2762)
-    visibility = ["//protobuf:__pkg__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//core",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
-        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf_javalite//:protobuf_java_lite",
     ],
 )


### PR DESCRIPTION
resolves https://github.com/grpc/grpc-java/issues/3585
Adding the changes described in the above issue.
I read somewhere that protobuf-java is scrapping lite support, 
so if this PR is useless please just close it. 
For now we successfully compile a grpc android app with that.