### PR TITLE
Encourage using grpc-netty-shaded instead of grpc-netty

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 ```xml
 <dependency>
   <groupId>io.grpc</groupId>
-  <artifactId>grpc-netty</artifactId>
+  <artifactId>grpc-netty-shaded</artifactId>
   <version>1.14.0</version>
 </dependency>
 <dependency>
@@ -47,12 +47,12 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 
 Or for Gradle with non-Android, add to your dependencies:
 ```gradle
-compile 'io.grpc:grpc-netty:1.14.0'
+compile 'io.grpc:grpc-netty-shaded:1.14.0'
 compile 'io.grpc:grpc-protobuf:1.14.0'
 compile 'io.grpc:grpc-stub:1.14.0'
 ```
 
-For Android client, use `grpc-okhttp` instead of `grpc-netty` and
+For Android client, use `grpc-okhttp` instead of `grpc-netty-shaded` and
 `grpc-protobuf-lite` or `grpc-protobuf-nano` instead of `grpc-protobuf`:
 ```gradle
 compile 'io.grpc:grpc-okhttp:1.14.0'

--- a/core/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/core/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -58,7 +58,8 @@ public abstract class ManagedChannelProvider {
   public static ManagedChannelProvider provider() {
     if (provider == null) {
       throw new ProviderNotFoundException("No functional channel service provider found. "
-          + "Try adding a dependency on the grpc-okhttp or grpc-netty artifact");
+          + "Try adding a dependency on the grpc-okhttp, grpc-netty, or grpc-netty-shaded "
+          + "artifact");
     }
     return provider;
   }

--- a/core/src/main/java/io/grpc/ServerProvider.java
+++ b/core/src/main/java/io/grpc/ServerProvider.java
@@ -53,7 +53,7 @@ public abstract class ServerProvider {
   public static ServerProvider provider() {
     if (provider == null) {
       throw new ProviderNotFoundException("No functional server found. "
-          + "Try adding a dependency on the grpc-netty artifact");
+          + "Try adding a dependency on the grpc-netty or grpc-netty-shaded artifact");
     }
     return provider;
   }

--- a/documentation/server-reflection-tutorial.md
+++ b/documentation/server-reflection-tutorial.md
@@ -23,7 +23,7 @@ need to make the following changes:
 +++ b/examples/build.gradle
 @@ -27,6 +27,7 @@
  dependencies {
-   compile "io.grpc:grpc-netty:${grpcVersion}"
+   compile "io.grpc:grpc-netty-shaded:${grpcVersion}"
    compile "io.grpc:grpc-protobuf:${grpcVersion}"
 +  compile "io.grpc:grpc-services:${grpcVersion}"
    compile "io.grpc:grpc-stub:${grpcVersion}"

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -30,7 +30,7 @@ def protocVersion = '3.5.1-1'
 dependencies {
     compile "com.google.api.grpc:proto-google-common-protos:1.0.0"
     compile "io.grpc:grpc-alts:${grpcVersion}"
-    compile "io.grpc:grpc-netty:${grpcVersion}"
+    compile "io.grpc:grpc-netty-shaded:${grpcVersion}"
     compile "io.grpc:grpc-protobuf:${grpcVersion}"
     compile "io.grpc:grpc-stub:${grpcVersion}"
     compileOnly "javax.annotation:javax.annotation-api:1.2"

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -40,7 +40,7 @@ def grpcVersion = '1.15.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.google.api.grpc:proto-google-common-protos:1.0.0"
-    compile "io.grpc:grpc-netty:${grpcVersion}"
+    compile "io.grpc:grpc-netty-shaded:${grpcVersion}"
     compile "io.grpc:grpc-protobuf:${grpcVersion}"
     compile "io.grpc:grpc-stub:${grpcVersion}"
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,7 +22,7 @@
   <dependencies>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty</artifactId>
+      <artifactId>grpc-netty-shaded</artifactId>
       <version>${grpc.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
grpc-netty is still really useful, but for most users who aren't doing
anything advanced using grpc-netty-shaded is much safer from a
dependency basis.

grpc-netty-shaded has seen more usage and has shown itself to be stable
and reduce the number of conflicts due to Netty versions.