### PR TITLE
java_grpc_library: re-add grpc-java repo to targets

### DIFF
--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -5,3 +5,6 @@ cat /VERSION
 
 cd github/grpc-java
 bazel build ...
+
+cd examples
+bazel build ...

--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -107,9 +107,9 @@ def java_grpc_library(name, srcs, deps, flavor=None,
   )
 
   added_deps = [
-      "//core",
-      "//stub",
-      "//protobuf",
+      "@io_grpc_grpc_java//core",
+      "@io_grpc_grpc_java//stub",
+      "@io_grpc_grpc_java//protobuf",
       "@com_google_guava_guava//jar",
   ]
   if flavor == "normal":


### PR DESCRIPTION
They were removed in 137c74d1 since it was believed they were unnecessary.
However, since they are in a macro and not a rule, they are relative to the
caller, not their definition.

Added building the examples to the kokoro CI. Note that this means the examples
are built twice: once in grpc-java's build and once in their own (because it
has a WORKSPACE). Given that the Bazel build is our fastest build, this
slowdown won't probably be an issue.

CC @cgrushko