### PR TITLE
all: update to latest alpn agent (backport to v1.9.x)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -218,7 +218,7 @@ subprojects {
                 math: 'org.apache.commons:commons-math3:3.6',
 
                 // Jetty ALPN dependencies
-                jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.6'
+                jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.7'
         ]
     }
 


### PR DESCRIPTION
Old branches fail to build unless we take this change.

