### PR TITLE
core: populate effective deadline to ClientStream

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -25,6 +25,7 @@ java_library(
     deps = [
         ":core",
         ":internal",
+        "//context",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
     ],

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -17,12 +17,15 @@
 package io.grpc.inprocess;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
+import static java.lang.Math.max;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Compressor;
+import io.grpc.Deadline;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Grpc;
@@ -53,6 +56,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckReturnValue;
@@ -664,6 +668,13 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
       @Override
       public void setMaxOutboundMessageSize(int maxSize) {}
+
+      @Override
+      public void setDeadline(Deadline deadline) {
+        headers.discardAll(TIMEOUT_KEY);
+        long effectiveTimeout = max(0, deadline.timeRemaining(TimeUnit.NANOSECONDS));
+        headers.put(TIMEOUT_KEY, effectiveTimeout);
+      }
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -26,7 +26,6 @@ import static io.grpc.internal.GrpcUtil.CONTENT_ACCEPT_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.CONTENT_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY;
 import static io.grpc.internal.GrpcUtil.MESSAGE_ENCODING_KEY;
-import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
 import static java.lang.Math.max;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -233,8 +232,8 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     Deadline effectiveDeadline = effectiveDeadline();
     boolean deadlineExceeded = effectiveDeadline != null && effectiveDeadline.isExpired();
     if (!deadlineExceeded) {
-      updateTimeoutHeaders(effectiveDeadline, callOptions.getDeadline(),
-          context.getDeadline(), headers);
+      logIfContextNarrowedTimeout(
+          effectiveDeadline, callOptions.getDeadline(), context.getDeadline());
       if (retryEnabled) {
         stream = clientTransportProvider.newRetriableStream(method, callOptions, headers, context);
       } else {
@@ -261,8 +260,13 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     if (callOptions.getMaxOutboundMessageSize() != null) {
       stream.setMaxOutboundMessageSize(callOptions.getMaxOutboundMessageSize());
     }
+    if (effectiveDeadline != null) {
+      stream.setDeadline(effectiveDeadline);
+    }
     stream.setCompressor(compressor);
-    stream.setFullStreamDecompression(fullStreamDecompression);
+    if (fullStreamDecompression) {
+      stream.setFullStreamDecompression(fullStreamDecompression);
+    }
     stream.setDecompressorRegistry(decompressorRegistry);
     channelCallsTracer.reportCallStarted();
     stream.start(new ClientStreamListenerImpl(observer));
@@ -288,34 +292,17 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     }
   }
 
-  /**
-   * Based on the deadline, calculate and set the timeout to the given headers.
-   */
-  private static void updateTimeoutHeaders(@Nullable Deadline effectiveDeadline,
-      @Nullable Deadline callDeadline, @Nullable Deadline outerCallDeadline, Metadata headers) {
-    headers.discardAll(TIMEOUT_KEY);
-
-    if (effectiveDeadline == null) {
+  private static void logIfContextNarrowedTimeout(
+      Deadline effectiveDeadline, @Nullable Deadline outerCallDeadline,
+      @Nullable Deadline callDeadline) {
+    if (!log.isLoggable(Level.FINE) || effectiveDeadline == null
+        || outerCallDeadline != effectiveDeadline) {
       return;
     }
 
     long effectiveTimeout = max(0, effectiveDeadline.timeRemaining(TimeUnit.NANOSECONDS));
-    headers.put(TIMEOUT_KEY, effectiveTimeout);
-
-    logIfContextNarrowedTimeout(effectiveTimeout, effectiveDeadline, outerCallDeadline,
-        callDeadline);
-  }
-
-  private static void logIfContextNarrowedTimeout(long effectiveTimeout,
-      Deadline effectiveDeadline, @Nullable Deadline outerCallDeadline,
-      @Nullable Deadline callDeadline) {
-    if (!log.isLoggable(Level.FINE) || outerCallDeadline != effectiveDeadline) {
-      return;
-    }
-
-    StringBuilder builder = new StringBuilder();
-    builder.append(String.format("Call timeout set to '%d' ns, due to context deadline.",
-        effectiveTimeout));
+    StringBuilder builder = new StringBuilder(String.format(
+        "Call timeout set to '%d' ns, due to context deadline.", effectiveTimeout));
     if (callDeadline == null) {
       builder.append(" Explicit call timeout was not set.");
     } else {

--- a/core/src/main/java/io/grpc/internal/ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ClientStream.java
@@ -17,8 +17,10 @@
 package io.grpc.internal;
 
 import io.grpc.Attributes;
+import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Status;
+import javax.annotation.Nonnull;
 
 /**
  * Extension of {@link Stream} to support client-side termination semantics.
@@ -85,6 +87,11 @@ public interface ClientStream extends Stream {
    * Sets the max size sent to the remote endpoint.
    */
   void setMaxOutboundMessageSize(int maxSize);
+
+  /**
+   * Sets the effective deadline of the RPC.
+   */
+  void setDeadline(@Nonnull Deadline deadline);
 
   /**
    * Attributes that the stream holds at the current moment.

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Attributes;
 import io.grpc.Compressor;
+import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -81,6 +82,16 @@ class DelayedStream implements ClientStream {
         }
       });
     }
+  }
+
+  @Override
+  public void setDeadline(final Deadline deadline) {
+    delayOrExecute(new Runnable() {
+      @Override
+      public void run() {
+        realStream.setDeadline(deadline);
+      }
+    });
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStream.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import com.google.common.base.MoreObjects;
 import io.grpc.Attributes;
 import io.grpc.Compressor;
+import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Status;
 import java.io.InputStream;
@@ -94,6 +95,11 @@ abstract class ForwardingClientStream implements ClientStream {
   @Override
   public void setMaxOutboundMessageSize(int maxSize) {
     delegate().setMaxOutboundMessageSize(maxSize);
+  }
+
+  @Override
+  public void setDeadline(Deadline deadline) {
+    delegate().setDeadline(deadline);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/NoopClientStream.java
+++ b/core/src/main/java/io/grpc/internal/NoopClientStream.java
@@ -18,9 +18,11 @@ package io.grpc.internal;
 
 import io.grpc.Attributes;
 import io.grpc.Compressor;
+import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Status;
 import java.io.InputStream;
+import javax.annotation.Nonnull;
 
 /**
  * An implementation of {@link ClientStream} that silently does nothing for the operations.
@@ -78,4 +80,7 @@ public class NoopClientStream implements ClientStream {
 
   @Override
   public void setMaxOutboundMessageSize(int maxSize) {}
+
+  @Override
+  public void setDeadline(@Nonnull Deadline deadline) {}
 }

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -25,6 +25,7 @@ import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Compressor;
+import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -483,6 +484,18 @@ abstract class RetriableStream<ReqT> implements ClientStream {
     }
 
     delayOrExecute(new MaxOutboundMessageSizeEntry());
+  }
+
+  @Override
+  public final void setDeadline(final Deadline deadline) {
+    class DeadlineEntry implements BufferEntry {
+      @Override
+      public void runWith(Substream substream) {
+        substream.stream.setDeadline(deadline);
+      }
+    }
+
+    delayOrExecute(new DeadlineEntry());
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/ForwardingClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingClientStreamTest.java
@@ -137,7 +137,7 @@ public class ForwardingClientStreamTest {
   public void setMaxInboundMessageSizeTest() {
     int size = 4567;
     forward.setMaxInboundMessageSize(size);
-    verify(mock).setMaxInboundMessageSize(size);;
+    verify(mock).setMaxInboundMessageSize(size);
   }
 
   @Test


### PR DESCRIPTION
Added `ClientStream.setDeadline(Deadline deadline)` method, which will set the timeout header.

Resolving #4412 