### PR TITLE
core,services: track server sockets in channelz

### DIFF
--- a/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, gRPC Authors All rights reserved.
+ * Copyright 2018, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
@@ -62,6 +62,7 @@ public class ChannelzBenchmark {
 
     serverSocketToRemove = create();
     channelz.addSocket(serverSocketToRemove);
+    channelz.addServerSocket(serverForServerSocket, serverSocketToRemove);
 
     populate(preexisting);
 

--- a/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.grpc.internal.Channelz.ServerStats;
+import io.grpc.internal.Channelz.SocketStats;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Javadoc.
+ */
+@State(Scope.Benchmark)
+public class ChannelzBenchmark {
+  // Number of items already present
+  @Param({"10", "100", "1000", "10000"})
+  public int preexisting;
+
+  public Channelz channelz = new Channelz();
+
+  public Instrumented<ServerStats> serverToRemove;
+
+  public Instrumented<ServerStats> serverToAdd;
+
+  public Instrumented<ServerStats> serverForServerSocket;
+  public Instrumented<SocketStats> serverSocketToAdd;
+  public Instrumented<SocketStats> serverSocketToRemove;
+
+  /**
+   * Javadoc.
+   */
+  @Setup
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void setUp() {
+    serverToRemove = create();
+    channelz.addServer(serverToRemove);
+
+    serverForServerSocket = create();
+    channelz.addServer(serverForServerSocket);
+
+    serverSocketToRemove = create();
+    channelz.addSocket(serverSocketToRemove);
+
+    populate(preexisting);
+
+    serverToAdd = create();
+    serverSocketToAdd = create();
+  }
+
+  private void populate(int count) {
+    for (int i = 0; i < count; i++) {
+      // for addNavigable / removeNavigable
+      Instrumented<ServerStats> srv = create();
+      channelz.addServer(srv);
+
+      // for add / remove
+      Instrumented<SocketStats> sock = create();
+      channelz.addSocket(sock);
+
+      // for addServerSocket / removeServerSocket
+      channelz.addServerSocket(serverForServerSocket, sock);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void addNavigable() {
+    channelz.addServer(serverToAdd);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void add() {
+    channelz.addSocket(serverSocketToAdd);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void addServerSocket() {
+    channelz.addServerSocket(serverForServerSocket, serverSocketToAdd);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void removeNavigable() {
+    channelz.removeServer(serverToRemove);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void remove() {
+    channelz.removeSocket(serverSocketToRemove);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void removeServerSocket() {
+    channelz.removeServerSocket(serverForServerSocket, serverSocketToRemove);
+  }
+
+  private static <T> Instrumented<T> create() {
+    return new Instrumented<T>() {
+      final LogId id = LogId.allocate("fake-tag");
+
+      @Override
+      public ListenableFuture<T> getStats() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public LogId getLogId() {
+        return id;
+      }
+    };
+  }
+}

--- a/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
@@ -61,7 +61,7 @@ public class ChannelzBenchmark {
     channelz.addServer(serverForServerSocket);
 
     serverSocketToRemove = create();
-    channelz.addSocket(serverSocketToRemove);
+    channelz.addClientSocket(serverSocketToRemove);
     channelz.addServerSocket(serverForServerSocket, serverSocketToRemove);
 
     populate(preexisting);
@@ -78,7 +78,7 @@ public class ChannelzBenchmark {
 
       // for add / remove
       Instrumented<SocketStats> sock = create();
-      channelz.addSocket(sock);
+      channelz.addClientSocket(sock);
 
       // for addServerSocket / removeServerSocket
       channelz.addServerSocket(serverForServerSocket, sock);
@@ -96,7 +96,7 @@ public class ChannelzBenchmark {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void add() {
-    channelz.addSocket(serverSocketToAdd);
+    channelz.addClientSocket(serverSocketToAdd);
   }
 
   @Benchmark
@@ -117,7 +117,7 @@ public class ChannelzBenchmark {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void remove() {
-    channelz.removeSocket(serverSocketToRemove);
+    channelz.removeClientSocket(serverSocketToRemove);
   }
 
   @Benchmark

--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -144,7 +144,8 @@ public final class Channelz {
 
   /** Returns a server list. */
   public ServerList getServers(long fromId, int maxPageSize) {
-    List<Instrumented<ServerStats>> serverList = new ArrayList<Instrumented<ServerStats>>();
+    List<Instrumented<ServerStats>> serverList
+        = new ArrayList<Instrumented<ServerStats>>(maxPageSize);
     Iterator<Instrumented<ServerStats>> iterator = servers.tailMap(fromId).values().iterator();
 
     while (iterator.hasNext() && serverList.size() < maxPageSize) {
@@ -160,7 +161,7 @@ public final class Channelz {
     if (serverSockets == null) {
       return null;
     }
-    List<WithLogId> socketList = new ArrayList<WithLogId>();
+    List<WithLogId> socketList = new ArrayList<WithLogId>(maxPageSize);
     Iterator<Instrumented<SocketStats>> iterator
         = serverSockets.tailMap(fromId).values().iterator();
     while (socketList.size() < maxPageSize && iterator.hasNext()) {

--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -208,11 +208,6 @@ public final class Channelz {
     return contains(clientSockets, transportRef);
   }
 
-  @VisibleForTesting
-  public boolean containsServerSocket(LogId transportRef) {
-    return getServerSocket(transportRef.getId()) != null;
-  }
-
   private static <T extends Instrumented<?>> void add(Map<Long, T> map, T object) {
     T prev = map.put(object.getLogId().getId(), object);
     assert prev == null;

--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -210,12 +210,14 @@ public final class Channelz {
 
   private static <T extends Instrumented<?>> void add(Map<Long, T> map, T object) {
     T prev = map.put(object.getLogId().getId(), object);
-    assert prev == null;
+    // TODO(zpencer): turn this on
+    // assert prev == null;
   }
 
   private static <T extends Instrumented<?>> void remove(Map<Long, T> map, T object) {
     T prev = map.remove(id(object));
-    assert prev != null;
+    // TODO(zpencer): turn this on
+    // assert prev != null;
   }
 
   private static <T extends Instrumented<?>> boolean contains(Map<Long, T> map, LogId id) {

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -220,7 +220,7 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
         new CallTracingTransport(
             transportFactory.newClientTransport(address, authority, userAgent, proxy),
             callsTracer);
-    channelz.addSocket(transport);
+    channelz.addClientSocket(transport);
     if (log.isLoggable(Level.FINE)) {
       log.log(Level.FINE, "[{0}] Created {1} for {2}",
           new Object[] {logId, transport.getLogId(), address});
@@ -574,7 +574,7 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
       } finally {
         channelExecutor.drain();
       }
-      channelz.removeSocket(transport);
+      channelz.removeClientSocket(transport);
       Preconditions.checkState(activeTransport != transport,
           "activeTransport still points to this transport. "
           + "Seems transportShutdown() was not called.");

--- a/core/src/test/java/io/grpc/internal/ChannelzTest.java
+++ b/core/src/test/java/io/grpc/internal/ChannelzTest.java
@@ -215,10 +215,10 @@ public final class ChannelzTest {
     Instrumented<SocketStats> socket = create();
     assertNull(channelz.getSocket(id(socket)));
 
-    channelz.addSocket(socket);
+    channelz.addClientSocket(socket);
     assertSame(socket, channelz.getSocket(id(socket)));
 
-    channelz.removeSocket(socket);
+    channelz.removeClientSocket(socket);
     assertNull(channelz.getSocket(id(socket)));
   }
 
@@ -260,18 +260,16 @@ public final class ChannelzTest {
     channelz.addServerSocket(server2, socket2);
 
     ServerSocketsList list1
-        = channelz.getServerSockets(id(server1), /*fromId=*/ 0, /*maxPageSize=*/ 1);
+        = channelz.getServerSockets(id(server1), /*fromId=*/ 0, /*maxPageSize=*/ 2);
     assertNotNull(list1);
     assertTrue(list1.end);
     assertThat(list1.sockets).containsExactly(socket1);
-    assertNull(channelz.getServerSocketForTest(id(server1), id(socket2)));
 
     ServerSocketsList list2
-        = channelz.getServerSockets(id(server2), /*fromId=*/ 0, /*maxPageSize=*/1);
+        = channelz.getServerSockets(id(server2), /*fromId=*/ 0, /*maxPageSize=*/2);
     assertNotNull(list2);
     assertTrue(list2.end);
     assertThat(list2.sockets).containsExactly(socket2);
-    assertNull(channelz.getServerSocketForTest(id(server2), id(socket1)));
   }
 
   private void assertEmptyServerSocketsPage(long serverId, long socketId) {

--- a/core/src/test/java/io/grpc/internal/ChannelzTest.java
+++ b/core/src/test/java/io/grpc/internal/ChannelzTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.internal.Channelz.id;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
@@ -27,6 +28,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.internal.Channelz.ChannelStats;
 import io.grpc.internal.Channelz.RootChannelList;
 import io.grpc.internal.Channelz.ServerList;
+import io.grpc.internal.Channelz.ServerSocketsList;
 import io.grpc.internal.Channelz.ServerStats;
 import io.grpc.internal.Channelz.SocketStats;
 import org.junit.Test;
@@ -35,6 +37,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public final class ChannelzTest {
+
   private final Channelz channelz = new Channelz();
 
   @Test
@@ -217,6 +220,66 @@ public final class ChannelzTest {
 
     channelz.removeSocket(socket);
     assertNull(channelz.getSocket(id(socket)));
+  }
+
+  @Test
+  public void serverSocket_noServer() {
+    assertNull(channelz.getServerSockets(/*serverId=*/ 1, /*fromId=*/0, /*maxPageSize=*/ 1));
+  }
+
+  @Test
+  public void serverSocket() {
+    Instrumented<ServerStats> server = create();
+    channelz.addServer(server);
+
+    Instrumented<SocketStats> socket = create();
+    assertEmptyServerSocketsPage(id(server), id(socket));
+
+    channelz.addServerSocket(server, socket);
+    ServerSocketsList page
+        = channelz.getServerSockets(id(server), id(socket), /*maxPageSize=*/ 1);
+    assertNotNull(page);
+    assertTrue(page.end);
+    assertThat(page.sockets).containsExactly(socket);
+
+    channelz.removeServerSocket(server, socket);
+    assertEmptyServerSocketsPage(id(server), id(socket));
+  }
+
+  @Test
+  public void serverSocket_eachServerSeparate() {
+    Instrumented<ServerStats> server1 = create();
+    Instrumented<ServerStats> server2 = create();
+
+    Instrumented<SocketStats> socket1 = create();
+    Instrumented<SocketStats> socket2 = create();
+
+    channelz.addServer(server1);
+    channelz.addServer(server2);
+    channelz.addServerSocket(server1, socket1);
+    channelz.addServerSocket(server2, socket2);
+
+    ServerSocketsList list1
+        = channelz.getServerSockets(id(server1), /*fromId=*/ 0, /*maxPageSize=*/ 1);
+    assertNotNull(list1);
+    assertTrue(list1.end);
+    assertThat(list1.sockets).containsExactly(socket1);
+    assertNull(channelz.getServerSocketForTest(id(server1), id(socket2)));
+
+    ServerSocketsList list2
+        = channelz.getServerSockets(id(server2), /*fromId=*/ 0, /*maxPageSize=*/1);
+    assertNotNull(list2);
+    assertTrue(list2.end);
+    assertThat(list2.sockets).containsExactly(socket2);
+    assertNull(channelz.getServerSocketForTest(id(server2), id(socket1)));
+  }
+
+  private void assertEmptyServerSocketsPage(long serverId, long socketId) {
+    ServerSocketsList emptyPage
+        = channelz.getServerSockets(serverId, socketId, /*maxPageSize=*/ 1);
+    assertNotNull(emptyPage);
+    assertTrue(emptyPage.end);
+    assertThat(emptyPage.sockets).isEmpty();
   }
 
   private static <T> Instrumented<T> create() {

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -926,9 +926,9 @@ public class InternalSubchannelTest {
     internalSubchannel.obtainActiveTransport();
 
     MockClientTransportInfo t0 = transports.poll();
-    assertTrue(channelz.containsSocket(t0.transport.getLogId()));
+    assertTrue(channelz.containsClientSocket(t0.transport.getLogId()));
     t0.listener.transportTerminated();
-    assertFalse(channelz.containsSocket(t0.transport.getLogId()));
+    assertFalse(channelz.containsClientSocket(t0.transport.getLogId()));
   }
 
   private void createInternalSubchannel(SocketAddress ... addrs) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -363,11 +363,11 @@ public class ManagedChannelImplTest {
     subchannel.requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
     assertNotNull(transportInfo);
-    assertTrue(channelz.containsSocket(transportInfo.transport.getLogId()));
+    assertTrue(channelz.containsClientSocket(transportInfo.transport.getLogId()));
 
     // terminate transport
     transportInfo.listener.transportTerminated();
-    assertFalse(channelz.containsSocket(transportInfo.transport.getLogId()));
+    assertFalse(channelz.containsClientSocket(transportInfo.transport.getLogId()));
 
     // terminate subchannel
     assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
@@ -400,11 +400,11 @@ public class ManagedChannelImplTest {
     oob.getSubchannel().requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
     assertNotNull(transportInfo);
-    assertTrue(channelz.containsSocket(transportInfo.transport.getLogId()));
+    assertTrue(channelz.containsClientSocket(transportInfo.transport.getLogId()));
 
     // terminate transport
     transportInfo.listener.transportTerminated();
-    assertFalse(channelz.containsSocket(transportInfo.transport.getLogId()));
+    assertFalse(channelz.containsClientSocket(transportInfo.transport.getLogId()));
 
     // terminate oobchannel
     oob.shutdown();

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.internal.Channelz.id;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -67,6 +68,7 @@ import io.grpc.ServerTransportFilter;
 import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
 import io.grpc.StringMarshaller;
+import io.grpc.internal.Channelz.ServerSocketsList;
 import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.ServerImpl.JumpToApplicationThreadServerStreamListener;
 import io.grpc.internal.testing.SingleMessageProducer;
@@ -1395,12 +1397,23 @@ public class ServerImplTest {
     createAndStartServer();
     SimpleServerTransport transport = new SimpleServerTransport();
 
-    assertFalse(builder.channelz.containsServerSocket(transport.getLogId()));
+    ServerSocketsList before = builder.channelz
+        .getServerSockets(id(server), id(transport), /*maxPageSize=*/ 1);
+    assertThat(before.sockets).isEmpty();
+    assertTrue(before.end);
+
     ServerTransportListener listener
         = transportServer.registerNewServerTransport(transport);
-    assertTrue(builder.channelz.containsServerSocket(transport.getLogId()));
+    ServerSocketsList added = builder.channelz
+        .getServerSockets(id(server), id(transport), /*maxPageSize=*/ 1);
+    assertThat(added.sockets).containsExactly(transport);
+    assertTrue(before.end);
+
     listener.transportTerminated();
-    assertFalse(builder.channelz.containsServerSocket(transport.getLogId()));
+    ServerSocketsList after = builder.channelz
+        .getServerSockets(id(server), id(transport), /*maxPageSize=*/ 1);
+    assertThat(after.sockets).isEmpty();
+    assertTrue(after.end);
   }
 
   private void createAndStartServer() throws IOException {

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1395,12 +1395,12 @@ public class ServerImplTest {
     createAndStartServer();
     SimpleServerTransport transport = new SimpleServerTransport();
 
-    assertFalse(builder.channelz.containsSocket(transport.getLogId()));
+    assertFalse(builder.channelz.containsServerSocket(transport.getLogId()));
     ServerTransportListener listener
         = transportServer.registerNewServerTransport(transport);
-    assertTrue(builder.channelz.containsSocket(transport.getLogId()));
+    assertTrue(builder.channelz.containsServerSocket(transport.getLogId()));
     listener.transportTerminated();
-    assertFalse(builder.channelz.containsSocket(transport.getLogId()));
+    assertFalse(builder.channelz.containsServerSocket(transport.getLogId()));
   }
 
   private void createAndStartServer() throws IOException {

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -31,6 +31,7 @@ import io.grpc.channelz.v1.Channel;
 import io.grpc.channelz.v1.ChannelData;
 import io.grpc.channelz.v1.ChannelData.State;
 import io.grpc.channelz.v1.ChannelRef;
+import io.grpc.channelz.v1.GetServerSocketsResponse;
 import io.grpc.channelz.v1.GetServersResponse;
 import io.grpc.channelz.v1.GetTopChannelsResponse;
 import io.grpc.channelz.v1.Server;
@@ -45,6 +46,7 @@ import io.grpc.internal.Channelz;
 import io.grpc.internal.Channelz.ChannelStats;
 import io.grpc.internal.Channelz.RootChannelList;
 import io.grpc.internal.Channelz.ServerList;
+import io.grpc.internal.Channelz.ServerSocketsList;
 import io.grpc.internal.Channelz.ServerStats;
 import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.Channelz.TransportStats;
@@ -237,6 +239,16 @@ final class ChannelzProtoUtil {
         .setEnd(servers.end);
     for (Instrumented<ServerStats> s : servers.servers) {
       responseBuilder.addServer(ChannelzProtoUtil.toServer(s));
+    }
+    return responseBuilder.build();
+  }
+
+  static GetServerSocketsResponse toGetServerSocketsResponse(ServerSocketsList serverSockets) {
+    GetServerSocketsResponse.Builder responseBuilder = GetServerSocketsResponse
+        .newBuilder()
+        .setEnd(serverSockets.end);
+    for (WithLogId s : serverSockets.sockets) {
+      responseBuilder.addSocketRef(ChannelzProtoUtil.toSocketRef(s));
     }
     return responseBuilder.build();
   }

--- a/services/src/main/java/io/grpc/services/ChannelzService.java
+++ b/services/src/main/java/io/grpc/services/ChannelzService.java
@@ -35,6 +35,7 @@ import io.grpc.channelz.v1.GetTopChannelsResponse;
 import io.grpc.internal.Channelz;
 import io.grpc.internal.Channelz.ChannelStats;
 import io.grpc.internal.Channelz.ServerList;
+import io.grpc.internal.Channelz.ServerSocketsList;
 import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.Instrumented;
 import io.grpc.stub.StreamObserver;
@@ -135,7 +136,14 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
   @Override
   public void getServerSockets(
       GetServerSocketsRequest request, StreamObserver<GetServerSocketsResponse> responseObserver) {
-    // TODO(zpencer): fill this one out after refactoring channelz class
-    responseObserver.onError(Status.UNIMPLEMENTED.asRuntimeException());
+    ServerSocketsList serverSockets
+        = channelz.getServerSockets(request.getServerId(), request.getStartSocketId(), maxPageSize);
+    if (serverSockets == null) {
+      responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
+      return;
+    }
+
+    responseObserver.onNext(ChannelzProtoUtil.toGetServerSocketsResponse(serverSockets));
+    responseObserver.onCompleted();
   }
 }

--- a/services/src/test/java/io/grpc/services/ChannelzServiceTest.java
+++ b/services/src/test/java/io/grpc/services/ChannelzServiceTest.java
@@ -132,7 +132,7 @@ public class ChannelzServiceTest {
     TestSocket socket = new TestSocket();
     assertSocketNotFound(socket.getLogId().getId());
 
-    channelz.addSocket(socket);
+    channelz.addClientSocket(socket);
     assertEquals(
         GetSocketResponse
             .newBuilder()
@@ -140,7 +140,7 @@ public class ChannelzServiceTest {
             .build(),
         getSocketHelper(socket.getLogId().getId()));
 
-    channelz.removeSocket(socket);
+    channelz.removeClientSocket(socket);
     assertSocketNotFound(socket.getLogId().getId());
   }
 


### PR DESCRIPTION
Rather than querying the ServerImpl for its sockets, we register them
into channelz as with all the other entities, for consistency.

Adjust the server/serversocket registration so that:
* server is added before the first transport
* server is removed after the last transport

Error conditions are checked with `assert` statements, so we throw in
tests. But in prod, an error in channelz should not prevent normal
gRPC operation.

I have tested a branch where we avoid using Long as map keys, and
instead use the LogId as the keys:
https://gist.github.com/zpencer/c04efaaa8b6772a8fa392539c45410ab

Long keys benchmark:
https://gist.github.com/zpencer/a31d470bb46c1205d3110e20fca0050e

LogId keys benchmark:
https://gist.github.com/zpencer/5a5c6c2cea9b12bfe480b7ee5c6ab0e4

We expect servers to have many sockets, and it appears using
WithLogId is worse. Let's stick with Long for now.

