### PR TITLE
core,netty: client sends rst stream when server half-closes

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -92,7 +92,6 @@ public abstract class AbstractClientStream extends AbstractStream
   private final Framer framer;
   private boolean useGet;
   private Metadata headers;
-  private boolean outboundClosed;
   /**
    * Whether cancel() has been called. This is not strictly necessary, but removes the delay between
    * cancel() being called and isReady() beginning to return false, since cancel is commonly
@@ -175,8 +174,8 @@ public abstract class AbstractClientStream extends AbstractStream
 
   @Override
   public final void halfClose() {
-    if (!outboundClosed) {
-      outboundClosed = true;
+    if (!transportState().isOutboundClosed()) {
+      transportState().setOutboundClosed();
       endOfMessages();
     }
   }
@@ -208,6 +207,9 @@ public abstract class AbstractClientStream extends AbstractStream
 
     private boolean deframerClosed = false;
     private Runnable deframerClosedTask;
+
+    /** Whether the client has half-closed the stream. */
+    private volatile boolean outboundClosed;
 
     /**
      * Whether the stream is closed from the transport's perspective. This can differ from {@link
@@ -251,6 +253,14 @@ public abstract class AbstractClientStream extends AbstractStream
     @Override
     protected final ClientStreamListener listener() {
       return listener;
+    }
+
+    private final void setOutboundClosed() {
+      outboundClosed = true;
+    }
+
+    protected final boolean isOutboundClosed() {
+      return outboundClosed;
     }
 
     /**

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -78,6 +78,7 @@ public class MessageFramer implements Framer {
   private final byte[] headerScratch = new byte[HEADER_LENGTH];
   private final WritableBufferAllocator bufferAllocator;
   private final StatsTraceContext statsTraceCtx;
+  // transportTracer is nullable until it is integrated with client transports
   private boolean closed;
 
   // Tracing and stats-related states

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -78,7 +78,6 @@ public class MessageFramer implements Framer {
   private final byte[] headerScratch = new byte[HEADER_LENGTH];
   private final WritableBufferAllocator bufferAllocator;
   private final StatsTraceContext statsTraceCtx;
-  // transportTracer is nullable until it is integrated with client transports
   private boolean closed;
 
   // Tracing and stats-related states

--- a/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
@@ -18,18 +18,19 @@ package io.grpc.netty;
 
 import com.google.common.base.Preconditions;
 import io.grpc.Status;
+import javax.annotation.Nullable;
 
 /**
  * Command sent from a Netty client stream to the handler to cancel the stream.
  */
 class CancelClientStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final NettyClientStream.TransportState stream;
-  private final Status reason;
+  @Nullable private final Status reason;
 
   CancelClientStreamCommand(NettyClientStream.TransportState stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream, "stream");
-    Preconditions.checkNotNull(reason, "reason");
-    Preconditions.checkArgument(!reason.isOk(), "Should not cancel with OK status");
+    Preconditions.checkArgument(
+        reason == null || !reason.isOk(), "Should not cancel with OK status");
     this.reason = reason;
   }
 
@@ -37,6 +38,7 @@ class CancelClientStreamCommand extends WriteQueue.AbstractQueuedCommand {
     return stream;
   }
 
+  @Nullable
   Status reason() {
     return reason;
   }

--- a/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelClientStreamCommand.java
@@ -18,19 +18,18 @@ package io.grpc.netty;
 
 import com.google.common.base.Preconditions;
 import io.grpc.Status;
-import javax.annotation.Nullable;
 
 /**
  * Command sent from a Netty client stream to the handler to cancel the stream.
  */
 class CancelClientStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final NettyClientStream.TransportState stream;
-  @Nullable private final Status reason;
+  private final Status reason;
 
   CancelClientStreamCommand(NettyClientStream.TransportState stream, Status reason) {
     this.stream = Preconditions.checkNotNull(stream, "stream");
-    Preconditions.checkArgument(
-        reason == null || !reason.isOk(), "Should not cancel with OK status");
+    Preconditions.checkNotNull(reason, "reason");
+    Preconditions.checkArgument(!reason.isOk(), "Should not cancel with OK status");
     this.reason = reason;
   }
 
@@ -38,7 +37,6 @@ class CancelClientStreamCommand extends WriteQueue.AbstractQueuedCommand {
     return stream;
   }
 
-  @Nullable
   Status reason() {
     return reason;
   }

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -524,7 +524,10 @@ class NettyClientHandler extends AbstractNettyHandler {
   private void cancelStream(ChannelHandlerContext ctx, CancelClientStreamCommand cmd,
       ChannelPromise promise) {
     NettyClientStream.TransportState stream = cmd.stream();
-    stream.transportReportStatus(cmd.reason(), true, new Metadata());
+    Status reason = cmd.reason();
+    if (reason != null) {
+      stream.transportReportStatus(reason, true, new Metadata());
+    }
     encoder().writeRstStream(ctx, stream.id(), Http2Error.CANCEL.code(), promise);
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -524,10 +524,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   private void cancelStream(ChannelHandlerContext ctx, CancelClientStreamCommand cmd,
       ChannelPromise promise) {
     NettyClientStream.TransportState stream = cmd.stream();
-    Status reason = cmd.reason();
-    if (reason != null) {
-      stream.transportReportStatus(reason, true, new Metadata());
-    }
+    stream.transportReportStatus(cmd.reason(), true, new Metadata());
     encoder().writeRstStream(ctx, stream.id(), Http2Error.CANCEL.code(), promise);
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -293,18 +293,10 @@ class NettyClientStream extends AbstractClientStream {
 
     void transportHeadersReceived(Http2Headers headers, boolean endOfStream) {
       if (endOfStream) {
-        transportTrailersReceived(Utils.convertTrailers(headers));
         if (!isOutboundClosed()) {
-          handler
-              .getWriteQueue()
-              .enqueue(
-                  new CancelClientStreamCommand(
-                      this,
-                      Status.INTERNAL.withDescription(
-                          "Cancelled stream after server closed. "
-                              + "The server's status should be reported instead of this one")),
-                  true);
+          handler.getWriteQueue().enqueue(new CancelClientStreamCommand(this, null), true);
         }
+        transportTrailersReceived(Utils.convertTrailers(headers));
       } else {
         transportHeadersReceived(Utils.convertHeaders(headers));
       }

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -262,6 +262,23 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
   }
 
   @Test
+  public void inboundTrailersBeforeHalfCloseSendsRstStream() {
+    stream().transportState().setId(STREAM_ID);
+    stream().transportState().transportHeadersReceived(grpcResponseHeaders(), false);
+    stream().transportState().transportHeadersReceived(grpcResponseTrailers(Status.OK), true);
+    verify(writeQueue).enqueue(isA(CancelClientStreamCommand.class), eq(true));
+  }
+
+  @Test
+  public void inboundTrailersAfterHalfCloseDoesNotSendRstStream() {
+    stream().transportState().setId(STREAM_ID);
+    stream().transportState().transportHeadersReceived(grpcResponseHeaders(), false);
+    stream.halfClose();
+    stream().transportState().transportHeadersReceived(grpcResponseTrailers(Status.OK), true);
+    verify(writeQueue, never()).enqueue(isA(CancelClientStreamCommand.class), eq(true));
+  }
+
+  @Test
   public void inboundStatusShouldSetStatus() throws Exception {
     stream().transportState().setId(STREAM_ID);
 
@@ -293,7 +310,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     stream().transportState().transportDataReceived(Unpooled.buffer(1000).writeZero(1000), false);
 
     // Now verify that cancel is sent and an error is reported to the listener
-    verify(writeQueue).enqueue(any(CancelClientStreamCommand.class), eq(true));
+    verify(writeQueue).enqueue(isA(CancelClientStreamCommand.class), eq(true));
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass(Metadata.class);
     verify(listener).closed(captor.capture(), same(PROCESSED), metadataCaptor.capture());

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -266,7 +266,12 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     stream().transportState().setId(STREAM_ID);
     stream().transportState().transportHeadersReceived(grpcResponseHeaders(), false);
     stream().transportState().transportHeadersReceived(grpcResponseTrailers(Status.OK), true);
-    verify(writeQueue).enqueue(isA(CancelClientStreamCommand.class), eq(true));
+
+    // Verify a cancel stream with reason=null is sent to the handler.
+    ArgumentCaptor<CancelClientStreamCommand> captor = ArgumentCaptor
+        .forClass(CancelClientStreamCommand.class);
+    verify(writeQueue).enqueue(captor.capture(), eq(true));
+    assertNull(captor.getValue().reason());
   }
 
   @Test

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -320,7 +320,7 @@ class OkHttpClientStream extends AbstractClientStream {
 
     @GuardedBy("lock")
     private void onEndOfStream() {
-      if (!framer().isClosed()) {
+      if (!isOutboundClosed()) {
         // If server's end-of-stream is received before client sends end-of-stream, we just send a
         // reset to server to fully close the server side stream.
         transport.finishStream(id(),null, PROCESSED, false, ErrorCode.CANCEL, null);


### PR DESCRIPTION
This addresses https://github.com/grpc/grpc-java/issues/4202. I tried to keep the changes minimal, to allow for easily backporting this to earlier releases if necessary.

Currently, if a server half-closes a stream with a Netty client, both server and client will hold onto the stream resources until (if ever) the client calls halfClose(). The same problem does not occur with an OkHttp client, as `OkHttpClientTransport.TransportState#onEndOfStream` triggers deletion of the stream reference on the client and sends a RST_STREAM to the server, which lets the Netty server drop the stream resources as well.

This PR changes the Netty client behavior to be similar to that of OkHttp clients: when end of stream is received from the server, the client sends a RST_STREAM if it has not already half-closed its side of the stream. OkHttp currently waits to do this until the deframer closes, which does not seem to be necessary: anything the client sends at this point will be ignored by the server, so we might as well close the stream as early as possible. This PR doesn't change the OkHttp behavior; that can be in a follow-up PR.

Sending the reset stream releases the stream resources in Netty due to triggering `Http2ConnectionHandler#processRstStreamWriteResult`, which ends up invoking `DefaultHttp2Connection.ActiveStreams#deactivate`, which removes the stream from the list of active streams. Without sending the reset stream, all of the client's streams remain active and a reference is retained to each.

We also almost certainly want to close the framer, if it isn't already closed, when the end of stream is seen from the server (again, this is left to a follow-up PR). Currently, the framer is only ever closed if the client invokes `halfClose()` on the stream. For both Netty and OkHttp, the client may continue to invoke `ClientCall#sendMessage()` even after the server half-closes, and the message goes all the way through the framer, even being reported as outbound bytes to the stats tracers, before ultimately being stopped at the transport layer before going out on the now-dead stream: for Netty, this happens in [DefaultHttp2ConnectionEncoder](https://github.com/netty/netty/blob/a91df58ca17d5b30c57c46dde5b1d60bb659b029/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java#L131) and for OkHttp it happens in [OutboundFlowController](https://github.com/grpc/grpc-java/blob/9224d2ab8f026c8b46eedaaae94b7c64fd27e809/okhttp/src/main/java/io/grpc/okhttp/OutboundFlowController.java#L108), but it would be much cleaner and more efficient to close the framer as soon as we know the stream was closed by the server.

There is likely still follow-up work to do on the server side to drop stream resources even when the client does not send the reset stream; this PR only changes client-side behavior.