### PR TITLE
core: Add support for List<EAG> in Subchannels

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -19,6 +19,7 @@ package io.grpc;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -455,14 +456,39 @@ public abstract class LoadBalancer {
      * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
      * Subchannels within {@link #shutdown}.
      *
+     * <p>The default implementation calls {@link #createSubchannel(List, Attributes)}.
+     * Implementations should not override this method.
+     *
      * @since 1.2.0
      */
-    public abstract Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs);
+    public Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
+      Preconditions.checkNotNull(addrs, "addrs");
+      return createSubchannel(Collections.singletonList(addrs), attrs);
+    }
+
+    /**
+     * Creates a Subchannel, which is a logical connection to the given group of addresses which are
+     * considered equivalent.  The {@code attrs} are custom attributes associated with this
+     * Subchannel, and can be accessed later through {@link Subchannel#getAttributes
+     * Subchannel.getAttributes()}.
+     *
+     * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
+     * Subchannels within {@link #shutdown}.
+     *
+     * @throws IllegalArgumentException if {@code attrs} is empty
+     * @since 1.14.0
+     */
+    public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
+      throw new UnsupportedOperationException();
+    }
 
     /**
      * Replaces the existing addresses used with {@code subchannel}. This method is superior to
      * {@link #createSubchannel} when the new and old addresses overlap, since the subchannel can
      * continue using an existing connection.
+     *
+     * <p>The default implementation calls {@link #updateSubchannelAddresses(
+     * LoadBalancer.Subchannel, List)}. Implementations should not override this method.
      *
      * @throws IllegalArgumentException if {@code subchannel} was not returned from {@link
      *     #createSubchannel}
@@ -470,6 +496,21 @@ public abstract class LoadBalancer {
      */
     public void updateSubchannelAddresses(
         Subchannel subchannel, EquivalentAddressGroup addrs) {
+      Preconditions.checkNotNull(addrs, "addrs");
+      updateSubchannelAddresses(subchannel, Collections.singletonList(addrs));
+    }
+
+    /**
+     * Replaces the existing addresses used with {@code subchannel}. This method is superior to
+     * {@link #createSubchannel} when the new and old addresses overlap, since the subchannel can
+     * continue using an existing connection.
+     *
+     * @throws IllegalArgumentException if {@code subchannel} was not returned from {@link
+     *     #createSubchannel} or {@code addrs} is empty
+     * @since 1.14.0
+     */
+    public void updateSubchannelAddresses(
+        Subchannel subchannel, List<EquivalentAddressGroup> addrs) {
       throw new UnsupportedOperationException();
     }
 
@@ -572,11 +613,30 @@ public abstract class LoadBalancer {
     public abstract void requestConnection();
 
     /**
-     * Returns the addresses that this Subchannel is bound to.
+     * Returns the addresses that this Subchannel is bound to. The default implementation calls
+     * getAllAddresses().
      *
+     * <p>The default implementation calls {@link #getAllAddresses()}. Implementations should not
+     * override this method.
+     *
+     * @throws IllegalStateException if this subchannel has more than one EquivalentAddressGroup.
+     *     Use getAllAddresses() instead
      * @since 1.2.0
      */
-    public abstract EquivalentAddressGroup getAddresses();
+    public EquivalentAddressGroup getAddresses() {
+      List<EquivalentAddressGroup> groups = getAllAddresses();
+      Preconditions.checkState(groups.size() == 1, "Does not have exactly one group");
+      return groups.get(0);
+    }
+
+    /**
+     * Returns the addresses that this Subchannel is bound to. The returned list will not be empty.
+     *
+     * @since 1.14.0
+     */
+    public List<EquivalentAddressGroup> getAllAddresses() {
+      throw new UnsupportedOperationException();
+    }
 
     /**
      * The same attributes passed to {@link Helper#createSubchannel Helper.createSubchannel()}.

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -475,7 +475,7 @@ public abstract class LoadBalancer {
      * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
      * Subchannels within {@link #shutdown}.
      *
-     * @throws IllegalArgumentException if {@code attrs} is empty
+     * @throws IllegalArgumentException if {@code addrs} is empty
      * @since 1.14.0
      */
     public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -43,6 +43,7 @@ import io.grpc.internal.Channelz.ChannelStats;
 import io.grpc.internal.Channelz.ChannelTrace;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -159,8 +160,8 @@ final class OobChannel extends ManagedChannel implements Instrumented<ChannelSta
         }
 
         @Override
-        public EquivalentAddressGroup getAddresses() {
-          return subchannel.getAddressGroup();
+        public List<EquivalentAddressGroup> getAllAddresses() {
+          return subchannel.getAddressGroups();
         }
 
         @Override
@@ -181,7 +182,7 @@ final class OobChannel extends ManagedChannel implements Instrumented<ChannelSta
   }
 
   void updateAddresses(EquivalentAddressGroup eag) {
-    subchannel.updateAddresses(eag);
+    subchannel.updateAddresses(Collections.singletonList(eag));
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -113,8 +113,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
             new EquivalentAddressGroup(new SocketAddress(){}, Attributes.EMPTY));
     Helper helper = new TestHelper() {
       @Override
-      public Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
-        assertThat(addrs).isEqualTo(servers.get(0));
+      public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
+        assertThat(addrs).isEqualTo(servers);
         return new TestSubchannel(addrs, attrs);
       }
 
@@ -147,8 +147,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
                 Attributes.EMPTY));
     Helper helper = new TestHelper() {
       @Override
-      public Subchannel createSubchannel(final EquivalentAddressGroup addrs, Attributes attrs) {
-        assertThat(addrs).isEqualTo(servers.get(0));
+      public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
+        assertThat(addrs).isEqualTo(servers);
         return new TestSubchannel(addrs, attrs);
       }
 
@@ -304,7 +304,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     }
 
     @Override
-    public Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
+    public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
       return delegate().createSubchannel(addrs, attrs);
     }
 
@@ -348,12 +348,12 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   private static class TestSubchannel extends Subchannel {
-    TestSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
+    TestSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
       this.addrs = addrs;
       this.attrs = attrs;
     }
 
-    final EquivalentAddressGroup addrs;
+    final List<EquivalentAddressGroup> addrs;
     final Attributes attrs;
 
     @Override
@@ -365,7 +365,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     }
 
     @Override
-    public EquivalentAddressGroup getAddresses() {
+    public List<EquivalentAddressGroup> getAllAddresses() {
       return addrs;
     }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -2064,7 +2064,8 @@ public class ManagedChannelImplTest {
     assertEquals(TARGET, getStats(channel).target);
 
     Subchannel subchannel = helper.createSubchannel(addressGroup, Attributes.EMPTY);
-    assertEquals(addressGroup.toString(), getStats((AbstractSubchannel) subchannel).target);
+    assertEquals(Collections.singletonList(addressGroup).toString(),
+        getStats((AbstractSubchannel) subchannel).target);
   }
 
   @Test


### PR DESCRIPTION
This avoids the needs to flatten to EAGs for cases like PickFirst,
making the Attributes in EAGs able to be used in communication with
core. See #4302 for some discussion on the topic.

-----

This alone will not be enough to rid ourselves of all flattening. We also
need to support List\<EAG> with OobChannels. But I'll do that as a later
PR.