### PR TITLE
core,services: move binary log logic to services

### DIFF
--- a/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
+++ b/core/src/main/java/io/grpc/internal/BinaryLogProvider.java
@@ -16,49 +16,18 @@
 
 package io.grpc.internal;
 
-import com.google.common.annotations.VisibleForTesting;
-import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
-import io.grpc.ClientInterceptors;
-import io.grpc.Context;
-import io.grpc.Internal;
-import io.grpc.InternalClientInterceptors;
-import io.grpc.InternalServerInterceptors;
 import io.grpc.InternalServiceProviders;
 import io.grpc.InternalServiceProviders.PriorityAccessor;
-import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
-import io.grpc.MethodDescriptor.Marshaller;
-import io.grpc.ServerCallHandler;
-import io.grpc.ServerInterceptor;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerStreamTracer;
-import io.opencensus.trace.Span;
-import io.opencensus.trace.Tracing;
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.util.Collections;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 public abstract class BinaryLogProvider implements Closeable {
-  // TODO(zpencer): move to services and make package private
-  @Internal
-  public static final Context.Key<CallId> SERVER_CALL_ID_CONTEXT_KEY
-      = Context.key("binarylog-context-key");
-  // TODO(zpencer): move to services and make package private when this class is moved
-  @Internal
-  public static final CallOptions.Key<CallId> CLIENT_CALL_ID_CALLOPTION_KEY
-      = CallOptions.Key.of("binarylog-calloptions-key", null);
-  @VisibleForTesting
-  public static final Marshaller<byte[]> BYTEARRAY_MARSHALLER = new ByteArrayMarshaller();
-
-  private static final Logger logger = Logger.getLogger(BinaryLogProvider.class.getName());
   private static final BinaryLogProvider PROVIDER = InternalServiceProviders.load(
       BinaryLogProvider.class,
       Collections.<Class<?>>emptyList(),
@@ -75,8 +44,6 @@ public abstract class BinaryLogProvider implements Closeable {
         }
       });
 
-  private final ClientInterceptor binaryLogShim = new BinaryLogShim();
-
   /**
    * Returns a {@code BinaryLogProvider}, or {@code null} if there is no provider.
    */
@@ -88,116 +55,25 @@ public abstract class BinaryLogProvider implements Closeable {
   /**
    * Wraps a channel to provide binary logging on {@link ClientCall}s as needed.
    */
-  Channel wrapChannel(Channel channel) {
-    return ClientInterceptors.intercept(channel, binaryLogShim);
-  }
-
-  private static MethodDescriptor<byte[], byte[]> toByteBufferMethod(
-      MethodDescriptor<?, ?> method) {
-    return method.toBuilder(BYTEARRAY_MARSHALLER, BYTEARRAY_MARSHALLER).build();
-  }
+  public abstract Channel wrapChannel(Channel channel);
 
   /**
    * Wraps a {@link ServerMethodDefinition} such that it performs binary logging if needed.
    */
-  final <ReqT, RespT> ServerMethodDefinition<?, ?> wrapMethodDefinition(
-      ServerMethodDefinition<ReqT, RespT> oMethodDef) {
-    ServerInterceptor binlogInterceptor =
-        getServerInterceptor(oMethodDef.getMethodDescriptor().getFullMethodName());
-    if (binlogInterceptor == null) {
-      return oMethodDef;
-    }
-    MethodDescriptor<byte[], byte[]> binMethod =
-        BinaryLogProvider.toByteBufferMethod(oMethodDef.getMethodDescriptor());
-    ServerMethodDefinition<byte[], byte[]> binDef = InternalServerInterceptors
-        .wrapMethod(oMethodDef, binMethod);
-    ServerCallHandler<byte[], byte[]> binlogHandler = InternalServerInterceptors
-        .interceptCallHandler(binlogInterceptor, binDef.getServerCallHandler());
-    return ServerMethodDefinition.create(binMethod, binlogHandler);
-  }
-
+  public abstract <ReqT, RespT> ServerMethodDefinition<?, ?> wrapMethodDefinition(
+      ServerMethodDefinition<ReqT, RespT> oMethodDef);
 
   /**
-   * Returns a {@link ServerInterceptor} for binary logging. gRPC is free to cache the interceptor,
-   * so the interceptor must be reusable across calls. At runtime, the request and response
-   * marshallers are always {@code Marshaller<InputStream>}.
-   * Returns {@code null} if this method is not binary logged.
-   */
-  // TODO(zpencer): ensure the interceptor properly handles retries and hedging
-  @Nullable
-  public abstract ServerInterceptor getServerInterceptor(String fullMethodName);
-
-  /**
-   * Returns a {@link ClientInterceptor} for binary logging. gRPC is free to cache the interceptor,
-   * so the interceptor must be reusable across calls. At runtime, the request and response
-   * marshallers are always {@code Marshaller<InputStream>}.
-   * Returns {@code null} if this method is not binary logged.
-   */
-  // TODO(zpencer): ensure the interceptor properly handles retries and hedging
-  @Nullable
-  public abstract ClientInterceptor getClientInterceptor(String fullMethodName);
-
-  @Override
-  public void close() throws IOException {
-    // default impl: noop
-    // TODO(zpencer): make BinaryLogProvider provide a BinaryLog, and this method belongs there
-  }
-
-  private static final ServerStreamTracer SERVER_CALLID_SETTER = new ServerStreamTracer() {
-    @Override
-    public Context filterContext(Context context) {
-      Context toRestore = context.attach();
-      try {
-        Span span = Tracing.getTracer().getCurrentSpan();
-        if (span == null) {
-          return context;
-        }
-
-        return context.withValue(SERVER_CALL_ID_CONTEXT_KEY, CallId.fromCensusSpan(span));
-      } finally {
-        context.detach(toRestore);
-      }
-    }
-  };
-
-  private static final ServerStreamTracer.Factory SERVER_CALLID_SETTER_FACTORY
-      = new ServerStreamTracer.Factory() {
-          @Override
-          public ServerStreamTracer newServerStreamTracer(String fullMethodName, Metadata headers) {
-            return SERVER_CALLID_SETTER;
-          }
-      };
-
-  /**
-   * Returns a {@link ServerStreamTracer.Factory} that copies the call ID to the {@link Context}
+   * Returns a {@link ServerStreamTracer.Factory} that copies the call ID to {@link io.grpc.Context}
    * as {@code SERVER_CALL_ID_CONTEXT_KEY}.
    */
-  public ServerStreamTracer.Factory getServerCallIdSetter() {
-    return SERVER_CALLID_SETTER_FACTORY;
-  }
-
-  private static final ClientInterceptor CLIENT_CALLID_SETTER = new ClientInterceptor() {
-    @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-      Span span = Tracing.getTracer().getCurrentSpan();
-      if (span == null) {
-        return next.newCall(method, callOptions);
-      }
-
-      return next.newCall(
-          method,
-          callOptions.withOption(CLIENT_CALL_ID_CALLOPTION_KEY, CallId.fromCensusSpan(span)));
-    }
-  };
+  public abstract ServerStreamTracer.Factory getServerCallIdSetter();
 
   /**
-   * Returns a {@link ClientInterceptor} that copies the call ID to the {@link CallOptions}
+   * Returns a {@link ClientInterceptor} that copies the call ID to {@link io.grpc.CallOptions}
    * as {@code CALL_CLIENT_CALL_ID_CALLOPTION_KEY}.
    */
-  public ClientInterceptor getClientCallIdSetter() {
-    return CLIENT_CALLID_SETTER;
-  }
+  public abstract ClientInterceptor getClientCallIdSetter();
 
   /**
    * A priority, from 0 to 10 that this provider should be used, taking the current environment into
@@ -212,76 +88,4 @@ public abstract class BinaryLogProvider implements Closeable {
    * If {@code false}, no other methods are safe to be called.
    */
   protected abstract boolean isAvailable();
-
-  // Creating a named class makes debugging easier
-  private static final class ByteArrayMarshaller implements Marshaller<byte[]> {
-    @Override
-    public InputStream stream(byte[] value) {
-      return new ByteArrayInputStream(value);
-    }
-
-    @Override
-    public byte[] parse(InputStream stream) {
-      try {
-        return parseHelper(stream);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    private byte[] parseHelper(InputStream stream) throws IOException {
-      try {
-        return IoUtils.toByteArray(stream);
-      } finally {
-        stream.close();
-      }
-    }
-  }
-
-  /**
-   * The pipeline of interceptors is hard coded when the {@link ManagedChannelImpl} is created.
-   * This shim interceptor should always be installed as a placeholder. When a call starts,
-   * this interceptor checks with the {@link BinaryLogProvider} to see if logging should happen
-   * for this particular {@link ClientCall}'s method.
-   */
-  private final class BinaryLogShim implements ClientInterceptor {
-    @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-        MethodDescriptor<ReqT, RespT> method,
-        CallOptions callOptions,
-        Channel next) {
-      ClientInterceptor binlogInterceptor = getClientInterceptor(method.getFullMethodName());
-      if (binlogInterceptor == null) {
-        return next.newCall(method, callOptions);
-      } else {
-        return InternalClientInterceptors
-            .wrapClientInterceptor(
-                binlogInterceptor,
-                BYTEARRAY_MARSHALLER,
-                BYTEARRAY_MARSHALLER)
-            .interceptCall(method, callOptions, next);
-      }
-    }
-  }
-
-  /**
-   * A CallId is two byte[] arrays both of size 8 that uniquely identifies the RPC. Users are
-   * free to use the byte arrays however they see fit.
-   */
-  public static final class CallId {
-    public final long hi;
-    public final long lo;
-
-    /**
-     * Creates an instance.
-     */
-    public CallId(long hi, long lo) {
-      this.hi = hi;
-      this.lo = lo;
-    }
-
-    static CallId fromCensusSpan(Span span) {
-      return new CallId(0, ByteBuffer.wrap(span.getContext().getSpanId().getBytes()).getLong());
-    }
-  }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -62,8 +62,6 @@ import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
-import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.IntegerMarshaller;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -77,13 +75,10 @@ import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.NameResolver;
 import io.grpc.SecurityLevel;
-import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.grpc.StringMarshaller;
 import io.grpc.internal.Channelz.ChannelStats;
-import io.grpc.internal.NoopClientCall.NoopClientCallListener;
 import io.grpc.internal.TestUtils.MockClientTransportInfo;
-import io.grpc.internal.testing.SingleMessageProducer;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -96,7 +91,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -197,7 +191,6 @@ public class ManagedChannelImplTest {
   private ObjectPool<Executor> oobExecutorPool;
   @Mock
   private CallCredentials creds;
-  private BinaryLogProvider binlogProvider = null;
   private BlockingQueue<MockClientTransportInfo> transports;
 
   private ArgumentCaptor<ClientStreamListener> streamListenerCaptor =
@@ -237,7 +230,6 @@ public class ManagedChannelImplTest {
         .userAgent(userAgent);
     builder.executorPool = executorPool;
     builder.idleTimeoutMillis = idleTimeoutMillis;
-    builder.binlogProvider = binlogProvider;
     builder.channelz = channelz;
     checkState(channel == null);
     channel = new ManagedChannelImpl(
@@ -2306,189 +2298,6 @@ public class ManagedChannelImplTest {
     channel.shutdownNow();
     assertEquals(SHUTDOWN, getStats(channel).state);
     assertEquals(SHUTDOWN, getStats(oobChannel).state);
-  }
-
-  @Test
-  public void binaryLogInterceptor_eventOrdering() throws Exception {
-    final List<ClientInterceptor> recvInitialMetadata = new ArrayList<ClientInterceptor>();
-    final List<ClientInterceptor> sendInitialMetadata = new ArrayList<ClientInterceptor>();
-    final List<ClientInterceptor> sendReq = new ArrayList<ClientInterceptor>();
-    final List<ClientInterceptor> recvResp = new ArrayList<ClientInterceptor>();
-    final List<ClientInterceptor> recvTrailingMetadata = new ArrayList<ClientInterceptor>();
-    final class TracingClientInterceptor implements ClientInterceptor {
-      @Override
-      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-          MethodDescriptor<ReqT, RespT> method,
-          CallOptions callOptions,
-          Channel next) {
-        final ClientInterceptor ref = this;
-        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
-          @Override
-          public void start(Listener<RespT> responseListener, Metadata headers) {
-            sendInitialMetadata.add(ref);
-            ClientCall.Listener<RespT> wListener =
-                new SimpleForwardingClientCallListener<RespT>(responseListener) {
-                  @Override
-                  public void onMessage(RespT message) {
-                    recvResp.add(ref);
-                    super.onMessage(message);
-                  }
-
-                  @Override
-                  public void onHeaders(Metadata headers) {
-                    recvInitialMetadata.add(ref);
-                    super.onHeaders(headers);
-                  }
-
-                  @Override
-                  public void onClose(Status status, Metadata trailers) {
-                    recvTrailingMetadata.add(ref);
-                    super.onClose(status, trailers);
-                  }
-                };
-            super.start(wListener, headers);
-          }
-
-          @Override
-          public void sendMessage(ReqT message) {
-            sendReq.add(ref);
-            super.sendMessage(message);
-          }
-        };
-      }
-    }
-
-    TracingClientInterceptor userInterceptor = new TracingClientInterceptor();
-    final TracingClientInterceptor binlogInterceptor = new TracingClientInterceptor();
-    binlogProvider = new BinaryLogProvider() {
-      @Nullable
-      @Override
-      public ServerInterceptor getServerInterceptor(String fullMethodName) {
-        return null;
-      }
-
-      @Override
-      public ClientInterceptor getClientInterceptor(String fullMethodName) {
-        return binlogInterceptor;
-      }
-
-      @Override
-      protected int priority() {
-        return 0;
-      }
-
-      @Override
-      protected boolean isAvailable() {
-        return true;
-      }
-    };
-
-    // perform an RPC
-    Metadata headers = new Metadata();
-    ClientStream mockStream = mock(ClientStream.class);
-    createChannel(
-        new FakeNameResolverFactory.Builder(expectedUri).build(),
-        ImmutableList.<ClientInterceptor>of(userInterceptor));
-    CallOptions options =
-        CallOptions.DEFAULT.withExecutor(executor.getScheduledExecutorService());
-    ClientCall<String, Integer> call = channel.newCall(method, options);
-    call.start(mockCallListener, headers);
-
-    Subchannel subchannel = helper.createSubchannel(addressGroup, Attributes.EMPTY);
-    subchannel.requestConnection();
-    MockClientTransportInfo transportInfo = transports.poll();
-    ConnectionClientTransport mockTransport = transportInfo.transport;
-    ManagedClientTransport.Listener transportListener = transportInfo.listener;
-    // binlog modifies the MethodDescriptor, so we can not use the same() matcher
-    when(mockTransport.newStream(
-        any(MethodDescriptor.class),
-        same(headers),
-        any(CallOptions.class)))
-        .thenReturn(mockStream);
-    transportListener.transportReady();
-    when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class)))
-        .thenReturn(PickResult.withSubchannel(subchannel));
-    helper.updateBalancingState(READY, mockPicker);
-
-    executor.runDueTasks();
-    verify(mockStream).start(streamListenerCaptor.capture());
-
-    ClientStreamListener streamListener = streamListenerCaptor.getValue();
-    streamListener.headersRead(new Metadata());
-    assertEquals(1, executor.runDueTasks());
-    String actualRequest = "hello world";
-    call.sendMessage(actualRequest);
-    streamListener.messagesAvailable(new SingleMessageProducer(method.streamResponse(1234)));
-    assertEquals(1, executor.runDueTasks());
-    call.halfClose();
-    streamListener.closed(Status.OK, new Metadata());
-    assertEquals(1, executor.runDueTasks());
-    // end: perform an RPC
-
-    assertThat(recvInitialMetadata).containsExactly(binlogInterceptor, userInterceptor).inOrder();
-    assertThat(sendInitialMetadata).containsExactly(userInterceptor, binlogInterceptor).inOrder();
-    assertThat(sendReq).containsExactly(userInterceptor, binlogInterceptor).inOrder();
-    assertThat(recvResp).containsExactly(binlogInterceptor, userInterceptor).inOrder();
-    assertThat(recvTrailingMetadata).containsExactly(binlogInterceptor, userInterceptor);
-  }
-
-  @Test
-  public void binaryLogInterceptor_intercept_reqResp() throws Exception {
-    final class TracingClientInterceptor implements ClientInterceptor {
-      private final List<MethodDescriptor<?, ?>> interceptedMethods =
-          new ArrayList<MethodDescriptor<?, ?>>();
-
-      @Override
-      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-          MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-        interceptedMethods.add(method);
-        return next.newCall(method, callOptions);
-      }
-    }
-
-    TracingClientInterceptor userInterceptor = new TracingClientInterceptor();
-    binlogProvider = new BinaryLogProvider() {
-      @Nullable
-      @Override
-      public ServerInterceptor getServerInterceptor(String fullMethodName) {
-        return null;
-      }
-
-      @Override
-      public ClientInterceptor getClientInterceptor(String fullMethodName) {
-        return new TracingClientInterceptor();
-      }
-
-      @Override
-      protected int priority() {
-        return 0;
-      }
-
-      @Override
-      protected boolean isAvailable() {
-        return true;
-      }
-    };
-    createChannel(
-        new FakeNameResolverFactory.Builder(expectedUri).build(),
-        Collections.<ClientInterceptor>singletonList(userInterceptor));
-    ClientCall<String, Integer> call =
-        channel.newCall(method, CallOptions.DEFAULT.withDeadlineAfter(0, TimeUnit.NANOSECONDS));
-    ClientCall.Listener<Integer> listener = new NoopClientCallListener<Integer>();
-    call.start(listener, new Metadata());
-    assertEquals(1, executor.runDueTasks());
-
-    String actualRequest = "hello world";
-    call.sendMessage(actualRequest);
-
-    // The user supplied interceptor must still operate on the original message types
-    assertThat(userInterceptor.interceptedMethods).hasSize(1);
-    assertSame(
-        method.getRequestMarshaller(),
-        userInterceptor.interceptedMethods.get(0).getRequestMarshaller());
-    assertSame(
-        method.getResponseMarshaller(),
-        userInterceptor.interceptedMethods.get(0).getResponseMarshaller());
   }
 
   private static class FakeBackoffPolicyProvider implements BackoffPolicy.Provider {

--- a/services/src/main/java/io/grpc/services/internal/BinaryLogProviderImpl.java
+++ b/services/src/main/java/io/grpc/services/internal/BinaryLogProviderImpl.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.services.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.Context;
+import io.grpc.ExperimentalApi;
+import io.grpc.InternalClientInterceptors;
+import io.grpc.InternalServerInterceptors;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerStreamTracer;
+import io.grpc.internal.BinaryLogProvider;
+import io.grpc.internal.IoUtils;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.Tracing;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/4209")
+public class BinaryLogProviderImpl extends BinaryLogProvider {
+  private static final Logger log = Logger.getLogger(BinaryLogProviderImpl.class.getName());
+  static final Context.Key<CallId> SERVER_CALL_ID_CONTEXT_KEY
+      = Context.key("binarylog-context-key");
+  static final CallOptions.Key<CallId> CLIENT_CALL_ID_CALLOPTION_KEY
+      = CallOptions.Key.of("binarylog-calloptions-key", null);
+  static final Marshaller<byte[]> BYTEARRAY_MARSHALLER = new ByteArrayMarshaller();
+
+  private final ClientInterceptor binaryLogShim = new BinaryLogShim();
+  private final boolean enabled;
+  private final BinaryLogSink sink;
+  private final BinaryLog.Factory factory;
+
+  /**
+   * Default constructor for service loader.
+   */
+  public BinaryLogProviderImpl() {
+    sink = BinaryLogSinkProvider.provider();
+    String globalConfigStr = System.getenv("GRPC_BINARY_LOG_CONFIG");
+    if (sink == null || globalConfigStr == null) {
+      log.log(
+          Level.INFO,
+          "Binary logging is disabled. Sink={} config={}",
+          new Object[] {sink, globalConfigStr});
+      enabled = false;
+      factory = null;
+      return;
+    }
+    factory = new BinaryLog.FactoryImpl(sink, globalConfigStr);
+    enabled = true;
+  }
+
+  @VisibleForTesting
+  BinaryLogProviderImpl(BinaryLogSink sink, BinaryLog.Factory factory) {
+    enabled = true;
+    this.sink = sink;
+    this.factory = factory;
+  }
+
+  @Override
+  public Channel wrapChannel(Channel channel) {
+    if (!enabled) {
+      return channel;
+    }
+    return ClientInterceptors.intercept(channel, binaryLogShim);
+  }
+
+  /**
+   * Wraps a {@link ServerMethodDefinition} such that it performs binary logging if needed.
+   */
+  @Override
+  public <ReqT, RespT> ServerMethodDefinition<?, ?> wrapMethodDefinition(
+      ServerMethodDefinition<ReqT, RespT> oMethodDef) {
+    if (!enabled) {
+      return oMethodDef;
+    }
+    ServerInterceptor binlogInterceptor =
+        factory.getServerInterceptor(oMethodDef.getMethodDescriptor().getFullMethodName());
+    if (binlogInterceptor == null) {
+      return oMethodDef;
+    }
+    MethodDescriptor<byte[], byte[]> binMethod =
+        toByteBufferMethod(oMethodDef.getMethodDescriptor());
+    ServerMethodDefinition<byte[], byte[]> binDef = InternalServerInterceptors
+        .wrapMethod(oMethodDef, binMethod);
+    ServerCallHandler<byte[], byte[]> binlogHandler = InternalServerInterceptors
+        .interceptCallHandler(binlogInterceptor, binDef.getServerCallHandler());
+    return ServerMethodDefinition.create(binMethod, binlogHandler);
+  }
+
+  private static MethodDescriptor<byte[], byte[]> toByteBufferMethod(
+      MethodDescriptor<?, ?> method) {
+    return method.toBuilder(BYTEARRAY_MARSHALLER, BYTEARRAY_MARSHALLER).build();
+  }
+
+  private static final ServerStreamTracer SERVER_CALLID_SETTER = new ServerStreamTracer() {
+    @Override
+    public Context filterContext(Context context) {
+      Context toRestore = context.attach();
+      try {
+        Span span = Tracing.getTracer().getCurrentSpan();
+        if (span == null) {
+          return context;
+        }
+
+        return context.withValue(SERVER_CALL_ID_CONTEXT_KEY, CallId.fromCensusSpan(span));
+      } finally {
+        context.detach(toRestore);
+      }
+    }
+  };
+
+  private static final ServerStreamTracer.Factory SERVER_CALLID_SETTER_FACTORY
+      = new ServerStreamTracer.Factory() {
+          @Override
+          public ServerStreamTracer newServerStreamTracer(String fullMethodName, Metadata headers) {
+            return SERVER_CALLID_SETTER;
+          }
+      };
+
+  @Override
+  public ServerStreamTracer.Factory getServerCallIdSetter() {
+    return SERVER_CALLID_SETTER_FACTORY;
+  }
+
+  private static final ClientInterceptor CLIENT_CALLID_SETTER = new ClientInterceptor() {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      Span span = Tracing.getTracer().getCurrentSpan();
+      if (span == null) {
+        return next.newCall(method, callOptions);
+      }
+
+      return next.newCall(
+          method,
+          callOptions.withOption(CLIENT_CALL_ID_CALLOPTION_KEY, CallId.fromCensusSpan(span)));
+    }
+  };
+
+  @Override
+  public ClientInterceptor getClientCallIdSetter() {
+    return CLIENT_CALLID_SETTER;
+  }
+
+  @Override
+  public void close() throws IOException {
+    sink.close();
+  }
+
+  // Creating a named class makes debugging easier
+  private static final class ByteArrayMarshaller implements Marshaller<byte[]> {
+    @Override
+    public InputStream stream(byte[] value) {
+      return new ByteArrayInputStream(value);
+    }
+
+    @Override
+    public byte[] parse(InputStream stream) {
+      try {
+        return parseHelper(stream);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    private byte[] parseHelper(InputStream stream) throws IOException {
+      try {
+        return IoUtils.toByteArray(stream);
+      } finally {
+        stream.close();
+      }
+    }
+  }
+
+  /**
+   * The pipeline of interceptors is hard coded when the ManagedChannelImpl is created.
+   * This shim interceptor should always be installed as a placeholder. When a call starts,
+   * this interceptor checks with the {@link BinaryLogProvider} to see if logging should happen
+   * for this particular {@link ClientCall}'s method.
+   */
+  private final class BinaryLogShim implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method,
+        CallOptions callOptions,
+        Channel next) {
+      ClientInterceptor binlogInterceptor
+          = factory.getClientInterceptor(method.getFullMethodName());
+      if (binlogInterceptor == null) {
+        return next.newCall(method, callOptions);
+      } else {
+        return InternalClientInterceptors
+            .wrapClientInterceptor(
+                binlogInterceptor,
+                BYTEARRAY_MARSHALLER,
+                BYTEARRAY_MARSHALLER)
+            .interceptCall(method, callOptions, next);
+      }
+    }
+  }
+
+  /**
+   * A CallId is two byte[] arrays both of size 8 that uniquely identifies the RPC. Users are
+   * free to use the byte arrays however they see fit.
+   */
+  public static final class CallId {
+    public final long hi;
+    public final long lo;
+
+    /**
+     * Creates an instance.
+     */
+    public CallId(long hi, long lo) {
+      this.hi = hi;
+      this.lo = lo;
+    }
+
+    static CallId fromCensusSpan(Span span) {
+      return new CallId(0, ByteBuffer.wrap(span.getContext().getSpanId().getBytes()).getLong());
+    }
+  }
+
+  @Override
+  protected int priority() {
+    return 5;
+  }
+
+  @Override
+  protected boolean isAvailable() {
+    return true;
+  }
+}

--- a/services/src/main/java/io/grpc/services/internal/BinaryLogSink.java
+++ b/services/src/main/java/io/grpc/services/internal/BinaryLogSink.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.services;
+package io.grpc.services.internal;
 
 import com.google.protobuf.MessageLite;
 import java.io.Closeable;

--- a/services/src/main/java/io/grpc/services/internal/BinaryLogSinkProvider.java
+++ b/services/src/main/java/io/grpc/services/internal/BinaryLogSinkProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.services;
+package io.grpc.services.internal;
 
 import io.grpc.InternalServiceProviders;
 import java.util.Collections;

--- a/services/src/main/resources/META-INF/services/io.grpc.internal.BinaryLogProvider
+++ b/services/src/main/resources/META-INF/services/io.grpc.internal.BinaryLogProvider
@@ -1,0 +1,1 @@
+io.grpc.services.internal.BinaryLogProviderImpl

--- a/services/src/test/java/io/grpc/IntegerMarshaller.java
+++ b/services/src/test/java/io/grpc/IntegerMarshaller.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.io.InputStream;
+
+/** Marshalls decimal-encoded integers. */
+public class IntegerMarshaller implements MethodDescriptor.Marshaller<Integer> {
+  public static final IntegerMarshaller INSTANCE = new IntegerMarshaller();
+
+  @Override
+  public InputStream stream(Integer value) {
+    return StringMarshaller.INSTANCE.stream(value.toString());
+  }
+
+  @Override
+  public Integer parse(InputStream stream) {
+    return Integer.valueOf(StringMarshaller.INSTANCE.parse(stream));
+  }
+}

--- a/services/src/test/java/io/grpc/StringMarshaller.java
+++ b/services/src/test/java/io/grpc/StringMarshaller.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static com.google.common.base.Charsets.UTF_8;
+
+import com.google.common.io.ByteStreams;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/** Marshalls UTF-8 encoded strings. */
+public class StringMarshaller implements MethodDescriptor.Marshaller<String> {
+  public static StringMarshaller INSTANCE = new StringMarshaller();
+
+  @Override
+  public InputStream stream(String value) {
+    return new ByteArrayInputStream(value.getBytes(UTF_8));
+  }
+
+  @Override
+  public String parse(InputStream stream) {
+    try {
+      return new String(ByteStreams.toByteArray(stream), UTF_8);
+    } catch (IOException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/services/src/test/java/io/grpc/services/internal/BinaryLogTest.java
+++ b/services/src/test/java/io/grpc/services/internal/BinaryLogTest.java
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package io.grpc.services;
+package io.grpc.services.internal;
 
-import static io.grpc.internal.BinaryLogProvider.BYTEARRAY_MARSHALLER;
-import static io.grpc.services.BinaryLog.DUMMY_SOCKET;
-import static io.grpc.services.BinaryLog.emptyCallId;
-import static io.grpc.services.BinaryLog.getCallIdForClient;
-import static io.grpc.services.BinaryLog.getCallIdForServer;
-import static io.grpc.services.BinaryLog.getPeerSocket;
+import static io.grpc.services.internal.BinaryLog.DUMMY_SOCKET;
+import static io.grpc.services.internal.BinaryLog.emptyCallId;
+import static io.grpc.services.internal.BinaryLog.getCallIdForClient;
+import static io.grpc.services.internal.BinaryLog.getCallIdForServer;
+import static io.grpc.services.internal.BinaryLog.getPeerSocket;
+import static io.grpc.services.internal.BinaryLogProviderImpl.BYTEARRAY_MARSHALLER;
+import static io.grpc.services.internal.BinaryLogProviderImpl.CLIENT_CALL_ID_CALLOPTION_KEY;
+import static io.grpc.services.internal.BinaryLogProviderImpl.SERVER_CALL_ID_CONTEXT_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -51,13 +53,11 @@ import io.grpc.binarylog.MetadataEntry;
 import io.grpc.binarylog.Peer;
 import io.grpc.binarylog.Peer.PeerType;
 import io.grpc.binarylog.Uint128;
-import io.grpc.internal.BinaryLogProvider;
-import io.grpc.internal.BinaryLogProvider.CallId;
 import io.grpc.internal.NoopClientCall;
 import io.grpc.internal.NoopServerCall;
-import io.grpc.services.BinaryLog.FactoryImpl;
-import io.grpc.services.BinaryLog.SinkWriter;
-import io.grpc.services.BinaryLog.SinkWriterImpl;
+import io.grpc.services.internal.BinaryLog.SinkWriter;
+import io.grpc.services.internal.BinaryLog.SinkWriterImpl;
+import io.grpc.services.internal.BinaryLogProviderImpl.CallId;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -689,7 +689,7 @@ public final class BinaryLogTest {
         CALL_ID,
         getCallIdForServer(
             Context.ROOT.withValue(
-                BinaryLogProvider.SERVER_CALL_ID_CONTEXT_KEY,
+                SERVER_CALL_ID_CONTEXT_KEY,
                 CALL_ID)));
   }
 
@@ -700,7 +700,7 @@ public final class BinaryLogTest {
         CALL_ID,
         getCallIdForClient(
             CallOptions.DEFAULT.withOption(
-                BinaryLogProvider.CLIENT_CALL_ID_CALLOPTION_KEY,
+                CLIENT_CALL_ID_CALLOPTION_KEY,
                 CALL_ID)));
   }
 
@@ -764,7 +764,7 @@ public final class BinaryLogTest {
             .interceptCall(
                 method,
                 CallOptions.DEFAULT.withOption(
-                    BinaryLogProvider.CLIENT_CALL_ID_CALLOPTION_KEY, CALL_ID),
+                    CLIENT_CALL_ID_CALLOPTION_KEY, CALL_ID),
                 channel);
 
     // send initial metadata
@@ -837,7 +837,7 @@ public final class BinaryLogTest {
   @Test
   public void serverInterceptor() throws Exception {
     Context.current()
-        .withValue(BinaryLogProvider.SERVER_CALL_ID_CONTEXT_KEY, CALL_ID)
+        .withValue(SERVER_CALL_ID_CONTEXT_KEY, CALL_ID)
         .call(new Callable<Void>() {
           @Override
           public Void call() throws Exception {
@@ -1006,6 +1006,6 @@ public final class BinaryLogTest {
   }
 
   private BinaryLog makeLog(String logConfigStr) {
-    return FactoryImpl.createBinaryLog(sink, logConfigStr);
+    return BinaryLog.FactoryImpl.createBinaryLog(sink, logConfigStr);
   }
 }


### PR DESCRIPTION
- some fields previously exposed as public for testing are now
  package private
- remove tests from ManagedChannelImplTest and ServerImplTest, they
  are not really needed since BinaryLogProviderImplTest already do
  very similar things
- No more static instance of BinaryLog.Factory, it will be created by
  BinaryLogProviderImpl's constructor