### PR TITLE
buildscripts: make unix.sh and make_dependencies.sh arch aware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ before_install:
     ln -s /tmp/gradle-wrapper $HOME/.gradle/wrapper
     # Work around https://github.com/travis-ci/travis-ci/issues/2317
   - if \[ "$TRAVIS_OS_NAME" = linux \]; then jdk_switcher use oraclejdk8; fi
-  - buildscripts/make_dependencies.sh # build protoc into /tmp/protobuf-${PROTOBUF_VERSION}
-  - ln -s "/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)" /tmp/protobuf
+  - buildscripts/make_dependencies.sh # build protoc into /tmp/protobuf
   - mkdir -p $HOME/.gradle
   - echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties
   - echo "failOnWarnings=true" >> $HOME/.gradle/gradle.properties

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -19,7 +19,6 @@ export OS_NAME=$(uname)
 
 # Proto deps
 buildscripts/make_dependencies.sh
-ln -s "/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)" /tmp/protobuf
 
 ./gradlew install
 

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -30,9 +30,6 @@ export ARCH="${ARCH:-64}"
 
 buildscripts/make_dependencies.sh
 
-# the install dir is hardcoded in make_dependencies.sh
-PROTO_INSTALL_DIR="/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)-x86_$ARCH"
-
 # Set properties via flags, do not pollute gradle.properties
 GRADLE_FLAGS="${GRADLE_FLAGS:-}"
 GRADLE_FLAGS+=" -PtargetArch=x86_$ARCH $GRADLE_FLAGS"

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -11,7 +11,8 @@
 # This script assumes `set -e`. Removing it may lead to undefined behavior.
 set -exu -o pipefail
 
-readonly GRPC_JAVA_DIR="$(cd $(dirname $(readlink -f "$0"))/../...; pwd)"
+# It would be nicer to use 'readlink -f' here but osx does not support it.
+readonly GRPC_JAVA_DIR="$(cd $(dirname "$0")/../.. && pwd)"
 
 if [[ -f /VERSION ]]; then
   cat /VERSION
@@ -26,9 +27,9 @@ cd $(dirname $0)/../..
 export PROTOBUF_VERSION=3.5.1
 
 # ARCH is 64 bit unless otherwise specified.
-export ARCH="${ARCH:-64}"
+ARCH="${ARCH:-64}"
 
-buildscripts/make_dependencies.sh
+ARCH="$ARCH" buildscripts/make_dependencies.sh
 
 # Set properties via flags, do not pollute gradle.properties
 GRADLE_FLAGS="${GRADLE_FLAGS:-}"
@@ -65,11 +66,9 @@ popd
 LOCAL_MVN_TEMP=$(mktemp -d)
 # Note that this disables parallel=true from GRADLE_FLAGS
 ./gradlew clean grpc-compiler:build grpc-compiler:uploadArchives $GRADLE_FLAGS \
-  -Dorg.gradle.parallel=false -PrepositoryDir=$LOCAL_MVN_TEMP
+  -Dorg.gradle.parallel=false -PrepositoryDir="$LOCAL_MVN_TEMP"
 
 readonly MVN_ARTIFACT_DIR="${MVN_ARTIFACT_DIR:-$GRPC_JAVA_DIR/mvn-artifacts}"
 
-if [[ ! -d $MVN_ARTIFACT_DIR ]]; then
-  mkdir -p $MVN_ARTIFACT_DIR
-fi
-cp -r $LOCAL_MVN_TEMP/* $MVN_ARTIFACT_DIR/
+mkdir -p "$MVN_ARTIFACT_DIR"
+cp -r "$LOCAL_MVN_TEMP"/* "$MVN_ARTIFACT_DIR"/

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -33,13 +33,6 @@ buildscripts/make_dependencies.sh
 # the install dir is hardcoded in make_dependencies.sh
 PROTO_INSTALL_DIR="/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)-x86_$ARCH"
 
-# If /tmp/protobuf exists then we just assume it's a symlink created by us.
-# It may be that it points to the wrong arch, so we idempotently set it now.
-if [[ -L /tmp/protobuf ]]; then
-  rm /tmp/protobuf
-fi
-ln -s $PROTO_INSTALL_DIR /tmp/protobuf;
-
 # Set properties via flags, do not pollute gradle.properties
 GRADLE_FLAGS="${GRADLE_FLAGS:-}"
 GRADLE_FLAGS+=" -PtargetArch=x86_$ARCH $GRADLE_FLAGS"

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -12,7 +12,7 @@
 set -exu -o pipefail
 
 # It would be nicer to use 'readlink -f' here but osx does not support it.
-readonly GRPC_JAVA_DIR="$(cd $(dirname "$0")/../.. && pwd)"
+readonly GRPC_JAVA_DIR="$(cd "$(dirname "$0")"/../.. && pwd)"
 
 if [[ -f /VERSION ]]; then
   cat /VERSION

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -69,8 +69,7 @@ LOCAL_MVN_TEMP=$(mktemp -d)
 
 readonly MVN_ARTIFACT_DIR="${MVN_ARTIFACT_DIR:-$GRPC_JAVA_DIR/mvn-artifacts}"
 
-if [[ ! -d $MVN_ARTIFACT_DIR/x86_$ARCH ]]; then
-  mkdir -p $MVN_ARTIFACT_DIR/x86_$ARCH
+if [[ ! -d $MVN_ARTIFACT_DIR ]]; then
+  mkdir -p $MVN_ARTIFACT_DIR
 fi
-mv $LOCAL_MVN_TEMP/* $MVN_ARTIFACT_DIR/x86_$ARCH/
-rmdir $LOCAL_MVN_TEMP
+cp -r $LOCAL_MVN_TEMP/* $MVN_ARTIFACT_DIR/

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 # This file is used for both Linux and MacOS builds.
+# For Linux, this script is called inside a docker container with
+# the correct environment for releases.
 # To run locally:
 #  ./buildscripts/kokoro/unix.sh
+# For 32 bit:
+#  ARCH=32 ./buildscripts/kokoro/unix.sh
 
 # This script assumes `set -e`. Removing it may lead to undefined behavior.
 set -exu -o pipefail
+
+readonly GRPC_JAVA_DIR="$(cd $(dirname $(readlink -f "$0"))/../...; pwd)"
 
 if [[ -f /VERSION ]]; then
   cat /VERSION
@@ -19,26 +25,24 @@ cd $(dirname $0)/../..
 # Proto deps
 export PROTOBUF_VERSION=3.5.1
 
-# TODO(zpencer): if linux builds use this script, then also repeat this process for 32bit (-m32)
-# Today, only macos uses this script and macos targets 64bit only
+# ARCH is 64 bit unless otherwise specified.
+export ARCH="${ARCH:-64}"
 
-CXX_FLAGS="-m64" LDFLAGS="" LD_LIBRARY_PATH="" buildscripts/make_dependencies.sh
+buildscripts/make_dependencies.sh
 
 # the install dir is hardcoded in make_dependencies.sh
-PROTO_INSTALL_DIR="/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)"
+PROTO_INSTALL_DIR="/tmp/protobuf-${PROTOBUF_VERSION}/$(uname -s)-$(uname -p)-x86_$ARCH"
 
-if [[ ! -e /tmp/protobuf ]]; then
-  ln -s $PROTO_INSTALL_DIR /tmp/protobuf;
+# If /tmp/protobuf exists then we just assume it's a symlink created by us.
+# It may be that it points to the wrong arch, so we idempotently set it now.
+if [[ -L /tmp/protobuf ]]; then
+  rm /tmp/protobuf
 fi
-
-# It's better to use 'readlink -f' but it's not available on macos
-if [[ "$(readlink /tmp/protobuf)" != "$PROTO_INSTALL_DIR" ]]; then
-  echo "/tmp/protobuf already exists but is not a symlink to $PROTO_INSTALL_DIR"
-  exit 1;
-fi
+ln -s $PROTO_INSTALL_DIR /tmp/protobuf;
 
 # Set properties via flags, do not pollute gradle.properties
 GRADLE_FLAGS="${GRADLE_FLAGS:-}"
+GRADLE_FLAGS+=" -PtargetArch=x86_$ARCH $GRADLE_FLAGS"
 GRADLE_FLAGS+=" -Pcheckstyle.ignoreFailures=false"
 GRADLE_FLAGS+=" -PfailOnWarnings=true"
 GRADLE_FLAGS+=" -PerrorProne=true"
@@ -70,10 +74,13 @@ popd
 
 LOCAL_MVN_TEMP=$(mktemp -d)
 # Note that this disables parallel=true from GRADLE_FLAGS
-./gradlew clean grpc-compiler:build grpc-compiler:uploadArchives $GRADLE_FLAGS -PtargetArch=x86_64 \
+./gradlew clean grpc-compiler:build grpc-compiler:uploadArchives $GRADLE_FLAGS \
   -Dorg.gradle.parallel=false -PrepositoryDir=$LOCAL_MVN_TEMP
 
-MVN_ARTIFACT_DIR="$PWD/mvn-artifacts"
-mkdir $MVN_ARTIFACT_DIR
-mv $LOCAL_MVN_TEMP/* $MVN_ARTIFACT_DIR
+readonly MVN_ARTIFACT_DIR="${MVN_ARTIFACT_DIR:-$GRPC_JAVA_DIR/mvn-artifacts}"
+
+if [[ ! -d $MVN_ARTIFACT_DIR/x86_$ARCH ]]; then
+  mkdir -p $MVN_ARTIFACT_DIR/x86_$ARCH
+fi
+mv $LOCAL_MVN_TEMP/* $MVN_ARTIFACT_DIR/x86_$ARCH/
 rmdir $LOCAL_MVN_TEMP

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -24,11 +24,13 @@ if [ -f ${INSTALL_DIR}/bin/protoc ]; then
   echo "Not building protobuf. Already built"
 # TODO(ejona): swap to `brew install --devel protobuf` once it is up-to-date
 else
-  wget -O - https://github.com/google/protobuf/archive/v${PROTOBUF_VERSION}.tar.gz | tar xz -C $DOWNLOAD_DIR
+  if [[ ! -d "$DOWNLOAD_DIR"/protobuf-"${PROTOBUF_VERSION}" ]]; then
+    wget -O - https://github.com/google/protobuf/archive/v${PROTOBUF_VERSION}.tar.gz | tar xz -C $DOWNLOAD_DIR
+  fi
   pushd $DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}
   ./autogen.sh
   # install here so we don't need sudo
-  ./configure CFLAGS=-m$ARCH CXXFLAGS=-m$ARCH LDFLAGS=-m$ARCH --disable-shared \
+  ./configure CFLAGS=-m"$ARCH" CXXFLAGS=-m"$ARCH" --disable-shared \
     --prefix="$INSTALL_DIR"
   # the same source dir is used for 32 and 64 bit builds, so we need to clean stale data first
   make clean
@@ -42,4 +44,4 @@ fi
 if [[ -L /tmp/protobuf ]]; then
   rm /tmp/protobuf
 fi
-ln -s $INSTALL_DIR /tmp/protobuf;
+ln -s "$INSTALL_DIR" /tmp/protobuf

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,8 +3,10 @@
 # Build protoc
 set -evux -o pipefail
 
+# ARCH is 64 bit unless otherwise specified.
+ARCH="${ARCH:-64}"
 DOWNLOAD_DIR=/tmp/source
-INSTALL_DIR="/tmp/protobuf-$PROTOBUF_VERSION/$(uname -s)-$(uname -p)"
+INSTALL_DIR="/tmp/protobuf-$PROTOBUF_VERSION/$(uname -s)-$(uname -p)-x86_$ARCH"
 mkdir -p $DOWNLOAD_DIR
 
 # Start with a sane default
@@ -26,7 +28,10 @@ else
   pushd $DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}
   ./autogen.sh
   # install here so we don't need sudo
-  ./configure --disable-shared --prefix="$INSTALL_DIR"
+  ./configure CFLAGS=-m$ARCH CXXFLAGS=-m$ARCH LDFLAGS=-m$ARCH --disable-shared \
+    --prefix="$INSTALL_DIR"
+  # the same source dir is used for 32 and 64 bit builds, so we need to clean stale data first
+  make clean
   make -j$NUM_CPU
   make install
   popd

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -42,4 +42,4 @@ fi
 if [[ -L /tmp/protobuf ]]; then
   rm /tmp/protobuf
 fi
-ln -s $PROTO_INSTALL_DIR /tmp/protobuf;
+ln -s $INSTALL_DIR /tmp/protobuf;

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -37,3 +37,9 @@ else
   popd
 fi
 
+# If /tmp/protobuf exists then we just assume it's a symlink created by us.
+# It may be that it points to the wrong arch, so we idempotently set it now.
+if [[ -L /tmp/protobuf ]]; then
+  rm /tmp/protobuf
+fi
+ln -s $PROTO_INSTALL_DIR /tmp/protobuf;


### PR DESCRIPTION
ARCH can be '32' or '64'. If it is not set then default to '64'.
Update intermediate and final artifact output dirs to include ARCH so
that runs do not clobber each other.

The linux release job will invoke unix.sh with `ARCH=32` and again
with `ARCH=64`.

`buildscripts/make_dependencies.sh` will be responsible for building
and making sure /tmp/protobuf/ is symlinked to the right arch.