### PR TITLE
Fix unused variables

### DIFF
--- a/core/src/test/java/io/grpc/PickFirstLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancerTest.java
@@ -132,7 +132,6 @@ public class PickFirstLoadBalancerTest {
   @Test
   public void pickAfterResolvedAndChanged() throws Exception {
     SocketAddress socketAddr = new FakeSocketAddress("newserver");
-    List<SocketAddress> newSocketAddresses = Lists.newArrayList(socketAddr);
     List<EquivalentAddressGroup> newServers =
         Lists.newArrayList(new EquivalentAddressGroup(socketAddr));
 

--- a/core/src/test/java/io/grpc/internal/JndiResourceResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/JndiResourceResolverTest.java
@@ -19,7 +19,6 @@ package io.grpc.internal;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import io.grpc.EquivalentAddressGroup;
 import io.grpc.internal.DnsNameResolver.AddressResolver;
 import io.grpc.internal.JndiResourceResolverFactory.JndiResourceResolver;
 import io.grpc.internal.JndiResourceResolverFactory.JndiResourceResolver.SrvRecord;

--- a/core/src/test/java/io/grpc/internal/JndiResourceResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/JndiResourceResolverTest.java
@@ -58,16 +58,15 @@ public class JndiResourceResolverTest {
       }
     };
     JndiResourceResolver resolver = new JndiResourceResolver();
-    List<EquivalentAddressGroup> results = null;
     try {
-      results = resolver.resolveSrv(addressResolver, "localhost");
+      resolver.resolveSrv(addressResolver, "localhost");
     } catch (javax.naming.CommunicationException e) {
       Assume.assumeNoException(e);
     } catch (javax.naming.NameNotFoundException e) {
       Assume.assumeNoException(e);
     }
   }
-  
+
   @Test
   public void parseSrvRecord() {
     SrvRecord record = JndiResourceResolver.parseSrvRecord("0 0 1234 foo.bar.com");

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -634,6 +634,7 @@ class NettyClientHandler extends AbstractNettyHandler {
         return true;
       }
     });
+    promise.setSuccess();
   }
 
   /**


### PR DESCRIPTION
Unused variables in tests were deleted. The unused variable in Netty
was a future that needed completing; that was a bug.