### PR TITLE
core: rename prepareToLoseNetwork() to enterIdle()

### DIFF
--- a/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
@@ -250,8 +250,8 @@ public final class AltsChannelBuilder extends ForwardingChannelBuilder<AltsChann
     }
 
     @Override
-    public void prepareToLoseNetwork() {
-      delegate.prepareToLoseNetwork();
+    public void enterIdle() {
+      delegate.enterIdle();
     }
   }
 }

--- a/core/src/main/java/io/grpc/ManagedChannel.java
+++ b/core/src/main/java/io/grpc/ManagedChannel.java
@@ -128,15 +128,15 @@ public abstract class ManagedChannel extends Channel {
    * continue. New RPCs on the channel will trigger creation of a new connection.
    *
    * <p>This is primarily intended for Android users when a device is transitioning from a cellular
-   * to a wifi connection. Initially the device will maintain both the cellular and wifi
-   * connections, but the OS also issues a notification that after a short time the cellular
-   * connection will be terminated. Apps may invoke this method to ensure that new RPCs are created
-   * using the wifi connection, rather than the soon-to-be-disconnected cellular network.
+   * to a wifi connection. The OS will issue a notification that a new network (wifi) has been made
+   * the default, but for approximately 30 seconds the device will maintain both the cellular
+   * and wifi connections. Apps may invoke this method to ensure that new RPCs are created using the
+   * new default wifi network, rather than the soon-to-be-disconnected cellular network.
    *
    * <p>No-op if not supported by implementation.
    *
    * @since 1.11.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4056")
-  public void prepareToLoseNetwork() {}
+  public void enterIdle() {}
 }

--- a/core/src/main/java/io/grpc/internal/ForwardingManagedChannel.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingManagedChannel.java
@@ -83,7 +83,7 @@ abstract class ForwardingManagedChannel extends ManagedChannel {
   }
 
   @Override
-  public void prepareToLoseNetwork() {
-    delegate.prepareToLoseNetwork();
+  public void enterIdle() {
+    delegate.enterIdle();
   }
 }

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -396,7 +396,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
     logger.log(Level.FINE, "[{0}] Entering idle mode", getLogId());
     // nameResolver and loadBalancer are guaranteed to be non-null.  If any of them were null,
     // either the idleModeTimer ran twice without exiting the idle mode, or the task in shutdown()
-    // did not cancel idleModeTimer, or prepareToLoseNetwork() ran while shutdown or in idle, all of
+    // did not cancel idleModeTimer, or enterIdle() ran while shutdown or in idle, all of
     // which are bugs.
     shutdownNameResolverAndLoadBalancer(true);
     nameResolver = getNameResolver(target, nameResolverFactory, nameResolverParams);
@@ -865,7 +865,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
   }
 
   @Override
-  public void prepareToLoseNetwork() {
+  public void enterIdle() {
     class PrepareToLoseNetworkRunnable implements Runnable {
       @Override
       public void run() {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1854,18 +1854,18 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void prepareToLoseNetworkEntersIdle() {
+  public void enterIdleEntersIdle() {
     createChannel(new FakeNameResolverFactory.Builder(expectedUri).build(), NO_INTERCEPTOR);
     helper.updateBalancingState(READY, mockPicker);
     assertEquals(READY, channel.getState(false));
 
-    channel.prepareToLoseNetwork();
+    channel.enterIdle();
 
     assertEquals(IDLE, channel.getState(false));
   }
 
   @Test
-  public void prepareToLoseNetworkAfterIdleTimerIsNoOp() {
+  public void enterIdleAfterIdleTimerIsNoOp() {
     long idleTimeoutMillis = 2000L;
     createChannel(
         new FakeNameResolverFactory.Builder(expectedUri).build(),
@@ -1875,7 +1875,7 @@ public class ManagedChannelImplTest {
     timer.forwardNanos(TimeUnit.MILLISECONDS.toNanos(idleTimeoutMillis));
     assertEquals(IDLE, channel.getState(false));
 
-    channel.prepareToLoseNetwork();
+    channel.enterIdle();
 
     assertEquals(IDLE, channel.getState(false));
   }


### PR DESCRIPTION
Still experimental api and subject to further name changes, but from our last API discussion, this is at least closer to the desired name. There's some potential confusion for gRPC devs between `enterIdle` the public API method and the private `ManagedChannelImpl#enterIdleMode` method that we may want to disambiguate further (by renaming `enterIdleMode`?), but not sure that's necessary at this point.