### PR TITLE
 grpclb: Cache Subchannels for 10 seconds after it is removed from the backendlist

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/CachedSubchannelPool.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/CachedSubchannelPool.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.grpclb;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.Subchannel;
+import java.util.HashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link SubchannelPool} that keeps returned {@link Subchannel}s for a given time before it's
+ * shut down by the pool.
+ */
+final class CachedSubchannelPool implements SubchannelPool {
+  private final HashMap<EquivalentAddressGroup, CacheEntry> cache =
+      new HashMap<EquivalentAddressGroup, CacheEntry>();
+
+  private Helper helper;
+  private ScheduledExecutorService timerService;
+
+  @VisibleForTesting
+  static final long SHUTDOWN_TIMEOUT_MS = 10000;
+
+  @Override
+  public void init(Helper helper, ScheduledExecutorService timerService) {
+    this.helper = checkNotNull(helper, "helper");
+    this.timerService = checkNotNull(timerService, "timerService");
+  }
+
+  @Override
+  public Subchannel takeOrCreateSubchannel(
+      EquivalentAddressGroup eag, Attributes defaultAttributes) {
+    CacheEntry entry = cache.remove(eag);
+    Subchannel subchannel;
+    if (entry == null) {
+      subchannel = helper.createSubchannel(eag, defaultAttributes);
+    } else {
+      subchannel = entry.subchannel;
+      entry.shutdownTimer.cancel(false);
+    }
+    return subchannel;
+  }
+
+  @Override
+  public void returnSubchannel(Subchannel subchannel) {
+    CacheEntry prev = cache.get(subchannel.getAddresses());
+    if (prev != null && prev.subchannel != subchannel) {
+      subchannel.shutdown();
+      return;
+    }
+    final ShutdownSubchannelTask shutdownTask = new ShutdownSubchannelTask(subchannel);
+    ScheduledFuture<?> shutdownTimer =
+        timerService.schedule(
+            new Runnable() {
+              @Override
+              public void run() {
+                helper.runSerialized(shutdownTask);
+              }
+            },
+            SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    shutdownTask.timer = shutdownTimer;
+    CacheEntry entry = new CacheEntry(subchannel, shutdownTimer);
+    cache.put(subchannel.getAddresses(), entry);
+  }
+
+  @Override
+  public void clear() {
+    for (CacheEntry entry : cache.values()) {
+      entry.shutdownTimer.cancel(false);
+      entry.subchannel.shutdown();
+    }
+    cache.clear();
+  }
+
+  @VisibleForTesting
+  class ShutdownSubchannelTask implements Runnable {
+    private final Subchannel subchannel;
+    private ScheduledFuture<?> timer;
+
+    private ShutdownSubchannelTask(Subchannel subchannel) {
+      this.subchannel = checkNotNull(subchannel, "subchannel");
+    }
+
+    // This runs in channelExecutor
+    @Override
+    public void run() {
+      // getSubchannel() may have cancelled the timer after the timer has expired but before this
+      // task is actually run in the channelExecutor.
+      if (!timer.isCancelled()) {
+        CacheEntry entry = cache.remove(subchannel.getAddresses());
+        checkState(entry.subchannel == subchannel, "Inconsistent state");
+        subchannel.shutdown();
+      }
+    }
+  }
+
+  private static class CacheEntry {
+    final Subchannel subchannel;
+    final ScheduledFuture<?> shutdownTimer;
+
+    CacheEntry(Subchannel subchannel, ScheduledFuture<?> shutdownTimer) {
+      this.subchannel = checkNotNull(subchannel, "subchannel");
+      this.shutdownTimer = checkNotNull(shutdownTimer, "shutdownTimer");
+    }
+  }
+}

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerFactory.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerFactory.java
@@ -50,7 +50,7 @@ public class GrpclbLoadBalancerFactory extends LoadBalancer.Factory {
   @Override
   public LoadBalancer newLoadBalancer(LoadBalancer.Helper helper) {
     return new GrpclbLoadBalancer(
-        helper, PickFirstBalancerFactory.getInstance(),
+        helper, new CachedSubchannelPool(), PickFirstBalancerFactory.getInstance(),
         RoundRobinLoadBalancerFactory.getInstance(),
         // TODO(zhangkun83): balancer sends load reporting RPCs from it, which also involves
         // channelExecutor thus may also run other tasks queued in the channelExecutor.  If such

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -58,7 +58,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -103,9 +102,6 @@ final class GrpclbState {
   private static final Attributes.Key<AtomicReference<ConnectivityStateInfo>> STATE_INFO =
       Attributes.Key.of("io.grpc.grpclb.GrpclbLoadBalancer.stateInfo");
 
-  private static final Attributes.Key<AtomicLong> USAGE =
-      Attributes.Key.of("io.grpc.grpclb.GrpclbLoadBalancer.usage");
-
   // Scheduled only once.  Never reset.
   @Nullable
   private FallbackModeTask fallbackTimer;
@@ -121,8 +117,6 @@ final class GrpclbState {
   @Nullable
   private LbStream lbStream;
   private Map<EquivalentAddressGroup, Subchannel> subchannels = Collections.emptyMap();
-
-  private boolean isShutdown;
 
   // Has the same size as the round-robin list from the balancer.
   // A drop entry from the round-robin list becomes a DropEntry here.
@@ -286,7 +280,6 @@ final class GrpclbState {
   }
 
   void shutdown() {
-    isShutdown = true;
     shutdownLbComm();
     // We close the subchannels through subchannelPool instead of helper just for convenience of
     // testing.
@@ -336,7 +329,6 @@ final class GrpclbState {
               .set(STATE_INFO,
                   new AtomicReference<ConnectivityStateInfo>(
                       ConnectivityStateInfo.forNonError(IDLE)))
-              .set(USAGE, new AtomicLong())
               .build();
           subchannel = subchannelPool.takeOrCreateSubchannel(eag, subchannelAttrs);
           subchannel.requestConnection();
@@ -647,11 +639,6 @@ final class GrpclbState {
     if (picker.dropList.equals(currentPicker.dropList)
         && picker.pickList.equals(currentPicker.pickList)) {
       return;
-    }
-    StringBuilder buffer = new StringBuilder();
-    for (DropEntry drop : picker.dropList) {
-      buffer.append(" ");
-      buffer.append(drop != null);
     }
     // No need to skip ErrorPicker. If the current picker is ErrorPicker, there won't be any pending
     // stream thus no time is wasted in re-process.

--- a/grpclb/src/main/java/io/grpc/grpclb/SubchannelPool.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/SubchannelPool.java
@@ -43,7 +43,8 @@ interface SubchannelPool {
   Subchannel takeOrCreateSubchannel(EquivalentAddressGroup eag, Attributes defaultAttributes);
 
   /**
-   * Returns a {@link Subchannel} to the pool.
+   * Puts a {@link Subchannel} back to the pool.  From this point the Subchannel is owned by the
+   * pool.
    */
   void returnSubchannel(Subchannel subchannel);
 

--- a/grpclb/src/main/java/io/grpc/grpclb/SubchannelPool.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/SubchannelPool.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.grpclb;
+
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.Subchannel;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Manages life-cycle of Subchannels for {@link GrpclbState}.
+ *
+ * <p>All methods are run from the ChannelExecutor that the helper uses.
+ */
+@NotThreadSafe
+interface SubchannelPool {
+  /**
+   * Pass essential utilities.
+   */
+  void init(Helper helper, ScheduledExecutorService timerService);
+
+  /**
+   * Takes a {@link Subchannel} from the pool for the given {@code eag} if there is one available.
+   * Otherwise, creates and returns a new {@code Subchannel} with the given {@code eag} and {@code
+   * defaultAttributes}.
+   */
+  Subchannel takeOrCreateSubchannel(EquivalentAddressGroup eag, Attributes defaultAttributes);
+
+  /**
+   * Returns a {@link Subchannel} to the pool.
+   */
+  void returnSubchannel(Subchannel subchannel);
+
+  /**
+   * Shuts down all subchannels in the pool immediately.
+   */
+  void clear();
+}

--- a/grpclb/src/test/java/io/grpc/grpclb/CachedSubchannelPoolTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/CachedSubchannelPoolTest.java
@@ -34,6 +34,7 @@ import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.Subchannel;
+import io.grpc.grpclb.CachedSubchannelPool.ShutdownSubchannelScheduledTask;
 import io.grpc.grpclb.CachedSubchannelPool.ShutdownSubchannelTask;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.SerializingExecutor;
@@ -56,6 +57,13 @@ public class CachedSubchannelPoolTest {
   private static final Attributes.Key<String> ATTR_KEY = Attributes.Key.of("test-attr");
   private static final Attributes ATTRS1 = Attributes.newBuilder().set(ATTR_KEY, "1").build();
   private static final Attributes ATTRS2 = Attributes.newBuilder().set(ATTR_KEY, "2").build();
+  private static final FakeClock.TaskFilter SHUTDOWN_SCHEDULED_TASK_FILTER =
+      new FakeClock.TaskFilter() {
+        @Override
+        public boolean shouldAccept(Runnable command) {
+          return command instanceof ShutdownSubchannelScheduledTask;
+        }
+      };
 
   private final SerializingExecutor channelExecutor =
       new SerializingExecutor(MoreExecutors.directExecutor());
@@ -179,17 +187,22 @@ public class CachedSubchannelPoolTest {
     Subchannel subchannel3 = pool.takeOrCreateSubchannel(EAG2, ATTRS1);
     assertThat(subchannel1).isNotSameAs(subchannel2);
 
+    assertThat(clock.getPendingTasks(SHUTDOWN_SCHEDULED_TASK_FILTER)).isEmpty();
     pool.returnSubchannel(subchannel2);
+    assertThat(clock.getPendingTasks(SHUTDOWN_SCHEDULED_TASK_FILTER)).hasSize(1);
 
     // If the subchannel being returned has an address that is the same as a subchannel in the pool,
     // the returned subchannel will be shut down.
     verify(subchannel1, never()).shutdown();
     pool.returnSubchannel(subchannel1);
+    assertThat(clock.getPendingTasks(SHUTDOWN_SCHEDULED_TASK_FILTER)).hasSize(1);
     verify(subchannel1).shutdown();
 
     pool.returnSubchannel(subchannel3);
+    assertThat(clock.getPendingTasks(SHUTDOWN_SCHEDULED_TASK_FILTER)).hasSize(2);
     // Returning the same subchannel twice has no effect.
     pool.returnSubchannel(subchannel3);
+    assertThat(clock.getPendingTasks(SHUTDOWN_SCHEDULED_TASK_FILTER)).hasSize(2);
 
     verify(subchannel2, never()).shutdown();
     verify(subchannel3, never()).shutdown();

--- a/grpclb/src/test/java/io/grpc/grpclb/CachedSubchannelPoolTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/CachedSubchannelPoolTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.grpclb;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.grpclb.CachedSubchannelPool.SHUTDOWN_TIMEOUT_MS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.Subchannel;
+import io.grpc.grpclb.CachedSubchannelPool.ShutdownSubchannelTask;
+import io.grpc.internal.FakeClock;
+import io.grpc.internal.SerializingExecutor;
+import java.util.ArrayList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/** Unit tests for {@link CachedSubchannelPool}. */
+@RunWith(JUnit4.class)
+public class CachedSubchannelPoolTest {
+  private static final EquivalentAddressGroup EAG1 =
+      new EquivalentAddressGroup(new FakeSocketAddress("fake-address-1"), Attributes.EMPTY);
+  private static final EquivalentAddressGroup EAG2 =
+      new EquivalentAddressGroup(new FakeSocketAddress("fake-address-2"), Attributes.EMPTY);
+  private static final Attributes.Key<String> ATTR_KEY = Attributes.Key.of("test-attr");
+  private static final Attributes ATTRS1 = Attributes.newBuilder().set(ATTR_KEY, "1").build();
+  private static final Attributes ATTRS2 = Attributes.newBuilder().set(ATTR_KEY, "2").build();
+
+  private final SerializingExecutor channelExecutor =
+      new SerializingExecutor(MoreExecutors.directExecutor());
+  private final Helper helper = mock(Helper.class);
+  private final FakeClock clock = new FakeClock();
+  private final CachedSubchannelPool pool = new CachedSubchannelPool();
+  private final ArrayList<Subchannel> mockSubchannels = new ArrayList<Subchannel>();
+
+  @Before
+  public void setUp() {
+    doAnswer(new Answer<Subchannel>() {
+        @Override
+        public Subchannel answer(InvocationOnMock invocation) throws Throwable {
+          Subchannel subchannel = mock(Subchannel.class);
+          EquivalentAddressGroup eag = (EquivalentAddressGroup) invocation.getArguments()[0];
+          Attributes attrs = (Attributes) invocation.getArguments()[1];
+          when(subchannel.getAddresses()).thenReturn(eag);
+          when(subchannel.getAttributes()).thenReturn(attrs);
+          mockSubchannels.add(subchannel);
+          return subchannel;
+        }
+      }).when(helper).createSubchannel(any(EquivalentAddressGroup.class), any(Attributes.class));
+    doAnswer(new Answer<Void>() {
+        @Override
+        public Void answer(InvocationOnMock invocation) throws Throwable {
+          Runnable task = (Runnable) invocation.getArguments()[0];
+          channelExecutor.execute(task);
+          return null;
+        }
+      }).when(helper).runSerialized(any(Runnable.class));
+    pool.init(helper, clock.getScheduledExecutorService());
+  }
+
+  @After
+  public void wrapUp() {
+    // Sanity checks
+    for (Subchannel subchannel : mockSubchannels) {
+      verify(subchannel, atMost(1)).shutdown();
+    }
+  }
+
+  @Test
+  public void subchannelExpireAfterReturned() {
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
+    assertThat(subchannel1).isNotNull();
+    verify(helper).createSubchannel(same(EAG1), same(ATTRS1));
+
+    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
+    assertThat(subchannel2).isNotNull();
+    assertThat(subchannel2).isNotSameAs(subchannel1);
+    verify(helper).createSubchannel(same(EAG2), same(ATTRS2));
+
+    pool.returnSubchannel(subchannel1);
+
+    // subchannel1 is 1ms away from expiration.
+    clock.forwardTime(SHUTDOWN_TIMEOUT_MS - 1, MILLISECONDS);
+    verify(subchannel1, never()).shutdown();
+
+    pool.returnSubchannel(subchannel2);
+
+    // subchannel1 expires. subchannel2 is (SHUTDOWN_TIMEOUT_MS - 1) away from expiration.
+    clock.forwardTime(1, MILLISECONDS);
+    verify(subchannel1).shutdown();
+
+    // subchanne2 expires.
+    clock.forwardTime(SHUTDOWN_TIMEOUT_MS - 1, MILLISECONDS);
+    verify(subchannel2).shutdown();
+
+    assertThat(clock.numPendingTasks()).isEqualTo(0);
+    verify(helper, times(2)).runSerialized(any(ShutdownSubchannelTask.class));
+  }
+
+  @Test
+  public void subchannelReused() {
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
+    assertThat(subchannel1).isNotNull();
+    verify(helper).createSubchannel(same(EAG1), same(ATTRS1));
+
+    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
+    assertThat(subchannel2).isNotNull();
+    assertThat(subchannel2).isNotSameAs(subchannel1);
+    verify(helper).createSubchannel(same(EAG2), same(ATTRS2));
+
+    pool.returnSubchannel(subchannel1);
+
+    // subchannel1 is 1ms away from expiration.
+    clock.forwardTime(SHUTDOWN_TIMEOUT_MS - 1, MILLISECONDS);
+
+    // This will cancel the shutdown timer for subchannel1
+    Subchannel subchannel1a = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
+    assertThat(subchannel1a).isSameAs(subchannel1);
+
+    pool.returnSubchannel(subchannel2);
+
+    // subchannel2 expires SHUTDOWN_TIMEOUT_MS after being returned
+    clock.forwardTime(SHUTDOWN_TIMEOUT_MS - 1, MILLISECONDS);
+    verify(subchannel2, never()).shutdown();
+    clock.forwardTime(1, MILLISECONDS);
+    verify(subchannel2).shutdown();
+
+    // pool will create a new channel for EAG2 when requested
+    Subchannel subchannel2a = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
+    assertThat(subchannel2a).isNotSameAs(subchannel2);
+    verify(helper, times(2)).createSubchannel(same(EAG2), same(ATTRS2));
+
+    // subchannel1 expires SHUTDOWN_TIMEOUT_MS after being returned
+    pool.returnSubchannel(subchannel1a);
+    clock.forwardTime(SHUTDOWN_TIMEOUT_MS - 1, MILLISECONDS);
+    verify(subchannel1a, never()).shutdown();
+    clock.forwardTime(1, MILLISECONDS);
+    verify(subchannel1a).shutdown();
+
+    assertThat(clock.numPendingTasks()).isEqualTo(0);
+    verify(helper, times(2)).runSerialized(any(ShutdownSubchannelTask.class));
+  }
+
+  @Test
+  public void returnDuplicateAddressSubchannel() {
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
+    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG1, ATTRS2);
+    Subchannel subchannel3 = pool.takeOrCreateSubchannel(EAG2, ATTRS1);
+    assertThat(subchannel1).isNotSameAs(subchannel2);
+
+    pool.returnSubchannel(subchannel2);
+
+    // If the subchannel being returned has an address that is the same as a subchannel in the pool,
+    // the returned subchannel will be shut down.
+    verify(subchannel1, never()).shutdown();
+    pool.returnSubchannel(subchannel1);
+    verify(subchannel1).shutdown();
+
+    pool.returnSubchannel(subchannel3);
+    // Returning the same subchannel twice has no effect.
+    pool.returnSubchannel(subchannel3);
+
+    verify(subchannel2, never()).shutdown();
+    verify(subchannel3, never()).shutdown();
+    verify(helper, never()).runSerialized(any(ShutdownSubchannelTask.class));
+  }
+
+  @Test
+  public void clear() {
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
+    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
+    Subchannel subchannel3 = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
+
+    pool.returnSubchannel(subchannel1);
+    pool.returnSubchannel(subchannel2);
+
+    verify(subchannel1, never()).shutdown();
+    verify(subchannel2, never()).shutdown();
+    pool.clear();
+    verify(subchannel1).shutdown();
+    verify(subchannel2).shutdown();
+
+    verify(subchannel3, never()).shutdown();
+    assertThat(clock.numPendingTasks()).isEqualTo(0);
+    verify(helper, never()).runSerialized(any(ShutdownSubchannelTask.class));
+  }
+}

--- a/grpclb/src/test/java/io/grpc/grpclb/FakeSocketAddress.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/FakeSocketAddress.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.grpclb;
+
+import java.net.SocketAddress;
+
+final class FakeSocketAddress extends SocketAddress {
+  final String name;
+
+  FakeSocketAddress(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "FakeSocketAddress-" + name;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof FakeSocketAddress) {
+      FakeSocketAddress otherAddr = (FakeSocketAddress) other;
+      return name.equals(otherAddr.name);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+}


### PR DESCRIPTION
This is to conform with the GRPCLB spec. The spec doesn't (yet) define
the actual timeout. We choose 10 seconds here arbitrarily.  It may be
configurable in the future.

This will fix internal bug b/74410243

@slash-lib 