### PR TITLE
Issue 4515: SSLHandshakeException when using ClientAuth.REQUIRE with two hosts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -289,8 +289,8 @@ NettyChannelBuilder or OkHttpChannelBuilder, respectively.
 ```java
 Server server = NettyServerBuilder.forPort(8443)
     .sslContext(GrpcSslContexts.forServer(certChainFile, privateKeyFile)
-        .trustManager(clientCertChainFile)
-        .clientAuth(ClientAuth.OPTIONAL)
+        .trustManager(clientCAsFile)
+        .clientAuth(ClientAuth.REQUIRE)
         .build());
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,8 +40,8 @@ Running the hello world with TLS is the same as the normal hello world, but take
 **hello-world-tls-server**:
 
 ```text
-USAGE: HelloWorldServerTls host port certChainFilePath privateKeyFilePath [clientCertChainFilePath]
-  Note: You only need to supply clientCertChainFilePath if you want to enable Mutual TLS.
+USAGE: HelloWorldServerTls host port certChainFilePath privateKeyFilePath [trustCertCollectionFilePath]
+  Note: You only need to supply trustCertCollectionFilePath if you want to enable Mutual TLS.
 ```
 
 **hello-world-tls-client**:
@@ -103,7 +103,7 @@ openssl pkcs8 -topk8 -nocrypt -in server.key -out server.pem
 
 ```bash
 # Server
-./build/install/examples/bin/hello-world-server-tls mate 54440 ~/Downloads/sslcert/server.crt ~/Downloads/sslcert/server.pem ~/Downloads/sslcert/client.crt
+./build/install/examples/bin/hello-world-server-tls mate 54440 ~/Downloads/sslcert/server.crt ~/Downloads/sslcert/server.pem ~/Downloads/sslcert/ca.crt
 # Client
 ./build/install/examples/bin/hello-world-client-tls mate 54440 ~/Downloads/sslcert/ca.crt ~/Downloads/sslcert/client.crt ~/Downloads/sslcert/client.pem
 ```

--- a/examples/src/main/java/io/grpc/examples/helloworldtls/HelloWorldServerTls.java
+++ b/examples/src/main/java/io/grpc/examples/helloworldtls/HelloWorldServerTls.java
@@ -44,26 +44,26 @@ public class HelloWorldServerTls {
     private final int port;
     private final String certChainFilePath;
     private final String privateKeyFilePath;
-    private final String clientCertChainFilePath;
+    private final String trustCertCollectionFilePath;
 
     public HelloWorldServerTls(String host,
                                int port,
                                String certChainFilePath,
                                String privateKeyFilePath,
-                               String clientCertChainFilePath) {
+                               String trustCertCollectionFilePath) {
         this.host = host;
         this.port = port;
         this.certChainFilePath = certChainFilePath;
         this.privateKeyFilePath = privateKeyFilePath;
-        this.clientCertChainFilePath = clientCertChainFilePath;
+        this.trustCertCollectionFilePath = trustCertCollectionFilePath;
     }
 
     private SslContextBuilder getSslContextBuilder() {
         SslContextBuilder sslClientContextBuilder = SslContextBuilder.forServer(new File(certChainFilePath),
                 new File(privateKeyFilePath));
-        if (clientCertChainFilePath != null) {
-            sslClientContextBuilder.trustManager(new File(clientCertChainFilePath));
-            sslClientContextBuilder.clientAuth(ClientAuth.OPTIONAL);
+        if (trustCertCollectionFilePath != null) {
+            sslClientContextBuilder.trustManager(new File(trustCertCollectionFilePath));
+            sslClientContextBuilder.clientAuth(ClientAuth.REQUIRE);
         }
         return GrpcSslContexts.configure(sslClientContextBuilder,
                 SslProvider.OPENSSL);
@@ -110,7 +110,7 @@ public class HelloWorldServerTls {
         if (args.length < 4 || args.length > 5) {
             System.out.println(
                     "USAGE: HelloWorldServerTls host port certChainFilePath privateKeyFilePath " +
-                    "[clientCertChainFilePath]\n  Note: You only need to supply clientCertChainFilePath if you want " +
+                    "[trustCertCollectionFilePath]\n  Note: You only need to supply trustCertCollectionFilePath if you want " +
                     "to enable Mutual TLS.");
             System.exit(0);
         }


### PR DESCRIPTION
examples: replace client certificate in trust store in 'Hello world example with TLS with mutual auth' with proper CA certificate to fix SSLV3_ALERT_HANDSHAKE_FAILURE in two host with different IPs setup, switch to required client auth to fail on incorrect configuration