### PR TITLE
kokoro: Avoid --include-build for Android

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -5,13 +5,6 @@ cat /VERSION
 
 BASE_DIR="$(pwd)"
 
-# Build Cronet
-
-cd "$BASE_DIR/github/grpc-java/cronet"
-./cronet_deps.sh
-../gradlew --include-build .. build
-
-
 # Install gRPC and codegen for the Android examples
 # (a composite gradle build can't find protoc-gen-grpc-java)
 
@@ -29,6 +22,15 @@ buildscripts/make_dependencies.sh
 ln -s "/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)" /tmp/protobuf
 
 ./gradlew install
+
+# Build Cronet
+
+pushd cronet
+./cronet_deps.sh
+../gradlew build
+popd
+
+# Build examples
 
 cd ./examples/android/clientcache
 ./gradlew build


### PR DESCRIPTION
Since 4369e8cd the --include-build just opens us up to trouble with
accidentally building the protoc plugin. Since we're going to do a
./gradlew install anyway, let's just wait until after that point for
building cronet.

This sort of problem was experienced while developing #4369.

CC @dapengzhang0 