### PR TITLE
move io.grpc.BinaryLogProvider to io.grpc.services

### DIFF
--- a/core/src/main/java/io/grpc/InternalClientInterceptors.java
+++ b/core/src/main/java/io/grpc/InternalClientInterceptors.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import io.grpc.MethodDescriptor.Marshaller;
+
+/**
+ * Internal accessor. Do not use.
+ */
+@Internal
+public final class InternalClientInterceptors {
+  public static <WReqT, WRespT> ClientInterceptor wrapClientInterceptor(
+      final ClientInterceptor interceptor,
+      final Marshaller<WReqT> reqMarshaller,
+      final Marshaller<WRespT> respMarshaller) {
+    return ClientInterceptors.wrapClientInterceptor(interceptor, reqMarshaller, respMarshaller);
+  }
+}

--- a/core/src/main/java/io/grpc/InternalServerInterceptors.java
+++ b/core/src/main/java/io/grpc/InternalServerInterceptors.java
@@ -26,6 +26,17 @@ public final class InternalServerInterceptors {
     return ServerInterceptors.InterceptCallHandler.create(interceptor, callHandler);
   }
 
+  public static <OReqT, ORespT, WReqT, WRespT> ServerMethodDefinition<WReqT, WRespT> wrapMethod(
+      final ServerMethodDefinition<OReqT, ORespT> definition,
+      final MethodDescriptor<WReqT, WRespT> wrappedMethod) {
+    return ServerInterceptors.wrapMethod(definition, wrappedMethod);
+  }
+
+  public static <ReqT, RespT> ServerCallHandler<ReqT, RespT> interceptCallHandlerCreate(
+        ServerInterceptor interceptor, ServerCallHandler<ReqT, RespT> callHandler) {
+    return ServerInterceptors.InterceptCallHandler.create(interceptor, callHandler);
+  }
+
   private InternalServerInterceptors() {
   }
 }

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -20,8 +20,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.opencensus.trace.unsafe.ContextUtils.CONTEXT_SPAN_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.BinaryLog;
 import io.grpc.BinaryLog.CallId;
-import io.grpc.BinaryLogProvider;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -386,7 +386,7 @@ final class CensusTracingModule {
               method,
               callOptions.withStreamTracerFactory(tracerFactory)
                   .withOption(
-                      BinaryLogProvider.CLIENT_CALL_ID_CALLOPTION_KEY,
+                      BinaryLog.CLIENT_CALL_ID_CALLOPTION_KEY,
                       new CallId(
                           0,
                           ByteBuffer.wrap(

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -31,7 +31,6 @@ import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
-import io.grpc.BinaryLogProvider;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -140,7 +139,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
 
   /**
    * We delegate to this channel, so that we can have interceptors as necessary. If there aren't
-   * any interceptors and the {@link BinaryLogProvider} is {@code null} then this will just be a
+   * any interceptors and the {@link io.grpc.BinaryLog} is {@code null} then this will just be a
    * {@link RealChannel}.
    */
   private final Channel interceptorChannel;

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -44,8 +44,8 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
+import io.grpc.BinaryLog;
 import io.grpc.BinaryLog.CallId;
-import io.grpc.BinaryLogProvider;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -1000,7 +1000,7 @@ public class CensusModulesTest {
     new CensusTracingModule(tracer, mock(BinaryFormat.class))
         .getClientInterceptor()
         .interceptCall(TestMethodDescriptors.voidMethod(), CallOptions.DEFAULT, c);
-    CallId callId = options.get().getOption(BinaryLogProvider.CLIENT_CALL_ID_CALLOPTION_KEY);
+    CallId callId = options.get().getOption(BinaryLog.CLIENT_CALL_ID_CALLOPTION_KEY);
     assertThat(callId.hi).isEqualTo(0);
     assertThat(callId.lo)
         .isEqualTo(ByteBuffer.wrap(mockableSpan.getContext().getSpanId().getBytes()).getLong());

--- a/services/src/main/java/io/grpc/services/BinaryLogProvider.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogProvider.java
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
-package io.grpc;
+package io.grpc.services;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import io.grpc.BinaryLog;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.Internal;
+import io.grpc.InternalClientInterceptors;
+import io.grpc.InternalServerInterceptors;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerMethodDefinition;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -61,9 +75,9 @@ public abstract class BinaryLogProvider extends BinaryLog {
     MethodDescriptor<byte[], byte[]> binMethod =
         BinaryLogProvider.toByteBufferMethod(oMethodDef.getMethodDescriptor());
     ServerMethodDefinition<byte[], byte[]> binDef =
-        ServerInterceptors.wrapMethod(oMethodDef, binMethod);
+        InternalServerInterceptors.wrapMethod(oMethodDef, binMethod);
     ServerCallHandler<byte[], byte[]> binlogHandler =
-        ServerInterceptors.InterceptCallHandler.create(
+        InternalServerInterceptors.interceptCallHandlerCreate(
             binlogInterceptor, binDef.getServerCallHandler());
     return ServerMethodDefinition.create(binMethod, binlogHandler);
   }
@@ -137,7 +151,7 @@ public abstract class BinaryLogProvider extends BinaryLog {
       if (binlogInterceptor == null) {
         return next.newCall(method, callOptions);
       } else {
-        return ClientInterceptors
+        return InternalClientInterceptors
             .wrapClientInterceptor(
                 binlogInterceptor,
                 BYTEARRAY_MARSHALLER,

--- a/services/src/main/java/io/grpc/services/BinaryLogProviderImpl.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogProviderImpl.java
@@ -17,7 +17,6 @@
 package io.grpc.services;
 
 import com.google.common.base.Preconditions;
-import io.grpc.BinaryLogProvider;
 import io.grpc.CallOptions;
 import io.grpc.ClientInterceptor;
 import io.grpc.ServerInterceptor;

--- a/services/src/main/java/io/grpc/services/BinlogHelper.java
+++ b/services/src/main/java/io/grpc/services/BinlogHelper.java
@@ -16,7 +16,7 @@
 
 package io.grpc.services;
 
-import static io.grpc.BinaryLogProvider.BYTEARRAY_MARSHALLER;
+import static io.grpc.services.BinaryLogProvider.BYTEARRAY_MARSHALLER;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;

--- a/services/src/main/java/io/grpc/services/CensusBinaryLogProvider.java
+++ b/services/src/main/java/io/grpc/services/CensusBinaryLogProvider.java
@@ -16,7 +16,6 @@
 
 package io.grpc.services;
 
-import io.grpc.BinaryLogProvider;
 import io.grpc.CallOptions;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracing;

--- a/services/src/test/java/io/grpc/services/BinlogHelperTest.java
+++ b/services/src/test/java/io/grpc/services/BinlogHelperTest.java
@@ -16,7 +16,7 @@
 
 package io.grpc.services;
 
-import static io.grpc.BinaryLogProvider.BYTEARRAY_MARSHALLER;
+import static io.grpc.services.BinaryLogProvider.BYTEARRAY_MARSHALLER;
 import static io.grpc.services.BinlogHelper.DUMMY_SOCKET;
 import static io.grpc.services.BinlogHelper.getPeerSocket;
 import static org.junit.Assert.assertEquals;
@@ -32,7 +32,6 @@ import com.google.common.primitives.Bytes;
 import com.google.protobuf.ByteString;
 import io.grpc.Attributes;
 import io.grpc.BinaryLog.CallId;
-import io.grpc.BinaryLogProvider;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;

--- a/services/src/test/java/io/grpc/services/CensusBinaryLogProviderTest.java
+++ b/services/src/test/java/io/grpc/services/CensusBinaryLogProviderTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.opencensus.trace.unsafe.ContextUtils.CONTEXT_SPAN_KEY;
 
 import io.grpc.BinaryLog.CallId;
-import io.grpc.BinaryLogProvider;
 import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.internal.testing.StatsTestUtils.MockableSpan;


### PR DESCRIPTION
BinaryLogProvider is purely an implementation of io.grpc.BinaryLog and can exist in services.

Add internal accessors for ServerInterceptors and ClientInterceptors because some helpers are pkg private
Fix tests that were once creating BinaryLogProvider instances, they should now only create io.grpc.BinaryLog instances