### PR TITLE
android: include proguard config to keep method names

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: "signing"
 android {
     compileSdkVersion 27
     defaultConfig {
+        consumerProguardFiles "proguard-rules.txt"
         minSdkVersion 14
         targetSdkVersion 27
         versionCode 1

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -1,5 +1,6 @@
 -keepclassmembers class io.grpc.okhttp.OkHttpChannelBuilder {
   io.grpc.okhttp.OkHttpChannelBuilder forTarget(java.lang.String);
+  io.grpc.okhttp.OkHttpChannelBuilder scheduledExecutorService(java.util.concurrent.ScheduledExecutorService);
   io.grpc.okhttp.OkHttpChannelBuilder sslSocketFactory(javax.net.ssl.SSLSocketFactory);
   io.grpc.okhttp.OkHttpChannelBuilder transportExecutor(java.util.concurrent.Executor);
 }

--- a/android/proguard-rules.txt
+++ b/android/proguard-rules.txt
@@ -1,0 +1,5 @@
+-keepclassmembers class io.grpc.okhttp.OkHttpChannelBuilder {
+  io.grpc.okhttp.OkHttpChannelBuilder forTarget(java.lang.String);
+  io.grpc.okhttp.OkHttpChannelBuilder sslSocketFactory(javax.net.ssl.SSLSocketFactory);
+  io.grpc.okhttp.OkHttpChannelBuilder transportExecutor(java.util.concurrent.Executor);
+}

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -114,18 +114,6 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
     }
   }
 
-  /** Set the delegate channel builder's hostnameVerifier. */
-  public AndroidChannelBuilder hostnameVerifier(@Nullable HostnameVerifier hostnameVerifier) {
-    try {
-      OKHTTP_CHANNEL_BUILDER_CLASS
-          .getMethod("hostnameVerifier", HostnameVerifier.class)
-          .invoke(delegateBuilder, hostnameVerifier);
-      return this;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to invoke hostnameVerifier on delegate builder", e);
-    }
-  }
-
   /** Set the delegate channel builder's sslSocketFactory. */
   public AndroidChannelBuilder sslSocketFactory(SSLSocketFactory factory) {
     try {
@@ -135,20 +123,6 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
       return this;
     } catch (Exception e) {
       throw new RuntimeException("Failed to invoke sslSocketFactory on delegate builder", e);
-    }
-  }
-
-  /** Set the delegate channel builder's scheduledExecutorService. */
-  public AndroidChannelBuilder scheduledExecutorService(
-      ScheduledExecutorService scheduledExecutorService) {
-    try {
-      OKHTTP_CHANNEL_BUILDER_CLASS
-          .getMethod("scheduledExecutorService", ScheduledExecutorService.class)
-          .invoke(delegateBuilder, scheduledExecutorService);
-      return this;
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "Failed to invoke scheduledExecutorService on delegate builder", e);
     }
   }
 

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -126,6 +126,20 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
     }
   }
 
+  /** Set the delegate channel builder's scheduledExecutorService. */
+  public AndroidChannelBuilder scheduledExecutorService(
+      ScheduledExecutorService scheduledExecutorService) {
+    try {
+      OKHTTP_CHANNEL_BUILDER_CLASS
+          .getMethod("scheduledExecutorService", ScheduledExecutorService.class)
+          .invoke(delegateBuilder, scheduledExecutorService);
+      return this;
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to invoke scheduledExecutorService on delegate builder", e);
+    }
+  }
+
   @Override
   protected ManagedChannelBuilder<?> delegate() {
     return delegateBuilder;

--- a/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
+++ b/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
@@ -113,6 +113,11 @@ public final class AndroidChannelBuilderTest {
   }
 
   @Test
+  public void scheduledExecutorService() {
+    AndroidChannelBuilder.forTarget("target").scheduledExecutorService(new ScheduledExecutorImpl());
+  }
+
+  @Test
   @Config(sdk = 23)
   public void nullContextDoesNotThrow_api23() {
     TestChannel delegateChannel = new TestChannel();

--- a/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
+++ b/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
@@ -107,26 +107,9 @@ public final class AndroidChannelBuilderTest {
   }
 
   @Test
-  public void hostnameVerifier() {
-    AndroidChannelBuilder.forTarget("target")
-        .hostnameVerifier(
-            new HostnameVerifier() {
-              @Override
-              public boolean verify(String hostname, SSLSession session) {
-                return true;
-              }
-            });
-  }
-
-  @Test
   public void sslSocketFactory() {
     AndroidChannelBuilder.forTarget("target")
         .sslSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
-  }
-
-  @Test
-  public void scheduledExecutorService() {
-    AndroidChannelBuilder.forTarget("target").scheduledExecutorService(new ScheduledExecutorImpl());
   }
 
   @Test


### PR DESCRIPTION
Redo of https://github.com/grpc/grpc-java/pull/4662. 

Also deletes some unnecessary forwarding methods from AndroidChannelBuilder