### PR TITLE
core: Document Metadata ownership passes to the Call{,Listener}

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -108,8 +108,10 @@ public abstract class ClientCall<ReqT, RespT> {
   public abstract static class Listener<T> {
 
     /**
-     * The response headers have been received. Headers always precede messages. Since {@link
-     * Metadata} is not thread-safe, the caller must not access {@code headers} after this point.
+     * The response headers have been received. Headers always precede messages.
+     *
+     * <p>Since {@link Metadata} is not thread-safe, the caller must not access (read or write)
+     * {@code headers} after this point.
      *
      * @param headers containing metadata sent by the server at the start of the response.
      */
@@ -126,8 +128,10 @@ public abstract class ClientCall<ReqT, RespT> {
     /**
      * The ClientCall has been closed. Any additional calls to the {@code ClientCall} will not be
      * processed by the server. No further receiving will occur and no further notifications will be
-     * made. Since {@link Metadata} is not thread-safe, the caller must not access {@code trailers}
-     * after this point.
+     * made.
+     *
+     * <p>Since {@link Metadata} is not thread-safe, the caller must not access (read or write)
+     * {@code trailers} after this point.
      *
      * <p>If {@code status} returns false for {@link Status#isOk()}, then the call failed.
      * An additional block of trailer metadata may be received at the end of the call from the
@@ -155,8 +159,10 @@ public abstract class ClientCall<ReqT, RespT> {
    * Start a call, using {@code responseListener} for processing response messages.
    *
    * <p>It must be called prior to any other method on this class, except for {@link #cancel} which
-   * may be called at any time. Since {@link Metadata} is not thread-safe, the caller must not
-   * access {@code headers} after this point.
+   * may be called at any time.
+   *
+   * <p>Since {@link Metadata} is not thread-safe, the caller must not access (read or write) {@code
+   * headers} after this point.
    *
    * @param responseListener receives response messages
    * @param headers which can contain extra call metadata, e.g. authentication credentials.

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -108,7 +108,8 @@ public abstract class ClientCall<ReqT, RespT> {
   public abstract static class Listener<T> {
 
     /**
-     * The response headers have been received. Headers always precede messages.
+     * The response headers have been received. Headers always precede messages. Since {@link
+     * Metadata} is not thread-safe, the caller must not access {@code headers} after this point.
      *
      * @param headers containing metadata sent by the server at the start of the response.
      */
@@ -125,7 +126,8 @@ public abstract class ClientCall<ReqT, RespT> {
     /**
      * The ClientCall has been closed. Any additional calls to the {@code ClientCall} will not be
      * processed by the server. No further receiving will occur and no further notifications will be
-     * made.
+     * made. Since {@link Metadata} is not thread-safe, the caller must not access {@code trailers}
+     * after this point.
      *
      * <p>If {@code status} returns false for {@link Status#isOk()}, then the call failed.
      * An additional block of trailer metadata may be received at the end of the call from the

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -109,8 +109,8 @@ public abstract class ServerCall<ReqT, RespT> {
    * Send response header metadata prior to sending a response message. This method may
    * only be called once and cannot be called after calls to {@link #sendMessage} or {@link #close}.
    *
-   * <p>Since {@link Metadata} is not thread-safe, the caller must not access {@code headers} after
-   * this point.
+   * <p>Since {@link Metadata} is not thread-safe, the caller must not access (read or write) {@code
+   * headers} after this point.
    *
    * @param headers metadata to send prior to any response body.
    * @throws IllegalStateException if {@code close} has been called, a message has been sent, or
@@ -147,8 +147,8 @@ public abstract class ServerCall<ReqT, RespT> {
    * notification should be expected, independent of {@code status}. Otherwise {@link
    * Listener#onCancel} has been or will be called.
    *
-   * <p>Since {@link Metadata} is not thread-safe, the caller must not access {@code trailers} after
-   * this point.
+   * <p>Since {@link Metadata} is not thread-safe, the caller must not access (read or write) {@code
+   * trailers} after this point.
    *
    * @throws IllegalStateException if call is already {@code close}d
    */

--- a/core/src/main/java/io/grpc/ServerCallHandler.java
+++ b/core/src/main/java/io/grpc/ServerCallHandler.java
@@ -26,8 +26,10 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface ServerCallHandler<RequestT, ResponseT> {
   /**
    * Produce a non-{@code null} listener for the incoming call. Implementations are free to call
-   * methods on {@code call} before this method has returned. Since {@link Metadata} is not
-   * thread-safe, the caller must not access {@code headers} after this point.
+   * methods on {@code call} before this method has returned.
+   *
+   * <p>Since {@link Metadata} is not thread-safe, the caller must not access (read or write) {@code
+   * headers} after this point.
    *
    * <p>If the implementation throws an exception, {@code call} will be closed with an error.
    * Implementations must not throw an exception if they started processing that may use {@code

--- a/core/src/main/java/io/grpc/ServerCallHandler.java
+++ b/core/src/main/java/io/grpc/ServerCallHandler.java
@@ -26,7 +26,8 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface ServerCallHandler<RequestT, ResponseT> {
   /**
    * Produce a non-{@code null} listener for the incoming call. Implementations are free to call
-   * methods on {@code call} before this method has returned.
+   * methods on {@code call} before this method has returned. Since {@link Metadata} is not
+   * thread-safe, the caller must not access {@code headers} after this point.
    *
    * <p>If the implementation throws an exception, {@code call} will be closed with an error.
    * Implementations must not throw an exception if they started processing that may use {@code


### PR DESCRIPTION
This was already clearly documented in ServerCall.Listener and
ClientCall.