### PR TITLE
services: make channelz constructor static

### DIFF
--- a/services/src/main/java/io/grpc/services/ChannelzService.java
+++ b/services/src/main/java/io/grpc/services/ChannelzService.java
@@ -48,7 +48,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
   private final Channelz channelz;
   private final int maxPageSize;
 
-  public ChannelzService newInstance(int maxPageSize) {
+  public static ChannelzService newInstance(int maxPageSize) {
     return new ChannelzService(Channelz.instance(), maxPageSize);
   }
 


### PR DESCRIPTION
Right now this is inaccessible to services.