### PR TITLE
buildscripts: avoid unbound variable error

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -40,7 +40,7 @@ cd ../helloworld
 
 # Skip APK size and dex count comparisons for non-PR builds
 
-if [[ -z "$KOKORO_GITHUB_PULL_REQUEST_COMMIT" ]]; then
+if [[ -z "${KOKORO_GITHUB_PULL_REQUEST_COMMIT:-}" ]]; then
     echo "Skipping APK size and dex count"
     exit 0
 fi


### PR DESCRIPTION
Use parameter expansion<sup>1</sup> to check if the pull request id environment variable is set (otherwise we get an unbound variable error due to `set -u`)

<sup>1</sup> https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html