### PR TITLE
inprocess: prevent null names, and define socket address equality

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessSocketAddress.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessSocketAddress.java
@@ -16,6 +16,8 @@
 
 package io.grpc.inprocess;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.net.SocketAddress;
 
 /**
@@ -26,16 +28,47 @@ public final class InProcessSocketAddress extends SocketAddress {
 
   private final String name;
 
+  /**
+   * @param name - The name of the inprocess channel or server.
+   * @since 1.0.0
+   */
   public InProcessSocketAddress(String name) {
-    this.name = name;
+    this.name = checkNotNull(name, "name");
   }
 
+  /**
+   * Gets the name of the inprocess channel or server.
+   *
+   * @since 1.0.0
+   */
   public String getName() {
     return name;
   }
-  
+
+  /**
+   * @since 1.14.0
+   */
   @Override
   public String toString() {
     return name;
+  }
+
+  /**
+   * @since 1.15.0
+   */
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+
+  /**
+   * @since 1.15.0
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof InProcessSocketAddress)) {
+      return false;
+    }
+    return name.equals(((InProcessSocketAddress) obj).name);
   }
 }

--- a/core/src/test/java/io/grpc/inprocess/InProcessSocketAddressTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessSocketAddressTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.inprocess;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class InProcessSocketAddressTest {
+
+  @Test
+  public void equal() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new InProcessSocketAddress("a"),
+            new InProcessSocketAddress(new String("a")))
+        .addEqualityGroup(
+            new InProcessSocketAddress("z"),
+            new InProcessSocketAddress("z"))
+        .addEqualityGroup(
+            new InProcessSocketAddress(""),
+            new InProcessSocketAddress("")
+        )
+        .testEquals();
+  }
+
+  @Test
+  public void hash() {
+    assertThat(new InProcessSocketAddress("a").hashCode())
+        .isEqualTo(new InProcessSocketAddress(new String("a")).hashCode());
+  }
+}


### PR DESCRIPTION
This is a minor API change, since names can no longer be null.  gRPC never constructed these addresses with null, but other users could.