### PR TITLE
netty: Fix regression in Java 9 ALPN support

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -219,6 +219,8 @@ public class GrpcSslContexts {
         apc = ALPN;
       } else if (JettyTlsUtil.isJettyNpnConfigured()) {
         apc = NPN;
+      } else if (JettyTlsUtil.isJava9AlpnAvailable()) {
+        apc = ALPN;
       } else {
         throw new IllegalArgumentException(
             SUN_PROVIDER_NAME + " selected, but Jetty NPN/ALPN unavailable");


### PR DESCRIPTION
Enable testing on Java 9+ in TlsTest, to prevent future regressions.

Fixes #4620