### PR TITLE
Bazel: Fix compilation in Java 9

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -16,17 +16,6 @@ java_library(
     ],
 )
 
-# javax.annotation.Generated is not included in the default root modules in 9,
-# see: http://openjdk.java.net/jeps/320.
-java_import(
-    name = "javax_annotation",
-    jars = [
-        "@javax_annotation_api//file",
-    ],
-    neverlink = 1,  # @Generated is source-retention
-    visibility = ["//visibility:public"],
-)
-
 java_library(
     name = "inprocess",
     srcs = glob([

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -16,6 +16,17 @@ java_library(
     ],
 )
 
+# javax.annotation.Generated is not included in the default root modules in 9,
+# see: http://openjdk.java.net/jeps/320.
+java_import(
+    name = "javax_annotation",
+    jars = [
+        "@javax_annotation_api//file",
+    ],
+    neverlink = 1,  # @Generated is source-retention
+    visibility = ["//visibility:public"],
+)
+
 java_library(
     name = "inprocess",
     srcs = glob([

--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -108,8 +108,8 @@ def java_grpc_library(name, srcs, deps, flavor=None,
 
   added_deps = [
       "@io_grpc_grpc_java//core",
-      "@io_grpc_grpc_java//core:javax_annotation",
       "@io_grpc_grpc_java//stub",
+      "@io_grpc_grpc_java//stub:javax_annotation",
       "@com_google_guava_guava//jar",
   ]
   if flavor == "normal":

--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -108,6 +108,7 @@ def java_grpc_library(name, srcs, deps, flavor=None,
 
   added_deps = [
       "@io_grpc_grpc_java//core",
+      "@io_grpc_grpc_java//core:javax_annotation",
       "@io_grpc_grpc_java//stub",
       "@com_google_guava_guava//jar",
   ]

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -285,8 +285,8 @@ def javax_annotation():
   # To circumvent use http_file following by java_import.
   native.http_file(
       name = "javax_annotation_api",
-      sha256 = "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
-      urls = ["http://central.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"],
+      sha256 = "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
+      urls = ["http://central.maven.org/maven2/javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar"],
   )
 
 def junit_junit():

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -27,6 +27,7 @@ def grpc_java_repositories(
     omit_io_netty_tcnative_boringssl_static=False,
     omit_io_opencensus_api=False,
     omit_io_opencensus_grpc_metrics=False,
+    omit_javax_annotation=False,
     omit_junit_junit=False,
     omit_org_apache_commons_lang3=False):
   """Imports dependencies for grpc-java."""
@@ -82,6 +83,8 @@ def grpc_java_repositories(
     io_opencensus_api()
   if not omit_io_opencensus_grpc_metrics:
     io_opencensus_grpc_metrics()
+  if not omit_javax_annotation:
+    javax_annotation()
   if not omit_junit_junit:
     junit_junit()
   if not omit_org_apache_commons_lang3:
@@ -275,6 +278,15 @@ def io_opencensus_grpc_metrics():
       name = "io_opencensus_opencensus_contrib_grpc_metrics",
       artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.11.0",
       sha1 = "d57b877f1a28a613452d45e35c7faae5af585258",
+  )
+
+def javax_annotation():
+  # TODO(davido): maven_jar does not support neverlink attribute.
+  # To circumvent use http_file following by java_import.
+  native.http_file(
+      name = "javax_annotation_api",
+      sha256 = "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
+      urls = ["http://central.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"],
   )
 
 def junit_junit():

--- a/stub/BUILD.bazel
+++ b/stub/BUILD.bazel
@@ -12,3 +12,14 @@ java_library(
         "@com_google_guava_guava//jar",
     ],
 )
+
+# javax.annotation.Generated is not included in the default root modules in 9,
+# see: http://openjdk.java.net/jeps/320.
+java_import(
+    name = "javax_annotation",
+    jars = [
+        "@javax_annotation_api//file",
+    ],
+    neverlink = 1,  # @Generated is source-retention
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Fixes: #3633.

Test Plan:

On most recent Bazel version run:

```
  $ bazel --host_javabase=/usr/lib64/jvm/java-9-openjdk \
    build --javacopt='--release 9' \
    --java_toolchain=@bazel_tools//tools/jdk:toolchain_jdk9 \
    examples:helloworld_java_grpc
```