### PR TITLE
buildscripts: do not echo secrets in sonatype upload

### DIFF
--- a/buildscripts/sonatype-upload.sh
+++ b/buildscripts/sonatype-upload.sh
@@ -87,7 +87,6 @@ REPOID="$(
   grep stagedRepositoryId |
   sed 's/.*<stagedRepositoryId>\(.*\)<\/stagedRepositoryId>.*/\1/'
   )"
-echo "Repository id: $REPOID"
 
 for X in $(cd "$DIR" && find -type f | cut -b 3-); do
   echo "Uploading $X"


### PR DESCRIPTION
Making this a bit more secretive so we can use it with kokoro.