### PR TITLE
buildscripts: sonatype uploader ussing CONF before it is set

### DIFF
--- a/buildscripts/sonatype-upload.sh
+++ b/buildscripts/sonatype-upload.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -eu -o pipefail
 
 if [ $# -ne 2 ]; then
   cat <<EOF
@@ -46,6 +46,7 @@ if [ -z "$DIR" ]; then
   exit 1
 fi
 
+CONF="$HOME/.config/sonatype-upload"
 [ -f "$CONF" ] && . "$CONF"
 
 if [ -z "$USERNAME" -o -z "$PASSWORD" ]; then
@@ -55,7 +56,6 @@ if [ -z "$USERNAME" -o -z "$PASSWORD" ]; then
   exit 1
 fi
 
-CONF="$HOME/.config/sonatype-upload"
 STAGING_URL="https://oss.sonatype.org/service/local/staging"
 
 # We go through the effort of using deloyByRepositoryId/ because it is

--- a/buildscripts/sonatype-upload.sh
+++ b/buildscripts/sonatype-upload.sh
@@ -49,6 +49,9 @@ fi
 CONF="$HOME/.config/sonatype-upload"
 [ -f "$CONF" ] && . "$CONF"
 
+USERNAME="${USERNAME:-}"
+PASSWORD="${PASSWORD:-}"
+
 if [ -z "$USERNAME" -o -z "$PASSWORD" ]; then
   # TODO(ejona86): if people would use it, could prompt for values to avoid
   # having passwords in plain-text.


### PR DESCRIPTION
Set $CONF before we use it.
Also enable some defensive bash flags to catch errors.