### PR TITLE
core: Add ChannelTracer

### DIFF
--- a/core/src/main/java/io/grpc/internal/ChannelTracer.java
+++ b/core/src/main/java/io/grpc/internal/ChannelTracer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.grpc.internal.Channelz.ChannelStats;
+import io.grpc.internal.Channelz.ChannelTrace;
+import io.grpc.internal.Channelz.ChannelTrace.Event;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * Tracks a collections of channel tracing events for a channel/subchannel.
+ */
+final class ChannelTracer {
+  private final Object lock = new Object();
+  @GuardedBy("lock")
+  private final Collection<Event> events;
+  private final long channelCreationTimeNanos;
+
+  @GuardedBy("lock")
+  private int eventsLogged;
+
+  ChannelTracer(final int maxEvents, long channelCreationTimeNanos) {
+    checkArgument(maxEvents > 0, "maxEvents must be greater than zero");
+    events = new ArrayDeque<Event>() {
+      @GuardedBy("lock")
+      @Override
+      public boolean add(Event event) {
+        if (size() == maxEvents) {
+          removeFirst();
+        }
+        eventsLogged++;
+        return super.add(event);
+      }
+    };
+    this.channelCreationTimeNanos = channelCreationTimeNanos;
+  }
+
+  void reportEvent(Event event) {
+    synchronized (lock) {
+      events.add(event);
+    }
+  }
+
+  void updateBuilder(ChannelStats.Builder builder) {
+    List<Event> eventsSnapshot;
+    int eventsLoggedSnapshot;
+    synchronized (lock) {
+      eventsLoggedSnapshot = eventsLogged;
+      eventsSnapshot = new ArrayList<Event>(events);
+    }
+    builder.setChannelTrace(new ChannelTrace.Builder()
+        .setNumEventsLogged(eventsLoggedSnapshot)
+        .setCreationTimeNanos(channelCreationTimeNanos)
+        .setEvents(eventsSnapshot)
+        .build());
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ChannelTracerTest.java
+++ b/core/src/test/java/io/grpc/internal/ChannelTracerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.grpc.internal.Channelz.ChannelStats;
+import io.grpc.internal.Channelz.ChannelTrace.Event;
+import io.grpc.internal.Channelz.ChannelTrace.Event.Severity;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link ChannelTracer}.
+ */
+@RunWith(JUnit4.class)
+public class ChannelTracerTest {
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void channelTracerWithZeroMaxEventsShouldThrow() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("maxEvents must be greater than zero");
+
+    new ChannelTracer(0 /* maxEvents*/, 3L /* channelCreationTimeNanos */);
+  }
+
+  @Test
+  public void reportEvents() {
+    ChannelTracer channelTracer =
+        new ChannelTracer(2 /* maxEvents*/, 3L /* channelCreationTimeNanos */);
+    ChannelStats.Builder builder = new ChannelStats.Builder();
+    Event e1 = new Event.Builder().setDescription("e1").setSeverity(Severity.CT_ERROR).build();
+    Event e2 = new Event.Builder().setDescription("e2").setSeverity(Severity.CT_INFO).build();
+    Event e3 = new Event.Builder().setDescription("e3").setSeverity(Severity.CT_WARNING).build();
+    Event e4 = new Event.Builder().setDescription("e4").setSeverity(Severity.CT_UNKNOWN).build();
+
+    channelTracer.reportEvent(e1);
+    channelTracer.updateBuilder(builder);
+    ChannelStats stats = builder.build();
+
+    assertThat(stats.channelTrace.events).containsExactly(e1);
+    assertThat(stats.channelTrace.numEventsLogged).isEqualTo(1);
+
+    channelTracer.reportEvent(e2);
+    channelTracer.updateBuilder(builder);
+    stats = builder.build();
+
+    assertThat(stats.channelTrace.events).containsExactly(e1, e2);
+    assertThat(stats.channelTrace.numEventsLogged).isEqualTo(2);
+
+    channelTracer.reportEvent(e3);
+    channelTracer.updateBuilder(builder);
+    stats = builder.build();
+
+    assertThat(stats.channelTrace.events).containsExactly(e2, e3);
+    assertThat(stats.channelTrace.numEventsLogged).isEqualTo(3);
+
+    channelTracer.reportEvent(e4);
+    channelTracer.updateBuilder(builder);
+    stats = builder.build();
+
+    assertThat(stats.channelTrace.events).containsExactly(e3, e4);
+    assertThat(stats.channelTrace.numEventsLogged).isEqualTo(4);
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ChannelTracerTest.java
+++ b/core/src/test/java/io/grpc/internal/ChannelTracerTest.java
@@ -40,7 +40,7 @@ public class ChannelTracerTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("maxEvents must be greater than zero");
 
-    new ChannelTracer(0 /* maxEvents*/, 3L /* channelCreationTimeNanos */);
+    new ChannelTracer(/* maxEvents= */ 0, /* channelCreationTimeNanos= */ 3L);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ChannelTracerTest.java
+++ b/core/src/test/java/io/grpc/internal/ChannelTracerTest.java
@@ -46,7 +46,7 @@ public class ChannelTracerTest {
   @Test
   public void reportEvents() {
     ChannelTracer channelTracer =
-        new ChannelTracer(2 /* maxEvents*/, 3L /* channelCreationTimeNanos */);
+        new ChannelTracer(/* maxEvents= */ 2, /* channelCreationTimeNanos= */ 3L);
     ChannelStats.Builder builder = new ChannelStats.Builder();
     Event e1 = new Event.Builder().setDescription("e1").setSeverity(Severity.CT_ERROR).build();
     Event e2 = new Event.Builder().setDescription("e2").setSeverity(Severity.CT_INFO).build();


### PR DESCRIPTION
This is a class similar to CallTracer, to be used for Channel Tracing.

The constructor arg `maxEvents` is a param supposed to be provided by `ManagedChannelBuilder`.