### PR TITLE
buildscripts: initial kokoro config for auto releasing artifacts

### DIFF
--- a/buildscripts/kokoro/release_artifacts.cfg
+++ b/buildscripts/kokoro/release_artifacts.cfg
@@ -1,0 +1,11 @@
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-java/buildscripts/kokoro/release_artifacts.sh"
+timeout_mins: 60
+
+action {
+  define_artifacts {
+    regex: ["**/mvn-artifacts/**"]
+  }
+}

--- a/buildscripts/kokoro/release_artifacts.sh
+++ b/buildscripts/kokoro/release_artifacts.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -veux -o pipefail
+
+if [[ -f /VERSION ]]; then
+  cat /VERSION
+fi
+
+readonly GRPC_JAVA_DIR=$(cd $(dirname $0)/../.. && pwd)
+
+# A place holder at the moment


### PR DESCRIPTION
The script does nothing at the moment other than set up the kokoro
job.