### PR TITLE
core/netty/okhttp: populate timeout header at stream creation time

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -24,6 +24,7 @@ import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
 import io.grpc.Attributes;
+import io.grpc.CallOptions;
 import io.grpc.InternalKnownTransport;
 import io.grpc.InternalMethodDescriptor;
 import io.grpc.Metadata;
@@ -65,6 +66,7 @@ class NettyClientStream extends AbstractClientStream {
       TransportState state,
       MethodDescriptor<?, ?> method,
       Metadata headers,
+      CallOptions callOptions,
       Channel channel,
       AsciiString authority,
       AsciiString scheme,
@@ -76,6 +78,7 @@ class NettyClientStream extends AbstractClientStream {
         statsTraceCtx,
         transportTracer,
         headers,
+        callOptions,
         useGet(method));
     this.state = checkNotNull(state, "transportState");
     this.writeQueue = state.handler.getWriteQueue();

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -166,6 +166,7 @@ class NettyClientTransport implements ConnectionClientTransport {
         },
         method,
         headers,
+        callOptions,
         channel,
         authority,
         negotiationHandler.scheme(),

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.io.BaseEncoding;
+import io.grpc.CallOptions;
 import io.grpc.InternalStatus;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -415,6 +416,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
     stream = new NettyClientStream(new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE),
         methodDescriptor,
         new Metadata(),
+        CallOptions.DEFAULT,
         channel,
         AsciiString.of("localhost"),
         AsciiString.of("http"),
@@ -442,6 +444,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE),
         methodDescriptor,
         new Metadata(),
+        CallOptions.DEFAULT,
         channel,
         AsciiString.of("localhost"),
         AsciiString.of("http"),
@@ -471,6 +474,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE),
         descriptor,
         new Metadata(),
+        CallOptions.DEFAULT,
         channel,
         AsciiString.of("localhost"),
         AsciiString.of("http"),
@@ -515,6 +519,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
         new TransportStateImpl(handler, DEFAULT_MAX_MESSAGE_SIZE),
         methodDescriptor,
         new Metadata(),
+        CallOptions.DEFAULT,
         channel,
         AsciiString.of("localhost"),
         AsciiString.of("http"),

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -22,6 +22,7 @@ import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 
 import com.google.common.io.BaseEncoding;
 import io.grpc.Attributes;
+import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -65,6 +66,7 @@ class OkHttpClientStream extends AbstractClientStream {
   OkHttpClientStream(
       MethodDescriptor<?, ?> method,
       Metadata headers,
+      CallOptions callOptions,
       AsyncFrameWriter frameWriter,
       OkHttpClientTransport transport,
       OutboundFlowController outboundFlow,
@@ -79,6 +81,7 @@ class OkHttpClientStream extends AbstractClientStream {
         statsTraceCtx,
         transportTracer,
         headers,
+        callOptions,
         method.isSafe());
     this.statsTraceCtx = checkNotNull(statsTraceCtx, "statsTraceCtx");
     this.method = method;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -335,6 +335,7 @@ class OkHttpClientTransport implements ConnectionClientTransport {
     return new OkHttpClientStream(
         method,
         headers,
+        callOptions,
         frameWriter,
         OkHttpClientTransport.this,
         outboundFlow,

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientStreamTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.io.BaseEncoding;
+import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
@@ -82,6 +83,7 @@ public class OkHttpClientStreamTest {
     stream = new OkHttpClientStream(
         methodDescriptor,
         new Metadata(),
+        CallOptions.DEFAULT,
         frameWriter,
         transport,
         flowController,
@@ -147,8 +149,9 @@ public class OkHttpClientStreamTest {
   public void start_userAgentRemoved() {
     Metadata metaData = new Metadata();
     metaData.put(GrpcUtil.USER_AGENT_KEY, "misbehaving-application");
-    stream = new OkHttpClientStream(methodDescriptor, metaData, frameWriter, transport,
-        flowController, lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
+    stream = new OkHttpClientStream(
+        methodDescriptor, metaData, CallOptions.DEFAULT, frameWriter, transport, flowController,
+        lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
         StatsTraceContext.NOOP, transportTracer);
     stream.start(new BaseClientStreamListener());
     stream.transportState().start(3);
@@ -162,8 +165,9 @@ public class OkHttpClientStreamTest {
   public void start_headerFieldOrder() {
     Metadata metaData = new Metadata();
     metaData.put(GrpcUtil.USER_AGENT_KEY, "misbehaving-application");
-    stream = new OkHttpClientStream(methodDescriptor, metaData, frameWriter, transport,
-        flowController, lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
+    stream = new OkHttpClientStream(
+        methodDescriptor, metaData, CallOptions.DEFAULT, frameWriter, transport, flowController,
+        lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
         StatsTraceContext.NOOP, transportTracer);
     stream.start(new BaseClientStreamListener());
     stream.transportState().start(3);
@@ -190,8 +194,9 @@ public class OkHttpClientStreamTest {
         .setRequestMarshaller(marshaller)
         .setResponseMarshaller(marshaller)
         .build();
-    stream = new OkHttpClientStream(getMethod, new Metadata(), frameWriter, transport,
-        flowController, lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
+    stream = new OkHttpClientStream(
+        getMethod, new Metadata(), CallOptions.DEFAULT, frameWriter, transport, flowController,
+        lock, MAX_MESSAGE_SIZE, "localhost", "good-application",
         StatsTraceContext.NOOP, transportTracer);
     stream.start(new BaseClientStreamListener());
 


### PR DESCRIPTION
Populate `CallOptions` to the constructor of `AbstractClientStream`, which recomputes the effective deadline, and put it in to the headers.