### PR TITLE
core: put @ExperimentalApi on CallOptions.of()

### DIFF
--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -259,8 +259,10 @@ public final class CallOptions {
      * @param defaultValue default value to return when value for key not set
      * @param <T> Key type
      * @return Key object
-     * @deprecated Use {@link #create} or {@link #createWithDefault} instead.
+     * @deprecated Use {@link #create} or {@link #createWithDefault} instead. This method will
+     *     be removed.
      */
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1869")
     @Deprecated
     public static <T> Key<T> of(String debugString, T defaultValue) {
       Preconditions.checkNotNull(debugString, "debugString");


### PR DESCRIPTION
This marks the method as still experimental, to be clear to users that
they are using an experimental api.

This is a follow up for:
https://github.com/grpc/grpc-java/pull/4457#pullrequestreview-120393893