### PR TITLE
okhttp: properly verify IPv6 address hosts

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
@@ -90,7 +90,7 @@ final class OkHttpTlsUpgrader {
   @VisibleForTesting
   static String canonicalizeHost(String host) {
     if (host.startsWith("[") && host.endsWith("]")) {
-      return host.substring(1, host.length()-1);
+      return host.substring(1, host.length() - 1);
     }
     return host;
   }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
@@ -87,6 +87,7 @@ final class OkHttpTlsUpgrader {
    *
    * @return {@param host} in a form consistent with X509 certificates
    */
+  @VisibleForTesting
   static String canonicalizeHost(String host) {
     if (host.startsWith("[") && host.endsWith("]")) {
       return host.substring(1, host.length()-1);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
@@ -70,9 +70,24 @@ final class OkHttpTlsUpgrader {
     if (hostnameVerifier == null) {
       hostnameVerifier = OkHostnameVerifier.INSTANCE;
     }
-    if (!hostnameVerifier.verify(host, sslSocket.getSession())) {
+    if (!hostnameVerifier.verify(canonicalizeHost(host), sslSocket.getSession())) {
       throw new SSLPeerUnverifiedException("Cannot verify hostname: " + host);
     }
     return sslSocket;
+  }
+
+  /**
+   * Converts a host from URI to X509 format.
+   *
+   * <p>IPv6 host addresses derived from URIs are enclosed in square brackets per RFC2732, but
+   * omit these brackets in X509 certificate subjectAltName extensions per RFC5280.
+   *
+   * @see <a href="https://www.ietf.org/rfc/rfc2732.txt">RFC2732</a>
+   * @see <a href="https://tools.ietf.org/html/rfc5280#section-4.2.1.6">RFC5280</a>
+   *
+   * @return {@param host} in a form consistent with X509 certificates
+   */
+  static String canonicalizeHost(String host) {
+    return host.replaceAll("[\\[\\]]", "");
   }
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpTlsUpgrader.java
@@ -88,6 +88,9 @@ final class OkHttpTlsUpgrader {
    * @return {@param host} in a form consistent with X509 certificates
    */
   static String canonicalizeHost(String host) {
-    return host.replaceAll("[\\[\\]]", "");
+    if (host.startsWith("[") && host.endsWith("]")) {
+      return host.substring(1, host.length()-1);
+    }
+    return host;
   }
 }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTlsUpgraderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTlsUpgraderTest.java
@@ -16,6 +16,8 @@
 
 package io.grpc.okhttp;
 
+import static io.grpc.okhttp.OkHttpTlsUpgrader.canonicalizeHost;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.grpc.okhttp.internal.Protocol;
@@ -31,5 +33,45 @@ public class OkHttpTlsUpgraderTest {
         OkHttpTlsUpgrader.TLS_PROTOCOLS.indexOf(Protocol.GRPC_EXP) == -1
             || OkHttpTlsUpgrader.TLS_PROTOCOLS.indexOf(Protocol.GRPC_EXP)
                 < OkHttpTlsUpgrader.TLS_PROTOCOLS.indexOf(Protocol.HTTP_2));
+  }
+
+  @Test public void upgrade_canonicalizeHost() {
+    // IPv4
+    assertEquals(canonicalizeHost("127.0.0.1"), "127.0.0.1");
+    assertEquals(canonicalizeHost("1.2.3.4"), "1.2.3.4");
+
+    // IPv6
+    assertEquals(canonicalizeHost("::1"), "::1");
+    assertEquals(canonicalizeHost("[::1]"), "::1");
+    assertEquals(canonicalizeHost("2001:db8::1"), "2001:db8::1");
+    assertEquals(canonicalizeHost("[2001:db8::1]"), "2001:db8::1");
+    assertEquals(canonicalizeHost("::192.168.0.1"), "::192.168.0.1");
+    assertEquals(canonicalizeHost("[::192.168.0.1]"), "::192.168.0.1");
+    assertEquals(canonicalizeHost("::ffff:192.168.0.1"), "::ffff:192.168.0.1");
+    assertEquals(canonicalizeHost("[::ffff:192.168.0.1]"), "::ffff:192.168.0.1");
+    assertEquals(canonicalizeHost("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210"),
+            "FEDC:BA98:7654:3210:FEDC:BA98:7654:3210");
+    assertEquals(canonicalizeHost("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]"),
+            "FEDC:BA98:7654:3210:FEDC:BA98:7654:3210");
+    assertEquals(canonicalizeHost("1080:0:0:0:8:800:200C:417A"), "1080:0:0:0:8:800:200C:417A");
+    assertEquals(canonicalizeHost("[1080:0:0:0:8:800:200C:417A]"), "1080:0:0:0:8:800:200C:417A");
+    assertEquals(canonicalizeHost("1080::8:800:200C:417A"), "1080::8:800:200C:417A");
+    assertEquals(canonicalizeHost("[1080::8:800:200C:417A]"), "1080::8:800:200C:417A");
+    assertEquals(canonicalizeHost("FF01::101"), "FF01::101");
+    assertEquals(canonicalizeHost("[FF01::101]"), "FF01::101");
+    assertEquals(canonicalizeHost("0:0:0:0:0:0:13.1.68.3"), "0:0:0:0:0:0:13.1.68.3");
+    assertEquals(canonicalizeHost("[0:0:0:0:0:0:13.1.68.3]"), "0:0:0:0:0:0:13.1.68.3");
+    assertEquals(canonicalizeHost("0:0:0:0:0:FFFF:129.144.52.38"), "0:0:0:0:0:FFFF:129.144.52.38");
+    assertEquals(canonicalizeHost("[0:0:0:0:0:FFFF:129.144.52.38]"), "0:0:0:0:0:FFFF:129.144.52.38");
+    assertEquals(canonicalizeHost("::13.1.68.3"), "::13.1.68.3");
+    assertEquals(canonicalizeHost("[::13.1.68.3]"), "::13.1.68.3");
+    assertEquals(canonicalizeHost("::FFFF:129.144.52.38"), "::FFFF:129.144.52.38");
+    assertEquals(canonicalizeHost("[::FFFF:129.144.52.38]"), "::FFFF:129.144.52.38");
+
+    // Hostnames
+    assertEquals(canonicalizeHost("go"), "go");
+    assertEquals(canonicalizeHost("localhost"), "localhost");
+    assertEquals(canonicalizeHost("squareup.com"), "squareup.com");
+    assertEquals(canonicalizeHost("www.nintendo.co.jp"), "www.nintendo.co.jp");
   }
 }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTlsUpgraderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTlsUpgraderTest.java
@@ -35,43 +35,13 @@ public class OkHttpTlsUpgraderTest {
                 < OkHttpTlsUpgrader.TLS_PROTOCOLS.indexOf(Protocol.HTTP_2));
   }
 
-  @Test public void upgrade_canonicalizeHost() {
-    // IPv4
-    assertEquals(canonicalizeHost("127.0.0.1"), "127.0.0.1");
-    assertEquals(canonicalizeHost("1.2.3.4"), "1.2.3.4");
+  @Test public void canonicalizeHosts() {
+    assertEquals("::1", canonicalizeHost("::1"));
+    assertEquals("::1", canonicalizeHost("[::1]"));
+    assertEquals("127.0.0.1", canonicalizeHost("127.0.0.1"));
+    assertEquals("some.long.url.com", canonicalizeHost("some.long.url.com"));
 
-    // IPv6
-    assertEquals(canonicalizeHost("::1"), "::1");
-    assertEquals(canonicalizeHost("[::1]"), "::1");
-    assertEquals(canonicalizeHost("2001:db8::1"), "2001:db8::1");
-    assertEquals(canonicalizeHost("[2001:db8::1]"), "2001:db8::1");
-    assertEquals(canonicalizeHost("::192.168.0.1"), "::192.168.0.1");
-    assertEquals(canonicalizeHost("[::192.168.0.1]"), "::192.168.0.1");
-    assertEquals(canonicalizeHost("::ffff:192.168.0.1"), "::ffff:192.168.0.1");
-    assertEquals(canonicalizeHost("[::ffff:192.168.0.1]"), "::ffff:192.168.0.1");
-    assertEquals(canonicalizeHost("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210"),
-            "FEDC:BA98:7654:3210:FEDC:BA98:7654:3210");
-    assertEquals(canonicalizeHost("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]"),
-            "FEDC:BA98:7654:3210:FEDC:BA98:7654:3210");
-    assertEquals(canonicalizeHost("1080:0:0:0:8:800:200C:417A"), "1080:0:0:0:8:800:200C:417A");
-    assertEquals(canonicalizeHost("[1080:0:0:0:8:800:200C:417A]"), "1080:0:0:0:8:800:200C:417A");
-    assertEquals(canonicalizeHost("1080::8:800:200C:417A"), "1080::8:800:200C:417A");
-    assertEquals(canonicalizeHost("[1080::8:800:200C:417A]"), "1080::8:800:200C:417A");
-    assertEquals(canonicalizeHost("FF01::101"), "FF01::101");
-    assertEquals(canonicalizeHost("[FF01::101]"), "FF01::101");
-    assertEquals(canonicalizeHost("0:0:0:0:0:0:13.1.68.3"), "0:0:0:0:0:0:13.1.68.3");
-    assertEquals(canonicalizeHost("[0:0:0:0:0:0:13.1.68.3]"), "0:0:0:0:0:0:13.1.68.3");
-    assertEquals(canonicalizeHost("0:0:0:0:0:FFFF:129.144.52.38"), "0:0:0:0:0:FFFF:129.144.52.38");
-    assertEquals(canonicalizeHost("[0:0:0:0:0:FFFF:129.144.52.38]"), "0:0:0:0:0:FFFF:129.144.52.38");
-    assertEquals(canonicalizeHost("::13.1.68.3"), "::13.1.68.3");
-    assertEquals(canonicalizeHost("[::13.1.68.3]"), "::13.1.68.3");
-    assertEquals(canonicalizeHost("::FFFF:129.144.52.38"), "::FFFF:129.144.52.38");
-    assertEquals(canonicalizeHost("[::FFFF:129.144.52.38]"), "::FFFF:129.144.52.38");
-
-    // Hostnames
-    assertEquals(canonicalizeHost("go"), "go");
-    assertEquals(canonicalizeHost("localhost"), "localhost");
-    assertEquals(canonicalizeHost("squareup.com"), "squareup.com");
-    assertEquals(canonicalizeHost("www.nintendo.co.jp"), "www.nintendo.co.jp");
+    // Extra square brackets in a malformed URI are retained
+    assertEquals("[::1]", canonicalizeHost("[[::1]]"));
   }
 }


### PR DESCRIPTION
Address mismatch between IPv6 address hosts derived from URIs and X509 subjectAltName extensions as discussed in #4278 