### PR TITLE
grpclb: Plumb attributes for OOB and backend channels

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -523,6 +523,9 @@ public abstract class LoadBalancer {
      *
      * @since 1.4.0
      */
+    // TODO(ejona): Allow passing a List<EAG> here and to updateOobChannelAddresses, but want to
+    // wait until https://github.com/grpc/grpc-java/issues/4469 is done.
+    // https://github.com/grpc/grpc-java/issues/4618
     public abstract ManagedChannel createOobChannel(EquivalentAddressGroup eag, String authority);
 
     /**

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -36,6 +36,12 @@ public final class GrpcAttributes {
   public static final Attributes.Key<String> ATTR_LB_ADDR_AUTHORITY =
       Attributes.Key.create("io.grpc.grpclb.lbAddrAuthority");
 
+  /**
+   * Whether this EquivalentAddressGroup was provided by a GRPCLB server. It would be rare for this
+   * value to be {@code false}; generally it would be better to not have the key present at all.
+   */
+  public static final Attributes.Key<Boolean> ATTR_LB_PROVIDED_BACKEND =
+      Attributes.Key.create("io.grpc.grpclb.lbProvidedBackend");
 
   private GrpcAttributes() {}
 }


### PR DESCRIPTION
These attributes can be used by ALTS-specific code to determine whether
ALTS or TLS should be used.

----

Updating the tests was a "find a failing line, figure out what attribute is appropriate" loop. I tried to make sure I put the correct attributes at each point, such that the tests are verifying the correct behavior instead of "whatever the behavior is now." But it was a pretty error-prone process.