### PR TITLE
Bump to Guava 20 (1.11 backport)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ subprojects {
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         nettyVersion = '4.1.22.Final'
-        guavaVersion = '19.0'
+        guavaVersion = '20.0'
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
@@ -220,7 +220,7 @@ subprojects {
                 junit: 'junit:junit:4.12',
                 mockito: 'org.mockito:mockito-core:1.9.5',
                 truth: 'com.google.truth:truth:0.36',
-                guava_testlib: 'com.google.guava:guava-testlib:19.0',
+                guava_testlib: 'com.google.guava:guava-testlib:20.0',
 
                 // Benchmark dependencies
                 hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10',

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,6 +11,8 @@ dependencies {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
         // prefer 2.1.2 from libraries instead of 2.2.0
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // prefer 20.0 from libraries instead of 19.0
+        exclude group: 'com.google.guava', module: 'guava'
         // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
     }
@@ -21,6 +23,8 @@ dependencies {
         exclude group: 'io.grpc', module: 'grpc-context'
         // prefer 2.1.2 from libraries instead of 2.2.0
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // prefer 20.0 from libraries instead of 19.0
+        exclude group: 'com.google.guava', module: 'guava'
     }
 
     testCompile project(':grpc-context').sourceSets.test.output,

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -15,8 +15,12 @@ buildscript {
 dependencies {
     compile project(':grpc-core'),
             libraries.protobuf,
-            libraries.guava,
-            libraries.protobuf_util
+            libraries.guava
+
+    compile (libraries.protobuf_util) {
+        // prefer 20.0 from libraries instead of 19.0
+        exclude group: 'com.google.guava', module: 'guava'
+    }
 
     compile (libraries.google_api_protos) {
         // 'com.google.api:api-common' transitively depends on auto-value, which breaks our

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -131,8 +131,8 @@ def com_google_errorprone_error_prone_annotations():
 def com_google_guava():
   native.maven_jar(
       name = "com_google_guava_guava",
-      artifact = "com.google.guava:guava:19.0",
-      sha1 = "6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9",
+      artifact = "com.google.guava:guava:20.0",
+      sha1 = "89507701249388e1ed5ddcf8c41f4ce1be7831ef",
   )
 
 def com_google_protobuf():

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -19,6 +19,8 @@ dependencies {
     compile (libraries.instrumentation_api) {
         // prefer 2.0.19 from libraries instead of 2.0.11
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // prefer 20.0 from libraries instead of 19.0
+        exclude group: 'com.google.guava', module: 'guava'
         // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
     }


### PR DESCRIPTION
Fixes #4176

This is a backport of #4262. Although it seems late to do a change like this for the release,
we've actually done this before in #2528. Also, since this is just a dependency change,
there's really no more testing that we should wait on (we're on HEAD internally, for
instance).