### PR TITLE
interop-testing: Improve failure messages for ping_ping

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -703,12 +703,12 @@ public abstract class AbstractInteropTest {
     for (int i = 0; i < requests.size(); i++) {
       assertNull(queue.peek());
       requestObserver.onNext(requests.get(i));
-      Object o = queue.poll(operationTimeoutMillis(), TimeUnit.MILLISECONDS);
-      assertNotNull("Timed out waiting for response", o);
-      if (o instanceof Throwable) {
-        throw new AssertionError((Throwable) o);
+      Object actualResponse = queue.poll(operationTimeoutMillis(), TimeUnit.MILLISECONDS);
+      assertNotNull("Timed out waiting for response", actualResponse);
+      if (actualResponse instanceof Throwable) {
+        throw new AssertionError((Throwable) actualResponse);
       }
-      assertEquals(goldenResponses.get(i), o);
+      assertEquals(goldenResponses.get(i), actualResponse);
     }
     requestObserver.onCompleted();
     assertEquals("Completed", queue.poll(operationTimeoutMillis(), TimeUnit.MILLISECONDS));

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -703,8 +703,12 @@ public abstract class AbstractInteropTest {
     for (int i = 0; i < requests.size(); i++) {
       assertNull(queue.peek());
       requestObserver.onNext(requests.get(i));
-      assertEquals(goldenResponses.get(i),
-                   queue.poll(operationTimeoutMillis(), TimeUnit.MILLISECONDS));
+      Object o = queue.poll(operationTimeoutMillis(), TimeUnit.MILLISECONDS);
+      assertNotNull("Timed out waiting for response", o);
+      if (o instanceof Throwable) {
+        throw new AssertionError((Throwable) o);
+      }
+      assertEquals(goldenResponses.get(i), o);
     }
     requestObserver.onCompleted();
     assertEquals("Completed", queue.poll(operationTimeoutMillis(), TimeUnit.MILLISECONDS));


### PR DESCRIPTION
Timeouts and Status returns can be common, and previously those cases
weren't that clear. For example, if there was a StatusRuntimeException
it would just print the status code and message, but not the causal
chain.