### PR TITLE
build.gradle: Filter -Xep instead of just -Xep:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
       allprojects {
         afterEvaluate { project ->
           project.tasks.withType(JavaCompile) {
-            options.compilerArgs.removeAll { it.startsWith("-Xep:") }
+            options.compilerArgs.removeAll { it.startsWith("-Xep") }
           }
         }
       }


### PR DESCRIPTION
-XepFilterPaths should be included in the filtering, otherwise
-PerrorProne=false will fail. I broke this in 1fb72ef6