### PR TITLE
core,netty,services: add server listen sockets to channelz proto service

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -19,6 +19,8 @@ package io.grpc.inprocess;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.grpc.ServerStreamTracer;
+import io.grpc.internal.Channelz.SocketStats;
+import io.grpc.internal.Instrumented;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.ServerListener;
@@ -74,6 +76,11 @@ final class InProcessServer implements InternalServer {
   @Override
   public int getPort() {
     return -1;
+  }
+
+  @Override
+  public List<Instrumented<SocketStats>> getListenSockets() {
+    return Collections.emptyList();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -263,7 +263,7 @@ public final class Channelz {
     public final long callsSucceeded;
     public final long callsFailed;
     public final long lastCallStartedMillis;
-    // TODO(zpencer): add listen sockets
+    public final List<Instrumented<SocketStats>> listenSockets;
 
     /**
      * Creates an instance.
@@ -272,11 +272,13 @@ public final class Channelz {
         long callsStarted,
         long callsSucceeded,
         long callsFailed,
-        long lastCallStartedMillis) {
+        long lastCallStartedMillis,
+        List<Instrumented<SocketStats>> listenSockets) {
       this.callsStarted = callsStarted;
       this.callsSucceeded = callsSucceeded;
       this.callsFailed = callsFailed;
       this.lastCallStartedMillis = lastCallStartedMillis;
+      this.listenSockets = Preconditions.checkNotNull(listenSockets);
     }
 
     public static final class Builder {
@@ -284,6 +286,7 @@ public final class Channelz {
       private long callsSucceeded;
       private long callsFailed;
       private long lastCallStartedMillis;
+      public List<Instrumented<SocketStats>> listenSockets = Collections.emptyList();
 
       public Builder setCallsStarted(long callsStarted) {
         this.callsStarted = callsStarted;
@@ -305,6 +308,13 @@ public final class Channelz {
         return this;
       }
 
+      /** Sets the listen sockets. */
+      public Builder setListenSockets(List<Instrumented<SocketStats>> listenSockets) {
+        Preconditions.checkNotNull(listenSockets);
+        this.listenSockets = Collections.unmodifiableList(listenSockets);
+        return this;
+      }
+
       /**
        * Builds an instance.
        */
@@ -313,7 +323,8 @@ public final class Channelz {
             callsStarted,
             callsSucceeded,
             callsFailed,
-            lastCallStartedMillis);
+            lastCallStartedMillis,
+            listenSockets);
       }
     }
   }
@@ -434,11 +445,11 @@ public final class Channelz {
   }
 
   public static final class SocketStats {
-    public final TransportStats data;
+    @Nullable public final TransportStats data;
     public final SocketAddress local;
-    public final SocketAddress remote;
-    public final Security security;
+    @Nullable public final SocketAddress remote;
     public final SocketOptions socketOptions;
+    @Nullable public final Security security;
 
     /** Creates an instance. */
     public SocketStats(

--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -42,8 +42,8 @@ public final class Channelz {
       = new ConcurrentSkipListMap<Long, Instrumented<ChannelStats>>();
   private final ConcurrentMap<Long, Instrumented<ChannelStats>> subchannels
       = new ConcurrentHashMap<Long, Instrumented<ChannelStats>>();
-  // An InProcessTransport can appear in both clientSockets and perServerSockets simultaneously
-  private final ConcurrentMap<Long, Instrumented<SocketStats>> clientSockets
+  // An InProcessTransport can appear in both otherSockets and perServerSockets simultaneously
+  private final ConcurrentMap<Long, Instrumented<SocketStats>> otherSockets
       = new ConcurrentHashMap<Long, Instrumented<SocketStats>>();
   private final ConcurrentMap<Long, ServerSocketMap> perServerSockets
       = new ConcurrentHashMap<Long, ServerSocketMap>();
@@ -81,7 +81,11 @@ public final class Channelz {
 
   /** Adds a socket. */
   public void addClientSocket(Instrumented<SocketStats> socket) {
-    add(clientSockets, socket);
+    add(otherSockets, socket);
+  }
+
+  public void addListenSocket(Instrumented<SocketStats> socket) {
+    add(otherSockets, socket);
   }
 
   /** Adds a server socket. */
@@ -108,7 +112,11 @@ public final class Channelz {
   }
 
   public void removeClientSocket(Instrumented<SocketStats> socket) {
-    remove(clientSockets, socket);
+    remove(otherSockets, socket);
+  }
+
+  public void removeListenSocket(Instrumented<SocketStats> socket) {
+    remove(otherSockets, socket);
   }
 
   /** Removes a server socket. */
@@ -174,7 +182,7 @@ public final class Channelz {
   /** Returns a socket. */
   @Nullable
   public Instrumented<SocketStats> getSocket(long id) {
-    Instrumented<SocketStats> clientSocket = clientSockets.get(id);
+    Instrumented<SocketStats> clientSocket = otherSockets.get(id);
     if (clientSocket != null) {
       return clientSocket;
     }
@@ -207,7 +215,7 @@ public final class Channelz {
 
   @VisibleForTesting
   public boolean containsClientSocket(LogId transportRef) {
-    return contains(clientSockets, transportRef);
+    return contains(otherSockets, transportRef);
   }
 
   private static <T extends Instrumented<?>> void add(Map<Long, T> map, T object) {

--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -311,7 +311,8 @@ public final class Channelz {
       /** Sets the listen sockets. */
       public Builder setListenSockets(List<Instrumented<SocketStats>> listenSockets) {
         Preconditions.checkNotNull(listenSockets);
-        this.listenSockets = Collections.unmodifiableList(listenSockets);
+        this.listenSockets = Collections.unmodifiableList(
+            new ArrayList<Instrumented<SocketStats>>(listenSockets));
         return this;
       }
 

--- a/core/src/main/java/io/grpc/internal/InternalServer.java
+++ b/core/src/main/java/io/grpc/internal/InternalServer.java
@@ -16,7 +16,10 @@
 
 package io.grpc.internal;
 
+import com.sun.istack.internal.NotNull;
+import io.grpc.internal.Channelz.SocketStats;
 import java.io.IOException;
+import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -47,4 +50,10 @@ public interface InternalServer {
    * available or does not make sense.
    */
   int getPort();
+
+  /**
+   * Returns the listen sockets of this server.
+   */
+  @NotNull
+  List<Instrumented<SocketStats>> getListenSockets();
 }

--- a/core/src/main/java/io/grpc/internal/InternalServer.java
+++ b/core/src/main/java/io/grpc/internal/InternalServer.java
@@ -16,7 +16,6 @@
 
 package io.grpc.internal;
 
-import com.sun.istack.internal.NotNull;
 import io.grpc.internal.Channelz.SocketStats;
 import java.io.IOException;
 import java.util.List;
@@ -52,8 +51,7 @@ public interface InternalServer {
   int getPort();
 
   /**
-   * Returns the listen sockets of this server.
+   * Returns the listen sockets of this server. May return an empty list but never returns null.
    */
-  @NotNull
   List<Instrumented<SocketStats>> getListenSockets();
 }

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -571,7 +571,8 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
 
   @Override
   public ListenableFuture<ServerStats> getStats() {
-    ServerStats.Builder builder = new ServerStats.Builder();
+    ServerStats.Builder builder = new ServerStats.Builder()
+        .setListenSockets(transportServer.getListenSockets());
     serverCallTracer.updateBuilder(builder);
     SettableFuture<ServerStats> ret = SettableFuture.create();
     ret.set(builder.build());

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -571,7 +571,8 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
 
   @Override
   public ListenableFuture<ServerStats> getStats() {
-    ServerStats.Builder builder = new ServerStats.Builder()
+    ServerStats.Builder builder
+        = new ServerStats.Builder()
         .setListenSockets(transportServer.getListenSockets());
     serverCallTracer.updateBuilder(builder);
     SettableFuture<ServerStats> ret = SettableFuture.create();

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -81,6 +81,7 @@ import java.io.InputStream;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
@@ -1461,6 +1462,11 @@ public class ServerImplTest {
     @Override
     public int getPort() {
       return -1;
+    }
+
+    @Override
+    public List<Instrumented<SocketStats>> getListenSockets() {
+      return Collections.emptyList();
     }
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -50,6 +50,8 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http2.StreamBufferingEncoder.Http2ChannelClosedException;
 import io.netty.util.AsciiString;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.Map;
@@ -339,7 +341,16 @@ class NettyClientTransport implements ConnectionClientTransport {
                     Utils.getSocketOptions(channel),
                     new Security()));
           }
-        });
+        })
+        .addListener(
+            new GenericFutureListener<Future<Object>>() {
+              @Override
+              public void operationComplete(Future<Object> future) throws Exception {
+                if (!future.isSuccess()) {
+                  result.setException(future.cause());
+                }
+              }
+            });;
     return result;
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -350,7 +350,7 @@ class NettyClientTransport implements ConnectionClientTransport {
                   result.setException(future.cause());
                 }
               }
-            });;
+            });
     return result;
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -245,7 +245,7 @@ class NettyServer implements InternalServer, WithLogId {
       public void operationComplete(ChannelFuture f) throws Exception {
         Instrumented<SocketStats> listenSocket = new ListenSocket(f.channel());
         listenSockets = ImmutableList.of(listenSocket);
-        channelz.addSocket(listenSocket);
+        channelz.addListenSocket(listenSocket);
       }
     });
     try {
@@ -273,7 +273,7 @@ class NettyServer implements InternalServer, WithLogId {
           log.log(Level.WARNING, "Error shutting down server", future.cause());
         }
         for (Instrumented<SocketStats> listenSocket : listenSockets) {
-          channelz.removeSocket(listenSocket);
+          channelz.removeListenSocket(listenSocket);
         }
         listenSockets = null;
         synchronized (NettyServer.this) {

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -344,6 +344,7 @@ class NettyServer implements InternalServer, WithLogId {
             /*data=*/ null,
             ch.localAddress(),
             /*remoteAddress=*/ null,
+            Utils.getSocketOptions(ch),
             /*security=*/ null));
         return ret;
       }
@@ -356,6 +357,7 @@ class NettyServer implements InternalServer, WithLogId {
                       /*data=*/ null,
                       ch.localAddress(),
                       /*remoteAddress=*/ null,
+                      Utils.getSocketOptions(ch),
                       /*security=*/ null));
                 }
               })

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -425,7 +425,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
         maxMessageSize, maxHeaderListSize, keepAliveTimeInNanos, keepAliveTimeoutInNanos,
         maxConnectionIdleInNanos,
         maxConnectionAgeInNanos, maxConnectionAgeGraceInNanos,
-        permitKeepAliveWithoutCalls, permitKeepAliveTimeInNanos);
+        permitKeepAliveWithoutCalls, permitKeepAliveTimeInNanos, channelz);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -33,6 +33,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPromise;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -222,7 +224,16 @@ class NettyServerTransport implements ServerTransport {
                     Utils.getSocketOptions(channel),
                     /*security=*/ null));
           }
-        });
+        })
+        .addListener(
+            new GenericFutureListener<Future<Object>>() {
+              @Override
+              public void operationComplete(Future<Object> future) throws Exception {
+                if (!future.isSuccess()) {
+                  result.setException(future.cause());
+                }
+              }
+            });
     return result;
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -48,6 +48,7 @@ import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
+import io.grpc.internal.Channelz;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
@@ -107,6 +108,7 @@ public class NettyClientTransportTest {
   private final List<NettyClientTransport> transports = new ArrayList<NettyClientTransport>();
   private final NioEventLoopGroup group = new NioEventLoopGroup(1);
   private final EchoServerListener serverListener = new EchoServerListener();
+  private final Channelz channelz = new Channelz();
   private Runnable tooManyPingsRunnable = new Runnable() {
     // Throwing is useless in this method, because Netty doesn't propagate the exception
     @Override public void run() {}
@@ -604,7 +606,8 @@ public class NettyClientTransportTest {
         DEFAULT_WINDOW_SIZE, DEFAULT_MAX_MESSAGE_SIZE, maxHeaderListSize,
         DEFAULT_SERVER_KEEPALIVE_TIME_NANOS, DEFAULT_SERVER_KEEPALIVE_TIMEOUT_NANOS,
         MAX_CONNECTION_IDLE_NANOS_DISABLED,
-        MAX_CONNECTION_AGE_NANOS_DISABLED, MAX_CONNECTION_AGE_GRACE_NANOS_INFINITE, true, 0);
+        MAX_CONNECTION_AGE_NANOS_DISABLED, MAX_CONNECTION_AGE_GRACE_NANOS_INFINITE, true, 0,
+        channelz);
     server.start(serverListener);
     address = TestUtils.testServerAddress(server.getPort());
     authority = GrpcUtil.authorityFromHostAndPort(address.getHostString(), address.getPort());

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -40,6 +40,7 @@ import io.grpc.channelz.v1.Server;
 import io.grpc.channelz.v1.ServerData;
 import io.grpc.channelz.v1.ServerRef;
 import io.grpc.channelz.v1.Socket;
+import io.grpc.channelz.v1.Socket.Builder;
 import io.grpc.channelz.v1.SocketData;
 import io.grpc.channelz.v1.SocketOption;
 import io.grpc.channelz.v1.SocketOptionLinger;
@@ -106,11 +107,14 @@ final class ChannelzProtoUtil {
 
   static Server toServer(Instrumented<ServerStats> obj) {
     ServerStats stats = getFuture(obj.getStats());
-    return Server
+    Server.Builder builder = Server
         .newBuilder()
         .setRef(toServerRef(obj))
-        .setData(toServerData(stats))
-        .build();
+        .setData(toServerData(stats));
+    for (Instrumented<SocketStats> listenSocket : stats.listenSockets) {
+      builder.addListenSocket(toSocketRef(listenSocket));
+    }
+    return builder.build();
   }
 
   static ServerData toServerData(ServerStats stats) {
@@ -125,15 +129,21 @@ final class ChannelzProtoUtil {
 
   static Socket toSocket(Instrumented<SocketStats> obj) {
     SocketStats socketStats = getFuture(obj.getStats());
-    return Socket.newBuilder()
+    Builder builder = Socket.newBuilder()
         .setRef(toSocketRef(obj))
-        .setRemote(toAddress(socketStats.remote))
-        .setLocal(toAddress(socketStats.local))
-        .setData(extractSocketData(socketStats))
-        .build();
+        .setLocal(toAddress(socketStats.local));
+    // listen sockets do not have remote nor data
+    if (socketStats.remote != null) {
+      builder.setRemote(toAddress(socketStats.remote));
+    }
+    if (socketStats.data != null) {
+      builder.setData(extractSocketData(socketStats));
+    }
+    return builder.build();
   }
 
   static Address toAddress(SocketAddress address) {
+    Preconditions.checkNotNull(address);
     Address.Builder builder = Address.newBuilder();
     if (address instanceof InetSocketAddress) {
       InetSocketAddress inetAddress = (InetSocketAddress) address;

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -152,6 +152,7 @@ final class ChannelzProtoUtil {
               .newBuilder()
               .setIpAddress(
                   ByteString.copyFrom(inetAddress.getAddress().getAddress()))
+              .setPort(inetAddress.getPort())
               .build());
     } else if (address.getClass().getName().endsWith("io.netty.channel.unix.DomainSocketAddress")) {
       builder.setUdsAddress(

--- a/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
+++ b/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
@@ -17,6 +17,7 @@
 package io.grpc.services;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.Channelz.id;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
@@ -55,9 +56,11 @@ import io.grpc.internal.Channelz.ServerList;
 import io.grpc.internal.Channelz.ServerSocketsList;
 import io.grpc.internal.Channelz.ServerStats;
 import io.grpc.internal.Channelz.SocketOptions;
+import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.Instrumented;
 import io.grpc.internal.WithLogId;
 import io.grpc.services.ChannelzTestHelper.TestChannel;
+import io.grpc.services.ChannelzTestHelper.TestListenSocket;
 import io.grpc.services.ChannelzTestHelper.TestServer;
 import io.grpc.services.ChannelzTestHelper.TestSocket;
 import io.netty.channel.unix.DomainSocketAddress;
@@ -168,6 +171,13 @@ public final class ChannelzProtoUtilTest {
       .setValue("some-made-up-value")
       .build();
 
+  private final TestListenSocket listenSocket = new TestListenSocket();
+  private final SocketRef listenSocketRef = SocketRef
+      .newBuilder()
+      .setName(listenSocket.toString())
+      .setSocketId(id(listenSocket))
+      .build();
+
   private final TestSocket socket = new TestSocket();
   private final SocketRef socketRef = SocketRef
       .newBuilder()
@@ -262,6 +272,21 @@ public final class ChannelzProtoUtilTest {
     socket.socketOptions = toBuilder(socket.socketOptions)
         .setSocketOptionLingerSeconds(10)
         .build();
+  }
+
+  @Test
+  public void toSocket_listenSocket() {
+    assertEquals(
+        Socket
+            .newBuilder()
+            .setRef(listenSocketRef)
+            .setLocal(localAddress)
+            .build(),
+        ChannelzProtoUtil.toSocket(listenSocket));
+  }
+
+  @Test
+  public void toSocketData() throws Exception {
     assertEquals(
         socketDataNoSockOpts
             .toBuilder()
@@ -318,7 +343,34 @@ public final class ChannelzProtoUtilTest {
 
   @Test
   public void toServer() throws Exception {
+    // no listen sockets
     assertEquals(serverProto, ChannelzProtoUtil.toServer(server));
+
+    // 1 listen socket
+    server.serverStats = toBuilder(server.serverStats)
+        .setListenSockets(ImmutableList.<Instrumented<SocketStats>>of(listenSocket))
+        .build();
+    assertEquals(
+        serverProto
+            .toBuilder()
+            .addListenSocket(listenSocketRef)
+            .build(),
+        ChannelzProtoUtil.toServer(server));
+
+    // multiple listen sockets
+    TestListenSocket otherListenSocket = new TestListenSocket();
+    SocketRef otherListenSocketRef = ChannelzProtoUtil.toSocketRef(otherListenSocket);
+    server.serverStats = toBuilder(server.serverStats)
+        .setListenSockets(
+            ImmutableList.<Instrumented<SocketStats>>of(listenSocket, otherListenSocket))
+        .build();
+    assertEquals(
+        serverProto
+            .toBuilder()
+            .addListenSocket(listenSocketRef)
+            .addListenSocket(otherListenSocketRef)
+            .build(),
+        ChannelzProtoUtil.toServer(server));
   }
 
   @Test
@@ -612,6 +664,7 @@ public final class ChannelzProtoUtilTest {
     return builder;
   }
 
+
   private static SocketOptions.Builder toBuilder(SocketOptions options) {
     SocketOptions.Builder builder = new SocketOptions.Builder()
         .setSocketOptionTimeoutMillis(options.soTimeoutMillis)
@@ -620,5 +673,14 @@ public final class ChannelzProtoUtilTest {
       builder.addOption(entry.getKey(), entry.getValue());
     }
     return builder;
+  }
+
+  private static ServerStats.Builder toBuilder(ServerStats stats) {
+    return new ServerStats.Builder()
+        .setCallsStarted(stats.callsStarted)
+        .setCallsSucceeded(stats.callsSucceeded)
+        .setCallsFailed(stats.callsFailed)
+        .setLastCallStartedMillis(stats.lastCallStartedMillis)
+        .setListenSockets(stats.listenSockets);
   }
 }

--- a/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
+++ b/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
@@ -177,6 +177,16 @@ public final class ChannelzProtoUtilTest {
       .setName(listenSocket.toString())
       .setSocketId(id(listenSocket))
       .build();
+  private final Address listenAddress = Address
+      .newBuilder()
+      .setTcpipAddress(
+          TcpIpAddress
+              .newBuilder()
+              .setIpAddress(ByteString.copyFrom(
+                  ((InetSocketAddress) listenSocket.listenAddress).getAddress().getAddress()))
+              .setPort(1234)
+              .build())
+      .build();
 
   private final TestSocket socket = new TestSocket();
   private final SocketRef socketRef = SocketRef
@@ -206,6 +216,7 @@ public final class ChannelzProtoUtilTest {
               .newBuilder()
               .setIpAddress(ByteString.copyFrom(
                   ((InetSocketAddress) socket.local).getAddress().getAddress()))
+              .setPort(1000)
               .build())
       .build();
   private final Address remoteAddress = Address
@@ -215,6 +226,7 @@ public final class ChannelzProtoUtilTest {
               .newBuilder()
               .setIpAddress(ByteString.copyFrom(
                   ((InetSocketAddress) socket.remote).getAddress().getAddress()))
+              .setPort(1000)
               .build())
       .build();
 
@@ -280,7 +292,7 @@ public final class ChannelzProtoUtilTest {
         Socket
             .newBuilder()
             .setRef(listenSocketRef)
-            .setLocal(localAddress)
+            .setLocal(listenAddress)
             .build(),
         ChannelzProtoUtil.toSocket(listenSocket));
   }
@@ -303,6 +315,7 @@ public final class ChannelzProtoUtilTest {
             TcpIpAddress
                 .newBuilder()
                 .setIpAddress(ByteString.copyFrom(inet4.getAddress().getAddress()))
+                .setPort(1000)
                 .build())
             .build(),
         ChannelzProtoUtil.toAddress(inet4));

--- a/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
+++ b/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
@@ -284,6 +284,12 @@ public final class ChannelzProtoUtilTest {
     socket.socketOptions = toBuilder(socket.socketOptions)
         .setSocketOptionLingerSeconds(10)
         .build();
+    assertEquals(
+        socketDataNoSockOpts
+            .toBuilder()
+            .addOption(sockOptlinger10s)
+            .build(),
+        ChannelzProtoUtil.extractSocketData(socket.getStats().get()));
   }
 
   @Test
@@ -302,7 +308,6 @@ public final class ChannelzProtoUtilTest {
     assertEquals(
         socketDataNoSockOpts
             .toBuilder()
-            .addOption(sockOptlinger10s)
             .build(),
         ChannelzProtoUtil.extractSocketData(socket.getStats().get()));
   }

--- a/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
+++ b/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
@@ -23,6 +23,7 @@ import io.grpc.internal.Channelz;
 import io.grpc.internal.Channelz.ChannelStats;
 import io.grpc.internal.Channelz.Security;
 import io.grpc.internal.Channelz.ServerStats;
+import io.grpc.internal.Channelz.SocketOptions;
 import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.Channelz.TransportStats;
 import io.grpc.internal.Instrumented;
@@ -88,6 +89,7 @@ final class ChannelzTestHelper {
               /*data=*/ null,
               listenAddress,
               /*remoteAddress=*/ null,
+              new SocketOptions.Builder().build(),
               /*security=*/ null));
       return ret;
     }

--- a/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
+++ b/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
@@ -76,13 +76,36 @@ final class ChannelzTestHelper {
     }
   }
 
+  static final class TestListenSocket implements Instrumented<SocketStats> {
+    private final LogId id = LogId.allocate("listensocket");
+    SocketAddress listenAddress = new InetSocketAddress("10.0.0.1", 1234);
+
+    @Override
+    public ListenableFuture<SocketStats> getStats() {
+      SettableFuture<SocketStats> ret = SettableFuture.create();
+      ret.set(
+          new SocketStats(
+              /*data=*/ null,
+              listenAddress,
+              /*remoteAddress=*/ null,
+              /*security=*/ null));
+      return ret;
+    }
+
+    @Override
+    public LogId getLogId() {
+      return id;
+    }
+  }
+
   static final class TestServer implements Instrumented<ServerStats> {
     private final LogId id = LogId.allocate("server");
     ServerStats serverStats = new ServerStats(
-      /*callsStarted=*/ 1,
-      /*callsSucceeded=*/ 2,
-      /*callsFailed=*/ 3,
-      /*lastCallStartedMillis=*/ 4);
+        /*callsStarted=*/ 1,
+        /*callsSucceeded=*/ 2,
+        /*callsFailed=*/ 3,
+        /*lastCallStartedMillis=*/ 4,
+        Collections.<Instrumented<SocketStats>>emptyList());
 
     @Override
     public ListenableFuture<ServerStats> getStats() {


### PR DESCRIPTION
This PR exposes listen sockets to the channelz service.
These sockets are not in the set of sockets discoverable via
`GetServerSockets`.

Server listen sockets differ from normal sockets in that only have
a local address and socket options.

Fixed an issue of socket addresses not reporting the port.