### PR TITLE
core: make channel stats' channel state consistent with subchannels

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -283,13 +283,13 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
   @Override
   public ListenableFuture<ChannelStats> getStats() {
     final SettableFuture<ChannelStats> ret = SettableFuture.create();
-    final ChannelStats.Builder builder = new Channelz.ChannelStats.Builder();
-    channelCallTracer.updateBuilder(builder);
-    builder.setTarget(target).setState(channelStateManager.getState());
     // subchannels and oobchannels can only be accessed from channelExecutor
     channelExecutor.executeLater(new Runnable() {
       @Override
       public void run() {
+        ChannelStats.Builder builder = new Channelz.ChannelStats.Builder();
+        channelCallTracer.updateBuilder(builder);
+        builder.setTarget(target).setState(channelStateManager.getState());
         List<WithLogId> children = new ArrayList<WithLogId>();
         children.addAll(subchannels);
         children.addAll(oobChannels);


### PR DESCRIPTION
Moved `setState()` inside of `channelExecutor` runnable together with `setSubchannels`, otherwise the state may be inconsistent with subchannels, say channel state is the initial IDLE but subchannels is non-empty with active transports, or channel state is READY but subchannels is empty.