### PR TITLE
context: Avoid deprecated Truth API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,7 +227,7 @@ subprojects {
             // Test dependencies.
             junit: 'junit:junit:4.12',
             mockito: 'org.mockito:mockito-core:1.9.5',
-            truth: 'com.google.truth:truth:0.36',
+            truth: 'com.google.truth:truth:0.42',
             guava_testlib: 'com.google.guava:guava-testlib:20.0',
 
             // Benchmark dependencies

--- a/context/src/test/java/io/grpc/testing/DeadlineSubject.java
+++ b/context/src/test/java/io/grpc/testing/DeadlineSubject.java
@@ -17,6 +17,8 @@
 package io.grpc.testing;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.lenientFormat;
+import static com.google.common.truth.Fact.simpleFact;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import com.google.common.truth.ComparableSubject;
@@ -60,11 +62,11 @@ public final class DeadlineSubject extends ComparableSubject<DeadlineSubject, De
         BigInteger expectedTimeRemaining = BigInteger.valueOf(expected.timeRemaining(NANOSECONDS));
         BigInteger deltaNanos = BigInteger.valueOf(timeUnit.toNanos(delta));
         if (actualTimeRemaining.subtract(expectedTimeRemaining).abs().compareTo(deltaNanos) > 0) {
-          failWithRawMessage(
-              "%s and <%s> should have been within <%sns> of each other",
-              actualAsString(),
-              expected,
-              deltaNanos);
+          failWithoutActual(
+              simpleFact(
+                  lenientFormat(
+                      "%s and <%s> should have been within <%sns> of each other",
+                      actualAsString(), expected, deltaNanos)));
         }
       }
     };


### PR DESCRIPTION
This helps an internal cleanup removing the old failWithRawMessage API.

CC @carl-mastrangelo 