### PR TITLE
netty: add listener prior to enqueuing CreateStreamCommand

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -152,8 +152,10 @@ class NettyClientStream extends AbstractClientStream {
       };
 
       // Write the command requesting the creation of the stream.
-      writeQueue.enqueue(new CreateStreamCommand(http2Headers, transportState(), get),
-          !method.getType().clientSendsOneMessage() || get).addListener(failureListener);
+      writeQueue.enqueue(
+          new CreateStreamCommand(http2Headers, transportState(), get),
+          channel.newPromise().addListener(failureListener),
+          !method.getType().clientSendsOneMessage() || get);
     }
 
     @Override


### PR DESCRIPTION
This may let transport report status a little more efficiently if CreateSreamCommand fails.