### PR TITLE
services: socket options were erroneously ignored if socket has no stats

### DIFF
--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -468,9 +468,9 @@ public final class Channelz {
         SocketOptions socketOptions,
         Security security) {
       this.data = data;
-      this.local = local;
+      this.local = Preconditions.checkNotNull(local);
       this.remote = remote;
-      this.socketOptions = socketOptions;
+      this.socketOptions = Preconditions.checkNotNull(socketOptions);
       this.security = security;
     }
   }

--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -468,7 +468,7 @@ public final class Channelz {
         SocketOptions socketOptions,
         Security security) {
       this.data = data;
-      this.local = Preconditions.checkNotNull(local);
+      this.local = Preconditions.checkNotNull(local, "local socket");
       this.remote = remote;
       this.socketOptions = Preconditions.checkNotNull(socketOptions);
       this.security = security;

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -89,6 +89,7 @@ import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -1981,6 +1982,11 @@ public class OkHttpClientTransportTest {
     @Override
     public synchronized void close() {
       frameReader.nextFrameAtEndOfStream();
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+      return InetSocketAddress.createUnresolved("127.0.0.1", 4000);
     }
   }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -1986,7 +1986,7 @@ public class OkHttpClientTransportTest {
 
     @Override
     public SocketAddress getLocalSocketAddress() {
-      return InetSocketAddress.createUnresolved("127.0.0.1", 4000);
+      return InetSocketAddress.createUnresolved("localhost", 4000);
     }
   }
 

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -185,9 +185,9 @@ final class ChannelzProtoUtil {
           .setLastMessageReceivedTimestamp(
               Timestamps.fromNanos(s.lastMessageReceivedTimeNanos))
           .setLocalFlowControlWindow(
-              Int64Value.newBuilder().setValue(s.localFlowControlWindow).build())
+              Int64Value.of(s.localFlowControlWindow))
           .setRemoteFlowControlWindow(
-              Int64Value.newBuilder().setValue(s.remoteFlowControlWindow).build());
+              Int64Value.of(s.remoteFlowControlWindow));
     }
     builder.addAllOption(toSocketOptionsList(socketStats.socketOptions));
     return builder.build();

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -137,9 +137,7 @@ final class ChannelzProtoUtil {
     if (socketStats.remote != null) {
       builder.setRemote(toAddress(socketStats.remote));
     }
-    if (socketStats.data != null) {
-      builder.setData(extractSocketData(socketStats));
-    }
+    builder.setData(extractSocketData(socketStats));
     return builder.build();
   }
 
@@ -168,29 +166,31 @@ final class ChannelzProtoUtil {
   }
 
   static SocketData extractSocketData(SocketStats socketStats) {
-    TransportStats s = socketStats.data;
-    return SocketData
-        .newBuilder()
-        .setStreamsStarted(s.streamsStarted)
-        .setStreamsSucceeded(s.streamsSucceeded)
-        .setStreamsFailed(s.streamsFailed)
-        .setMessagesSent(s.messagesSent)
-        .setMessagesReceived(s.messagesReceived)
-        .setKeepAlivesSent(s.keepAlivesSent)
-        .setLastLocalStreamCreatedTimestamp(
-            Timestamps.fromNanos(s.lastLocalStreamCreatedTimeNanos))
-        .setLastRemoteStreamCreatedTimestamp(
-            Timestamps.fromNanos(s.lastRemoteStreamCreatedTimeNanos))
-        .setLastMessageSentTimestamp(
-            Timestamps.fromNanos(s.lastMessageSentTimeNanos))
-        .setLastMessageReceivedTimestamp(
-            Timestamps.fromNanos(s.lastMessageReceivedTimeNanos))
-        .setLocalFlowControlWindow(
-            Int64Value.newBuilder().setValue(s.localFlowControlWindow).build())
-        .setRemoteFlowControlWindow(
-            Int64Value.newBuilder().setValue(s.remoteFlowControlWindow).build())
-        .addAllOption(toSocketOptionsList(socketStats.socketOptions))
-        .build();
+    SocketData.Builder builder = SocketData.newBuilder();
+    if (socketStats.data != null) {
+      TransportStats s = socketStats.data;
+      builder
+          .setStreamsStarted(s.streamsStarted)
+          .setStreamsSucceeded(s.streamsSucceeded)
+          .setStreamsFailed(s.streamsFailed)
+          .setMessagesSent(s.messagesSent)
+          .setMessagesReceived(s.messagesReceived)
+          .setKeepAlivesSent(s.keepAlivesSent)
+          .setLastLocalStreamCreatedTimestamp(
+              Timestamps.fromNanos(s.lastLocalStreamCreatedTimeNanos))
+          .setLastRemoteStreamCreatedTimestamp(
+              Timestamps.fromNanos(s.lastRemoteStreamCreatedTimeNanos))
+          .setLastMessageSentTimestamp(
+              Timestamps.fromNanos(s.lastMessageSentTimeNanos))
+          .setLastMessageReceivedTimestamp(
+              Timestamps.fromNanos(s.lastMessageReceivedTimeNanos))
+          .setLocalFlowControlWindow(
+              Int64Value.newBuilder().setValue(s.localFlowControlWindow).build())
+          .setRemoteFlowControlWindow(
+              Int64Value.newBuilder().setValue(s.remoteFlowControlWindow).build());
+    }
+    builder.addAllOption(toSocketOptionsList(socketStats.socketOptions));
+    return builder.build();
   }
 
   public static final String SO_LINGER = "SO_LINGER";

--- a/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
+++ b/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
@@ -257,8 +257,7 @@ public final class ChannelzProtoUtilTest {
               .newBuilder()
               .setIpAddress(ByteString.copyFrom(
                   ((InetSocketAddress) listenSocket.listenAddress).getAddress().getAddress()))
-              .setPort(1234)
-              .build())
+              .setPort(1234))
       .build();
 
   private final TestSocket socket = new TestSocket();
@@ -279,8 +278,8 @@ public final class ChannelzProtoUtilTest {
       .setKeepAlivesSent(8)
       .setLastMessageSentTimestamp(Timestamps.fromNanos(9))
       .setLastMessageReceivedTimestamp(Timestamps.fromNanos(10))
-      .setLocalFlowControlWindow(Int64Value.newBuilder().setValue(11).build())
-      .setRemoteFlowControlWindow(Int64Value.newBuilder().setValue(12).build())
+      .setLocalFlowControlWindow(Int64Value.newBuilder().setValue(11))
+      .setRemoteFlowControlWindow(Int64Value.newBuilder().setValue(12))
       .build();
   private final Address localAddress = Address
       .newBuilder()
@@ -289,8 +288,7 @@ public final class ChannelzProtoUtilTest {
               .newBuilder()
               .setIpAddress(ByteString.copyFrom(
                   ((InetSocketAddress) socket.local).getAddress().getAddress()))
-              .setPort(1000)
-              .build())
+              .setPort(1000))
       .build();
   private final Address remoteAddress = Address
       .newBuilder()
@@ -299,8 +297,7 @@ public final class ChannelzProtoUtilTest {
               .newBuilder()
               .setIpAddress(ByteString.copyFrom(
                   ((InetSocketAddress) socket.remote).getAddress().getAddress()))
-              .setPort(1000)
-              .build())
+              .setPort(1000))
       .build();
 
   @Test
@@ -360,8 +357,7 @@ public final class ChannelzProtoUtilTest {
                         SocketOption
                             .newBuilder()
                             .setName("listen_option")
-                            .setValue("listen_option_value").build())
-                    .build())
+                            .setValue("listen_option_value")))
             .build(),
         ChannelzProtoUtil.toSocket(listenSocket));
   }
@@ -381,8 +377,7 @@ public final class ChannelzProtoUtilTest {
                     .newBuilder(socketDataWithDataNoSockOpts)
                     .addOption(
                         SocketOption.newBuilder()
-                            .setName("test_name").setValue("test_value").build())
-                    .build())
+                            .setName("test_name").setValue("test_value")))
             .build(),
         ChannelzProtoUtil.toSocket(socket));
   }
@@ -425,8 +420,7 @@ public final class ChannelzProtoUtilTest {
             TcpIpAddress
                 .newBuilder()
                 .setIpAddress(ByteString.copyFrom(inet4.getAddress().getAddress()))
-                .setPort(1000)
-                .build())
+                .setPort(1000))
             .build(),
         ChannelzProtoUtil.toAddress(inet4));
   }
@@ -439,8 +433,7 @@ public final class ChannelzProtoUtilTest {
         Address.newBuilder().setUdsAddress(
             UdsAddress
                 .newBuilder()
-                .setFilename(path)
-                .build())
+                .setFilename(path))
             .build(),
         ChannelzProtoUtil.toAddress(uds));
   }
@@ -458,8 +451,7 @@ public final class ChannelzProtoUtilTest {
         Address.newBuilder().setOtherAddress(
             OtherAddress
                 .newBuilder()
-                .setName(name)
-                .build())
+                .setName(name))
             .build(),
         ChannelzProtoUtil.toAddress(other));
   }

--- a/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
+++ b/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
@@ -89,7 +89,7 @@ final class ChannelzTestHelper {
               /*data=*/ null,
               listenAddress,
               /*remote=*/ null,
-              new SocketOptions.Builder().build(),
+              new SocketOptions.Builder().addOption("listen_option", "listen_option_value").build(),
               /*security=*/ null));
       return ret;
     }


### PR DESCRIPTION
This fixes listen sockets. It is ok to have no data but report socket
options.