### PR TITLE
buildscripts: assume artifacts are coalesced in upload_artifacts (#4439) (backport to v1.12.x)

### DIFF
--- a/buildscripts/kokoro/upload_artifacts.sh
+++ b/buildscripts/kokoro/upload_artifacts.sh
@@ -10,20 +10,23 @@ readonly GRPC_JAVA_DIR="$(cd "$(dirname "$0")"/../.. && pwd)"
 echo "Verifying that all artifacts are here..."
 find "$KOKORO_GFILE_DIR"
 
+# The output from all the jobs are coalesced into a single dir
+LOCAL_MVN_ARTIFACTS="$KOKORO_GFILE_DIR"/github/grpc-java/mvn-artifacts/
+
 # verify that files from all 3 grouped jobs are present.
 # platform independent artifacts, from linux job:
-[[ "$(find "$KOKORO_GFILE_DIR" -type f -iname 'grpc-core-*.jar' | wc -l)" != '0' ]]
+[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'grpc-core-*.jar' | wc -l)" != '0' ]]
 
 # from linux job:
-[[ "$(find "$KOKORO_GFILE_DIR" -type f -iname 'protoc-gen-grpc-java-*-linux-x86_64.exe' | wc -l)" != '0' ]]
-[[ "$(find "$KOKORO_GFILE_DIR" -type f -iname 'protoc-gen-grpc-java-*-linux-x86_32.exe' | wc -l)" != '0' ]]
+[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-linux-x86_64.exe' | wc -l)" != '0' ]]
+[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-linux-x86_32.exe' | wc -l)" != '0' ]]
 
 # from macos job:
-[[ "$(find "$KOKORO_GFILE_DIR" -type f -iname 'protoc-gen-grpc-java-*-osx-x86_64.exe' | wc -l)" != '0' ]]
+[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-osx-x86_64.exe' | wc -l)" != '0' ]]
 
 # from windows job:
-[[ "$(find "$KOKORO_GFILE_DIR" -type f -iname 'protoc-gen-grpc-java-*-windows-x86_64.exe' | wc -l)" != '0' ]]
-[[ "$(find "$KOKORO_GFILE_DIR" -type f -iname 'protoc-gen-grpc-java-*-windows-x86_32.exe' | wc -l)" != '0' ]]
+[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-windows-x86_64.exe' | wc -l)" != '0' ]]
+[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-windows-x86_32.exe' | wc -l)" != '0' ]]
 
 
 mkdir -p ~/.config/
@@ -39,19 +42,17 @@ gpg --version
 # This is the version found on kokoro.
 if gpg --version | grep 'gpg (GnuPG) 1.'; then
   # This command was tested on 1.4.16
-  find "$KOKORO_GFILE_DIR" -type f -exec \
+  find "$LOCAL_MVN_ARTIFACTS" -type f -exec \
   bash -c 'cat ~/java_signing/passphrase | gpg --batch --passphrase-fd 0 --detach-sign -o {}.asc {}' \;
 fi
 
 # This is the version found on corp workstations. Maybe kokoro will be updated to gpg2 some day.
 if gpg --version | grep 'gpg (GnuPG) 2.'; then
   # This command was tested on 2.2.2
-  find "$KOKORO_GFILE_DIR" -type f -exec \
+  find "$LOCAL_MVN_ARTIFACTS" -type f -exec \
     gpg --batch --passphrase-file ~/java_signing/passphrase --pinentry-mode loopback \
     --detach-sign -o {}.asc {} \;
 fi
 
 STAGING_REPO=a93898609ef848
-find "$KOKORO_GFILE_DIR" -name 'mvn-artifacts' -type d -exec \
-  "$GRPC_JAVA_DIR"/buildscripts/sonatype-upload.sh \
-  "$STAGING_REPO" {} \;
+"$GRPC_JAVA_DIR"/buildscripts/sonatype-upload.sh "$STAGING_REPO" "$LOCAL_MVN_ARTIFACTS"


### PR DESCRIPTION
The `find` was unnecessary. Update the sanity check to reflect this
assumption.