### PR TITLE
services: fix channelz linter warnings

### DIFF
--- a/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
+++ b/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
@@ -440,7 +440,7 @@ public final class ChannelzProtoUtilTest {
         ChannelzProtoUtil.toSocket(socket).getSecurity());
 
     socket.security = new Channelz.Security(
-        new Channelz.Tls("TLS_NULL_WITH_NULL_NULL", /*localcert=*/ null, remote));
+        new Channelz.Tls("TLS_NULL_WITH_NULL_NULL", /*localCert=*/ null, remote));
     assertEquals(
         Security.newBuilder().setTls(
             Tls.newBuilder()
@@ -450,7 +450,7 @@ public final class ChannelzProtoUtilTest {
         ChannelzProtoUtil.toSocket(socket).getSecurity());
 
     socket.security = new Channelz.Security(
-        new Channelz.Tls("TLS_NULL_WITH_NULL_NULL", local, /*remotecert=*/ null));
+        new Channelz.Tls("TLS_NULL_WITH_NULL_NULL", local, /*remoteCert=*/ null));
     assertEquals(
         Security.newBuilder().setTls(
             Tls.newBuilder()

--- a/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
+++ b/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
@@ -16,6 +16,7 @@
 
 package io.grpc.services;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.ConnectivityState;
@@ -76,6 +77,13 @@ final class ChannelzTestHelper {
     public LogId getLogId() {
       return id;
     }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("logId", getLogId())
+          .toString();
+    }
   }
 
   static final class TestListenSocket implements Instrumented<SocketStats> {
@@ -99,6 +107,13 @@ final class ChannelzTestHelper {
     public LogId getLogId() {
       return id;
     }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("logId", getLogId())
+          .toString();
+    }
   }
 
   static final class TestServer implements Instrumented<ServerStats> {
@@ -120,6 +135,13 @@ final class ChannelzTestHelper {
     @Override
     public LogId getLogId() {
       return id;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("logId", getLogId())
+          .toString();
     }
   }
 
@@ -146,6 +168,13 @@ final class ChannelzTestHelper {
     @Override
     public LogId getLogId() {
       return id;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("logId", getLogId())
+          .toString();
     }
   }
 }


### PR DESCRIPTION
- final classes should have toString()
- fix arg name mismatch