### PR TITLE
benchmarks: Modernize TLS configuration

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -72,7 +72,6 @@ task openloop_client(type: CreateStartScripts) {
 task qps_server(type: CreateStartScripts) {
     mainClassName = "io.grpc.benchmarks.qps.AsyncServer"
     applicationName = "qps_server"
-    defaultJvmOpts = ["-javaagent:" + configurations.alpnagent.asPath] + vmArgs
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
 }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
@@ -88,7 +88,6 @@ class LoadClient {
               config.hasSecurityParams()
                   ? config.getSecurityParams().getServerHostOverride()
                   : null,
-              true,
               Utils.DEFAULT_FLOW_CONTROL_WINDOW,
               false);
     }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
@@ -32,7 +32,6 @@ import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.STREAMING_R
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TESTCA;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TLS;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TRANSPORT;
-import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.USE_DEFAULT_CIPHERS;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.WARMUP_DURATION;
 
 import com.google.common.base.Preconditions;
@@ -308,7 +307,7 @@ public class AsyncClient {
   public static void main(String... args) throws Exception {
     ClientConfiguration.Builder configBuilder = ClientConfiguration.newBuilder(
         ADDRESS, CHANNELS, OUTSTANDING_RPCS, CLIENT_PAYLOAD, SERVER_PAYLOAD,
-        TLS, TESTCA, USE_DEFAULT_CIPHERS, TRANSPORT, DURATION, WARMUP_DURATION, DIRECTEXECUTOR,
+        TLS, TESTCA, TRANSPORT, DURATION, WARMUP_DURATION, DIRECTEXECUTOR,
         SAVE_HISTOGRAM, STREAMING_RPCS, FLOW_CONTROL_WINDOW);
     ClientConfiguration config;
     try {

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ClientConfiguration.java
@@ -67,7 +67,7 @@ public class ClientConfiguration implements Configuration {
 
   public ManagedChannel newChannel() throws IOException {
     return Utils.newClientChannel(transport, address, tls, testca, authorityOverride,
-        useDefaultCiphers, flowControlWindow, directExecutor);
+        flowControlWindow, directExecutor);
   }
 
   public Messages.SimpleRequest newRequest() {
@@ -174,13 +174,6 @@ public class ClientConfiguration implements Configuration {
       @Override
       protected void setClientValue(ClientConfiguration config, String value) {
         config.testca = parseBoolean(value);
-      }
-    },
-    USE_DEFAULT_CIPHERS("", "Use the default JDK ciphers for TLS (Used to support Java 7).",
-            "" + DEFAULT.useDefaultCiphers) {
-      @Override
-      protected void setClientValue(ClientConfiguration config, String value) {
-        config.useDefaultCiphers = parseBoolean(value);
       }
     },
     TRANSPORT("STR", Transport.getDescriptionString(), DEFAULT.transport.name().toLowerCase()) {

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
@@ -30,7 +30,6 @@ import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TARGET_QPS;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TESTCA;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TLS;
 import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.TRANSPORT;
-import static io.grpc.benchmarks.qps.ClientConfiguration.ClientParam.USE_DEFAULT_CIPHERS;
 
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
@@ -66,7 +65,7 @@ public class OpenLoopClient {
   public static void main(String... args) throws Exception {
     ClientConfiguration.Builder configBuilder = ClientConfiguration.newBuilder(
         ADDRESS, TARGET_QPS, CLIENT_PAYLOAD, SERVER_PAYLOAD, TLS,
-        TESTCA, USE_DEFAULT_CIPHERS, TRANSPORT, DURATION, SAVE_HISTOGRAM, FLOW_CONTROL_WINDOW);
+        TESTCA, TRANSPORT, DURATION, SAVE_HISTOGRAM, FLOW_CONTROL_WINDOW);
     ClientConfiguration config;
     try {
       config = configBuilder.build(args);

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/ServerConfiguration.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/ServerConfiguration.java
@@ -38,7 +38,6 @@ class ServerConfiguration implements Configuration {
 
   Transport transport = Transport.NETTY_NIO;
   boolean tls;
-  boolean useDefaultCiphers;
   boolean directExecutor;
   SocketAddress address;
   int flowControlWindow = NettyChannelBuilder.DEFAULT_FLOW_CONTROL_WINDOW;
@@ -157,13 +156,6 @@ class ServerConfiguration implements Configuration {
       @Override
       protected void setServerValue(ServerConfiguration config, String value) {
         config.tls = parseBoolean(value);
-      }
-    },
-    USE_DEFAULT_CIPHERS("", "Use the default JDK ciphers for TLS (Used to support Java 7).",
-            "false") {
-      @Override
-      protected void setServerValue(ServerConfiguration config, String value) {
-        config.useDefaultCiphers = parseBoolean(value);
       }
     },
     TRANSPORT("STR", Transport.getDescriptionString(), DEFAULT.transport.name().toLowerCase()) {


### PR DESCRIPTION
NIO does not mean to use Jetty ALPN; the only reason to use Jetty ALPN
is to test OkHttp. We don't need to disable ciphers to test Java 7
(except for OkHttp, which we don't care about on Java 7 and it wasn't
plumbed already) and we _really_ don't want people to copy the code to
do so. useTransportSecurity()/usePlaintext() are preferred over the
transport-specific NegotiationType.

Fixes #4223