### PR TITLE
netty/internal: add InternalNettyChannelBuilder.buildTransportFactory().

### DIFF
--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -17,6 +17,7 @@
 package io.grpc.netty;
 
 import io.grpc.Internal;
+import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ProxyParameters;
 import java.net.SocketAddress;
 
@@ -72,6 +73,10 @@ public final class InternalNettyChannelBuilder {
 
   public static void setStatsRecordStartedRpcs(NettyChannelBuilder builder, boolean value) {
     builder.setStatsRecordStartedRpcs(value);
+  }
+
+  public static ClientTransportFactory buildTransportFactory(NettyChannelBuilder builder) {
+    return builder.buildTransportFactory();
   }
 
   private InternalNettyChannelBuilder() {}


### PR DESCRIPTION
This is needed internally for building netty transports outside of a channel.