### PR TITLE
buildscripts: add explicit dependency on appengine SDK

### DIFF
--- a/gae-interop-testing/gae-jdk7/build.gradle
+++ b/gae-interop-testing/gae-jdk7/build.gradle
@@ -42,7 +42,6 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
   providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-  compile 'com.google.appengine:appengine:1.9.59'
   compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
   // Deps needed by all gRPC apps in GAE
   compile libraries.google_api_protos

--- a/gae-interop-testing/gae-jdk7/build.gradle
+++ b/gae-interop-testing/gae-jdk7/build.gradle
@@ -43,6 +43,7 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 dependencies {
   providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
   compile 'com.google.appengine:appengine:1.9.59'
+  compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
   // Deps needed by all gRPC apps in GAE
   compile libraries.google_api_protos
   compile project(":grpc-okhttp")

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -42,7 +42,6 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
   providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-  compile 'com.google.appengine:appengine:1.9.59'
   compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
   // Deps needed by all gRPC apps in GAE
   compile libraries.google_api_protos

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -43,6 +43,7 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 dependencies {
   providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
   compile 'com.google.appengine:appengine:1.9.59'
+  compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
   // Deps needed by all gRPC apps in GAE
   compile libraries.google_api_protos
   compile project(":grpc-okhttp")


### PR DESCRIPTION
For some reason this is now required to avoid this exception:
java.lang.ClassNotFoundException: com.google.appengine.api.ThreadManager