### PR TITLE
cronet: delay cast to ExperimentalCronetEngine

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -56,7 +56,7 @@ public final class CronetChannelBuilder extends
   /** Creates a new builder for the given server host, port and CronetEngine. */
   public static CronetChannelBuilder forAddress(String host, int port, CronetEngine cronetEngine) {
     Preconditions.checkNotNull(cronetEngine, "cronetEngine");
-    return new CronetChannelBuilder(host, port, (ExperimentalCronetEngine) cronetEngine);
+    return new CronetChannelBuilder(host, port, cronetEngine);
   }
 
   /**
@@ -73,7 +73,7 @@ public final class CronetChannelBuilder extends
     throw new UnsupportedOperationException("call forAddress(String, int, CronetEngine) instead");
   }
 
-  private final ExperimentalCronetEngine cronetEngine;
+  private final CronetEngine cronetEngine;
 
   private boolean alwaysUsePut = false;
 
@@ -84,7 +84,7 @@ public final class CronetChannelBuilder extends
   private boolean trafficStatsUidSet;
   private int trafficStatsUid;
 
-  private CronetChannelBuilder(String host, int port, ExperimentalCronetEngine cronetEngine) {
+  private CronetChannelBuilder(String host, int port, CronetEngine cronetEngine) {
     super(
         InetSocketAddress.createUnresolved(host, port),
         GrpcUtil.authorityFromHostAndPort(host, port));
@@ -224,14 +224,14 @@ public final class CronetChannelBuilder extends
    * StreamBuilderFactory impl that applies TrafficStats tags to stream builders that are produced.
    */
   private static class TaggingStreamFactory extends StreamBuilderFactory {
-    private final ExperimentalCronetEngine cronetEngine;
+    private final CronetEngine cronetEngine;
     private final boolean trafficStatsTagSet;
     private final int trafficStatsTag;
     private final boolean trafficStatsUidSet;
     private final int trafficStatsUid;
 
     TaggingStreamFactory(
-        ExperimentalCronetEngine cronetEngine,
+        CronetEngine cronetEngine,
         boolean trafficStatsTagSet,
         int trafficStatsTag,
         boolean trafficStatsUidSet,
@@ -247,9 +247,14 @@ public final class CronetChannelBuilder extends
     public BidirectionalStream.Builder newBidirectionalStreamBuilder(
         String url, BidirectionalStream.Callback callback, Executor executor) {
       ExperimentalBidirectionalStream.Builder builder =
-          cronetEngine.newBidirectionalStreamBuilder(url, callback, executor);
-      if (trafficStatsTagSet) builder.setTrafficStatsTag(trafficStatsTag);
-      if (trafficStatsUidSet) builder.setTrafficStatsUid(trafficStatsUid);
+          ((ExperimentalCronetEngine) cronetEngine)
+              .newBidirectionalStreamBuilder(url, callback, executor);
+      if (trafficStatsTagSet) {
+        builder.setTrafficStatsTag(trafficStatsTag);
+      }
+      if (trafficStatsUidSet) {
+        builder.setTrafficStatsUid(trafficStatsUid);
+      }
       return builder;
     }
   }


### PR DESCRIPTION
We actually require an `ExperimentalCronetEngine` to create any streams, but our API previously allowed any `CronetEngine` and delayed the cast until an RPC was created. https://github.com/grpc/grpc-java/pull/4208 moved the cast earlier, which broke some internal tests (using mocked CronetEngines) that never actually sent an RPC. We should adjust the API here to require an `ExperimentalCronetEngine` upfront, but this PR restores the delayed cast behavior to fix existing tests, until I have time to update the internal user's test code along with the API change.

cc @JensenPaul 