### PR TITLE
netty,okhttp: make rpc followed by racy transport shutdown transparent-retry-able

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -460,6 +460,8 @@ class NettyClientHandler extends AbstractNettyHandler {
           throws Exception {
     if (lifecycleManager.getShutdownThrowable() != null) {
       // The connection is going away, just terminate the stream now.
+      command.stream().transportReportStatus(
+          lifecycleManager.getShutdownStatus(), RpcProgress.REFUSED, true, new Metadata());
       promise.setFailure(lifecycleManager.getShutdownThrowable());
       return;
     }

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -459,7 +459,8 @@ class NettyClientHandler extends AbstractNettyHandler {
   private void createStream(CreateStreamCommand command, final ChannelPromise promise)
           throws Exception {
     if (lifecycleManager.getShutdownThrowable() != null) {
-      // The connection is going away, just terminate the stream now.
+      // The connection is going away (it is really the GO_AWAY case)
+      // just terminate the stream now.
       command.stream().transportReportStatus(
           lifecycleManager.getShutdownStatus(), RpcProgress.REFUSED, true, new Metadata());
       promise.setFailure(lifecycleManager.getShutdownThrowable());

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -459,7 +459,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   private void createStream(CreateStreamCommand command, final ChannelPromise promise)
           throws Exception {
     if (lifecycleManager.getShutdownThrowable() != null) {
-      // The connection is going away (it is really the GO_AWAY case)
+      // The connection is going away (it is really the GOAWAY case),
       // just terminate the stream now.
       command.stream().transportReportStatus(
           lifecycleManager.getShutdownStatus(), RpcProgress.REFUSED, true, new Metadata());

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -351,15 +351,14 @@ class OkHttpClientTransport implements ConnectionClientTransport {
 
   @GuardedBy("lock")
   void streamReadyToStart(OkHttpClientStream clientStream) {
-    synchronized (lock) {
-      if (goAwayStatus != null) {
-        clientStream.transportState().transportReportStatus(goAwayStatus, true, new Metadata());
-      } else if (streams.size() >= maxConcurrentStreams) {
-        pendingStreams.add(clientStream);
-        setInUse();
-      } else {
-        startStream(clientStream);
-      }
+    if (goAwayStatus != null) {
+      clientStream.transportState().transportReportStatus(
+          goAwayStatus, RpcProgress.REFUSED, true, new Metadata());
+    } else if (streams.size() >= maxConcurrentStreams) {
+      pendingStreams.add(clientStream);
+      setInUse();
+    } else {
+      startStream(clientStream);
     }
   }
 


### PR DESCRIPTION
A new RPC starts with the following steps:

1. Pick a READY transport
2. the READY transport calls `transport.newStream()`
3. the new stream calls `stream.start()`
4. `stream.start()` invokes or enqueus `writeHeaders()` (or for GET request, noop)

A racy transport shutdown could happen between 3 and 4, and by the retry spec, the RPC should be transparent-retry-able in this case. For Netty and OkHttp transport implementation, before step 4, (even if step 1, 2, and 3 excluding 4 are made atomic,) the http2-stream for the RPC is not created, so the current transparent retry logic does not apply and need fix.

Of course, if step 1, 2, and 3 including 4 are made atomic, and not with GET, there will be no such problem.