### PR TITLE
all: TimeProvider to use nanos rather than millis more consistently

### DIFF
--- a/core/src/main/java/io/grpc/internal/Channelz.java
+++ b/core/src/main/java/io/grpc/internal/Channelz.java
@@ -279,7 +279,7 @@ public final class Channelz {
     public final long callsStarted;
     public final long callsSucceeded;
     public final long callsFailed;
-    public final long lastCallStartedMillis;
+    public final long lastCallStartedNanos;
     public final List<Instrumented<SocketStats>> listenSockets;
 
     /**
@@ -289,12 +289,12 @@ public final class Channelz {
         long callsStarted,
         long callsSucceeded,
         long callsFailed,
-        long lastCallStartedMillis,
+        long lastCallStartedNanos,
         List<Instrumented<SocketStats>> listenSockets) {
       this.callsStarted = callsStarted;
       this.callsSucceeded = callsSucceeded;
       this.callsFailed = callsFailed;
-      this.lastCallStartedMillis = lastCallStartedMillis;
+      this.lastCallStartedNanos = lastCallStartedNanos;
       this.listenSockets = checkNotNull(listenSockets);
     }
 
@@ -302,7 +302,7 @@ public final class Channelz {
       private long callsStarted;
       private long callsSucceeded;
       private long callsFailed;
-      private long lastCallStartedMillis;
+      private long lastCallStartedNanos;
       public List<Instrumented<SocketStats>> listenSockets = Collections.emptyList();
 
       public Builder setCallsStarted(long callsStarted) {
@@ -320,8 +320,8 @@ public final class Channelz {
         return this;
       }
 
-      public Builder setLastCallStartedMillis(long lastCallStartedMillis) {
-        this.lastCallStartedMillis = lastCallStartedMillis;
+      public Builder setLastCallStartedNanos(long lastCallStartedNanos) {
+        this.lastCallStartedNanos = lastCallStartedNanos;
         return this;
       }
 
@@ -341,7 +341,7 @@ public final class Channelz {
             callsStarted,
             callsSucceeded,
             callsFailed,
-            lastCallStartedMillis,
+            lastCallStartedNanos,
             listenSockets);
       }
     }
@@ -358,7 +358,7 @@ public final class Channelz {
     public final long callsStarted;
     public final long callsSucceeded;
     public final long callsFailed;
-    public final long lastCallStartedMillis;
+    public final long lastCallStartedNanos;
     public final List<WithLogId> subchannels;
     public final List<WithLogId> sockets;
 
@@ -372,7 +372,7 @@ public final class Channelz {
         long callsStarted,
         long callsSucceeded,
         long callsFailed,
-        long lastCallStartedMillis,
+        long lastCallStartedNanos,
         List<WithLogId> subchannels,
         List<WithLogId> sockets) {
       Preconditions.checkState(
@@ -385,7 +385,7 @@ public final class Channelz {
       this.callsStarted = callsStarted;
       this.callsSucceeded = callsSucceeded;
       this.callsFailed = callsFailed;
-      this.lastCallStartedMillis = lastCallStartedMillis;
+      this.lastCallStartedNanos = lastCallStartedNanos;
       this.subchannels = checkNotNull(subchannels);
       this.sockets = checkNotNull(sockets);
     }
@@ -397,7 +397,7 @@ public final class Channelz {
       private long callsStarted;
       private long callsSucceeded;
       private long callsFailed;
-      private long lastCallStartedMillis;
+      private long lastCallStartedNanos;
       private List<WithLogId> subchannels = Collections.emptyList();
       private List<WithLogId> sockets = Collections.emptyList();
 
@@ -431,8 +431,8 @@ public final class Channelz {
         return this;
       }
 
-      public Builder setLastCallStartedMillis(long lastCallStartedMillis) {
-        this.lastCallStartedMillis = lastCallStartedMillis;
+      public Builder setLastCallStartedNanos(long lastCallStartedNanos) {
+        this.lastCallStartedNanos = lastCallStartedNanos;
         return this;
       }
 
@@ -461,7 +461,7 @@ public final class Channelz {
             callsStarted,
             callsSucceeded,
             callsFailed,
-            lastCallStartedMillis,
+            lastCallStartedNanos,
             subchannels,
             sockets);
       }

--- a/core/src/main/java/io/grpc/internal/TimeProvider.java
+++ b/core/src/main/java/io/grpc/internal/TimeProvider.java
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
-package io.grpc.grpclb;
+package io.grpc.internal;
+
+import java.util.concurrent.TimeUnit;
 
 /**
- * Allow time manipulation in tests.
+ * Time source representing the current system time in nanos. Used to inject a fake clock
+ * into unit tests.
  */
-interface TimeProvider {
-  long currentTimeMillis();
+public interface TimeProvider {
+  /** Returns the current nano time. */
+  long currentTimeNanos();
+
+  TimeProvider SYSTEM_TIME_PROVIDER = new TimeProvider() {
+    final long offsetNanos =
+        TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis()) - System.nanoTime();
+
+    @Override
+    public long currentTimeNanos() {
+      return System.nanoTime() + offsetNanos;
+    }
+  };
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -149,10 +149,10 @@ public class ManagedChannelImplTest {
   private final CallTracer.Factory channelStatsFactory = new CallTracer.Factory() {
     @Override
     public CallTracer create() {
-      return new CallTracer(new CallTracer.TimeProvider() {
+      return new CallTracer(new TimeProvider() {
         @Override
-        public long currentTimeMillis() {
-          return executor.currentTimeMillis();
+        public long currentTimeNanos() {
+          return executor.getTicker().read();
         }
       });
     }
@@ -2104,7 +2104,7 @@ public class ManagedChannelImplTest {
     assertEquals(0, getStats(channel).callsStarted);
     call.start(mockCallListener, new Metadata());
     assertEquals(1, getStats(channel).callsStarted);
-    assertEquals(executor.currentTimeMillis(), getStats(channel).lastCallStartedMillis);
+    assertEquals(executor.getTicker().read(), getStats(channel).lastCallStartedNanos);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -110,7 +110,7 @@ public class ServerCallImplTest {
     tracer.updateBuilder(beforeBuilder);
     ServerStats before = beforeBuilder.build();
     assertEquals(0, before.callsStarted);
-    assertEquals(0, before.lastCallStartedMillis);
+    assertEquals(0, before.lastCallStartedNanos);
 
     call = new ServerCallImpl<Long, Long>(stream, UNARY_METHOD, requestHeaders, context,
         DecompressorRegistry.getDefaultInstance(), CompressorRegistry.getDefaultInstance(),

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
@@ -23,6 +23,7 @@ import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.internal.TimeProvider;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -99,7 +100,7 @@ final class GrpclbClientLoadRecorder extends ClientStreamTracer.Factory {
   ClientStats generateLoadReport() {
     ClientStats.Builder statsBuilder =
         ClientStats.newBuilder()
-        .setTimestamp(Timestamps.fromMillis(time.currentTimeMillis()))
+        .setTimestamp(Timestamps.fromNanos(time.currentTimeNanos()))
         .setNumCallsStarted(callsStartedUpdater.getAndSet(this, 0))
         .setNumCallsFinished(callsFinishedUpdater.getAndSet(this, 0))
         .setNumCallsFinishedWithClientFailedToSend(callsFailedToSendUpdater.getAndSet(this, 0))

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -28,6 +28,7 @@ import io.grpc.grpclb.GrpclbConstants.LbPolicy;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.LogId;
 import io.grpc.internal.ObjectPool;
+import io.grpc.internal.TimeProvider;
 import io.grpc.internal.WithLogId;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerFactory.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerFactory.java
@@ -21,6 +21,7 @@ import io.grpc.LoadBalancer;
 import io.grpc.PickFirstBalancerFactory;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourcePool;
+import io.grpc.internal.TimeProvider;
 import io.grpc.util.RoundRobinLoadBalancerFactory;
 
 /**
@@ -33,12 +34,6 @@ import io.grpc.util.RoundRobinLoadBalancerFactory;
 public class GrpclbLoadBalancerFactory extends LoadBalancer.Factory {
 
   private static final GrpclbLoadBalancerFactory INSTANCE = new GrpclbLoadBalancerFactory();
-  private static final TimeProvider TIME_PROVIDER = new TimeProvider() {
-      @Override
-      public long currentTimeMillis() {
-        return System.currentTimeMillis();
-      }
-    };
 
   private GrpclbLoadBalancerFactory() {
   }
@@ -57,6 +52,6 @@ public class GrpclbLoadBalancerFactory extends LoadBalancer.Factory {
         // load should not be on the shared scheduled executor, we should use a combination of the
         // scheduled executor and the default app executor.
         SharedResourcePool.forResource(GrpcUtil.TIMER_SERVICE),
-        TIME_PROVIDER);
+        TimeProvider.SYSTEM_TIME_PROVIDER);
   }
 }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -43,6 +43,7 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.grpclb.LoadBalanceResponse.LoadBalanceResponseTypeCase;
 import io.grpc.internal.LogId;
+import io.grpc.internal.TimeProvider;
 import io.grpc.stub.StreamObserver;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -74,6 +74,7 @@ import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.SerializingExecutor;
+import io.grpc.internal.TimeProvider;
 import io.grpc.stub.StreamObserver;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -137,8 +138,8 @@ public class GrpclbLoadBalancerTest {
   private final ArrayList<String> failingLbAuthorities = new ArrayList<String>();
   private final TimeProvider timeProvider = new TimeProvider() {
       @Override
-      public long currentTimeMillis() {
-        return fakeClock.currentTimeMillis();
+      public long currentTimeNanos() {
+        return fakeClock.getTicker().read();
       }
     };
   private io.grpc.Server fakeLbServer;
@@ -685,7 +686,7 @@ public class GrpclbLoadBalancerTest {
         eq(LoadBalanceRequest.newBuilder()
             .setClientStats(
                 ClientStats.newBuilder(expectedReport)
-                .setTimestamp(Timestamps.fromMillis(fakeClock.currentTimeMillis()))
+                .setTimestamp(Timestamps.fromNanos(fakeClock.getTicker().read()))
                 .build())
             .build()));
   }

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -21,7 +21,6 @@ import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.TransportTracer;
 import io.grpc.internal.testing.AbstractTransportTest;
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -36,13 +35,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NettyTransportTest extends AbstractTransportTest {
   private final FakeClock fakeClock = new FakeClock();
-  private final TransportTracer.Factory fakeClockTransportTracer = new TransportTracer.Factory(
-      new TransportTracer.TimeProvider() {
-        @Override
-        public long currentTimeMillis() {
-          return fakeClock.currentTimeMillis();
-        }
-      });
   // Avoid LocalChannel for testing because LocalChannel can fail with
   // io.netty.channel.ChannelException instead of java.net.ConnectException which breaks
   // serverNotListening test.
@@ -95,8 +87,8 @@ public class NettyTransportTest extends AbstractTransportTest {
   }
 
   @Override
-  protected long currentTimeMillis() {
-    return fakeClock.currentTimeMillis();
+  protected long fakeCurrentTimeNanos() {
+    return fakeClock.getTicker().read();
   }
 
   @Override

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -22,7 +22,6 @@ import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.TransportTracer;
 import io.grpc.internal.testing.AbstractTransportTest;
 import io.grpc.netty.NettyServerBuilder;
 import java.net.InetSocketAddress;
@@ -38,13 +37,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class OkHttpTransportTest extends AbstractTransportTest {
   private final FakeClock fakeClock = new FakeClock();
-  private final TransportTracer.Factory fakeClockTransportTracer = new TransportTracer.Factory(
-      new TransportTracer.TimeProvider() {
-        @Override
-        public long currentTimeMillis() {
-          return fakeClock.currentTimeMillis();
-        }
-      });
   private ClientTransportFactory clientFactory = OkHttpChannelBuilder
       // Although specified here, address is ignored because we never call build.
       .forAddress("localhost", 0)
@@ -100,8 +92,8 @@ public class OkHttpTransportTest extends AbstractTransportTest {
   }
 
   @Override
-  protected long currentTimeMillis() {
-    return fakeClock.currentTimeMillis();
+  protected long fakeCurrentTimeNanos() {
+    return fakeClock.getTicker().read();
   }
 
   // TODO(ejona): Flaky/Broken

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -138,7 +138,7 @@ final class ChannelzProtoUtil {
         .setCallsStarted(stats.callsStarted)
         .setCallsSucceeded(stats.callsSucceeded)
         .setCallsFailed(stats.callsFailed)
-        .setLastCallStartedTimestamp(Timestamps.fromMillis(stats.lastCallStartedMillis))
+        .setLastCallStartedTimestamp(Timestamps.fromNanos(stats.lastCallStartedNanos))
         .build();
   }
 
@@ -359,7 +359,7 @@ final class ChannelzProtoUtil {
         .setCallsStarted(stats.callsStarted)
         .setCallsSucceeded(stats.callsSucceeded)
         .setCallsFailed(stats.callsFailed)
-        .setLastCallStartedTimestamp(Timestamps.fromMillis(stats.lastCallStartedMillis));
+        .setLastCallStartedTimestamp(Timestamps.fromNanos(stats.lastCallStartedNanos));
     if (stats.channelTrace != null) {
       builder.setTrace(toChannelTrace(stats.channelTrace));
     }

--- a/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
+++ b/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
@@ -106,7 +106,7 @@ public final class ChannelzProtoUtilTest {
       .setCallsStarted(1)
       .setCallsSucceeded(2)
       .setCallsFailed(3)
-      .setLastCallStartedTimestamp(Timestamps.fromMillis(4))
+      .setLastCallStartedTimestamp(Timestamps.fromNanos(4))
       .build();
   private final Channel channelProto = Channel
       .newBuilder()
@@ -127,7 +127,7 @@ public final class ChannelzProtoUtilTest {
       .setCallsStarted(1)
       .setCallsSucceeded(2)
       .setCallsFailed(3)
-      .setLastCallStartedTimestamp(Timestamps.fromMillis(4))
+      .setLastCallStartedTimestamp(Timestamps.fromNanos(4))
       .build();
   private final Subchannel subchannelProto = Subchannel
         .newBuilder()
@@ -146,7 +146,7 @@ public final class ChannelzProtoUtilTest {
       .setCallsStarted(1)
       .setCallsSucceeded(2)
       .setCallsFailed(3)
-      .setLastCallStartedTimestamp(Timestamps.fromMillis(4))
+      .setLastCallStartedTimestamp(Timestamps.fromNanos(4))
       .build();
   private final Server serverProto = Server
       .newBuilder()
@@ -912,7 +912,7 @@ public final class ChannelzProtoUtilTest {
         .setCallsStarted(stats.callsStarted)
         .setCallsSucceeded(stats.callsSucceeded)
         .setCallsFailed(stats.callsFailed)
-        .setLastCallStartedMillis(stats.lastCallStartedMillis);
+        .setLastCallStartedNanos(stats.lastCallStartedNanos);
     if (!stats.subchannels.isEmpty()) {
       builder.setSubchannels(stats.subchannels);
     }
@@ -938,7 +938,7 @@ public final class ChannelzProtoUtilTest {
         .setCallsStarted(stats.callsStarted)
         .setCallsSucceeded(stats.callsSucceeded)
         .setCallsFailed(stats.callsFailed)
-        .setLastCallStartedMillis(stats.lastCallStartedMillis)
+        .setLastCallStartedNanos(stats.lastCallStartedNanos)
         .setListenSockets(stats.listenSockets);
   }
 }

--- a/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
+++ b/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
@@ -122,7 +122,7 @@ final class ChannelzTestHelper {
         /*callsStarted=*/ 1,
         /*callsSucceeded=*/ 2,
         /*callsFailed=*/ 3,
-        /*lastCallStartedMillis=*/ 4,
+        /*lastCallStartedNanos=*/ 4,
         Collections.<Instrumented<SocketStats>>emptyList());
 
     @Override
@@ -154,7 +154,7 @@ final class ChannelzTestHelper {
         .setCallsStarted(1)
         .setCallsSucceeded(2)
         .setCallsFailed(3)
-        .setLastCallStartedMillis(4)
+        .setLastCallStartedNanos(4)
         .setSubchannels(Collections.<WithLogId>emptyList())
         .setSockets(Collections.<WithLogId>emptyList())
         .build();


### PR DESCRIPTION
This is the same practice as #2833
More PRs switching to nanos may come after.