### PR TITLE
Make available the address the server is bound to

### DIFF
--- a/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
@@ -203,6 +203,11 @@ public final class AltsServerBuilder extends ServerBuilder<AltsServerBuilder> {
     }
 
     @Override
+    public InetSocketAddress mainAddress() {
+      return delegate.mainAddress();
+    }
+
+    @Override
     public int getPort() {
       return delegate.getPort();
     }

--- a/core/src/main/java/io/grpc/Server.java
+++ b/core/src/main/java/io/grpc/Server.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +38,16 @@ public abstract class Server {
    * @since 1.0.0
    */
   public abstract Server start() throws IOException;
+
+  /**
+   * Returns the address the server is listening on.  This can return null if there is no actual
+   * address or the result otherwise does not make sense.  Result is undefined after the server is
+   * terminated.
+   *
+   * @throws IllegalStateException if the server has not yet been started.
+   * @since 1.0.0
+   */
+  public abstract InetSocketAddress mainAddress();
 
   /**
    * Returns the port number the server is listening on.  This can return -1 if there is no actual

--- a/core/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -27,6 +27,7 @@ import io.grpc.internal.ObjectPool;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerTransportListener;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,6 +73,11 @@ final class InProcessServer implements InternalServer {
     if (registry.putIfAbsent(name, this) != null) {
       throw new IOException("name already registered: " + name);
     }
+  }
+
+  @Override
+  public InetSocketAddress mainAddress() {
+    return null;
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/InternalServer.java
+++ b/core/src/main/java/io/grpc/internal/InternalServer.java
@@ -18,6 +18,7 @@ package io.grpc.internal;
 
 import io.grpc.internal.Channelz.SocketStats;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -43,6 +44,12 @@ public interface InternalServer {
    * method may only be called once.
    */
   void shutdown();
+
+  /**
+   * Returns what underlying address the server is listening on, or null if the address is not
+   * available or does not make sense.
+   */
+  InetSocketAddress mainAddress();
 
   /**
    * Returns what underlying port the server is listening on, or -1 if the port number is not

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -48,6 +48,7 @@ import io.grpc.Status;
 import io.grpc.internal.Channelz.ServerStats;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -168,12 +169,18 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
   }
 
   @Override
-  public int getPort() {
+  public InetSocketAddress mainAddress() {
     synchronized (lock) {
       checkState(started, "Not started");
       checkState(!terminated, "Already terminated");
-      return transportServer.getPort();
+      return transportServer.mainAddress();
     }
+  }
+
+  @Override
+  public int getPort() {
+    InetSocketAddress mainAddress = mainAddress();
+    return mainAddress != null ? mainAddress.getPort() : -1;
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -79,6 +79,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1031,6 +1032,11 @@ public class ServerImplTest {
   public void getPort() throws Exception {
     transportServer = new SimpleServer() {
       @Override
+      public InetSocketAddress mainAddress() {
+        return new InetSocketAddress("localhost", 65535);
+      }
+
+      @Override
       public int getPort() {
         return 65535;
       }
@@ -1353,6 +1359,11 @@ public class ServerImplTest {
     @Override
     public void start(ServerListener listener) throws IOException {
       this.listener = listener;
+    }
+
+    @Override
+    public InetSocketAddress mainAddress() {
+      return null;
     }
 
     @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -135,15 +135,21 @@ class NettyServer implements InternalServer, WithLogId {
   }
 
   @Override
-  public int getPort() {
+  public InetSocketAddress mainAddress() {
     if (channel == null) {
-      return -1;
+      return null;
     }
     SocketAddress localAddr = channel.localAddress();
     if (!(localAddr instanceof InetSocketAddress)) {
-      return -1;
+      return null;
     }
-    return ((InetSocketAddress) localAddr).getPort();
+    return (InetSocketAddress) localAddr;
+  }
+
+  @Override
+  public int getPort() {
+    InetSocketAddress mainAddress = mainAddress();
+    return mainAddress != null ? mainAddress.getPort() : -1;
   }
 
   @Override


### PR DESCRIPTION
I'd like the address that the server was bound to. Right now there's no way to know if it's only accepting requests from localhost or if it's also accepting requests from other machines.

I'd like to add support for hot-reloading of GRPC servers. This feature means that if you've made a code change, when a request comes in the server will be recompiled and then continue with processing the request. This is a really nifty feature that Play Framework pioneered that requires integration with the build system (since the code needs to be recompiled). Gradle already has support for this feature built-in, but it currently expects the server to make available its address as an `InetSocketAddress`

P.S. hello @carl-mastrangelo! my first real GRPC PR :-) hope you've been well!