### PR TITLE
Bump protobuf-gradle-plugin to 0.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ buildscript {
   dependencies {
     // ASSUMES GRADLE 2.12 OR HIGHER. Use plugin version 0.7.5 with earlier
     // gradle versions
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.5'
   }
 }
 

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.3"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.3"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.3"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies { // ASSUMES GRADLE 2.12 OR HIGHER. Use plugin version 0.7.5 with earlier
         // gradle versions
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3' }
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.5' }
 }
 
 repositories {


### PR DESCRIPTION
The version bump happened in some places already, but many references
were missed.

This fixes the following warning that shows up with newer versions of
Gradle:
> Using TaskInputs.file() with something that doesn't resolve to a File
> object has been deprecated and is scheduled to be removed in Gradle
> 5.0. Use TaskInputs.files() instead.