### PR TITLE
core: channel tracing log only when number of backends changed between zeor and nonzero

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -211,7 +211,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
   @CheckForNull
   private final ChannelTracer channelTracer;
   private final Channelz channelz;
-  private Boolean nonzeroBackends; // a flag for doing channel tracing when flipped
+  private Boolean zeroBackends; // a flag for doing channel tracing when flipped
 
   // One instance per channel.
   private final ChannelBufferMeter channelBufferUsed = new ChannelBufferMeter();
@@ -1247,13 +1247,13 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
             new Object[]{getLogId(), servers, config});
       }
 
-      if (channelTracer != null && (nonzeroBackends == null || !nonzeroBackends)) {
+      if (channelTracer != null && (zeroBackends == null || zeroBackends)) {
         channelTracer.reportEvent(new ChannelTrace.Event.Builder()
             .setDescription("Address resolved: " + servers)
             .setSeverity(ChannelTrace.Event.Severity.CT_INFO)
             .setTimestampNanos(timeProvider.currentTimeNanos())
             .build());
-        nonzeroBackends = true;
+        zeroBackends = false;
       }
 
       final class NamesResolved implements Runnable {
@@ -1294,13 +1294,13 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
       checkArgument(!error.isOk(), "the error status must not be OK");
       logger.log(Level.WARNING, "[{0}] Failed to resolve name. status={1}",
           new Object[] {getLogId(), error});
-      if (channelTracer != null && (nonzeroBackends == null || nonzeroBackends)) {
+      if (channelTracer != null && (zeroBackends == null || !zeroBackends)) {
         channelTracer.reportEvent(new ChannelTrace.Event.Builder()
             .setDescription("Failed to resolve name")
             .setSeverity(ChannelTrace.Event.Severity.CT_WARNING)
             .setTimestampNanos(timeProvider.currentTimeNanos())
             .build());
-        nonzeroBackends = false;
+        zeroBackends = true;
       }
       channelExecutor
           .executeLater(

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -2139,6 +2139,40 @@ public class ManagedChannelImplTest {
   }
 
   @Test
+  public void channelTracing_nameResolvedEvent_zeorAndNonzeroBackends() throws Exception {
+    timer.forwardNanos(1234);
+    channelBuilder.maxTraceEvents(10);
+    List<EquivalentAddressGroup> servers = new ArrayList<EquivalentAddressGroup>();
+    servers.add(new EquivalentAddressGroup(socketAddress));
+    FakeNameResolverFactory nameResolverFactory =
+        new FakeNameResolverFactory.Builder(expectedUri).setServers(servers).build();
+    channelBuilder.nameResolverFactory(nameResolverFactory);
+    createChannel();
+
+    int prevSize = getStats(channel).channelTrace.events.size();
+    nameResolverFactory.resolvers.get(0).listener.onAddresses(
+        Collections.singletonList(new EquivalentAddressGroup(
+            Arrays.asList(new SocketAddress() {}, new SocketAddress() {}))),
+        Attributes.EMPTY);
+    assertThat(getStats(channel).channelTrace.events).hasSize(prevSize);
+
+    prevSize = getStats(channel).channelTrace.events.size();
+    nameResolverFactory.resolvers.get(0).listener.onError(Status.INTERNAL);
+    assertThat(getStats(channel).channelTrace.events).hasSize(prevSize + 1);
+
+    prevSize = getStats(channel).channelTrace.events.size();
+    nameResolverFactory.resolvers.get(0).listener.onError(Status.INTERNAL);
+    assertThat(getStats(channel).channelTrace.events).hasSize(prevSize);
+
+    prevSize = getStats(channel).channelTrace.events.size();
+    nameResolverFactory.resolvers.get(0).listener.onAddresses(
+        Collections.singletonList(new EquivalentAddressGroup(
+            Arrays.asList(new SocketAddress() {}, new SocketAddress() {}))),
+        Attributes.EMPTY);
+    assertThat(getStats(channel).channelTrace.events).hasSize(prevSize + 1);
+  }
+
+  @Test
   public void channelTracing_stateChangeEvent() throws Exception {
     channelBuilder.maxTraceEvents(10);
     createChannel();


### PR DESCRIPTION
This is to implement one of changes made in the spec
https://github.com/grpc/proposal/pull/89/files