### PR TITLE
core: compare doubles with compare instead of ==

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetryPolicy.java
+++ b/core/src/main/java/io/grpc/internal/RetryPolicy.java
@@ -77,7 +77,7 @@ final class RetryPolicy {
     return this.maxAttempts == that.maxAttempts
         && this.initialBackoffNanos == that.initialBackoffNanos
         && this.maxBackoffNanos == that.maxBackoffNanos
-        && this.backoffMultiplier == that.backoffMultiplier
+        && Double.compare(this.backoffMultiplier, that.backoffMultiplier) == 0
         && Objects.equal(this.retryableStatusCodes, that.retryableStatusCodes);
   }
 


### PR DESCRIPTION
This reverts one line in 0a598c0

Always not compare equality for doubles with `==`.