### PR TITLE
core: forward toString for forwarding classes

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import com.google.common.base.MoreObjects;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -217,6 +218,11 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   @Override
   public ManagedChannel build() {
     return delegate().build();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }
 
   /**

--- a/core/src/main/java/io/grpc/PartialForwardingClientCall.java
+++ b/core/src/main/java/io/grpc/PartialForwardingClientCall.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import com.google.common.base.MoreObjects;
 import javax.annotation.Nullable;
 
 /**
@@ -56,5 +57,10 @@ abstract class PartialForwardingClientCall<ReqT, RespT> extends ClientCall<ReqT,
   @Override
   public Attributes getAttributes() {
     return delegate().getAttributes();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }
 }

--- a/core/src/main/java/io/grpc/PartialForwardingClientCallListener.java
+++ b/core/src/main/java/io/grpc/PartialForwardingClientCallListener.java
@@ -16,6 +16,8 @@
 
 package io.grpc;
 
+import com.google.common.base.MoreObjects;
+
 /**
  * A {@link ClientCall.Listener} which forwards all of its methods to another {@link
  * ClientCall.Listener} which may have a different parameterized type than the
@@ -40,5 +42,10 @@ abstract class PartialForwardingClientCallListener<RespT> extends ClientCall.Lis
   @Override
   public void onReady() {
     delegate().onReady();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }
 }

--- a/core/src/main/java/io/grpc/PartialForwardingServerCall.java
+++ b/core/src/main/java/io/grpc/PartialForwardingServerCall.java
@@ -16,6 +16,8 @@
 
 package io.grpc;
 
+import com.google.common.base.MoreObjects;
+
 /**
  * A {@link ServerCall} which forwards all of it's methods to another {@link ServerCall} which
  * may have a different onMessage() message type.
@@ -72,5 +74,10 @@ abstract class PartialForwardingServerCall<ReqT, RespT> extends ServerCall<ReqT,
   @Override
   public String getAuthority() {
     return delegate().getAuthority();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }
 }

--- a/core/src/main/java/io/grpc/PartialForwardingServerCallListener.java
+++ b/core/src/main/java/io/grpc/PartialForwardingServerCallListener.java
@@ -16,6 +16,8 @@
 
 package io.grpc;
 
+import com.google.common.base.MoreObjects;
+
 /**
  * A {@link ServerCall.Listener} which forwards all of its methods to another {@link
  * ServerCall.Listener} which may have a different parameterized type than the
@@ -46,5 +48,10 @@ abstract class PartialForwardingServerCallListener<ReqT>
   @Override
   public void onReady() {
     delegate().onReady();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }
 }

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStream.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import com.google.common.base.MoreObjects;
 import io.grpc.Attributes;
 import io.grpc.Compressor;
 import io.grpc.DecompressorRegistry;
@@ -98,5 +99,10 @@ abstract class ForwardingClientStream implements ClientStream {
   @Override
   public Attributes getAttributes() {
     return delegate().getAttributes();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }
 }

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStreamListener.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStreamListener.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import com.google.common.base.MoreObjects;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
@@ -46,5 +47,10 @@ abstract class ForwardingClientStreamListener implements ClientStreamListener {
   @Override
   public void onReady() {
     delegate().onReady();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }
 }

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
@@ -64,7 +65,7 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "[" + delegate().toString() + "]";
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ForwardingManagedChannel.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingManagedChannel.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import com.google.common.base.MoreObjects;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ConnectivityState;
@@ -85,5 +86,10 @@ abstract class ForwardingManagedChannel extends ManagedChannel {
   @Override
   public void enterIdle() {
     delegate.enterIdle();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate).toString();
   }
 }

--- a/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import io.grpc.NameResolver;
 
 /**
@@ -49,5 +50,10 @@ abstract class ForwardingNameResolver extends NameResolver {
   @Override
   public void refresh() {
     delegate.refresh();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate).toString();
   }
 }

--- a/core/src/main/java/io/grpc/internal/ForwardingReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingReadableBuffer.java
@@ -16,6 +16,7 @@
 
 package io.grpc.internal;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -98,5 +99,10 @@ public abstract class ForwardingReadableBuffer implements ReadableBuffer {
   @Override
   public void close() {
     buf.close();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", buf).toString();
   }
 }

--- a/core/src/test/java/io/grpc/ForwardingTestUtil.java
+++ b/core/src/test/java/io/grpc/ForwardingTestUtil.java
@@ -17,11 +17,13 @@
 package io.grpc;
 
 import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.base.Defaults;
+import com.google.common.base.MoreObjects;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -67,6 +69,20 @@ public final class ForwardingTestUtil {
       } catch (InvocationTargetException e) {
         throw new AssertionError(String.format("Method was not forwarded: %s", method));
       }
+    }
+
+    boolean skipToString = false;
+    for (Method method : skippedMethods) {
+      if (method.getName().equals("toString")) {
+        skipToString = true;
+        break;
+      }
+    }
+    if (!skipToString) {
+      String actual = forwarder.toString();
+      String expected =
+          MoreObjects.toStringHelper(forwarder).add("delegate", mockDelegate).toString();
+      assertEquals("Method toString() was not forwarded properly", expected, actual);
     }
   }
 }


### PR DESCRIPTION
Forward `toString()` method for forwarding classes to improve debug information.

For example, `ForwardingManagedChannel.toString()` will return something like:

```
ForwardingManagedChannel{delegate=ManagedChannelImpl{logId=tag-13247, target=localhost:8080}}
``` 