### PR TITLE
services: Specify serialVersionUID for the dummy SocketAddress

### DIFF
--- a/services/src/main/java/io/grpc/services/BinaryLog.java
+++ b/services/src/main/java/io/grpc/services/BinaryLog.java
@@ -81,7 +81,7 @@ final class BinaryLog implements ServerInterceptor, ClientInterceptor {
   @VisibleForTesting
   static final byte[] dumyCallId = new byte[16];
   @VisibleForTesting
-  static final SocketAddress DUMMY_SOCKET = new SocketAddress() { };
+  static final SocketAddress DUMMY_SOCKET = new DummySocketAddress();
   @VisibleForTesting
   static final boolean DUMMY_IS_COMPRESSED = false;
 
@@ -618,5 +618,9 @@ final class BinaryLog implements ServerInterceptor, ClientInterceptor {
   @VisibleForTesting
   static int flagsForMessage(boolean compressed) {
     return compressed ? 1 : 0;
+  }
+
+  private static class DummySocketAddress extends SocketAddress {
+    private static final long serialVersionUID = 0;
   }
 }


### PR DESCRIPTION
This fixes a serial warning that breaks the build when building
_without_ ErrorProne. I have no clue why _disabling_ ErrorProne makes
the warning pop up, but whatever, the warning is legit.

I also gave it a name, since the anonymous $1 seems weird if we're
providing a serialVersionUID. Not to say we're actually supporting
serializing this object. But if we ever see a serialized form show up in
the future, having a more clear name would make it obvious what it is.