### PR TITLE
(low priority) core,netty,interop-testing: stabilize maxInboundMessageSize API

### DIFF
--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -293,12 +293,12 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * <p>This method is advisory, and implementations may decide to not enforce this.  Currently,
    * the only known transport to not enforce this is {@code InProcessTransport}.
    *
-   * @param max the maximum number of bytes a single message can be.
+   * @param bytes the maximum number of bytes a single message can be.
    * @return this
    * @throws IllegalArgumentException if max is negative.
    * @since 1.1.0
    */
-  public T maxInboundMessageSize(int max) {
+  public T maxInboundMessageSize(int bytes) {
     // intentional nop
     return thisT();
   }

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -294,8 +294,8 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * the only known transport to not enforce this is {@code InProcessTransport}.
    *
    * @param max the maximum number of bytes a single message can be.
-   * @throws IllegalArgumentException if max is negative.
    * @return this
+   * @throws IllegalArgumentException if max is negative.
    * @since 1.1.0
    */
   public T maxInboundMessageSize(int max) {

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -295,11 +296,12 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    *
    * @param bytes the maximum number of bytes a single message can be.
    * @return this
-   * @throws IllegalArgumentException if max is negative.
+   * @throws IllegalArgumentException if bytes is negative.
    * @since 1.1.0
    */
   public T maxInboundMessageSize(int bytes) {
-    // intentional nop
+    // intentional noop rather than throw, this method is only advisory.
+    Preconditions.checkArgument(bytes >= 0, "bytes must be >= 0");
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -298,7 +298,6 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @return this
    * @since 1.1.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2307")
   public T maxInboundMessageSize(int max) {
     // intentional nop
     return thisT();

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -16,6 +16,7 @@
 
 package io.grpc;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.InputStream;
 import java.util.concurrent.Executor;
@@ -214,12 +215,14 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    *
    * @param bytes the maximum number of bytes a single message can be.
    * @return this
-   * @throws IllegalArgumentException if max is negative.
+   * @throws IllegalArgumentException if bytes is negative.
    * @throws UnsupportedOperationException if unsupported.
    * @since 1.13.0
    */
   public T maxInboundMessageSize(int bytes) {
-    throw new UnsupportedOperationException();
+    // intentional noop rather than throw, this method is only advisory.
+    Preconditions.checkArgument(bytes >= 0, "bytes must be >= 0");
+    return thisT();
   }
 
   /**
@@ -232,4 +235,13 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
    * @since 1.0.0
    */
   public abstract Server build();
+
+  /**
+   * Returns the correctly typed version of the builder.
+   */
+  private T thisT() {
+    @SuppressWarnings("unchecked")
+    T thisT = (T) this;
+    return thisT;
+  }
 }

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -204,6 +204,25 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   }
 
   /**
+   * Sets the maximum message size allowed to be received on the server. If not called,
+   * defaults to 4 MiB. The default provides protection to servers who haven't considered the
+   * possibility of receiving large messages while trying to be large enough to not be hit in normal
+   * usage.
+   *
+   * <p>This method is advisory, and implementations may decide to not enforce this.  Currently,
+   * the only known transport to not enforce this is {@code InProcessServer}.
+   *
+   * @param bytes the maximum number of bytes a single message can be.
+   * @return this
+   * @throws IllegalArgumentException if max is negative.
+   * @throws UnsupportedOperationException if unsupported.
+   * @since 1.13.0
+   */
+  public T maxInboundMessageSize(int bytes) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Builds a server using the given parameters.
    *
    * <p>The returned service will not been started or be bound a port. You will need to start it

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -147,7 +147,7 @@ public class TestServiceServer {
       server =
           NettyServerBuilder.forPort(port)
               .sslContext(sslContext)
-              .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+              .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
               .addService(
                   ServerInterceptors.intercept(
                       new TestServiceImpl(executor), TestServiceImpl.interceptors()))

--- a/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/AutoWindowSizingOnTest.java
@@ -37,7 +37,8 @@ public class AutoWindowSizingOnTest extends AbstractInteropTest {
 
   @Override
   protected AbstractServerImplBuilder<?> getServerBuilder() {
-    return NettyServerBuilder.forPort(0).maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
+    return NettyServerBuilder.forPort(0)
+        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE);
   }
 
   @Override

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyLocalChannelTest.java
@@ -38,7 +38,7 @@ public class Http2NettyLocalChannelTest extends AbstractInteropTest {
     return NettyServerBuilder
         .forAddress(new LocalAddress("in-process-1"))
         .flowControlWindow(65 * 1024)
-        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .channelType(LocalServerChannel.class);
   }
 

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2NettyTest.java
@@ -46,7 +46,7 @@ public class Http2NettyTest extends AbstractInteropTest {
     try {
       return NettyServerBuilder.forPort(0)
           .flowControlWindow(65 * 1024)
-          .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+          .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(GrpcSslContexts
               .forServer(TestUtils.loadCert("server1.pem"), TestUtils.loadCert("server1.key"))
               .clientAuth(ClientAuth.REQUIRE)

--- a/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/Http2OkHttpTest.java
@@ -78,7 +78,7 @@ public class Http2OkHttpTest extends AbstractInteropTest {
       contextBuilder.ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE);
       return NettyServerBuilder.forPort(0)
           .flowControlWindow(65 * 1024)
-          .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+          .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
           .sslContext(contextBuilder.build());
     } catch (IOException ex) {
       throw new RuntimeException(ex);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TransportCompressionTest.java
@@ -86,7 +86,7 @@ public class TransportCompressionTest extends AbstractInteropTest {
   @Override
   protected AbstractServerImplBuilder<?> getServerBuilder() {
     return NettyServerBuilder.forPort(0)
-        .maxMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
+        .maxInboundMessageSize(AbstractInteropTest.MAX_MESSAGE_SIZE)
         .compressorRegistry(compressors)
         .decompressorRegistry(decompressors)
         .intercept(new ServerInterceptor() {

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -268,12 +268,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
     return maxInboundMessageSize(maxMessageSize);
   }
 
-  /**
-   * Sets the maximum message size allowed to be received on the server. If not called,
-   * defaults to 4 MiB. The default provides protection to services who haven't considered the
-   * possibility of receiving large messages while trying to be large enough to not be hit in normal
-   * usage.
-   */
+  /** {@inheritDoc} */
   @Override
   public NettyServerBuilder maxInboundMessageSize(int bytes) {
     checkArgument(bytes >= 0, "bytes must be >= 0");

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -259,10 +259,25 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    * defaults to 4 MiB. The default provides protection to services who haven't considered the
    * possibility of receiving large messages while trying to be large enough to not be hit in normal
    * usage.
+   *
+   * @deprecated Call {@link #maxInboundMessageSize} instead. This method will be removed in a
+   *     future release.
    */
+  @Deprecated
   public NettyServerBuilder maxMessageSize(int maxMessageSize) {
-    checkArgument(maxMessageSize >= 0, "maxMessageSize must be >= 0");
-    this.maxMessageSize = maxMessageSize;
+    return maxInboundMessageSize(maxMessageSize);
+  }
+
+  /**
+   * Sets the maximum message size allowed to be received on the server. If not called,
+   * defaults to 4 MiB. The default provides protection to services who haven't considered the
+   * possibility of receiving large messages while trying to be large enough to not be hit in normal
+   * usage.
+   */
+  @Override
+  public NettyServerBuilder maxInboundMessageSize(int bytes) {
+    checkArgument(bytes >= 0, "bytes must be >= 0");
+    this.maxMessageSize = bytes;
     return this;
   }
 


### PR DESCRIPTION
On server side, `maxMessageSize` is deprecated for
`maxInboundMessageSize` to match the channel builder.

Update usages to use new setter.

fixes https://github.com/grpc/grpc-java/issues/2563