### PR TITLE
services: allow binlog env str to be empty or null

### DIFF
--- a/services/src/main/java/io/grpc/services/BinaryLogProviderImpl.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogProviderImpl.java
@@ -52,14 +52,22 @@ class BinaryLogProviderImpl extends BinaryLogProvider {
   @Nullable
   @Override
   public ServerInterceptor getServerInterceptor(String fullMethodName) {
-    return factory.getLog(fullMethodName).getServerInterceptor(getServerCallId());
+    BinlogHelper helperForMethod = factory.getLog(fullMethodName);
+    if (helperForMethod == null) {
+      return null;
+    }
+    return helperForMethod.getServerInterceptor(getServerCallId());
   }
 
   @Nullable
   @Override
   public ClientInterceptor getClientInterceptor(
       String fullMethodName, CallOptions callOptions) {
-    return factory.getLog(fullMethodName).getClientInterceptor(getClientCallId(callOptions));
+    BinlogHelper helperForMethod = factory.getLog(fullMethodName);
+    if (helperForMethod == null) {
+      return null;
+    }
+    return helperForMethod.getClientInterceptor(getClientCallId(callOptions));
   }
 
   protected CallId getServerCallId() {

--- a/services/src/test/java/io/grpc/services/BinaryLogProviderImplTest.java
+++ b/services/src/test/java/io/grpc/services/BinaryLogProviderImplTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.services;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import io.grpc.CallOptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link BinaryLogProviderImpl}. */
+@RunWith(JUnit4.class)
+public class BinaryLogProviderImplTest {
+  @Test
+  public void configStrNullTest() throws Exception {
+    BinaryLogSink sink = mock(BinaryLogSink.class);
+    BinaryLogProviderImpl binlog = new BinaryLogProviderImpl(sink, /*configStr=*/ null);
+    assertNull(binlog.getServerInterceptor("package.service/method"));
+    assertNull(binlog.getClientInterceptor("package.service/method", CallOptions.DEFAULT));
+  }
+
+  @Test
+  public void configStrEmptyTest() throws Exception {
+    BinaryLogSink sink = mock(BinaryLogSink.class);
+    BinaryLogProviderImpl binlog = new BinaryLogProviderImpl(sink, "");
+    assertNull(binlog.getServerInterceptor("package.service/method"));
+    assertNull(binlog.getClientInterceptor("package.service/method", CallOptions.DEFAULT));
+  }
+}


### PR DESCRIPTION
Binary log objects are explicitly passed into channel and server
builders, but the configuration is something that's from the
environment variables. An unset or empty GRPC_BINARY_LOG_CONFIG
should be allowed.
