### PR TITLE
Ignore proto-generated code for ErrorProne

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,8 +175,10 @@ subprojects {
           [compileJava, compileTestJava, compileJmhJava].each() {
             // Protobuf-generated code produces some warnings.
             // https://github.com/google/protobuf/issues/2718
-            it.options.compilerArgs += ["-Xlint:-cast", "-Xep:MissingOverride:OFF",
-                "-Xep:ReferenceEquality:OFF", "-Xep:FunctionalInterfaceClash:OFF"]
+            it.options.compilerArgs += [
+                "-Xlint:-cast",
+                "-XepExcludedPaths:.*/src/generated/[^/]+/java/.*",
+            ]
           }
         }
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -151,15 +151,16 @@ sourceSets {
 }
 
 compileTestJava {
-  options.compilerArgs += ["-Xlint:-cast", "-Xep:MissingOverride:OFF",
-      "-Xep:ReferenceEquality:OFF", "-Xep:FunctionalInterfaceClash:OFF"]
+  options.compilerArgs += [
+      "-Xlint:-cast",
+      "-XepExcludedPaths:.*/build/generated/source/proto/.*",
+  ]
 }
 
 compileTestLiteJava {
+  options.compilerArgs = compileTestJava.options.compilerArgs
   // Protobuf-generated Lite produces quite a few warnings.
-  options.compilerArgs += ["-Xlint:-rawtypes", "-Xlint:-unchecked",
-      "-Xep:MissingOverride:OFF", "-Xep:ReferenceEquality:OFF",
-      "-Xep:FallThrough:OFF"]
+  options.compilerArgs += ["-Xlint:-rawtypes", "-Xlint:-unchecked", "-Xlint:-fallthrough"]
 }
 
 compileTestNanoJava {

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -28,8 +28,7 @@ dependencies {
 compileTestJava {
   // Protobuf-generated Lite produces quite a few warnings.
   options.compilerArgs += ["-Xlint:-rawtypes", "-Xlint:-unchecked", "-Xlint:-fallthrough",
-        "-Xep:MissingOverride:OFF", "-Xep:ReferenceEquality:OFF", "-Xep:FallThrough:OFF",
-        "-Xep:JavaLangClash:OFF" /* The Enum protobuf clashes */]
+        "-XepExcludedPaths:.*/build/generated/source/proto/.*"]
 }
 
 protobuf {


### PR DESCRIPTION
Previously if protobuf-generated code triggered ErrorProne we'd have to disable
the failing check for all code in that task. With -XepExcludedPaths we can
disable the ErrorProne-checking just for protobuf. Note that we continue using
ErrorProne on our generated code. Also note this only applies to ErrorProne
checks; JDK checks still require task-level disabling.