### PR TITLE
Client-side support for h2c via Upgrade #4518

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -79,6 +79,7 @@ public class TestServiceClient {
   private String testCase = "empty_unary";
   private boolean useTls = true;
   private boolean useAlts = false;
+  private boolean useH2cUpgrade = false;
   private String customCredentialsType;
   private boolean useTestCa;
   private boolean useOkHttp;
@@ -120,6 +121,8 @@ public class TestServiceClient {
         testCase = value;
       } else if ("use_tls".equals(key)) {
         useTls = Boolean.parseBoolean(value);
+      } else if ("use_upgrade".equals(key)) {
+        useH2cUpgrade = Boolean.parseBoolean(value);
       } else if ("use_alts".equals(key)) {
         useAlts = Boolean.parseBoolean(value);
       } else if ("custom_credentials_type".equals(key)) {
@@ -148,7 +151,7 @@ public class TestServiceClient {
         break;
       }
     }
-    if (useAlts) {
+    if (useAlts || useH2cUpgrade) {
       useTls = false;
     }
     if (usage) {
@@ -166,6 +169,9 @@ public class TestServiceClient {
           + "\n  --use_tls=true|false        Whether to use TLS. Default " + c.useTls
           + "\n  --use_alts=true|false       Whether to use ALTS. Enable ALTS will disable TLS."
           + "\n                              Default " + c.useAlts
+          + "\n  --use_upgrade=true|false    Whether to use the h2c Upgrade mechanism."
+          + "\n                              Enabling h2c Upgrade will disable TLS."
+          + "\n                              Default " + c.useH2cUpgrade
           + "\n  --custom_credentials_type   Custom credentials type to use. Default "
             + c.customCredentialsType
           + "\n  --use_test_ca=true|false    Whether to trust our fake CA. Requires --use_tls=true "
@@ -370,7 +376,8 @@ public class TestServiceClient {
         NettyChannelBuilder nettyBuilder =
             NettyChannelBuilder.forAddress(serverHost, serverPort)
                 .flowControlWindow(65 * 1024)
-                .negotiationType(useTls ? NegotiationType.TLS : NegotiationType.PLAINTEXT)
+                .negotiationType(useTls ? NegotiationType.TLS :
+                  (useH2cUpgrade ? NegotiationType.PLAINTEXT_UPGRADE : NegotiationType.PLAINTEXT))
                 .sslContext(sslContext);
         if (serverHostOverride != null) {
           nettyBuilder.overrideAuthority(serverHostOverride);

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -50,6 +50,7 @@ import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
 import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 import io.netty.handler.codec.http2.DefaultHttp2RemoteFlowController;
+import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionAdapter;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
@@ -339,8 +340,12 @@ class NettyClientHandler extends AbstractNettyHandler {
   }
 
   private void onHeadersRead(int streamId, Http2Headers headers, boolean endStream) {
-    NettyClientStream.TransportState stream = clientStream(requireHttp2Stream(streamId));
-    stream.transportHeadersReceived(headers, endStream);
+    // Stream 1 is reserved for the Upgrade response, so we should ignore its headers here:
+    if (streamId != Http2CodecUtil.HTTP_UPGRADE_STREAM_ID) {
+      NettyClientStream.TransportState stream = clientStream(requireHttp2Stream(streamId));
+      stream.transportHeadersReceived(headers, endStream);
+    }
+
     if (keepAliveManager != null) {
       keepAliveManager.onDataReceived();
     }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -341,7 +341,8 @@ public final class ProtocolNegotiators {
       HttpClientCodec httpClientCodec = new HttpClientCodec();
       final HttpClientUpgradeHandler upgrader =
           new HttpClientUpgradeHandler(httpClientCodec, upgradeCodec, 1000);
-      return new BufferingHttp2UpgradeHandler(httpClientCodec, upgrader, handler, handler.getAuthority());
+      return new BufferingHttp2UpgradeHandler(httpClientCodec, upgrader, handler,
+          handler.getAuthority());
     }
   }
 

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -42,6 +42,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpClientUpgradeHandler;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.Http2ClientUpgradeCodec;
@@ -332,6 +333,7 @@ public final class ProtocolNegotiators {
   }
 
   static final class PlaintextUpgradeNegotiator implements ProtocolNegotiator {
+
     @Override
     public Handler newHandler(GrpcHttp2ConnectionHandler handler) {
       // Register the plaintext upgrader
@@ -339,7 +341,7 @@ public final class ProtocolNegotiators {
       HttpClientCodec httpClientCodec = new HttpClientCodec();
       final HttpClientUpgradeHandler upgrader =
           new HttpClientUpgradeHandler(httpClientCodec, upgradeCodec, 1000);
-      return new BufferingHttp2UpgradeHandler(upgrader, handler);
+      return new BufferingHttp2UpgradeHandler(httpClientCodec, upgrader, handler, handler.getAuthority());
     }
   }
 
@@ -714,9 +716,13 @@ public final class ProtocolNegotiators {
 
     private final GrpcHttp2ConnectionHandler grpcHandler;
 
-    BufferingHttp2UpgradeHandler(ChannelHandler handler, GrpcHttp2ConnectionHandler grpcHandler) {
-      super(handler);
+    private final String authority;
+
+    BufferingHttp2UpgradeHandler(ChannelHandler handler, ChannelHandler upgradeHandler,
+        GrpcHttp2ConnectionHandler grpcHandler, String authority) {
+      super(handler, upgradeHandler);
       this.grpcHandler = grpcHandler;
+      this.authority = authority;
     }
 
     @Override
@@ -730,6 +736,7 @@ public final class ProtocolNegotiators {
       // which causes the upgrade headers to be added
       DefaultHttpRequest upgradeTrigger =
           new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+      upgradeTrigger.headers().add(HttpHeaderNames.HOST, authority);
       ctx.writeAndFlush(upgradeTrigger);
       super.channelActive(ctx);
     }


### PR DESCRIPTION
Upgrading from HTTP/1.1 to h2c (HTTP/2 in cleartext).

This is best avoided if possible (since it not widely implemented and comes at
the cost of a roundtrip), but a nice option to have.

Based on work by @xujianhai in #3529

Related to #3528 and fixes #4518

Not sure how to properly test this...