### PR TITLE
util: Improve RoundRobinLoadBalancer scalability with stickiness

### DIFF
--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory.java
@@ -326,10 +326,10 @@ public final class RoundRobinLoadBalancerFactory extends LoadBalancer.Factory {
       Subchannel maybeRegister(
           String stickinessValue, @Nonnull Subchannel subchannel, List<Subchannel> rrList) {
         final Ref<Subchannel> newSubchannelRef = subchannel.getAttributes().get(STICKY_REF);
-        Ref<Subchannel> existingSubchannelRef;
         while (true) {
-          if ((existingSubchannelRef =
-              stickinessMap.putIfAbsent(stickinessValue, newSubchannelRef)) == null) {
+          Ref<Subchannel> existingSubchannelRef =
+              stickinessMap.putIfAbsent(stickinessValue, newSubchannelRef);
+          if (existingSubchannelRef == null) {
             // new entry
             addToEvictionQueue(stickinessValue);
             return subchannel;

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -49,7 +49,6 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
-import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.Metadata;
@@ -275,9 +274,9 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void pickerRoundRobin() throws Exception {
-    Subchannel subchannel = mockChannelWithPickResult();
-    Subchannel subchannel1 = mockChannelWithPickResult();
-    Subchannel subchannel2 = mockChannelWithPickResult();
+    Subchannel subchannel = mock(Subchannel.class);
+    Subchannel subchannel1 = mock(Subchannel.class);
+    Subchannel subchannel2 = mock(Subchannel.class);
 
     Picker picker = new Picker(Collections.unmodifiableList(Lists.<Subchannel>newArrayList(
         subchannel, subchannel1, subchannel2)), null /* status */, null /* stickinessState */);
@@ -288,15 +287,6 @@ public class RoundRobinLoadBalancerTest {
     assertEquals(subchannel1, picker.pickSubchannel(mockArgs).getSubchannel());
     assertEquals(subchannel2, picker.pickSubchannel(mockArgs).getSubchannel());
     assertEquals(subchannel, picker.pickSubchannel(mockArgs).getSubchannel());
-  }
-
-  private Subchannel mockChannelWithPickResult() {
-    Subchannel subchannel = mock(Subchannel.class);
-    when(subchannel.getAttributes()).thenReturn(Attributes.newBuilder()
-        .set(RoundRobinLoadBalancer.PICK_RESULT,
-            new Ref<PickResult>(PickResult.withSubchannel(subchannel)))
-        .build());
-    return subchannel;
   }
 
   @Test

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -49,6 +49,7 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.Metadata;
@@ -274,9 +275,9 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void pickerRoundRobin() throws Exception {
-    Subchannel subchannel = mock(Subchannel.class);
-    Subchannel subchannel1 = mock(Subchannel.class);
-    Subchannel subchannel2 = mock(Subchannel.class);
+    Subchannel subchannel = mockChannelWithPickResult();
+    Subchannel subchannel1 = mockChannelWithPickResult();
+    Subchannel subchannel2 = mockChannelWithPickResult();
 
     Picker picker = new Picker(Collections.unmodifiableList(Lists.<Subchannel>newArrayList(
         subchannel, subchannel1, subchannel2)), null /* status */, null /* stickinessState */);
@@ -287,6 +288,15 @@ public class RoundRobinLoadBalancerTest {
     assertEquals(subchannel1, picker.pickSubchannel(mockArgs).getSubchannel());
     assertEquals(subchannel2, picker.pickSubchannel(mockArgs).getSubchannel());
     assertEquals(subchannel, picker.pickSubchannel(mockArgs).getSubchannel());
+  }
+
+  private Subchannel mockChannelWithPickResult() {
+    Subchannel subchannel = mock(Subchannel.class);
+    when(subchannel.getAttributes()).thenReturn(Attributes.newBuilder()
+        .set(RoundRobinLoadBalancer.PICK_RESULT,
+            new Ref<PickResult>(PickResult.withSubchannel(subchannel)))
+        .build());
+    return subchannel;
   }
 
   @Test


### PR DESCRIPTION
- Rework stickiness picker logic to be non-blocking
- Stash `Subchannel` ref in an attribute rather than dedicated map

Possibly controversial:
- Stash constant/immutable `PickResult` in `Subchannel` attribute to avoid identical allocation on every rpc