### PR TITLE
android: avoid static init of robolectric shadows

### DIFF
--- a/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
+++ b/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
@@ -48,10 +48,10 @@ import org.robolectric.shadows.ShadowNetworkInfo;
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = {AndroidChannelBuilderTest.ShadowDefaultNetworkListenerConnectivityManager.class})
 public final class AndroidChannelBuilderTest {
-  private static final NetworkInfo WIFI_CONNECTED =
+  private final NetworkInfo WIFI_CONNECTED =
       ShadowNetworkInfo.newInstance(
           NetworkInfo.DetailedState.CONNECTED, ConnectivityManager.TYPE_WIFI, 0, true, true);
-  private static final NetworkInfo WIFI_DISCONNECTED =
+  private final NetworkInfo WIFI_DISCONNECTED =
       ShadowNetworkInfo.newInstance(
           NetworkInfo.DetailedState.DISCONNECTED, ConnectivityManager.TYPE_WIFI, 0, true, false);
   private final NetworkInfo MOBILE_CONNECTED =


### PR DESCRIPTION
Some robolectric test runners do not have access to the Android runtime during static initialization, causing these variable declarations to fail.