### PR TITLE
stub: clarify StreamObservers interaction

### DIFF
--- a/stub/src/main/java/io/grpc/stub/StreamObservers.java
+++ b/stub/src/main/java/io/grpc/stub/StreamObservers.java
@@ -28,7 +28,8 @@ import java.util.Iterator;
 public final class StreamObservers {
   /**
    * Copy the values of an {@link Iterator} to the target {@link CallStreamObserver} while properly
-   * accounting for outbound flow-control.
+   * accounting for outbound flow-control.  After calling this method, {@code target} should no
+   * longer be used.
    *
    * <p>For clients this method is safe to call inside {@link ClientResponseObserver#beforeStart},
    * on servers it is safe to call inside the service method implementation.
@@ -59,7 +60,8 @@ public final class StreamObservers {
 
   /**
    * Copy the values of an {@link Iterable} to the target {@link CallStreamObserver} while properly
-   * accounting for outbound flow-control.
+   * accounting for outbound flow-control.  After calling this method, {@code target} should no
+   * longer be used.
    *
    * <p>For clients this method is safe to call inside {@link ClientResponseObserver#beforeStart},
    * on servers it is safe to call inside the service method implementation.


### PR DESCRIPTION
Updates #4558

It appears in the linked bug that onError is called from outside.  I don't believe this is safe because thew onReadyCallback is going to call onCompleted.  In the case of an error, it seems like the iterator should be stopped, but there isn't a great way to phrase this.  Ideas welcome.