### PR TITLE
core: Convert KeepAliveManager to use Rescheduler

### DIFF
--- a/core/src/main/java/io/grpc/internal/KeepAliveManager.java
+++ b/core/src/main/java/io/grpc/internal/KeepAliveManager.java
@@ -17,11 +17,12 @@
 package io.grpc.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Status;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -30,18 +31,20 @@ import java.util.concurrent.TimeUnit;
  * Manages keepalive pings.
  */
 public class KeepAliveManager {
-  private static final SystemTicker SYSTEM_TICKER = new SystemTicker();
   private static final long MIN_KEEPALIVE_TIME_NANOS = TimeUnit.SECONDS.toNanos(10);
   private static final long MIN_KEEPALIVE_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(10L);
 
-  private final ScheduledExecutorService scheduler;
-  private final Ticker ticker;
   private final KeepAlivePinger keepAlivePinger;
+  private final ScheduledExecutorService scheduler;
+  private final long keepAliveTimeInNanos;
+  private final long keepAliveTimeoutInNanos;
   private final boolean keepAliveDuringTransportIdle;
+  private final Rescheduler sendPingRescheduler;
+
   private State state = State.IDLE;
-  private long nextKeepaliveTime;
+  /** Whether a ping was suppressed because the channel was inactive. */
+  private boolean pingSuppressed;
   private ScheduledFuture<?> shutdownFuture;
-  private ScheduledFuture<?> pingFuture;
   private final Runnable shutdown = new LogExceptionRunnable(new Runnable() {
     @Override
     public void run() {
@@ -59,36 +62,6 @@ public class KeepAliveManager {
       }
     }
   });
-  private final Runnable sendPing = new LogExceptionRunnable(new Runnable() {
-    @Override
-    public void run() {
-      pingFuture = null;
-      boolean shouldSendPing = false;
-      synchronized (KeepAliveManager.this) {
-        if (state == State.PING_SCHEDULED) {
-          shouldSendPing = true;
-          state = State.PING_SENT;
-          // Schedule a shutdown. It fires if we don't receive the ping response within the timeout.
-          shutdownFuture = scheduler.schedule(shutdown, keepAliveTimeoutInNanos,
-              TimeUnit.NANOSECONDS);
-        } else if (state == State.PING_DELAYED) {
-          // We have received some data. Reschedule the ping with the new time.
-          pingFuture = scheduler.schedule(
-              sendPing,
-              nextKeepaliveTime - ticker.read(),
-              TimeUnit.NANOSECONDS);
-          state = State.PING_SCHEDULED;
-        }
-      }
-      if (shouldSendPing) {
-        // Send the ping.
-        keepAlivePinger.ping();
-      }
-    }
-  });
-
-  private long keepAliveTimeInNanos;
-  private long keepAliveTimeoutInNanos;
 
   private enum State {
     /*
@@ -101,10 +74,6 @@ public class KeepAliveManager {
      * some data.
      */
     PING_SCHEDULED,
-    /*
-     * We need to delay the scheduled keepalive ping.
-     */
-    PING_DELAYED,
     /*
      * The ping has been sent out. Waiting for a ping response.
      */
@@ -125,25 +94,31 @@ public class KeepAliveManager {
   public KeepAliveManager(KeepAlivePinger keepAlivePinger, ScheduledExecutorService scheduler,
                           long keepAliveTimeInNanos, long keepAliveTimeoutInNanos,
                           boolean keepAliveDuringTransportIdle) {
-    this(keepAlivePinger, scheduler, SYSTEM_TICKER, keepAliveTimeInNanos, keepAliveTimeoutInNanos,
-        keepAliveDuringTransportIdle);
+    this(keepAlivePinger, scheduler, Stopwatch.createUnstarted(), keepAliveTimeInNanos,
+        keepAliveTimeoutInNanos, keepAliveDuringTransportIdle);
   }
 
   @VisibleForTesting
   KeepAliveManager(KeepAlivePinger keepAlivePinger, ScheduledExecutorService scheduler,
-                   Ticker ticker, long keepAliveTimeInNanos, long keepAliveTimeoutInNanos,
+                   Stopwatch stopwatch, long keepAliveTimeInNanos, long keepAliveTimeoutInNanos,
                    boolean keepAliveDuringTransportIdle) {
     this.keepAlivePinger = checkNotNull(keepAlivePinger, "keepAlivePinger");
     this.scheduler = checkNotNull(scheduler, "scheduler");
-    this.ticker = checkNotNull(ticker, "ticker");
     this.keepAliveTimeInNanos = keepAliveTimeInNanos;
     this.keepAliveTimeoutInNanos = keepAliveTimeoutInNanos;
     this.keepAliveDuringTransportIdle = keepAliveDuringTransportIdle;
-    nextKeepaliveTime = ticker.read() + keepAliveTimeInNanos;
+    Runnable sendPing = new LogExceptionRunnable(new Runnable() {
+      @Override public void run() {
+        sendPing();
+      }
+    });
+    this.sendPingRescheduler = new Rescheduler(
+        sendPing, new SynchronizedDirectExecutor(), scheduler, stopwatch);
   }
 
   /** Start keepalive monitoring. */
   public synchronized void onTransportStarted() {
+    sendPingRescheduler.reschedule(keepAliveTimeInNanos, TimeUnit.NANOSECONDS);
     if (keepAliveDuringTransportIdle) {
       onTransportActive();
     }
@@ -153,27 +128,19 @@ public class KeepAliveManager {
    * Transport has received some data so that we can delay sending keepalives.
    */
   public synchronized void onDataReceived() {
-    nextKeepaliveTime = ticker.read() + keepAliveTimeInNanos;
-    // We do not cancel the ping future here. This avoids constantly scheduling and cancellation in
-    // a busy transport. Instead, we update the status here and reschedule later. So we actually
-    // keep one sendPing task always in flight when there're active rpcs.
     if (state == State.PING_SCHEDULED) {
-      state = State.PING_DELAYED;
+      sendPingRescheduler.reschedule(keepAliveTimeInNanos, TimeUnit.NANOSECONDS);
     } else if (state == State.PING_SENT || state == State.IDLE_AND_PING_SENT) {
-      // Ping acked or effectively ping acked. Cancel shutdown, and then if not idle,
-      // schedule a new keep-alive ping.
+      // Ping acked or effectively ping acked.
       if (shutdownFuture != null) {
         shutdownFuture.cancel(false);
       }
       if (state == State.IDLE_AND_PING_SENT) {
-        // not to schedule new pings until onTransportActive
         state = State.IDLE;
-        return;
+      } else {
+        state = State.PING_SCHEDULED;
       }
-      // schedule a new ping
-      state = State.PING_SCHEDULED;
-      checkState(pingFuture == null, "There should be no outstanding pingFuture");
-      pingFuture = scheduler.schedule(sendPing, keepAliveTimeInNanos, TimeUnit.NANOSECONDS);
+      sendPingRescheduler.reschedule(keepAliveTimeInNanos, TimeUnit.NANOSECONDS);
     }
   }
 
@@ -182,14 +149,12 @@ public class KeepAliveManager {
    */
   public synchronized void onTransportActive() {
     if (state == State.IDLE) {
-      // When the transport goes active, we do not reset the nextKeepaliveTime. This allows us to
+      // When the transport goes active, we do not reset the ping rescheduler. This allows us to
       // quickly check whether the connection is still working.
       state = State.PING_SCHEDULED;
-      if (pingFuture == null) {
-        pingFuture = scheduler.schedule(
-            sendPing,
-            nextKeepaliveTime - ticker.read(),
-            TimeUnit.NANOSECONDS);
+      if (pingSuppressed) {
+        pingSuppressed = false;
+        sendPing();
       }
     } else if (state == State.IDLE_AND_PING_SENT) {
       state = State.PING_SENT;
@@ -203,7 +168,7 @@ public class KeepAliveManager {
     if (keepAliveDuringTransportIdle) {
       return;
     }
-    if (state == State.PING_SCHEDULED || state == State.PING_DELAYED) {
+    if (state == State.PING_SCHEDULED) {
       state = State.IDLE;
     }
     if (state == State.PING_SENT) {
@@ -220,10 +185,30 @@ public class KeepAliveManager {
       if (shutdownFuture != null) {
         shutdownFuture.cancel(false);
       }
-      if (pingFuture != null) {
-        pingFuture.cancel(false);
-        pingFuture = null;
-      }
+      sendPingRescheduler.cancel(true);
+    }
+  }
+
+  /**
+   * Timer for keepalive expired; proceed to send a ping. Does not actually send a ping if in IDLE
+   * state.
+   */
+  private synchronized void sendPing() {
+    // Note that this method is generally called with the lock already held
+    if (state == State.PING_SCHEDULED) {
+      state = State.PING_SENT;
+      // Avoid calling the keepAlivePinger with lock held
+      scheduler.execute(new LogExceptionRunnable(new Runnable() {
+        @Override public void run() {
+          // Send the ping.
+          keepAlivePinger.ping();
+        }
+      }));
+      // Schedule a shutdown. It fires if we don't receive the ping response within the timeout.
+      shutdownFuture = scheduler.schedule(shutdown, keepAliveTimeoutInNanos,
+          TimeUnit.NANOSECONDS);
+    } else if (state == State.IDLE) {
+      pingSuppressed = true;
     }
   }
 
@@ -239,6 +224,14 @@ public class KeepAliveManager {
    */
   public static long clampKeepAliveTimeoutInNanos(long keepAliveTimeoutInNanos) {
     return Math.max(keepAliveTimeoutInNanos, MIN_KEEPALIVE_TIMEOUT_NANOS);
+  }
+
+  private class SynchronizedDirectExecutor implements Executor {
+    @Override public void execute(Runnable run) {
+      synchronized (KeepAliveManager.this) {
+        run.run();
+      }
+    }
   }
 
   public interface KeepAlivePinger {
@@ -281,22 +274,6 @@ public class KeepAliveManager {
     public void onPingTimeout() {
       transport.shutdownNow(Status.UNAVAILABLE.withDescription(
           "Keepalive failed. The connection is likely gone"));
-    }
-  }
-
-  // TODO(zsurocking): Classes below are copied from Deadline.java. We should consider share the
-  // code.
-
-  /** Time source representing nanoseconds since fixed but arbitrary point in time. */
-  abstract static class Ticker {
-    /** Returns the number of nanoseconds since this source's epoch. */
-    public abstract long read();
-  }
-
-  private static class SystemTicker extends Ticker {
-    @Override
-    public long read() {
-      return System.nanoTime();
     }
   }
 }

--- a/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
+++ b/core/src/test/java/io/grpc/internal/KeepAliveManagerTest.java
@@ -18,12 +18,15 @@ package io.grpc.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Iterables;
 import io.grpc.Status;
 import io.grpc.internal.KeepAliveManager.ClientKeepAlivePinger;
 import io.grpc.internal.KeepAliveManager.KeepAlivePinger;
@@ -36,108 +39,74 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public final class KeepAliveManagerTest {
-  private final FakeTicker ticker = new FakeTicker();
+  private final FakeClock fakeClock = new FakeClock();
   private KeepAliveManager keepAliveManager;
   @Mock private KeepAlivePinger keepAlivePinger;
-  @Mock private ConnectionClientTransport transport;
-  @Mock private ScheduledExecutorService scheduler;
-  @Captor
-  private ArgumentCaptor<Status> statusCaptor;
-
-  static class FakeTicker extends KeepAliveManager.Ticker {
-    long time;
-
-    @Override
-    public long read() {
-      return time;
-    }
-  }
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    keepAliveManager = new KeepAliveManager(keepAlivePinger, scheduler, ticker, 1000, 2000, false);
+    ScheduledExecutorService scheduler = fakeClock.getScheduledExecutorService();
+    Stopwatch stopwatch = fakeClock.getStopwatchSupplier().get();
+    keepAliveManager = new KeepAliveManager(
+        keepAlivePinger, scheduler, stopwatch, 1000, 2000, false);
+    keepAliveManager.onTransportStarted();
   }
 
   @Test
   public void sendKeepAlivePings() {
-    ticker.time = 1;
+    fakeClock.forwardNanos(1);
     // Transport becomes active. We should schedule keepalive pings.
     keepAliveManager.onTransportActive();
-    ArgumentCaptor<Long> delayCaptor = ArgumentCaptor.forClass(Long.class);
-    ArgumentCaptor<Runnable> sendPingCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler, times(1)).schedule(sendPingCaptor.capture(), delayCaptor.capture(),
-        isA(TimeUnit.class));
-    Runnable sendPing = sendPingCaptor.getValue();
-    Long delay = delayCaptor.getValue();
-    assertEquals(1000 - 1, delay.longValue());
+    ScheduledFuture<?> future = Iterables.getFirst(fakeClock.getPendingTasks(), null);
+    assertEquals(1000 - 1, future.getDelay(TimeUnit.NANOSECONDS));
 
-    ScheduledFuture<?> shutdownFuture = mock(ScheduledFuture.class);
-    doReturn(shutdownFuture)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
     // Mannually running the Runnable will send the ping. Shutdown task should be scheduled.
-    ticker.time = 1000;
-    sendPing.run();
+    fakeClock.forwardNanos(999);
     verify(keepAlivePinger).ping();
-    verify(scheduler, times(2)).schedule(isA(Runnable.class), delayCaptor.capture(),
-        isA(TimeUnit.class));
-    delay = delayCaptor.getValue();
+    ScheduledFuture<?> shutdownFuture = Iterables.getFirst(fakeClock.getPendingTasks(), null);
     // Keepalive timeout is 2000.
-    assertEquals(2000, delay.longValue());
+    assertEquals(2000, shutdownFuture.getDelay(TimeUnit.NANOSECONDS));
 
     // Ping succeeds. Reschedule another ping.
-    ticker.time = 1100;
+    fakeClock.forwardNanos(100);
     keepAliveManager.onDataReceived();
-    verify(scheduler, times(3)).schedule(isA(Runnable.class), delayCaptor.capture(),
-        isA(TimeUnit.class));
+    future = Iterables.getFirst(fakeClock.getPendingTasks(), null);
     // Shutdown task has been cancelled.
-    verify(shutdownFuture).cancel(isA(Boolean.class));
-    delay = delayCaptor.getValue();
+    assertTrue(shutdownFuture.isCancelled());
     // Next ping should be exactly 1000 nanoseconds later.
-    assertEquals(1000, delay.longValue());
+    assertEquals(1000, future.getDelay(TimeUnit.NANOSECONDS));
   }
 
   @Test
   public void keepAlivePingDelayedByIncomingData() {
-    ScheduledFuture<?> future = mock(ScheduledFuture.class);
-    doReturn(future)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
-
     // Transport becomes active. We should schedule keepalive pings.
     keepAliveManager.onTransportActive();
-    ArgumentCaptor<Runnable> sendPingCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler, times(1)).schedule(sendPingCaptor.capture(), isA(Long.class),
-        isA(TimeUnit.class));
-    Runnable sendPing = sendPingCaptor.getValue();
 
     // We receive some data. We may need to delay the ping.
-    ticker.time = 1500;
+    fakeClock.forwardNanos(990);
     keepAliveManager.onDataReceived();
-    ticker.time = 1600;
-    sendPing.run();
+    fakeClock.forwardNanos(20);
     // We didn't send the ping.
-    verify(transport, times(0)).ping(isA(ClientTransport.PingCallback.class),
-        isA(Executor.class));
+    verify(keepAlivePinger, never()).ping();
     // Instead we reschedule.
-    ArgumentCaptor<Long> delayCaptor = ArgumentCaptor.forClass(Long.class);
-    verify(scheduler, times(2)).schedule(isA(Runnable.class), delayCaptor.capture(),
-        isA(TimeUnit.class));
-    Long delay = delayCaptor.getValue();
-    assertEquals(1500 + 1000 - 1600, delay.longValue());
+    ScheduledFuture<?> future = Iterables.getFirst(fakeClock.getPendingTasks(), null);
+    assertEquals(1000 - 20, future.getDelay(TimeUnit.NANOSECONDS));
   }
 
   @Test
   public void clientKeepAlivePinger_pingTimeout() {
+    ConnectionClientTransport transport = mock(ConnectionClientTransport.class);
     keepAlivePinger = new ClientKeepAlivePinger(transport);
 
     keepAlivePinger.onPingTimeout();
 
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(transport).shutdownNow(statusCaptor.capture());
     Status status = statusCaptor.getValue();
     assertThat(status.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
@@ -147,6 +116,7 @@ public final class KeepAliveManagerTest {
 
   @Test
   public void clientKeepAlivePinger_pingFailure() {
+    ConnectionClientTransport transport = mock(ConnectionClientTransport.class);
     keepAlivePinger = new ClientKeepAlivePinger(transport);
     keepAlivePinger.ping();
     ArgumentCaptor<ClientTransport.PingCallback> pingCallbackCaptor =
@@ -156,6 +126,7 @@ public final class KeepAliveManagerTest {
 
     pingCallback.onFailure(new Throwable());
 
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(transport).shutdownNow(statusCaptor.capture());
     Status status = statusCaptor.getValue();
     assertThat(status.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
@@ -163,114 +134,84 @@ public final class KeepAliveManagerTest {
         "Keepalive failed. The connection is likely gone");
   }
 
-
   @Test
   public void onTransportTerminationCancelsShutdownFuture() {
     // Transport becomes active. We should schedule keepalive pings.
     keepAliveManager.onTransportActive();
-    ArgumentCaptor<Runnable> sendPingCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler, times(1))
-        .schedule(sendPingCaptor.capture(), isA(Long.class), isA(TimeUnit.class));
-    Runnable sendPing = sendPingCaptor.getValue();
 
-    ScheduledFuture<?> shutdownFuture = mock(ScheduledFuture.class);
-    doReturn(shutdownFuture)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
     // Mannually running the Runnable will send the ping. Shutdown task should be scheduled.
-    ticker.time = 1000;
-    sendPing.run();
+    fakeClock.forwardNanos(1000);
+    ScheduledFuture<?> shutdownFuture = Iterables.getFirst(fakeClock.getPendingTasks(), null);
 
     keepAliveManager.onTransportTermination();
 
     // Shutdown task has been cancelled.
-    verify(shutdownFuture).cancel(isA(Boolean.class));
+    assertTrue(shutdownFuture.isCancelled());
   }
 
   @Test
   public void keepAlivePingTimesOut() {
     // Transport becomes active. We should schedule keepalive pings.
     keepAliveManager.onTransportActive();
-    ArgumentCaptor<Runnable> sendPingCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler, times(1)).schedule(sendPingCaptor.capture(), isA(Long.class),
-        isA(TimeUnit.class));
-    Runnable sendPing = sendPingCaptor.getValue();
 
-    ScheduledFuture<?> shutdownFuture = mock(ScheduledFuture.class);
-    doReturn(shutdownFuture)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
     // Mannually running the Runnable will send the ping. Shutdown task should be scheduled.
-    ticker.time = 1000;
-    sendPing.run();
+    fakeClock.forwardNanos(1000);
     verify(keepAlivePinger).ping();
-    ArgumentCaptor<Runnable> shutdownCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler, times(2)).schedule(shutdownCaptor.capture(), isA(Long.class),
-        isA(TimeUnit.class));
-    Runnable shutdown = shutdownCaptor.getValue();
 
     // We do not receive the ping response. Shutdown runnable runs.
-    // TODO(zdapeng): use FakeClock.ScheduledExecutorService
-    ticker.time = 3000;
-    shutdown.run();
+    fakeClock.forwardNanos(2000);
     verify(keepAlivePinger).onPingTimeout();
 
     // We receive the ping response too late.
     keepAliveManager.onDataReceived();
     // No more ping should be scheduled.
-    verify(scheduler, times(2)).schedule(isA(Runnable.class), isA(Long.class),
-        isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).isEmpty();
   }
 
   @Test
   public void transportGoesIdle() {
-    ScheduledFuture<?> pingFuture = mock(ScheduledFuture.class);
-    doReturn(pingFuture)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
-
     // Transport becomes active. We should schedule keepalive pings.
     keepAliveManager.onTransportActive();
-    ArgumentCaptor<Runnable> sendPingCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler, times(1)).schedule(sendPingCaptor.capture(), isA(Long.class),
-        isA(TimeUnit.class));
-    Runnable sendPing = sendPingCaptor.getValue();
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
 
     // Transport becomes idle. Nothing should happen when ping runnable runs.
     keepAliveManager.onTransportIdle();
-    sendPing.run();
+    fakeClock.forwardNanos(1000);
     // Ping was not sent.
-    verify(transport, times(0)).ping(isA(ClientTransport.PingCallback.class), isA(Executor.class));
+    verify(keepAlivePinger, never()).ping();
     // No new ping got scheduled.
-    verify(scheduler, times(1)).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).isEmpty();
 
     // But when transport goes back to active
     keepAliveManager.onTransportActive();
-    // Then we do schedule another ping
-    verify(scheduler, times(2)).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
+    fakeClock.runDueTasks();
+    // Ping is now sent.
+    verify(keepAlivePinger).ping();
   }
 
   @Test
   public void transportGoesIdle_doesntCauseIdleWhenEnabled() {
     keepAliveManager.onTransportTermination();
-    keepAliveManager = new KeepAliveManager(keepAlivePinger, scheduler, ticker, 1000, 2000, true);
+    ScheduledExecutorService scheduler = fakeClock.getScheduledExecutorService();
+    Stopwatch stopwatch = fakeClock.getStopwatchSupplier().get();
+    keepAliveManager = new KeepAliveManager(
+        keepAlivePinger, scheduler, stopwatch, 1000, 2000, true);
     keepAliveManager.onTransportStarted();
 
     // Keepalive scheduling should have started immediately.
-    ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler).schedule(runnableCaptor.capture(), isA(Long.class),
-        isA(TimeUnit.class));
-    Runnable sendPing = runnableCaptor.getValue();
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
 
     keepAliveManager.onTransportActive();
 
     // Transport becomes idle. Should not impact the sending of the ping.
     keepAliveManager.onTransportIdle();
-    sendPing.run();
+    fakeClock.forwardNanos(1000);
     // Ping was sent.
     verify(keepAlivePinger).ping();
     // Shutdown is scheduled.
-    verify(scheduler, times(2)).schedule(runnableCaptor.capture(), isA(Long.class),
-        isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
     // Shutdown is triggered.
-    runnableCaptor.getValue().run();
+    fakeClock.forwardNanos(2000);
     verify(keepAlivePinger).onPingTimeout();
   }
 
@@ -278,42 +219,28 @@ public final class KeepAliveManagerTest {
   public void transportGoesIdleAfterPingSent() {
     // Transport becomes active. We should schedule keepalive pings.
     keepAliveManager.onTransportActive();
-    ArgumentCaptor<Runnable> sendPingCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler, times(1)).schedule(sendPingCaptor.capture(), isA(Long.class),
-        isA(TimeUnit.class));
-    Runnable sendPing = sendPingCaptor.getValue();
 
-    ScheduledFuture<?> shutdownFuture = mock(ScheduledFuture.class);
-    doReturn(shutdownFuture)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
     // Mannually running the Runnable will send the ping. Shutdown task should be scheduled.
-    // TODO(zdapeng): user FakeClock.ScheduledExecutorService
-    ticker.time = 1000;
-    sendPing.run();
+    fakeClock.forwardNanos(1000);
+    ScheduledFuture<?> shutdownFuture = Iterables.getFirst(fakeClock.getPendingTasks(), null);
     verify(keepAlivePinger).ping();
-    verify(scheduler, times(2)).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
 
-    // Transport becomes idle. No more ping should be scheduled after we receive a ping response.
+    // Transport becomes idle. Ping scheduled after we receive a ping response.
     keepAliveManager.onTransportIdle();
-    ticker.time = 1100;
+    fakeClock.forwardNanos(100);
     keepAliveManager.onDataReceived();
-    verify(scheduler, times(2)).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
     // Shutdown task has been cancelled.
-    verify(shutdownFuture).cancel(isA(Boolean.class));
-
-    // Transport becomes active again. Another ping is scheduled.
-    keepAliveManager.onTransportActive();
-    verify(scheduler, times(3)).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
+    assertTrue(shutdownFuture.isCancelled());
   }
 
   @Test
   public void transportGoesIdleBeforePingSent() {
     // Transport becomes active. We should schedule keepalive pings.
-    ScheduledFuture<?> pingFuture = mock(ScheduledFuture.class);
-    doReturn(pingFuture)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
     keepAliveManager.onTransportActive();
-    verify(scheduler, times(1)).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
+    ScheduledFuture<?> pingFuture = Iterables.getFirst(fakeClock.getPendingTasks(), null);
 
     // Data is received, and we go to ping delayed
     keepAliveManager.onDataReceived();
@@ -323,67 +250,47 @@ public final class KeepAliveManagerTest {
 
     // Transport becomes active again, we don't need to reschedule another ping
     keepAliveManager.onTransportActive();
-    verify(scheduler, times(1)).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).containsExactly(pingFuture);
   }
 
   @Test
   public void transportShutsdownAfterPingScheduled() {
-    ScheduledFuture<?> pingFuture = mock(ScheduledFuture.class);
-    doReturn(pingFuture)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
     // Ping will be scheduled.
     keepAliveManager.onTransportActive();
-    verify(scheduler, times(1)).schedule(isA(Runnable.class), isA(Long.class),
-        isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
+    ScheduledFuture<?> pingFuture = Iterables.getFirst(fakeClock.getPendingTasks(), null);
     // Transport is shutting down.
     keepAliveManager.onTransportTermination();
     // Ping future should have been cancelled.
-    verify(pingFuture).cancel(isA(Boolean.class));
+    assertTrue(pingFuture.isCancelled());
   }
 
   @Test
   public void transportShutsdownAfterPingSent() {
     keepAliveManager.onTransportActive();
-    ArgumentCaptor<Runnable> sendPingCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler, times(1)).schedule(sendPingCaptor.capture(), isA(Long.class),
-        isA(TimeUnit.class));
-    Runnable sendPing = sendPingCaptor.getValue();
 
-    ScheduledFuture<?> shutdownFuture = mock(ScheduledFuture.class);
-    doReturn(shutdownFuture)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
     // Mannually running the Runnable will send the ping. Shutdown task should be scheduled.
-    ticker.time = 1000;
-    sendPing.run();
+    fakeClock.forwardNanos(1000);
     verify(keepAlivePinger).ping();
-    verify(scheduler, times(2)).schedule(isA(Runnable.class), isA(Long.class),
-        isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
+    ScheduledFuture<?> shutdownFuture = Iterables.getFirst(fakeClock.getPendingTasks(), null);
 
     // Transport is shutting down.
     keepAliveManager.onTransportTermination();
     // Shutdown task has been cancelled.
-    verify(shutdownFuture).cancel(isA(Boolean.class));
+    assertTrue(shutdownFuture.isCancelled());
   }
 
   @Test
   public void pingSentThenIdleThenActiveThenAck() {
     keepAliveManager.onTransportActive();
-    ArgumentCaptor<Runnable> sendPingCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(scheduler, times(1))
-        .schedule(sendPingCaptor.capture(), isA(Long.class), isA(TimeUnit.class));
-    Runnable sendPing = sendPingCaptor.getValue();
-    ScheduledFuture<?> shutdownFuture = mock(ScheduledFuture.class);
     // ping scheduled
-    doReturn(shutdownFuture)
-        .when(scheduler).schedule(isA(Runnable.class), isA(Long.class), isA(TimeUnit.class));
 
     // Mannually running the Runnable will send the ping.
-    ticker.time = 1000;
-    sendPing.run();
+    fakeClock.forwardNanos(1000);
 
     // shutdown scheduled
-    verify(scheduler, times(2))
-        .schedule(sendPingCaptor.capture(), isA(Long.class), isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
     verify(keepAlivePinger).ping();
 
     keepAliveManager.onTransportIdle();
@@ -393,8 +300,9 @@ public final class KeepAliveManagerTest {
     keepAliveManager.onDataReceived();
 
     // another ping scheduled
-    verify(scheduler, times(3))
-        .schedule(sendPingCaptor.capture(), isA(Long.class), isA(TimeUnit.class));
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
+    fakeClock.forwardNanos(1000);
+    verify(keepAlivePinger, times(2)).ping();
   }
 }
 


### PR DESCRIPTION
This is a bit more than a POC, but less than a full PR. I know I need to heavily rework comments, for instance. Do we think this is a good change? I feel I should point out I abuse the scheduler with a `scheduler.execute()`. That could be fixed by avoiding/having an alternative to Executor in Rescheduler that would return a Runnable.

TODO: adjust comments