### PR TITLE
services: binlog method name should include leading / char

### DIFF
--- a/services/src/main/java/io/grpc/services/BinlogHelper.java
+++ b/services/src/main/java/io/grpc/services/BinlogHelper.java
@@ -119,7 +119,7 @@ final class BinlogHelper {
         CallId callId) {
       Preconditions.checkArgument(methodName == null || !isServer);
       Preconditions.checkArgument(timeout == null || !isServer);
-      // In java, we strip the leading '/'. To be consistent with the rest of gRPC we must
+      // Java does not include the leading '/'. To be consistent with the rest of gRPC we must
       // include the '/' in the fully qualified name for binlogs.
       Preconditions.checkArgument(methodName == null || !methodName.startsWith("/"));
       GrpcLogEntry.Builder entryBuilder = GrpcLogEntry.newBuilder()
@@ -148,7 +148,7 @@ final class BinlogHelper {
         SocketAddress peerSocket) {
       Preconditions.checkArgument(methodName == null || isServer);
       Preconditions.checkArgument(timeout == null || isServer);
-      // In java, we strip the leading '/'. To be consistent with the rest of gRPC we must
+      // Java does not include the leading '/'. To be consistent with the rest of gRPC we must
       // include the '/' in the fully qualified name for binlogs.
       Preconditions.checkArgument(methodName == null || !methodName.startsWith("/"));
       GrpcLogEntry.Builder entryBuilder = GrpcLogEntry.newBuilder()

--- a/services/src/main/java/io/grpc/services/BinlogHelper.java
+++ b/services/src/main/java/io/grpc/services/BinlogHelper.java
@@ -119,6 +119,9 @@ final class BinlogHelper {
         CallId callId) {
       Preconditions.checkArgument(methodName == null || !isServer);
       Preconditions.checkArgument(timeout == null || !isServer);
+      // In java, we strip the leading '/'. To be consistent with the rest of gRPC we must
+      // include the '/' in the fully qualified name for binlogs.
+      Preconditions.checkArgument(methodName == null || !methodName.startsWith("/"));
       GrpcLogEntry.Builder entryBuilder = GrpcLogEntry.newBuilder()
           .setSequenceIdWithinCall(seq)
           .setType(Type.SEND_INITIAL_METADATA)
@@ -126,7 +129,7 @@ final class BinlogHelper {
           .setCallId(callIdToProto(callId));
       addMetadataToProto(entryBuilder, metadata, maxHeaderBytes);
       if (methodName != null) {
-        entryBuilder.setMethodName(methodName);
+        entryBuilder.setMethodName("/" + methodName);
       }
       if (timeout != null) {
         entryBuilder.setTimeout(timeout);
@@ -145,6 +148,9 @@ final class BinlogHelper {
         SocketAddress peerSocket) {
       Preconditions.checkArgument(methodName == null || isServer);
       Preconditions.checkArgument(timeout == null || isServer);
+      // In java, we strip the leading '/'. To be consistent with the rest of gRPC we must
+      // include the '/' in the fully qualified name for binlogs.
+      Preconditions.checkArgument(methodName == null || !methodName.startsWith("/"));
       GrpcLogEntry.Builder entryBuilder = GrpcLogEntry.newBuilder()
           .setSequenceIdWithinCall(seq)
           .setType(Type.RECV_INITIAL_METADATA)
@@ -153,7 +159,7 @@ final class BinlogHelper {
           .setPeer(socketToProto(peerSocket));
       addMetadataToProto(entryBuilder, metadata, maxHeaderBytes);
       if (methodName != null) {
-        entryBuilder.setMethodName(methodName);
+        entryBuilder.setMethodName("/" + methodName);
       }
       if (timeout != null) {
         entryBuilder.setTimeout(timeout);

--- a/services/src/test/java/io/grpc/services/BinlogHelperTest.java
+++ b/services/src/test/java/io/grpc/services/BinlogHelperTest.java
@@ -575,7 +575,7 @@ public final class BinlogHelperTest {
     verify(sink).write(
         metadataToProtoTestHelper(nonEmptyMetadata, 10).toBuilder()
             .setSequenceIdWithinCall(1)
-            .setMethodName("service/method")
+            .setMethodName("/service/method")
             .setTimeout(Durations.fromMillis(1234))
             .setType(GrpcLogEntry.Type.SEND_INITIAL_METADATA)
             .setLogger(GrpcLogEntry.Logger.CLIENT)
@@ -592,7 +592,7 @@ public final class BinlogHelperTest {
     verify(sink).write(
         metadataToProtoTestHelper(nonEmptyMetadata, 10).toBuilder()
             .setSequenceIdWithinCall(1)
-            .setMethodName("service/method")
+            .setMethodName("/service/method")
             .setType(GrpcLogEntry.Type.SEND_INITIAL_METADATA)
             .setLogger(GrpcLogEntry.Logger.CLIENT)
             .setCallId(BinlogHelper.callIdToProto(CALL_ID))
@@ -615,7 +615,7 @@ public final class BinlogHelperTest {
     verify(sink).write(
         metadataToProtoTestHelper(nonEmptyMetadata, 10).toBuilder()
             .setSequenceIdWithinCall(1)
-            .setMethodName("service/method")
+            .setMethodName("/service/method")
             .setTimeout(Durations.fromMillis(1234))
             .setType(GrpcLogEntry.Type.RECV_INITIAL_METADATA)
             .setLogger(GrpcLogEntry.Logger.SERVER)
@@ -634,7 +634,7 @@ public final class BinlogHelperTest {
     verify(sink).write(
         metadataToProtoTestHelper(nonEmptyMetadata, 10).toBuilder()
             .setSequenceIdWithinCall(1)
-            .setMethodName("service/method")
+            .setMethodName("/service/method")
             .setType(GrpcLogEntry.Type.RECV_INITIAL_METADATA)
             .setLogger(GrpcLogEntry.Logger.SERVER)
             .setCallId(BinlogHelper.callIdToProto(CALL_ID))


### PR DESCRIPTION
Java is unlike the other implementations that our code strips the leading `/`.
When we log the method name, we should be consistent with the
other implementations and put back the `/`.