### PR TITLE
services: Use RE2/J

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -218,6 +218,7 @@ subprojects {
                 netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.8.Final',
 
                 conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:1.0.1',
+                re2j: 'com.google.re2j:re2j:1.2',
 
                 // Test dependencies.
                 junit: 'junit:junit:4.12',

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -11,6 +11,7 @@ def grpc_java_repositories(
     omit_com_google_protobuf_java=False,
     omit_com_google_protobuf_javalite=False,
     omit_com_google_protobuf_nano_protobuf_javanano=False,
+    omit_com_google_re2j=False,
     omit_com_google_truth_truth=False,
     omit_com_squareup_okhttp=False,
     omit_com_squareup_okio=False,
@@ -51,6 +52,8 @@ def grpc_java_repositories(
     com_google_protobuf_javalite()
   if not omit_com_google_protobuf_nano_protobuf_javanano:
     com_google_protobuf_nano_protobuf_javanano()
+  if not omit_com_google_re2j:
+    com_google_re2j()
   if not omit_com_google_truth_truth:
     com_google_truth_truth()
   if not omit_com_squareup_okhttp:
@@ -166,6 +169,13 @@ def com_google_protobuf_nano_protobuf_javanano():
       name = "com_google_protobuf_nano_protobuf_javanano",
       artifact = "com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-5",
       sha1 = "357e60f95cebb87c72151e49ba1f570d899734f8",
+  )
+
+def com_google_re2j():
+  native.maven_jar(
+      name = "com_google_re2j",
+      artifact = "com.google.re2j:re2j:1.2",
+      sha1 = "499d5e041f962fefd0f245a9325e8125608ebb54",
   )
 
 def com_google_truth_truth():

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -20,6 +20,7 @@ dependencies {
         // prefer 20.0 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
     }
+    compile libraries.re2j
 
     compileOnly libraries.javax_annotation
     testCompile project(':grpc-testing'),

--- a/services/src/main/java/io/grpc/services/BinlogHelper.java
+++ b/services/src/main/java/io/grpc/services/BinlogHelper.java
@@ -22,6 +22,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.protobuf.ByteString;
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
 import io.grpc.Attributes;
 import io.grpc.BinaryLog.CallId;
 import io.grpc.CallOptions;
@@ -60,8 +62,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 


### PR DESCRIPTION
RE2/J ensures linear time matching, and as such is preferred over `java.util.regex` for safety in the mono repo. While currently safe, this conversion future-proofs any `Pattern`s in BinlogHelper, and removes the need to maintain an exception for gRPC wrt. use of regexes.