### PR TITLE
core: Avoid compare default TagContext in thread local with empty.

### DIFF
--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -261,7 +261,7 @@ public class CensusModulesTest {
         ctx.detach(origCtx);
       }
     } else {
-      assertEquals(Tags.getTagger().empty(), TAG_CONTEXT_KEY.get());
+      assertEquals(Tags.getTagger().getCurrentTagContext(), TAG_CONTEXT_KEY.get());
       assertNull(ContextUtils.CONTEXT_SPAN_KEY.get());
       call = interceptedChannel.newCall(method, CALL_OPTIONS);
     }


### PR DESCRIPTION
In OpenCensus implementation we store an empty `TagContext` as default in thread local, but that's an implementation detail and the behavior may vary between different implementations. Update the test to compare thread-local `TagContext` with an API call `getCurrentTagContext()` instead, to avoid testing the underlying implementation.

/cc @dinooliva @sebright