### PR TITLE
alts: Use Guava base16 decoding functions in tests

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -22,7 +22,8 @@ dependencies {
             project(':grpc-stub'),
             libraries.lang,
             libraries.protobuf
-    testCompile libraries.guava_testlib,
+    testCompile libraries.guava,
+                libraries.guava_testlib,
                 libraries.junit,
                 libraries.mockito,
                 libraries.truth

--- a/alts/src/test/java/io/grpc/alts/internal/AesGcmHkdfAeadCrypterTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AesGcmHkdfAeadCrypterTest.java
@@ -18,10 +18,10 @@ package io.grpc.alts.internal;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
+import com.google.common.io.BaseEncoding;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
-import javax.xml.bind.DatatypeConverter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -78,27 +78,27 @@ public final class AesGcmHkdfAeadCrypterTest {
     }
 
     TestVectorBuilder withKey(String key) {
-      this.key = DatatypeConverter.parseHexBinary(key);
+      this.key = BaseEncoding.base16().lowerCase().decode(key);
       return this;
     }
 
     TestVectorBuilder withNonce(String nonce) {
-      this.nonce = DatatypeConverter.parseHexBinary(nonce);
+      this.nonce = BaseEncoding.base16().lowerCase().decode(nonce);
       return this;
     }
 
     TestVectorBuilder withAad(String aad) {
-      this.aad = DatatypeConverter.parseHexBinary(aad);
+      this.aad = BaseEncoding.base16().lowerCase().decode(aad);
       return this;
     }
 
     TestVectorBuilder withPlaintext(String plaintext) {
-      this.plaintext = DatatypeConverter.parseHexBinary(plaintext);
+      this.plaintext = BaseEncoding.base16().lowerCase().decode(plaintext);
       return this;
     }
 
     TestVectorBuilder withCiphertext(String ciphertext) {
-      this.ciphertext = DatatypeConverter.parseHexBinary(ciphertext);
+      this.ciphertext = BaseEncoding.base16().lowerCase().decode(ciphertext);
       return this;
     }
   }


### PR DESCRIPTION
The previously used javax.xml.bind.DatatypeConverter is deprecated in
Java 9.