### PR TITLE
interop-testing: Fix clientStreaming interop test does not fail on missing trailers

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -559,8 +559,19 @@ public abstract class AbstractInteropTest {
       requestObserver.onNext(request);
     }
     requestObserver.onCompleted();
-    assertEquals(goldenResponse, responseObserver.firstValue().get());
     responseObserver.awaitCompletion();
+    assertEquals(goldenResponse, responseObserver.firstValue().get());
+    assertThat(responseObserver.getValues()).hasSize(1);
+    final Throwable t = responseObserver.getError();
+    if(t != null) {
+      // AssertionError(String, Throwable) only present in Android API 19+ & Java 7+
+      throw new AssertionError("RPC failed") {
+        @Override
+            public synchronized Throwable getCause() {
+              return t;
+            }
+      };
+    }
   }
 
   /**

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -559,18 +559,13 @@ public abstract class AbstractInteropTest {
       requestObserver.onNext(request);
     }
     requestObserver.onCompleted();
-    responseObserver.awaitCompletion();
+
     assertEquals(goldenResponse, responseObserver.firstValue().get());
+    responseObserver.awaitCompletion();
     assertThat(responseObserver.getValues()).hasSize(1);
-    final Throwable t = responseObserver.getError();
+    Throwable t = responseObserver.getError();
     if (t != null) {
-      // AssertionError(String, Throwable) only present in Android API 19+ & Java 7+
-      throw new AssertionError("RPC failed") {
-        @Override
-            public synchronized Throwable getCause() {
-              return t;
-            }
-      };
+      throw new AssertionError(t);
     }
   }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -563,7 +563,7 @@ public abstract class AbstractInteropTest {
     assertEquals(goldenResponse, responseObserver.firstValue().get());
     assertThat(responseObserver.getValues()).hasSize(1);
     final Throwable t = responseObserver.getError();
-    if(t != null) {
+    if (t != null) {
       // AssertionError(String, Throwable) only present in Android API 19+ & Java 7+
       throw new AssertionError("RPC failed") {
         @Override


### PR DESCRIPTION
If the server sends all response message but does not send the trailers, client throws
StatusRuntimeException: INTERNAL: Received unexpected EOS on DATA frame from server