### PR TITLE
gradle: Use config_loc in checkstyle

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -26,13 +26,12 @@ subprojects {
     apply plugin: "checkstyle"
 
     checkstyle {
-        configFile = file("$rootDir/../buildscripts/checkstyle.xml")
+        configDir = file("$rootDir/../buildscripts")
         toolVersion = "6.17"
         ignoreFailures = false
         if (rootProject.hasProperty("checkstyle.ignoreFailures")) {
             ignoreFailures = rootProject.properties["checkstyle.ignoreFailures"].toBoolean()
         }
-        configProperties["rootDir"] = "$rootDir/../"
     }
 
     // Checkstyle doesn't run automatically with android

--- a/build.gradle
+++ b/build.gradle
@@ -295,13 +295,12 @@ subprojects {
     }
 
     checkstyle {
-        configFile = file("$rootDir/buildscripts/checkstyle.xml")
+        configDir = file("$rootDir/buildscripts")
         toolVersion = "6.17"
         ignoreFailures = false
         if (rootProject.hasProperty("checkstyle.ignoreFailures")) {
             ignoreFailures = rootProject.properties["checkstyle.ignoreFailures"].toBoolean()
         }
-        configProperties["rootDir"] = rootDir
     }
 
     checkstyleMain {

--- a/buildscripts/checkstyle.xml
+++ b/buildscripts/checkstyle.xml
@@ -21,7 +21,7 @@
     <property name="severity" value="error"/>
 
     <module name="Header">
-      <property name="headerFile" value="${rootDir}/buildscripts/checkstyle.license"/>
+      <property name="headerFile" value="${config_loc}/checkstyle.license"/>
       <property name="ignoreLines" value="2"/>
       <property name="fileExtensions" value="java"/>
     </module>


### PR DESCRIPTION
We previously passed a custom variable to the checkstyle configuration.
In Gradle 4.0 config_loc was added for the same purpose. The default
configDir is $projectDir/config/checkstyle which is different for each
project; we need to override it to always point to the root project.