### PR TITLE
examples: kotlin example test sources should be in  test sourceset

### DIFF
--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -29,7 +29,7 @@ android {
     // Android Studio 3.1 does not automatically pick up '<src_set>/kotlin' as source input
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
-        main.java.srcDirs += 'src/test/kotlin'
+        main.test.srcDirs += 'src/test/kotlin'
         androidTest.java.srcDirs += 'src/androidTest/kotlin'
     }
 

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -29,7 +29,7 @@ android {
     // Android Studio 3.1 does not automatically pick up '<src_set>/kotlin' as source input
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
-        main.test.srcDirs += 'src/test/kotlin'
+        test.java.srcDirs += 'src/test/kotlin'
         androidTest.java.srcDirs += 'src/androidTest/kotlin'
     }
 


### PR DESCRIPTION
Putting them in the main sourceset is incorrect.