### PR TITLE
core: idle mode timer runnable should never be null (#4315) (backport to v1.9.x)

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -362,12 +362,13 @@ public final class ManagedChannelImpl
       return;
     }
     cancelIdleTimer();
-    idleModeTimer = new IdleModeTimer();
+    final IdleModeTimer nextIdleModeTimer = new IdleModeTimer();
+    idleModeTimer = nextIdleModeTimer;
     idleModeTimerFuture = transportFactory.getScheduledExecutorService().schedule(
         new LogExceptionRunnable(new Runnable() {
             @Override
             public void run() {
-              channelExecutor.executeLater(idleModeTimer).drain();
+              channelExecutor.executeLater(nextIdleModeTimer).drain();
             }
           }),
         idleTimeoutMillis, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Without using a final local variable, cancelling a task can make the
runnable become null when it's executed.