### PR TITLE
alts: Use grpc-netty-shaded instead of grpc-netty

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -1,3 +1,10 @@
+buildscript {
+    repositories { jcenter() }
+    dependencies { classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4' }
+}
+
+apply plugin: 'com.github.johnrengelman.shadow'
+
 description = "gRPC: ALTS"
 
 sourceCompatibility = 1.7
@@ -39,3 +46,28 @@ configureProtoCompilation()
 }
 
 javadoc { exclude 'io/grpc/alts/internal/**' }
+
+artifacts {
+    archives shadowJar
+}
+
+// We want to use grpc-netty-shaded instead of grpc-netty. But we also want our
+// source to work with Bazel, so we rewrite the code as part of the build.
+shadowJar {
+    classifier = null
+    dependencies {
+        exclude(dependency {true})
+    }
+    relocate 'io.grpc.netty', 'io.grpc.netty.shaded.io.grpc.netty'
+    relocate 'io.netty', 'io.grpc.netty.shaded.io.netty'
+}
+
+[
+    install.repositories.mavenInstaller,
+    uploadArchives.repositories.mavenDeployer,
+]*.pom*.whenConfigured { pom ->
+    def netty = pom.dependencies.find {dep -> dep.artifactId == 'grpc-netty'}
+    netty.artifactId = "grpc-netty-shaded"
+    // Depend on specific version of grpc-netty-shaded because it is unstable API
+    netty.version = "[" + netty.version + "]"
+}

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -51,6 +51,12 @@ artifacts {
     archives shadowJar
 }
 
+jar {
+    // Must use a different classifier to avoid conflicting with shadowJar
+    classifier = 'original'
+}
+configurations.archives.artifacts.removeAll { it.classifier == "original" }
+
 // We want to use grpc-netty-shaded instead of grpc-netty. But we also want our
 // source to work with Bazel, so we rewrite the code as part of the build.
 shadowJar {
@@ -67,6 +73,8 @@ shadowJar {
     uploadArchives.repositories.mavenDeployer,
 ]*.pom*.whenConfigured { pom ->
     def netty = pom.dependencies.find {dep -> dep.artifactId == 'grpc-netty'}
+    // Swap our dependency to grpc-netty-shaded. Projects depending on this via
+    // project(':grpc-alts') will still be using the non-shaded form.
     netty.artifactId = "grpc-netty-shaded"
     // Depend on specific version of grpc-netty-shaded because it is unstable API
     netty.version = "[" + netty.version + "]"

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -35,7 +35,8 @@ dependencies {
     compile "io.grpc:grpc-stub:${grpcVersion}"
     compileOnly "javax.annotation:javax.annotation-api:1.2"
 
-    // Used for TLS in HelloWorldServerTls
+    // Used in HelloWorldServerTls
+    compile "io.grpc:grpc-netty:${grpcVersion}"
     compile "io.netty:netty-tcnative-boringssl-static:${nettyTcNativeVersion}"
 
     compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -46,11 +46,19 @@
       <version>${grpc.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- Used in HelloWorldServerTls -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <version>${netty.tcnative.version}</version>
     </dependency>
+
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>

--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -24,6 +24,12 @@ artifacts { // We want uploadArchives to handle the shadowJar; we don't care abo
     // uploadShadow
     archives shadowJar }
 
+jar {
+    // Must use a different classifier to avoid conflicting with shadowJar
+    classifier = 'original'
+}
+configurations.archives.artifacts.removeAll { it.classifier == "original" }
+
 shadowJar {
     classifier = null
     dependencies {


### PR DESCRIPTION
There's no good way to provide users of ALTS a choice between grpc-netty
and grpc-netty-shaded. Since Netty is not exposed through the ALTS API
surface, we opt for the shaded version as it has fewer deployment
issues. However, this also means that we _can't_ expose any Netty API,
like EventLoopGroup.

--------------

The core problem is that we need to be able to use ALTS with grpc-netty-shaded, as it greatly reduces the diamond dependency issues users experience. With grpc-netty it may not be possible to produce a working executable, depending on what your other dependencies are. ALTS is the first dependency we've had on grpc-netty.

It seems we are painting ourselves into a corner with ALTS, as I feel like I'm threading a needle amongst all the constraints involved. But I don't see any path that avoids doing so. So while I'm not happy with this approach, it seems better than all the other approaches.

CC @jiangtaoli2016