### PR TITLE
buildscripts: add explicit dependency on appengine SDK (backport to 1.9)

### DIFF
--- a/gae-interop-testing/gae-jdk7/build.gradle
+++ b/gae-interop-testing/gae-jdk7/build.gradle
@@ -39,7 +39,7 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
   providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-  compile 'com.google.appengine:appengine:1.9.59'
+  compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
   // Deps needed by all gRPC apps in GAE
   compile libraries.google_api_protos
   compile project(":grpc-okhttp")

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -39,7 +39,7 @@ apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
   providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-  compile 'com.google.appengine:appengine:1.9.59'
+  compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
   // Deps needed by all gRPC apps in GAE
   compile libraries.google_api_protos
   compile project(":grpc-okhttp")


### PR DESCRIPTION
This fixes the following in GAE:
java.lang.ClassNotFoundException: com.google.appengine.api.ThreadManager