### PR TITLE
core: keep root channels separate from subchannels in channelz

### DIFF
--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -33,7 +33,7 @@ public final class Channelz {
       new ConcurrentHashMap<Long, Instrumented<ServerStats>>();
   private final ConcurrentMap<Long, Instrumented<ChannelStats>> rootChannels =
       new ConcurrentHashMap<Long, Instrumented<ChannelStats>>();
-  private final ConcurrentMap<Long, Instrumented<ChannelStats>> channels =
+  private final ConcurrentMap<Long, Instrumented<ChannelStats>> subchannels =
       new ConcurrentHashMap<Long, Instrumented<ChannelStats>>();
   private final ConcurrentMap<Long, Instrumented<SocketStats>> sockets =
       new ConcurrentHashMap<Long, Instrumented<SocketStats>>();
@@ -50,12 +50,11 @@ public final class Channelz {
     add(servers, server);
   }
 
-  public void addChannel(Instrumented<ChannelStats> channel) {
-    add(channels, channel);
+  public void addSubchannel(Instrumented<ChannelStats> subchannel) {
+    add(subchannels, subchannel);
   }
 
   public void addRootChannel(Instrumented<ChannelStats> rootChannel) {
-    addChannel(rootChannel);
     add(rootChannels, rootChannel);
   }
 
@@ -67,12 +66,11 @@ public final class Channelz {
     remove(servers, server);
   }
 
-  public void removeChannel(Instrumented<ChannelStats> channel) {
-    remove(channels, channel);
+  public void removeSubchannel(Instrumented<ChannelStats> subchannel) {
+    remove(subchannels, subchannel);
   }
 
   public void removeRootChannel(Instrumented<ChannelStats> channel) {
-    removeChannel(channel);
     remove(rootChannels, channel);
   }
 
@@ -86,8 +84,8 @@ public final class Channelz {
   }
 
   @VisibleForTesting
-  public boolean containsChannel(LogId channelRef) {
-    return contains(channels, channelRef);
+  public boolean containsSubchannel(LogId subchannelRef) {
+    return contains(subchannels, subchannelRef);
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -996,7 +996,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
               @Override
               void onTerminated(InternalSubchannel is) {
                 subchannels.remove(is);
-                channelz.removeChannel(is);
+                channelz.removeSubchannel(is);
                 maybeTerminateChannel();
               }
 
@@ -1022,7 +1022,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
             proxyDetector,
             channelz,
             callTracerFactory.create());
-      channelz.addChannel(internalSubchannel);
+      channelz.addSubchannel(internalSubchannel);
       subchannel.subchannel = internalSubchannel;
       logger.log(Level.FINE, "[{0}] {1} created for {2}",
           new Object[] {getLogId(), internalSubchannel.getLogId(), addressGroup});
@@ -1093,7 +1093,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
             @Override
             void onTerminated(InternalSubchannel is) {
               oobChannels.remove(oobChannel);
-              channelz.removeChannel(is);
+              channelz.removeSubchannel(is);
               oobChannel.handleSubchannelTerminated();
               maybeTerminateChannel();
             }
@@ -1107,8 +1107,8 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
           proxyDetector,
           channelz,
           callTracerFactory.create());
-      channelz.addChannel(oobChannel);
-      channelz.addChannel(internalSubchannel);
+      channelz.addSubchannel(oobChannel);
+      channelz.addSubchannel(internalSubchannel);
       oobChannel.setSubchannel(internalSubchannel);
       runSerialized(new Runnable() {
           @Override

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -243,7 +243,7 @@ final class OobChannel extends ManagedChannel implements Instrumented<ChannelSta
     // When delayedTransport is terminated, it shuts down subchannel.  Therefore, at this point
     // both delayedTransport and subchannel have terminated.
     executorPool.returnObject(executor);
-    channelz.removeChannel(this);
+    channelz.removeSubchannel(this);
     terminatedLatch.countDown();
   }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -340,24 +340,23 @@ public class ManagedChannelImplTest {
   public void channelzMembership() throws Exception {
     createChannel(new FakeNameResolverFactory.Builder(expectedUri).build(), NO_INTERCEPTOR);
     assertTrue(channelz.containsRootChannel(channel.getLogId()));
-    assertTrue(channelz.containsChannel(channel.getLogId()));
+    assertFalse(channelz.containsSubchannel(channel.getLogId()));
     channel.shutdownNow();
     channel.awaitTermination(5, TimeUnit.SECONDS);
     assertFalse(channelz.containsRootChannel(channel.getLogId()));
-    assertFalse(channelz.containsChannel(channel.getLogId()));
+    assertFalse(channelz.containsSubchannel(channel.getLogId()));
   }
 
   @Test
   public void channelzMembership_subchannel() throws Exception {
     createChannel(new FakeNameResolverFactory.Builder(expectedUri).build(), NO_INTERCEPTOR);
     assertTrue(channelz.containsRootChannel(channel.getLogId()));
-    assertTrue(channelz.containsChannel(channel.getLogId()));
 
     AbstractSubchannel subchannel =
         (AbstractSubchannel) helper.createSubchannel(addressGroup, Attributes.EMPTY);
     // subchannels are not root channels
     assertFalse(channelz.containsRootChannel(subchannel.getInternalSubchannel().getLogId()));
-    assertTrue(channelz.containsChannel(subchannel.getInternalSubchannel().getLogId()));
+    assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
     assertThat(getStats(channel).subchannels)
         .containsExactly(subchannel.getInternalSubchannel().getLogId());
 
@@ -371,16 +370,15 @@ public class ManagedChannelImplTest {
     assertFalse(channelz.containsSocket(transportInfo.transport.getLogId()));
 
     // terminate subchannel
-    assertTrue(channelz.containsChannel(subchannel.getInternalSubchannel().getLogId()));
+    assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
     subchannel.shutdown();
     timer.forwardTime(ManagedChannelImpl.SUBCHANNEL_SHUTDOWN_DELAY_SECONDS, TimeUnit.SECONDS);
     timer.runDueTasks();
-    assertFalse(channelz.containsChannel(subchannel.getInternalSubchannel().getLogId()));
+    assertFalse(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
     assertThat(getStats(channel).subchannels).isEmpty();
 
     // channel still appears
     assertTrue(channelz.containsRootChannel(channel.getLogId()));
-    assertTrue(channelz.containsChannel(channel.getLogId()));
   }
 
   @Test
@@ -389,15 +387,15 @@ public class ManagedChannelImplTest {
     OobChannel oob = (OobChannel) helper.createOobChannel(addressGroup, authority);
     // oob channels are not root channels
     assertFalse(channelz.containsRootChannel(oob.getLogId()));
-    assertTrue(channelz.containsChannel(oob.getLogId()));
+    assertTrue(channelz.containsSubchannel(oob.getLogId()));
     assertThat(getStats(channel).subchannels).containsExactly(oob.getLogId());
-    assertTrue(channelz.containsChannel(oob.getLogId()));
+    assertTrue(channelz.containsSubchannel(oob.getLogId()));
 
     AbstractSubchannel subchannel = (AbstractSubchannel) oob.getSubchannel();
-    assertTrue(channelz.containsChannel(subchannel.getInternalSubchannel().getLogId()));
+    assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
     assertThat(getStats(oob).subchannels)
         .containsExactly(subchannel.getInternalSubchannel().getLogId());
-    assertTrue(channelz.containsChannel(subchannel.getInternalSubchannel().getLogId()));
+    assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
 
     oob.getSubchannel().requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
@@ -410,13 +408,12 @@ public class ManagedChannelImplTest {
 
     // terminate oobchannel
     oob.shutdown();
-    assertFalse(channelz.containsChannel(oob.getLogId()));
+    assertFalse(channelz.containsSubchannel(oob.getLogId()));
     assertThat(getStats(channel).subchannels).isEmpty();
-    assertFalse(channelz.containsChannel(subchannel.getInternalSubchannel().getLogId()));
+    assertFalse(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
 
     // channel still appears
     assertTrue(channelz.containsRootChannel(channel.getLogId()));
-    assertTrue(channelz.containsChannel(channel.getLogId()));
   }
 
   @Test


### PR DESCRIPTION
It is a channelz requirement that subchannels and channels are
separate, and we can not retrieve a root channel by asking for a
subchannel and vice versa.