### PR TITLE
netty,okhttp,testing: always set TRANSPORT_ATTR_REMOTE_ADDR

### DIFF
--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -214,8 +214,7 @@ public final class ProtocolNegotiators {
     private final ProtocolNegotiator.Handler originalHandler;
 
     public BufferUntilProxyTunnelledHandler(
-        ProxyHandler proxyHandler,
-        ProtocolNegotiator.Handler handler) {
+        ProxyHandler proxyHandler, ProtocolNegotiator.Handler handler) {
       super(proxyHandler, handler);
       this.originalHandler = handler;
     }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -199,7 +199,7 @@ public final class ProtocolNegotiators {
           proxyHandler = new HttpProxyHandler(proxyAddress, proxyUsername, proxyPassword);
         }
         return new BufferUntilProxyTunnelledHandler(
-            proxyHandler, negotiator.newHandler(http2Handler), http2Handler);
+            proxyHandler, negotiator.newHandler(http2Handler));
       }
     }
 
@@ -212,15 +212,12 @@ public final class ProtocolNegotiators {
   static final class BufferUntilProxyTunnelledHandler extends AbstractBufferingHandler
       implements ProtocolNegotiator.Handler {
     private final ProtocolNegotiator.Handler originalHandler;
-    private final GrpcHttp2ConnectionHandler grpcHandler;
 
     public BufferUntilProxyTunnelledHandler(
         ProxyHandler proxyHandler,
-        ProtocolNegotiator.Handler handler,
-        GrpcHttp2ConnectionHandler grpcHandler) {
+        ProtocolNegotiator.Handler handler) {
       super(proxyHandler, handler);
       this.originalHandler = handler;
-      this.grpcHandler = grpcHandler;
     }
 
 
@@ -233,11 +230,6 @@ public final class ProtocolNegotiators {
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
       if (evt instanceof ProxyConnectionEvent) {
         writeBufferedAndRemove(ctx);
-        grpcHandler.handleProtocolNegotiationCompleted(
-            Attributes.newBuilder()
-                .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
-                .build()
-        );
       }
       super.userEventTriggered(ctx, evt);
     }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -123,7 +123,7 @@ class OkHttpClientStream extends AbstractClientStream {
 
   @Override
   public Attributes getAttributes() {
-    return Attributes.EMPTY;
+    return transportState().getAttributes();
   }
 
   class Sink implements AbstractClientStream.Sink {
@@ -316,6 +316,12 @@ class OkHttpClientStream extends AbstractClientStream {
         return;
       }
       super.transportDataReceived(new OkHttpReadableBuffer(frame), endOfStream);
+    }
+
+    public Attributes getAttributes() {
+      synchronized (lock) {
+        return transport.getAttributes();
+      }
     }
 
     @GuardedBy("lock")

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -58,6 +58,7 @@ class OkHttpClientStream extends AbstractClientStream {
   private volatile int id = ABSENT_ID;
   private final TransportState state;
   private final Sink sink = new Sink();
+  private final Attributes attributes;
 
   private boolean useGet = false;
 
@@ -83,6 +84,10 @@ class OkHttpClientStream extends AbstractClientStream {
     this.method = method;
     this.authority = authority;
     this.userAgent = userAgent;
+    // OkHttpClientStream is only created after the transport has finished connecting,
+    // so it is safe to read the transport attributes.
+    // We make a copy here for convenience, even though we can ask the transport.
+    this.attributes = transport.getAttributes();
     this.state = new TransportState(maxMessageSize, statsTraceCtx, lock, frameWriter, outboundFlow,
         transport);
   }
@@ -123,7 +128,7 @@ class OkHttpClientStream extends AbstractClientStream {
 
   @Override
   public Attributes getAttributes() {
-    return transportState().getAttributes();
+    return attributes;
   }
 
   class Sink implements AbstractClientStream.Sink {
@@ -316,12 +321,6 @@ class OkHttpClientStream extends AbstractClientStream {
         return;
       }
       super.transportDataReceived(new OkHttpReadableBuffer(frame), endOfStream);
-    }
-
-    // Safe to call without lock
-    @SuppressWarnings("GuardedBy")
-    public Attributes getAttributes() {
-      return transport.getAttributes();
     }
 
     @GuardedBy("lock")

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -318,10 +318,10 @@ class OkHttpClientStream extends AbstractClientStream {
       super.transportDataReceived(new OkHttpReadableBuffer(frame), endOfStream);
     }
 
+    // Safe to call without lock
+    @SuppressWarnings("GuardedBy")
     public Attributes getAttributes() {
-      synchronized (lock) {
-        return transport.getAttributes();
-      }
+      return transport.getAttributes();
     }
 
     @GuardedBy("lock")

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -454,7 +454,6 @@ class OkHttpClientTransport implements ConnectionClientTransport {
         Variant variant = new Http2();
         BufferedSink sink;
         Socket sock;
-        Attributes attrs;
         try {
           if (proxy == null) {
             sock = new Socket(address.getAddress(), address.getPort());
@@ -471,7 +470,9 @@ class OkHttpClientTransport implements ConnectionClientTransport {
           sock.setTcpNoDelay(true);
           source = Okio.buffer(Okio.source(sock));
           sink = Okio.buffer(Okio.sink(sock));
-          attrs = Attributes
+          // TODO(zhangkun83): fill channel security attributes
+          // The return value of OkHttpTlsUpgrader.upgrade is an SSLSocket that has this info
+          attributes = Attributes
               .newBuilder()
               .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, sock.getRemoteSocketAddress())
               .build();
@@ -490,10 +491,6 @@ class OkHttpClientTransport implements ConnectionClientTransport {
         synchronized (lock) {
           socket = sock;
           maxConcurrentStreams = Integer.MAX_VALUE;
-
-          // TODO(zhangkun83): fill channel security attributes
-          // The return value of OkHttpTlsUpgrader.upgrade is an SSLSocket that has this info
-          attributes = attrs;
 
           startPendingStreams();
         }

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -228,7 +228,7 @@ public abstract class AbstractTransportTest {
   public void frameAfterRstStreamShouldNotBreakClientChannel() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -295,7 +295,7 @@ public abstract class AbstractTransportTest {
     server.start(serverListener);
     client = newClientTransport(server);
     InOrder inOrder = inOrder(mockClientTransportListener);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     Status shutdownReason = Status.UNAVAILABLE.withDescription("shutdown called");
     client.shutdown(shutdownReason);
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportTerminated();
@@ -309,7 +309,7 @@ public abstract class AbstractTransportTest {
     server.start(serverListener);
     client = newClientTransport(server);
     InOrder inOrder = inOrder(mockClientTransportListener);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportReady();
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -337,7 +337,7 @@ public abstract class AbstractTransportTest {
   public void openStreamPreventsTermination() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -389,7 +389,7 @@ public abstract class AbstractTransportTest {
   public void shutdownNowKillsClientStream() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -426,7 +426,7 @@ public abstract class AbstractTransportTest {
   public void shutdownNowKillsServerStream() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -467,7 +467,7 @@ public abstract class AbstractTransportTest {
   public void ping() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     ClientTransport.PingCallback mockPingCallback = mock(ClientTransport.PingCallback.class);
     try {
       client.ping(mockPingCallback, MoreExecutors.directExecutor());
@@ -483,7 +483,7 @@ public abstract class AbstractTransportTest {
   public void ping_duringShutdown() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     // Stream prevents termination
     ClientStream stream = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
@@ -505,7 +505,7 @@ public abstract class AbstractTransportTest {
   public void ping_afterTermination() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportReady();
     Status shutdownReason = Status.UNAVAILABLE.withDescription("shutdown called");
     client.shutdown(shutdownReason);
@@ -527,7 +527,7 @@ public abstract class AbstractTransportTest {
     InOrder inOrder = inOrder(clientStreamTracerFactory);
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     // Stream prevents termination
     ClientStream stream = client.newStream(methodDescriptor, new Metadata(), callOptions);
     inOrder.verify(clientStreamTracerFactory).newClientStreamTracer(
@@ -567,7 +567,7 @@ public abstract class AbstractTransportTest {
     // dealing with afterTermination is harder than duringShutdown.
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportReady();
     Status shutdownReason = Status.UNAVAILABLE.withDescription("shutdown called");
     client.shutdown(shutdownReason);
@@ -591,7 +591,7 @@ public abstract class AbstractTransportTest {
   public void transportInUse_normalClose() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     ClientStream stream1 = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener1 = new ClientStreamListenerBase();
     stream1.start(clientStreamListener1);
@@ -621,7 +621,7 @@ public abstract class AbstractTransportTest {
   public void transportInUse_clientCancel() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     ClientStream stream1 = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener1 = new ClientStreamListenerBase();
     stream1.start(clientStreamListener1);
@@ -646,7 +646,7 @@ public abstract class AbstractTransportTest {
     InOrder serverInOrder = inOrder(serverStreamTracerFactory);
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -801,7 +801,7 @@ public abstract class AbstractTransportTest {
   public void authorityPropagation() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
             = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
@@ -820,7 +820,7 @@ public abstract class AbstractTransportTest {
   public void zeroMessageStream() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -856,7 +856,7 @@ public abstract class AbstractTransportTest {
   public void earlyServerClose_withServerHeaders() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -891,7 +891,7 @@ public abstract class AbstractTransportTest {
   public void earlyServerClose_noServerHeaders() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -935,7 +935,7 @@ public abstract class AbstractTransportTest {
   public void earlyServerClose_serverFailure() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -1013,7 +1013,7 @@ public abstract class AbstractTransportTest {
   public void clientCancel() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -1044,7 +1044,7 @@ public abstract class AbstractTransportTest {
   public void clientCancelFromWithinMessageRead() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -1131,7 +1131,7 @@ public abstract class AbstractTransportTest {
   public void serverCancel() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -1179,7 +1179,7 @@ public abstract class AbstractTransportTest {
 
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener =
         serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -1340,7 +1340,7 @@ public abstract class AbstractTransportTest {
   public void interactionsAfterServerStreamCloseAreNoops() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -1372,7 +1372,7 @@ public abstract class AbstractTransportTest {
   public void interactionsAfterClientStreamCancelAreNoops() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -1408,7 +1408,7 @@ public abstract class AbstractTransportTest {
   public void transportTracer_streamStarted() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     if (!haveTransportTracer()) {
@@ -1493,7 +1493,7 @@ public abstract class AbstractTransportTest {
   public void transportTracer_server_streamEnded_ok() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
     clientStream.start(clientStreamListener);
@@ -1532,7 +1532,7 @@ public abstract class AbstractTransportTest {
   public void transportTracer_server_streamEnded_nonOk() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
     clientStream.start(clientStreamListener);
@@ -1572,7 +1572,7 @@ public abstract class AbstractTransportTest {
   public void transportTracer_client_streamEnded_nonOk() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
     clientStream.start(clientStreamListener);
@@ -1607,7 +1607,7 @@ public abstract class AbstractTransportTest {
   public void transportTracer_server_receive_msg() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
     clientStream.start(clientStreamListener);
@@ -1652,7 +1652,7 @@ public abstract class AbstractTransportTest {
   public void transportTracer_server_send_msg() throws Exception {
     server.start(serverListener);
     client = newClientTransport(server);
-    runIfNotNull(client.start(mockClientTransportListener));
+    startTransport(client, mockClientTransportListener);
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
     clientStream.start(clientStreamListener);
@@ -1696,7 +1696,7 @@ public abstract class AbstractTransportTest {
   public void socketStats_addresses() throws Exception {
     server.start(serverListener);
     ManagedClientTransport client = newClientTransport(server);
-    runIfNotNull(client.start(mock(ManagedClientTransport.Listener.class)));
+    startTransport(client, mockClientTransportListener);
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
     clientStream.start(clientStreamListener);
@@ -1727,7 +1727,8 @@ public abstract class AbstractTransportTest {
    */
   private void doPingPong(MockServerListener serverListener) throws Exception {
     ManagedClientTransport client = newClientTransport(server);
-    runIfNotNull(client.start(mock(ManagedClientTransport.Listener.class)));
+    ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
+    startTransport(client, listener);
     ClientStream clientStream = client.newStream(methodDescriptor, new Metadata(), callOptions);
     ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
     clientStream.start(clientStreamListener);
@@ -1791,6 +1792,14 @@ public abstract class AbstractTransportTest {
       runnable.run();
     }
   }
+
+  private static void startTransport(
+      ManagedClientTransport clientTransport,
+      ManagedClientTransport.Listener listener) {
+    runIfNotNull(clientTransport.start(listener));
+    verify(listener, timeout(100)).transportReady();
+  }
+
 
   private static class MockServerListener implements ServerListener {
     public final BlockingQueue<MockServerTransportListener> listeners

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -1800,7 +1800,6 @@ public abstract class AbstractTransportTest {
     verify(listener, timeout(100)).transportReady();
   }
 
-
   private static class MockServerListener implements ServerListener {
     public final BlockingQueue<MockServerTransportListener> listeners
         = new LinkedBlockingQueue<MockServerTransportListener>();

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -68,8 +68,6 @@ import io.grpc.internal.ServerTransportListener;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.List;
@@ -1709,9 +1707,7 @@ public abstract class AbstractTransportTest {
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     ServerStream serverStream = serverStreamCreation.stream;
 
-    // clients do not have TRANSPORT_ATTR_REMOTE_ADDR so use a hack for serverAddress
-    SocketAddress serverAddress
-        = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), server.getPort());
+    SocketAddress serverAddress = clientStream.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
     SocketAddress clientAddress = serverStream.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
 
     SocketStats clientSocketStats = client.getStats().get();


### PR DESCRIPTION
Always set the remote address, no reason why this should be a TLS-only
feature. This is needed for channelz, and is especially useful in unit
tests where we are using plaintext.