### PR TITLE
buildscripts: always keep mvn artifacts

### DIFF
--- a/buildscripts/kokoro/macos.cfg
+++ b/buildscripts/kokoro/macos.cfg
@@ -4,7 +4,7 @@
 build_file: "grpc-java/buildscripts/kokoro/unix.sh"
 timeout_mins: 45
 
-# We always build artifacts, but we only copy them here when MVN_ARTIFACTS is set in unix.sh
+# We always build mvn artifacts.
 action {
   define_artifacts {
     regex: ["**/mvn-artifacts/**"]

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -74,9 +74,6 @@ LOCAL_MVN_TEMP=$(mktemp -d)
 ./gradlew clean grpc-compiler:build grpc-compiler:uploadArchives $GRADLE_FLAGS -PtargetArch=x86_64 \
   -Dorg.gradle.parallel=false -PrepositoryDir=$LOCAL_MVN_TEMP
 
-if [[ -z "${MVN_ARTIFACTS:-}" ]]; then
-  exit 0
-fi
 MVN_ARTIFACT_DIR="$PWD/mvn-artifacts"
 mkdir $MVN_ARTIFACT_DIR
 mv $LOCAL_MVN_TEMP/* $MVN_ARTIFACT_DIR

--- a/buildscripts/kokoro/windows.bat
+++ b/buildscripts/kokoro/windows.bat
@@ -20,8 +20,6 @@ set PATH=C:\Program Files\java\jdk1.8.0_152\bin;%PATH%
 cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\windows32.bat" || exit /b 1
 cmd.exe /C "%WORKSPACE%\buildscripts\kokoro\windows64.bat" || exit /b 1
 
-IF DEFINED MVN_ARTIFACTS (
-  mkdir mvn-artifacts
-  move artifacts\x86_64 mvn-artifacts\x86_64
-  move artifacts\x86_32 mvn-artifacts\x86_32
-)
+mkdir mvn-artifacts
+move artifacts\x86_64 mvn-artifacts\x86_64
+move artifacts\x86_32 mvn-artifacts\x86_32

--- a/buildscripts/kokoro/windows.cfg
+++ b/buildscripts/kokoro/windows.cfg
@@ -3,6 +3,8 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/windows.bat"
 timeout_mins: 45
+
+# We always build mvn artifacts.
 action {
   define_artifacts {
     regex: ["**/build/test-results/**/*.xml", "**/mvn-artifacts/**"]


### PR DESCRIPTION
Since C is always keeping artifacts, it's easier if we just did the
same. If this becomes a problem it makes more sense to set a TTL
policy on the storage backend.