### PR TITLE
gae-interop-testing: Disable special_status_message

### DIFF
--- a/gae-interop-testing/gae-jdk7/build.gradle
+++ b/gae-interop-testing/gae-jdk7/build.gradle
@@ -53,6 +53,11 @@ dependencies {
     runtime libraries.opencensus_impl_lite
 }
 
+compileJava {
+    // Disable "No processor claimed any of these annotations: org.junit.Ignore"
+    options.compilerArgs += ["-Xlint:-processing"]
+}
+
 // [START model]
 appengine {
     // App Engine tasks configuration

--- a/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
@@ -158,16 +158,24 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
     }
 
     // grpc-test.sandbox.googleapis.com does not support these tests
+    @Ignore
     @Override
     public void customMetadata() { }
 
+    @Ignore
     @Override
     public void statusCodeAndMessage() { }
 
+    @Ignore
     @Override
     public void exchangeMetadataUnaryCall() { }
 
+    @Ignore
     @Override
     public void exchangeMetadataStreamingCall() { }
+
+    @Ignore
+    @Override
+    public void specialStatusMessage() {}
   }
 }

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -50,6 +50,11 @@ dependencies {
     compile libraries.netty_tcnative
 }
 
+compileJava {
+    // Disable "No processor claimed any of these annotations: org.junit.Ignore"
+    options.compilerArgs += ["-Xlint:-processing"]
+}
+
 // [START model]
 appengine {
     // App Engine tasks configuration

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -30,6 +30,7 @@ import java.util.Calendar;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.junit.Ignore;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
@@ -102,16 +103,24 @@ public final class NettyClientInteropServlet extends HttpServlet {
     }
 
     // grpc-test.sandbox.googleapis.com does not support these tests
+    @Ignore
     @Override
     public void customMetadata() { }
 
+    @Ignore
     @Override
     public void statusCodeAndMessage() { }
 
+    @Ignore
     @Override
     public void exchangeMetadataUnaryCall() { }
 
+    @Ignore
     @Override
     public void exchangeMetadataStreamingCall() { }
+
+    @Ignore
+    @Override
+    public void specialStatusMessage() {}
   }
 }


### PR DESCRIPTION
The server doesn't support Echo Status.

CC @zpencer 

This fixes a regression caused by #4682