### PR TITLE
core,services: implement binarylog Client and ServerInterceptor

### DIFF
--- a/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
@@ -39,6 +39,9 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 public abstract class BinaryLogProvider implements Closeable {
+  @VisibleForTesting
+  public static final Marshaller<InputStream> IDENTITY_MARSHALLER = new IdentityMarshaller();
+
   private static final Logger logger = Logger.getLogger(BinaryLogProvider.class.getName());
   private static final BinaryLogProvider PROVIDER = InternalServiceProviders.load(
       BinaryLogProvider.class,
@@ -55,8 +58,6 @@ public abstract class BinaryLogProvider implements Closeable {
           return provider.priority();
         }
       });
-  @VisibleForTesting
-  static final Marshaller<InputStream> IDENTITY_MARSHALLER = new IdentityMarshaller();
 
   private final ClientInterceptor binaryLogShim = new BinaryLogShim();
 

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -715,7 +715,7 @@ public final class GrpcUtil {
    * Closes an InputStream, ignoring IOExceptions.
    * This method exists because Guava's {@code Closeables.closeQuietly()} is beta.
    */
-  static void closeQuietly(@Nullable InputStream message) {
+  public static void closeQuietly(@Nullable InputStream message) {
     if (message == null) {
       return;
     }

--- a/services/src/main/java/io/grpc/services/BinaryLog.java
+++ b/services/src/main/java/io/grpc/services/BinaryLog.java
@@ -297,7 +297,7 @@ final class BinaryLog implements ServerInterceptor, ClientInterceptor {
     return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
-        writer.logSendInitialMetadata(headers, false, DUMMY_CALLID, DUMMY_SOCKET);
+        writer.logSendInitialMetadata(headers, CLIENT, DUMMY_CALLID, DUMMY_SOCKET);
         ClientCall.Listener<RespT> wListener =
             new SimpleForwardingClientCallListener<RespT>(responseListener) {
               @Override
@@ -312,13 +312,13 @@ final class BinaryLog implements ServerInterceptor, ClientInterceptor {
 
               @Override
               public void onHeaders(Metadata headers) {
-                writer.logRecvInitialMetadata(headers, false, DUMMY_CALLID, DUMMY_SOCKET);
+                writer.logRecvInitialMetadata(headers, CLIENT, DUMMY_CALLID, DUMMY_SOCKET);
                 super.onHeaders(headers);
               }
 
               @Override
               public void onClose(Status status, Metadata trailers) {
-                writer.logTrailingMetadata(trailers, false, DUMMY_CALLID);
+                writer.logTrailingMetadata(trailers, CLIENT, DUMMY_CALLID);
                 super.onClose(status, trailers);
               }
             };


### PR DESCRIPTION
To make unit tests easier, added the BinaryLogSinkWriter abstract
class, which allows verifying high level arguments rather than low
level protobufs.