### PR TITLE
core,netty,okhttp,testing: nest TransportStats inside SocketStats for channelz

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -30,7 +30,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ConnectionClientTransport;
@@ -225,9 +225,9 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   }
 
   @Override
-  public ListenableFuture<TransportStats> getStats() {
+  public ListenableFuture<SocketStats> getStats() {
     // TODO(zpencer): add transport tracing to in-process server
-    SettableFuture<TransportStats> ret = SettableFuture.create();
+    SettableFuture<SocketStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;
   }

--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ConnectivityState;
+import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,8 +35,8 @@ public final class Channelz {
       new ConcurrentHashMap<Long, Instrumented<ChannelStats>>();
   private final ConcurrentMap<Long, Instrumented<ChannelStats>> channels =
       new ConcurrentHashMap<Long, Instrumented<ChannelStats>>();
-  private final ConcurrentMap<Long, Instrumented<TransportStats>> transports =
-      new ConcurrentHashMap<Long, Instrumented<TransportStats>>();
+  private final ConcurrentMap<Long, Instrumented<SocketStats>> sockets =
+      new ConcurrentHashMap<Long, Instrumented<SocketStats>>();
 
   @VisibleForTesting
   public Channelz() {
@@ -58,8 +59,8 @@ public final class Channelz {
     add(rootChannels, rootChannel);
   }
 
-  public void addTransport(Instrumented<TransportStats> transport) {
-    add(transports, transport);
+  public void addSocket(Instrumented<SocketStats> socket) {
+    add(sockets, socket);
   }
 
   public void removeServer(Instrumented<ServerStats> server) {
@@ -75,8 +76,8 @@ public final class Channelz {
     remove(rootChannels, channel);
   }
 
-  public void removeTransport(Instrumented<TransportStats> transport) {
-    remove(transports, transport);
+  public void removeSocket(Instrumented<SocketStats> socket) {
+    remove(sockets, socket);
   }
 
   @VisibleForTesting
@@ -95,8 +96,8 @@ public final class Channelz {
   }
 
   @VisibleForTesting
-  public boolean containsTransport(LogId transportRef) {
-    return contains(transports, transportRef);
+  public boolean containsSocket(LogId transportRef) {
+    return contains(sockets, transportRef);
   }
 
   private static <T extends Instrumented<?>> void add(Map<Long, T> map, T object) {
@@ -117,6 +118,7 @@ public final class Channelz {
     public final long callsSucceeded;
     public final long callsFailed;
     public final long lastCallStartedMillis;
+    // TODO(zpencer): add listen sockets
 
     /**
      * Creates an instance.
@@ -133,13 +135,10 @@ public final class Channelz {
     }
 
     public static final class Builder {
-      private String target;
-      private ConnectivityState state;
       private long callsStarted;
       private long callsSucceeded;
       private long callsFailed;
       private long lastCallStartedMillis;
-      public List<LogId> subchannels;
 
       public Builder setCallsStarted(long callsStarted) {
         this.callsStarted = callsStarted;
@@ -264,6 +263,29 @@ public final class Channelz {
             lastCallStartedMillis,
             subchannels);
       }
+    }
+  }
+
+  public static final class Security {
+    // TODO(zpencer): fill this in
+  }
+
+  public static final class SocketStats {
+    public final TransportStats data;
+    public final SocketAddress local;
+    public final SocketAddress remote;
+    public final Security security;
+
+    /** Creates an instance. */
+    public SocketStats(
+        TransportStats data,
+        SocketAddress local,
+        SocketAddress remote,
+        Security security) {
+      this.data = data;
+      this.local = local;
+      this.remote = remote;
+      this.security = security;
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -19,7 +19,7 @@ package io.grpc.internal;
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.SocketStats;
 import java.util.concurrent.Executor;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * are expected to execute quickly.
  */
 @ThreadSafe
-public interface ClientTransport extends Instrumented<TransportStats> {
+public interface ClientTransport extends Instrumented<SocketStats> {
 
   /**
    * Creates a new stream for sending messages to a remote end-point.

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -27,7 +27,7 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.SocketStats;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -189,8 +189,8 @@ final class DelayedClientTransport implements ManagedClientTransport {
   }
 
   @Override
-  public ListenableFuture<TransportStats> getStats() {
-    SettableFuture<TransportStats> ret = SettableFuture.create();
+  public ListenableFuture<SocketStats> getStats() {
+    SettableFuture<SocketStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;
   }

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -24,7 +24,7 @@ import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.SocketStats;
 import java.util.concurrent.Executor;
 
 /**
@@ -55,8 +55,8 @@ class FailingClientTransport implements ClientTransport {
   }
 
   @Override
-  public ListenableFuture<TransportStats> getStats() {
-    SettableFuture<TransportStats> ret = SettableFuture.create();
+  public ListenableFuture<SocketStats> getStats() {
+    SettableFuture<SocketStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;
   }

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -22,7 +22,7 @@ import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.SocketStats;
 import java.util.concurrent.Executor;
 
 abstract class ForwardingConnectionClientTransport implements ConnectionClientTransport {
@@ -68,7 +68,7 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
   }
 
   @Override
-  public ListenableFuture<TransportStats> getStats() {
+  public ListenableFuture<SocketStats> getStats() {
     return delegate().getStats();
   }
 

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -36,7 +36,7 @@ import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.internal.StreamListener.MessageProducer;
 import java.io.IOException;
@@ -692,7 +692,7 @@ public final class GrpcUtil {
         }
 
         @Override
-        public ListenableFuture<TransportStats> getStats() {
+        public ListenableFuture<SocketStats> getStats() {
           return transport.getStats();
         }
       };

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -218,7 +218,7 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
         new CallTracingTransport(
             transportFactory.newClientTransport(address, authority, userAgent, proxy),
             callsTracer);
-    channelz.addTransport(transport);
+    channelz.addSocket(transport);
     if (log.isLoggable(Level.FINE)) {
       log.log(Level.FINE, "[{0}] Created {1} for {2}",
           new Object[] {logId, transport.getLogId(), address});
@@ -572,7 +572,7 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
       } finally {
         channelExecutor.drain();
       }
-      channelz.removeTransport(transport);
+      channelz.removeSocket(transport);
       Preconditions.checkState(activeTransport != transport,
           "activeTransport still points to this transport. "
           + "Seems transportShutdown() was not called.");

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -380,7 +380,7 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
           @Override public void run() {}
         }, null);
       }
-      channelz.addTransport(transport);
+      channelz.addSocket(transport);
     }
 
     @Override
@@ -408,7 +408,7 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
         }
         transportClosed(transport);
       } finally {
-        channelz.removeTransport(transport);
+        channelz.removeSocket(transport);
       }
     }
 

--- a/core/src/main/java/io/grpc/internal/ServerTransport.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransport.java
@@ -17,11 +17,11 @@
 package io.grpc.internal;
 
 import io.grpc.Status;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.SocketStats;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** An inbound connection. */
-public interface ServerTransport extends Instrumented<TransportStats> {
+public interface ServerTransport extends Instrumented<SocketStats> {
   /**
    * Initiates an orderly shutdown of the transport. Existing streams continue, but new streams will
    * eventually begin failing. New streams "eventually" begin failing because shutdown may need to

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -23,6 +23,8 @@ import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.SharedResourcePool;
 import io.grpc.internal.testing.AbstractTransportTest;
 import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -61,5 +63,12 @@ public class InProcessTransportTest extends AbstractTransportTest {
     // TODO(zhangkun83): InProcessTransport doesn't record metrics for now
     // (https://github.com/grpc/grpc-java/issues/2284)
     return false;
+  }
+
+  @Test
+  @Ignore
+  @Override
+  public void socketStats_addresses() throws Exception {
+    // test does not apply to in-process
   }
 }

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -956,9 +956,9 @@ public class InternalSubchannelTest {
     internalSubchannel.obtainActiveTransport();
 
     MockClientTransportInfo t0 = transports.poll();
-    assertTrue(channelz.containsTransport(t0.transport.getLogId()));
+    assertTrue(channelz.containsSocket(t0.transport.getLogId()));
     t0.listener.transportTerminated();
-    assertFalse(channelz.containsTransport(t0.transport.getLogId()));
+    assertFalse(channelz.containsSocket(t0.transport.getLogId()));
   }
 
   private void createInternalSubchannel(SocketAddress ... addrs) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -340,11 +340,11 @@ public class ManagedChannelImplTest {
     subchannel.requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
     assertNotNull(transportInfo);
-    assertTrue(channelz.containsTransport(transportInfo.transport.getLogId()));
+    assertTrue(channelz.containsSocket(transportInfo.transport.getLogId()));
 
     // terminate transport
     transportInfo.listener.transportTerminated();
-    assertFalse(channelz.containsTransport(transportInfo.transport.getLogId()));
+    assertFalse(channelz.containsSocket(transportInfo.transport.getLogId()));
 
     // terminate subchannel
     assertTrue(channelz.containsChannel(subchannel.getInternalSubchannel().getLogId()));
@@ -378,11 +378,11 @@ public class ManagedChannelImplTest {
     oob.getSubchannel().requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
     assertNotNull(transportInfo);
-    assertTrue(channelz.containsTransport(transportInfo.transport.getLogId()));
+    assertTrue(channelz.containsSocket(transportInfo.transport.getLogId()));
 
     // terminate transport
     transportInfo.listener.transportTerminated();
-    assertFalse(channelz.containsTransport(transportInfo.transport.getLogId()));
+    assertFalse(channelz.containsSocket(transportInfo.transport.getLogId()));
 
     // terminate oobchannel
     oob.shutdown();

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -67,7 +67,7 @@ import io.grpc.ServerTransportFilter;
 import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
 import io.grpc.StringMarshaller;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.ServerImpl.JumpToApplicationThreadServerStreamListener;
 import io.grpc.internal.testing.SingleMessageProducer;
 import io.grpc.internal.testing.TestServerStreamTracer;
@@ -1385,12 +1385,12 @@ public class ServerImplTest {
     createAndStartServer();
     SimpleServerTransport transport = new SimpleServerTransport();
 
-    assertFalse(builder.channelz.containsTransport(transport.getLogId()));
+    assertFalse(builder.channelz.containsSocket(transport.getLogId()));
     ServerTransportListener listener
         = transportServer.registerNewServerTransport(transport);
-    assertTrue(builder.channelz.containsTransport(transport.getLogId()));
+    assertTrue(builder.channelz.containsSocket(transport.getLogId()));
     listener.transportTerminated();
-    assertFalse(builder.channelz.containsTransport(transport.getLogId()));
+    assertFalse(builder.channelz.containsSocket(transport.getLogId()));
   }
 
   private void createAndStartServer() throws IOException {
@@ -1474,8 +1474,8 @@ public class ServerImplTest {
     }
 
     @Override
-    public ListenableFuture<TransportStats> getStats() {
-      SettableFuture<TransportStats> ret = SettableFuture.create();
+    public ListenableFuture<SocketStats> getStats() {
+      SettableFuture<SocketStats> ret = SettableFuture.create();
       ret.set(null);
       return ret;
     }

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -26,7 +26,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.cronet.CronetChannelBuilder.StreamBuilderFactory;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.LogId;
@@ -94,8 +94,8 @@ class CronetClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public ListenableFuture<TransportStats> getStats() {
-    SettableFuture<TransportStats> f = SettableFuture.create();
+  public ListenableFuture<SocketStats> getStats() {
+    SettableFuture<SocketStats> f = SettableFuture.create();
     f.set(null);
     return f;
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -37,7 +37,8 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
-import io.grpc.internal.Channelz.TransportStats;
+import io.grpc.internal.Channelz.Security;
+import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
@@ -893,10 +894,14 @@ class OkHttpClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public ListenableFuture<TransportStats> getStats() {
+  public ListenableFuture<SocketStats> getStats() {
     synchronized (lock) {
-      SettableFuture<TransportStats> ret = SettableFuture.create();
-      ret.set(transportTracer.getStats());
+      SettableFuture<SocketStats> ret = SettableFuture.create();
+      ret.set(new SocketStats(
+          transportTracer.getStats(),
+          socket.getLocalSocketAddress(),
+          socket.getRemoteSocketAddress(),
+          new Security()));
       return ret;
     }
   }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -51,10 +51,12 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
+import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.Channelz.TransportStats;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
+import io.grpc.internal.Instrumented;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.IoUtils;
 import io.grpc.internal.ManagedClientTransport;
@@ -66,6 +68,9 @@ import io.grpc.internal.ServerTransportListener;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -1402,10 +1407,10 @@ public abstract class AbstractTransportTest {
     long serverFirstTimestampNanos;
     long clientFirstTimestampNanos;
     {
-      TransportStats serverBefore = serverTransportListener.transport.getStats().get();
+      TransportStats serverBefore = getTransportStats(serverTransportListener.transport);
       assertEquals(0, serverBefore.streamsStarted);
       assertEquals(0, serverBefore.lastStreamCreatedTimeNanos);
-      TransportStats clientBefore = client.getStats().get();
+      TransportStats clientBefore = getTransportStats(client);
       assertEquals(0, clientBefore.streamsStarted);
       assertEquals(0, clientBefore.lastStreamCreatedTimeNanos);
 
@@ -1415,14 +1420,14 @@ public abstract class AbstractTransportTest {
       StreamCreation serverStreamCreation = serverTransportListener
           .takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-      TransportStats serverAfter = serverTransportListener.transport.getStats().get();
+      TransportStats serverAfter = getTransportStats(serverTransportListener.transport);
       assertEquals(1, serverAfter.streamsStarted);
       serverFirstTimestampNanos = serverAfter.lastStreamCreatedTimeNanos;
       assertEquals(
           currentTimeMillis(),
           TimeUnit.NANOSECONDS.toMillis(serverAfter.lastStreamCreatedTimeNanos));
 
-      TransportStats clientAfter = client.getStats().get();
+      TransportStats clientAfter = getTransportStats(client);
       assertEquals(1, clientAfter.streamsStarted);
       clientFirstTimestampNanos = clientAfter.lastStreamCreatedTimeNanos;
       assertEquals(
@@ -1438,9 +1443,9 @@ public abstract class AbstractTransportTest {
 
     // start second stream
     {
-      TransportStats serverBefore = serverTransportListener.transport.getStats().get();
+      TransportStats serverBefore = getTransportStats(serverTransportListener.transport);
       assertEquals(1, serverBefore.streamsStarted);
-      TransportStats clientBefore = client.getStats().get();
+      TransportStats clientBefore = getTransportStats(client);
       assertEquals(1, clientBefore.streamsStarted);
 
       ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
@@ -1449,7 +1454,7 @@ public abstract class AbstractTransportTest {
       StreamCreation serverStreamCreation = serverTransportListener
           .takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-      TransportStats serverAfter = serverTransportListener.transport.getStats().get();
+      TransportStats serverAfter = getTransportStats(serverTransportListener.transport);
       assertEquals(2, serverAfter.streamsStarted);
       assertEquals(
           TimeUnit.MILLISECONDS.toNanos(elapsedMillis),
@@ -1458,7 +1463,7 @@ public abstract class AbstractTransportTest {
           TimeUnit.NANOSECONDS.toMillis(serverAfter.lastStreamCreatedTimeNanos);
       assertEquals(currentTimeMillis(), serverSecondTimestamp);
 
-      TransportStats clientAfter = client.getStats().get();
+      TransportStats clientAfter = getTransportStats(client);
       assertEquals(2, clientAfter.streamsStarted);
       assertEquals(
           TimeUnit.MILLISECONDS.toNanos(elapsedMillis),
@@ -1489,10 +1494,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportStats serverBefore = serverTransportListener.transport.getStats().get();
+    TransportStats serverBefore = getTransportStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.streamsSucceeded);
     assertEquals(0, serverBefore.streamsFailed);
-    TransportStats clientBefore = client.getStats().get();
+    TransportStats clientBefore = getTransportStats(client);
     assertEquals(0, clientBefore.streamsSucceeded);
     assertEquals(0, clientBefore.streamsFailed);
 
@@ -1503,10 +1508,10 @@ public abstract class AbstractTransportTest {
     assertNotNull(clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
 
-    TransportStats serverAfter = serverTransportListener.transport.getStats().get();
+    TransportStats serverAfter = getTransportStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.streamsSucceeded);
     assertEquals(0, serverAfter.streamsFailed);
-    TransportStats clientAfter = client.getStats().get();
+    TransportStats clientAfter = getTransportStats(client);
     assertEquals(1, clientAfter.streamsSucceeded);
     assertEquals(0, clientAfter.streamsFailed);
   }
@@ -1528,10 +1533,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportStats serverBefore = serverTransportListener.transport.getStats().get();
+    TransportStats serverBefore = getTransportStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.streamsFailed);
     assertEquals(0, serverBefore.streamsSucceeded);
-    TransportStats clientBefore = client.getStats().get();
+    TransportStats clientBefore = getTransportStats(client);
     assertEquals(0, clientBefore.streamsFailed);
     assertEquals(0, clientBefore.streamsSucceeded);
 
@@ -1541,10 +1546,10 @@ public abstract class AbstractTransportTest {
     assertNotNull(clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
 
-    TransportStats serverAfter = serverTransportListener.transport.getStats().get();
+    TransportStats serverAfter = getTransportStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.streamsFailed);
     assertEquals(0, serverAfter.streamsSucceeded);
-    TransportStats clientAfter = client.getStats().get();
+    TransportStats clientAfter = getTransportStats(client);
     assertEquals(1, clientAfter.streamsFailed);
     assertEquals(0, clientAfter.streamsSucceeded);
 
@@ -1567,10 +1572,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportStats serverBefore = serverTransportListener.transport.getStats().get();
+    TransportStats serverBefore = getTransportStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.streamsFailed);
     assertEquals(0, serverBefore.streamsSucceeded);
-    TransportStats clientBefore = client.getStats().get();
+    TransportStats clientBefore = getTransportStats(client);
     assertEquals(0, clientBefore.streamsFailed);
     assertEquals(0, clientBefore.streamsSucceeded);
 
@@ -1578,10 +1583,10 @@ public abstract class AbstractTransportTest {
     // do not validate stats until close() has been called on server
     assertNotNull(serverStreamCreation.listener.status.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-    TransportStats serverAfter = serverTransportListener.transport.getStats().get();
+    TransportStats serverAfter = getTransportStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.streamsFailed);
     assertEquals(0, serverAfter.streamsSucceeded);
-    TransportStats clientAfter = client.getStats().get();
+    TransportStats clientAfter = getTransportStats(client);
     assertEquals(1, clientAfter.streamsFailed);
     assertEquals(0, clientAfter.streamsSucceeded);
   }
@@ -1604,10 +1609,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportStats serverBefore = serverTransportListener.transport.getStats().get();
+    TransportStats serverBefore = getTransportStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.messagesReceived);
     assertEquals(0, serverBefore.lastMessageReceivedTimeNanos);
-    TransportStats clientBefore = client.getStats().get();
+    TransportStats clientBefore = getTransportStats(client);
     assertEquals(0, clientBefore.messagesSent);
     assertEquals(0, clientBefore.lastMessageSentTimeNanos);
 
@@ -1617,12 +1622,12 @@ public abstract class AbstractTransportTest {
     clientStream.halfClose();
     verifyMessageCountAndClose(serverStreamListener.messageQueue, 1);
 
-    TransportStats serverAfter = serverTransportListener.transport.getStats().get();
+    TransportStats serverAfter = getTransportStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.messagesReceived);
     long serverTimestamp =
         TimeUnit.NANOSECONDS.toMillis(serverAfter.lastMessageReceivedTimeNanos);
     assertEquals(currentTimeMillis(), serverTimestamp);
-    TransportStats clientAfter = client.getStats().get();
+    TransportStats clientAfter = getTransportStats(client);
     assertEquals(1, clientAfter.messagesSent);
     long clientTimestamp =
         TimeUnit.NANOSECONDS.toMillis(clientAfter.lastMessageSentTimeNanos);
@@ -1648,10 +1653,10 @@ public abstract class AbstractTransportTest {
       return;
     }
 
-    TransportStats serverBefore = serverTransportListener.transport.getStats().get();
+    TransportStats serverBefore = getTransportStats(serverTransportListener.transport);
     assertEquals(0, serverBefore.messagesSent);
     assertEquals(0, serverBefore.lastMessageSentTimeNanos);
-    TransportStats clientBefore = client.getStats().get();
+    TransportStats clientBefore = getTransportStats(client);
     assertEquals(0, clientBefore.messagesReceived);
     assertEquals(0, clientBefore.lastMessageReceivedTimeNanos);
 
@@ -1661,11 +1666,11 @@ public abstract class AbstractTransportTest {
     serverStream.flush();
     verifyMessageCountAndClose(clientStreamListener.messageQueue, 1);
 
-    TransportStats serverAfter = serverTransportListener.transport.getStats().get();
+    TransportStats serverAfter = getTransportStats(serverTransportListener.transport);
     assertEquals(1, serverAfter.messagesSent);
     long serverTimestmap = TimeUnit.NANOSECONDS.toMillis(serverAfter.lastMessageSentTimeNanos);
     assertEquals(currentTimeMillis(), serverTimestmap);
-    TransportStats clientAfter = client.getStats().get();
+    TransportStats clientAfter = getTransportStats(client);
     assertEquals(1, clientAfter.messagesReceived);
     long clientTimestmap =
         TimeUnit.NANOSECONDS.toMillis(clientAfter.lastMessageReceivedTimeNanos);
@@ -1673,6 +1678,35 @@ public abstract class AbstractTransportTest {
 
 
     serverStream.close(Status.OK, new Metadata());
+  }
+
+  @Test
+  public void socketStats_addresses() throws Exception {
+    server.start(serverListener);
+    ManagedClientTransport client = newClientTransport(server);
+    runIfNotNull(client.start(mock(ManagedClientTransport.Listener.class)));
+    ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
+    ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
+    clientStream.start(clientStreamListener);
+
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+
+    // clients do not have TRANSPORT_ATTR_REMOTE_ADDR so use a hack for serverAddress
+    SocketAddress serverAddress
+        = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), server.getPort());
+    SocketAddress clientAddress = serverStream.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
+
+    SocketStats clientSocketStats = client.getStats().get();
+    assertEquals(clientAddress, clientSocketStats.local);
+    assertEquals(serverAddress, clientSocketStats.remote);
+
+    SocketStats serverSocketStats = serverTransportListener.transport.getStats().get();
+    assertEquals(serverAddress, serverSocketStats.local);
+    assertEquals(clientAddress, serverSocketStats.remote);
   }
 
   /**
@@ -1969,5 +2003,10 @@ public abstract class AbstractTransportTest {
     public String parseBytes(byte[] serialized) {
       return new String(serialized, UTF_8);
     }
+  }
+
+  private static TransportStats getTransportStats(Instrumented<SocketStats> socket)
+      throws ExecutionException, InterruptedException {
+    return socket.getStats().get().data;
   }
 }


### PR DESCRIPTION
Transport ststistics should really be a child member of SocketStats.
While we're at it, let's add the local and remote SocketAddress to
SocketStats, with a test.