### PR TITLE
core: always call StreamTracer.streamClosed() when stream is officially closed

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -128,7 +128,6 @@ public abstract class AbstractServerStream extends AbstractStream
     Preconditions.checkNotNull(trailers, "trailers");
     if (!outboundClosed) {
       outboundClosed = true;
-      statsTraceCtx.streamClosed(status);
       endOfMessages();
       addStatusToTrailers(trailers, status);
       // Safe to set without synchronization because access is tightly controlled.
@@ -336,6 +335,7 @@ public abstract class AbstractServerStream extends AbstractStream
           statsTraceCtx.streamClosed(newStatus);
           getTransportTracer().reportStreamClosed(false);
         } else {
+          statsTraceCtx.streamClosed(closedStatus);
           getTransportTracer().reportStreamClosed(closedStatus.isOk());
         }
         listenerClosed = true;

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -776,10 +776,10 @@ public abstract class AbstractTransportTest {
     trailers.put(asciiKey, "dupvalue");
     trailers.put(binaryKey, "äbinarytrailers");
     serverStream.close(status, trailers);
-    assertSame(status, serverStreamTracer1.getStatus());
     assertNull(serverStreamTracer1.nextInboundEvent());
     assertNull(serverStreamTracer1.nextOutboundEvent());
     assertCodeEquals(Status.OK, serverStreamListener.status.get(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    assertSame(status, serverStreamTracer1.getStatus());
     Status clientStreamStatus = clientStreamListener.status.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     Metadata clientStreamTrailers =
         clientStreamListener.trailers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Previously StreamTracer.streamClosed() is called in
ServerStream.close(), but it is not exactly when the stream is
officially closed.  ServerStreamListener.closed() is guaranteed to be
called and it is the official end of the stream.