### PR TITLE
buildscripts: build windows artifacts in kokoro

### DIFF
--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -17,53 +17,8 @@ set ESCWORKSPACE=%WORKSPACE:\=\\%
 set JAVA_HOME=
 set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
 
-mkdir grpc-java-helper32
-cd grpc-java-helper32
-call "%VS120COMNTOOLS%\vsvars32.bat" || exit /b 1
-call "%WORKSPACE%\buildscripts\make_dependencies.bat" || exit /b 1
-
-cd "%WORKSPACE%"
-
-SET TARGET_ARCH=x86_32
-SET FAIL_ON_WARNINGS=true
-SET VC_PROTOBUF_LIBS=%ESCWORKSPACE%\\grpc-java-helper32\\protobuf-%PROTOBUF_VER%\\cmake\\build\\Release
-SET VC_PROTOBUF_INCLUDE=%ESCWORKSPACE%\\grpc-java-helper32\\protobuf-%PROTOBUF_VER%\\cmake\\build\\include
-SET GRADLE_FLAGS=-PtargetArch=%TARGET_ARCH% -PfailOnWarnings=%FAIL_ON_WARNINGS% -PvcProtobufLibs=%VC_PROTOBUF_LIBS% -PvcProtobufInclude=%VC_PROTOBUF_INCLUDE%
-
-cmd.exe /C "%WORKSPACE%\gradlew.bat %GRADLE_FLAGS% build"
-set GRADLEEXIT=%ERRORLEVEL%
-
-@rem Rename test results .xml files to format parsable by Kokoro
-@echo off
-for /r %%F in (TEST-*.xml) do (
-  mkdir "%%~dpnF"
-  move "%%F" "%%~dpnF\sponge_log.xml" >NUL
-)
-@echo on
-
-IF NOT %GRADLEEXIT% == 0 (
-  exit /b %GRADLEEXIT%
-)
-
-@rem make sure no daemons have any files open
-cmd.exe /C "%WORKSPACE%\gradlew.bat --stop"
-
-cmd.exe /C "%WORKSPACE%\gradlew.bat  %GRADLE_FLAGS% -Dorg.gradle.parallel=false -PrepositoryDir=%WORKSPACE%\artifacts\x86_32\ clean grpc-compiler:build grpc-compiler:uploadArchives" || exit /b 1
-
-mkdir grpc-java-helper64
-cd grpc-java-helper64
-call "%VS120COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat" || exit /b 1
-call "%WORKSPACE%\buildscripts\make_dependencies.bat" || exit /b 1
-
-cd "%WORKSPACE%"
-
-SET TARGET_ARCH=x86_64
-SET FAIL_ON_WARNINGS=true
-SET VC_PROTOBUF_LIBS=%ESCWORKSPACE%\\grpc-java-helper64\\protobuf-%PROTOBUF_VER%\\cmake\\build\\Release
-SET VC_PROTOBUF_INCLUDE=%ESCWORKSPACE%\\grpc-java-helper64\\protobuf-%PROTOBUF_VER%\\cmake\\build\\include
-SET GRADLE_FLAGS=-PtargetArch=%TARGET_ARCH% -PfailOnWarnings=%FAIL_ON_WARNINGS% -PvcProtobufLibs=%VC_PROTOBUF_LIBS% -PvcProtobufInclude=%VC_PROTOBUF_INCLUDE%
-
-cmd.exe /C "%WORKSPACE%\gradlew.bat  %GRADLE_FLAGS% -Dorg.gradle.parallel=false -PrepositoryDir=%WORKSPACE%\artifacts\x86_64\ clean grpc-compiler:build grpc-compiler:uploadArchives" || exit /b 1
+cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\win32.bat" || exit /b 1
+cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\win64.bat" || exit /b 1
 
 IF DEFINED MVN_ARTIFACTS (
   mkdir mvn-artifacts

--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -17,8 +17,8 @@ set ESCWORKSPACE=%WORKSPACE:\=\\%
 set JAVA_HOME=
 set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
 
-cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\win32.bat" || exit /b 1
-cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\win64.bat" || exit /b 1
+cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\windows32.bat" || exit /b 1
+cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\windows64.bat" || exit /b 1
 
 IF DEFINED MVN_ARTIFACTS (
   mkdir mvn-artifacts

--- a/buildscripts/kokoro/windows.cfg
+++ b/buildscripts/kokoro/windows.cfg
@@ -5,6 +5,6 @@ build_file: "grpc-java/buildscripts/kokoro/windows.bat"
 timeout_mins: 45
 action {
   define_artifacts {
-    regex: "**/build/test-results/**/*.xml"
+    regex: ["**/build/test-results/**/*.xml", "**/mvn-artifacts/**"]
   }
 }

--- a/buildscripts/kokoro/windows32.bat
+++ b/buildscripts/kokoro/windows32.bat
@@ -1,0 +1,51 @@
+@rem ##########################################################################
+@rem
+@rem Runs tests and then builds artifacts to %WORKSPACE%\artifacts\
+@rem
+@rem ##########################################################################
+
+type c:\VERSION
+
+@rem Enter repo root
+cd /d %~dp0\..\..
+
+set WORKSPACE=T:\src\github\grpc-java
+set ESCWORKSPACE=%WORKSPACE:\=\\%
+
+
+@rem Clear JAVA_HOME to prevent a different Java version from being used
+set JAVA_HOME=
+set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
+
+mkdir grpc-java-helper32
+cd grpc-java-helper32
+call "%VS120COMNTOOLS%\vsvars32.bat" || exit /b 1
+call "%WORKSPACE%\buildscripts\make_dependencies.bat" || exit /b 1
+
+cd "%WORKSPACE%"
+
+SET TARGET_ARCH=x86_32
+SET FAIL_ON_WARNINGS=true
+SET VC_PROTOBUF_LIBS=%ESCWORKSPACE%\\grpc-java-helper32\\protobuf-%PROTOBUF_VER%\\cmake\\build\\Release
+SET VC_PROTOBUF_INCLUDE=%ESCWORKSPACE%\\grpc-java-helper32\\protobuf-%PROTOBUF_VER%\\cmake\\build\\include
+SET GRADLE_FLAGS=-PtargetArch=%TARGET_ARCH% -PfailOnWarnings=%FAIL_ON_WARNINGS% -PvcProtobufLibs=%VC_PROTOBUF_LIBS% -PvcProtobufInclude=%VC_PROTOBUF_INCLUDE%
+
+cmd.exe /C "%WORKSPACE%\gradlew.bat %GRADLE_FLAGS% build"
+set GRADLEEXIT=%ERRORLEVEL%
+
+@rem Rename test results .xml files to format parsable by Kokoro
+@echo off
+for /r %%F in (TEST-*.xml) do (
+  mkdir "%%~dpnF"
+  move "%%F" "%%~dpnF\sponge_log.xml" >NUL
+)
+@echo on
+
+IF NOT %GRADLEEXIT% == 0 (
+  exit /b %GRADLEEXIT%
+)
+
+@rem make sure no daemons have any files open
+cmd.exe /C "%WORKSPACE%\gradlew.bat --stop"
+
+cmd.exe /C "%WORKSPACE%\gradlew.bat  %GRADLE_FLAGS% -Dorg.gradle.parallel=false -PrepositoryDir=%WORKSPACE%\artifacts\x86_32\ clean grpc-compiler:build grpc-compiler:uploadArchives" || exit /b 1

--- a/buildscripts/kokoro/windows64.bat
+++ b/buildscripts/kokoro/windows64.bat
@@ -1,0 +1,35 @@
+@rem ##########################################################################
+@rem
+@rem Builds artifacts for x86_64 into %WORKSPACE%\artifacts\
+@rem
+@rem ##########################################################################
+
+type c:\VERSION
+
+@rem Enter repo root
+cd /d %~dp0\..\..
+
+set WORKSPACE=T:\src\github\grpc-java
+set ESCWORKSPACE=%WORKSPACE:\=\\%
+
+@rem Clear JAVA_HOME to prevent a different Java version from being used
+set JAVA_HOME=
+set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
+
+mkdir grpc-java-helper64
+cd grpc-java-helper64
+call "%VS120COMNTOOLS%\..\..\VC\bin\amd64\vcvars64.bat" || exit /b 1
+call "%WORKSPACE%\buildscripts\make_dependencies.bat" || exit /b 1
+
+cd "%WORKSPACE%"
+
+SET TARGET_ARCH=x86_64
+SET FAIL_ON_WARNINGS=true
+SET VC_PROTOBUF_LIBS=%ESCWORKSPACE%\\grpc-java-helper64\\protobuf-%PROTOBUF_VER%\\cmake\\build\\Release
+SET VC_PROTOBUF_INCLUDE=%ESCWORKSPACE%\\grpc-java-helper64\\protobuf-%PROTOBUF_VER%\\cmake\\build\\include
+SET GRADLE_FLAGS=-PtargetArch=%TARGET_ARCH% -PfailOnWarnings=%FAIL_ON_WARNINGS% -PvcProtobufLibs=%VC_PROTOBUF_LIBS% -PvcProtobufInclude=%VC_PROTOBUF_INCLUDE%
+
+@rem make sure no daemons have any files open
+cmd.exe /C "%WORKSPACE%\gradlew.bat --stop"
+
+cmd.exe /C "%WORKSPACE%\gradlew.bat  %GRADLE_FLAGS% -Dorg.gradle.parallel=false -PrepositoryDir=%WORKSPACE%\artifacts\x86_64\ clean grpc-compiler:build grpc-compiler:uploadArchives" || exit /b 1

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -32,6 +32,8 @@ cd build
 if "%PLATFORM%" == "X64" (
   @rem Note the space
   SET CMAKE_VSARCH= Win64
+) else (
+  SET CMAKE_VSARCH=
 )
 cmake -Dprotobuf_BUILD_TESTS=OFF -G "Visual Studio %VisualStudioVersion:~0,2%%CMAKE_VSARCH%" .. || exit /b 1
 msbuild /maxcpucount /p:Configuration=Release libprotoc.vcxproj || exit /b 1

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -26,7 +26,14 @@ del protobuf.zip
 pushd protobuf-%PROTOBUF_VER%\cmake
 mkdir build
 cd build
-cmake -Dprotobuf_BUILD_TESTS=OFF -G "Visual Studio %VisualStudioVersion:~0,2%" .. || exit /b 1
+
+@rem cmake does not detect x86_64 from the vcvars64.bat variables.
+@rem If vcvars64.bat has set PLATFORM to X64, then inform cmake to use the Win64 version of VS
+if "%PLATFORM%" == "X64" (
+  @rem Note the space
+  SET CMAKE_VSARCH= Win64
+)
+cmake -Dprotobuf_BUILD_TESTS=OFF -G "Visual Studio %VisualStudioVersion:~0,2%%CMAKE_VSARCH%" .. || exit /b 1
 msbuild /maxcpucount /p:Configuration=Release libprotoc.vcxproj || exit /b 1
 call extract_includes.bat || exit /b 1
 popd


### PR DESCRIPTION
We always build the artifacts, but only store them in placer via
kokoro if MVN_ARTIFACTS is set to a non empty value.
MVN_ARTIFACTS is not set by default right now.

Click on the windows invocation URL and click placer link to find the artifacts:
https://source.cloud.google.com/results/invocations/8cf374ec-52f8-4e21-ae81-3a957d60953d/details