### PR TITLE
android: include proguard config to keep method names

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: "signing"
 android {
     compileSdkVersion 27
     defaultConfig {
+        consumerProguardFiles "proguard-rules.txt"
         minSdkVersion 14
         targetSdkVersion 27
         versionCode 1

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -1,0 +1,7 @@
+-keepclassmembers class io.grpc.okhttp.OkHttpChannelBuilder {
+  io.grpc.okhttp.OkHttpChannelBuilder forTarget(java.lang.String);
+  io.grpc.okhttp.OkHttpChannelBuilder hostnameVerifier(javax.net.ssl.HostnameVerifier);
+  io.grpc.okhttp.OkHttpChannelBuilder scheduledExecutorService(java.util.concurrent.ScheduledExecutorService);
+  io.grpc.okhttp.OkHttpChannelBuilder sslSocketFactory(javax.net.ssl.SSLSocketFactory);
+  io.grpc.okhttp.OkHttpChannelBuilder transportExecutor(java.util.concurrent.Executor);
+}


### PR DESCRIPTION
Otherwise these are stripped out by Proguard, which doesn't know to preserve them, since (without taking a dependency on grpc-okhttp) the reflective lookup is of the form `Class.forName("io.grpc.okhttp.OkHttpChannelBuilder").getMethod(x)` instead of the Proguard-friendly`OkHttpChannelBuilder.class.getMethod(x)`. 

These rules are specific to OkHttpChannelBuilder (a requirement but not dependency to use AndroidChannelBuilder). They can be generified later if we add support for CronetChannelBuilder as well.

Adding as a `consumerProguardFiles` means that the proguard file is included in the library artifact and automatically incorporated into the app's proguard configuration. See the "Library modules may include their own ProGuard configuration file" section of the [Android library docs](https://developer.android.com/studio/projects/android-library#Considerations) for more details.