### PR TITLE
all: add gradle format checker

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -4,27 +4,23 @@ description = "gRPC: All"
 
 buildscript {
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-    dependencies {
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
-    }
+    dependencies { classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1' }
 }
 
 def subprojects = [
-  project(':grpc-auth'),
-  project(':grpc-core'),
-  project(':grpc-context'),
-  project(':grpc-netty'),
-  project(':grpc-okhttp'),
-  project(':grpc-protobuf'),
-  project(':grpc-protobuf-lite'),
-  project(':grpc-protobuf-nano'),
-  project(':grpc-stub'),
-  project(':grpc-testing'),
+    project(':grpc-auth'),
+    project(':grpc-core'),
+    project(':grpc-context'),
+    project(':grpc-netty'),
+    project(':grpc-okhttp'),
+    project(':grpc-protobuf'),
+    project(':grpc-protobuf-lite'),
+    project(':grpc-protobuf-nano'),
+    project(':grpc-stub'),
+    project(':grpc-testing'),
 ]
 
 for (subproject in rootProject.subprojects) {
@@ -56,8 +52,8 @@ task jacocoMerge(type: JacocoMerge) {
     mustRunAfter(subprojects.jacocoTestReport.mustRunAfter)
     destinationFile = file("${buildDir}/jacoco/test.exec")
     executionData = files(subprojects.jacocoTestReport.executionData)
-        .plus(project(':grpc-interop-testing').jacocoTestReport.executionData)
-        .filter { f -> f.exists() }
+            .plus(project(':grpc-interop-testing').jacocoTestReport.executionData)
+            .filter { f -> f.exists() }
 }
 
 jacocoTestReport {
@@ -72,7 +68,9 @@ jacocoTestReport {
     classDirectories = files(subprojects.sourceSets.main.output)
     classDirectories = files(classDirectories.files.collect {
         fileTree(dir: it,
-                exclude: ['**/io/grpc/okhttp/internal/**'])
+        exclude: [
+            '**/io/grpc/okhttp/internal/**'
+        ])
     })
 }
 
@@ -80,6 +78,4 @@ coveralls {
     sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
 }
 
-tasks.coveralls {
-    dependsOn(jacocoTestReport)
-}
+tasks.coveralls { dependsOn(jacocoTestReport) }

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -5,14 +5,10 @@ targetCompatibility = 1.7
 
 buildscript {
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-    dependencies {
-        classpath libraries.protobuf_plugin
-    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 dependencies {
@@ -24,10 +20,10 @@ dependencies {
             libraries.protobuf
     runtime project(':grpc-grpclb')
     testCompile libraries.guava,
-                libraries.guava_testlib,
-                libraries.junit,
-                libraries.mockito,
-                libraries.truth
+            libraries.guava_testlib,
+            libraries.junit,
+            libraries.mockito,
+            libraries.truth
     signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 
@@ -36,9 +32,10 @@ configureProtoCompilation()
 [compileJava, compileTestJava].each() {
     // ALTS retuns a lot of futures that we mostly don't care about.
     // protobuf calls valueof. Will be fixed in next release (google/protobuf#4046)
-    it.options.compilerArgs += ["-Xlint:-deprecation", "-Xep:FutureReturnValueIgnored:OFF"]
+    it.options.compilerArgs += [
+        "-Xlint:-deprecation",
+        "-Xep:FutureReturnValueIgnored:OFF"
+    ]
 }
 
-javadoc {
-    exclude 'io/grpc/alts/internal/**'
-}
+javadoc { exclude 'io/grpc/alts/internal/**' }

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -14,26 +14,19 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
-        debug {
-            minifyEnabled false
-        }
+        debug { minifyEnabled false }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    lintOptions {
-        disable 'InvalidPackage', 'HardcodedText'
-    }
+    lintOptions { disable 'InvalidPackage', 'HardcodedText' }
 }
 
 protobuf {
-    protoc {
-        artifact = 'com.google.protobuf:protoc:3.5.1-1'
-    }
+    protoc { artifact = 'com.google.protobuf:protoc:3.5.1-1' }
     plugins {
-        grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -47,10 +40,8 @@ protobuf {
             }
 
             task.plugins {
-                grpc {
-                    // Options added to --grpc_out
-                    option 'nano'
-                }
+                grpc { // Options added to --grpc_out
+                    option 'nano' }
             }
         }
     }
@@ -73,7 +64,5 @@ dependencies {
 }
 
 gradle.projectsEvaluated {
-    tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:deprecation"
-    }
+    tasks.withType(JavaCompile) { options.compilerArgs << "-Xlint:deprecation" }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,9 +9,7 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -33,9 +31,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
-    lintOptions {
-        abortOnError false
-    }
+    lintOptions { abortOnError false }
 }
 
 repositories {

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -3,6 +3,6 @@ dependencies {
     compile project(':grpc-core'),
             libraries.google_auth_credentials
     testCompile project(':grpc-testing'),
-                libraries.oauth_client
+            libraries.oauth_client
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,13 +1,9 @@
 buildscript {
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-    dependencies {
-        classpath libraries.protobuf_plugin
-    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 apply plugin: 'application'
@@ -41,23 +37,25 @@ dependencies {
 }
 
 compileJava {
-  // The Control.Void protobuf clashes
-  options.compilerArgs += ["-Xep:JavaLangClash:OFF"]
+    // The Control.Void protobuf clashes
+    options.compilerArgs += ["-Xep:JavaLangClash:OFF"]
 }
 
 configureProtoCompilation()
 
 def vmArgs = [
-        "-server",
-        "-Xms2g",
-        "-Xmx2g",
-        "-XX:+PrintGCDetails"
+    "-server",
+    "-Xms2g",
+    "-Xmx2g",
+    "-XX:+PrintGCDetails"
 ]
 
 task qps_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.benchmarks.qps.AsyncClient"
     applicationName = "qps_client"
-    defaultJvmOpts = ["-javaagent:" + configurations.alpnagent.asPath] + vmArgs
+    defaultJvmOpts = [
+        "-javaagent:" + configurations.alpnagent.asPath
+    ].plus(vmArgs)
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
 }
@@ -65,7 +63,9 @@ task qps_client(type: CreateStartScripts) {
 task openloop_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.benchmarks.qps.OpenLoopClient"
     applicationName = "openloop_client"
-    defaultJvmOpts = ["-javaagent:" + configurations.alpnagent.asPath] + vmArgs
+    defaultJvmOpts = [
+        "-javaagent:" + configurations.alpnagent.asPath
+    ].plus(vmArgs)
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
 }
@@ -80,7 +80,9 @@ task qps_server(type: CreateStartScripts) {
 task benchmark_worker(type: CreateStartScripts) {
     mainClassName = "io.grpc.benchmarks.driver.LoadWorker"
     applicationName = "benchmark_worker"
-    defaultJvmOpts = ["-javaagent:" + configurations.alpnagent.asPath] + vmArgs
+    defaultJvmOpts = [
+        "-javaagent:" + configurations.alpnagent.asPath
+    ].plus(vmArgs)
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,17 @@
 buildscript {
-  repositories {
-    mavenLocal()
-    maven {
-      url "https://plugins.gradle.org/m2/"
+    repositories {
+        mavenLocal()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
-  }
-  dependencies {
-    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.13.0"
-    classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
-    classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.0'
-    classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
-    classpath 'net.ltgt.gradle:gradle-apt-plugin:0.13'
-    classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.5"
-    classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.2.5'
-  }
+    dependencies {
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.13.0"
+        classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.0'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
+        classpath 'net.ltgt.gradle:gradle-apt-plugin:0.13'
+        classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.5"
+        classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.2.5'
+    }
 }
 
 subprojects {
@@ -29,24 +27,24 @@ subprojects {
     // The plugin only has an effect if a signature is specified
     apply plugin: "ru.vyarus.animalsniffer"
     if (!rootProject.hasProperty('errorProne') || rootProject.errorProne.toBoolean()) {
-      apply plugin: "net.ltgt.errorprone"
-      apply plugin: "net.ltgt.apt"
+        apply plugin: "net.ltgt.errorprone"
+        apply plugin: "net.ltgt.apt"
 
-      dependencies {
-        // The ErrorProne plugin defaults to the latest, which would break our
-        // build if error prone releases a new version with a new check
-        errorprone 'com.google.errorprone:error_prone_core:2.2.0'
-        apt 'com.google.guava:guava-beta-checker:1.0'
-      }
-    } else {
-      // Remove per-project error-prone checker config
-      allprojects {
-        afterEvaluate { project ->
-          project.tasks.withType(JavaCompile) {
-            options.compilerArgs.removeAll { it.startsWith("-Xep") }
-          }
+        dependencies {
+            // The ErrorProne plugin defaults to the latest, which would break our
+            // build if error prone releases a new version with a new check
+            errorprone 'com.google.errorprone:error_prone_core:2.2.0'
+            apt 'com.google.guava:guava-beta-checker:1.0'
         }
-      }
+    } else {
+        // Remove per-project error-prone checker config
+        allprojects {
+            afterEvaluate { project ->
+                project.tasks.withType(JavaCompile) {
+                    options.compilerArgs.removeAll { it.startsWith("-Xep") }
+                }
+            }
+        }
     }
     // TODO(zpencer): remove when intellij 2017.2 is released
     // https://github.com/gradle/gradle/issues/2315
@@ -59,15 +57,21 @@ subprojects {
     targetCompatibility = 1.6
 
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
         mavenLocal()
     }
 
-    [compileJava, compileTestJava, compileJmhJava].each() {
-        it.options.compilerArgs += ["-Xlint:all", "-Xlint:-options", "-Xlint:-path"]
+    [
+        compileJava,
+        compileTestJava,
+        compileJmhJava
+    ].each() {
+        it.options.compilerArgs += [
+            "-Xlint:all",
+            "-Xlint:-options",
+            "-Xlint:-path"
+        ]
         it.options.encoding = "UTF-8"
         if (rootProject.hasProperty('failOnWarnings') && rootProject.failOnWarnings.toBoolean()) {
             it.options.compilerArgs += ["-Werror"]
@@ -75,18 +79,21 @@ subprojects {
     }
 
     compileTestJava {
-      // serialVersionUID is basically guaranteed to be useless in our tests
-      // LinkedList doesn't hurt much in tests and has lots of usages
-      options.compilerArgs += ["-Xlint:-serial", "-Xep:JdkObsolete:OFF"]
+        // serialVersionUID is basically guaranteed to be useless in our tests
+        // LinkedList doesn't hurt much in tests and has lots of usages
+        options.compilerArgs += [
+            "-Xlint:-serial",
+            "-Xep:JdkObsolete:OFF"
+        ]
     }
 
     jar.manifest {
         attributes('Implementation-Title': name,
-                'Implementation-Version': version,
-                'Built-By': System.getProperty('user.name'),
-                'Built-JDK': System.getProperty('java.version'),
-                'Source-Compatibility': sourceCompatibility,
-                'Target-Compatibility': targetCompatibility)
+        'Implementation-Version': version,
+        'Built-By': System.getProperty('user.name'),
+        'Built-JDK': System.getProperty('java.version'),
+        'Source-Compatibility': sourceCompatibility,
+        'Target-Compatibility': targetCompatibility)
     }
 
     javadoc.options {
@@ -108,79 +115,75 @@ subprojects {
         opencensusVersion = '0.12.3'
 
         configureProtoCompilation = {
-          String generatedSourcePath = "${projectDir}/src/generated"
-          if (rootProject.childProjects.containsKey('grpc-compiler')) {
-            // Only when the codegen is built along with the project, will we be able to recompile
-            // the proto files.
-            project.apply plugin: 'com.google.protobuf'
-            project.protobuf {
-              protoc {
-                if (project.hasProperty('protoc')) {
-                  path = project.protoc
-                } else {
-                  artifact = "com.google.protobuf:protoc:${protocVersion}"
-                }
-              }
-              plugins {
-                grpc {
-                  path = javaPluginPath
-                }
-              }
-              generateProtoTasks {
-                all().each { task ->
-                  task.dependsOn ':grpc-compiler:java_pluginExecutable'
-                  // Delete the generated sources first, so that we can be alerted if they are not re-compiled.
-                  task.dependsOn 'deleteGeneratedSource' + task.sourceSet.name
-                  // Recompile protos when the codegen has been changed
-                  task.inputs.file javaPluginPath
-                  // Recompile protos when build.gradle has been changed, because
-                  // it's possible the version of protoc has been changed.
-                  task.inputs.file "${rootProject.projectDir}/build.gradle"
-                  task.plugins {
-                    grpc {
-                      option 'noversion'
+            String generatedSourcePath = "${projectDir}/src/generated"
+            if (rootProject.childProjects.containsKey('grpc-compiler')) {
+                // Only when the codegen is built along with the project, will we be able to recompile
+                // the proto files.
+                project.apply plugin: 'com.google.protobuf'
+                project.protobuf {
+                    protoc {
+                        if (project.hasProperty('protoc')) {
+                            path = project.protoc
+                        } else {
+                            artifact = "com.google.protobuf:protoc:${protocVersion}"
+                        }
                     }
-                  }
+                    plugins { grpc { path = javaPluginPath } }
+                    generateProtoTasks {
+                        all().each { task ->
+                            task.dependsOn ':grpc-compiler:java_pluginExecutable'
+                            // Delete the generated sources first, so that we can be alerted if they are not re-compiled.
+                            task.dependsOn 'deleteGeneratedSource' + task.sourceSet.name
+                            // Recompile protos when the codegen has been changed
+                            task.inputs.file javaPluginPath
+                            // Recompile protos when build.gradle has been changed, because
+                            // it's possible the version of protoc has been changed.
+                            task.inputs.file "${rootProject.projectDir}/build.gradle"
+                            task.plugins { grpc { option 'noversion' } }
+                        }
+                    }
+                    generatedFilesBaseDir = generatedSourcePath
                 }
-              }
-              generatedFilesBaseDir = generatedSourcePath
+
+                sourceSets.each { sourceSet ->
+                    task "deleteGeneratedSource${sourceSet.name}" {
+                        doLast {
+                            project.delete project.fileTree(dir: generatedSourcePath + '/' + sourceSet.name)
+                        }
+                    }
+                }
+            } else {
+                // Otherwise, we just use the checked-in generated code.
+                project.sourceSets {
+                    main {
+                        java {
+                            srcDir "${generatedSourcePath}/main/java"
+                            srcDir "${generatedSourcePath}/main/javanano"
+                            srcDir "${generatedSourcePath}/main/grpc"
+                        }
+                    }
+                    test {
+                        java {
+                            srcDir "${generatedSourcePath}/test/java"
+                            srcDir "${generatedSourcePath}/test/javanano"
+                            srcDir "${generatedSourcePath}/test/grpc"
+                        }
+                    }
+                }
             }
 
-            sourceSets.each { sourceSet ->
-              task "deleteGeneratedSource${sourceSet.name}" {
-                doLast {
-                  project.delete project.fileTree(dir: generatedSourcePath + '/' + sourceSet.name)
-                }
-              }
+            [
+                compileJava,
+                compileTestJava,
+                compileJmhJava
+            ].each() {
+                // Protobuf-generated code produces some warnings.
+                // https://github.com/google/protobuf/issues/2718
+                it.options.compilerArgs += [
+                    "-Xlint:-cast",
+                    "-XepExcludedPaths:.*/src/generated/[^/]+/java/.*",
+                ]
             }
-          } else {
-            // Otherwise, we just use the checked-in generated code.
-            project.sourceSets {
-              main {
-                java {
-                  srcDir "${generatedSourcePath}/main/java"
-                  srcDir "${generatedSourcePath}/main/javanano"
-                  srcDir "${generatedSourcePath}/main/grpc"
-                }
-              }
-              test {
-                java {
-                  srcDir "${generatedSourcePath}/test/java"
-                  srcDir "${generatedSourcePath}/test/javanano"
-                  srcDir "${generatedSourcePath}/test/grpc"
-                }
-              }
-            }
-          }
-
-          [compileJava, compileTestJava, compileJmhJava].each() {
-            // Protobuf-generated code produces some warnings.
-            // https://github.com/google/protobuf/issues/2718
-            it.options.compilerArgs += [
-                "-Xlint:-cast",
-                "-XepExcludedPaths:.*/src/generated/[^/]+/java/.*",
-            ]
-          }
         }
 
         def epoll_suffix = "";
@@ -189,50 +192,50 @@ subprojects {
             epoll_suffix = ":" + osdetector.classifier
         }
         libraries = [
-                errorprone: "com.google.errorprone:error_prone_annotations:2.1.2",
-                gson: "com.google.code.gson:gson:2.7",
-                guava: "com.google.guava:guava:${guavaVersion}",
-                hpack: 'com.twitter:hpack:0.10.1',
-                javax_annotation: 'javax.annotation:javax.annotation-api:1.2',
-                jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
-                oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.9.0',
-                google_api_protos: 'com.google.api.grpc:proto-google-common-protos:1.0.0',
-                google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.9.0',
-                okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
-                okio: 'com.squareup.okio:okio:1.13.0',
-                opencensus_api: "io.opencensus:opencensus-api:${opencensusVersion}",
-                opencensus_contrib_grpc_metrics: "io.opencensus:opencensus-contrib-grpc-metrics:${opencensusVersion}",
-                opencensus_impl: "io.opencensus:opencensus-impl:${opencensusVersion}",
-                opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
-                instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
-                protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
-                protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
-                protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",
-                protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
-                protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.5',
-                protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
-                lang: "org.apache.commons:commons-lang3:3.5",
+            errorprone: "com.google.errorprone:error_prone_annotations:2.1.2",
+            gson: "com.google.code.gson:gson:2.7",
+            guava: "com.google.guava:guava:${guavaVersion}",
+            hpack: 'com.twitter:hpack:0.10.1',
+            javax_annotation: 'javax.annotation:javax.annotation-api:1.2',
+            jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
+            oauth_client: 'com.google.auth:google-auth-library-oauth2-http:0.9.0',
+            google_api_protos: 'com.google.api.grpc:proto-google-common-protos:1.0.0',
+            google_auth_credentials: 'com.google.auth:google-auth-library-credentials:0.9.0',
+            okhttp: 'com.squareup.okhttp:okhttp:2.5.0',
+            okio: 'com.squareup.okio:okio:1.13.0',
+            opencensus_api: "io.opencensus:opencensus-api:${opencensusVersion}",
+            opencensus_contrib_grpc_metrics: "io.opencensus:opencensus-contrib-grpc-metrics:${opencensusVersion}",
+            opencensus_impl: "io.opencensus:opencensus-impl:${opencensusVersion}",
+            opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
+            instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
+            protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
+            protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
+            protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",
+            protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
+            protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.5',
+            protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
+            lang: "org.apache.commons:commons-lang3:3.5",
 
-                netty: "io.netty:netty-codec-http2:[${nettyVersion}]",
-                netty_epoll: "io.netty:netty-transport-native-epoll:${nettyVersion}" + epoll_suffix,
-                netty_proxy_handler: "io.netty:netty-handler-proxy:${nettyVersion}",
-                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.8.Final',
+            netty: "io.netty:netty-codec-http2:[${nettyVersion}]",
+            netty_epoll: "io.netty:netty-transport-native-epoll:${nettyVersion}" + epoll_suffix,
+            netty_proxy_handler: "io.netty:netty-handler-proxy:${nettyVersion}",
+            netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.8.Final',
 
-                conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:1.0.1',
-                re2j: 'com.google.re2j:re2j:1.2',
+            conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:1.0.1',
+            re2j: 'com.google.re2j:re2j:1.2',
 
-                // Test dependencies.
-                junit: 'junit:junit:4.12',
-                mockito: 'org.mockito:mockito-core:1.9.5',
-                truth: 'com.google.truth:truth:0.36',
-                guava_testlib: 'com.google.guava:guava-testlib:20.0',
+            // Test dependencies.
+            junit: 'junit:junit:4.12',
+            mockito: 'org.mockito:mockito-core:1.9.5',
+            truth: 'com.google.truth:truth:0.36',
+            guava_testlib: 'com.google.guava:guava-testlib:20.0',
 
-                // Benchmark dependencies
-                hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10',
-                math: 'org.apache.commons:commons-math3:3.6',
+            // Benchmark dependencies
+            hdrhistogram: 'org.hdrhistogram:HdrHistogram:2.1.10',
+            math: 'org.apache.commons:commons-math3:3.6',
 
-                // Jetty ALPN dependencies
-                jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.7'
+            // Jetty ALPN dependencies
+            jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.7'
         ]
     }
 
@@ -243,7 +246,10 @@ subprojects {
         compile {
             // Detect Maven Enforcer's dependencyConvergence failures. We only
             // care for artifacts used as libraries by others.
-            if (!(project.name in ['grpc-benchmarks', 'grpc-interop-testing'])) {
+            if (!(project.name in [
+                'grpc-benchmarks',
+                'grpc-interop-testing'
+            ])) {
                 resolutionStrategy.failOnVersionConflict()
             }
         }
@@ -251,14 +257,14 @@ subprojects {
 
     dependencies {
         testCompile libraries.junit,
-                    libraries.mockito,
-                    libraries.truth
+                libraries.mockito,
+                libraries.truth
 
         // Configuration for modules that use Jetty ALPN agent
         alpnagent libraries.jetty_alpn_agent
 
         jmh 'org.openjdk.jmh:jmh-core:1.19',
-            'org.openjdk.jmh:jmh-generator-bytecode:1.19'
+                'org.openjdk.jmh:jmh-generator-bytecode:1.19'
     }
 
     signing {
@@ -268,11 +274,11 @@ subprojects {
 
     // Disable JavaDoc doclint on Java 8. It's annoying.
     if (JavaVersion.current().isJava8Compatible()) {
-      allprojects {
-        tasks.withType(Javadoc) {
-          options.addStringOption('Xdoclint:none', '-quiet')
+        allprojects {
+            tasks.withType(Javadoc) {
+                options.addStringOption('Xdoclint:none', '-quiet')
+            }
         }
-      }
     }
 
     checkstyle {
@@ -304,7 +310,9 @@ subprojects {
         // depends on core; core's testCompile depends on testing)
         includeTests = false
         if (project.hasProperty('jmhIncludeSingleClass')) {
-          include = [project.property('jmhIncludeSingleClass')]
+            include = [
+                project.property('jmhIncludeSingleClass')
+            ]
         }
     }
 
@@ -318,36 +326,34 @@ subprojects {
         from sourceSets.main.allSource
     }
 
-    artifacts {
-        archives javadocJar, sourcesJar
-    }
+    artifacts { archives javadocJar, sourcesJar }
 
     uploadArchives.repositories.mavenDeployer {
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
         if (rootProject.hasProperty('repositoryDir')) {
-          repository(url: new File(rootProject.repositoryDir).toURI())
+            repository(url: new File(rootProject.repositoryDir).toURI())
         } else {
-          String stagingUrl
-          if (rootProject.hasProperty('repositoryId')) {
-            stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
-               rootProject.repositoryId
-          } else {
-            stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-          }
-          def configureAuth = {
-            if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
-              authentication(userName: rootProject.ossrhUsername, password: rootProject.ossrhPassword)
+            String stagingUrl
+            if (rootProject.hasProperty('repositoryId')) {
+                stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
+                        rootProject.repositoryId
+            } else {
+                stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
             }
-          }
-          repository(url: stagingUrl, configureAuth)
-          snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/', configureAuth)
+            def configureAuth = {
+                if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
+                    authentication(userName: rootProject.ossrhUsername, password: rootProject.ossrhPassword)
+                }
+            }
+            repository(url: stagingUrl, configureAuth)
+            snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/', configureAuth)
         }
     }
     uploadArchives.onlyIf { !name.contains("grpc-gae-interop-testing") }
 
     [
-      install.repositories.mavenInstaller,
-      uploadArchives.repositories.mavenDeployer,
+        install.repositories.mavenInstaller,
+        uploadArchives.repositories.mavenDeployer,
     ]*.pom*.whenConfigured { pom ->
         pom.project {
             name "$project.group:$project.name"
@@ -380,12 +386,17 @@ subprojects {
             }
         }
         if (!(project.name in
-            ["grpc-stub", "grpc-protobuf", "grpc-protobuf-lite", "grpc-protobuf-nano"])) {
-          def core = pom.dependencies.find {dep -> dep.artifactId == 'grpc-core'}
-          if (core != null) {
-            // Depend on specific version of grpc-core because internal package is unstable
-            core.version = "[" + core.version + "]"
-          }
+        [
+            "grpc-stub",
+            "grpc-protobuf",
+            "grpc-protobuf-lite",
+            "grpc-protobuf-nano"
+        ])) {
+            def core = pom.dependencies.find {dep -> dep.artifactId == 'grpc-core'}
+            if (core != null) {
+                // Depend on specific version of grpc-core because internal package is unstable
+                core.version = "[" + core.version + "]"
+            }
         }
     }
     // At a test failure, log the stack trace to the console so that we don't
@@ -404,19 +415,19 @@ subprojects {
 // Run with: ./gradlew japicmp --continue
 def baselineGrpcVersion = '1.6.1'
 def publicApiSubprojects = [
-        // TODO: uncomment after grpc-alts artifact is published.
-        // ':grpc-alts',
-        ':grpc-auth',
-        ':grpc-context',
-        ':grpc-core',
-        ':grpc-grpclb',
-        ':grpc-netty',
-        ':grpc-okhttp',
-        ':grpc-protobuf',
-        ':grpc-protobuf-lite',
-        ':grpc-protobuf-nano',
-        ':grpc-stub',
-        ':grpc-testing',
+    // TODO: uncomment after grpc-alts artifact is published.
+    // ':grpc-alts',
+    ':grpc-auth',
+    ':grpc-context',
+    ':grpc-core',
+    ':grpc-grpclb',
+    ':grpc-netty',
+    ':grpc-okhttp',
+    ':grpc-protobuf',
+    ':grpc-protobuf-lite',
+    ':grpc-protobuf-nano',
+    ':grpc-stub',
+    ':grpc-testing',
 ]
 
 publicApiSubprojects.each { name ->
@@ -436,7 +447,7 @@ publicApiSubprojects.each { name ->
             String depJar = "${project.name}-${baselineGrpcVersion}.jar"
             Configuration configuration = configurations.detachedConfiguration(
                     dependencies.create(depModule)
-            )
+                    )
             baselineArtifact = files(configuration.files).filter {
                 it.name.equals(depJar)
             }.singleFile

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
   }
   dependencies {
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.13.0"
     classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
     classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.0'
     classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
@@ -466,5 +467,17 @@ publicApiSubprojects.each { name ->
             // TODO(zpencer): enable after japicmp-gradle-plugin/pull/15
             // annotationExcludes = ['@io.grpc.ExperimentalApi']
         }
+    }
+}
+
+// format checkers
+apply plugin: "com.diffplug.gradle.spotless"
+apply plugin: 'groovy'
+spotless {
+    groovyGradle {
+        target '**/*.gradle'
+        greclipse()
+        indentWithSpaces()
+        paddedCell()
     }
 }

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -5,25 +5,21 @@ description = 'The protoc plugin for gRPC Java'
 
 buildscript {
     repositories {
-        maven {
-          // The google mirror is less flaky than mavenCentral()
-          url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
         mavenLocal()
     }
-    dependencies {
-        classpath libraries.protobuf_plugin
-    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 def artifactStagingPath = "$buildDir/artifacts" as File
 // Adds space-delimited arguments from the environment variable env to the
 // argList.
 def addEnvArgs = { env, argList ->
-  def value = System.getenv(env)
-  if (value != null) {
-    value.split(' +').each() { it -> argList.add(it) }
-  }
+    def value = System.getenv(env)
+    if (value != null) {
+        value.split(' +').each() { it -> argList.add(it) }
+    }
 }
 
 // Adds corresponding "-l" option to the argList if libName is not found in
@@ -32,10 +28,10 @@ def addEnvArgs = { env, argList ->
 // order to get statically linked, otherwise we add the libraries through "-l"
 // so that they can be searched for in default search paths.
 def addLibraryIfNotLinked = { libName, argList ->
-  def ldflags = System.env.LDFLAGS
-  if (ldflags == null || !ldflags.contains('lib' + libName + '.a')) {
-    argList.add('-l' + libName)
-  }
+    def ldflags = System.env.LDFLAGS
+    if (ldflags == null || !ldflags.contains('lib' + libName + '.a')) {
+        argList.add('-l' + libName)
+    }
 }
 
 def String arch = rootProject.hasProperty('targetArch') ? rootProject.targetArch : osdetector.arch
@@ -43,298 +39,281 @@ def boolean vcDisable = rootProject.hasProperty('vcDisable') ? rootProject.vcDis
 def boolean usingVisualCpp // Whether VisualCpp is actually available and selected
 
 model {
-  toolChains {
-    // If you have both VC and Gcc installed, VC will be selected, unless you
-    // set 'vcDisable=true'
-    if (!vcDisable) {
-      visualCpp(VisualCpp) {
-        // Prefer vcvars-provided environment over registry-discovered environment
-        def String vsDir = System.getenv("VSINSTALLDIR")
-        def String winDir = System.getenv("WindowsSdkDir")
-        if (vsDir != null && winDir != null) {
-          installDir = vsDir
-          windowsSdkDir = winDir
+    toolChains {
+        // If you have both VC and Gcc installed, VC will be selected, unless you
+        // set 'vcDisable=true'
+        if (!vcDisable) {
+            visualCpp(VisualCpp) {
+                // Prefer vcvars-provided environment over registry-discovered environment
+                def String vsDir = System.getenv("VSINSTALLDIR")
+                def String winDir = System.getenv("WindowsSdkDir")
+                if (vsDir != null && winDir != null) {
+                    installDir = vsDir
+                    windowsSdkDir = winDir
+                }
+            }
         }
-      }
+        gcc(Gcc) {
+            target("ppcle_64")
+            target("aarch_64")
+        }
+        clang(Clang) {
+        }
     }
-    gcc(Gcc) {
-      target("ppcle_64")
-      target("aarch_64")
-    }
-    clang(Clang) {
-    }
-  }
 
-  platforms {
-    x86_32 {
-      architecture "x86"
+    platforms {
+        x86_32 { architecture "x86" }
+        x86_64 { architecture "x86_64" }
+        ppcle_64 { architecture "ppcle_64" }
+        aarch_64 { architecture "aarch_64" }
     }
-    x86_64 {
-      architecture "x86_64"
-    }
-    ppcle_64 {
-      architecture "ppcle_64"
-    }
-    aarch_64 {
-      architecture "aarch_64"
-    }
-  }
 
-  components {
-    java_plugin(NativeExecutableSpec) {
-      if (arch in ['x86_32', 'x86_64', 'ppcle_64', 'aarch_64']) {
-        // If arch is not within the defined platforms, we do not specify the
-        // targetPlatform so that Gradle will choose what is appropriate.
-        targetPlatform arch
-      }
-      baseName "$protocPluginBaseName"
+    components {
+        java_plugin(NativeExecutableSpec) {
+            if (arch in [
+                'x86_32',
+                'x86_64',
+                'ppcle_64',
+                'aarch_64'
+            ]) {
+                // If arch is not within the defined platforms, we do not specify the
+                // targetPlatform so that Gradle will choose what is appropriate.
+                targetPlatform arch
+            }
+            baseName "$protocPluginBaseName"
+        }
     }
-  }
 
-  binaries {
-    all {
-      if (toolChain in Gcc || toolChain in Clang) {
-        cppCompiler.define("GRPC_VERSION", version)
-        cppCompiler.args "--std=c++0x"
-        addEnvArgs("CXXFLAGS", cppCompiler.args)
-        addEnvArgs("CPPFLAGS", cppCompiler.args)
-        if (osdetector.os == "osx") {
-          cppCompiler.args "-mmacosx-version-min=10.7", "-stdlib=libc++"
-          addLibraryIfNotLinked('protoc', linker.args)
-          addLibraryIfNotLinked('protobuf', linker.args)
-        } else if (osdetector.os == "windows") {
-          linker.args "-static", "-lprotoc", "-lprotobuf", "-static-libgcc", "-static-libstdc++",
-                      "-s"
-        } else {
-          // Link protoc, protobuf, libgcc and libstdc++ statically.
-          // Link other (system) libraries dynamically.
-          // Clang under OSX doesn't support these options.
-          linker.args "-Wl,-Bstatic", "-lprotoc", "-lprotobuf", "-static-libgcc",
-                      "-static-libstdc++",
-                      "-Wl,-Bdynamic", "-lpthread", "-s"
+    binaries {
+        all {
+            if (toolChain in Gcc || toolChain in Clang) {
+                cppCompiler.define("GRPC_VERSION", version)
+                cppCompiler.args "--std=c++0x"
+                addEnvArgs("CXXFLAGS", cppCompiler.args)
+                addEnvArgs("CPPFLAGS", cppCompiler.args)
+                if (osdetector.os == "osx") {
+                    cppCompiler.args "-mmacosx-version-min=10.7", "-stdlib=libc++"
+                    addLibraryIfNotLinked('protoc', linker.args)
+                    addLibraryIfNotLinked('protobuf', linker.args)
+                } else if (osdetector.os == "windows") {
+                    linker.args "-static", "-lprotoc", "-lprotobuf", "-static-libgcc", "-static-libstdc++",
+                            "-s"
+                } else {
+                    // Link protoc, protobuf, libgcc and libstdc++ statically.
+                    // Link other (system) libraries dynamically.
+                    // Clang under OSX doesn't support these options.
+                    linker.args "-Wl,-Bstatic", "-lprotoc", "-lprotobuf", "-static-libgcc",
+                            "-static-libstdc++",
+                            "-Wl,-Bdynamic", "-lpthread", "-s"
+                }
+                addEnvArgs("LDFLAGS", linker.args)
+            } else if (toolChain in VisualCpp) {
+                usingVisualCpp = true
+                cppCompiler.define("GRPC_VERSION", version)
+                cppCompiler.args "/EHsc", "/MT"
+                if (rootProject.hasProperty('vcProtobufInclude')) {
+                    cppCompiler.args "/I${rootProject.vcProtobufInclude}"
+                }
+                linker.args "libprotobuf.lib", "libprotoc.lib"
+                if (rootProject.hasProperty('vcProtobufLibs')) {
+                    linker.args "/LIBPATH:${rootProject.vcProtobufLibs}"
+                }
+            }
         }
-        addEnvArgs("LDFLAGS", linker.args)
-      } else if (toolChain in VisualCpp) {
-        usingVisualCpp = true
-        cppCompiler.define("GRPC_VERSION", version)
-        cppCompiler.args "/EHsc", "/MT"
-        if (rootProject.hasProperty('vcProtobufInclude')) {
-          cppCompiler.args "/I${rootProject.vcProtobufInclude}"
-        }
-        linker.args "libprotobuf.lib", "libprotoc.lib"
-        if (rootProject.hasProperty('vcProtobufLibs')) {
-          linker.args "/LIBPATH:${rootProject.vcProtobufLibs}"
-        }
-      }
     }
-  }
 }
 
 configurations {
-  testLiteCompile
-  testNanoCompile
+    testLiteCompile
+    testNanoCompile
 }
 
 dependencies {
-  testCompile project(':grpc-protobuf'),
-              project(':grpc-stub')
-  testLiteCompile project(':grpc-protobuf-lite'),
-                  project(':grpc-stub')
-  testNanoCompile project(':grpc-protobuf-nano'),
-                  project(':grpc-stub')
+    testCompile project(':grpc-protobuf'),
+            project(':grpc-stub')
+    testLiteCompile project(':grpc-protobuf-lite'),
+            project(':grpc-stub')
+    testNanoCompile project(':grpc-protobuf-nano'),
+            project(':grpc-stub')
 }
 
 sourceSets {
-  testLite {
-    proto {
-      setSrcDirs(['src/test/proto'])
+    testLite {
+        proto { setSrcDirs(['src/test/proto']) }
     }
-  }
-  testNano {
-    proto {
-      setSrcDirs(['src/test/proto'])
+    testNano {
+        proto { setSrcDirs(['src/test/proto']) }
     }
-  }
 }
 
 compileTestJava {
-  options.compilerArgs += [
-      "-Xlint:-cast",
-      "-XepExcludedPaths:.*/build/generated/source/proto/.*",
-  ]
+    options.compilerArgs += [
+        "-Xlint:-cast",
+        "-XepExcludedPaths:.*/build/generated/source/proto/.*",
+    ]
 }
 
 compileTestLiteJava {
-  options.compilerArgs = compileTestJava.options.compilerArgs
-  // Protobuf-generated Lite produces quite a few warnings.
-  options.compilerArgs += ["-Xlint:-rawtypes", "-Xlint:-unchecked", "-Xlint:-fallthrough"]
+    options.compilerArgs = compileTestJava.options.compilerArgs
+    // Protobuf-generated Lite produces quite a few warnings.
+    options.compilerArgs += [
+        "-Xlint:-rawtypes",
+        "-Xlint:-unchecked",
+        "-Xlint:-fallthrough"
+    ]
 }
 
 compileTestNanoJava {
-  options.compilerArgs = compileTestJava.options.compilerArgs
+    options.compilerArgs = compileTestJava.options.compilerArgs
 }
 
 protobuf {
-  protoc {
-    if (project.hasProperty('protoc')) {
-      path = project.protoc
-    } else {
-      artifact = "com.google.protobuf:protoc:${protocVersion}"
-    }
-  }
-  plugins {
-    javalite {
-      if (project.hasProperty('protoc-gen-javalite')) {
-        path = project['protoc-gen-javalite']
-      } else {
-        artifact = libraries.protoc_lite
-      }
-    }
-    grpc {
-      path = javaPluginPath
-    }
-  }
-  generateProtoTasks {
-    all().each { task ->
-      task.dependsOn 'java_pluginExecutable'
-      task.inputs.file javaPluginPath
-    }
-    ofSourceSet('test')*.plugins {
-      grpc {}
-    }
-    ofSourceSet('testLite')*.each { task ->
-      task.builtins {
-        remove java
-      }
-      task.plugins {
-        javalite {}
-        grpc {
-          option 'lite'
+    protoc {
+        if (project.hasProperty('protoc')) {
+            path = project.protoc
+        } else {
+            artifact = "com.google.protobuf:protoc:${protocVersion}"
         }
-      }
     }
-    ofSourceSet('testNano').each { task ->
-      task.builtins {
-        remove java
-        javanano {
-          option 'ignore_services=true'
+    plugins {
+        javalite {
+            if (project.hasProperty('protoc-gen-javalite')) {
+                path = project['protoc-gen-javalite']
+            } else {
+                artifact = libraries.protoc_lite
+            }
         }
-      }
-      task.plugins {
-        grpc {
-          option 'nano'
-        }
-      }
+        grpc { path = javaPluginPath }
     }
-  }
+    generateProtoTasks {
+        all().each { task ->
+            task.dependsOn 'java_pluginExecutable'
+            task.inputs.file javaPluginPath
+        }
+        ofSourceSet('test')*.plugins { grpc {} }
+        ofSourceSet('testLite')*.each { task ->
+            task.builtins { remove java }
+            task.plugins {
+                javalite {}
+                grpc { option 'lite' }
+            }
+        }
+        ofSourceSet('testNano').each { task ->
+            task.builtins {
+                remove java
+                javanano { option 'ignore_services=true' }
+            }
+            task.plugins { grpc { option 'nano' } }
+        }
+    }
 }
 
 checkstyleTestNano {
-  source = fileTree(dir: "src/testNano", include: "**/*.java")
+    source = fileTree(dir: "src/testNano", include: "**/*.java")
 }
 
 println "*** Building codegen requires Protobuf version ${protocVersion}"
 println "*** Please refer to https://github.com/grpc/grpc-java/blob/master/COMPILING.md#how-to-build-code-generation-plugin"
 
 task buildArtifacts(type: Copy) {
-  dependsOn 'java_pluginExecutable'
-  from("$buildDir/exe") {
-    if (osdetector.os != 'windows') {
-      rename 'protoc-gen-grpc-java', '$0.exe'
+    dependsOn 'java_pluginExecutable'
+    from("$buildDir/exe") {
+        if (osdetector.os != 'windows') {
+            rename 'protoc-gen-grpc-java', '$0.exe'
+        }
     }
-  }
-  into artifactStagingPath
+    into artifactStagingPath
 }
 
 archivesBaseName = "$protocPluginBaseName"
 
 artifacts {
-  archives("$artifactStagingPath/java_plugin/${protocPluginBaseName}.exe" as File) {
-    classifier osdetector.os + "-" + arch
-    type "exe"
-    extension "exe"
-    builtBy buildArtifacts
-  }
+    archives("$artifactStagingPath/java_plugin/${protocPluginBaseName}.exe" as File) {
+        classifier osdetector.os + "-" + arch
+        type "exe"
+        extension "exe"
+        builtBy buildArtifacts
+    }
 }
 
 // Exe files are skipped by Maven by default. Override it.
 // Also skip jar files that is generated by the java plugin.
 [
-  install.repositories.mavenInstaller,
-  uploadArchives.repositories.mavenDeployer,
+    install.repositories.mavenInstaller,
+    uploadArchives.repositories.mavenDeployer,
 ]*.setFilter {artifact, file ->
-  ! (file.getName().endsWith('jar') || file.getName().endsWith('jar.asc'))
+    ! (file.getName().endsWith('jar') || file.getName().endsWith('jar.asc'))
 }
 
 [
-  uploadArchives.repositories.mavenDeployer,
+    uploadArchives.repositories.mavenDeployer,
 ]*.beforeDeployment { it ->
-  if (!usingVisualCpp) {
-    def ret = exec {
-      executable 'bash'
-      args 'check-artifact.sh', osdetector.os, arch
+    if (!usingVisualCpp) {
+        def ret = exec {
+            executable 'bash'
+            args 'check-artifact.sh', osdetector.os, arch
+        }
+        if (ret.exitValue != 0) {
+            throw new GradleException("check-artifact.sh exited with " + ret.exitValue)
+        }
+    } else {
+        def exeName = "$artifactStagingPath/java_plugin/${protocPluginBaseName}.exe"
+        def os = new ByteArrayOutputStream()
+        def ret = exec {
+            executable 'dumpbin'
+            args '/nologo', '/dependents', exeName
+            standardOutput = os
+        }
+        if (ret.exitValue != 0) {
+            throw new GradleException("dumpbin exited with " + ret.exitValue)
+        }
+        def dlls = os.toString() =~ /Image has the following dependencies:\s+(.*)\s+Summary/
+        if (dlls[0][1] != "KERNEL32.dll") {
+            throw new Exception("unexpected dll deps: " + dlls[0][1]);
+        }
+        os.reset()
+        ret = exec {
+            executable 'dumpbin'
+            args '/nologo', '/headers', exeName
+            standardOutput = os
+        }
+        if (ret.exitValue != 0) {
+            throw new GradleException("dumpbin exited with " + ret.exitValue)
+        }
+        def machine = os.toString() =~ / machine \(([^)]+)\)/
+        def expectedArch = [x86_32: "x86", x86_64: "x64"][arch]
+        if (machine[0][1] != expectedArch) {
+            throw new Exception("unexpected architecture: " + machine[0][1]);
+        }
     }
-    if (ret.exitValue != 0) {
-      throw new GradleException("check-artifact.sh exited with " + ret.exitValue)
-    }
-  } else {
-    def exeName = "$artifactStagingPath/java_plugin/${protocPluginBaseName}.exe"
-    def os = new ByteArrayOutputStream()
-    def ret = exec {
-      executable 'dumpbin'
-      args '/nologo', '/dependents', exeName
-      standardOutput = os
-    }
-    if (ret.exitValue != 0) {
-      throw new GradleException("dumpbin exited with " + ret.exitValue)
-    }
-    def dlls = os.toString() =~ /Image has the following dependencies:\s+(.*)\s+Summary/
-    if (dlls[0][1] != "KERNEL32.dll") {
-      throw new Exception("unexpected dll deps: " + dlls[0][1]);
-    }
-    os.reset()
-    ret = exec {
-      executable 'dumpbin'
-      args '/nologo', '/headers', exeName
-      standardOutput = os
-    }
-    if (ret.exitValue != 0) {
-      throw new GradleException("dumpbin exited with " + ret.exitValue)
-    }
-    def machine = os.toString() =~ / machine \(([^)]+)\)/
-    def expectedArch = [x86_32: "x86", x86_64: "x64"][arch]
-    if (machine[0][1] != expectedArch) {
-      throw new Exception("unexpected architecture: " + machine[0][1]);
-    }
-  }
 }
 
 [
-  install.repositories.mavenInstaller,
-  uploadArchives.repositories.mavenDeployer,
+    install.repositories.mavenInstaller,
+    uploadArchives.repositories.mavenDeployer,
 ]*.pom*.whenConfigured { pom ->
-  pom.project {
-    // This isn't any sort of Java archive artifact, and OSSRH doesn't enforce
-    // javadoc for 'pom' packages. 'exe' would be a more appropriate packaging
-    // value, but it isn't clear how that will be interpreted. In addition,
-    // 'pom' is typically the value used when building an exe with Maven.
-    packaging = "pom"
-  }
+    pom.project {
+        // This isn't any sort of Java archive artifact, and OSSRH doesn't enforce
+        // javadoc for 'pom' packages. 'exe' would be a more appropriate packaging
+        // value, but it isn't clear how that will be interpreted. In addition,
+        // 'pom' is typically the value used when building an exe with Maven.
+        packaging = "pom"
+    }
 }
 
 def configureTestTask(Task task, String dep, String extraPackage) {
-  test.dependsOn task
-  task.dependsOn "generateTest${dep}Proto"
-  if (osdetector.os != 'windows') {
-    task.executable "diff"
-    task.args "-u"
-  } else {
-    task.executable "fc"
-  }
-  // File isn't found on Windows if last slash is forward-slash
-  def slash = System.getProperty("file.separator")
-  task.args "$buildDir/generated/source/proto/test${dep}/grpc/io/grpc/testing/compiler${extraPackage}${slash}TestServiceGrpc.java",
-       "$projectDir/src/test${dep}/golden/TestService.java.txt"
+    test.dependsOn task
+    task.dependsOn "generateTest${dep}Proto"
+    if (osdetector.os != 'windows') {
+        task.executable "diff"
+        task.args "-u"
+    } else {
+        task.executable "fc"
+    }
+    // File isn't found on Windows if last slash is forward-slash
+    def slash = System.getProperty("file.separator")
+    task.args "$buildDir/generated/source/proto/test${dep}/grpc/io/grpc/testing/compiler${extraPackage}${slash}TestServiceGrpc.java",
+            "$projectDir/src/test${dep}/golden/TestService.java.txt"
 }
 
 task testGolden(type: Exec)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     }
 
     testCompile project(':grpc-context').sourceSets.test.output,
-                project(':grpc-testing')
+            project(':grpc-testing')
 
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
@@ -41,5 +41,8 @@ javadoc {
 
 animalsniffer {
     // Don't check sourceSets.jmh
-    sourceSets = [sourceSets.main, sourceSets.test]
+    sourceSets = [
+        sourceSets.main,
+        sourceSets.test
+    ]
 }

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -7,9 +7,7 @@ buildscript {
         google()
         jcenter()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-    }
+    dependencies { classpath 'com.android.tools.build:gradle:3.0.1' }
 }
 
 allprojects {
@@ -30,22 +28,14 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
-        debug {
-            minifyEnabled false
-        }
+        debug { minifyEnabled false }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    testOptions {
-        unitTests {
-            includeAndroidResources = true
-        }
-    }
-    lintOptions {
-        disable 'InvalidPackage'
-    }
+    testOptions { unitTests { includeAndroidResources = true } }
+    lintOptions { disable 'InvalidPackage' }
 }
 
 dependencies {

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -14,9 +14,7 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
-        debug {
-            minifyEnabled false
-        }
+        debug { minifyEnabled false }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -30,25 +28,18 @@ android {
 }
 
 protobuf {
-    protoc {
-        artifact = 'com.google.protobuf:protoc:3.4.0'
-    }
+    protoc { artifact = 'com.google.protobuf:protoc:3.4.0' }
     plugins {
-        javalite {
-            artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0"
-        }
-        grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
             task.plugins {
                 javalite {}
-                grpc {
-                    // Options added to --grpc_out
-                    option 'lite'
-                }
+                grpc { // Options added to --grpc_out
+                    option 'lite' }
             }
         }
     }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -13,9 +13,7 @@ android {
         versionName "1.0"
     }
     buildTypes {
-        debug {
-            minifyEnabled false
-        }
+        debug { minifyEnabled false }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -29,25 +27,18 @@ android {
 }
 
 protobuf {
-    protoc {
-        artifact = 'com.google.protobuf:protoc:3.5.1-1'
-    }
+    protoc { artifact = 'com.google.protobuf:protoc:3.5.1-1' }
     plugins {
-        javalite {
-            artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0"
-        }
-        grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
             task.plugins {
                 javalite {}
-                grpc {
-                    // Options added to --grpc_out
-                    option 'lite'
-                }
+                grpc { // Options added to --grpc_out
+                    option 'lite' }
             }
         }
     }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -5,16 +5,14 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-    applicationId "io.grpc.routeguideexample"
+        applicationId "io.grpc.routeguideexample"
         minSdkVersion 14
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
     buildTypes {
-        debug {
-            minifyEnabled false
-        }
+        debug { minifyEnabled false }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -28,25 +26,18 @@ android {
 }
 
 protobuf {
-    protoc {
-        artifact = 'com.google.protobuf:protoc:3.5.1-1'
-    }
+    protoc { artifact = 'com.google.protobuf:protoc:3.5.1-1' }
     plugins {
-        javalite {
-            artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0"
-        }
-        grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
             task.plugins {
                 javalite {}
-                grpc {
-                    // Options added to --grpc_out
-                    option 'lite'
-                }
+                grpc { // Options added to --grpc_out
+                    option 'lite' }
             }
         }
     }

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -22,6 +22,4 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}
+task clean(type: Delete) { delete rootProject.buildDir }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -2,25 +2,19 @@ apply plugin: 'java'
 apply plugin: 'com.google.protobuf'
 
 buildscript {
-  repositories {
-    maven {
-      // The google mirror is less flaky than mavenCentral()
-      url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+    repositories {
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-  }
-  dependencies {
-    // ASSUMES GRADLE 2.12 OR HIGHER. Use plugin version 0.7.5 with earlier
-    // gradle versions
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
-  }
+    dependencies { // ASSUMES GRADLE 2.12 OR HIGHER. Use plugin version 0.7.5 with earlier
+        // gradle versions
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3' }
 }
 
 repositories {
-  maven {
-      // The google mirror is less flaky than mavenCentral()
-    url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-  }
-  mavenLocal()
+    maven { // The google mirror is less flaky than mavenCentral()
+        url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+    mavenLocal()
 }
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
@@ -34,37 +28,31 @@ def protobufVersion = '3.5.1'
 def protocVersion = '3.5.1-1'
 
 dependencies {
-  compile "com.google.api.grpc:proto-google-common-protos:1.0.0"
-  compile "io.grpc:grpc-alts:${grpcVersion}"
-  compile "io.grpc:grpc-netty:${grpcVersion}"
-  compile "io.grpc:grpc-protobuf:${grpcVersion}"
-  compile "io.grpc:grpc-stub:${grpcVersion}"
-  compileOnly "javax.annotation:javax.annotation-api:1.2"
+    compile "com.google.api.grpc:proto-google-common-protos:1.0.0"
+    compile "io.grpc:grpc-alts:${grpcVersion}"
+    compile "io.grpc:grpc-netty:${grpcVersion}"
+    compile "io.grpc:grpc-protobuf:${grpcVersion}"
+    compile "io.grpc:grpc-stub:${grpcVersion}"
+    compileOnly "javax.annotation:javax.annotation-api:1.2"
 
-  // Used for TLS in HelloWorldServerTls
-  compile "io.netty:netty-tcnative-boringssl-static:${nettyTcNativeVersion}"
+    // Used for TLS in HelloWorldServerTls
+    compile "io.netty:netty-tcnative-boringssl-static:${nettyTcNativeVersion}"
 
-  compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"
+    compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"
 
-  testCompile "io.grpc:grpc-testing:${grpcVersion}"
-  testCompile "junit:junit:4.12"
-  testCompile "org.mockito:mockito-core:1.9.5"
+    testCompile "io.grpc:grpc-testing:${grpcVersion}"
+    testCompile "junit:junit:4.12"
+    testCompile "org.mockito:mockito-core:1.9.5"
 }
 
 protobuf {
-  protoc {
-    artifact = "com.google.protobuf:protoc:${protocVersion}"
-  }
-  plugins {
-    grpc {
-      artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
+    protoc { artifact = "com.google.protobuf:protoc:${protocVersion}" }
+    plugins {
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
     }
-  }
-  generateProtoTasks {
-    all()*.plugins {
-      grpc {}
+    generateProtoTasks {
+        all()*.plugins { grpc {} }
     }
-  }
 }
 
 // Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
@@ -86,77 +74,77 @@ apply plugin: 'application'
 startScripts.enabled = false
 
 task routeGuideServer(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.routeguide.RouteGuideServer'
-  applicationName = 'route-guide-server'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.routeguide.RouteGuideServer'
+    applicationName = 'route-guide-server'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 task routeGuideClient(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.routeguide.RouteGuideClient'
-  applicationName = 'route-guide-client'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.routeguide.RouteGuideClient'
+    applicationName = 'route-guide-client'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 task helloWorldServer(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.helloworld.HelloWorldServer'
-  applicationName = 'hello-world-server'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.helloworld.HelloWorldServer'
+    applicationName = 'hello-world-server'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 task helloWorldClient(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.helloworld.HelloWorldClient'
-  applicationName = 'hello-world-client'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.helloworld.HelloWorldClient'
+    applicationName = 'hello-world-client'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 task helloWorldAltsServer(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.alts.HelloWorldAltsServer'
-  applicationName = 'hello-world-alts-server'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.alts.HelloWorldAltsServer'
+    applicationName = 'hello-world-alts-server'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 task helloWorldAltsClient(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.alts.HelloWorldAltsClient'
-  applicationName = 'hello-world-alts-client'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.alts.HelloWorldAltsClient'
+    applicationName = 'hello-world-alts-client'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 task helloWorldTlsServer(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.helloworldtls.HelloWorldServerTls'
-  applicationName = 'hello-world-tls-server'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.helloworldtls.HelloWorldServerTls'
+    applicationName = 'hello-world-tls-server'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 task helloWorldTlsClient(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.helloworldtls.HelloWorldClientTls'
-  applicationName = 'hello-world-tls-client'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.helloworldtls.HelloWorldClientTls'
+    applicationName = 'hello-world-tls-client'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 task compressingHelloWorldClient(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.experimental.CompressingHelloWorldClient'
-  applicationName = 'compressing-hello-world-client'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.experimental.CompressingHelloWorldClient'
+    applicationName = 'compressing-hello-world-client'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 applicationDistribution.into('bin') {
-  from(routeGuideServer)
-  from(routeGuideClient)
-  from(helloWorldServer)
-  from(helloWorldClient)
-  from(helloWorldAltsServer)
-  from(helloWorldAltsClient)
-  from(helloWorldTlsServer)
-  from(helloWorldTlsClient)
-  from(compressingHelloWorldClient)
-  fileMode = 0755
+    from(routeGuideServer)
+    from(routeGuideClient)
+    from(helloWorldServer)
+    from(helloWorldClient)
+    from(helloWorldAltsServer)
+    from(helloWorldAltsClient)
+    from(helloWorldTlsServer)
+    from(helloWorldTlsClient)
+    from(compressingHelloWorldClient)
+    fileMode = 0755
 }

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -15,9 +15,7 @@ android {
         versionName "1.0"
     }
     buildTypes {
-        debug {
-            minifyEnabled false
-        }
+        debug { minifyEnabled false }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -51,25 +49,18 @@ android {
 }
 
 protobuf {
-    protoc {
-        artifact = 'com.google.protobuf:protoc:3.5.1-1'
-    }
+    protoc { artifact = 'com.google.protobuf:protoc:3.5.1-1' }
     plugins {
-        javalite {
-            artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0"
-        }
-        grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
+        javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
             task.plugins {
                 javalite {}
-                grpc {
-                    // Options added to --grpc_out
-                    option 'lite'
-                }
+                grpc { // Options added to --grpc_out
+                    option 'lite' }
             }
         }
     }
@@ -86,6 +77,4 @@ dependencies {
     compile 'io.grpc:grpc-stub:1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 }
 
-repositories {
-    mavenCentral()
-}
+repositories { mavenCentral() }

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -13,21 +13,21 @@ apply plugin: 'application'
 
 
 buildscript {
-  ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.2.21'
 
-  repositories {
-    mavenCentral()
-    mavenLocal()
-  }
-  dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.5'
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-  }
+    repositories {
+        mavenCentral()
+        mavenLocal()
+    }
+    dependencies {
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.5'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
 }
 
 repositories {
-  mavenCentral()
-  mavenLocal()
+    mavenCentral()
+    mavenLocal()
 }
 
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
@@ -38,51 +38,45 @@ repositories {
 def grpcVersion = '1.14.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 
 dependencies {
-  compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-  compile "com.google.api.grpc:proto-google-common-protos:1.0.0"
-  compile "io.grpc:grpc-netty:${grpcVersion}"
-  compile "io.grpc:grpc-protobuf:${grpcVersion}"
-  compile "io.grpc:grpc-stub:${grpcVersion}"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    compile "com.google.api.grpc:proto-google-common-protos:1.0.0"
+    compile "io.grpc:grpc-netty:${grpcVersion}"
+    compile "io.grpc:grpc-protobuf:${grpcVersion}"
+    compile "io.grpc:grpc-stub:${grpcVersion}"
 
-  testCompile "io.grpc:grpc-testing:${grpcVersion}" // gRCP testing utilities
-  testCompile "junit:junit:4.12"
-  testCompile "org.mockito:mockito-core:1.9.5"
+    testCompile "io.grpc:grpc-testing:${grpcVersion}" // gRCP testing utilities
+    testCompile "junit:junit:4.12"
+    testCompile "org.mockito:mockito-core:1.9.5"
 }
 
 protobuf {
-  protoc {
-    artifact = 'com.google.protobuf:protoc:3.5.1-1'
-  }
-  plugins {
-    grpc {
-      artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
+    protoc { artifact = 'com.google.protobuf:protoc:3.5.1-1' }
+    plugins {
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
     }
-  }
-  generateProtoTasks {
-    all()*.plugins {
-      grpc {}
+    generateProtoTasks {
+        all()*.plugins { grpc {} }
     }
-  }
 }
 
 startScripts.enabled = false
 
 task helloWorldServer(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.helloworld.HelloWorldServer'
-  applicationName = 'hello-world-server'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.helloworld.HelloWorldServer'
+    applicationName = 'hello-world-server'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 task helloWorldClient(type: CreateStartScripts) {
-  mainClassName = 'io.grpc.examples.helloworld.HelloWorldClient'
-  applicationName = 'hello-world-client'
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+    mainClassName = 'io.grpc.examples.helloworld.HelloWorldClient'
+    applicationName = 'hello-world-client'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
 }
 
 applicationDistribution.into('bin') {
-  from(helloWorldServer)
-  from(helloWorldClient)
-  fileMode = 0755
+    from(helloWorldServer)
+    from(helloWorldClient)
+    fileMode = 0755
 }

--- a/gae-interop-testing/gae-jdk7/build.gradle
+++ b/gae-interop-testing/gae-jdk7/build.gradle
@@ -13,27 +13,25 @@
 //  limitations under the License.
 description = 'gRPC: gae interop testing (jdk7)'
 
-buildscript {    // Configuration for building
-  repositories {
-    jcenter()    // Bintray's repository - a fast Maven Central mirror & more
-    maven {
-      // The google mirror is less flaky than mavenCentral()
-      url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+buildscript {
+    // Configuration for building
+    repositories {
+        jcenter()    // Bintray's repository - a fast Maven Central mirror & more
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-  }
-  dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.5'
-    classpath 'com.squareup.okhttp:okhttp:2.5.0'
-  }
+    dependencies {
+        classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.5'
+        classpath 'com.squareup.okhttp:okhttp:2.5.0'
+    }
 }
 
-repositories {   // repositories for Jar's you access in your code
-  mavenLocal()
-  maven {
-    // The google mirror is less flaky than mavenCentral()
-    url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-  }
-  jcenter()
+repositories {
+    // repositories for Jar's you access in your code
+    mavenLocal()
+    maven { // The google mirror is less flaky than mavenCentral()
+        url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+    jcenter()
 }
 
 apply plugin: 'java'                              // standard Java tasks
@@ -41,34 +39,36 @@ apply plugin: 'war'                               // standard Web Archive plugin
 apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
-  providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-  compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
-  // Deps needed by all gRPC apps in GAE
-  compile libraries.google_api_protos
-  compile project(":grpc-okhttp")
-  compile project(":grpc-protobuf")
-  compile project(":grpc-stub")
-  compile (project(":grpc-interop-testing")) {
-    exclude group: 'io.opencensus', module: 'opencensus-impl'
-  }
-  // The lite version of opencensus is required for jdk7 GAE
-  runtime libraries.opencensus_impl_lite
+    providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
+    compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
+    // Deps needed by all gRPC apps in GAE
+    compile libraries.google_api_protos
+    compile project(":grpc-okhttp")
+    compile project(":grpc-protobuf")
+    compile project(":grpc-stub")
+    compile (project(":grpc-interop-testing")) {
+        exclude group: 'io.opencensus', module: 'opencensus-impl'
+    }
+    // The lite version of opencensus is required for jdk7 GAE
+    runtime libraries.opencensus_impl_lite
 }
 
 // [START model]
-appengine {  // App Engine tasks configuration
-  run {      // local (dev_appserver) configuration (standard environments only)
-    port = 8080                 // default
-  }
+appengine {
+    // App Engine tasks configuration
+    run {      // local (dev_appserver) configuration (standard environments only)
+        port = 8080                 // default
+    }
 
-  deploy {   // deploy configuration
-    // default - stop the current version
-    stopPreviousVersion = System.getProperty('gaeStopPreviousVersion') ?: true
-    // default - make this the current version
-    promote = System.getProperty('gaePromote') ?: true
-    // Use -DgaeDeployVersion if set, otherwise the version is null and the plugin will generate it
-    version = System.getProperty('gaeDeployVersion')
-  }
+    deploy {
+        // deploy configuration
+        // default - stop the current version
+        stopPreviousVersion = System.getProperty('gaeStopPreviousVersion') ?: true
+        // default - make this the current version
+        promote = System.getProperty('gaePromote') ?: true
+        // Use -DgaeDeployVersion if set, otherwise the version is null and the plugin will generate it
+        version = System.getProperty('gaeDeployVersion')
+    }
 }
 // [END model]
 
@@ -80,65 +80,69 @@ targetCompatibility = 1.7
 
 /** Returns the service name. */
 String getGaeProject() {
-  def stream = new ByteArrayOutputStream()
-  exec {
-    executable 'gcloud'
-    args = ['config', 'get-value', 'project']
-    standardOutput = stream
-  }
-  return stream.toString().trim()
+    def stream = new ByteArrayOutputStream()
+    exec {
+        executable 'gcloud'
+        args = [
+            'config',
+            'get-value',
+            'project'
+        ]
+        standardOutput = stream
+    }
+    return stream.toString().trim()
 }
 
 String getService(java.nio.file.Path projectPath) {
-  Node xml = new XmlParser().parse(projectPath.resolve("src/main/webapp/WEB-INF/appengine-web.xml").toFile())
-  if (xml.service.isEmpty()) {
-    return null
-  } else {
-    return xml.service.text()
-  }
+    Node xml = new XmlParser().parse(projectPath.resolve("src/main/webapp/WEB-INF/appengine-web.xml").toFile())
+    if (xml.service.isEmpty()) {
+        return null
+    } else {
+        return xml.service.text()
+    }
 }
 
 String getAppUrl(String project, String service, String version) {
-  if (version != null && service != null) {
-    return "http://${version}.${service}.${project}.appspot.com"
-  } else {
-    return "http://${project}.appspot.com"
-  }
+    if (version != null && service != null) {
+        return "http://${version}.${service}.${project}.appspot.com"
+    } else {
+        return "http://${project}.appspot.com"
+    }
 }
 
 task runInteropTestRemote(dependsOn: 'appengineDeploy') {
-  doLast {
-    // give remote app some time to settle down
-    sleep(20000)
+    doLast {
+        // give remote app some time to settle down
+        sleep(20000)
 
-    def appUrl = getAppUrl(
-            getGaeProject(),
-            getService(project.getProjectDir().toPath()),
-            System.getProperty('gaeDeployVersion'))
-    logger.log(LogLevel.INFO, "the appURL=" + appUrl)
-    def client = new com.squareup.okhttp.OkHttpClient()
-    // The test suite can take a while to run
-    client.setReadTimeout(3, java.util.concurrent.TimeUnit.MINUTES)
-    // The '?jdk8' argument is ignored by the server, it exists only to tag the request log entry
-    def interopRequest = new com.squareup.okhttp.Request.Builder()
-            .url("${appUrl}/?jdk7").build()
+        def appUrl = getAppUrl(
+                getGaeProject(),
+                getService(project.getProjectDir().toPath()),
+                System.getProperty('gaeDeployVersion'))
+        logger.log(LogLevel.INFO, "the appURL=" + appUrl)
+        def client = new com.squareup.okhttp.OkHttpClient()
+        // The test suite can take a while to run
+        client.setReadTimeout(3, java.util.concurrent.TimeUnit.MINUTES)
+        // The '?jdk8' argument is ignored by the server, it exists only to tag the request log entry
+        def interopRequest = new com.squareup.okhttp.Request.Builder()
+                .url("${appUrl}/?jdk7").build()
 
-    // Retry in case GAE is slow and times out
-    int maxRetries = 5
-    String result = null
-    Throwable caught = null
-    for (int attempt = 0; attempt < maxRetries; attempt++) {
-      try {
-        def response = client.newCall(interopRequest).execute()
-        result = response.body().string()
-        if (response.code() == 200) {
-          return
+        // Retry in case GAE is slow and times out
+        int maxRetries = 5
+        String result = null
+        Throwable caught = null
+        for (int attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                def response = client.newCall(interopRequest).execute()
+                result = response.body().string()
+                if (response.code() == 200) {
+                    return
+                }
+            } catch (Throwable t) {
+                caught = t
+                logger.log(LogLevel.ERROR, "caught exception. will retry if possible", t)
+            }
         }
-      } catch (Throwable t) {
-        caught = t
-        logger.log(LogLevel.ERROR, "caught exception. will retry if possible", t)
-      }
+        throw new GradleException("Interop test failed:\nresponse: ${result}\nthrowable:${caught}")
     }
-    throw new GradleException("Interop test failed:\nresponse: ${result}\nthrowable:${caught}")
-  }
 }

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -13,27 +13,25 @@
 //  limitations under the License.
 description = 'gRPC: gae interop testing (jdk8)'
 
-buildscript {    // Configuration for building
-  repositories {
-    jcenter()    // Bintray's repository - a fast Maven Central mirror & more
-    maven {
-      // The google mirror is less flaky than mavenCentral()
-      url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
+buildscript {
+    // Configuration for building
+    repositories {
+        jcenter()    // Bintray's repository - a fast Maven Central mirror & more
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-  }
-  dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.5'
-    classpath 'com.squareup.okhttp:okhttp:2.5.0'
-  }
+    dependencies {
+        classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.5'
+        classpath 'com.squareup.okhttp:okhttp:2.5.0'
+    }
 }
 
-repositories {   // repositories for Jar's you access in your code
-  mavenLocal()
-  maven {
-    // The google mirror is less flaky than mavenCentral()
-    url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-  }
-  jcenter()
+repositories {
+    // repositories for Jar's you access in your code
+    mavenLocal()
+    maven { // The google mirror is less flaky than mavenCentral()
+        url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+    jcenter()
 }
 
 apply plugin: 'java'                              // standard Java tasks
@@ -41,31 +39,33 @@ apply plugin: 'war'                               // standard Web Archive plugin
 apply plugin: 'com.google.cloud.tools.appengine'  // App Engine tasks
 
 dependencies {
-  providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-  compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
-  // Deps needed by all gRPC apps in GAE
-  compile libraries.google_api_protos
-  compile project(":grpc-okhttp")
-  compile project(":grpc-protobuf")
-  compile project(":grpc-stub")
-  compile project(":grpc-interop-testing")
-  compile libraries.netty_tcnative
+    providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
+    compile 'com.google.appengine:appengine-api-1.0-sdk:1.9.59'
+    // Deps needed by all gRPC apps in GAE
+    compile libraries.google_api_protos
+    compile project(":grpc-okhttp")
+    compile project(":grpc-protobuf")
+    compile project(":grpc-stub")
+    compile project(":grpc-interop-testing")
+    compile libraries.netty_tcnative
 }
 
 // [START model]
-appengine {  // App Engine tasks configuration
-  run {      // local (dev_appserver) configuration (standard environments only)
-    port = 8080                 // default
-  }
+appengine {
+    // App Engine tasks configuration
+    run {      // local (dev_appserver) configuration (standard environments only)
+        port = 8080                 // default
+    }
 
-  deploy {   // deploy configuration
-    // default - stop the current version
-    stopPreviousVersion = System.getProperty('gaeStopPreviousVersion') ?: true
-    // default - make this the current version
-    promote = System.getProperty('gaePromote') ?: true
-    // Use -DgaeDeployVersion if set, otherwise the version is null and the plugin will generate it
-    version = System.getProperty('gaeDeployVersion')
-  }
+    deploy {
+        // deploy configuration
+        // default - stop the current version
+        stopPreviousVersion = System.getProperty('gaeStopPreviousVersion') ?: true
+        // default - make this the current version
+        promote = System.getProperty('gaePromote') ?: true
+        // Use -DgaeDeployVersion if set, otherwise the version is null and the plugin will generate it
+        version = System.getProperty('gaeDeployVersion')
+    }
 }
 // [END model]
 
@@ -77,75 +77,79 @@ targetCompatibility = 1.8
 
 /** Returns the service name. */
 String getGaeProject() {
-  def stream = new ByteArrayOutputStream()
-  exec {
-    executable 'gcloud'
-    args = ['config', 'get-value', 'project']
-    standardOutput = stream
-  }
-  return stream.toString().trim()
+    def stream = new ByteArrayOutputStream()
+    exec {
+        executable 'gcloud'
+        args = [
+            'config',
+            'get-value',
+            'project'
+        ]
+        standardOutput = stream
+    }
+    return stream.toString().trim()
 }
 
 String getService(java.nio.file.Path projectPath) {
-  Node xml = new XmlParser().parse(projectPath.resolve("src/main/webapp/WEB-INF/appengine-web.xml").toFile())
-  if (xml.service.isEmpty()) {
-    return null
-  } else {
-    return xml.service.text()
-  }
+    Node xml = new XmlParser().parse(projectPath.resolve("src/main/webapp/WEB-INF/appengine-web.xml").toFile())
+    if (xml.service.isEmpty()) {
+        return null
+    } else {
+        return xml.service.text()
+    }
 }
 
 String getAppUrl(String project, String service, String version) {
-  if (version != null && service != null) {
-    return "http://${version}.${service}.${project}.appspot.com"
-  } else {
-    return "http://${project}.appspot.com"
-  }
+    if (version != null && service != null) {
+        return "http://${version}.${service}.${project}.appspot.com"
+    } else {
+        return "http://${project}.appspot.com"
+    }
 }
 
 task runInteropTestRemote(dependsOn: 'appengineDeploy') {
-  doLast {
-    // give remote app some time to settle down
-    sleep(20000)
+    doLast {
+        // give remote app some time to settle down
+        sleep(20000)
 
-    def appUrl = getAppUrl(
-            getGaeProject(),
-            getService(project.getProjectDir().toPath()),
-            System.getProperty('gaeDeployVersion'))
-    logger.log(LogLevel.INFO, "the appURL=" + appUrl)
-    def client = new com.squareup.okhttp.OkHttpClient()
-    // The '?jdk8' argument is ignored by the server, it exists only to tag the request log entry
-    client.setReadTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
-    def request = new com.squareup.okhttp.Request.Builder()
-            .url("${appUrl}/long_lived_channel?jdk8").build()
-    def result1 = client.newCall(request).execute()
-    def result2 = client.newCall(request).execute()
-    if (result1.code() != 200 || result2.code() != 200) {
-      throw new GradleException("Unable to reuse same channel across requests")
-    }
-
-    // The test suite can take a while to run
-    client.setReadTimeout(3, java.util.concurrent.TimeUnit.MINUTES)
-    // The '?jdk8' argument is ignored by the server, it exists only to tag the request log entry
-    def interopRequest = new com.squareup.okhttp.Request.Builder()
-            .url("${appUrl}/?jdk8").build()
-
-    // Retry in case GAE is slow and times out
-    int maxRetries = 5
-    String result = null
-    Throwable caught = null
-    for (int attempt = 0; attempt < maxRetries; attempt++) {
-      try {
-        def response = client.newCall(interopRequest).execute()
-        result = response.body().string()
-        if (response.code() == 200) {
-          return
+        def appUrl = getAppUrl(
+                getGaeProject(),
+                getService(project.getProjectDir().toPath()),
+                System.getProperty('gaeDeployVersion'))
+        logger.log(LogLevel.INFO, "the appURL=" + appUrl)
+        def client = new com.squareup.okhttp.OkHttpClient()
+        // The '?jdk8' argument is ignored by the server, it exists only to tag the request log entry
+        client.setReadTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+        def request = new com.squareup.okhttp.Request.Builder()
+                .url("${appUrl}/long_lived_channel?jdk8").build()
+        def result1 = client.newCall(request).execute()
+        def result2 = client.newCall(request).execute()
+        if (result1.code() != 200 || result2.code() != 200) {
+            throw new GradleException("Unable to reuse same channel across requests")
         }
-      } catch (Throwable t) {
-        caught = t
-        logger.log(LogLevel.ERROR, "caught exception. will retry if possible", t)
-      }
+
+        // The test suite can take a while to run
+        client.setReadTimeout(3, java.util.concurrent.TimeUnit.MINUTES)
+        // The '?jdk8' argument is ignored by the server, it exists only to tag the request log entry
+        def interopRequest = new com.squareup.okhttp.Request.Builder()
+                .url("${appUrl}/?jdk8").build()
+
+        // Retry in case GAE is slow and times out
+        int maxRetries = 5
+        String result = null
+        Throwable caught = null
+        for (int attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                def response = client.newCall(interopRequest).execute()
+                result = response.body().string()
+                if (response.code() == 200) {
+                    return
+                }
+            } catch (Throwable t) {
+                caught = t
+                logger.log(LogLevel.ERROR, "caught exception. will retry if possible", t)
+            }
+        }
+        throw new GradleException("Interop test failed:\nresponse: ${result}\nthrowable:${caught}")
     }
-    throw new GradleException("Interop test failed:\nresponse: ${result}\nthrowable:${caught}")
-  }
 }

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -2,14 +2,10 @@ description = "gRPC: GRPCLB LoadBalancer plugin"
 
 buildscript {
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-    dependencies {
-        classpath libraries.protobuf_plugin
-    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 dependencies {
@@ -23,7 +19,7 @@ dependencies {
     }
     compileOnly libraries.javax_annotation
     testCompile libraries.truth,
-                project(':grpc-core').sourceSets.test.output
+            project(':grpc-core').sourceSets.test.output
 }
 
 configureProtoCompilation()

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -5,15 +5,11 @@ startScripts.enabled = false
 
 // Add dependency on the protobuf plugin
 buildscript {
-  repositories {
-      maven {
-          // The google mirror is less flaky than mavenCentral()
-          url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-      }
-  }
-  dependencies {
-    classpath libraries.protobuf_plugin
-  }
+    repositories {
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
+    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 dependencies {
@@ -53,12 +49,12 @@ test {
 task test_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.TestServiceClient"
     applicationName = "test-client"
-    defaultJvmOpts = ["-javaagent:JAVAAGENT_APP_HOME" + configurations.alpnagent.singleFile.name]
+    defaultJvmOpts = [
+        "-javaagent:JAVAAGENT_APP_HOME" + configurations.alpnagent.singleFile.name
+    ]
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + configurations.runtime
-    dependencies {
-        runtime configurations.alpnagent
-    }
+    dependencies { runtime configurations.alpnagent }
     doLast {
         unixScript.text = unixScript.text.replace('JAVAAGENT_APP_HOME', '\$APP_HOME/lib/')
         windowsScript.text = windowsScript.text.replace('JAVAAGENT_APP_HOME', '%APP_HOME%\\lib\\')
@@ -84,7 +80,10 @@ task stresstest_client(type: CreateStartScripts) {
     applicationName = "stresstest-client"
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + configurations.runtime
-    defaultJvmOpts = ["-verbose:gc", "-XX:+PrintFlagsFinal"]
+    defaultJvmOpts = [
+        "-verbose:gc",
+        "-XX:+PrintFlagsFinal"
+    ]
 }
 
 task http2_client(type: CreateStartScripts) {

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -6,16 +6,18 @@ dependencies {
 
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
-                project(':grpc-testing'),
-                project(':grpc-testing-proto')
+            project(':grpc-testing'),
+            project(':grpc-testing-proto')
     testRuntime libraries.netty_tcnative,
-                libraries.conscrypt
+            libraries.conscrypt
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
 [compileJava, compileTestJava].each() {
-  // Netty retuns a lot of futures that we mostly don't care about.
-  it.options.compilerArgs += ["-Xep:FutureReturnValueIgnored:OFF"]
+    // Netty retuns a lot of futures that we mostly don't care about.
+    it.options.compilerArgs += [
+        "-Xep:FutureReturnValueIgnored:OFF"
+    ]
 }
 
 javadoc {
@@ -24,11 +26,7 @@ javadoc {
 }
 
 project.sourceSets {
-    main {
-        java {
-            srcDir "${projectDir}/third_party/netty/java"
-        }
-    }
+    main { java { srcDir "${projectDir}/third_party/netty/java" } }
 }
 
 test {

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -1,36 +1,28 @@
 buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
-    }
+    repositories { jcenter() }
+    dependencies { classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2' }
 }
 
 apply plugin: 'com.github.johnrengelman.shadow'
 
 description = "gRPC: Netty Shaded"
 
-sourceSets {
-    testShadow {}
-}
+sourceSets { testShadow {} }
 
 dependencies {
     compile project(':grpc-netty')
     runtime libraries.netty_tcnative
     testShadowCompile files(shadowJar),
-                      configurations.shadow,
-                      project(':grpc-testing-proto'),
-                      project(':grpc-testing'),
-                      libraries.truth
+            configurations.shadow,
+            project(':grpc-testing-proto'),
+            project(':grpc-testing'),
+            libraries.truth
     shadow project(':grpc-core')
 }
 
-artifacts {
-    // We want uploadArchives to handle the shadowJar; we don't care about
+artifacts { // We want uploadArchives to handle the shadowJar; we don't care about
     // uploadShadow
-    archives shadowJar
-}
+    archives shadowJar }
 
 shadowJar {
     classifier = null

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -6,22 +6,14 @@ dependencies {
 
     // Tests depend on base class defined by core module.
     testCompile project(':grpc-core').sourceSets.test.output,
-                project(':grpc-testing'),
-                project(':grpc-netty')
+            project(':grpc-testing'),
+            project(':grpc-netty')
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
 
 project.sourceSets {
-    main {
-        java {
-            srcDir "${projectDir}/third_party/okhttp/main/java"
-        }
-    }
-    test {
-        java {
-            srcDir "${projectDir}/third_party/okhttp/test/java"
-        }
-    }
+    main { java { srcDir "${projectDir}/third_party/okhttp/main/java" } }
+    test { java { srcDir "${projectDir}/third_party/okhttp/test/java" } }
 }
 
 checkstyleMain.exclude '**/io/grpc/okhttp/internal/**'

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -1,14 +1,10 @@
 buildscript {
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
         mavenLocal()
     }
-    dependencies {
-        classpath libraries.protobuf_plugin
-    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 apply plugin: 'com.google.protobuf'
@@ -26,36 +22,36 @@ dependencies {
 }
 
 compileTestJava {
-  // Protobuf-generated Lite produces quite a few warnings.
-  options.compilerArgs += ["-Xlint:-rawtypes", "-Xlint:-unchecked", "-Xlint:-fallthrough",
-        "-XepExcludedPaths:.*/build/generated/source/proto/.*"]
+    // Protobuf-generated Lite produces quite a few warnings.
+    options.compilerArgs += [
+        "-Xlint:-rawtypes",
+        "-Xlint:-unchecked",
+        "-Xlint:-fallthrough",
+        "-XepExcludedPaths:.*/build/generated/source/proto/.*"
+    ]
 }
 
 protobuf {
-  protoc {
-    if (project.hasProperty('protoc')) {
-      path = project.protoc
-    } else {
-      artifact = "com.google.protobuf:protoc:${protocVersion}"
+    protoc {
+        if (project.hasProperty('protoc')) {
+            path = project.protoc
+        } else {
+            artifact = "com.google.protobuf:protoc:${protocVersion}"
+        }
     }
-  }
-  plugins {
-    javalite {
-      if (project.hasProperty('protoc-gen-javalite')) {
-        path = project['protoc-gen-javalite']
-      } else {
-        artifact = libraries.protoc_lite
-      }
+    plugins {
+        javalite {
+            if (project.hasProperty('protoc-gen-javalite')) {
+                path = project['protoc-gen-javalite']
+            } else {
+                artifact = libraries.protoc_lite
+            }
+        }
     }
-  }
-  generateProtoTasks {
-    ofSourceSet('test')*.each { task ->
-      task.builtins {
-        remove java
-      }
-      task.plugins {
-        javalite {}
-      }
+    generateProtoTasks {
+        ofSourceSet('test')*.each { task ->
+            task.builtins { remove java }
+            task.plugins { javalite {} }
+        }
     }
-  }
 }

--- a/protobuf-nano/build.gradle
+++ b/protobuf-nano/build.gradle
@@ -1,14 +1,10 @@
 // Add dependency on the protobuf plugin
 buildscript {
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-    dependencies {
-        classpath libraries.protobuf_plugin
-    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 description = 'gRPC: Protobuf Nano'
@@ -23,16 +19,14 @@ dependencies {
 configureProtoCompilation()
 
 if (project.hasProperty('protobuf')) {
-  protobuf {
-    generateProtoTasks {
-      all().each { task ->
-        task.builtins {
-          remove java
-          javanano {
-            option 'ignore_services=true'
-          }
+    protobuf {
+        generateProtoTasks {
+            all().each { task ->
+                task.builtins {
+                    remove java
+                    javanano { option 'ignore_services=true' }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -2,14 +2,10 @@ description = 'gRPC: Protobuf'
 
 buildscript {
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-    dependencies {
-        classpath libraries.protobuf_plugin
-    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 dependencies {

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,14 +1,10 @@
 // Add dependency on the protobuf plugin
 buildscript {
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-    dependencies {
-        classpath libraries.protobuf_plugin
-    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 description = "gRPC: Services"

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,8 +42,8 @@ project(':grpc-benchmarks').projectDir = "$rootDir/benchmarks" as File
 project(':grpc-services').projectDir = "$rootDir/services" as File
 
 if (settings.hasProperty('skipCodegen') && skipCodegen.toBoolean()) {
-  println '*** Skipping the build of codegen and compilation of proto files because skipCodegen=true'
+    println '*** Skipping the build of codegen and compilation of proto files because skipCodegen=true'
 } else {
-  include ":grpc-compiler"
-  project(':grpc-compiler').projectDir = "$rootDir/compiler" as File
+    include ":grpc-compiler"
+    project(':grpc-compiler').projectDir = "$rootDir/compiler" as File
 }

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -2,7 +2,7 @@ description = "gRPC: Stub"
 dependencies {
     compile project(':grpc-core')
     testCompile libraries.truth,
-    project(':grpc-testing')
+            project(':grpc-testing')
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }
 

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -3,14 +3,10 @@ description = "gRPC: Testing Protos"
 // Add dependency on the protobuf plugin
 buildscript {
     repositories {
-        maven {
-            // The google mirror is less flaky than mavenCentral()
-            url "https://maven-central.storage-download.googleapis.com/repos/central/data/"
-        }
+        maven { // The google mirror is less flaky than mavenCentral()
+            url "https://maven-central.storage-download.googleapis.com/repos/central/data/" }
     }
-    dependencies {
-        classpath libraries.protobuf_plugin
-    }
+    dependencies { classpath libraries.protobuf_plugin }
 }
 
 dependencies {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -17,9 +17,7 @@ dependencies {
     compileOnly libraries.truth
 
     testCompile project(':grpc-testing-proto'),
-                project(':grpc-core').sourceSets.test.output
+            project(':grpc-core').sourceSets.test.output
 }
 
-javadoc {
-  exclude 'io/grpc/internal/**'
-}
+javadoc { exclude 'io/grpc/internal/**' }


### PR DESCRIPTION
This PR adds an automatic gradle format checker and reformats all the *.gradle files. After this, new changes to *.gradle files will fail to build if not in good format, just like checkStyle failure.

commit 1 adds the [spotless formatter plugin](https://github.com/diffplug/spotless/tree/master/plugin-gradle).
commit 2 applies the formatter task.


