### PR TITLE
core: turn PairSocketAddress into ProxySocketAddress

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -184,12 +184,7 @@ final class DnsNameResolver extends NameResolver {
           if (proxy != null) {
             EquivalentAddressGroup server =
                 new EquivalentAddressGroup(
-                    new PairSocketAddress(
-                        destination,
-                        Attributes
-                            .newBuilder()
-                            .set(ProxyDetector.PROXY_PARAMS_KEY, proxy)
-                            .build()));
+                    new ProxySocketAddress(destination, proxy));
             savedListener.onAddresses(Collections.singletonList(server), Attributes.EMPTY);
             return;
           }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -222,9 +222,9 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
     SocketAddress address = addressIndex.getCurrentAddress();
 
     ProxyParameters proxy = null;
-    if (address instanceof PairSocketAddress) {
-      proxy = ((PairSocketAddress) address).getAttributes().get(ProxyDetector.PROXY_PARAMS_KEY);
-      address = ((PairSocketAddress) address).getAddress();
+    if (address instanceof ProxySocketAddress) {
+      proxy = ((ProxySocketAddress) address).getProxyParameters();
+      address = ((ProxySocketAddress) address).getAddress();
     }
 
     ClientTransportFactory.ClientTransportOptions options =

--- a/core/src/main/java/io/grpc/internal/ProxyDetector.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetector.java
@@ -16,7 +16,6 @@
 
 package io.grpc.internal;
 
-import io.grpc.Attributes;
 import java.io.IOException;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -28,7 +27,6 @@ import javax.annotation.Nullable;
  * {@link io.grpc.NameResolver}.
  */
 public interface ProxyDetector {
-  Attributes.Key<ProxyParameters> PROXY_PARAMS_KEY = Attributes.Key.create("proxy-params-key");
   /**
    * Given a target address, returns which proxy address should be used. If no proxy should be
    * used, then return value will be null. The address of the {@link ProxyParameters} is always

--- a/core/src/main/java/io/grpc/internal/ProxySocketAddress.java
+++ b/core/src/main/java/io/grpc/internal/ProxySocketAddress.java
@@ -18,26 +18,25 @@ package io.grpc.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import io.grpc.Attributes;
 import java.net.SocketAddress;
 
 /**
- * A data structure to associate a {@link SocketAddress} with {@link Attributes}.
+ * A data structure to associate a {@link SocketAddress} with {@link ProxyParameters}.
  */
-final class PairSocketAddress extends SocketAddress {
+final class ProxySocketAddress extends SocketAddress {
   private static final long serialVersionUID = -6854992294603212793L;
 
   private final SocketAddress address;
-  private final Attributes attributes;
+  private final ProxyParameters proxyParameters;
 
   @VisibleForTesting
-  PairSocketAddress(SocketAddress address, Attributes attributes) {
+  ProxySocketAddress(SocketAddress address, ProxyParameters proxyParameters) {
     this.address = Preconditions.checkNotNull(address);
-    this.attributes = Preconditions.checkNotNull(attributes);
+    this.proxyParameters = Preconditions.checkNotNull(proxyParameters);
   }
 
-  public Attributes getAttributes() {
-    return attributes;
+  public ProxyParameters getProxyParameters() {
+    return proxyParameters;
   }
 
   public SocketAddress getAddress() {

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -313,8 +313,8 @@ public class DnsNameResolverTest {
     EquivalentAddressGroup eag = result.get(0);
     assertThat(eag.getAddresses()).hasSize(1);
 
-    PairSocketAddress socketAddress = (PairSocketAddress) eag.getAddresses().get(0);
-    assertSame(proxyParameters, socketAddress.getAttributes().get(ProxyDetector.PROXY_PARAMS_KEY));
+    ProxySocketAddress socketAddress = (ProxySocketAddress) eag.getAddresses().get(0);
+    assertSame(proxyParameters, socketAddress.getProxyParameters());
     assertTrue(((InetSocketAddress) socketAddress.getAddress()).isUnresolved());
   }
 


### PR DESCRIPTION
This internal class will only ever be used to plumb proxy info.