### PR TITLE
buildscripts: Remove set -x from run_in_docker.sh

### DIFF
--- a/buildscripts/run_in_docker.sh
+++ b/buildscripts/run_in_docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -eu -o pipefail
 
 quote() {
   local arg


### PR DESCRIPTION
Printing the commands is pretty ugly output and not particularly
helpful, unless debugging the logic. If needing to debug, just add the
-x locally.