### PR TITLE
core,netty,okhttp,services: expose socket options to channelz

### DIFF
--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -466,9 +466,10 @@ public final class Channelz {
         Integer timeoutMillis,
         Integer lingerSeconds,
         Map<String, String> others) {
+      Preconditions.checkNotNull(others);
       this.soTimeoutMillis = timeoutMillis;
       this.lingerSeconds = lingerSeconds;
-      this.others = Collections.unmodifiableMap(Preconditions.checkNotNull(others));
+      this.others = Collections.unmodifiableMap(new HashMap<String, String>(others));
     }
 
     public static final class Builder {
@@ -491,7 +492,7 @@ public final class Channelz {
       }
 
       public Builder addOption(String name, String value) {
-        others.put(name, value);
+        others.put(name, Preconditions.checkNotNull(value));
         return this;
       }
 

--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -22,6 +22,7 @@ import io.grpc.ConnectivityState;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -437,17 +438,76 @@ public final class Channelz {
     public final SocketAddress local;
     public final SocketAddress remote;
     public final Security security;
+    public final SocketOptions socketOptions;
 
     /** Creates an instance. */
     public SocketStats(
         TransportStats data,
         SocketAddress local,
         SocketAddress remote,
+        SocketOptions socketOptions,
         Security security) {
       this.data = data;
       this.local = local;
       this.remote = remote;
+      this.socketOptions = socketOptions;
       this.security = security;
+    }
+  }
+
+  public static final class SocketOptions {
+    public final Map<String, String> others;
+    // In netty, the value of a channel option may be null.
+    @Nullable public final Integer soTimeoutMillis;
+    @Nullable public final Integer lingerSeconds;
+
+    /** Creates an instance. */
+    public SocketOptions(
+        Integer timeoutMillis,
+        Integer lingerSeconds,
+        Map<String, String> others) {
+      this.soTimeoutMillis = timeoutMillis;
+      this.lingerSeconds = lingerSeconds;
+      this.others = Collections.unmodifiableMap(Preconditions.checkNotNull(others));
+    }
+
+    public static final class Builder {
+      private final Map<String, String> others = new HashMap<String, String>();
+      private Integer timeoutMillis;
+      private Integer lingerSeconds;
+
+      /** The value of {@link java.net.Socket#getSoTimeout()}. */
+      public Builder setSocketOptionTimeoutMillis(Integer timeoutMillis) {
+        this.timeoutMillis = timeoutMillis;
+        return this;
+      }
+
+      /** The value of {@link java.net.Socket#getSoLinger()}.
+       * Note: SO_LINGER is typically expressed in seconds.
+       */
+      public Builder setSocketOptionLingerSeconds(Integer lingerSeconds) {
+        this.lingerSeconds = lingerSeconds;
+        return this;
+      }
+
+      public Builder addOption(String name, String value) {
+        others.put(name, value);
+        return this;
+      }
+
+      public Builder addOption(String name, int value) {
+        others.put(name, Integer.toString(value));
+        return this;
+      }
+
+      public Builder addOption(String name, boolean value) {
+        others.put(name, Boolean.toString(value));
+        return this;
+      }
+
+      public SocketOptions build() {
+        return new SocketOptions(timeoutMillis, lingerSeconds, others);
+      }
     }
   }
 

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -68,7 +68,7 @@ public class InProcessTransportTest extends AbstractTransportTest {
   @Test
   @Ignore
   @Override
-  public void socketStats_addresses() throws Exception {
+  public void socketStats() throws Exception {
     // test does not apply to in-process
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -323,6 +323,7 @@ class NettyClientTransport implements ConnectionClientTransport {
               transportTracer.getStats(),
               channel.localAddress(),
               channel.remoteAddress(),
+              Utils.getSocketOptions(channel),
               new Security()));
       return result;
     }
@@ -335,6 +336,7 @@ class NettyClientTransport implements ConnectionClientTransport {
                     transportTracer.getStats(),
                     channel.localAddress(),
                     channel.remoteAddress(),
+                    Utils.getSocketOptions(channel),
                     new Security()));
           }
         });

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -206,6 +206,7 @@ class NettyServerTransport implements ServerTransport {
               transportTracer.getStats(),
               channel.localAddress(),
               channel.remoteAddress(),
+              Utils.getSocketOptions(channel),
               /*security=*/ null));
       return result;
     }
@@ -218,6 +219,7 @@ class NettyServerTransport implements ServerTransport {
                     transportTracer.getStats(),
                     channel.localAddress(),
                     channel.remoteAddress(),
+                    Utils.getSocketOptions(channel),
                     /*security=*/ null));
           }
         });

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -232,8 +232,8 @@ class Utils {
         continue;
       }
       Object value = opt.getValue();
-      String valueStr = value != null ? value.toString() : "null";
-      b.addOption(key.name(), valueStr);
+      // zpencer: Can a netty option be null?
+      b.addOption(key.name(), String.valueOf(value));
     }
     return b.build();
   }

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -19,6 +19,8 @@ package io.grpc.netty;
 import static io.grpc.internal.GrpcUtil.CONTENT_TYPE_KEY;
 import static io.grpc.internal.TransportFrameUtil.toHttp2Headers;
 import static io.grpc.internal.TransportFrameUtil.toRawSerializedHeaders;
+import static io.netty.channel.ChannelOption.SO_LINGER;
+import static io.netty.channel.ChannelOption.SO_TIMEOUT;
 import static io.netty.util.CharsetUtil.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -26,9 +28,13 @@ import com.google.common.base.Preconditions;
 import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.internal.Channelz;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2InboundHeaders;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -38,6 +44,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -199,6 +206,36 @@ class Utils {
     public String toString() {
       return name;
     }
+  }
+
+  static Channelz.SocketOptions getSocketOptions(Channel channel) {
+    ChannelConfig config = channel.config();
+    Channelz.SocketOptions.Builder b = new Channelz.SocketOptions.Builder();
+
+    // The API allows returning null but not sure if it can happen in practice.
+    // Let's be paranoid and do null checking just in case.
+    Integer lingerSeconds = config.getOption(SO_LINGER);
+    if (lingerSeconds != null) {
+      b.setSocketOptionLingerSeconds(lingerSeconds);
+    }
+
+    Integer timeoutMillis = config.getOption(SO_TIMEOUT);
+    if (timeoutMillis != null) {
+      // in java, SO_TIMEOUT only applies to receiving
+      b.setSocketOptionTimeoutMillis(timeoutMillis);
+    }
+
+    for (Entry<ChannelOption<?>, Object> opt : config.getOptions().entrySet()) {
+      ChannelOption<?> key = opt.getKey();
+      // Constants are pooled, so there should only be one instance of each constant
+      if (key.equals(SO_LINGER) || key.equals(SO_TIMEOUT)) {
+        continue;
+      }
+      Object value = opt.getValue();
+      String valueStr = value != null ? value.toString() : "null";
+      b.addOption(key.name(), valueStr);
+    }
+    return b.build();
   }
 
   private Utils() {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -911,6 +911,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
           transportTracer.getStats(),
           socket.getLocalSocketAddress(),
           socket.getRemoteSocketAddress(),
+          Utils.getSocketOptions(socket),
           new Security()));
       return ret;
     }

--- a/okhttp/src/main/java/io/grpc/okhttp/Utils.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Utils.java
@@ -24,16 +24,18 @@ import io.grpc.internal.TransportFrameUtil;
 import io.grpc.okhttp.internal.CipherSuite;
 import io.grpc.okhttp.internal.ConnectionSpec;
 import io.grpc.okhttp.internal.framed.Header;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.net.Socket;
 import java.net.SocketException;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Common utility methods for OkHttp transport.
  */
 class Utils {
+  private static final Logger log = Logger.getLogger(Utils.class.getName());
+
   static final int DEFAULT_WINDOW_SIZE = 65535;
   static final int CONNECTION_STREAM_ID = 0;
 
@@ -87,71 +89,73 @@ class Utils {
   /**
    * Attempts to capture all known socket options and return the results as a
    * {@link Channelz.SocketOptions}. If getting a socket option threw an exception,
-   * log the error to the output object and move on to the next option.
+   * log the error to the logger and report the value as an error in the response.
    */
   static Channelz.SocketOptions getSocketOptions(Socket socket) {
     Channelz.SocketOptions.Builder builder = new Channelz.SocketOptions.Builder();
     try {
       builder.setSocketOptionLingerSeconds(socket.getSoLinger());
     } catch (SocketException e) {
-      builder.addOption("channelzerror:SO_LINGER", exceptionToString(e));
+      log.log(Level.SEVERE, "Exception caught while reading socket option", e);
+      builder.addOption("SO_LINGER", "channelz_internal_error");
     }
 
     try {
       builder.setSocketOptionTimeoutMillis(socket.getSoTimeout());
     } catch (Exception e) {
-      builder.addOption("channelzerror:SO_TIMEOUT", exceptionToString(e));
+      log.log(Level.SEVERE, "Exception caught while reading socket option", e);
+      builder.addOption("SO_TIMEOUT", "channelz_internal_error");
     }
 
     try {
       builder.addOption("TCP_NODELAY", socket.getTcpNoDelay());
     } catch (SocketException e) {
-      builder.addOption("channelzerror:TCP_NODELAY", exceptionToString(e));
+      log.log(Level.SEVERE, "Exception caught while reading socket option", e);
+      builder.addOption("TCP_NODELAY", "channelz_internal_error");
     }
 
     try {
       builder.addOption("SO_REUSEADDR", socket.getReuseAddress());
     } catch (SocketException e) {
-      builder.addOption("channelzerror:SO_REUSEADDR", exceptionToString(e));
+      log.log(Level.SEVERE, "Exception caught while reading socket option", e);
+      builder.addOption("SO_REUSEADDR", "channelz_internal_error");
     }
 
     try {
       builder.addOption("SO_SNDBUF", socket.getSendBufferSize());
     } catch (SocketException e) {
-      builder.addOption("channelzerror:SO_SNDBUF", exceptionToString(e));
+      log.log(Level.SEVERE, "Exception caught while reading socket option", e);
+      builder.addOption("SO_SNDBUF", "channelz_internal_error");
     }
 
     try {
       builder.addOption("SO_RECVBUF", socket.getReceiveBufferSize());
     } catch (SocketException e) {
-      builder.addOption("channelzerror:SO_RECVBUF", exceptionToString(e));
+      log.log(Level.SEVERE, "Exception caught while reading socket option", e);
+      builder.addOption("SO_RECVBUF", "channelz_internal_error");
     }
 
     try {
       builder.addOption("SO_KEEPALIVE", socket.getKeepAlive());
     } catch (SocketException e) {
-      builder.addOption("channelzerror:SO_KEEPALIVE", exceptionToString(e));
+      log.log(Level.SEVERE, "Exception caught while reading socket option", e);
+      builder.addOption("SO_KEEPALIVE", "channelz_internal_error");
     }
 
     try {
       builder.addOption("SO_OOBINLINE", socket.getOOBInline());
     } catch (SocketException e) {
-      builder.addOption("channelzerror:SO_OOBINLINE", exceptionToString(e));
+      log.log(Level.SEVERE, "Exception caught while reading socket option", e);
+      builder.addOption("SO_OOBINLINE", "channelz_internal_error");
     }
 
     try {
       builder.addOption("IP_TOS", socket.getTrafficClass());
     } catch (SocketException e) {
-      builder.addOption("channelzerror:IP_TOS", exceptionToString(e));
+      log.log(Level.SEVERE, "Exception caught while reading socket option", e);
+      builder.addOption("IP_TOS", "channelz_internal_error");
     }
     return builder.build();
-  }
-
-  private static String exceptionToString(Exception e) {
-    StringWriter sw = new StringWriter();
-    PrintWriter pw = new PrintWriter(sw);
-    e.printStackTrace(pw);
-    return sw.toString();
   }
 
   private Utils() {

--- a/okhttp/src/test/java/io/grpc/okhttp/UtilsTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/UtilsTest.java
@@ -19,9 +19,11 @@ package io.grpc.okhttp;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import io.grpc.internal.Channelz.SocketOptions;
 import io.grpc.okhttp.internal.CipherSuite;
 import io.grpc.okhttp.internal.ConnectionSpec;
 import io.grpc.okhttp.internal.TlsVersion;
+import java.net.Socket;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
@@ -68,5 +70,30 @@ public class UtilsTest {
     for (int i = 0; i < cipherSuitesSize; i++) {
       assertEquals(CipherSuite.forJavaName(squareCipherSuites.get(i).name()), cipherSuites.get(i));
     }
+  }
+
+  @Test
+  public void getSocketOptions() throws Exception {
+    Socket socket = new Socket();
+    socket.setSoLinger(true, 2);
+    socket.setSoTimeout(3);
+    socket.setTcpNoDelay(true);
+    socket.setReuseAddress(true);
+    socket.setReceiveBufferSize(4000);
+    socket.setSendBufferSize(5000);
+    socket.setKeepAlive(true);
+    socket.setOOBInline(true);
+    socket.setTrafficClass(8); // note: see javadoc for valid input values
+
+    SocketOptions socketOptions = Utils.getSocketOptions(socket);
+    assertEquals(2, (int) socketOptions.lingerSeconds);
+    assertEquals(3, (int) socketOptions.soTimeoutMillis);
+    assertEquals("true", socketOptions.others.get("TCP_NODELAY"));
+    assertEquals("true", socketOptions.others.get("SO_REUSEADDR"));
+    assertEquals("4000", socketOptions.others.get("SO_RECVBUF"));
+    assertEquals("5000", socketOptions.others.get("SO_SNDBUF"));
+    assertEquals("true", socketOptions.others.get("SO_KEEPALIVE"));
+    assertEquals("true", socketOptions.others.get("SO_OOBINLINE"));
+    assertEquals("8", socketOptions.others.get("IP_TOS"));
   }
 }

--- a/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
+++ b/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
@@ -19,6 +19,7 @@ package io.grpc.services;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.ConnectivityState;
+import io.grpc.internal.Channelz;
 import io.grpc.internal.Channelz.ChannelStats;
 import io.grpc.internal.Channelz.Security;
 import io.grpc.internal.Channelz.ServerStats;
@@ -54,12 +55,18 @@ final class ChannelzTestHelper {
         /*remoteFlowControlWindow=*/ 12);
     SocketAddress local = new InetSocketAddress("10.0.0.1", 1000);
     SocketAddress remote = new InetSocketAddress("10.0.0.2", 1000);
-
+    Channelz.SocketOptions socketOptions = new Channelz.SocketOptions.Builder().build();
 
     @Override
     public ListenableFuture<SocketStats> getStats() {
       SettableFuture<SocketStats> ret = SettableFuture.create();
-      ret.set(new SocketStats(transportStats, local, remote, new Security()));
+      ret.set(
+          new SocketStats(
+              transportStats,
+              local,
+              remote,
+              socketOptions,
+              new Security()));
       return ret;
     }
 

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -80,7 +80,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -1693,9 +1692,8 @@ public abstract class AbstractTransportTest {
     serverStream.close(Status.OK, new Metadata());
   }
 
-  @Ignore("hardcoding 127.0.0.1 fails in ipv6")
   @Test
-  public void socketStats_addresses() throws Exception {
+  public void socketStats() throws Exception {
     server.start(serverListener);
     ManagedClientTransport client = newClientTransport(server);
     startTransport(client, mockClientTransportListener);
@@ -1715,10 +1713,16 @@ public abstract class AbstractTransportTest {
     SocketStats clientSocketStats = client.getStats().get();
     assertEquals(clientAddress, clientSocketStats.local);
     assertEquals(serverAddress, clientSocketStats.remote);
+    // very basic sanity check that socket options are populated
+    assertNotNull(clientSocketStats.socketOptions.lingerSeconds);
+    assertTrue(clientSocketStats.socketOptions.others.containsKey("SO_SNDBUF"));
 
     SocketStats serverSocketStats = serverTransportListener.transport.getStats().get();
     assertEquals(serverAddress, serverSocketStats.local);
     assertEquals(clientAddress, serverSocketStats.remote);
+    // very basic sanity check that socket options are populated
+    assertNotNull(serverSocketStats.socketOptions.lingerSeconds);
+    assertTrue(serverSocketStats.socketOptions.others.containsKey("SO_SNDBUF"));
   }
 
   /**


### PR DESCRIPTION
For okhttp, expose the standard options from the Socket object.

For netty, expose all the `io.netty.channel.ChannelOption`s of the
`channel.config()`.