### PR TITLE
buildscripts: fix GAE dummy app deploy races

### DIFF
--- a/buildscripts/kokoro/gae-interop.sh
+++ b/buildscripts/kokoro/gae-interop.sh
@@ -40,16 +40,16 @@ DUMMY_EXISTS_CMD="gcloud app versions describe $DUMMY_DEFAULT_VERSION --service=
 DEPLOY_DUMMY_CMD="./gradlew $GRADLE_FLAGS -DgaeDeployVersion=$DUMMY_DEFAULT_VERSION :grpc-gae-interop-testing-jdk8:appengineDeploy"
 
 # Deploy the dummy 'default' version. We only require that it exists when cleanup() is called.
+# It ok if we race with another run and fail here, because the end result is idempotent.
 set +e
 $DUMMY_EXISTS_CMD
 EXIST=$?
-set -e
-
 if [[ $EXIST != 0 ]]; then
   $DEPLOY_DUMMY_CMD
 else
   echo "default version already exists: $DUMMY_DEFAULT_VERSION"
 fi
+set -e
 
 ##
 ## Begin JDK8 test
@@ -83,7 +83,8 @@ set +e
 echo "Cleaning out stale deploys from previous runs, it is ok if this part fails"
 
 # Sometimes the trap based cleanup fails.
-# Delete all versions older than 1 hour. This expression is an ISO8601 relative date:
+# Delete all versions whose name starts with 'kokoro' and is older than 1 hour.
+# This expression is an ISO8601 relative date:
 # https://cloud.google.com/sdk/gcloud/reference/topic/datetimes
-gcloud app versions list --format="get(version.id)" --filter="service=$KOKORO_GAE_SERVICE AND version.createTime<'-p1h'" | xargs -i gcloud app services delete $KOKORO_GAE_SERVICE --version {} --quiet
+gcloud app versions list --format="get(version.id)" --filter="service=$KOKORO_GAE_SERVICE AND version : 'kokoro*' AND version.createTime<'-p1h'" | xargs -i gcloud app services delete $KOKORO_GAE_SERVICE --version {} --quiet
 exit 0


### PR DESCRIPTION
This fixes a race where we can race with another deploy of the
'dummy' version.

Also, when we delete old versions, only delete versions beginning with
'kokoro'. This would make races even less likely because the
'dummy-default' should normally stick around forever.

This fixes this failure:
https://source.cloud.google.com/results/invocations/6b24aed4-7dc3-490a-87ea-c870d1435184/targets/grpc%2Fjava%2Fpresubmit%2Fgae-interop/log