### PR TITLE
netty,services: fix param comment lint

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -343,7 +343,7 @@ class NettyServer implements InternalServer, WithLogId {
         ret.set(new SocketStats(
             /*data=*/ null,
             ch.localAddress(),
-            /*remoteAddress=*/ null,
+            /*remote=*/ null,
             Utils.getSocketOptions(ch),
             /*security=*/ null));
         return ret;
@@ -356,7 +356,7 @@ class NettyServer implements InternalServer, WithLogId {
                   ret.set(new SocketStats(
                       /*data=*/ null,
                       ch.localAddress(),
-                      /*remoteAddress=*/ null,
+                      /*remote=*/ null,
                       Utils.getSocketOptions(ch),
                       /*security=*/ null));
                 }

--- a/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
+++ b/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
@@ -88,7 +88,7 @@ final class ChannelzTestHelper {
           new SocketStats(
               /*data=*/ null,
               listenAddress,
-              /*remoteAddress=*/ null,
+              /*remote=*/ null,
               new SocketOptions.Builder().build(),
               /*security=*/ null));
       return ret;


### PR DESCRIPTION
Fix linter complaint because comment does not match arg name.