### PR TITLE
compiler: allow capitalized java keywords as rpc names

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <iterator>
 #include <map>
+#include <set>
 #include <vector>
 #include <google/protobuf/compiler/java/java_names.h>
 #include <google/protobuf/descriptor.h>
@@ -33,9 +34,67 @@ using google::protobuf::io::Printer;
 using google::protobuf::SourceLocation;
 using std::to_string;
 
+// java keywords from: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html
+static std::set<string> java_keywords = {
+  "abstract",
+  "assert",
+  "boolean",
+  "break",
+  "byte",
+  "case",
+  "catch",
+  "char",
+  "class",
+  "const",
+  "continue",
+  "default",
+  "do",
+  "double",
+  "else",
+  "enum",
+  "extends",
+  "final",
+  "finally",
+  "float",
+  "for",
+  "goto",
+  "if",
+  "implements",
+  "import",
+  "instanceof",
+  "int",
+  "interface",
+  "long",
+  "native",
+  "new",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "short",
+  "static",
+  "strictfp",
+  "super",
+  "switch",
+  "synchronized",
+  "this",
+  "throw",
+  "throws",
+  "transient",
+  "try",
+  "void",
+  "volatile",
+  "while",
+  // additional ones added by us
+  "true",
+  "false",
+};
+
 // Adjust a method name prefix identifier to follow the JavaBean spec:
 //   - decapitalize the first letter
 //   - remove embedded underscores & capitalize the following letter
+//  Finally, if the result is a reserved java keyword, append an underscore.
 static string MixedLower(const string& word) {
   string w;
   w += tolower(word[0]);
@@ -48,7 +107,10 @@ static string MixedLower(const string& word) {
       after_underscore = false;
     }
   }
-  return w;
+  if (java_keywords.find(w) == java_keywords.end()) {
+    return w;
+  }
+  return w + "_";
 }
 
 // Converts to the identifier to the ALL_UPPER_CASE format.

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -107,10 +107,10 @@ static string MixedLower(const string& word) {
       after_underscore = false;
     }
   }
-  if (java_keywords.find(w) == java_keywords.end()) {
-    return w;
+  if (java_keywords.find(w) != java_keywords.end()) {
+    return w + "_";
   }
-  return w + "_";
+  return w;
 }
 
 // Converts to the identifier to the ALL_UPPER_CASE format.

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -34,7 +34,7 @@ using google::protobuf::io::Printer;
 using google::protobuf::SourceLocation;
 using std::to_string;
 
-// java keywords from: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html
+// java keywords from: https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.9
 static std::set<string> java_keywords = {
   "abstract",
   "assert",

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -215,6 +215,43 @@ public final class TestServiceGrpc {
      }
      return getHalfBidiCallMethod;
   }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getImportMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_IMPORT = getImportMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getImportMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getImportMethod() {
+    return getImportMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getImportMethodHelper() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse> getImportMethod;
+    if ((getImportMethod = TestServiceGrpc.getImportMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getImportMethod = TestServiceGrpc.getImportMethod) == null) {
+          TestServiceGrpc.getImportMethod = getImportMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "Import"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new TestServiceMethodDescriptorSupplier("Import"))
+                  .build();
+          }
+        }
+     }
+     return getImportMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -304,6 +341,17 @@ public final class TestServiceGrpc {
       return asyncUnimplementedStreamingCall(getHalfBidiCallMethodHelper(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * An RPC method whose Java name collides with a keyword, and whose generated
+     * method should have a '_' appended.
+     * </pre>
+     */
+    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> import_(
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(getImportMethodHelper(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -341,6 +389,13 @@ public final class TestServiceGrpc {
                 io.grpc.testing.integration.Test.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
                   this, METHODID_HALF_BIDI_CALL)))
+          .addMethod(
+            getImportMethodHelper(),
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingInputCallRequest,
+                io.grpc.testing.integration.Test.StreamingInputCallResponse>(
+                  this, METHODID_IMPORT)))
           .build();
     }
   }
@@ -428,6 +483,18 @@ public final class TestServiceGrpc {
       return asyncBidiStreamingCall(
           getChannel().newCall(getHalfBidiCallMethodHelper(), getCallOptions()), responseObserver);
     }
+
+    /**
+     * <pre>
+     * An RPC method whose Java name collides with a keyword, and whose generated
+     * method should have a '_' appended.
+     * </pre>
+     */
+    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> import_(
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncBidiStreamingCall(
+          getChannel().newCall(getImportMethodHelper(), getCallOptions()), responseObserver);
+    }
   }
 
   /**
@@ -514,6 +581,7 @@ public final class TestServiceGrpc {
   private static final int METHODID_STREAMING_INPUT_CALL = 2;
   private static final int METHODID_FULL_BIDI_CALL = 3;
   private static final int METHODID_HALF_BIDI_CALL = 4;
+  private static final int METHODID_IMPORT = 5;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -559,6 +627,9 @@ public final class TestServiceGrpc {
         case METHODID_HALF_BIDI_CALL:
           return (io.grpc.stub.StreamObserver<Req>) serviceImpl.halfBidiCall(
               (io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse>) responseObserver);
+        case METHODID_IMPORT:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.import_(
+              (io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse>) responseObserver);
         default:
           throw new AssertionError();
       }
@@ -615,6 +686,7 @@ public final class TestServiceGrpc {
               .addMethod(getStreamingInputCallMethodHelper())
               .addMethod(getFullBidiCallMethodHelper())
               .addMethod(getHalfBidiCallMethodHelper())
+              .addMethod(getImportMethodHelper())
               .build();
         }
       }

--- a/compiler/src/test/proto/test.proto
+++ b/compiler/src/test/proto/test.proto
@@ -23,6 +23,11 @@ message StreamingOutputCallRequest {
 message StreamingOutputCallResponse {
 }
 
+// Because these are capitalized, they do not collide with Java keywords.
+// Had they been 'native' or 'volatile' then protoc would generate invalid Java code.
+message Native {}
+message Volatile {}
+
 // Test service that supports all call types.
 service TestService {
   // One request followed by one response.
@@ -51,4 +56,8 @@ service TestService {
   // first request.
   rpc HalfBidiCall(stream StreamingOutputCallRequest)
       returns (stream StreamingOutputCallResponse);
+
+  // An RPC method whose Java name collides with a keyword, and whose generated
+  // method should have a '_' appended.
+  rpc Import(stream StreamingInputCallRequest) returns (stream StreamingInputCallResponse);
 }

--- a/compiler/src/test/proto/test.proto
+++ b/compiler/src/test/proto/test.proto
@@ -23,11 +23,6 @@ message StreamingOutputCallRequest {
 message StreamingOutputCallResponse {
 }
 
-// Because these are capitalized, they do not collide with Java keywords.
-// Had they been 'native' or 'volatile' then protoc would generate invalid Java code.
-message Native {}
-message Volatile {}
-
 // Test service that supports all call types.
 service TestService {
   // One request followed by one response.

--- a/compiler/src/testLite/golden/TestService.java.txt
+++ b/compiler/src/testLite/golden/TestService.java.txt
@@ -210,6 +210,42 @@ public final class TestServiceGrpc {
      }
      return getHalfBidiCallMethod;
   }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getImportMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> METHOD_IMPORT = getImportMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getImportMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getImportMethod() {
+    return getImportMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.Test.StreamingInputCallResponse> getImportMethodHelper() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse> getImportMethod;
+    if ((getImportMethod = TestServiceGrpc.getImportMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getImportMethod = TestServiceGrpc.getImportMethod) == null) {
+          TestServiceGrpc.getImportMethod = getImportMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.Test.StreamingInputCallRequest, io.grpc.testing.integration.Test.StreamingInputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "Import"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingInputCallRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.lite.ProtoLiteUtils.marshaller(
+                  io.grpc.testing.integration.Test.StreamingInputCallResponse.getDefaultInstance()))
+                  .build();
+          }
+        }
+     }
+     return getImportMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -299,6 +335,17 @@ public final class TestServiceGrpc {
       return asyncUnimplementedStreamingCall(getHalfBidiCallMethodHelper(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * An RPC method whose Java name collides with a keyword, and whose generated
+     * method should have a '_' appended.
+     * </pre>
+     */
+    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> import_(
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(getImportMethodHelper(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -336,6 +383,13 @@ public final class TestServiceGrpc {
                 io.grpc.testing.integration.Test.StreamingOutputCallRequest,
                 io.grpc.testing.integration.Test.StreamingOutputCallResponse>(
                   this, METHODID_HALF_BIDI_CALL)))
+          .addMethod(
+            getImportMethodHelper(),
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.Test.StreamingInputCallRequest,
+                io.grpc.testing.integration.Test.StreamingInputCallResponse>(
+                  this, METHODID_IMPORT)))
           .build();
     }
   }
@@ -423,6 +477,18 @@ public final class TestServiceGrpc {
       return asyncBidiStreamingCall(
           getChannel().newCall(getHalfBidiCallMethodHelper(), getCallOptions()), responseObserver);
     }
+
+    /**
+     * <pre>
+     * An RPC method whose Java name collides with a keyword, and whose generated
+     * method should have a '_' appended.
+     * </pre>
+     */
+    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallRequest> import_(
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncBidiStreamingCall(
+          getChannel().newCall(getImportMethodHelper(), getCallOptions()), responseObserver);
+    }
   }
 
   /**
@@ -509,6 +575,7 @@ public final class TestServiceGrpc {
   private static final int METHODID_STREAMING_INPUT_CALL = 2;
   private static final int METHODID_FULL_BIDI_CALL = 3;
   private static final int METHODID_HALF_BIDI_CALL = 4;
+  private static final int METHODID_IMPORT = 5;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -554,6 +621,9 @@ public final class TestServiceGrpc {
         case METHODID_HALF_BIDI_CALL:
           return (io.grpc.stub.StreamObserver<Req>) serviceImpl.halfBidiCall(
               (io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingOutputCallResponse>) responseObserver);
+        case METHODID_IMPORT:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.import_(
+              (io.grpc.stub.StreamObserver<io.grpc.testing.integration.Test.StreamingInputCallResponse>) responseObserver);
         default:
           throw new AssertionError();
       }
@@ -574,6 +644,7 @@ public final class TestServiceGrpc {
               .addMethod(getStreamingInputCallMethodHelper())
               .addMethod(getFullBidiCallMethodHelper())
               .addMethod(getHalfBidiCallMethodHelper())
+              .addMethod(getImportMethodHelper())
               .build();
         }
       }

--- a/compiler/src/testNano/golden/TestService.java.txt
+++ b/compiler/src/testNano/golden/TestService.java.txt
@@ -222,6 +222,44 @@ public final class TestServiceGrpc {
     }
     return getHalfBidiCallMethod;
   }
+  private static final int ARG_IN_METHOD_IMPORT = 10;
+  private static final int ARG_OUT_METHOD_IMPORT = 11;
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getImportMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> METHOD_IMPORT = getImportMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getImportMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getImportMethod() {
+    return getImportMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+      io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getImportMethodHelper() {
+    io.grpc.MethodDescriptor<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest, io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> getImportMethod;
+    if ((getImportMethod = TestServiceGrpc.getImportMethod) == null) {
+      synchronized (TestServiceGrpc.class) {
+        if ((getImportMethod = TestServiceGrpc.getImportMethod) == null) {
+          TestServiceGrpc.getImportMethod = getImportMethod = 
+              io.grpc.MethodDescriptor.<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest, io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "grpc.testing.TestService", "Import"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest>(ARG_IN_METHOD_IMPORT)))
+              .setResponseMarshaller(io.grpc.protobuf.nano.NanoUtils.<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>marshaller(
+                  new NanoFactory<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>(ARG_OUT_METHOD_IMPORT)))
+              .build();
+        }
+      }
+    }
+    return getImportMethod;
+  }
 
   private static final class NanoFactory<T extends com.google.protobuf.nano.MessageNano>
       implements io.grpc.protobuf.nano.MessageNanoFactory<T> {
@@ -264,6 +302,12 @@ public final class TestServiceGrpc {
         break;
       case ARG_OUT_METHOD_HALF_BIDI_CALL:
         o = new io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse();
+        break;
+      case ARG_IN_METHOD_IMPORT:
+        o = new io.grpc.testing.integration.nano.Test.StreamingInputCallRequest();
+        break;
+      case ARG_OUT_METHOD_IMPORT:
+        o = new io.grpc.testing.integration.nano.Test.StreamingInputCallResponse();
         break;
       default:
         throw new AssertionError();
@@ -362,6 +406,17 @@ public final class TestServiceGrpc {
       return asyncUnimplementedStreamingCall(getHalfBidiCallMethodHelper(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * An RPC method whose Java name collides with a keyword, and whose generated
+     * method should have a '_' appended.
+     * </pre>
+     */
+    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> import_(
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(getImportMethodHelper(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -399,6 +454,13 @@ public final class TestServiceGrpc {
                 io.grpc.testing.integration.nano.Test.StreamingOutputCallRequest,
                 io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>(
                   this, METHODID_HALF_BIDI_CALL)))
+          .addMethod(
+            getImportMethodHelper(),
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                io.grpc.testing.integration.nano.Test.StreamingInputCallRequest,
+                io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>(
+                  this, METHODID_IMPORT)))
           .build();
     }
   }
@@ -486,6 +548,18 @@ public final class TestServiceGrpc {
       return asyncBidiStreamingCall(
           getChannel().newCall(getHalfBidiCallMethodHelper(), getCallOptions()), responseObserver);
     }
+
+    /**
+     * <pre>
+     * An RPC method whose Java name collides with a keyword, and whose generated
+     * method should have a '_' appended.
+     * </pre>
+     */
+    public io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallRequest> import_(
+        io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse> responseObserver) {
+      return asyncBidiStreamingCall(
+          getChannel().newCall(getImportMethodHelper(), getCallOptions()), responseObserver);
+    }
   }
 
   /**
@@ -572,6 +646,7 @@ public final class TestServiceGrpc {
   private static final int METHODID_STREAMING_INPUT_CALL = 2;
   private static final int METHODID_FULL_BIDI_CALL = 3;
   private static final int METHODID_HALF_BIDI_CALL = 4;
+  private static final int METHODID_IMPORT = 5;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -617,6 +692,9 @@ public final class TestServiceGrpc {
         case METHODID_HALF_BIDI_CALL:
           return (io.grpc.stub.StreamObserver<Req>) serviceImpl.halfBidiCall(
               (io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingOutputCallResponse>) responseObserver);
+        case METHODID_IMPORT:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.import_(
+              (io.grpc.stub.StreamObserver<io.grpc.testing.integration.nano.Test.StreamingInputCallResponse>) responseObserver);
         default:
           throw new AssertionError();
       }
@@ -637,6 +715,7 @@ public final class TestServiceGrpc {
               .addMethod(getStreamingInputCallMethodHelper())
               .addMethod(getFullBidiCallMethodHelper())
               .addMethod(getHalfBidiCallMethodHelper())
+              .addMethod(getImportMethodHelper())
               .build();
         }
       }


### PR DESCRIPTION
previously `Import` fails because it gets turned into a method named
`import`. This PR makes the method be named `import_`, everything else
stays the same, such as the name in the method descriptor.

Note: `iMport` or `iMPORT` or any variation of capitalizations that is
not `Import` always worked. `Import` gets translated into `import`
because of our attempts to camel case the names.

fixes https://github.com/grpc/grpc-java/issues/2195