### PR TITLE
Plumb EAG attributes to transports and Netty's ProtocolNegotiator

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -29,7 +29,8 @@ dependencies {
 
     testCompile project(':grpc-context').sourceSets.test.output,
             project(':grpc-testing'),
-            project(':grpc-grpclb')
+            project(':grpc-grpclb'),
+            libraries.guava_testlib
 
     signature "org.codehaus.mojo.signature:java16:1.1@signature"
 }

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -24,7 +24,6 @@ import io.grpc.internal.AbstractManagedChannelImplBuilder;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.ProxyParameters;
 import io.grpc.internal.SharedResourceHolder;
 import java.net.SocketAddress;
 import java.util.concurrent.ScheduledExecutorService;
@@ -171,11 +170,11 @@ public final class InProcessChannelBuilder extends
 
     @Override
     public ConnectionClientTransport newClientTransport(
-        SocketAddress addr, String authority, String userAgent, ProxyParameters proxy) {
+        SocketAddress addr, ClientTransportOptions options) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
-      return new InProcessTransport(name, authority, userAgent);
+      return new InProcessTransport(name, options.getAuthority(), options.getUserAgent());
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -29,7 +29,6 @@ import io.grpc.Status;
 import java.net.SocketAddress;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.annotation.Nullable;
 
 final class CallCredentialsApplyingTransportFactory implements ClientTransportFactory {
   private final ClientTransportFactory delegate;
@@ -43,10 +42,9 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
 
   @Override
   public ConnectionClientTransport newClientTransport(
-      SocketAddress serverAddress, String authority, @Nullable String userAgent,
-      @Nullable ProxyParameters proxy) {
+      SocketAddress serverAddress, ClientTransportOptions options) {
     return new CallCredentialsApplyingTransport(
-        delegate.newClientTransport(serverAddress, authority, userAgent, proxy), authority);
+        delegate.newClientTransport(serverAddress, options), options.getAuthority());
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -76,7 +76,6 @@ public class CallCredentialsApplyingTest {
 
   private static final String AUTHORITY = "testauthority";
   private static final String USER_AGENT = "testuseragent";
-  private static final ProxyParameters NO_PROXY = null;
   private static final Attributes.Key<String> ATTR_KEY = Attributes.Key.create("somekey");
   private static final String ATTR_VALUE = "somevalue";
   private static final MethodDescriptor<String, Integer> method =
@@ -99,18 +98,23 @@ public class CallCredentialsApplyingTest {
 
   @Before
   public void setUp() {
+    ClientTransportFactory.ClientTransportOptions clientTransportOptions =
+        new ClientTransportFactory.ClientTransportOptions()
+          .setAuthority(AUTHORITY)
+          .setUserAgent(USER_AGENT);
+
     MockitoAnnotations.initMocks(this);
     origHeaders.put(ORIG_HEADER_KEY, ORIG_HEADER_VALUE);
-    when(mockTransportFactory.newClientTransport(address, AUTHORITY, USER_AGENT, NO_PROXY))
+    when(mockTransportFactory.newClientTransport(address, clientTransportOptions))
         .thenReturn(mockTransport);
     when(mockTransport.newStream(same(method), any(Metadata.class), any(CallOptions.class)))
         .thenReturn(mockStream);
     ClientTransportFactory transportFactory = new CallCredentialsApplyingTransportFactory(
         mockTransportFactory, mockExecutor);
-    transport = (ForwardingConnectionClientTransport) transportFactory.newClientTransport(
-        address, AUTHORITY, USER_AGENT, NO_PROXY);
+    transport = (ForwardingConnectionClientTransport)
+        transportFactory.newClientTransport(address, clientTransportOptions);
     callOptions = CallOptions.DEFAULT.withCallCredentials(mockCreds);
-    verify(mockTransportFactory).newClientTransport(address, AUTHORITY, USER_AGENT, NO_PROXY);
+    verify(mockTransportFactory).newClientTransport(address, clientTransportOptions);
     assertSame(mockTransport, transport.delegate());
   }
 

--- a/core/src/test/java/io/grpc/internal/ClientTransportFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientTransportFactoryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.grpc.Attributes;
+import io.grpc.internal.ClientTransportFactory.ClientTransportOptions;
+import java.net.InetSocketAddress;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ClientTransportFactoryTest {
+  private String authority = "testing123";
+  private Attributes eagAttributes =
+      Attributes.newBuilder().set(Attributes.Key.create("fake key"), "fake value").build();
+  private String userAgent = "best-ua/3.14";
+  private ProxyParameters proxyParameters =
+      new ProxyParameters(new InetSocketAddress(0), null, null);
+
+  @Test
+  public void clientTransportOptions_init_checkNotNulls() {
+    ClientTransportOptions cto = new ClientTransportOptions();
+    assertThat(cto.getAuthority()).isNotNull();
+    assertThat(cto.getEagAttributes()).isEqualTo(Attributes.EMPTY);
+  }
+
+  @Test
+  public void clientTransportOptions_getsMatchSets() {
+    ClientTransportOptions cto = new ClientTransportOptions()
+        .setAuthority(authority)
+        .setEagAttributes(eagAttributes)
+        .setUserAgent(userAgent)
+        .setProxyParameters(proxyParameters);
+    assertThat(cto.getAuthority()).isEqualTo(authority);
+    assertThat(cto.getEagAttributes()).isEqualTo(eagAttributes);
+    assertThat(cto.getUserAgent()).isEqualTo(userAgent);
+    assertThat(cto.getProxyParameters()).isSameAs(proxyParameters);
+  }
+
+  @Test
+  public void clientTransportOptions_equals() {
+    new EqualsTester()
+        .addEqualityGroup(new ClientTransportOptions())
+        .addEqualityGroup(
+            new ClientTransportOptions()
+              .setAuthority(authority),
+            new ClientTransportOptions()
+              .setAuthority(authority)
+              .setEagAttributes(Attributes.EMPTY))
+        .addEqualityGroup(
+            new ClientTransportOptions()
+              .setAuthority(authority)
+              .setEagAttributes(eagAttributes))
+        .addEqualityGroup(
+            new ClientTransportOptions()
+              .setAuthority(authority)
+              .setEagAttributes(eagAttributes)
+              .setUserAgent(userAgent))
+        .addEqualityGroup(
+            new ClientTransportOptions()
+              .setAuthority(authority)
+              .setEagAttributes(eagAttributes)
+              .setUserAgent(userAgent)
+              .setProxyParameters(proxyParameters),
+            new ClientTransportOptions()
+              .setAuthority(authority)
+              .setEagAttributes(eagAttributes)
+              .setUserAgent(userAgent)
+              .setProxyParameters(proxyParameters))
+        .testEquals();
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -159,7 +159,8 @@ public class ManagedChannelImplIdlenessTest {
     // Verify the initial idleness
     verify(mockLoadBalancerFactory, never()).newLoadBalancer(any(Helper.class));
     verify(mockTransportFactory, never()).newClientTransport(
-        any(SocketAddress.class), anyString(), anyString(), any(ProxyParameters.class));
+        any(SocketAddress.class),
+        any(ClientTransportFactory.ClientTransportOptions.class));
     verify(mockNameResolver, never()).start(any(NameResolver.Listener.class));
   }
 
@@ -359,13 +360,19 @@ public class ManagedChannelImplIdlenessTest {
     // Now make an RPC on an OOB channel
     ManagedChannel oob = helper.createOobChannel(servers.get(0), "oobauthority");
     verify(mockTransportFactory, never())
-        .newClientTransport(any(SocketAddress.class), same("oobauthority"), same(USER_AGENT),
-            same(NO_PROXY));
+        .newClientTransport(
+            any(SocketAddress.class),
+            eq(new ClientTransportFactory.ClientTransportOptions()
+              .setAuthority("oobauthority")
+              .setUserAgent(USER_AGENT)));
     ClientCall<String, Integer> oobCall = oob.newCall(method, CallOptions.DEFAULT);
     oobCall.start(mockCallListener2, new Metadata());
     verify(mockTransportFactory)
-        .newClientTransport(any(SocketAddress.class), same("oobauthority"), same(USER_AGENT),
-            same(NO_PROXY));
+        .newClientTransport(
+            any(SocketAddress.class),
+            eq(new ClientTransportFactory.ClientTransportOptions()
+              .setAuthority("oobauthority")
+              .setUserAgent(USER_AGENT)));
     MockClientTransportInfo oobTransportInfo = newTransports.poll();
     assertEquals(0, newTransports.size());
     // The OOB transport reports in-use state

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -90,8 +90,9 @@ final class TestUtils {
         return mockTransport;
       }
     }).when(mockTransportFactory)
-        .newClientTransport(any(SocketAddress.class), any(String.class), any(String.class),
-            any(ProxyParameters.class));
+        .newClientTransport(
+            any(SocketAddress.class),
+            any(ClientTransportFactory.ClientTransportOptions.class));
 
     return captor;
   }

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -228,11 +228,11 @@ public final class CronetChannelBuilder extends
     }
 
     @Override
-    public ConnectionClientTransport newClientTransport(SocketAddress addr, String authority,
-        @Nullable String userAgent, @Nullable ProxyParameters proxy) {
+    public ConnectionClientTransport newClientTransport(
+        SocketAddress addr, ClientTransportOptions options) {
       InetSocketAddress inetSocketAddr = (InetSocketAddress) addr;
-      return new CronetClientTransport(streamFactory, inetSocketAddr, authority, userAgent,
-          executor, maxMessageSize, alwaysUsePut, transportTracer);
+      return new CronetClientTransport(streamFactory, inetSocketAddr, options.getAuthority(),
+          options.getUserAgent(), executor, maxMessageSize, alwaysUsePut, transportTracer);
     }
 
     @Override

--- a/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetChannelBuilderTest.java
@@ -27,6 +27,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.cronet.CronetChannelBuilder.CronetTransportFactory;
 import io.grpc.internal.ClientTransportFactory;
+import io.grpc.internal.ClientTransportFactory.ClientTransportOptions;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.testing.TestMethodDescriptors;
 import java.net.InetSocketAddress;
@@ -60,7 +61,7 @@ public final class CronetChannelBuilderTest {
     CronetClientTransport transport =
         (CronetClientTransport)
             transportFactory.newClientTransport(
-                new InetSocketAddress("localhost", 443), "", null, null);
+                new InetSocketAddress("localhost", 443), new ClientTransportOptions());
     CronetClientStream stream = transport.newStream(method, new Metadata(), CallOptions.DEFAULT);
 
     assertTrue(stream.idempotent);
@@ -74,7 +75,7 @@ public final class CronetChannelBuilderTest {
     CronetClientTransport transport =
         (CronetClientTransport)
             transportFactory.newClientTransport(
-                new InetSocketAddress("localhost", 443), "", null, null);
+                new InetSocketAddress("localhost", 443), new ClientTransportOptions());
     CronetClientStream stream = transport.newStream(method, new Metadata(), CallOptions.DEFAULT);
 
     assertFalse(stream.idempotent);

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
@@ -77,4 +77,9 @@ public abstract class GrpcHttp2ConnectionHandler extends Http2ConnectionHandler 
   public void notifyUnused() {
     channelUnused.setSuccess(null);
   }
+
+  /** Get the attributes of the EquivalentAddressGroup used to create this transport. */
+  public Attributes getEagAttributes() {
+    return Attributes.EMPTY;
+  }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -508,12 +508,15 @@ public final class NettyChannelBuilder
 
     @Override
     public ConnectionClientTransport newClientTransport(
-        SocketAddress serverAddress, String authority, @Nullable String userAgent,
-        @Nullable ProxyParameters proxy) {
+        SocketAddress serverAddress, ClientTransportOptions options) {
       checkState(!closed, "The transport factory is closed.");
 
       TransportCreationParamsFilter dparams =
-          transportCreationParamsFilterFactory.create(serverAddress, authority, userAgent, proxy);
+          transportCreationParamsFilterFactory.create(
+              serverAddress,
+              options.getAuthority(),
+              options.getUserAgent(),
+              options.getProxyParameters());
 
       final AtomicBackoff.State keepAliveTimeNanosState = keepAliveTimeNanos.getState();
       Runnable tooManyPingsRunnable = new Runnable() {

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -530,7 +530,7 @@ public final class NettyChannelBuilder
           dparams.getProtocolNegotiator(), flowControlWindow,
           maxMessageSize, maxHeaderListSize, keepAliveTimeNanosState.get(), keepAliveTimeoutNanos,
           keepAliveWithoutCalls, dparams.getAuthority(), dparams.getUserAgent(),
-          tooManyPingsRunnable, transportTracer);
+          tooManyPingsRunnable, transportTracer, options.getEagAttributes());
       return transport;
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -91,6 +91,7 @@ class NettyClientTransport implements ConnectionClientTransport {
   private ClientTransportLifecycleManager lifecycleManager;
   /** Since not thread-safe, may only be used from event loop. */
   private final TransportTracer transportTracer;
+  private final Attributes eagAttributes;
 
   NettyClientTransport(
       SocketAddress address, Class<? extends Channel> channelType,
@@ -98,7 +99,7 @@ class NettyClientTransport implements ConnectionClientTransport {
       ProtocolNegotiator negotiator, int flowControlWindow, int maxMessageSize,
       int maxHeaderListSize, long keepAliveTimeNanos, long keepAliveTimeoutNanos,
       boolean keepAliveWithoutCalls, String authority, @Nullable String userAgent,
-      Runnable tooManyPingsRunnable, TransportTracer transportTracer) {
+      Runnable tooManyPingsRunnable, TransportTracer transportTracer, Attributes eagAttributes) {
     this.negotiator = Preconditions.checkNotNull(negotiator, "negotiator");
     this.address = Preconditions.checkNotNull(address, "address");
     this.group = Preconditions.checkNotNull(group, "group");
@@ -115,6 +116,7 @@ class NettyClientTransport implements ConnectionClientTransport {
     this.tooManyPingsRunnable =
         Preconditions.checkNotNull(tooManyPingsRunnable, "tooManyPingsRunnable");
     this.transportTracer = Preconditions.checkNotNull(transportTracer, "transportTracer");
+    this.eagAttributes = Preconditions.checkNotNull(eagAttributes, "eagAttributes");
   }
 
   @Override
@@ -194,7 +196,8 @@ class NettyClientTransport implements ConnectionClientTransport {
         maxHeaderListSize,
         GrpcUtil.STOPWATCH_SUPPLIER,
         tooManyPingsRunnable,
-        transportTracer);
+        transportTracer,
+        eagAttributes);
     NettyHandlerSettings.setAutoWindow(handler);
 
     negotiationHandler = negotiator.newHandler(handler);

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -52,6 +52,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusException;
@@ -720,7 +721,8 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
         maxHeaderListSize,
         stopwatchSupplier,
         tooManyPingsRunnable,
-        transportTracer);
+        transportTracer,
+        Attributes.EMPTY);
   }
 
   @Override

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -96,9 +96,8 @@ public class NettyTransportTest extends AbstractTransportTest {
     int port = server.getPort();
     return clientFactory.newClientTransport(
         new InetSocketAddress("localhost", port),
-        testAuthority(server),
-        null /* agent */,
-        null /* proxy */);
+        new ClientTransportFactory.ClientTransportOptions()
+          .setAuthority(testAuthority(server)));
   }
 
   @Test

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -33,7 +33,6 @@ import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.KeepAliveManager;
-import io.grpc.internal.ProxyParameters;
 import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.internal.TransportTracer;
@@ -517,8 +516,7 @@ public class OkHttpChannelBuilder extends
 
     @Override
     public ConnectionClientTransport newClientTransport(
-        SocketAddress addr, String authority, @Nullable String userAgent,
-        @Nullable ProxyParameters proxy) {
+        SocketAddress addr, ClientTransportOptions options) {
       if (closed) {
         throw new IllegalStateException("The transport factory is closed.");
       }
@@ -532,14 +530,14 @@ public class OkHttpChannelBuilder extends
       InetSocketAddress inetSocketAddr = (InetSocketAddress) addr;
       OkHttpClientTransport transport = new OkHttpClientTransport(
           inetSocketAddr,
-          authority,
-          userAgent,
+          options.getAuthority(),
+          options.getUserAgent(),
           executor,
           socketFactory,
           hostnameVerifier,
           connectionSpec,
           maxMessageSize,
-          proxy,
+          options.getProxyParameters(),
           tooManyPingsRunnable,
           transportTracerFactory.create());
       if (enableKeepAlive) {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -114,7 +114,7 @@ public class OkHttpChannelBuilderTest {
   public void usePlaintext_newClientTransportAllowed() {
     OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("host", 1234).usePlaintext();
     builder.buildTransportFactory().newClientTransport(new InetSocketAddress(5678),
-        "dummy_authority", "dummy_userAgent", null /* proxy */);
+        new ClientTransportFactory.ClientTransportOptions());
   }
 
   @Test

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -82,9 +82,8 @@ public class OkHttpTransportTest extends AbstractTransportTest {
     int port = server.getPort();
     return clientFactory.newClientTransport(
         new InetSocketAddress("localhost", port),
-        testAuthority(server),
-        null /* agent */,
-        null /* proxy */);
+        new ClientTransportFactory.ClientTransportOptions()
+          .setAuthority(testAuthority(server)));
   }
 
   @Override

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractClientTransportFactoryTest.java
@@ -40,6 +40,7 @@ public abstract class AbstractClientTransportFactoryTest {
     ClientTransportFactory transportFactory = newClientTransportFactory();
     transportFactory.close();
     transportFactory.newClientTransport(
-        new InetSocketAddress("localhost", 12345), "localhost:" + 12345, "agent", null);
+        new InetSocketAddress("localhost", 12345),
+        new ClientTransportFactory.ClientTransportOptions());
   }
 }


### PR DESCRIPTION
There's two commits here, they are likely easiest to review separately. The first commit message provides some details that should help review for that commit (which is larger).

If need be, I can split the EAG plumbing changes out of the first commit and only have it be plumbing for ClientTransportOptions.

These changes are "noisy" because the method signature changed. There's not really much interesting code here, other than the new ClientTransportOptions and a few added tests.