### PR TITLE
services: allow binlog to blacklist methods

### DIFF
--- a/services/src/test/java/io/grpc/services/BinlogHelperTest.java
+++ b/services/src/test/java/io/grpc/services/BinlogHelperTest.java
@@ -20,6 +20,7 @@ import static io.grpc.services.BinaryLogProvider.BYTEARRAY_MARSHALLER;
 import static io.grpc.services.BinlogHelper.DUMMY_SOCKET;
 import static io.grpc.services.BinlogHelper.getPeerSocket;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.eq;
@@ -266,10 +267,13 @@ public final class BinlogHelperTest {
 
   @Test
   public void configBinLog_blacklist() {
-    assertNull(makeLog("*,-p.s/method", "p.s/method"));
-    assertNull(makeLog("-p.s/method,*", "p.s/method"));
-    assertNull(makeLog("p.s/*,-p.s/method", "p.s/method"));
-    assertNull(makeLog("-p.s/method,p.s/*", "p.s/method"));
+    assertNull(makeLog("*,-p.s/blacklisted", "p.s/blacklisted"));
+    assertNull(makeLog("-p.s/blacklisted,*", "p.s/blacklisted"));
+    assertNotNull(makeLog("-p.s/method,*", "p.s/allowed"));
+
+    assertNull(makeLog("p.s/*,-p.s/blacklisted", "p.s/blacklisted"));
+    assertNull(makeLog("-p.s/blacklisted,p.s/*", "p.s/blacklisted"));
+    assertNotNull(makeLog("-p.s/blacklisted,p.s/*", "p.s/allowed"));
   }
 
   @Test

--- a/services/src/test/java/io/grpc/services/BinlogHelperTest.java
+++ b/services/src/test/java/io/grpc/services/BinlogHelperTest.java
@@ -265,6 +265,14 @@ public final class BinlogHelperTest {
   }
 
   @Test
+  public void configBinLog_blacklist() {
+    assertNull(makeLog("*,-p.s/method", "p.s/method"));
+    assertNull(makeLog("-p.s/method,*", "p.s/method"));
+    assertNull(makeLog("p.s/*,-p.s/method", "p.s/method"));
+    assertNull(makeLog("-p.s/method,p.s/*", "p.s/method"));
+  }
+
+  @Test
   public void configBinLog_ignoreDuplicates_global() throws Exception {
     String configStr = "*{h},p.s/m,*{h:256}";
     // The duplicate


### PR DESCRIPTION
The spec says users can specify a blacklist a method from binlogs by
saying "-package.service/method".