### PR TITLE
stub: no initial request when auto inbound flow control is disabled

### DIFF
--- a/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
@@ -532,8 +532,11 @@ public class ProtoReflectionServiceTest {
         (ClientCallStreamObserver<ServerReflectionRequest>)
             stub.serverReflectionInfo(clientResponseObserver);
 
-    // ClientCalls.startCall() calls request(1) initially, so we should get an immediate response.
+    // We should not get an initial response until we request it.
     requestObserver.onNext(flowControlRequest);
+    assertEquals(0, clientResponseObserver.getResponses().size());
+
+    requestObserver.request(1);
     assertEquals(1, clientResponseObserver.getResponses().size());
     assertEquals(flowControlGoldenResponse, clientResponseObserver.getResponses().get(0));
 
@@ -557,17 +560,16 @@ public class ProtoReflectionServiceTest {
         (ClientCallStreamObserver<ServerReflectionRequest>)
             stub.serverReflectionInfo(clientResponseObserver);
 
-    // ClientCalls.startCall() calls request(1) initially, so make additional request.
-    requestObserver.onNext(flowControlRequest);
+    // ClientCalls.startCall() does not request initially, so we make one request.
     requestObserver.onNext(flowControlRequest);
     requestObserver.onCompleted();
-    assertEquals(1, clientResponseObserver.getResponses().size());
+    assertEquals(0, clientResponseObserver.getResponses().size());
     assertFalse(clientResponseObserver.onCompleteCalled());
 
     requestObserver.request(1);
     assertTrue(clientResponseObserver.onCompleteCalled());
-    assertEquals(2, clientResponseObserver.getResponses().size());
-    assertEquals(flowControlGoldenResponse, clientResponseObserver.getResponses().get(1));
+    assertEquals(1, clientResponseObserver.getResponses().size());
+    assertEquals(flowControlGoldenResponse, clientResponseObserver.getResponses().get(0));
   }
 
   private final ServerReflectionRequest flowControlRequest =

--- a/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
+++ b/stub/src/test/java/io/grpc/stub/ClientCallsTest.java
@@ -278,7 +278,7 @@ public class ClientCallsTest {
       }
     });
     listener.get().onMessage("message");
-    assertThat(requests).containsExactly(1);
+    assertThat(requests).isEmpty();
   }
 
   @Test
@@ -365,7 +365,7 @@ public class ClientCallsTest {
     };
     ClientCalls.asyncServerStreamingCall(call, 1, responseObserver);
     listener.get().onMessage("message");
-    assertThat(requests).containsExactly(5, 1).inOrder();
+    assertThat(requests).containsExactly(5);
   }
 
   @Test
@@ -435,6 +435,7 @@ public class ClientCallsTest {
 
     CallStreamObserver<Integer> integerStreamObserver = (CallStreamObserver<Integer>)
         ClientCalls.asyncBidiStreamingCall(clientCall, responseObserver);
+    integerStreamObserver.request(1);
     semaphore.acquire();
     integerStreamObserver.request(2);
     semaphore.acquire();
@@ -442,7 +443,7 @@ public class ClientCallsTest {
     integerStreamObserver.onCompleted();
     assertTrue(latch.await(5, TimeUnit.SECONDS));
     // Verify that number of messages produced in each onReady handler call matches the number
-    // requested by the client. Note that ClientCalls.asyncBidiStreamingCall will request(1)
+    // requested by the client.
     assertEquals(Arrays.asList(0, 1, 1, 2, 2, 2), receivedMessages);
   }
 


### PR DESCRIPTION
This commit prevents ClientCalls from making an initial request for
response messages when the user provides a ClientResponseObserver that
has disabled auto inbound flow control by calling
ClientCallStreamObserver.disableAutoInboundFlowControl() in beforeStart.

The previous behaviour was confusing and undersirable for observers
trying to implement their own flow control,
as values were produced before they were requested.
This behaviour was mentioned in
https://github.com/grpc/grpc-java/issues/1788#issuecomment-260898948

The initial requests are still made for ResponseObservers that haven't
disabled auto inbound flow control.