### PR TITLE
Remove DoNotMock annotation in favor of JavaDoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,7 @@ subprojects {
             epoll_suffix = ":" + osdetector.classifier
         }
         libraries = [
-            errorprone: "com.google.errorprone:error_prone_annotations:2.1.2",
+            errorprone: "com.google.errorprone:error_prone_annotations:2.2.0",
             gson: "com.google.code.gson:gson:2.7",
             guava: "com.google.guava:guava:${guavaVersion}",
             hpack: 'com.twitter:hpack:0.10.1',

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,8 +9,6 @@ dependencies {
     compile (libraries.opencensus_api) {
         // prefer 3.0.0 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 2.1.2 from libraries instead of 2.2.0
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         // prefer 20.0 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
         // we'll always be more up-to-date
@@ -21,8 +19,6 @@ dependencies {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
         // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
-        // prefer 2.1.2 from libraries instead of 2.2.0
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         // prefer 20.0 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
     }

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -16,7 +16,6 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.DoNotMock;
 import javax.annotation.Nullable;
 
 /**
@@ -95,10 +94,11 @@ import javax.annotation.Nullable;
  *   call.request(1);
  * </pre>
  *
+ * <p>DO NOT MOCK: Use InProcessServerBuilder and make a test server instead.
+ *
  * @param <ReqT> type of message sent one or more times to the server.
  * @param <RespT> type of message received one or more times from the server.
  */
-@DoNotMock("Use InProcessServerBuilder and make a test server instead")
 public abstract class ClientCall<ReqT, RespT> {
   /**
    * Callbacks for receiving metadata, response messages and completion status from the server.

--- a/core/src/main/java/io/grpc/ServerCall.java
+++ b/core/src/main/java/io/grpc/ServerCall.java
@@ -16,7 +16,6 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.DoNotMock;
 import javax.annotation.Nullable;
 
 /**
@@ -33,10 +32,11 @@ import javax.annotation.Nullable;
  *
  * <p>Methods are guaranteed to be non-blocking. Implementations are not required to be thread-safe.
  *
+ * <p>DO NOT MOCK: Use InProcessTransport and make a fake server instead.
+ *
  * @param <ReqT> parsed type of request message.
  * @param <RespT> parsed type of response message.
  */
-@DoNotMock("Use InProcessTransport and make a fake server instead")
 public abstract class ServerCall<ReqT, RespT> {
 
   /**

--- a/core/src/main/java/io/grpc/StreamTracer.java
+++ b/core/src/main/java/io/grpc/StreamTracer.java
@@ -16,15 +16,15 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.DoNotMock;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Listens to events on a stream to collect metrics.
+ *
+ * <p>DO NOT MOCK: Use TestStreamTracer. Mocks are not thread-safe
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
 @ThreadSafe
-@DoNotMock
 public abstract class StreamTracer {
   /**
    * Stream is closed.  This will be called exactly once.

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -133,8 +133,8 @@ def com_google_code_gson():
 def com_google_errorprone_error_prone_annotations():
   native.maven_jar(
       name = "com_google_errorprone_error_prone_annotations",
-      artifact = "com.google.errorprone:error_prone_annotations:2.1.2",
-      sha1 = "6dcc08f90f678ac33e5ef78c3c752b6f59e63e0c",
+      artifact = "com.google.errorprone:error_prone_annotations:2.2.0",
+      sha1 = "88e3c593e9b3586e1c6177f89267da6fc6986f0c",
   )
 
 def com_google_guava():

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -18,7 +18,6 @@ package io.grpc.stub;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.errorprone.annotations.DoNotMock;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -41,11 +40,13 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>Configuration is stored in {@link CallOptions} and is passed to the {@link Channel} when
  * performing an RPC.
  *
+ * <p>DO NOT MOCK: Customizing options doesn't work properly in mocks. Use InProcessChannelBuilder
+ * to create a real channel suitable for testing. It is also possible to mock Channel instead.
+ *
  * @since 1.0.0
  * @param <S> the concrete type of this stub.
  */
 @ThreadSafe
-@DoNotMock
 @CheckReturnValue
 public abstract class AbstractStub<S extends AbstractStub<S>> {
   private final Channel channel;

--- a/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/CallStreamObserver.java
@@ -16,7 +16,6 @@
 
 package io.grpc.stub;
 
-import com.google.errorprone.annotations.DoNotMock;
 import io.grpc.ExperimentalApi;
 
 /**
@@ -37,9 +36,11 @@ import io.grpc.ExperimentalApi;
  *
  * <p>Like {@code StreamObserver}, implementations are not required to be thread-safe; if multiple
  * threads will be writing to an instance concurrently, the application must synchronize its calls.
+ *
+ * <p>DO NOT MOCK: The API is too complex to reliably mock. Use InProcessChannelBuilder to create
+ * "real" RPCs suitable for testing.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1788")
-@DoNotMock
 public abstract class CallStreamObserver<V> implements StreamObserver<V> {
 
   /**

--- a/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCallStreamObserver.java
@@ -16,7 +16,6 @@
 
 package io.grpc.stub;
 
-import com.google.errorprone.annotations.DoNotMock;
 import io.grpc.ExperimentalApi;
 
 import javax.annotation.Nullable;
@@ -27,9 +26,11 @@ import javax.annotation.Nullable;
  *
  * <p>Like {@code StreamObserver}, implementations are not required to be thread-safe; if multiple
  * threads will be writing to an instance concurrently, the application must synchronize its calls.
+ *
+ * <p>DO NOT MOCK: The API is too complex to reliably mock. Use InProcessChannelBuilder to create
+ * "real" RPCs suitable for testing and make a fake for the server-side.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1788")
-@DoNotMock
 public abstract class ClientCallStreamObserver<V> extends CallStreamObserver<V> {
   /**
    * Prevent any further processing for this {@code ClientCallStreamObserver}. No further messages

--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -16,7 +16,6 @@
 
 package io.grpc.stub;
 
-import com.google.errorprone.annotations.DoNotMock;
 import io.grpc.ExperimentalApi;
 
 /**
@@ -25,9 +24,11 @@ import io.grpc.ExperimentalApi;
  *
  * <p>Like {@code StreamObserver}, implementations are not required to be thread-safe; if multiple
  * threads will be writing to an instance concurrently, the application must synchronize its calls.
+ *
+ * <p>DO NOT MOCK: The API is too complex to reliably mock. Use InProcessChannelBuilder to create
+ * "real" RPCs suitable for testing and interact with the server using a normal client stub.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1788")
-@DoNotMock
 public abstract class ServerCallStreamObserver<V> extends CallStreamObserver<V> {
 
   /**


### PR DESCRIPTION
DoNotMock was removed from error_prone_annotations in 2.1.3, because
there was no enforcement mechanism (which is in google/error-prone#572).
Guava and Trust also depend on error_prone_annotations and are beginning
to use newer versions, so our usage of DoNotMock is causing diamond
dependency problems. This allows us to update to 2.2.0.

The annotations were useful internally; we're solving that in cl/205294089.

------

This came out of trying to fix #4655.