### PR TITLE
core: Update OpenCensus version. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
-        opencensusVersion = '0.13.2'
+        opencensusVersion = '0.14.0'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
-        opencensusVersion = '0.12.3'
+        opencensusVersion = '0.13.2'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
-        opencensusVersion = '0.14.0'
+        opencensusVersion = '0.17.0'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -65,7 +65,6 @@ import javax.annotation.Nullable;
  * starts earlier than the ServerCall.  Therefore, only one tracer is created per stream/call and
  * it's the tracer that reports the summary to Census.
  */
-@SuppressWarnings("deprecation")
 public final class CensusStatsModule {
   private static final Logger logger = Logger.getLogger(CensusStatsModule.class.getName());
   private static final double NANOS_PER_MILLI = TimeUnit.MILLISECONDS.toNanos(1);
@@ -329,14 +328,14 @@ public final class CensusStatsModule {
       TagValue methodTag = TagValue.create(fullMethodName);
       this.startCtx =
           module.tagger.toBuilder(parentCtx)
-          .put(RpcMeasureConstants.RPC_METHOD, methodTag)
+          .put(DeprecatedCensusConstants.RPC_METHOD, methodTag)
           .put(RpcMeasureConstants.GRPC_CLIENT_METHOD, methodTag)
           .build();
       this.stopwatch = module.stopwatchSupplier.get().start();
       this.recordFinishedRpcs = recordFinishedRpcs;
       if (recordStartedRpcs) {
         module.statsRecorder.newMeasureMap()
-            .put(RpcMeasureConstants.RPC_CLIENT_STARTED_COUNT, 1)
+            .put(DeprecatedCensusConstants.RPC_CLIENT_STARTED_COUNT, 1)
             .put(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS, 1)
             .record(startCtx);
       }
@@ -394,18 +393,20 @@ public final class CensusStatsModule {
       }
       MeasureMap measureMap = module.statsRecorder.newMeasureMap()
           // TODO(songya): remove the deprecated measure constants once they are completed removed.
-          .put(RpcMeasureConstants.RPC_CLIENT_FINISHED_COUNT, 1)
+          .put(DeprecatedCensusConstants.RPC_CLIENT_FINISHED_COUNT, 1)
           // The latency is double value
-          .put(RpcMeasureConstants.RPC_CLIENT_ROUNDTRIP_LATENCY, roundtripNanos / NANOS_PER_MILLI)
-          .put(RpcMeasureConstants.RPC_CLIENT_REQUEST_COUNT, tracer.outboundMessageCount)
-          .put(RpcMeasureConstants.RPC_CLIENT_RESPONSE_COUNT, tracer.inboundMessageCount)
-          .put(RpcMeasureConstants.RPC_CLIENT_REQUEST_BYTES, tracer.outboundWireSize)
-          .put(RpcMeasureConstants.RPC_CLIENT_RESPONSE_BYTES, tracer.inboundWireSize)
           .put(
-              RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
+              DeprecatedCensusConstants.RPC_CLIENT_ROUNDTRIP_LATENCY,
+              roundtripNanos / NANOS_PER_MILLI)
+          .put(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_COUNT, tracer.outboundMessageCount)
+          .put(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_COUNT, tracer.inboundMessageCount)
+          .put(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_BYTES, tracer.outboundWireSize)
+          .put(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_BYTES, tracer.inboundWireSize)
+          .put(
+              DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
               tracer.outboundUncompressedSize)
           .put(
-              RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
+              DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
               tracer.inboundUncompressedSize)
 
           // New RPC measure constants.
@@ -418,14 +419,14 @@ public final class CensusStatsModule {
           .put(RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC, tracer.outboundWireSize)
           .put(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC, tracer.inboundWireSize);
       if (!status.isOk()) {
-        measureMap.put(RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT, 1);
+        measureMap.put(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT, 1);
       }
       TagValue statusTag = TagValue.create(status.getCode().toString());
       measureMap.record(
           module
               .tagger
               .toBuilder(startCtx)
-              .put(RpcMeasureConstants.RPC_STATUS, statusTag)
+              .put(DeprecatedCensusConstants.RPC_STATUS, statusTag)
               .put(RpcMeasureConstants.GRPC_CLIENT_STATUS, statusTag)
               .build());
     }
@@ -518,7 +519,7 @@ public final class CensusStatsModule {
       this.recordFinishedRpcs = recordFinishedRpcs;
       if (recordStartedRpcs) {
         module.statsRecorder.newMeasureMap()
-            .put(RpcMeasureConstants.RPC_SERVER_STARTED_COUNT, 1)
+            .put(DeprecatedCensusConstants.RPC_SERVER_STARTED_COUNT, 1)
             .put(RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS, 1)
             .record(parentCtx);
       }
@@ -609,15 +610,21 @@ public final class CensusStatsModule {
       long elapsedTimeNanos = stopwatch.elapsed(TimeUnit.NANOSECONDS);
       MeasureMap measureMap = module.statsRecorder.newMeasureMap()
           // TODO(songya): remove the deprecated measure constants once they are completed removed.
-          .put(RpcMeasureConstants.RPC_SERVER_FINISHED_COUNT, 1)
+          .put(DeprecatedCensusConstants.RPC_SERVER_FINISHED_COUNT, 1)
           // The latency is double value
-          .put(RpcMeasureConstants.RPC_SERVER_SERVER_LATENCY, elapsedTimeNanos / NANOS_PER_MILLI)
-          .put(RpcMeasureConstants.RPC_SERVER_RESPONSE_COUNT, outboundMessageCount)
-          .put(RpcMeasureConstants.RPC_SERVER_REQUEST_COUNT, inboundMessageCount)
-          .put(RpcMeasureConstants.RPC_SERVER_RESPONSE_BYTES, outboundWireSize)
-          .put(RpcMeasureConstants.RPC_SERVER_REQUEST_BYTES, inboundWireSize)
-          .put(RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES, outboundUncompressedSize)
-          .put(RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES, inboundUncompressedSize)
+          .put(
+              DeprecatedCensusConstants.RPC_SERVER_SERVER_LATENCY,
+              elapsedTimeNanos / NANOS_PER_MILLI)
+          .put(DeprecatedCensusConstants.RPC_SERVER_RESPONSE_COUNT, outboundMessageCount)
+          .put(DeprecatedCensusConstants.RPC_SERVER_REQUEST_COUNT, inboundMessageCount)
+          .put(DeprecatedCensusConstants.RPC_SERVER_RESPONSE_BYTES, outboundWireSize)
+          .put(DeprecatedCensusConstants.RPC_SERVER_REQUEST_BYTES, inboundWireSize)
+          .put(
+              DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
+              outboundUncompressedSize)
+          .put(
+              DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
+              inboundUncompressedSize)
 
           // New RPC measure constants.
           .put(RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY, elapsedTimeNanos / NANOS_PER_MILLI)
@@ -626,14 +633,14 @@ public final class CensusStatsModule {
           .put(RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC, outboundWireSize)
           .put(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC, inboundWireSize);
       if (!status.isOk()) {
-        measureMap.put(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT, 1);
+        measureMap.put(DeprecatedCensusConstants.RPC_SERVER_ERROR_COUNT, 1);
       }
       TagValue statusTag = TagValue.create(status.getCode().toString());
       measureMap.record(
           module
               .tagger
               .toBuilder(parentCtx)
-              .put(RpcMeasureConstants.RPC_STATUS, statusTag)
+              .put(DeprecatedCensusConstants.RPC_STATUS, statusTag)
               .put(RpcMeasureConstants.GRPC_SERVER_STATUS, statusTag)
               .build());
     }
@@ -667,7 +674,7 @@ public final class CensusStatsModule {
       parentCtx =
           tagger
               .toBuilder(parentCtx)
-              .put(RpcMeasureConstants.RPC_METHOD, methodTag)
+              .put(DeprecatedCensusConstants.RPC_METHOD, methodTag)
               .put(RpcMeasureConstants.GRPC_SERVER_METHOD, methodTag)
               .build();
       return new ServerTracer(

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -65,6 +65,7 @@ import javax.annotation.Nullable;
  * starts earlier than the ServerCall.  Therefore, only one tracer is created per stream/call and
  * it's the tracer that reports the summary to Census.
  */
+@SuppressWarnings("deprecation")
 public final class CensusStatsModule {
   private static final Logger logger = Logger.getLogger(CensusStatsModule.class.getName());
   private static final double NANOS_PER_MILLI = TimeUnit.MILLISECONDS.toNanos(1);

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -335,7 +335,9 @@ public final class CensusStatsModule {
       this.stopwatch = module.stopwatchSupplier.get().start();
       this.recordFinishedRpcs = recordFinishedRpcs;
       if (recordStartedRpcs) {
-        module.statsRecorder.newMeasureMap().put(RpcMeasureConstants.RPC_CLIENT_STARTED_COUNT, 1)
+        module.statsRecorder.newMeasureMap()
+            .put(RpcMeasureConstants.RPC_CLIENT_STARTED_COUNT, 1)
+            .put(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS, 1)
             .record(startCtx);
       }
     }
@@ -515,7 +517,9 @@ public final class CensusStatsModule {
       this.tagger = tagger;
       this.recordFinishedRpcs = recordFinishedRpcs;
       if (recordStartedRpcs) {
-        module.statsRecorder.newMeasureMap().put(RpcMeasureConstants.RPC_SERVER_STARTED_COUNT, 1)
+        module.statsRecorder.newMeasureMap()
+            .put(RpcMeasureConstants.RPC_SERVER_STARTED_COUNT, 1)
+            .put(RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS, 1)
             .record(parentCtx);
       }
     }

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -326,10 +326,11 @@ public final class CensusStatsModule {
         boolean recordFinishedRpcs) {
       this.module = module;
       this.parentCtx = checkNotNull(parentCtx);
+      TagValue methodTag = TagValue.create(fullMethodName);
       this.startCtx =
           module.tagger.toBuilder(parentCtx)
-          .put(RpcMeasureConstants.RPC_METHOD, TagValue.create(fullMethodName))
-          .put(RpcMeasureConstants.GRPC_CLIENT_METHOD, TagValue.create(fullMethodName))
+          .put(RpcMeasureConstants.RPC_METHOD, methodTag)
+          .put(RpcMeasureConstants.GRPC_CLIENT_METHOD, methodTag)
           .build();
       this.stopwatch = module.stopwatchSupplier.get().start();
       this.recordFinishedRpcs = recordFinishedRpcs;
@@ -417,14 +418,13 @@ public final class CensusStatsModule {
       if (!status.isOk()) {
         measureMap.put(RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT, 1);
       }
+      TagValue statusTag = TagValue.create(status.getCode().toString());
       measureMap.record(
           module
               .tagger
               .toBuilder(startCtx)
-              .put(RpcMeasureConstants.RPC_STATUS, TagValue.create(status.getCode().toString()))
-              .put(
-                  RpcMeasureConstants.GRPC_CLIENT_STATUS,
-                  TagValue.create(status.getCode().toString()))
+              .put(RpcMeasureConstants.RPC_STATUS, statusTag)
+              .put(RpcMeasureConstants.GRPC_CLIENT_STATUS, statusTag)
               .build());
     }
   }
@@ -624,14 +624,13 @@ public final class CensusStatsModule {
       if (!status.isOk()) {
         measureMap.put(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT, 1);
       }
+      TagValue statusTag = TagValue.create(status.getCode().toString());
       measureMap.record(
           module
               .tagger
               .toBuilder(parentCtx)
-              .put(RpcMeasureConstants.RPC_STATUS, TagValue.create(status.getCode().toString()))
-              .put(
-                  RpcMeasureConstants.GRPC_SERVER_STATUS,
-                  TagValue.create(status.getCode().toString()))
+              .put(RpcMeasureConstants.RPC_STATUS, statusTag)
+              .put(RpcMeasureConstants.GRPC_SERVER_STATUS, statusTag)
               .build());
     }
 
@@ -660,11 +659,12 @@ public final class CensusStatsModule {
       if (parentCtx == null) {
         parentCtx = tagger.empty();
       }
+      TagValue methodTag = TagValue.create(fullMethodName);
       parentCtx =
           tagger
               .toBuilder(parentCtx)
-              .put(RpcMeasureConstants.RPC_METHOD, TagValue.create(fullMethodName))
-              .put(RpcMeasureConstants.GRPC_SERVER_METHOD, TagValue.create(fullMethodName))
+              .put(RpcMeasureConstants.RPC_METHOD, methodTag)
+              .put(RpcMeasureConstants.GRPC_SERVER_METHOD, methodTag)
               .build();
       return new ServerTracer(
           CensusStatsModule.this,

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -36,7 +36,6 @@ import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.StreamTracer;
-import io.opencensus.contrib.grpc.metrics.RpcMeasureConstants;
 import io.opencensus.stats.MeasureMap;
 import io.opencensus.stats.Stats;
 import io.opencensus.stats.StatsRecorder;
@@ -329,14 +328,12 @@ public final class CensusStatsModule {
       this.startCtx =
           module.tagger.toBuilder(parentCtx)
           .put(DeprecatedCensusConstants.RPC_METHOD, methodTag)
-          .put(RpcMeasureConstants.GRPC_CLIENT_METHOD, methodTag)
           .build();
       this.stopwatch = module.stopwatchSupplier.get().start();
       this.recordFinishedRpcs = recordFinishedRpcs;
       if (recordStartedRpcs) {
         module.statsRecorder.newMeasureMap()
             .put(DeprecatedCensusConstants.RPC_CLIENT_STARTED_COUNT, 1)
-            .put(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS, 1)
             .record(startCtx);
       }
     }
@@ -407,17 +404,7 @@ public final class CensusStatsModule {
               tracer.outboundUncompressedSize)
           .put(
               DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
-              tracer.inboundUncompressedSize)
-
-          // New RPC measure constants.
-          // The latency is double value
-          .put(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY, roundtripNanos / NANOS_PER_MILLI)
-          .put(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC, tracer.outboundMessageCount)
-          .put(
-              RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC,
-              tracer.inboundMessageCount)
-          .put(RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC, tracer.outboundWireSize)
-          .put(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC, tracer.inboundWireSize);
+              tracer.inboundUncompressedSize);
       if (!status.isOk()) {
         measureMap.put(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT, 1);
       }
@@ -427,7 +414,6 @@ public final class CensusStatsModule {
               .tagger
               .toBuilder(startCtx)
               .put(DeprecatedCensusConstants.RPC_STATUS, statusTag)
-              .put(RpcMeasureConstants.GRPC_CLIENT_STATUS, statusTag)
               .build());
     }
   }
@@ -520,7 +506,6 @@ public final class CensusStatsModule {
       if (recordStartedRpcs) {
         module.statsRecorder.newMeasureMap()
             .put(DeprecatedCensusConstants.RPC_SERVER_STARTED_COUNT, 1)
-            .put(RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS, 1)
             .record(parentCtx);
       }
     }
@@ -624,14 +609,7 @@ public final class CensusStatsModule {
               outboundUncompressedSize)
           .put(
               DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
-              inboundUncompressedSize)
-
-          // New RPC measure constants.
-          .put(RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY, elapsedTimeNanos / NANOS_PER_MILLI)
-          .put(RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC, outboundMessageCount)
-          .put(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC, inboundMessageCount)
-          .put(RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC, outboundWireSize)
-          .put(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC, inboundWireSize);
+              inboundUncompressedSize);
       if (!status.isOk()) {
         measureMap.put(DeprecatedCensusConstants.RPC_SERVER_ERROR_COUNT, 1);
       }
@@ -641,7 +619,6 @@ public final class CensusStatsModule {
               .tagger
               .toBuilder(parentCtx)
               .put(DeprecatedCensusConstants.RPC_STATUS, statusTag)
-              .put(RpcMeasureConstants.GRPC_SERVER_STATUS, statusTag)
               .build());
     }
 
@@ -675,7 +652,6 @@ public final class CensusStatsModule {
           tagger
               .toBuilder(parentCtx)
               .put(DeprecatedCensusConstants.RPC_METHOD, methodTag)
-              .put(RpcMeasureConstants.GRPC_SERVER_METHOD, methodTag)
               .build();
       return new ServerTracer(
           CensusStatsModule.this,

--- a/core/src/main/java/io/grpc/internal/DeprecatedCensusConstants.java
+++ b/core/src/main/java/io/grpc/internal/DeprecatedCensusConstants.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opencensus.contrib.grpc.metrics.RpcMeasureConstants;
+import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.Measure.MeasureLong;
+import io.opencensus.tags.TagKey;
+
+/** Holder class for the deprecated OpenCensus constants. */
+@SuppressWarnings("deprecation")
+@VisibleForTesting
+public final class DeprecatedCensusConstants {
+
+  public static final TagKey RPC_STATUS = RpcMeasureConstants.RPC_STATUS;
+  public static final TagKey RPC_METHOD = RpcMeasureConstants.RPC_METHOD;
+
+  public static final MeasureLong RPC_CLIENT_ERROR_COUNT =
+      RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT;
+  public static final MeasureDouble RPC_CLIENT_REQUEST_BYTES =
+      RpcMeasureConstants.RPC_CLIENT_REQUEST_BYTES;
+  public static final MeasureDouble RPC_CLIENT_RESPONSE_BYTES =
+      RpcMeasureConstants.RPC_CLIENT_RESPONSE_BYTES;
+  public static final MeasureDouble RPC_CLIENT_ROUNDTRIP_LATENCY =
+      RpcMeasureConstants.RPC_CLIENT_ROUNDTRIP_LATENCY;
+  public static final MeasureDouble RPC_CLIENT_SERVER_ELAPSED_TIME =
+      RpcMeasureConstants.RPC_CLIENT_SERVER_ELAPSED_TIME;
+  public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES =
+      RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES;
+  public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES =
+      RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES;
+  public static final MeasureLong RPC_CLIENT_STARTED_COUNT =
+      RpcMeasureConstants.RPC_CLIENT_STARTED_COUNT;
+  public static final MeasureLong RPC_CLIENT_FINISHED_COUNT =
+      RpcMeasureConstants.RPC_CLIENT_FINISHED_COUNT;
+  public static final MeasureLong RPC_CLIENT_REQUEST_COUNT =
+      RpcMeasureConstants.RPC_CLIENT_REQUEST_COUNT;
+  public static final MeasureLong RPC_CLIENT_RESPONSE_COUNT =
+      RpcMeasureConstants.RPC_CLIENT_RESPONSE_COUNT;
+
+  public static final MeasureLong RPC_SERVER_ERROR_COUNT =
+      RpcMeasureConstants.RPC_SERVER_ERROR_COUNT;
+  public static final MeasureDouble RPC_SERVER_REQUEST_BYTES =
+      RpcMeasureConstants.RPC_SERVER_REQUEST_BYTES;
+  public static final MeasureDouble RPC_SERVER_RESPONSE_BYTES =
+      RpcMeasureConstants.RPC_SERVER_RESPONSE_BYTES;
+  public static final MeasureDouble RPC_SERVER_SERVER_ELAPSED_TIME =
+      RpcMeasureConstants.RPC_SERVER_SERVER_ELAPSED_TIME;
+  public static final MeasureDouble RPC_SERVER_SERVER_LATENCY =
+      RpcMeasureConstants.RPC_SERVER_SERVER_LATENCY;
+  public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES =
+      RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES;
+  public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES =
+      RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES;
+  public static final MeasureLong RPC_SERVER_STARTED_COUNT =
+      RpcMeasureConstants.RPC_SERVER_STARTED_COUNT;
+  public static final MeasureLong RPC_SERVER_FINISHED_COUNT =
+      RpcMeasureConstants.RPC_SERVER_FINISHED_COUNT;
+  public static final MeasureLong RPC_SERVER_REQUEST_COUNT =
+      RpcMeasureConstants.RPC_SERVER_REQUEST_COUNT;
+  public static final MeasureLong RPC_SERVER_RESPONSE_COUNT =
+      RpcMeasureConstants.RPC_SERVER_RESPONSE_COUNT;
+
+  DeprecatedCensusConstants() {}
+}

--- a/core/src/main/java/io/grpc/internal/DeprecatedCensusConstants.java
+++ b/core/src/main/java/io/grpc/internal/DeprecatedCensusConstants.java
@@ -76,5 +76,5 @@ public final class DeprecatedCensusConstants {
   public static final MeasureLong RPC_SERVER_RESPONSE_COUNT =
       RpcMeasureConstants.RPC_SERVER_RESPONSE_COUNT;
 
-  DeprecatedCensusConstants() {}
+  private DeprecatedCensusConstants() {}
 }

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -375,6 +375,7 @@ public class CensusModulesTest {
       TagValue methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), methodTagOld.asString());
       assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_STARTED_COUNT));
+      assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
       TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
       assertEquals(method.getFullMethodName(), methodTagNew.asString());
     } else {
@@ -523,6 +524,7 @@ public class CensusModulesTest {
     TagValue methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
     assertEquals(method.getFullMethodName(), methodTagOld.asString());
     assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_STARTED_COUNT));
+    assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
     TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
     assertEquals(method.getFullMethodName(), methodTagNew.asString());
 
@@ -880,6 +882,7 @@ public class CensusModulesTest {
       TagValue methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), methodTagOld.asString());
       assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_STARTED_COUNT));
+      assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS));
       TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
       assertEquals(method.getFullMethodName(), methodTagNew.asString());
     } else {

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -63,7 +63,6 @@ import io.grpc.internal.testing.StatsTestUtils.FakeTagContextBinarySerializer;
 import io.grpc.internal.testing.StatsTestUtils.FakeTagger;
 import io.grpc.internal.testing.StatsTestUtils.MockableSpan;
 import io.grpc.testing.GrpcServerRule;
-import io.opencensus.contrib.grpc.metrics.RpcMeasureConstants;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagValue;
 import io.opencensus.trace.BlankSpan;
@@ -281,15 +280,13 @@ public class CensusModulesTest {
     assertNotNull(record);
     TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertEquals(method.getFullMethodName(), methodTagOld.asString());
-    TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
-    assertEquals(method.getFullMethodName(), methodTagNew.asString());
     if (nonDefaultContext) {
       TagValue extraTag = record.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra value", extraTag.asString());
-      assertEquals(3, record.tags.size());
+      assertEquals(2, record.tags.size());
     } else {
       assertNull(record.tags.get(StatsTestUtils.EXTRA_TAG));
-      assertEquals(2, record.tags.size());
+      assertEquals(1, record.tags.size());
     }
 
     if (nonDefaultContext) {
@@ -319,10 +316,6 @@ public class CensusModulesTest {
     assertEquals(method.getFullMethodName(), methodTagOld.asString());
     TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
     assertEquals(Status.Code.PERMISSION_DENIED.toString(), statusTagOld.asString());
-    methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
-    assertEquals(method.getFullMethodName(), methodTagNew.asString());
-    TagValue statusTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS);
-    assertEquals(Status.Code.PERMISSION_DENIED.toString(), statusTagNew.asString());
     if (nonDefaultContext) {
       TagValue extraTag = record.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra value", extraTag.asString());
@@ -370,14 +363,11 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
       assertNotNull(record);
       assertNoServerContent(record);
-      assertEquals(2, record.tags.size());
+      assertEquals(1, record.tags.size());
       TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), methodTagOld.asString());
       assertEquals(
           1, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_STARTED_COUNT));
-      assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
-      TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
-      assertEquals(method.getFullMethodName(), methodTagNew.asString());
     } else {
       assertNull(statsRecorder.pollRecord());
     }
@@ -436,24 +426,6 @@ public class CensusModulesTest {
               DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
       assertEquals(30 + 100 + 16 + 24,
           record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
-
-      TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
-      assertEquals(method.getFullMethodName(), methodTagNew.asString());
-      TagValue statusTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS);
-      assertEquals(Status.Code.OK.toString(), statusTagNew.asString());
-      assertEquals(
-          2, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC));
-      assertEquals(
-          1028 + 99,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC));
-      assertEquals(
-          2,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC));
-      assertEquals(
-          33 + 154,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC));
-      assertEquals(30 + 100 + 16 + 24,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY));
     } else {
       assertNull(statsRecorder.pollRecord());
     }
@@ -528,15 +500,12 @@ public class CensusModulesTest {
     StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
     assertNotNull(record);
     assertNoServerContent(record);
-    assertEquals(2, record.tags.size());
+    assertEquals(1, record.tags.size());
     TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertEquals(method.getFullMethodName(), methodTagOld.asString());
     assertEquals(
         1,
         record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_STARTED_COUNT));
-    assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
-    TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
-    assertEquals(method.getFullMethodName(), methodTagNew.asString());
 
     // Completion record
     record = statsRecorder.pollRecord();
@@ -571,23 +540,6 @@ public class CensusModulesTest {
         3000,
         record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
     assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
-
-    methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
-    assertEquals(method.getFullMethodName(), methodTagNew.asString());
-    TagValue statusTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS);
-    assertEquals(Status.Code.DEADLINE_EXCEEDED.toString(), statusTagNew.asString());
-    assertEquals(
-        0, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC));
-    assertEquals(
-        0, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC));
-    assertEquals(
-        0,
-        record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC));
-    assertEquals(
-        0, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC));
-    assertEquals(
-        3000, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY));
   }
 
   @Test
@@ -652,11 +604,9 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord clientRecord = statsRecorder.pollRecord();
       assertNotNull(clientRecord);
       assertNoServerContent(clientRecord);
-      assertEquals(3, clientRecord.tags.size());
+      assertEquals(2, clientRecord.tags.size());
       TagValue clientMethodTagOld = clientRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), clientMethodTagOld.asString());
-      TagValue clientMethodTagNew = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
-      assertEquals(method.getFullMethodName(), clientMethodTagNew.asString());
       TagValue clientPropagatedTag = clientRecord.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra-tag-value-897", clientPropagatedTag.asString());
     }
@@ -680,9 +630,6 @@ public class CensusModulesTest {
             .put(
                 DeprecatedCensusConstants.RPC_METHOD,
                 TagValue.create(method.getFullMethodName()))
-            .put(
-                RpcMeasureConstants.GRPC_SERVER_METHOD,
-                TagValue.create(method.getFullMethodName()))
             .build(),
         TAG_CONTEXT_KEY.get(serverContext));
 
@@ -694,11 +641,9 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord serverRecord = statsRecorder.pollRecord();
       assertNotNull(serverRecord);
       assertNoClientContent(serverRecord);
-      assertEquals(3, serverRecord.tags.size());
+      assertEquals(2, serverRecord.tags.size());
       TagValue serverMethodTagOld = serverRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), serverMethodTagOld.asString());
-      TagValue serverMethodTagNew = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
-      assertEquals(method.getFullMethodName(), serverMethodTagNew.asString());
       TagValue serverPropagatedTag = serverRecord.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra-tag-value-897", serverPropagatedTag.asString());
 
@@ -711,10 +656,6 @@ public class CensusModulesTest {
       TagValue serverStatusTagOld = serverRecord.tags.get(DeprecatedCensusConstants.RPC_STATUS);
       assertEquals(Status.Code.OK.toString(), serverStatusTagOld.asString());
       assertNull(serverRecord.getMetric(DeprecatedCensusConstants.RPC_SERVER_ERROR_COUNT));
-      serverMethodTagNew = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
-      assertEquals(method.getFullMethodName(), serverMethodTagNew.asString());
-      TagValue serverStatusTagNew = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_STATUS);
-      assertEquals(Status.Code.OK.toString(), serverStatusTagNew.asString());
       serverPropagatedTag = serverRecord.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra-tag-value-897", serverPropagatedTag.asString());
     }
@@ -733,10 +674,6 @@ public class CensusModulesTest {
       TagValue clientStatusTagOld = clientRecord.tags.get(DeprecatedCensusConstants.RPC_STATUS);
       assertEquals(Status.Code.OK.toString(), clientStatusTagOld.asString());
       assertNull(clientRecord.getMetric(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT));
-      TagValue clientMethodTagNew = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
-      assertEquals(method.getFullMethodName(), clientMethodTagNew.asString());
-      TagValue clientStatusTagNew = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS);
-      assertEquals(Status.Code.OK.toString(), clientStatusTagNew.asString());
       TagValue clientPropagatedTag = clientRecord.tags.get(StatsTestUtils.EXTRA_TAG);
       assertEquals("extra-tag-value-897", clientPropagatedTag.asString());
     }
@@ -900,15 +837,12 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
       assertNotNull(record);
       assertNoClientContent(record);
-      assertEquals(2, record.tags.size());
+      assertEquals(1, record.tags.size());
       TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), methodTagOld.asString());
       assertEquals(
           1,
           record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_STARTED_COUNT));
-      assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS));
-      TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
-      assertEquals(method.getFullMethodName(), methodTagNew.asString());
     } else {
       assertNull(statsRecorder.pollRecord());
     }
@@ -920,9 +854,6 @@ public class CensusModulesTest {
             .emptyBuilder()
             .put(
                 DeprecatedCensusConstants.RPC_METHOD,
-                TagValue.create(method.getFullMethodName()))
-            .put(
-                RpcMeasureConstants.GRPC_SERVER_METHOD,
                 TagValue.create(method.getFullMethodName()))
             .build(),
         statsCtx);
@@ -979,24 +910,6 @@ public class CensusModulesTest {
               DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
       assertEquals(100 + 16 + 24,
           record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_SERVER_LATENCY));
-
-      TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
-      assertEquals(method.getFullMethodName(), methodTagNew.asString());
-      TagValue statusTagNew = record.tags.get(RpcMeasureConstants.GRPC_SERVER_STATUS);
-      assertEquals(Status.Code.CANCELLED.toString(), statusTagNew.asString());
-      assertEquals(
-          2, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC));
-      assertEquals(
-          1028 + 99,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC));
-      assertEquals(
-          2,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC));
-      assertEquals(
-          34 + 154,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC));
-      assertEquals(100 + 16 + 24,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY));
     } else {
       assertNull(statsRecorder.pollRecord());
     }
@@ -1125,12 +1038,6 @@ public class CensusModulesTest {
     assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_SERVER_LATENCY));
     assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
     assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
-
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY));
   }
 
   private static void assertNoClientContent(StatsTestUtils.MetricsRecord record) {
@@ -1143,12 +1050,5 @@ public class CensusModulesTest {
     assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
     assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
     assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
-
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY));
-    assertNull(record.getMetric(RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY));
   }
 }

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -99,7 +99,6 @@ import org.mockito.MockitoAnnotations;
  * Test for {@link CensusStatsModule} and {@link CensusTracingModule}.
  */
 @RunWith(JUnit4.class)
-@SuppressWarnings("deprecation")
 public class CensusModulesTest {
   private static final CallOptions.Key<String> CUSTOM_OPTION =
       CallOptions.Key.createWithDefault("option1", "default");
@@ -280,7 +279,7 @@ public class CensusModulesTest {
 
     StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
     assertNotNull(record);
-    TagValue methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+    TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertEquals(method.getFullMethodName(), methodTagOld.asString());
     TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
     assertEquals(method.getFullMethodName(), methodTagNew.asString());
@@ -316,9 +315,9 @@ public class CensusModulesTest {
     // The intercepting listener calls callEnded() on ClientCallTracer, which records to Census.
     record = statsRecorder.pollRecord();
     assertNotNull(record);
-    methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+    methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertEquals(method.getFullMethodName(), methodTagOld.asString());
-    TagValue statusTagOld = record.tags.get(RpcMeasureConstants.RPC_STATUS);
+    TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
     assertEquals(Status.Code.PERMISSION_DENIED.toString(), statusTagOld.asString());
     methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
     assertEquals(method.getFullMethodName(), methodTagNew.asString());
@@ -372,9 +371,10 @@ public class CensusModulesTest {
       assertNotNull(record);
       assertNoServerContent(record);
       assertEquals(2, record.tags.size());
-      TagValue methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+      TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), methodTagOld.asString());
-      assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_STARTED_COUNT));
+      assertEquals(
+          1, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_STARTED_COUNT));
       assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
       TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
       assertEquals(method.getFullMethodName(), methodTagNew.asString());
@@ -409,25 +409,33 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
       assertNotNull(record);
       assertNoServerContent(record);
-      TagValue methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+      TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), methodTagOld.asString());
-      TagValue statusTagOld = record.tags.get(RpcMeasureConstants.RPC_STATUS);
+      TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
       assertEquals(Status.Code.OK.toString(), statusTagOld.asString());
-      assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_FINISHED_COUNT));
-      assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT));
-      assertEquals(2, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_REQUEST_COUNT));
       assertEquals(
-          1028 + 99, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_REQUEST_BYTES));
+          1, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_FINISHED_COUNT));
+      assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT));
+      assertEquals(
+          2, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_COUNT));
+      assertEquals(
+          1028 + 99,
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_BYTES));
       assertEquals(
           1128 + 865,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
-      assertEquals(2, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_RESPONSE_COUNT));
+          record.getMetricAsLongOrFail(
+              DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
       assertEquals(
-          33 + 154, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_RESPONSE_BYTES));
-      assertEquals(67 + 552,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
+          2, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_COUNT));
+      assertEquals(
+          33 + 154,
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_BYTES));
+      assertEquals(
+          67 + 552,
+          record.getMetricAsLongOrFail(
+              DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
       assertEquals(30 + 100 + 16 + 24,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
 
       TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
       assertEquals(method.getFullMethodName(), methodTagNew.asString());
@@ -521,9 +529,11 @@ public class CensusModulesTest {
     assertNotNull(record);
     assertNoServerContent(record);
     assertEquals(2, record.tags.size());
-    TagValue methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+    TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertEquals(method.getFullMethodName(), methodTagOld.asString());
-    assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_STARTED_COUNT));
+    assertEquals(
+        1,
+        record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_STARTED_COUNT));
     assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS));
     TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
     assertEquals(method.getFullMethodName(), methodTagNew.asString());
@@ -532,23 +542,35 @@ public class CensusModulesTest {
     record = statsRecorder.pollRecord();
     assertNotNull(record);
     assertNoServerContent(record);
-    methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+    methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertEquals(method.getFullMethodName(), methodTagOld.asString());
-    TagValue statusTagOld = record.tags.get(RpcMeasureConstants.RPC_STATUS);
+    TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
     assertEquals(Status.Code.DEADLINE_EXCEEDED.toString(), statusTagOld.asString());
-    assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_FINISHED_COUNT));
-    assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT));
-    assertEquals(0, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_REQUEST_COUNT));
-    assertEquals(0, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_REQUEST_BYTES));
-    assertEquals(0,
-        record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
-    assertEquals(0, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_RESPONSE_COUNT));
-    assertEquals(0, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_RESPONSE_BYTES));
-    assertEquals(0,
-        record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
     assertEquals(
-        3000, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
+        1,
+        record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_FINISHED_COUNT));
+    assertEquals(
+        1,
+        record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT));
+    assertEquals(
+        0, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_COUNT));
+    assertEquals(
+        0, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_BYTES));
+    assertEquals(
+        0,
+        record.getMetricAsLongOrFail(
+            DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
+    assertEquals(
+        0, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_COUNT));
+    assertEquals(
+        0, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_BYTES));
+    assertEquals(0,
+        record.getMetricAsLongOrFail(
+            DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
+    assertEquals(
+        3000,
+        record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
 
     methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
     assertEquals(method.getFullMethodName(), methodTagNew.asString());
@@ -631,7 +653,7 @@ public class CensusModulesTest {
       assertNotNull(clientRecord);
       assertNoServerContent(clientRecord);
       assertEquals(3, clientRecord.tags.size());
-      TagValue clientMethodTagOld = clientRecord.tags.get(RpcMeasureConstants.RPC_METHOD);
+      TagValue clientMethodTagOld = clientRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), clientMethodTagOld.asString());
       TagValue clientMethodTagNew = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
       assertEquals(method.getFullMethodName(), clientMethodTagNew.asString());
@@ -656,7 +678,7 @@ public class CensusModulesTest {
     assertEquals(
         tagger.toBuilder(clientCtx)
             .put(
-                RpcMeasureConstants.RPC_METHOD,
+                DeprecatedCensusConstants.RPC_METHOD,
                 TagValue.create(method.getFullMethodName()))
             .put(
                 RpcMeasureConstants.GRPC_SERVER_METHOD,
@@ -673,7 +695,7 @@ public class CensusModulesTest {
       assertNotNull(serverRecord);
       assertNoClientContent(serverRecord);
       assertEquals(3, serverRecord.tags.size());
-      TagValue serverMethodTagOld = serverRecord.tags.get(RpcMeasureConstants.RPC_METHOD);
+      TagValue serverMethodTagOld = serverRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), serverMethodTagOld.asString());
       TagValue serverMethodTagNew = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
       assertEquals(method.getFullMethodName(), serverMethodTagNew.asString());
@@ -684,11 +706,11 @@ public class CensusModulesTest {
       serverRecord = statsRecorder.pollRecord();
       assertNotNull(serverRecord);
       assertNoClientContent(serverRecord);
-      serverMethodTagOld = serverRecord.tags.get(RpcMeasureConstants.RPC_METHOD);
+      serverMethodTagOld = serverRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), serverMethodTagOld.asString());
-      TagValue serverStatusTagOld = serverRecord.tags.get(RpcMeasureConstants.RPC_STATUS);
+      TagValue serverStatusTagOld = serverRecord.tags.get(DeprecatedCensusConstants.RPC_STATUS);
       assertEquals(Status.Code.OK.toString(), serverStatusTagOld.asString());
-      assertNull(serverRecord.getMetric(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT));
+      assertNull(serverRecord.getMetric(DeprecatedCensusConstants.RPC_SERVER_ERROR_COUNT));
       serverMethodTagNew = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
       assertEquals(method.getFullMethodName(), serverMethodTagNew.asString());
       TagValue serverStatusTagNew = serverRecord.tags.get(RpcMeasureConstants.GRPC_SERVER_STATUS);
@@ -706,11 +728,11 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord clientRecord = statsRecorder.pollRecord();
       assertNotNull(clientRecord);
       assertNoServerContent(clientRecord);
-      TagValue clientMethodTagOld = clientRecord.tags.get(RpcMeasureConstants.RPC_METHOD);
+      TagValue clientMethodTagOld = clientRecord.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), clientMethodTagOld.asString());
-      TagValue clientStatusTagOld = clientRecord.tags.get(RpcMeasureConstants.RPC_STATUS);
+      TagValue clientStatusTagOld = clientRecord.tags.get(DeprecatedCensusConstants.RPC_STATUS);
       assertEquals(Status.Code.OK.toString(), clientStatusTagOld.asString());
-      assertNull(clientRecord.getMetric(RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT));
+      assertNull(clientRecord.getMetric(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT));
       TagValue clientMethodTagNew = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD);
       assertEquals(method.getFullMethodName(), clientMethodTagNew.asString());
       TagValue clientStatusTagNew = clientRecord.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS);
@@ -879,9 +901,11 @@ public class CensusModulesTest {
       assertNotNull(record);
       assertNoClientContent(record);
       assertEquals(2, record.tags.size());
-      TagValue methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+      TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), methodTagOld.asString());
-      assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_STARTED_COUNT));
+      assertEquals(
+          1,
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_STARTED_COUNT));
       assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS));
       TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
       assertEquals(method.getFullMethodName(), methodTagNew.asString());
@@ -895,7 +919,7 @@ public class CensusModulesTest {
         tagger
             .emptyBuilder()
             .put(
-                RpcMeasureConstants.RPC_METHOD,
+                DeprecatedCensusConstants.RPC_METHOD,
                 TagValue.create(method.getFullMethodName()))
             .put(
                 RpcMeasureConstants.GRPC_SERVER_METHOD,
@@ -928,25 +952,33 @@ public class CensusModulesTest {
       StatsTestUtils.MetricsRecord record = statsRecorder.pollRecord();
       assertNotNull(record);
       assertNoClientContent(record);
-      TagValue methodTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+      TagValue methodTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
       assertEquals(method.getFullMethodName(), methodTagOld.asString());
-      TagValue statusTagOld = record.tags.get(RpcMeasureConstants.RPC_STATUS);
+      TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
       assertEquals(Status.Code.CANCELLED.toString(), statusTagOld.asString());
-      assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_FINISHED_COUNT));
-      assertEquals(1, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT));
-      assertEquals(2, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_RESPONSE_COUNT));
       assertEquals(
-          1028 + 99, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_RESPONSE_BYTES));
+          1, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_FINISHED_COUNT));
+      assertEquals(
+          1, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_ERROR_COUNT));
+      assertEquals(
+          2, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_RESPONSE_COUNT));
+      assertEquals(
+          1028 + 99,
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_RESPONSE_BYTES));
       assertEquals(
           1128 + 865,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
-      assertEquals(2, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_REQUEST_COUNT));
+          record.getMetricAsLongOrFail(
+              DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
       assertEquals(
-          34 + 154, record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_REQUEST_BYTES));
+          2, record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_REQUEST_COUNT));
+      assertEquals(
+          34 + 154,
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_REQUEST_BYTES));
       assertEquals(67 + 552,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
+          record.getMetricAsLongOrFail(
+              DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
       assertEquals(100 + 16 + 24,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_SERVER_LATENCY));
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_SERVER_LATENCY));
 
       TagValue methodTagNew = record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
       assertEquals(method.getFullMethodName(), methodTagNew.asString());
@@ -1084,15 +1116,15 @@ public class CensusModulesTest {
   }
 
   private static void assertNoServerContent(StatsTestUtils.MetricsRecord record) {
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_REQUEST_COUNT));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_RESPONSE_COUNT));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_REQUEST_BYTES));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_RESPONSE_BYTES));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_SERVER_ELAPSED_TIME));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_SERVER_LATENCY));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_ERROR_COUNT));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_REQUEST_COUNT));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_RESPONSE_COUNT));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_REQUEST_BYTES));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_RESPONSE_BYTES));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_SERVER_ELAPSED_TIME));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_SERVER_LATENCY));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
 
     assertNull(record.getMetric(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC));
     assertNull(record.getMetric(RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC));
@@ -1102,15 +1134,15 @@ public class CensusModulesTest {
   }
 
   private static void assertNoClientContent(StatsTestUtils.MetricsRecord record) {
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_REQUEST_COUNT));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_RESPONSE_COUNT));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_REQUEST_BYTES));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_RESPONSE_BYTES));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
-    assertNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_ERROR_COUNT));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_COUNT));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_COUNT));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_BYTES));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_BYTES));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_SERVER_ELAPSED_TIME));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
+    assertNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
 
     assertNull(record.getMetric(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC));
     assertNull(record.getMetric(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC));

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -99,6 +99,7 @@ import org.mockito.MockitoAnnotations;
  * Test for {@link CensusStatsModule} and {@link CensusTracingModule}.
  */
 @RunWith(JUnit4.class)
+@SuppressWarnings("deprecation")
 public class CensusModulesTest {
   private static final CallOptions.Key<String> CUSTOM_OPTION =
       CallOptions.Key.createWithDefault("option1", "default");

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -140,6 +140,7 @@ import org.mockito.verification.VerificationMode;
  *
  * <p> New tests should avoid using Mockito to support running on AppEngine.</p>
  */
+@SuppressWarnings("deprecation")
 public abstract class AbstractInteropTest {
   private static Logger logger = Logger.getLogger(AbstractInteropTest.class.getName());
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -93,7 +93,6 @@ import io.grpc.testing.integration.Messages.StreamingInputCallRequest;
 import io.grpc.testing.integration.Messages.StreamingInputCallResponse;
 import io.grpc.testing.integration.Messages.StreamingOutputCallRequest;
 import io.grpc.testing.integration.Messages.StreamingOutputCallResponse;
-import io.opencensus.contrib.grpc.metrics.RpcMeasureConstants;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import io.opencensus.trace.Span;
@@ -1932,12 +1931,6 @@ public abstract class AbstractInteropTest {
     TagValue methodNameTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertNotNull("method name tagged", methodNameTagOld);
     assertEquals("method names match", methodName, methodNameTagOld.asString());
-
-    TagValue methodNameTagNew =
-        Type.CLIENT.equals(type) ? record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD)
-            : record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
-    assertNotNull("method name tagged", methodNameTagNew);
-    assertEquals("method names match", methodName, methodNameTagNew.asString());
   }
 
   private static void checkEndTags(
@@ -1949,17 +1942,6 @@ public abstract class AbstractInteropTest {
     TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
     assertNotNull("status tagged", statusTagOld);
     assertEquals(status.toString(), statusTagOld.asString());
-
-    TagValue methodNameTagNew =
-        Type.CLIENT.equals(type) ? record.tags.get(RpcMeasureConstants.GRPC_CLIENT_METHOD)
-            : record.tags.get(RpcMeasureConstants.GRPC_SERVER_METHOD);
-    assertNotNull("method name tagged", methodNameTagNew);
-    assertEquals("method names match", methodName, methodNameTagNew.asString());
-    TagValue statusTagNew =
-        Type.CLIENT.equals(type) ? record.tags.get(RpcMeasureConstants.GRPC_CLIENT_STATUS)
-            : record.tags.get(RpcMeasureConstants.GRPC_SERVER_STATUS);
-    assertNotNull("status tagged", statusTagNew);
-    assertEquals(status.toString(), statusTagNew.asString());
   }
 
   private enum Type {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -753,15 +753,14 @@ public abstract class AbstractInteropTest {
 
     if (metricsExpected()) {
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-      checkStartTags(clientStartRecord, "grpc.testing.TestService/StreamingInputCall", Type.CLIENT);
+      checkStartTags(clientStartRecord, "grpc.testing.TestService/StreamingInputCall");
       // CensusStreamTracerModule record final status in the interceptor, thus is guaranteed to be
       // recorded.  The tracer stats rely on the stream being created, which is not always the case
       // in this test.  Therefore we don't check the tracer stats.
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord, "grpc.testing.TestService/StreamingInputCall",
-          Status.CANCELLED.getCode(),
-          Type.CLIENT);
+          Status.CANCELLED.getCode());
       // Do not check server-side metrics, because the status on the server side is undetermined.
     }
   }
@@ -1067,13 +1066,12 @@ public abstract class AbstractInteropTest {
       // stats.
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkStartTags(
-          clientStartRecord, "grpc.testing.TestService/StreamingOutputCall", Type.CLIENT);
+          clientStartRecord, "grpc.testing.TestService/StreamingOutputCall");
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord,
           "grpc.testing.TestService/StreamingOutputCall",
-          Status.Code.DEADLINE_EXCEEDED,
-          Type.CLIENT);
+          Status.Code.DEADLINE_EXCEEDED);
       // Do not check server-side metrics, because the status on the server side is undetermined.
     }
   }
@@ -1104,13 +1102,12 @@ public abstract class AbstractInteropTest {
       // stats.
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkStartTags(
-          clientStartRecord, "grpc.testing.TestService/StreamingOutputCall", Type.CLIENT);
+          clientStartRecord, "grpc.testing.TestService/StreamingOutputCall");
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord,
           "grpc.testing.TestService/StreamingOutputCall",
-          Status.Code.DEADLINE_EXCEEDED,
-          Type.CLIENT);
+          Status.Code.DEADLINE_EXCEEDED);
       // Do not check server-side metrics, because the status on the server side is undetermined.
     }
   }
@@ -1132,12 +1129,11 @@ public abstract class AbstractInteropTest {
     // deadline is exceeded before the call is created. Therefore we don't check the tracer stats.
     if (metricsExpected()) {
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-      checkStartTags(clientStartRecord, "grpc.testing.TestService/EmptyCall", Type.CLIENT);
+      checkStartTags(clientStartRecord, "grpc.testing.TestService/EmptyCall");
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord, "grpc.testing.TestService/EmptyCall",
-          Status.DEADLINE_EXCEEDED.getCode(),
-          Type.CLIENT);
+          Status.DEADLINE_EXCEEDED.getCode());
     }
 
     // warm up the channel
@@ -1153,12 +1149,11 @@ public abstract class AbstractInteropTest {
     assertStatsTrace("grpc.testing.TestService/EmptyCall", Status.Code.OK);
     if (metricsExpected()) {
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-      checkStartTags(clientStartRecord, "grpc.testing.TestService/EmptyCall", Type.CLIENT);
+      checkStartTags(clientStartRecord, "grpc.testing.TestService/EmptyCall");
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord, "grpc.testing.TestService/EmptyCall",
-          Status.DEADLINE_EXCEEDED.getCode(),
-          Type.CLIENT);
+          Status.DEADLINE_EXCEEDED.getCode());
     }
   }
 
@@ -1592,13 +1587,12 @@ public abstract class AbstractInteropTest {
       // recorded.  The tracer stats rely on the stream being created, which is not always the case
       // in this test, thus we will not check that.
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
-      checkStartTags(clientStartRecord, "grpc.testing.TestService/FullDuplexCall", Type.CLIENT);
+      checkStartTags(clientStartRecord, "grpc.testing.TestService/FullDuplexCall");
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord(5, TimeUnit.SECONDS);
       checkEndTags(
           clientEndRecord,
           "grpc.testing.TestService/FullDuplexCall",
-          Status.DEADLINE_EXCEEDED.getCode(),
-          Type.CLIENT);
+          Status.DEADLINE_EXCEEDED.getCode());
     }
   }
 
@@ -1866,9 +1860,9 @@ public abstract class AbstractInteropTest {
       // CensusStreamTracerModule records final status in interceptor, which is guaranteed to be
       // done before application receives status.
       MetricsRecord clientStartRecord = clientStatsRecorder.pollRecord();
-      checkStartTags(clientStartRecord, method, Type.CLIENT);
+      checkStartTags(clientStartRecord, method);
       MetricsRecord clientEndRecord = clientStatsRecorder.pollRecord();
-      checkEndTags(clientEndRecord, method, code, Type.CLIENT);
+      checkEndTags(clientEndRecord, method, code);
 
       if (requests != null && responses != null) {
         checkCensus(clientEndRecord, false, requests, responses);
@@ -1901,8 +1895,8 @@ public abstract class AbstractInteropTest {
       }
       assertNotNull(serverStartRecord);
       assertNotNull(serverEndRecord);
-      checkStartTags(serverStartRecord, method, Type.SERVER);
-      checkEndTags(serverEndRecord, method, code, Type.SERVER);
+      checkStartTags(serverStartRecord, method);
+      checkEndTags(serverEndRecord, method, code);
       if (requests != null && responses != null) {
         checkCensus(serverEndRecord, true, requests, responses);
       }
@@ -1926,7 +1920,7 @@ public abstract class AbstractInteropTest {
     }
   }
 
-  private static void checkStartTags(MetricsRecord record, String methodName, Type type) {
+  private static void checkStartTags(MetricsRecord record, String methodName) {
     assertNotNull("record is not null", record);
     TagValue methodNameTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertNotNull("method name tagged", methodNameTagOld);
@@ -1934,7 +1928,7 @@ public abstract class AbstractInteropTest {
   }
 
   private static void checkEndTags(
-      MetricsRecord record, String methodName, Status.Code status, Type type) {
+      MetricsRecord record, String methodName, Status.Code status) {
     assertNotNull("record is not null", record);
     TagValue methodNameTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertNotNull("method name tagged", methodNameTagOld);
@@ -1942,11 +1936,6 @@ public abstract class AbstractInteropTest {
     TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
     assertNotNull("status tagged", statusTagOld);
     assertEquals(status.toString(), statusTagOld.asString());
-  }
-
-  private enum Type {
-    CLIENT,
-    SERVER
   }
 
   /**

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -65,6 +65,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.auth.MoreCallCredentials;
 import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.CensusStatsModule;
+import io.grpc.internal.DeprecatedCensusConstants;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.testing.StatsTestUtils;
 import io.grpc.internal.testing.StatsTestUtils.FakeStatsRecorder;
@@ -140,7 +141,6 @@ import org.mockito.verification.VerificationMode;
  *
  * <p> New tests should avoid using Mockito to support running on AppEngine.</p>
  */
-@SuppressWarnings("deprecation")
 public abstract class AbstractInteropTest {
   private static Logger logger = Logger.getLogger(AbstractInteropTest.class.getName());
 
@@ -1929,7 +1929,7 @@ public abstract class AbstractInteropTest {
 
   private static void checkStartTags(MetricsRecord record, String methodName, Type type) {
     assertNotNull("record is not null", record);
-    TagValue methodNameTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+    TagValue methodNameTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertNotNull("method name tagged", methodNameTagOld);
     assertEquals("method names match", methodName, methodNameTagOld.asString());
 
@@ -1943,10 +1943,10 @@ public abstract class AbstractInteropTest {
   private static void checkEndTags(
       MetricsRecord record, String methodName, Status.Code status, Type type) {
     assertNotNull("record is not null", record);
-    TagValue methodNameTagOld = record.tags.get(RpcMeasureConstants.RPC_METHOD);
+    TagValue methodNameTagOld = record.tags.get(DeprecatedCensusConstants.RPC_METHOD);
     assertNotNull("method name tagged", methodNameTagOld);
     assertEquals("method names match", methodName, methodNameTagOld.asString());
-    TagValue statusTagOld = record.tags.get(RpcMeasureConstants.RPC_STATUS);
+    TagValue statusTagOld = record.tags.get(DeprecatedCensusConstants.RPC_STATUS);
     assertNotNull("status tagged", statusTagOld);
     assertEquals(status.toString(), statusTagOld.asString());
 
@@ -2016,39 +2016,43 @@ public abstract class AbstractInteropTest {
     if (isServer) {
       assertEquals(
           requests.size(),
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_REQUEST_COUNT));
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_REQUEST_COUNT));
       assertEquals(
           responses.size(),
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_RESPONSE_COUNT));
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_SERVER_RESPONSE_COUNT));
       assertEquals(
           uncompressedRequestsSize,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
+          record.getMetricAsLongOrFail(
+              DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES));
       assertEquals(
           uncompressedResponsesSize,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
-      assertNotNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_SERVER_LATENCY));
+          record.getMetricAsLongOrFail(
+              DeprecatedCensusConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES));
+      assertNotNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_SERVER_LATENCY));
       // It's impossible to get the expected wire sizes because it may be compressed, so we just
       // check if they are recorded.
-      assertNotNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_REQUEST_BYTES));
-      assertNotNull(record.getMetric(RpcMeasureConstants.RPC_SERVER_RESPONSE_BYTES));
+      assertNotNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_REQUEST_BYTES));
+      assertNotNull(record.getMetric(DeprecatedCensusConstants.RPC_SERVER_RESPONSE_BYTES));
     } else {
       assertEquals(
           requests.size(),
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_REQUEST_COUNT));
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_COUNT));
       assertEquals(
           responses.size(),
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_RESPONSE_COUNT));
+          record.getMetricAsLongOrFail(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_COUNT));
       assertEquals(
           uncompressedRequestsSize,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
+          record.getMetricAsLongOrFail(
+              DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES));
       assertEquals(
           uncompressedResponsesSize,
-          record.getMetricAsLongOrFail(RpcMeasureConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
-      assertNotNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
+          record.getMetricAsLongOrFail(
+              DeprecatedCensusConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES));
+      assertNotNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_ROUNDTRIP_LATENCY));
       // It's impossible to get the expected wire sizes because it may be compressed, so we just
       // check if they are recorded.
-      assertNotNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_REQUEST_BYTES));
-      assertNotNull(record.getMetric(RpcMeasureConstants.RPC_CLIENT_RESPONSE_BYTES));
+      assertNotNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_REQUEST_BYTES));
+      assertNotNull(record.getMetric(DeprecatedCensusConstants.RPC_CLIENT_RESPONSE_BYTES));
     }
   }
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -290,18 +290,18 @@ def io_netty_transport():
     )
 
 def io_opencensus_api():
-  native.maven_jar(
-      name = "io_opencensus_opencensus_api",
-      artifact = "io.opencensus:opencensus-api:0.14.0",
-      sha1 = "0c0f8c4d96e5ec83d13085bdbe01175ffd37d552",
-  )
+    native.maven_jar(
+        name = "io_opencensus_opencensus_api",
+        artifact = "io.opencensus:opencensus-api:0.17.0",
+        sha1 = "0b9c91321f9c9f20f3a4627bfd9e3097164f85e6",
+    )
 
 def io_opencensus_grpc_metrics():
-  native.maven_jar(
-      name = "io_opencensus_opencensus_contrib_grpc_metrics",
-      artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.14.0",
-      sha1 = "9cd197d7667e7a012cb7270351dc8325909df889",
-  )
+    native.maven_jar(
+        name = "io_opencensus_opencensus_contrib_grpc_metrics",
+        artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.17.0",
+        sha1 = "4b82972073361704f57fa2107910242f1143df25",
+    )
 
 def javax_annotation():
     # Use //stub:javax_annotation for neverlink=1 support.

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -292,15 +292,15 @@ def io_netty_transport():
 def io_opencensus_api():
   native.maven_jar(
       name = "io_opencensus_opencensus_api",
-      artifact = "io.opencensus:opencensus-api:0.13.2",
-      sha1 = "dbdce105ac7c01ce09cfbbe6546dcf5905a1d5c7",
+      artifact = "io.opencensus:opencensus-api:0.14.0",
+      sha1 = "0c0f8c4d96e5ec83d13085bdbe01175ffd37d552",
   )
 
 def io_opencensus_grpc_metrics():
   native.maven_jar(
       name = "io_opencensus_opencensus_contrib_grpc_metrics",
-      artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.13.2",
-      sha1 = "1e36a084d6900e312835fbbeb5853a6ff776bda7",
+      artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.14.0",
+      sha1 = "9cd197d7667e7a012cb7270351dc8325909df889",
   )
 
 def javax_annotation():

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -290,18 +290,18 @@ def io_netty_transport():
     )
 
 def io_opencensus_api():
-    native.maven_jar(
-        name = "io_opencensus_opencensus_api",
-        artifact = "io.opencensus:opencensus-api:0.12.3",
-        sha1 = "743f074095f29aa985517299545e72cc99c87de0",
-    )
+  native.maven_jar(
+      name = "io_opencensus_opencensus_api",
+      artifact = "io.opencensus:opencensus-api:0.13.2",
+      sha1 = "dbdce105ac7c01ce09cfbbe6546dcf5905a1d5c7",
+  )
 
 def io_opencensus_grpc_metrics():
-    native.maven_jar(
-        name = "io_opencensus_opencensus_contrib_grpc_metrics",
-        artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.12.3",
-        sha1 = "a4c7ff238a91b901c8b459889b6d0d7a9d889b4d",
-    )
+  native.maven_jar(
+      name = "io_opencensus_opencensus_contrib_grpc_metrics",
+      artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.13.2",
+      sha1 = "1e36a084d6900e312835fbbeb5853a6ff776bda7",
+  )
 
 def javax_annotation():
     # Use //stub:javax_annotation for neverlink=1 support.

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -328,6 +328,7 @@ public class StatsTestUtils {
     /**
      * Creates a MockableSpan with a random trace ID and span ID.
      */
+    @SuppressWarnings("deprecation")
     public static MockableSpan generateRandomSpan(Random random) {
       return new MockableSpan(
           SpanContext.create(

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -58,6 +58,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
+@SuppressWarnings("deprecation")
 public class StatsTestUtils {
   private StatsTestUtils() {
   }

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -58,7 +58,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("deprecation")
 public class StatsTestUtils {
   private StatsTestUtils() {
   }


### PR DESCRIPTION
Related to https://github.com/census-instrumentation/opencensus-java/issues/1207.

OpenCensus has updated the RPC constants in [Specs](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md) recently, and in OpenCensus-Java these new constants are added since v0.13.0. This PR updates gRPC to use the latest OpenCensus version, ~~and record stats against the new RPC constants.~~

~~Note that gRPC also needs to record stats against the deprecated constants, to keep backwards compatibility.~~

/cc @bogdandrutu @dinooliva @sebright 