### PR TITLE
protobuf: fix @since for fromStatusAndTrailers

### DIFF
--- a/protobuf/src/main/java/io/grpc/protobuf/StatusProto.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/StatusProto.java
@@ -151,7 +151,7 @@ public final class StatusProto {
    * {@code status}.
    *
    * @return the embedded google.rpc.Status or {@code null} if it is not present.
-   * @since 1.10.0
+   * @since 1.11.0
    */
   @Nullable
   public static com.google.rpc.Status fromStatusAndTrailers(Status status, Metadata trailers) {


### PR DESCRIPTION
It was added in 1e9bd9a8 which was initially released in v1.11.0.