### PR TITLE
updated dependency from 2.0.6 to 2.0.7 in security documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -90,7 +90,7 @@ In Maven, you can use the [os-maven-plugin](https://github.com/trustin/os-maven-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>2.0.6.Final</version>
+      <version>2.0.7.Final</version>
     </dependency>
   </dependencies>
 </project>
@@ -108,7 +108,7 @@ buildscript {
 }
 
 dependencies {
-    compile 'io.netty:netty-tcnative-boringssl-static:2.0.6.Final'
+    compile 'io.netty:netty-tcnative-boringssl-static:2.0.7.Final'
 }
 ```
 
@@ -143,7 +143,7 @@ In Maven, you can use the [os-maven-plugin](https://github.com/trustin/os-maven-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>2.0.6.Final</version>
+      <version>2.0.7.Final</version>
       <classifier>${tcnative.classifier}</classifier>
     </dependency>
   </dependencies>
@@ -211,7 +211,7 @@ if (osdetector.os == "linux" && osdetector.release.isLike("fedora")) {
 }
 
 dependencies {
-    compile 'io.netty:netty-tcnative:2.0.6.Final:' + tcnative_classifier
+    compile 'io.netty:netty-tcnative:2.0.7.Final:' + tcnative_classifier
 }
 ```
 


### PR DESCRIPTION
Master currently is for grpc >= 0.11 so it doesn't make sense that the SECURITY.md instructs to use the 2.0.6 (which triggers an error) - see https://github.com/grpc/grpc-java/issues/3989