### PR TITLE
core: remove io.grpc core dependency on census

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -12,7 +12,6 @@ java_library(
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_errorprone_error_prone_annotations//jar",
         "@com_google_guava_guava//jar",
-        "@io_opencensus_opencensus_api//jar",
     ],
 )
 

--- a/core/src/main/java/io/grpc/BinaryLogProvider.java
+++ b/core/src/main/java/io/grpc/BinaryLogProvider.java
@@ -19,14 +19,12 @@ package io.grpc;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.grpc.MethodDescriptor.Marshaller;
-import io.opencensus.trace.Span;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import javax.annotation.Nullable;
 
 // TODO(zpencer): rename class to AbstractBinaryLog
@@ -164,10 +162,6 @@ public abstract class BinaryLogProvider implements Closeable {
     public CallId(long hi, long lo) {
       this.hi = hi;
       this.lo = lo;
-    }
-
-    public static CallId fromCensusSpan(Span span) {
-      return new CallId(0, ByteBuffer.wrap(span.getContext().getSpanId().getBytes()).getLong());
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -21,6 +21,7 @@ import static io.opencensus.trace.unsafe.ContextUtils.CONTEXT_SPAN_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.BinaryLogProvider;
+import io.grpc.BinaryLogProvider.CallId;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -40,6 +41,7 @@ import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.propagation.BinaryFormat;
+import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -385,7 +387,10 @@ final class CensusTracingModule {
               callOptions.withStreamTracerFactory(tracerFactory)
                   .withOption(
                       BinaryLogProvider.CLIENT_CALL_ID_CALLOPTION_KEY,
-                      BinaryLogProvider.CallId.fromCensusSpan(tracerFactory.span)));
+                      new CallId(
+                          0,
+                          ByteBuffer.wrap(
+                              tracerFactory.span.getContext().getSpanId().getBytes()).getLong())));
       return new SimpleForwardingClientCall<ReqT, RespT>(call) {
         @Override
         public void start(Listener<RespT> responseListener, Metadata headers) {

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -961,7 +961,10 @@ public class CensusModulesTest {
   @Test
   public void callIdFromSpan() {
     MockableSpan mockableSpan = MockableSpan.generateRandomSpan(new Random(0));
-    CallId callId = CallId.fromCensusSpan(mockableSpan);
+    CallId callId = new CallId(
+        0,
+        ByteBuffer.wrap(
+            mockableSpan.getContext().getSpanId().getBytes()).getLong());
     assertThat(callId.hi).isEqualTo(0);
     assertThat(callId.lo)
         .isEqualTo(ByteBuffer.wrap(mockableSpan.getContext().getSpanId().getBytes()).getLong());

--- a/services/src/main/java/io/grpc/services/CensusBinaryLogProvider.java
+++ b/services/src/main/java/io/grpc/services/CensusBinaryLogProvider.java
@@ -20,12 +20,16 @@ import io.grpc.BinaryLogProvider;
 import io.grpc.CallOptions;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracing;
+import java.nio.ByteBuffer;
 
 final class CensusBinaryLogProvider extends BinaryLogProviderImpl {
   @Override
   protected CallId getServerCallId() {
     Span currentSpan = Tracing.getTracer().getCurrentSpan();
-    return CallId.fromCensusSpan(currentSpan);
+    return new CallId(
+        0,
+        ByteBuffer.wrap(
+            currentSpan.getContext().getSpanId().getBytes()).getLong());
   }
 
   @Override


### PR DESCRIPTION
io.grpc (core) does not strictly require census. Move the usages and
and remove census from BUILD.bazel .