### PR TITLE
core,services: fix lints

### DIFF
--- a/core/src/main/java/io/grpc/InternalClientInterceptors.java
+++ b/core/src/main/java/io/grpc/InternalClientInterceptors.java
@@ -23,10 +23,10 @@ import io.grpc.MethodDescriptor.Marshaller;
  */
 @Internal
 public final class InternalClientInterceptors {
-  public static <WReqT, WRespT> ClientInterceptor wrapClientInterceptor(
+  public static <ReqT, RespT> ClientInterceptor wrapClientInterceptor(
       final ClientInterceptor interceptor,
-      final Marshaller<WReqT> reqMarshaller,
-      final Marshaller<WRespT> respMarshaller) {
+      final Marshaller<ReqT> reqMarshaller,
+      final Marshaller<RespT> respMarshaller) {
     return ClientInterceptors.wrapClientInterceptor(interceptor, reqMarshaller, respMarshaller);
   }
 }

--- a/core/src/main/java/io/grpc/InternalServerInterceptors.java
+++ b/core/src/main/java/io/grpc/InternalServerInterceptors.java
@@ -26,14 +26,15 @@ public final class InternalServerInterceptors {
     return ServerInterceptors.InterceptCallHandler.create(interceptor, callHandler);
   }
 
-  public static <OReqT, ORespT, WReqT, WRespT> ServerMethodDefinition<WReqT, WRespT> wrapMethod(
-      final ServerMethodDefinition<OReqT, ORespT> definition,
-      final MethodDescriptor<WReqT, WRespT> wrappedMethod) {
+  public static <OrigReqT, OrigRespT, WrapReqT, WrapRespT>
+      ServerMethodDefinition<WrapReqT, WrapRespT> wrapMethod(
+      final ServerMethodDefinition<OrigReqT, OrigRespT> definition,
+      final MethodDescriptor<WrapReqT, WrapRespT> wrappedMethod) {
     return ServerInterceptors.wrapMethod(definition, wrappedMethod);
   }
 
   public static <ReqT, RespT> ServerCallHandler<ReqT, RespT> interceptCallHandlerCreate(
-        ServerInterceptor interceptor, ServerCallHandler<ReqT, RespT> callHandler) {
+      ServerInterceptor interceptor, ServerCallHandler<ReqT, RespT> callHandler) {
     return ServerInterceptors.InterceptCallHandler.create(interceptor, callHandler);
   }
 

--- a/services/src/test/java/io/grpc/services/BinaryLogProviderTest.java
+++ b/services/src/test/java/io/grpc/services/BinaryLogProviderTest.java
@@ -406,7 +406,7 @@ public class BinaryLogProviderTest {
 
 
   private static class StringMarshaller implements MethodDescriptor.Marshaller<String> {
-    public static StringMarshaller INSTANCE = new StringMarshaller();
+    public static final StringMarshaller INSTANCE = new StringMarshaller();
 
     @Override
     public InputStream stream(String value) {


### PR DESCRIPTION
- Type parameters must be upper camel case
- constant case field must be final