### PR TITLE
buildscripts: build linux artifacts in kokoro

### DIFF
--- a/buildscripts/kokoro/linux.cfg
+++ b/buildscripts/kokoro/linux.cfg
@@ -1,10 +1,10 @@
 # Config file for internal CI
 
 # Location of the continuous shell script in repository.
-build_file: "grpc-java/buildscripts/kokoro/macos.sh"
+build_file: "grpc-java/buildscripts/kokoro/linux.sh"
 timeout_mins: 45
 
-# We always build artifacts, but we only copy them here when MVN_ARTIFACTS is set in unix.sh
+# We always build mvn artifacts.
 action {
   define_artifacts {
     regex: ["**/mvn-artifacts/**"]

--- a/buildscripts/kokoro/linux.sh
+++ b/buildscripts/kokoro/linux.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -exu -o pipefail
+
+# Runs all the tests and builds mvn artifacts.
+# mvn artifacts are stored in grpc-java/mvn-artifacts/
+
+ARCH=32 $(dirname $0)/unix.sh
+ARCH=64 $(dirname $0)/unix.sh

--- a/buildscripts/kokoro/macos.sh
+++ b/buildscripts/kokoro/macos.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -exu -o pipefail
+
+# run unix.sh with default ARCH, which is 64 bit.
+$(dirname $0)/unix.sh

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,8 +3,10 @@
 # Build protoc
 set -evux -o pipefail
 
+# ARCH is 64 bit unless otherwise specified.
+ARCH="${ARCH:-64}"
 DOWNLOAD_DIR=/tmp/source
-INSTALL_DIR="/tmp/protobuf-$PROTOBUF_VERSION/$(uname -s)-$(uname -p)"
+INSTALL_DIR="/tmp/protobuf-$PROTOBUF_VERSION/$(uname -s)-$(uname -p)-x86_$ARCH"
 mkdir -p $DOWNLOAD_DIR
 
 # Start with a sane default
@@ -26,7 +28,10 @@ else
   pushd $DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}
   ./autogen.sh
   # install here so we don't need sudo
-  ./configure --disable-shared --prefix="$INSTALL_DIR"
+  ./configure CFLAGS=-m$ARCH CXXFLAGS=-m$ARCH LDFLAGS=-m$ARCH --disable-shared \
+    --prefix="$INSTALL_DIR"
+  # the same source dir is used for 32 and 64 bit builds, so we need to clean stale data first
+  make clean
   make -j$NUM_CPU
   make install
   popd


### PR DESCRIPTION
Update unix.sh and make_dependencies.sh to support an ARCH env var.
Add linux.sh and linux.cfg to build both x86_64 and x86_32.