### PR TITLE
 Add (Client|Server)Call#cork method. 

### DIFF
--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -17,7 +17,6 @@
 package io.grpc;
 
 import com.google.errorprone.annotations.DoNotMock;
-import io.grpc.internal.ClientStream;
 import javax.annotation.Nullable;
 
 /**
@@ -256,15 +255,16 @@ public abstract class ClientCall<ReqT, RespT> {
   }
 
   /**
-   * Defers flushing the messages written using {@link #sendMessage(Object)} to the
-   * transport until the write buffer is full. The amount of data buffered while corked is
-   * dependent on the transport implementation so users of this API should not make strong
-   * assumptions about how long data is buffered while corked.
+   * Defers flushing the messages written using {@link #sendMessage(Object)} until the cork is
+   * closed or as necessary to prevent excessive buffering. The amount of data buffered while
+   * corked is dependent on the transport implementation so users of this API should not make
+   * strong assumptions about how long data is buffered while corked.
    *
    * <p>Corking can provide throughput gains by allowing a transport to perform fewer writes to
    * the underlying network.
    *
-   * <p>The {@link ClientStream#flush()} is being deferred until all opened corks are closed.
+   * <p>In case of multiple {@link Cork}s being open, all of them need to be closed in order to
+   * trigger flushing.
    *
    * @since 1.14.0
    */

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -255,6 +255,20 @@ public abstract class ClientCall<ReqT, RespT> {
   }
 
   /**
+   * Defers flushing the messages written using {@link #sendMessage(Object)} to the
+   * transport until the write buffer is full. The amount of data buffered while corked is
+   * dependent on the transport implementation so users of this API should not make strong
+   * assumptions about how long data is buffered while corked.
+   *
+   * <p>Corking can provide throughput gains by allowing a transport to perform fewer writes to
+   * the underlying network.
+   */
+  @ExperimentalApi
+  public Cork cork() {
+    return new Cork.NoopCork();
+  }
+
+  /**
    * Returns additional properties of the call. May only be called after {@link Listener#onHeaders}
    * or {@link Listener#onClose}. If called prematurely, the implementation may throw {@code
    * IllegalStateException} or return arbitrary {@code Attributes}.
@@ -268,4 +282,5 @@ public abstract class ClientCall<ReqT, RespT> {
   public Attributes getAttributes() {
     return Attributes.EMPTY;
   }
+
 }

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import com.google.errorprone.annotations.DoNotMock;
+import io.grpc.internal.ClientStream;
 import javax.annotation.Nullable;
 
 /**
@@ -262,6 +263,10 @@ public abstract class ClientCall<ReqT, RespT> {
    *
    * <p>Corking can provide throughput gains by allowing a transport to perform fewer writes to
    * the underlying network.
+   *
+   * <p>The {@link ClientStream#flush()} is being deferred until all opened corks are closed.
+   *
+   * @since 1.14.0
    */
   @ExperimentalApi
   public Cork cork() {

--- a/core/src/main/java/io/grpc/Cork.java
+++ b/core/src/main/java/io/grpc/Cork.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import java.io.Closeable;
+
+/**
+ * Defers flushing the messages written using {@link ClientCall#sendMessage(Object)} and
+ * {@link ServerCall#sendMessage(Object)} transport until the write buffer is full.
+ * The amount of data buffered while corked is dependent on the transport implementation
+ * so users of this API should not make strong assumptions about how long data is buffered while
+ * corked.
+ *
+ * <p>Corking can provide throughput gains by allowing a transport to perform fewer writes to
+ * the underlying network.
+ */
+public interface Cork extends Closeable {
+
+  /**
+   * No-Op implementation of {@link Cork} interface.
+   */
+  class NoopCork implements Cork {
+
+    @Override
+    public void close() {
+      // noop
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/Cork.java
+++ b/core/src/main/java/io/grpc/Cork.java
@@ -28,6 +28,7 @@ import java.io.Closeable;
  * <p>Corking can provide throughput gains by allowing a transport to perform fewer writes to
  * the underlying network.
  */
+@ExperimentalApi
 public interface Cork extends Closeable {
 
   /**
@@ -40,4 +41,7 @@ public interface Cork extends Closeable {
       // noop
     }
   }
+
+  @Override
+  void close();
 }

--- a/core/src/main/java/io/grpc/PartialForwardingClientCall.java
+++ b/core/src/main/java/io/grpc/PartialForwardingClientCall.java
@@ -50,6 +50,11 @@ abstract class PartialForwardingClientCall<ReqT, RespT> extends ClientCall<ReqT,
   }
 
   @Override
+  public Cork cork() {
+    return delegate().cork();
+  }
+
+  @Override
   public boolean isReady() {
     return delegate().isReady();
   }

--- a/core/src/main/java/io/grpc/PartialForwardingServerCall.java
+++ b/core/src/main/java/io/grpc/PartialForwardingServerCall.java
@@ -66,6 +66,11 @@ abstract class PartialForwardingServerCall<ReqT, RespT> extends ServerCall<ReqT,
   }
 
   @Override
+  public Cork cork() {
+    return delegate().cork();
+  }
+
+  @Override
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1779")
   public Attributes getAttributes() {
     return delegate().getAttributes();

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -189,6 +189,20 @@ public abstract class ServerCall<ReqT, RespT> {
   }
 
   /**
+   * Defers flushing the messages written using {@link #sendMessage(Object)} to the
+   * transport until the write buffer is full. The amount of data buffered while corked is
+   * dependent on the transport implementation so users of this API should not make strong
+   * assumptions about how long data is buffered while corked.
+   *
+   * <p>Corking can provide throughput gains by allowing a transport to perform fewer writes to
+   * the underlying network.
+   */
+  @ExperimentalApi
+  public Cork cork() {
+    return new Cork.NoopCork();
+  }
+
+  /**
    * Returns properties of a single call.
    *
    * <p>Attributes originate from the transport and can be altered by {@link ServerTransportFilter}.

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -17,7 +17,6 @@
 package io.grpc;
 
 import com.google.errorprone.annotations.DoNotMock;
-import io.grpc.internal.ServerStream;
 import javax.annotation.Nullable;
 
 /**
@@ -190,15 +189,16 @@ public abstract class ServerCall<ReqT, RespT> {
   }
 
   /**
-   * Defers flushing the messages written using {@link #sendMessage(Object)} to the
-   * transport until the write buffer is full. The amount of data buffered while corked is
-   * dependent on the transport implementation so users of this API should not make strong
-   * assumptions about how long data is buffered while corked.
+   * Defers flushing the messages written using {@link #sendMessage(Object)} until the cork is
+   * closed or as necessary to prevent excessive buffering. The amount of data buffered while
+   * corked is dependent on the transport implementation so users of this API should not make
+   * strong assumptions about how long data is buffered while corked.
    *
    * <p>Corking can provide throughput gains by allowing a transport to perform fewer writes to
    * the underlying network.
    *
-   * <p>The {@link ServerStream#flush()} is being deferred until all opened corks are closed.
+   * <p>In case of multiple {@link Cork}s being open, all of them need to be closed in order to
+   * trigger flushing.
    *
    * @since 1.14.0
    */

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import com.google.errorprone.annotations.DoNotMock;
+import io.grpc.internal.ServerStream;
 import javax.annotation.Nullable;
 
 /**
@@ -196,6 +197,10 @@ public abstract class ServerCall<ReqT, RespT> {
    *
    * <p>Corking can provide throughput gains by allowing a transport to perform fewer writes to
    * the underlying network.
+   *
+   * <p>The {@link ServerStream#flush()} is being deferred until all opened corks are closed.
+   *
+   * @since 1.14.0
    */
   @ExperimentalApi
   public Cork cork() {

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -30,6 +30,7 @@ import static java.lang.Math.max;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.Sets;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
@@ -38,6 +39,7 @@ import io.grpc.Compressor;
 import io.grpc.CompressorRegistry;
 import io.grpc.Context;
 import io.grpc.Context.CancellationListener;
+import io.grpc.Cork;
 import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.InternalDecompressorRegistry;
@@ -48,6 +50,7 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -84,6 +87,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
   private boolean fullStreamDecompression;
   private DecompressorRegistry decompressorRegistry = DecompressorRegistry.getDefaultInstance();
   private CompressorRegistry compressorRegistry = CompressorRegistry.getDefaultInstance();
+  private final Set<Cork> corks = Sets.newConcurrentHashSet();
 
   ClientCallImpl(
       MethodDescriptor<ReqT, RespT> method, Executor executor, CallOptions callOptions,
@@ -431,7 +435,7 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     // For unary requests, we don't flush since we know that halfClose should be coming soon. This
     // allows us to piggy-back the END_STREAM=true on the last message frame without opening the
     // possibility of broken applications forgetting to call halfClose without noticing.
-    if (!unaryRequest) {
+    if (!unaryRequest && corks.size() == 0) {
       stream.flush();
     }
   }
@@ -440,6 +444,22 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
   public void setMessageCompression(boolean enabled) {
     checkState(stream != null, "Not started");
     stream.setMessageCompression(enabled);
+  }
+
+  @Override
+  public Cork cork() {
+    final Cork cork = new Cork() {
+
+      @Override
+      public void close() {
+        checkState(corks.remove(this), "cork already closed");
+        if (corks.size() == 0) {
+          stream.flush();
+        }
+      }
+    };
+    checkState(corks.add(cork), "unable to add cork");
+    return cork;
   }
 
   @Override


### PR DESCRIPTION
Hi, this is a follow up for abandoned #994 and #996. This should allow user to trade-off latency for throughput.

We ended up doing manual batching on client side, which adds complexity to the client app.