### PR TITLE
netty: Remove option to pass promise to WriteQueue

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -165,9 +165,8 @@ class NettyClientStream extends AbstractClientStream {
       if (numBytes > 0) {
         // Add the bytes to outbound flow control.
         onSendingBytes(numBytes);
-        writeQueue.enqueue(
-            new SendGrpcFrameCommand(transportState(), bytebuf, endOfStream),
-            channel.newPromise().addListener(new ChannelFutureListener() {
+        writeQueue.enqueue(new SendGrpcFrameCommand(transportState(), bytebuf, endOfStream), flush)
+            .addListener(new ChannelFutureListener() {
               @Override
               public void operationComplete(ChannelFuture future) throws Exception {
                 // If the future succeeds when http2stream is null, the stream has been cancelled
@@ -179,7 +178,7 @@ class NettyClientStream extends AbstractClientStream {
                   NettyClientStream.this.getTransportTracer().reportMessageSent(numMessages);
                 }
               }
-            }), flush);
+            });
       } else {
         // The frame is empty and will not impact outbound flow control. Just send it.
         writeQueue.enqueue(new SendGrpcFrameCommand(transportState(), bytebuf, endOfStream), flush);

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -123,9 +123,8 @@ class NettyServerStream extends AbstractServerStream {
       final int numBytes = bytebuf.readableBytes();
       // Add the bytes to outbound flow control.
       onSendingBytes(numBytes);
-      writeQueue.enqueue(
-          new SendGrpcFrameCommand(transportState(), bytebuf, false),
-          channel.newPromise().addListener(new ChannelFutureListener() {
+      writeQueue.enqueue(new SendGrpcFrameCommand(transportState(), bytebuf, false), flush)
+          .addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
               // Remove the bytes from outbound flow control, optionally notifying
@@ -135,7 +134,7 @@ class NettyServerStream extends AbstractServerStream {
                 transportTracer.reportMessageSent(numMessages);
               }
             }
-          }), flush);
+          });
     }
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/WriteQueue.java
+++ b/netty/src/main/java/io/grpc/netty/WriteQueue.java
@@ -75,22 +75,10 @@ class WriteQueue {
    */
   @CanIgnoreReturnValue
   ChannelFuture enqueue(QueuedCommand command, boolean flush) {
-    return enqueue(command, channel.newPromise(), flush);
-  }
-
-  /**
-   * Enqueue a write command with a completion listener.
-   *
-   * @param command a write to be executed on the channel.
-   * @param promise to be marked on the completion of the write.
-   * @param flush true if a flush of the write should be schedule, false if a later call to
-   *              enqueue will schedule the flush.
-   */
-  @CanIgnoreReturnValue
-  ChannelFuture enqueue(QueuedCommand command, ChannelPromise promise, boolean flush) {
     // Detect erroneous code that tries to reuse command objects.
     Preconditions.checkArgument(command.promise() == null, "promise must not be set on command");
 
+    ChannelPromise promise = channel.newPromise();
     command.promise(promise);
     queue.add(command);
     if (flush) {

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -326,7 +326,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
 
   @CanIgnoreReturnValue
   protected final ChannelFuture enqueue(WriteQueue.QueuedCommand command) {
-    ChannelFuture future = writeQueue.enqueue(command, newPromise(), true);
+    ChannelFuture future = writeQueue.enqueue(command, true);
     channel.runPendingTasks();
     return future;
   }


### PR DESCRIPTION
Passing a promise to WriteQueue was only misused to add a listener on
the promise before issuing the write. Although in this case the listener
ordering will be "random" because listeners are being added from two
different threads, in general we always want to add a listener after the
write returns to let any lower-level listeners be registered first.

Future work can resolve the "random" listener order by passing the
listener to the WriteQueue and adding the listener from the event loop.