### PR TITLE
okhttp: fix HPACK reader bug (1.11 backport)

### DIFF
--- a/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/framed/Hpack.java
+++ b/okhttp/third_party/okhttp/java/io/grpc/okhttp/internal/framed/Hpack.java
@@ -164,7 +164,6 @@ final class Hpack {
     }
 
     private void clearDynamicTable() {
-      headerList.clear();
       Arrays.fill(dynamicTable, null);
       nextHeaderIndex = dynamicTable.length - 1;
       headerCount = 0;


### PR DESCRIPTION
Backport of the first commit of #4276. (The subsequent commits in that PR are improvements and test additions that are not needed for 1.11) This fixes #4261.

