### PR TITLE
core: refactor ManagedChannelImplTest with a configurable builder

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -139,6 +139,7 @@ public abstract class AbstractManagedChannelImplBuilder
 
   private int maxInboundMessageSize = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
+  @Nullable
   BinaryLogProvider binlogProvider = BinaryLogProvider.provider();
 
   /**


### PR DESCRIPTION
In current code of `ManagedChannelImplTest`, new tests will have to add more and more custom args in `createChannel(...)`, and each time when a custom arg is needed all other default args need be repeatedly provided in `createChannel(...)`. In most cases those args are just builder attributes. So this PR makes ManagedChannelImplTest easier to stub by providing a builder field, then new tests will just set necessary builder attributes before calling `createChannel()`.