### PR TITLE
Don't close in TSREI in cancelled contexts

### DIFF
--- a/core/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
+++ b/core/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
@@ -161,16 +161,16 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
 
     @Override
     public void close(final Status status, final Metadata trailers) {
-      if (!closeCalled) {
-        closeCalled = true;
+      serializingExecutor.execute(new Runnable() {
+        @Override
+        public void run() {
+          if (!closeCalled) {
+            closeCalled = true;
 
-        serializingExecutor.execute(new Runnable() {
-          @Override
-          public void run() {
             SerializingServerCall.super.close(status, trailers);
           }
-        });
-      }
+        }
+      });
     }
 
     @Override

--- a/core/src/test/java/io/grpc/util/UtilServerInterceptorsTest.java
+++ b/core/src/test/java/io/grpc/util/UtilServerInterceptorsTest.java
@@ -140,7 +140,6 @@ public class UtilServerInterceptorsTest {
     final Metadata expectedMetadata;
 
     int numCloses;
-    int numMismatchedCloses;
 
     FakeServerCall(Status expectedStatus, Metadata expectedMetadata) {
       this.expectedStatus = expectedStatus;
@@ -152,8 +151,6 @@ public class UtilServerInterceptorsTest {
     public void close(Status status, Metadata trailers) {
       if (status == expectedStatus && trailers == expectedMetadata) {
         numCloses++;
-      } else {
-        numMismatchedCloses++;
       }
     }
   }


### PR DESCRIPTION
A cancelled context in a ServerCall will have already closed - this
suppresses log messages indicating "context already closed" from
when SREs are thrown as a result of active client requests within the
context.