### PR TITLE
services: turn channelz null futures into Status.UNIMPLEMENTED

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -226,7 +226,6 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
   @Override
   public ListenableFuture<SocketStats> getStats() {
-    // TODO(zpencer): add transport tracing to in-process server
     SettableFuture<SocketStats> ret = SettableFuture.create();
     ret.set(null);
     return ret;

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -376,7 +376,14 @@ final class ChannelzProtoUtil {
 
   private static <T> T getFuture(ListenableFuture<T> future) {
     try {
-      return future.get();
+      T ret = future.get();
+      if (ret == null) {
+        throw Status.UNIMPLEMENTED
+            .withDescription("The entity's stats can not be retrieved. "
+                + "If this is an InProcessTransport this is expected.")
+            .asRuntimeException();
+      }
+      return ret;
     } catch (InterruptedException e) {
       throw Status.INTERNAL.withCause(e).asRuntimeException();
     } catch (ExecutionException e) {


### PR DESCRIPTION
Then channelz GUI will take this into account. This is particularly
useful for InProcessTransport, where I have decided we do not need
special support for in channelz. The server and channel stats are
already sufficient.

Fixes https://github.com/grpc/grpc-java/issues/4344