### PR TITLE
buildscript: fix jdk9, remove jdk10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ before_install:
     ln -s /tmp/gradle-caches-modules-2 $HOME/.gradle/caches/modules-2
   - mkdir -p $HOME/.gradle &&
     ln -s /tmp/gradle-wrapper $HOME/.gradle/wrapper
-    # Work around https://github.com/travis-ci/travis-ci/issues/2317
-  - if \[ "$TRAVIS_OS_NAME" = linux \]; then jdk_switcher use oraclejdk8; fi
   - buildscripts/make_dependencies.sh # build protoc into /tmp/protobuf
   - mkdir -p $HOME/.gradle
   - echo "checkstyle.ignoreFailures=false" >> $HOME/.gradle/gradle.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ os:
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
 
 notifications:
   email: false

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,6 +15,9 @@
     <protobuf.version>3.5.1</protobuf.version>
     <protoc.version>3.5.1-1</protoc.version>
     <netty.tcnative.version>2.0.7.Final</netty.tcnative.version>
+    <!-- required for jdk9 -->
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
We do not want to always use jdk8, this allows the `jdk:` section to
select the jdk