### PR TITLE
core: Add a toString to InProcessSocketAddress

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessSocketAddress.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessSocketAddress.java
@@ -33,4 +33,9 @@ public final class InProcessSocketAddress extends SocketAddress {
   public String getName() {
     return name;
   }
+  
+  @Override
+  public String toString() {
+    return name;
+  }
 }


### PR DESCRIPTION
The motivation here is that we want to write an interceptor to log the "remote-addr" attribute of a gRPC call. The attribute is a `SocketAddress` type which usually have reasonable `toString` methods but for the inprocess case we special case it. This PR is designed to provide a sensible `toString` for this case.