### PR TITLE
android: initialize listener with isConnected=false

### DIFF
--- a/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
+++ b/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
@@ -256,15 +256,21 @@ public final class AndroidChannelBuilderTest {
 
   @Test
   @Config(sdk = 24)
-  public void newChannelWithConnection_entersIdleOnConnectionChange_api24() {
+  public void newChannelWithConnection_entersIdleOnSecondConnectionChange_api24() {
     shadowConnectivityManager.setActiveNetworkInfo(MOBILE_CONNECTED);
     TestChannel delegateChannel = new TestChannel();
     ManagedChannel androidChannel =
         new AndroidChannelBuilder.AndroidChannel(
             delegateChannel, RuntimeEnvironment.application.getApplicationContext());
 
+    // The first onAvailable() may just signal that the device was connected when the callback is
+    // registered, rather than indicating a changed network, so we do not enter idle.
     shadowConnectivityManager.setActiveNetworkInfo(WIFI_CONNECTED);
-    assertThat(delegateChannel.resetCount).isEqualTo(0);
+    assertThat(delegateChannel.resetCount).isEqualTo(1);
+    assertThat(delegateChannel.enterIdleCount).isEqualTo(0);
+
+    shadowConnectivityManager.setActiveNetworkInfo(MOBILE_CONNECTED);
+    assertThat(delegateChannel.resetCount).isEqualTo(1);
     assertThat(delegateChannel.enterIdleCount).isEqualTo(1);
 
     androidChannel.shutdown();


### PR DESCRIPTION
Observed on a Pixel XL emulator running API 26 that onAvailable() is invoked immediately upon registering a default network listener, rather than only upon a subsequent change (as originally assumed in the code). The Android docs are not clear about the intended behavior here, so this modifies AndroidChannel to start in "disconnected" state - if onAvailable() fires immediately, we will only invoke resetConnectBackoff (a no-op if not in TRANSIENT_FAILURE) rather than the potentially more expensive enterIdle(). Subsequent behavior is unchanged.