### PR TITLE
Downgrade to Truth 0.41 for Java 7 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ subprojects {
             // Test dependencies.
             junit: 'junit:junit:4.12',
             mockito: 'org.mockito:mockito-core:1.9.5',
-            truth: 'com.google.truth:truth:0.42',
+            truth: 'com.google.truth:truth:0.41',
             guava_testlib: 'com.google.guava:guava-testlib:20.0',
 
             // Benchmark dependencies
@@ -250,7 +250,9 @@ subprojects {
             // care for artifacts used as libraries by others.
             if (!(project.name in [
                 'grpc-benchmarks',
-                'grpc-interop-testing'
+                'grpc-interop-testing',
+                'grpc-gae-interop-testing-jdk7',
+                'grpc-gae-interop-testing-jdk8',
             ])) {
                 resolutionStrategy.failOnVersionConflict()
             }


### PR DESCRIPTION
gae-jdk7 in particular is failing with the 0.42 Truth because it depends
on org.checkerframework:checker-qual 2.5.3 instead of 2.0.0.

------

This is a workaround. We're going to need to figure out a long-term strategy. We have to be able to update to newer versions.