### PR TITLE
core,netty,okhttp: make toString more consistent for channelz

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
 import static java.lang.Math.max;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
@@ -210,7 +211,10 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
   @Override
   public String toString() {
-    return getLogId() + "(" + name + ")";
+    return MoreObjects.toStringHelper(this)
+        .add("logId", logId.getId())
+        .add("name", name)
+        .toString();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -23,6 +23,7 @@ import static io.grpc.ConnectivityState.SHUTDOWN;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
@@ -387,6 +388,16 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
     }
     if (savedPendingTransport != null) {
       savedPendingTransport.shutdown(reason);
+    }
+  }
+
+  @Override
+  public String toString() {
+    synchronized (lock) {
+      return MoreObjects.toStringHelper(this)
+          .add("logId", logId.getId())
+          .add("addressGroup", addressGroup.toString())
+          .toString();
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -393,9 +393,11 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
 
   @Override
   public String toString() {
+    // addressGroupCopy being a little stale is fine, just avoid calling toString with the lock
+    // since there may be many addresses.
     Object addressGroupCopy;
     synchronized (lock) {
-      addressGroupCopy = addressGroup.toString();
+      addressGroupCopy = addressGroup;
     }
     return MoreObjects.toStringHelper(this)
           .add("logId", logId.getId())

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -399,7 +399,7 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
     }
     return MoreObjects.toStringHelper(this)
           .add("logId", logId.getId())
-          .add("addressGroup", addressGroupCopy.toString())
+          .add("addressGroup", addressGroupCopy)
           .toString();
   }
 

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -393,12 +393,14 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
 
   @Override
   public String toString() {
+    Object addressGroupCopy;
     synchronized (lock) {
-      return MoreObjects.toStringHelper(this)
-          .add("logId", logId.getId())
-          .add("addressGroup", addressGroup.toString())
-          .toString();
+      addressGroupCopy = addressGroup.toString();
     }
+    return MoreObjects.toStringHelper(this)
+          .add("logId", logId.getId())
+          .add("addressGroup", addressGroupCopy.toString())
+          .toString();
   }
 
   @GuardedBy("lock")

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1320,7 +1320,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("logId", logId)
+        .add("logId", logId.getId())
         .add("target", target)
         .toString();
   }

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -272,6 +273,14 @@ final class OobChannel extends ManagedChannel implements Instrumented<ChannelSta
   @Override
   public LogId getLogId() {
     return logId;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("logId", logId.getId())
+        .add("authority", authority)
+        .toString();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -584,7 +584,7 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("logId", logId)
+        .add("logId", logId.getId())
         .add("transportServer", transportServer)
         .toString();
   }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -20,6 +20,7 @@ import static io.grpc.internal.GrpcUtil.KEEPALIVE_TIME_NANOS_DISABLED;
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -298,7 +299,11 @@ class NettyClientTransport implements ConnectionClientTransport {
 
   @Override
   public String toString() {
-    return getLogId() + "(" + address + ")";
+    return MoreObjects.toStringHelper(this)
+        .add("logId", logId.getId())
+        .add("address", address)
+        .add("channel", channel)
+        .toString();
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -308,7 +308,7 @@ class NettyServer implements InternalServer, WithLogId {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("logId", logId.toString())
+        .add("logId", logId.getId())
         .add("address", address)
         .toString();
   }

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -308,7 +308,7 @@ class NettyServer implements InternalServer, WithLogId {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("logId", logId)
+        .add("logId", logId.toString())
         .add("address", address)
         .toString();
   }
@@ -391,6 +391,14 @@ class NettyServer implements InternalServer, WithLogId {
     @Override
     public LogId getLogId() {
       return id;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("logId", id.getId())
+          .add("channel", ch)
+          .toString();
     }
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -17,6 +17,7 @@
 package io.grpc.netty;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -234,6 +235,15 @@ class NettyServerTransport implements ServerTransport {
         channel.remoteAddress(),
         Utils.getSocketOptions(ch),
         grpcHandler == null ? null : grpcHandler.getSecurityInfo());
+
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("logId", logId.getId())
+        .add("channel", channel)
+        .toString();
   }
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
@@ -618,7 +619,10 @@ class OkHttpClientTransport implements ConnectionClientTransport {
 
   @Override
   public String toString() {
-    return getLogId() + "(" + address + ")";
+    return MoreObjects.toStringHelper(this)
+        .add("logId", logId.getId())
+        .add("address", address)
+        .toString();
   }
 
   @Override


### PR DESCRIPTION
Use MoreObjects.toStringHelper and use only the log id's long value,
because the class name is already present in the toStringHelper.