### PR TITLE
auth: Require PRIVACY_AND_INTEGRITY for GoogleCredentials

### DIFF
--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -26,6 +26,7 @@ import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import java.io.IOException;
@@ -51,7 +52,10 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
       = Logger.getLogger(GoogleAuthLibraryCallCredentials.class.getName());
   private static final JwtHelper jwtHelper
       = createJwtHelperOrNull(GoogleAuthLibraryCallCredentials.class.getClassLoader());
+  private static final Class<? extends Credentials> googleCredentialsClass
+      = loadGoogleCredentialsClass();
 
+  private final boolean requirePrivacy;
   @VisibleForTesting
   final Credentials creds;
 
@@ -65,9 +69,18 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
   @VisibleForTesting
   GoogleAuthLibraryCallCredentials(Credentials creds, JwtHelper jwtHelper) {
     checkNotNull(creds, "creds");
+    boolean requirePrivacy = false;
+    if (googleCredentialsClass != null) {
+      // All GoogleCredentials instances are bearer tokens and should only be used on private
+      // channels. This catches all return values from GoogleCredentials.getApplicationDefault().
+      // This should be checked before upgrading the Service Account to JWT, as JWT is also a bearer
+      // token.
+      requirePrivacy = googleCredentialsClass.isInstance(creds);
+    }
     if (jwtHelper != null) {
       creds = jwtHelper.tryServiceAccountToJwt(creds);
     }
+    this.requirePrivacy = requirePrivacy;
     this.creds = creds;
   }
 
@@ -77,6 +90,14 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
   @Override
   public void applyRequestMetadata(MethodDescriptor<?, ?> method, Attributes attrs,
       Executor appExecutor, final MetadataApplier applier) {
+    SecurityLevel security = checkNotNull(attrs.get(ATTR_SECURITY_LEVEL), "securityLevel");
+    if (requirePrivacy && security != SecurityLevel.PRIVACY_AND_INTEGRITY) {
+      applier.fail(Status.UNAUTHENTICATED
+          .withDescription("Credentials require channel with PRIVACY_AND_INTEGRITY security level. "
+            + "Observed security level: " + security));
+      return;
+    }
+
     String authority = checkNotNull(attrs.get(ATTR_AUTHORITY), "authority");
     final URI uri;
     try {
@@ -212,6 +233,19 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
       log.log(Level.WARNING, "Failed to create JWT helper. This is unexpected", caughtException);
     }
     return null;
+  }
+
+  @Nullable
+  private static Class<? extends Credentials> loadGoogleCredentialsClass() {
+    Class<?> rawGoogleCredentialsClass;
+    try {
+      // Can't use a loader as it disables ProGuard's reference detection and would fail to rename
+      // this reference. Unfortunately this will initialize the class.
+      rawGoogleCredentialsClass = Class.forName("com.google.auth.oauth2.GoogleCredentials");
+    } catch (ClassNotFoundException ex) {
+      return null;
+    }
+    return rawGoogleCredentialsClass.asSubclass(Credentials.class);
   }
 
   @VisibleForTesting

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -90,11 +90,17 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
   @Override
   public void applyRequestMetadata(MethodDescriptor<?, ?> method, Attributes attrs,
       Executor appExecutor, final MetadataApplier applier) {
-    SecurityLevel security = checkNotNull(attrs.get(ATTR_SECURITY_LEVEL), "securityLevel");
+    SecurityLevel security = attrs.get(ATTR_SECURITY_LEVEL);
+    if (security == null) {
+      // Although the API says ATTR_SECURITY_LEVEL is required, no one was really looking at it thus
+      // there may be transports that got away without setting it.  Now we start to check it, it'd
+      // be less disruptive to tolerate nulls.
+      security = SecurityLevel.NONE;
+    }
     if (requirePrivacy && security != SecurityLevel.PRIVACY_AND_INTEGRITY) {
       applier.fail(Status.UNAUTHENTICATED
           .withDescription("Credentials require channel with PRIVACY_AND_INTEGRITY security level. "
-            + "Observed security level: " + security));
+              + "Observed security level: " + security));
       return;
     }
 

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -249,6 +249,7 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
       // this reference. Unfortunately this will initialize the class.
       rawGoogleCredentialsClass = Class.forName("com.google.auth.oauth2.GoogleCredentials");
     } catch (ClassNotFoundException ex) {
+      log.log(Level.FINE, "Failed to load GoogleCredentials", ex);
       return null;
     }
     return rawGoogleCredentialsClass.asSubclass(Credentials.class);


### PR DESCRIPTION
This keeps them more secure. Other types of creds are left as-is, since
we don't quite know if it makes sense to have a similar restriction. (It
likely does make sense, but this is a more precise change for our
needs.)

This is a rollforward of 8e9d4cbe5cb455315e55846e91706cccecb4b577
which was rolled back in de9515269635d2e8e84540fcd6744cc1a69ce81b

Reference: #4528