### PR TITLE
buildscripts: Hard-code PROTOBUF_VERSION in make_dependencies.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: java
 env:
   global:
     - GRADLE_OPTS=-Xmx512m
-    - PROTOBUF_VERSION=3.5.1
     - LDFLAGS=-L/tmp/protobuf/lib
     - CXXFLAGS=-I/tmp/protobuf/include
     - LD_LIBRARY_PATH=/tmp/protobuf/lib
@@ -52,7 +51,7 @@ notifications:
 
 cache:
   directories:
-    - /tmp/protobuf-${PROTOBUF_VERSION}
+    - /tmp/protobuf-*
     - /tmp/gradle-caches-modules-2
     - /tmp/gradle-wrapper
 

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -11,7 +11,6 @@ BASE_DIR="$(pwd)"
 cd "$BASE_DIR/github/grpc-java"
 
 export GRADLE_OPTS=-Xmx512m
-export PROTOBUF_VERSION=3.5.1
 export LDFLAGS=-L/tmp/protobuf/lib
 export CXXFLAGS=-I/tmp/protobuf/include
 export LD_LIBRARY_PATH=/tmp/protobuf/lib

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -23,9 +23,6 @@ cd $(dirname $0)/../..
 
 # TODO(zpencer): always make sure we are using Oracle jdk8
 
-# Proto deps
-export PROTOBUF_VERSION=3.5.1
-
 # ARCH is 64 bit unless otherwise specified.
 ARCH="${ARCH:-64}"
 

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,6 +3,8 @@
 # Build protoc
 set -evux -o pipefail
 
+PROTOBUF_VERSION=3.5.1
+
 # ARCH is 64 bit unless otherwise specified.
 ARCH="${ARCH:-64}"
 DOWNLOAD_DIR=/tmp/source
@@ -45,3 +47,11 @@ if [[ -L /tmp/protobuf ]]; then
   rm /tmp/protobuf
 fi
 ln -s "$INSTALL_DIR" /tmp/protobuf
+
+cat <<EOF
+To compile with the build dependencies:
+
+export LDFLAGS=-L/tmp/protobuf/lib
+export CXXFLAGS=-I/tmp/protobuf/include
+export LD_LIBRARY_PATH=/tmp/protobuf/lib
+EOF


### PR DESCRIPTION
We always want to use a consistent version of protobuf; avoid the need
for the caller (which may be a person running the script) to specify the
version.