### PR TITLE
services,core: make BinaryLogSink visible, add setter

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -211,6 +211,12 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
     return thisT();
   }
 
+  @Override
+  public T setBinaryLog(BinaryLog binaryLog) {
+    delegate().setBinaryLog(binaryLog);
+    return thisT();
+  }
+
   /**
    * Returns the {@link ManagedChannel} built by the delegate by default. Overriding method can
    * return different value.

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -451,6 +451,19 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
+   * Sets the BinaryLog object that this channel should log to. The channel does not take
+   * ownership of the object, and users are responsible for calling {@link BinaryLog#close()}.
+   *
+   * @param binaryLog the object to provide logging.
+   * @return this
+   * @since 1.13.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4017")
+  public T setBinaryLog(BinaryLog binaryLog) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Builds a channel using the given parameters.
    *
    * @since 1.0.0

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -226,6 +226,19 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   }
 
   /**
+   * Sets the BinaryLog object that this server should log to. The channel does not take
+   * ownership of the object, and users are responsible for calling {@link BinaryLog#close()}.
+   *
+   * @param binaryLog the object to provide logging.
+   * @return this
+   * @since 1.13.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4017")
+  public T setBinaryLog(BinaryLog binaryLog) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Builds a server using the given parameters.
    *
    * <p>The returned service will not been started or be bound a port. You will need to start it

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -331,6 +331,12 @@ public abstract class AbstractManagedChannelImplBuilder
     return thisT();
   }
 
+  @Override
+  public final T setBinaryLog(BinaryLog binlog) {
+    this.binlog = binlog;
+    return thisT();
+  }
+
   /**
    * Override the default stats implementation.
    */

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -199,6 +199,12 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
     return thisT();
   }
 
+  @Override
+  public final T setBinaryLog(BinaryLog binaryLog) {
+    this.binlog = binaryLog;
+    return thisT();
+  }
+
   /**
    * Override the default stats implementation.
    */

--- a/services/src/main/java/io/grpc/services/BinaryLogProviderImpl.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogProviderImpl.java
@@ -37,6 +37,10 @@ class BinaryLogProviderImpl extends BinaryLogProvider {
     this(new TempFileSink(), System.getenv("GRPC_BINARY_LOG_CONFIG"));
   }
 
+  public BinaryLogProviderImpl(BinaryLogSink sink) throws IOException {
+    this(sink, System.getenv("GRPC_BINARY_LOG_CONFIG"));
+  }
+
   /**
    * Creates an instance.
    * @param sink ownership is transferred to this class.

--- a/services/src/main/java/io/grpc/services/BinaryLogSink.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogSink.java
@@ -17,9 +17,14 @@
 package io.grpc.services;
 
 import com.google.protobuf.MessageLite;
+import io.grpc.ExperimentalApi;
 import java.io.Closeable;
 
-interface BinaryLogSink extends Closeable {
+/**
+ * A class that accepts binary log messages.
+ */
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/4017")
+public interface BinaryLogSink extends Closeable {
   /**
    * Writes the {@code message} to the destination.
    */

--- a/services/src/main/java/io/grpc/services/BinaryLogs.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogs.java
@@ -26,8 +26,16 @@ public final class BinaryLogs {
     return new BinaryLogProviderImpl();
   }
 
+  public static BinaryLog createBinaryLog(BinaryLogSink sink) throws IOException {
+    return new BinaryLogProviderImpl(sink);
+  }
+
   public static BinaryLog createCensusBinaryLog() throws IOException {
     return new CensusBinaryLogProvider();
+  }
+
+  public static BinaryLog createCensusBinaryLog(BinaryLogSink sink) throws IOException {
+    return new CensusBinaryLogProvider(sink);
   }
 
   private BinaryLogs() {}

--- a/services/src/main/java/io/grpc/services/CensusBinaryLogProvider.java
+++ b/services/src/main/java/io/grpc/services/CensusBinaryLogProvider.java
@@ -29,6 +29,10 @@ final class CensusBinaryLogProvider extends BinaryLogProviderImpl {
     super();
   }
 
+  public CensusBinaryLogProvider(BinaryLogSink sink) throws IOException {
+    super(sink);
+  }
+
   CensusBinaryLogProvider(BinaryLogSink sink, String configStr) throws IOException {
     super(sink, configStr);
   }


### PR DESCRIPTION
The BinaryLogSink needs to be extendable.
The io.grpc.BinaryLog needs to be settable for a channel or server.