### PR TITLE
buildscripts: workaround for su issue in grpc-java-releasing docker

### DIFF
--- a/buildscripts/grpc-java-releasing/Dockerfile
+++ b/buildscripts/grpc-java-releasing/Dockerfile
@@ -1,5 +1,16 @@
 FROM protoc-artifacts:latest
 
+# set via docker flag: --build-arg VAR=<val>
+ARG USERNAME
+ARG UID
+ARG GID
+
+RUN groupadd -g $GID $USERNAME
+RUN useradd -m -u $UID -g $GID -s /bin/bash $USERNAME
+
+# need newest curl
+RUN yum -y update; yum clean all
+
 COPY scl-enable-devtoolset.sh /
 
 # Start in devtoolset environment that uses GCC 4.7

--- a/buildscripts/grpc-java-releasing/Dockerfile
+++ b/buildscripts/grpc-java-releasing/Dockerfile
@@ -8,9 +8,6 @@ ARG GID
 RUN groupadd -g $GID $USERNAME
 RUN useradd -m -u $UID -g $GID -s /bin/bash $USERNAME
 
-# need newest curl
-RUN yum -y update; yum clean all
-
 COPY scl-enable-devtoolset.sh /
 
 # Start in devtoolset environment that uses GCC 4.7

--- a/buildscripts/run_in_docker.sh
+++ b/buildscripts/run_in_docker.sh
@@ -10,31 +10,14 @@ quote() {
   done
 }
 
-if [[ "${1:-}" != "in-docker" ]]; then
-  readonly grpc_java_dir="$(dirname $(readlink -f "$0"))/.."
-  exec docker run -it --rm=true -v "${grpc_java_dir}:/grpc-java" -w /grpc-java \
-    grpc-java-releasing \
-    ./buildscripts/run_in_docker.sh in-docker "$(id -u)" "$(id -g)" "$@"
-fi
+readonly GRPC_JAVA_DIR="$(dirname $(readlink -f "$0"))/.."
+readonly USER=$(whoami)
+cd $GRPC_JAVA_DIR/buildscripts/
+docker build -t grpc-java-releasing-$USER grpc-java-releasing \
+  --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
+  --build-arg USERNAME=$USER
 
-## In Docker
-
-shift
-
-readonly swap_uid="$1"
-readonly swap_gid="$2"
-shift 2
-
-# Java uses NSS to determine the user's home. If that fails it uses '?' in the
-# current directory. So we need to set up the user's home in /etc/passwd.
-# If this wasn't the case, we could have passed -u to docker run and avoided
-# this script inside the container. JAVA_TOOL_OPTIONS is okay, but is noisy.
-groupadd thegroup -g "$swap_gid"
-useradd theuser -u "$swap_uid" -g "$swap_gid" -m
-if [[ "$#" -eq 0 ]]; then
-  exec su theuser
-else
-  # runuser is too old in the container to support the -u flag; if it did, we'd
-  # be able to remove the 'quote' function.
-  exec su theuser -c "$(quote "$@")"
-fi
+exec docker run -it --user $USER --rm=true -v \
+ "${GRPC_JAVA_DIR}:/grpc-java" -w /grpc-java \
+ grpc-java-releasing-$USER \
+ /bin/bash -c "$(quote "$@")"


### PR DESCRIPTION
Workaround for this issue observed using Docker 17.12:

```
~/git/protobuf/protoc-artifacts$ docker build -t protoc-artifacts .

~/git/grpc-java/buildscripts/grpc-java-releasing$ docker build -t grpc-java-releasing .

spencerfang@spencerfang:~/git/grpc-java/buildscripts$ ./run_in_docker.sh whoami
su: /bin/bash: Resource temporarily unavailable
```

Because the UID and GID are baked into the image, I append -$(whoami)
to the docker image name.

The plan is to use `run_in_docker.sh` to invoke a script that runs `kokoro/unix.sh`
for x86_32 and x86_64.