### PR TITLE
 auth: Require PRIVACY_AND_INTEGRITY for GoogleCredentials

### DIFF
--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -26,6 +26,7 @@ import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import java.io.IOException;
@@ -51,7 +52,10 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
       = Logger.getLogger(GoogleAuthLibraryCallCredentials.class.getName());
   private static final JwtHelper jwtHelper
       = createJwtHelperOrNull(GoogleAuthLibraryCallCredentials.class.getClassLoader());
+  private static final Class<? extends Credentials> googleCredentialsClass
+      = loadGoogleCredentialsClass();
 
+  private final boolean requirePrivacy;
   @VisibleForTesting
   final Credentials creds;
 
@@ -65,9 +69,18 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
   @VisibleForTesting
   GoogleAuthLibraryCallCredentials(Credentials creds, JwtHelper jwtHelper) {
     checkNotNull(creds, "creds");
+    boolean requirePrivacy = false;
+    if (googleCredentialsClass != null) {
+      // All GoogleCredentials instances are bearer tokens and should only be used on private
+      // channels. This catches all return values from GoogleCredentials.getApplicationDefault().
+      // This should be checked before upgrading the Service Account to JWT, as JWT is also a bearer
+      // token.
+      requirePrivacy = googleCredentialsClass.isInstance(creds);
+    }
     if (jwtHelper != null) {
       creds = jwtHelper.tryServiceAccountToJwt(creds);
     }
+    this.requirePrivacy = requirePrivacy;
     this.creds = creds;
   }
 
@@ -77,6 +90,14 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
   @Override
   public void applyRequestMetadata(MethodDescriptor<?, ?> method, Attributes attrs,
       Executor appExecutor, final MetadataApplier applier) {
+    SecurityLevel security = checkNotNull(attrs.get(ATTR_SECURITY_LEVEL), "securityLevel");
+    if (requirePrivacy && security != SecurityLevel.PRIVACY_AND_INTEGRITY) {
+      applier.fail(Status.UNAUTHENTICATED
+          .withDescription("Credentials require channel with PRIVACY_AND_INTEGRITY security level. "
+            + "Observed security level: " + security));
+      return;
+    }
+
     String authority = checkNotNull(attrs.get(ATTR_AUTHORITY), "authority");
     final URI uri;
     try {
@@ -212,6 +233,19 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
       log.log(Level.WARNING, "Failed to create JWT helper. This is unexpected", caughtException);
     }
     return null;
+  }
+
+  @Nullable
+  private static Class<? extends Credentials> loadGoogleCredentialsClass() {
+    Class<?> rawGoogleCredentialsClass;
+    try {
+      // Can't use a loader as it disables ProGuard's reference detection and would fail to rename
+      // this reference. Unfortunately this will initialize the class.
+      rawGoogleCredentialsClass = Class.forName("com.google.auth.oauth2.GoogleCredentials");
+    } catch (ClassNotFoundException ex) {
+      return null;
+    }
+    return rawGoogleCredentialsClass.asSubclass(Credentials.class);
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -24,6 +24,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
+import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Compressor;
 import io.grpc.Deadline;
@@ -32,6 +33,7 @@ import io.grpc.DecompressorRegistry;
 import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.SecurityLevel;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.internal.Channelz.SocketStats;
@@ -88,6 +90,9 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   private Set<InProcessStream> streams = new HashSet<InProcessStream>();
   @GuardedBy("this")
   private List<ServerStreamTracer.Factory> serverStreamTracerFactories;
+  private final Attributes attributes = Attributes.newBuilder()
+      .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
+      .build();
 
   public InProcessTransport(String name, String authority, String userAgent) {
     this.name = name;
@@ -224,7 +229,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
   @Override
   public Attributes getAttributes() {
-    return Attributes.EMPTY;
+    return attributes;
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -313,8 +313,7 @@ class NettyClientTransport implements ConnectionClientTransport {
 
   @Override
   public Attributes getAttributes() {
-    // TODO(zhangkun83): fill channel security attributes
-    return Attributes.EMPTY;
+    return handler.getAttributes();
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -22,8 +22,10 @@ import static io.grpc.netty.GrpcSslContexts.NEXT_PROTOCOL_VERSIONS;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
+import io.grpc.CallCredentials;
 import io.grpc.Grpc;
 import io.grpc.Internal;
+import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.internal.Channelz;
 import io.grpc.internal.GrpcUtil;
@@ -645,6 +647,7 @@ public final class ProtocolNegotiators {
                 Attributes.newBuilder()
                     .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, session)
                     .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
+                    .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
                     .build(),
                 new Channelz.Security(new Channelz.Tls(session)));
             writeBufferedAndRemove(ctx);
@@ -692,6 +695,7 @@ public final class ProtocolNegotiators {
           Attributes
               .newBuilder()
               .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
+              .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
               .build(),
           /*securityInfo=*/ null);
       super.channelActive(ctx);
@@ -734,6 +738,7 @@ public final class ProtocolNegotiators {
             Attributes
                 .newBuilder()
                 .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
+                .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
                 .build(),
             /*securityInfo=*/ null);
       } else if (evt == HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_REJECTED) {

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -503,17 +503,10 @@ public class NettyClientTransportTest {
     address = TestUtils.testServerAddress(12345);
     authority = GrpcUtil.authorityFromHostAndPort(address.getHostString(), address.getPort());
 
-    NettyClientTransport transport = newTransport(
-        new ProtocolNegotiator() {
-          @Override
-          public Handler newHandler(GrpcHttp2ConnectionHandler handler) {
-            return null;
-          }
-        });
+    NettyClientTransport transport = newTransport(new NoopProtocolNegotiator());
+    callMeMaybe(transport.start(clientTransportListener));
 
     assertEquals(Attributes.EMPTY, transport.getAttributes());
-
-    transports.clear();
   }
 
   @Test

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -31,11 +31,13 @@ import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.internal.http.StatusLine;
 import io.grpc.Attributes;
+import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
@@ -478,12 +480,13 @@ class OkHttpClientTransport implements ConnectionClientTransport {
           sock.setTcpNoDelay(true);
           source = Okio.buffer(Okio.source(sock));
           sink = Okio.buffer(Okio.sink(sock));
-          // TODO(zhangkun83): fill channel security attributes
           // The return value of OkHttpTlsUpgrader.upgrade is an SSLSocket that has this info
           attributes = Attributes
               .newBuilder()
               .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, sock.getRemoteSocketAddress())
               .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, sslSession)
+              .set(CallCredentials.ATTR_SECURITY_LEVEL,
+                  sslSession == null ? SecurityLevel.NONE : SecurityLevel.PRIVACY_AND_INTEGRITY)
               .build();
         } catch (StatusException e) {
           startGoAway(0, ErrorCode.INTERNAL_ERROR, e.getStatus());


### PR DESCRIPTION
This keeps them more secure. Other types of creds are left as-is, since
we don't quite know if it makes sense to have a similar restriction. (It
likely does make sense, but this is a more precise change for our
needs.)

I will keep the two separate commits when merging. Each commit has a commit message, although the two commits are pretty disjoint, so it's not a big deal to review it all at once.