### PR TITLE
core: do not use InternalServerInterceptors in BinaryLogProvider

### DIFF
--- a/core/src/main/java/io/grpc/BinaryLogProvider.java
+++ b/core/src/main/java/io/grpc/BinaryLogProvider.java
@@ -66,10 +66,11 @@ public abstract class BinaryLogProvider implements Closeable {
     }
     MethodDescriptor<byte[], byte[]> binMethod =
         BinaryLogProvider.toByteBufferMethod(oMethodDef.getMethodDescriptor());
-    ServerMethodDefinition<byte[], byte[]> binDef = InternalServerInterceptors
-        .wrapMethod(oMethodDef, binMethod);
-    ServerCallHandler<byte[], byte[]> binlogHandler = InternalServerInterceptors
-        .interceptCallHandler(binlogInterceptor, binDef.getServerCallHandler());
+    ServerMethodDefinition<byte[], byte[]> binDef =
+        ServerInterceptors.wrapMethod(oMethodDef, binMethod);
+    ServerCallHandler<byte[], byte[]> binlogHandler =
+        ServerInterceptors.InterceptCallHandler.create(
+            binlogInterceptor, binDef.getServerCallHandler());
     return ServerMethodDefinition.create(binMethod, binlogHandler);
   }
 

--- a/core/src/main/java/io/grpc/InternalServerInterceptors.java
+++ b/core/src/main/java/io/grpc/InternalServerInterceptors.java
@@ -26,12 +26,6 @@ public final class InternalServerInterceptors {
     return ServerInterceptors.InterceptCallHandler.create(interceptor, callHandler);
   }
 
-  public static <ReqT, RespT> ServerMethodDefinition<ReqT, RespT> wrapMethod(
-      ServerMethodDefinition<?, ?> definition,
-      MethodDescriptor<ReqT, RespT> wrappedMethod) {
-    return ServerInterceptors.wrapMethod(definition, wrappedMethod);
-  }
-
   private InternalServerInterceptors() {
   }
 }


### PR DESCRIPTION
Now that they are in `io.grpc` the accessor is not needed.