### PR TITLE
netty: fix getListenSockets race

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -262,7 +262,7 @@ class NettyServer implements InternalServer, WithLogId {
     try {
       channelzFuture.await();
     } catch (InterruptedException ex) {
-      throw new RuntimeException("Interrupted while registering listen socket to channelz");
+      throw new RuntimeException("Interrupted while registering listen socket to channelz", ex);
     }
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -243,9 +243,6 @@ class NettyServer implements InternalServer, WithLogId {
     ChannelFuture future = b.bind(address);
     try {
       future.await();
-      Instrumented<SocketStats> listenSocket = new ListenSocket(future.channel());
-      listenSockets = ImmutableList.of(listenSocket);
-      channelz.addListenSocket(listenSocket);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       throw new RuntimeException("Interrupted waiting for bind");
@@ -254,6 +251,9 @@ class NettyServer implements InternalServer, WithLogId {
       throw new IOException("Failed to bind", future.cause());
     }
     channel = future.channel();
+    Instrumented<SocketStats> listenSocket = new ListenSocket(channel);
+    listenSockets = ImmutableList.of(listenSocket);
+    channelz.addListenSocket(listenSocket);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -93,8 +93,8 @@ class NettyServer implements InternalServer, WithLogId {
   private final TransportTracer.Factory transportTracerFactory;
   private final Channelz channelz;
   // Only set once during start(). This code assumes all listen sockets are created at startup
-  // and never changed. In the future we may have >1 listen socket.
-  private ImmutableList<Instrumented<SocketStats>> listenSockets = ImmutableList.of();
+  // and never changed. In the future we may have >1 listen socket. Unset at shutdown.
+  private volatile ImmutableList<Instrumented<SocketStats>> listenSockets = ImmutableList.of();
 
   NettyServer(
       SocketAddress address, Class<? extends ServerChannel> channelType,


### PR DESCRIPTION
Fix race by avoiding async handler. This was leading to a flakey test:
channelzListenSocket