### PR TITLE
compiler: unbreak docker file

### DIFF
--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,5 +1,13 @@
 FROM protoc-artifacts:latest
 
+# Update curl so git cloning and dep fetching works
+#   https://github.com/google/protobuf/issues/4419
+# Context for `yum clean all` workaround:
+#   https://github.com/CentOS/sig-cloud-instance-images/issues/15
+RUN yum -y update; yum clean all
+
+RUN git clone https://github.com/google/protobuf.git
+
 RUN scl enable devtoolset-1.1 'bash -c "cd /protobuf && \
     git fetch && \
     git checkout v3.5.1 && \


### PR DESCRIPTION
The protoc-artifacts image does not provide the protoc code in
/protobuf anymore, we must download it ourselves:
https://github.com/google/protobuf/commit/5f052ae7ae8a757dd919e95e0f1481e08fef749b#diff-0bc9399720fa75bdc363a61a50cd2609

The wget workaround works to download the protobuf sources, but ./autogen.sh
still uses curl to fetch its depedencies:
https://github.com/google/protobuf/issues/4419