### PR TITLE
Remove Throwable from MessageDeframer

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -307,8 +307,7 @@ public abstract class AbstractClientStream extends AbstractStream
           deframeFailed(
               Status.INTERNAL
                   .withDescription(
-                      String.format("Can't find full stream decompressor for %s", streamEncoding))
-                  .asRuntimeException());
+                      String.format("Can't find full stream decompressor for %s", streamEncoding)));
           return;
         }
       }
@@ -318,17 +317,15 @@ public abstract class AbstractClientStream extends AbstractStream
         Decompressor decompressor = decompressorRegistry.lookupDecompressor(messageEncoding);
         if (decompressor == null) {
           deframeFailed(
-              Status.INTERNAL
-                  .withDescription(String.format("Can't find decompressor for %s", messageEncoding))
-                  .asRuntimeException());
+              Status.INTERNAL.withDescription(
+                  String.format("Can't find decompressor for %s", messageEncoding)));
           return;
         } else if (decompressor != Codec.Identity.NONE) {
           if (compressedStream) {
             deframeFailed(
                 Status.INTERNAL
                     .withDescription(
-                        String.format("Full stream and gRPC message encoding cannot both be set"))
-                    .asRuntimeException());
+                        String.format("Full stream and gRPC message encoding cannot both be set")));
             return;
           }
           setDecompressor(decompressor);

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -232,10 +232,7 @@ public abstract class AbstractServerStream extends AbstractStream
         if (!immediateCloseRequested && hasPartialMessage) {
           // We've received the entire stream and have data available but we don't have
           // enough to read the next frame ... this is bad.
-          deframeFailed(
-              Status.INTERNAL
-                  .withDescription("Encountered end-of-stream mid-frame")
-                  .asRuntimeException());
+          deframeFailed(Status.INTERNAL.withDescription("Encountered end-of-stream mid-frame"));
           deframerClosedTask = null;
           return;
         }

--- a/core/src/main/java/io/grpc/internal/ApplicationThreadDeframer.java
+++ b/core/src/main/java/io/grpc/internal/ApplicationThreadDeframer.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.grpc.Decompressor;
+import io.grpc.Status;
 import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -161,12 +162,12 @@ public class ApplicationThreadDeframer implements Deframer, MessageDeframer.List
   }
 
   @Override
-  public void deframeFailed(final Throwable cause) {
+  public void deframeFailed(final Status status) {
     transportExecutor.runOnTransportThread(
         new Runnable() {
           @Override
           public void run() {
-            storedListener.deframeFailed(cause);
+            storedListener.deframeFailed(status);
           }
         });
   }

--- a/core/src/main/java/io/grpc/internal/Deframer.java
+++ b/core/src/main/java/io/grpc/internal/Deframer.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import io.grpc.Decompressor;
+import io.grpc.Status;
 
 /** Interface for deframing gRPC messages. */
 public interface Deframer {
@@ -42,20 +43,22 @@ public interface Deframer {
 
   /**
    * Requests up to the given number of messages from the call. No additional messages will be
-   * delivered.
+   * delivered.  Returns an Ok {@link Status} if there were no problems, or an error status
+   * otherwise.
    *
    * <p>If {@link #close()} has been called, this method will have no effect.
    *
    * @param numMessages the requested number of messages to be delivered to the listener.
    */
-  void request(int numMessages);
+  Status request(int numMessages);
 
   /**
-   * Adds the given data to this deframer and attempts delivery to the listener.
+   * Adds the given data to this deframer and attempts delivery to the listener.  Returns an Ok
+   * {@link Status} if there were no problems, or an error status otherwise.
    *
    * @param data the raw data read from the remote endpoint. Must be non-null.
    */
-  void deframe(ReadableBuffer data);
+  Status deframe(ReadableBuffer data);
 
   /** Close when any messages currently queued have been requested and delivered. */
   void closeWhenComplete();

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -78,7 +78,7 @@ public class MessageDeframer implements Closeable, Deframer {
      *
      * @param cause the actual failure
      */
-    void deframeFailed(Throwable cause);
+    void deframeFailed(Status status);
   }
 
   private enum State {

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -243,13 +243,11 @@ public class AbstractClientStreamTest {
     stream.transportState().inboundHeadersReceived(headers);
 
     verifyNoMoreInteractions(mockListener);
-    Throwable t = ((BaseTransportState) stream.transportState()).getDeframeFailedCause();
-    assertEquals(Status.INTERNAL.getCode(), Status.fromThrowable(t).getCode());
+    Status s = ((BaseTransportState) stream.transportState()).getDeframeFailedStatus();
+    assertEquals(Status.INTERNAL.getCode(), s.getCode());
     assertTrue(
         "unexpected deframe failed description",
-        Status.fromThrowable(t)
-            .getDescription()
-            .startsWith("Can't find full stream decompressor for"));
+        s.getDescription().startsWith("Can't find full stream decompressor for"));
   }
 
   @Test
@@ -265,13 +263,11 @@ public class AbstractClientStreamTest {
     stream.transportState().inboundHeadersReceived(headers);
 
     verifyNoMoreInteractions(mockListener);
-    Throwable t = ((BaseTransportState) stream.transportState()).getDeframeFailedCause();
-    assertEquals(Status.INTERNAL.getCode(), Status.fromThrowable(t).getCode());
+    Status s = ((BaseTransportState) stream.transportState()).getDeframeFailedStatus();
+    assertEquals(Status.INTERNAL.getCode(), s.getCode());
     assertTrue(
         "unexpected deframe failed description",
-        Status.fromThrowable(t)
-            .getDescription()
-            .equals("Full stream and gRPC message encoding cannot both be set"));
+        s.getDescription().equals("Full stream and gRPC message encoding cannot both be set"));
   }
 
   @Test
@@ -309,11 +305,11 @@ public class AbstractClientStreamTest {
     stream.transportState().inboundHeadersReceived(headers);
 
     verifyNoMoreInteractions(mockListener);
-    Throwable t = ((BaseTransportState) stream.transportState()).getDeframeFailedCause();
-    assertEquals(Status.INTERNAL.getCode(), Status.fromThrowable(t).getCode());
+    Status s = ((BaseTransportState) stream.transportState()).getDeframeFailedStatus();
+    assertEquals(Status.INTERNAL.getCode(), s.getCode());
     assertTrue(
         "unexpected deframe failed description",
-        Status.fromThrowable(t).getDescription().startsWith("Can't find decompressor for"));
+        s.getDescription().startsWith("Can't find decompressor for"));
   }
 
   @Test
@@ -525,10 +521,10 @@ public class AbstractClientStreamTest {
   }
 
   private static class BaseTransportState extends AbstractClientStream.TransportState {
-    private Throwable deframeFailedCause;
+    private Status deframeFailedStatus;
 
-    private Throwable getDeframeFailedCause() {
-      return deframeFailedCause;
+    private Status getDeframeFailedStatus() {
+      return deframeFailedStatus;
     }
 
     public BaseTransportState(StatsTraceContext statsTraceCtx, TransportTracer transportTracer) {
@@ -536,9 +532,9 @@ public class AbstractClientStreamTest {
     }
 
     @Override
-    public void deframeFailed(Throwable cause) {
-      assertNull("deframeFailed already called", deframeFailedCause);
-      deframeFailedCause = cause;
+    public void deframeFailed(Status status) {
+      assertNull("deframeFailed already called", status);
+      deframeFailedStatus = status;
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -533,7 +533,7 @@ public class AbstractClientStreamTest {
 
     @Override
     public void deframeFailed(Status status) {
-      assertNull("deframeFailed already called", status);
+      assertNull("deframeFailed already called", deframeFailedStatus);
       deframeFailedStatus = status;
     }
 

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -380,8 +380,7 @@ public class AbstractServerStreamTest {
       }
 
       @Override
-      public void deframeFailed(Throwable cause) {
-        Status status = Status.fromThrowable(cause);
+      public void deframeFailed(Status status) {
         transportReportStatus(status);
       }
 

--- a/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
@@ -21,10 +21,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Bytes;
@@ -51,6 +54,8 @@ public class ApplicationThreadDeframerTest {
 
   @Before
   public void setUp() {
+    when(mockDeframer.request(anyInt())).thenReturn(Status.OK);
+    when(mockDeframer.deframe(any(ReadableBuffer.class))).thenReturn(Status.OK);
     // ApplicationThreadDeframer constructor injects itself as the wrapped deframer's listener.
     verify(mockDeframer).setListener(applicationThreadDeframer);
   }
@@ -107,11 +112,11 @@ public class ApplicationThreadDeframerTest {
 
   @Test
   public void deframeFailedInvokesTransportExecutor() {
-    Throwable cause = new Throwable("error");
-    applicationThreadDeframer.deframeFailed(cause);
+    Status status = Status.UNAVAILABLE;
+    applicationThreadDeframer.deframeFailed(status);
     assertNull(listener.deframeFailedStatus);
     transportExecutor.runStoredRunnable();
-    assertEquals(cause, listener.deframeFailedStatus);
+    assertEquals(status, listener.deframeFailedStatus);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Bytes;
+import io.grpc.Status;
 import io.grpc.internal.StreamListener.MessageProducer;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -108,9 +109,9 @@ public class ApplicationThreadDeframerTest {
   public void deframeFailedInvokesTransportExecutor() {
     Throwable cause = new Throwable("error");
     applicationThreadDeframer.deframeFailed(cause);
-    assertNull(listener.deframeFailedCause);
+    assertNull(listener.deframeFailedStatus);
     transportExecutor.runStoredRunnable();
-    assertEquals(cause, listener.deframeFailedCause);
+    assertEquals(cause, listener.deframeFailedStatus);
   }
 
   @Test
@@ -136,7 +137,7 @@ public class ApplicationThreadDeframerTest {
     private MessageProducer storedProducer;
     private int bytesRead;
     private boolean deframerClosedWithPartialMessage;
-    private Throwable deframeFailedCause;
+    private Status deframeFailedStatus;
 
     private void runStoredProducer() {
       assertNotNull(storedProducer);
@@ -162,9 +163,9 @@ public class ApplicationThreadDeframerTest {
     }
 
     @Override
-    public void deframeFailed(Throwable cause) {
-      assertNull(deframeFailedCause);
-      deframeFailedCause = cause;
+    public void deframeFailed(Status status) {
+      assertNull(deframeFailedStatus);
+      deframeFailedStatus = status;
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Bytes;
 import io.grpc.Status;
+import io.grpc.internal.Deframer.StatusHolder;
 import io.grpc.internal.StreamListener.MessageProducer;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -54,8 +55,8 @@ public class ApplicationThreadDeframerTest {
 
   @Before
   public void setUp() {
-    when(mockDeframer.request(anyInt())).thenReturn(Status.OK);
-    when(mockDeframer.deframe(any(ReadableBuffer.class))).thenReturn(Status.OK);
+    when(mockDeframer.request(anyInt())).thenReturn(StatusHolder.NO_STATUS);
+    when(mockDeframer.deframe(any(ReadableBuffer.class))).thenReturn(StatusHolder.NO_STATUS);
     // ApplicationThreadDeframer constructor injects itself as the wrapped deframer's listener.
     verify(mockDeframer).setListener(applicationThreadDeframer);
   }

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -354,7 +354,7 @@ public class Http2ClientStreamTransportStateTest {
     }
 
     @Override
-    public void deframeFailed(Throwable cause) {}
+    public void deframeFailed(Status status) {}
 
     @Override
     public void bytesRead(int processedBytes) {}

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -286,8 +286,8 @@ class NettyClientStream extends AbstractClientStream {
     }
 
     @Override
-    public void deframeFailed(Throwable cause) {
-      http2ProcessingFailed(Status.fromThrowable(cause), true, new Metadata());
+    public void deframeFailed(Status status) {
+      http2ProcessingFailed(status, true, new Metadata());
     }
 
     void transportHeadersReceived(Http2Headers headers, boolean endOfStream) {

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -187,9 +187,8 @@ class NettyServerStream extends AbstractServerStream {
     }
 
     @Override
-    public void deframeFailed(Throwable cause) {
-      log.log(Level.WARNING, "Exception processing message", cause);
-      Status status = Status.fromThrowable(cause);
+    public void deframeFailed(Status status) {
+      log.log(Level.WARNING, "Exception processing message {0}", status);
       transportReportStatus(status);
       handler.getWriteQueue().enqueue(new CancelServerStreamCommand(this, status), true);
     }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -259,8 +259,8 @@ class OkHttpClientStream extends AbstractClientStream {
 
     @Override
     @GuardedBy("lock")
-    public void deframeFailed(Throwable cause) {
-      http2ProcessingFailed(Status.fromThrowable(cause), true, new Metadata());
+    public void deframeFailed(Status status) {
+      http2ProcessingFailed(status, true, new Metadata());
     }
 
     @Override


### PR DESCRIPTION
Internal cleanup, avoids creating an exception and uses Status in place.