### PR TITLE
Upgrade to Truth 0.42

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ subprojects {
             // Test dependencies.
             junit: 'junit:junit:4.12',
             mockito: 'org.mockito:mockito-core:1.9.5',
-            truth: 'com.google.truth:truth:0.41',
+            truth: 'com.google.truth:truth:0.42',
             guava_testlib: 'com.google.guava:guava-testlib:20.0',
 
             // Benchmark dependencies

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -23,8 +23,13 @@ dependencies {
             project(':grpc-testing'),
             libraries.junit,
             libraries.mockito,
-            libraries.oauth_client,
-            libraries.truth
+            libraries.oauth_client
+    compile (libraries.truth) {
+        // Disable because it uses Java 8 bytecode, which breaks gae-java7
+        exclude group: 'com.google.auto.value', module: 'auto-value-annotations'
+        // Disable because it uses Java 8 bytecode, which breaks gae-java7
+        exclude group: 'org.checkerframework', module: 'checker-qual'
+    }
     compileOnly libraries.javax_annotation
     runtime libraries.opencensus_impl,
             libraries.netty_tcnative


### PR DESCRIPTION
Truth 0.42 brings in some Java 8 bytecode, but they are only in
annotations. So we remove them for gae-java7, otherwise they cause the
build to fail with messages like:

> Unable to stage app: Class file is Java 8 but max supported is Java 7: com/google/auto/value/extension/memoized/Memoized.class in /usr/local/google/home/ejona/clients/grpc-java/gae-interop-testing/gae-jdk7/build/exploded-grpc-gae-interop-testing-jdk7/WEB-INF/lib/auto-value-annotations-1.6.2.jar
> Unable to stage app: Class file is Java 8 but max supported is Java 7: org/checkerframework/dataflow/qual/Pure$Kind.class in /tmpfs/src/github/grpc-java/gae-interop-testing/gae-jdk7/build/exploded-grpc-gae-interop-testing-jdk7/WEB-INF/lib/checker-qual-2.5.3.jar

I manually tested the interop client with Java 7 and it ran without
issue.

This fixes the issues experienced with Truth 0.42 before in #4664.
Related: google/truth#479

-----

CC @carl-mastrangelo 