### PR TITLE
RELEASING.md: Push branch before tag

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -127,7 +127,9 @@ Tagging the Release
    version was updated since the last release.
 
    ```bash
-   $ git checkout -b release v$MAJOR.$MINOR.x
+   $ git checkout v$MAJOR.$MINOR.x
+   $ git pull upstream v$MAJOR.$MINOR.x
+   $ git checkout -b release
    # Bump documented versions. Don't forget protobuf version
    $ ${EDITOR:-nano -w} README.md
    $ git commit -a -m "Update README to reference $MAJOR.$MINOR.$PATCH"
@@ -160,8 +162,8 @@ Tagging the Release
    ```bash
    $ git checkout v$MAJOR.$MINOR.x
    $ git merge --ff-only release
-   $ git push upstream v$MAJOR.$MINOR.$PATCH
    $ git push upstream v$MAJOR.$MINOR.x
+   $ git push upstream v$MAJOR.$MINOR.$PATCH
    ```
 6. Close the release milestone.
 


### PR DESCRIPTION
If the release branch (i.e., v1.11.x) was not up-to-date with the local
repo, then the push to update the branch will fail. Doing it first
allows you to notice, merge in the updates and fix the tag before
pushing it.

Also document pulling the most up-to-date version of the release branch
before creating the 'release' branch. That would reduce the amount of
time the release branch could be modified.