### PR TITLE
examples: upgrade protobuf-maven-plugin to 0.5.1

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:3.5.1-1:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>


### PR DESCRIPTION
This was missed in 2094bb4d8

CC @jorgheymans, oops, we missed this in review.