### PR TITLE
GAE: call channel.shutdown()

### DIFF
--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/LongLivedChannel.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/LongLivedChannel.java
@@ -46,8 +46,8 @@ public final class LongLivedChannel extends HttpServlet {
   public void destroy() {
     try {
       channel.shutdownNow().awaitTermination(1, TimeUnit.SECONDS);
-    } catch (Throwable t) {
-      throw new RuntimeException(t);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/LongLivedChannel.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/LongLivedChannel.java
@@ -23,6 +23,7 @@ import io.grpc.testing.integration.Messages.Payload;
 import io.grpc.testing.integration.Messages.SimpleRequest;
 import io.grpc.testing.integration.Messages.SimpleResponse;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -40,6 +41,15 @@ public final class LongLivedChannel extends HttpServlet {
   private static final String INTEROP_TEST_ADDRESS = "grpc-test.sandbox.googleapis.com:443";
   private final ManagedChannel channel =
       ManagedChannelBuilder.forTarget(INTEROP_TEST_ADDRESS).build();
+
+  @Override
+  public void destroy() {
+    try {
+      channel.shutdownNow().awaitTermination(1, TimeUnit.SECONDS);
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
 
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -294,7 +294,7 @@ public abstract class AbstractInteropTest {
   @After
   public void tearDown() throws Exception {
     if (channel != null) {
-      channel.shutdownNow().awaitTermination(2, TimeUnit.SECONDS);
+      channel.shutdownNow().awaitTermination(1, TimeUnit.SECONDS);
     }
     stopServer();
   }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -294,7 +294,7 @@ public abstract class AbstractInteropTest {
   @After
   public void tearDown() throws Exception {
     if (channel != null) {
-      channel.shutdown();
+      channel.shutdownNow().awaitTermination(2, TimeUnit.SECONDS);
     }
     stopServer();
   }


### PR DESCRIPTION
OkHttpClientInteropServlet and NettyClientInteropServlet both run the
`@After` method from AbstractInteropTest. Let's make sure we await
termination.

For the long lived channel test, do the cleanup in `destroy`.