### PR TITLE
core,netty: add NettySocketSupport to populate TcpInfo

### DIFF
--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -475,25 +475,284 @@ public final class Channelz {
     }
   }
 
+  public static final class TcpInfo {
+    public final int state;
+    public final int caState;
+    public final int retransmits;
+    public final int probes;
+    public final int backoff;
+    public final int options;
+    public final int sndWscale;
+    public final int rcvWscale;
+    public final int rto;
+    public final int ato;
+    public final int sndMss;
+    public final int rcvMss;
+    public final int unacked;
+    public final int sacked;
+    public final int lost;
+    public final int retrans;
+    public final int fackets;
+    public final int lastDataSent;
+    public final int lastAckSent;
+    public final int lastDataRecv;
+    public final int lastAckRecv;
+    public final int pmtu;
+    public final int rcvSsthresh;
+    public final int rtt;
+    public final int rttvar;
+    public final int sndSsthresh;
+    public final int sndCwnd;
+    public final int advmss;
+    public final int reordering;
+
+    TcpInfo(int state, int caState, int retransmits, int probes, int backoff, int options,
+        int sndWscale, int rcvWscale, int rto, int ato, int sndMss, int rcvMss, int unacked,
+        int sacked, int lost, int retrans, int fackets, int lastDataSent, int lastAckSent,
+        int lastDataRecv, int lastAckRecv, int pmtu, int rcvSsthresh, int rtt, int rttvar,
+        int sndSsthresh, int sndCwnd, int advmss, int reordering) {
+      this.state = state;
+      this.caState = caState;
+      this.retransmits = retransmits;
+      this.probes = probes;
+      this.backoff = backoff;
+      this.options = options;
+      this.sndWscale = sndWscale;
+      this.rcvWscale = rcvWscale;
+      this.rto = rto;
+      this.ato = ato;
+      this.sndMss = sndMss;
+      this.rcvMss = rcvMss;
+      this.unacked = unacked;
+      this.sacked = sacked;
+      this.lost = lost;
+      this.retrans = retrans;
+      this.fackets = fackets;
+      this.lastDataSent = lastDataSent;
+      this.lastAckSent = lastAckSent;
+      this.lastDataRecv = lastDataRecv;
+      this.lastAckRecv = lastAckRecv;
+      this.pmtu = pmtu;
+      this.rcvSsthresh = rcvSsthresh;
+      this.rtt = rtt;
+      this.rttvar = rttvar;
+      this.sndSsthresh = sndSsthresh;
+      this.sndCwnd = sndCwnd;
+      this.advmss = advmss;
+      this.reordering = reordering;
+    }
+
+    public static final class Builder {
+      private int state;
+      private int caState;
+      private int retransmits;
+      private int probes;
+      private int backoff;
+      private int options;
+      private int sndWscale;
+      private int rcvWscale;
+      private int rto;
+      private int ato;
+      private int sndMss;
+      private int rcvMss;
+      private int unacked;
+      private int sacked;
+      private int lost;
+      private int retrans;
+      private int fackets;
+      private int lastDataSent;
+      private int lastAckSent;
+      private int lastDataRecv;
+      private int lastAckRecv;
+      private int pmtu;
+      private int rcvSsthresh;
+      private int rtt;
+      private int rttvar;
+      private int sndSsthresh;
+      private int sndCwnd;
+      private int advmss;
+      private int reordering;
+
+      public Builder setState(int state) {
+        this.state = state;
+        return this;
+      }
+
+      public Builder setCaState(int caState) {
+        this.caState = caState;
+        return this;
+      }
+
+      public Builder setRetransmits(int retransmits) {
+        this.retransmits = retransmits;
+        return this;
+      }
+
+      public Builder setProbes(int probes) {
+        this.probes = probes;
+        return this;
+      }
+
+      public Builder setBackoff(int backoff) {
+        this.backoff = backoff;
+        return this;
+      }
+
+      public Builder setOptions(int options) {
+        this.options = options;
+        return this;
+      }
+
+      public Builder setSndWscale(int sndWscale) {
+        this.sndWscale = sndWscale;
+        return this;
+      }
+
+      public Builder setRcvWscale(int rcvWscale) {
+        this.rcvWscale = rcvWscale;
+        return this;
+      }
+
+      public Builder setRto(int rto) {
+        this.rto = rto;
+        return this;
+      }
+
+      public Builder setAto(int ato) {
+        this.ato = ato;
+        return this;
+      }
+
+      public Builder setSndMss(int sndMss) {
+        this.sndMss = sndMss;
+        return this;
+      }
+
+      public Builder setRcvMss(int rcvMss) {
+        this.rcvMss = rcvMss;
+        return this;
+      }
+
+      public Builder setUnacked(int unacked) {
+        this.unacked = unacked;
+        return this;
+      }
+
+      public Builder setSacked(int sacked) {
+        this.sacked = sacked;
+        return this;
+      }
+
+      public Builder setLost(int lost) {
+        this.lost = lost;
+        return this;
+      }
+
+      public Builder setRetrans(int retrans) {
+        this.retrans = retrans;
+        return this;
+      }
+
+      public Builder setFackets(int fackets) {
+        this.fackets = fackets;
+        return this;
+      }
+
+      public Builder setLastDataSent(int lastDataSent) {
+        this.lastDataSent = lastDataSent;
+        return this;
+      }
+
+      public Builder setLastAckSent(int lastAckSent) {
+        this.lastAckSent = lastAckSent;
+        return this;
+      }
+
+      public Builder setLastDataRecv(int lastDataRecv) {
+        this.lastDataRecv = lastDataRecv;
+        return this;
+      }
+
+      public Builder setLastAckRecv(int lastAckRecv) {
+        this.lastAckRecv = lastAckRecv;
+        return this;
+      }
+
+      public Builder setPmtu(int pmtu) {
+        this.pmtu = pmtu;
+        return this;
+      }
+
+      public Builder setRcvSsthresh(int rcvSsthresh) {
+        this.rcvSsthresh = rcvSsthresh;
+        return this;
+      }
+
+      public Builder setRtt(int rtt) {
+        this.rtt = rtt;
+        return this;
+      }
+
+      public Builder setRttvar(int rttvar) {
+        this.rttvar = rttvar;
+        return this;
+      }
+
+      public Builder setSndSsthresh(int sndSsthresh) {
+        this.sndSsthresh = sndSsthresh;
+        return this;
+      }
+
+      public Builder setSndCwnd(int sndCwnd) {
+        this.sndCwnd = sndCwnd;
+        return this;
+      }
+
+      public Builder setAdvmss(int advmss) {
+        this.advmss = advmss;
+        return this;
+      }
+
+      public Builder setReordering(int reordering) {
+        this.reordering = reordering;
+        return this;
+      }
+
+      /** Builds an instance. */
+      public TcpInfo build() {
+        return new TcpInfo(
+            state, caState, retransmits, probes, backoff, options, sndWscale, rcvWscale,
+            rto, ato, sndMss, rcvMss, unacked, sacked, lost, retrans, fackets, lastDataSent,
+            lastAckSent, lastDataRecv, lastAckRecv, pmtu, rcvSsthresh, rtt, rttvar, sndSsthresh,
+            sndCwnd, advmss, reordering);
+      }
+    }
+  }
+
   public static final class SocketOptions {
     public final Map<String, String> others;
     // In netty, the value of a channel option may be null.
     @Nullable public final Integer soTimeoutMillis;
     @Nullable public final Integer lingerSeconds;
+    @Nullable public final TcpInfo tcpInfo;
 
     /** Creates an instance. */
     public SocketOptions(
-        Integer timeoutMillis,
-        Integer lingerSeconds,
+        @Nullable Integer timeoutMillis,
+        @Nullable Integer lingerSeconds,
+        @Nullable TcpInfo tcpInfo,
         Map<String, String> others) {
       Preconditions.checkNotNull(others);
       this.soTimeoutMillis = timeoutMillis;
       this.lingerSeconds = lingerSeconds;
+      this.tcpInfo = tcpInfo;
       this.others = Collections.unmodifiableMap(new HashMap<String, String>(others));
     }
 
     public static final class Builder {
       private final Map<String, String> others = new HashMap<String, String>();
+
+      private TcpInfo tcpInfo;
       private Integer timeoutMillis;
       private Integer lingerSeconds;
 
@@ -508,6 +767,11 @@ public final class Channelz {
        */
       public Builder setSocketOptionLingerSeconds(Integer lingerSeconds) {
         this.lingerSeconds = lingerSeconds;
+        return this;
+      }
+
+      public Builder setTcpInfo(TcpInfo tcpInfo) {
+        this.tcpInfo = tcpInfo;
         return this;
       }
 
@@ -527,7 +791,7 @@ public final class Channelz {
       }
 
       public SocketOptions build() {
-        return new SocketOptions(timeoutMillis, lingerSeconds, others);
+        return new SocketOptions(timeoutMillis, lingerSeconds, tcpInfo, others);
       }
     }
   }

--- a/netty/src/main/java/io/grpc/netty/NettySocketSupport.java
+++ b/netty/src/main/java/io/grpc/netty/NettySocketSupport.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.internal.Channelz.TcpInfo;
+import io.netty.channel.Channel;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * An class for getting low level socket info.
+ */
+final class NettySocketSupport {
+
+  /**
+   * Returns the info on the socket if possible. Returns null if the info can not be discovered.
+   */
+  @Nullable
+  public static NativeSocketOptions getNativeSocketOptions(Channel ch) {
+    // TODO(zpencer): if netty-epoll, use reflection to call EpollSocketChannel.tcpInfo()
+    // And/or if some other low level socket support library is available, call it now.
+    return null;
+  }
+
+  /**
+   * A TcpInfo and additional other info that will be turned into channelz socket options.
+   */
+  public static final class NativeSocketOptions {
+    @Nullable public final TcpInfo tcpInfo;
+    public final ImmutableMap<String, String> otherInfo;
+
+    /** Creates an instance. */
+    public NativeSocketOptions(
+        TcpInfo tcpInfo,
+        Map<String, String> otherInfo) {
+      Preconditions.checkNotNull(otherInfo);
+      this.tcpInfo = tcpInfo;
+      this.otherInfo = ImmutableMap.copyOf(new HashMap<String, String>(otherInfo));
+    }
+  }
+
+  private NettySocketSupport() {}
+}

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -32,6 +32,7 @@ import io.grpc.internal.Channelz;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2InboundHeaders;
+import io.grpc.netty.NettySocketSupport.NativeSocketOptions;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOption;
@@ -234,6 +235,14 @@ class Utils {
       Object value = opt.getValue();
       // zpencer: Can a netty option be null?
       b.addOption(key.name(), String.valueOf(value));
+    }
+
+    NativeSocketOptions nativeOptions = NettySocketSupport.getNativeSocketOptions(channel);
+    if (nativeOptions != null) {
+      b.setTcpInfo(nativeOptions.tcpInfo); // may be null
+      for (Entry<String, String> entry : nativeOptions.otherInfo.entrySet()) {
+        b.addOption(entry.getKey(), entry.getValue());
+      }
     }
     return b.build();
   }

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -44,6 +44,7 @@ import io.grpc.channelz.v1.Socket.Builder;
 import io.grpc.channelz.v1.SocketData;
 import io.grpc.channelz.v1.SocketOption;
 import io.grpc.channelz.v1.SocketOptionLinger;
+import io.grpc.channelz.v1.SocketOptionTcpInfo;
 import io.grpc.channelz.v1.SocketOptionTimeout;
 import io.grpc.channelz.v1.SocketRef;
 import io.grpc.channelz.v1.Subchannel;
@@ -194,6 +195,7 @@ final class ChannelzProtoUtil {
 
   public static final String SO_LINGER = "SO_LINGER";
   public static final String SO_TIMEOUT = "SO_TIMEOUT";
+  public static final String TCP_INFO = "TCP_INFO";
 
   static SocketOption toSocketOptionLinger(int lingerSeconds) {
     final SocketOptionLinger lingerOpt;
@@ -227,6 +229,45 @@ final class ChannelzProtoUtil {
         .build();
   }
 
+  static SocketOption toSocketOptionTcpInfo(Channelz.TcpInfo i) {
+    SocketOptionTcpInfo tcpInfo = SocketOptionTcpInfo.newBuilder()
+        .setTcpiState(i.state)
+        .setTcpiCaState(i.caState)
+        .setTcpiRetrans(i.retransmits)
+        .setTcpiProbes(i.probes)
+        .setTcpiBackoff(i.backoff)
+        .setTcpiOptions(i.options)
+        .setTcpiSndWscale(i.sndWscale)
+        .setTcpiRcvWscale(i.rcvWscale)
+        .setTcpiRto(i.rto)
+        .setTcpiAto(i.ato)
+        .setTcpiSndMss(i.sndMss)
+        .setTcpiRcvMss(i.rcvMss)
+        .setTcpiUnacked(i.unacked)
+        .setTcpiSacked(i.sacked)
+        .setTcpiLost(i.lost)
+        .setTcpiRetrans(i.retrans)
+        .setTcpiFackets(i.fackets)
+        .setTcpiLastDataSent(i.lastDataSent)
+        .setTcpiLastAckSent(i.lastAckSent)
+        .setTcpiLastDataRecv(i.lastDataRecv)
+        .setTcpiLastAckRecv(i.lastAckRecv)
+        .setTcpiPmtu(i.pmtu)
+        .setTcpiRcvSsthresh(i.rcvSsthresh)
+        .setTcpiRtt(i.rtt)
+        .setTcpiRttvar(i.rttvar)
+        .setTcpiSndSsthresh(i.sndSsthresh)
+        .setTcpiSndCwnd(i.sndCwnd)
+        .setTcpiAdvmss(i.advmss)
+        .setTcpiReordering(i.reordering)
+        .build();
+    return SocketOption
+        .newBuilder()
+        .setName(TCP_INFO)
+        .setAdditional(Any.pack(tcpInfo))
+        .build();
+  }
+
   static SocketOption toSocketOptionAdditional(String name, String value) {
     Preconditions.checkNotNull(name);
     Preconditions.checkNotNull(value);
@@ -241,6 +282,9 @@ final class ChannelzProtoUtil {
     }
     if (options.soTimeoutMillis != null) {
       ret.add(toSocketOptionTimeout(SO_TIMEOUT, options.soTimeoutMillis));
+    }
+    if (options.tcpInfo != null) {
+      ret.add(toSocketOptionTcpInfo(options.tcpInfo));
     }
     for (Entry<String, String> entry : options.others.entrySet()) {
       ret.add(toSocketOptionAdditional(entry.getKey(), entry.getValue()));

--- a/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
+++ b/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
@@ -45,6 +45,7 @@ import io.grpc.channelz.v1.Socket;
 import io.grpc.channelz.v1.SocketData;
 import io.grpc.channelz.v1.SocketOption;
 import io.grpc.channelz.v1.SocketOptionLinger;
+import io.grpc.channelz.v1.SocketOptionTcpInfo;
 import io.grpc.channelz.v1.SocketOptionTimeout;
 import io.grpc.channelz.v1.SocketRef;
 import io.grpc.channelz.v1.Subchannel;
@@ -171,6 +172,77 @@ public final class ChannelzProtoUtilTest {
       .setValue("some-made-up-value")
       .build();
 
+  private final Channelz.TcpInfo channelzTcpInfo
+      = new Channelz.TcpInfo.Builder()
+      .setState(70)
+      .setCaState(71)
+      .setRetransmits(72)
+      .setProbes(73)
+      .setBackoff(74)
+      .setOptions(75)
+      .setSndWscale(76)
+      .setRcvWscale(77)
+      .setRto(78)
+      .setAto(79)
+      .setSndMss(710)
+      .setRcvMss(711)
+      .setUnacked(712)
+      .setSacked(713)
+      .setLost(714)
+      .setRetrans(715)
+      .setFackets(716)
+      .setLastDataSent(717)
+      .setLastAckSent(718)
+      .setLastDataRecv(719)
+      .setLastAckRecv(720)
+      .setPmtu(721)
+      .setRcvSsthresh(722)
+      .setRtt(723)
+      .setRttvar(724)
+      .setSndSsthresh(725)
+      .setSndCwnd(726)
+      .setAdvmss(727)
+      .setReordering(728)
+      .build();
+
+  private final SocketOption socketOptionTcpInfo = SocketOption
+      .newBuilder()
+      .setName("TCP_INFO")
+      .setAdditional(
+          Any.pack(
+              SocketOptionTcpInfo.newBuilder()
+                  .setTcpiState(70)
+                  .setTcpiCaState(71)
+                  .setTcpiRetrans(72)
+                  .setTcpiProbes(73)
+                  .setTcpiBackoff(74)
+                  .setTcpiOptions(75)
+                  .setTcpiSndWscale(76)
+                  .setTcpiRcvWscale(77)
+                  .setTcpiRto(78)
+                  .setTcpiAto(79)
+                  .setTcpiSndMss(710)
+                  .setTcpiRcvMss(711)
+                  .setTcpiUnacked(712)
+                  .setTcpiSacked(713)
+                  .setTcpiLost(714)
+                  .setTcpiRetrans(715)
+                  .setTcpiFackets(716)
+                  .setTcpiLastDataSent(717)
+                  .setTcpiLastAckSent(718)
+                  .setTcpiLastDataRecv(719)
+                  .setTcpiLastAckRecv(720)
+                  .setTcpiPmtu(721)
+                  .setTcpiRcvSsthresh(722)
+                  .setTcpiRtt(723)
+                  .setTcpiRttvar(724)
+                  .setTcpiSndSsthresh(725)
+                  .setTcpiSndCwnd(726)
+                  .setTcpiAdvmss(727)
+                  .setTcpiReordering(728)
+                  .build()))
+      .build();
+
   private final TestListenSocket listenSocket = new TestListenSocket();
   private final SocketRef listenSocketRef = SocketRef
       .newBuilder()
@@ -283,11 +355,13 @@ public final class ChannelzProtoUtilTest {
     // with options
     socket.socketOptions = toBuilder(socket.socketOptions)
         .setSocketOptionLingerSeconds(10)
+        .setTcpInfo(channelzTcpInfo)
         .build();
     assertEquals(
         socketDataNoSockOpts
             .toBuilder()
             .addOption(sockOptlinger10s)
+            .addOption(socketOptionTcpInfo)
             .build(),
         ChannelzProtoUtil.extractSocketData(socket.getStats().get()));
   }
@@ -624,6 +698,13 @@ public final class ChannelzProtoUtilTest {
     assertEquals(
         sockOptAdditional,
         ChannelzProtoUtil.toSocketOptionAdditional("SO_MADE_UP_OPTION", "some-made-up-value"));
+  }
+
+  @Test
+  public void toSocketOptionTcpInfo() {
+    assertEquals(
+        socketOptionTcpInfo,
+        ChannelzProtoUtil.toSocketOptionTcpInfo(channelzTcpInfo));
   }
 
   @Test


### PR DESCRIPTION
NettySocketSupport is responsible for making the low level calls to
get and populate the TcpInfo structure.