### PR TITLE
core: re-enable panic mode after all affected internal tests have been fixed.

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -119,11 +119,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
       @Override
       void handleUncaughtThrowable(Throwable t) {
         super.handleUncaughtThrowable(t);
-        // Disabled because it breaks some tests, as it detects pre-existing issues.
-        // See #3293
-        if (false) {
-          panic(t);
-        }
+        panic(t);
       }
     };
 


### PR DESCRIPTION
Resolves #3293