### PR TITLE
Fix errror message when DNS name is invalid.

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -132,10 +132,11 @@ final class DnsNameResolver extends NameResolver {
     this.executorResource = executorResource;
     // Must prepend a "//" to the name when constructing a URI, otherwise it will be treated as an
     // opaque URI, thus the authority and host of the resulted URI would be null.
-    URI nameUri = URI.create("//" + name);
+    URI nameUri = URI.create("//" + checkNotNull(name));
+    Preconditions.checkArgument(nameUri.getHost() != null, "Invalid DNS name: %s", name);
     authority = Preconditions.checkNotNull(nameUri.getAuthority(),
         "nameUri (%s) doesn't have an authority", nameUri);
-    host = Preconditions.checkNotNull(nameUri.getHost(), "host");
+    host = nameUri.getHost();
     if (nameUri.getPort() == -1) {
       Integer defaultPort = params.get(NameResolver.Factory.PARAMS_DEFAULT_PORT);
       if (defaultPort != null) {

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -132,7 +132,7 @@ final class DnsNameResolver extends NameResolver {
     this.executorResource = executorResource;
     // Must prepend a "//" to the name when constructing a URI, otherwise it will be treated as an
     // opaque URI, thus the authority and host of the resulted URI would be null.
-    URI nameUri = URI.create("//" + checkNotNull(name));
+    URI nameUri = URI.create("//" + checkNotNull(name, "name"));
     Preconditions.checkArgument(nameUri.getHost() != null, "Invalid DNS name: %s", name);
     authority = Preconditions.checkNotNull(nameUri.getAuthority(),
         "nameUri (%s) doesn't have an authority", nameUri);

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -156,6 +156,26 @@ public class DnsNameResolverTest {
   }
 
   @Test
+  public void nullDnsName() {
+    try {
+      newResolver(null, DEFAULT_PORT);
+      fail("Expected NullPointerException");
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void invalidDnsName_containsUnderscore() {
+    try {
+      newResolver("host_1", DEFAULT_PORT);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
   public void resolve() throws Exception {
     final List<InetAddress> answer1 = createAddressList(2);
     final List<InetAddress> answer2 = createAddressList(1);


### PR DESCRIPTION
It used to throw NPE, since URI.create creates URI with null hostname. Now it
thorws IllegalArgumentException for invalid DNS name, NPE for null name.

Resolves #3701 