### PR TITLE
examples: Fix comment in HelloWorldClient

### DIFF
--- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
+++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldClient.java
@@ -41,7 +41,7 @@ public class HelloWorldClient {
         .build());
   }
 
-  /** Construct client for accessing RouteGuide server using the existing channel. */
+  /** Construct client for accessing HelloWorld server using the existing channel. */
   HelloWorldClient(ManagedChannel channel) {
     this.channel = channel;
     blockingStub = GreeterGrpc.newBlockingStub(channel);


### PR DESCRIPTION
This client talks to HelloWorld server and not to the route guide one.