### PR TITLE
core: Handle null ProxySelector

### DIFF
--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -222,7 +222,13 @@ class ProxyDetectorImpl implements ProxyDetector {
       return null;
     }
 
-    List<Proxy> proxies = proxySelector.get().select(uri);
+    ProxySelector proxySelector = this.proxySelector.get();
+    if (proxySelector == null) {
+      log.log(Level.FINE, "proxy selector is null, so continuing without proxy lookup");
+      return null;
+    }
+
+    List<Proxy> proxies = proxySelector.select(uri);
     if (proxies.size() > 1) {
       log.warning("More than 1 proxy detected, gRPC will select the first one");
     }

--- a/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
@@ -197,4 +197,18 @@ public class ProxyDetectorImplTest {
             proxyPassword),
         detected);
   }
+
+  @Test
+  public void proxySelectorReturnsNull() throws Exception {
+    ProxyDetectorImpl proxyDetector = new ProxyDetectorImpl(
+        new Supplier<ProxySelector>() {
+          @Override
+          public ProxySelector get() {
+            return null;
+          }
+        },
+        authenticator,
+        null);
+    assertNull(proxyDetector.proxyFor(destination));
+  }
 }


### PR DESCRIPTION
ProxySelector.getDefault() can return null

Fixes #4677