### PR TITLE
gae-interop-testing: increase response verbosity

### DIFF
--- a/gae-interop-testing/gae-jdk7/build.gradle
+++ b/gae-interop-testing/gae-jdk7/build.gradle
@@ -140,7 +140,7 @@ task runInteropTestRemote(dependsOn: 'appengineDeploy') {
             try {
                 def response = client.newCall(interopRequest).execute()
                 result = response.body().string()
-                logger.log(LogLevel.INFO, result)
+                project.println(result)
                 if (response.code() == 200) {
                     return
                 }

--- a/gae-interop-testing/gae-jdk7/build.gradle
+++ b/gae-interop-testing/gae-jdk7/build.gradle
@@ -140,6 +140,7 @@ task runInteropTestRemote(dependsOn: 'appengineDeploy') {
             try {
                 def response = client.newCall(interopRequest).execute()
                 result = response.body().string()
+                logger.log(LogLevel.INFO, result)
                 if (response.code() == 200) {
                     return
                 }
@@ -148,6 +149,6 @@ task runInteropTestRemote(dependsOn: 'appengineDeploy') {
                 logger.log(LogLevel.ERROR, "caught exception. will retry if possible", t)
             }
         }
-        throw new GradleException("Interop test failed:\nresponse: ${result}\nthrowable:${caught}")
+        throw new GradleException("Interop test failed:\nthrowable:${caught}")
     }
 }

--- a/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
@@ -30,6 +30,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -54,7 +56,7 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
   private static final String INTEROP_TEST_ADDRESS = "grpc-test.sandbox.googleapis.com:443";
 
   private static final class LogEntryRecorder extends Handler {
-    private List<LogRecord> loggedMessages = new ArrayList<LogRecord>();
+    private Queue<LogRecord> loggedMessages = new ConcurrentLinkedQueue<>();
 
     @Override
     public void publish(LogRecord logRecord) {
@@ -77,20 +79,21 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
     }
   }
 
-  private final LogEntryRecorder handler = new LogEntryRecorder();
-
-  @Override
-  public void init() {
-    Logger.getLogger("").addHandler(handler);
-  }
-
-  @Override
-  public void destroy() {
-    Logger.getLogger("").removeHandler(handler);
-  }
-
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    LogEntryRecorder handler = new LogEntryRecorder();
+    try {
+      Logger.getLogger("").addHandler(handler);
+      doGetHelper(req, resp);
+    } finally {
+      Logger.getLogger("").removeHandler(handler);
+    }
+    resp.getWriter().append("=======================================\n")
+        .append("Server side java.util.logging messages:\n")
+        .append(handler.getLogOutput());
+  }
+
+  private void doGetHelper(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     resp.setContentType("text/plain");
     PrintWriter writer = resp.getWriter();
     writer.println("Test invoked at: ");
@@ -172,10 +175,6 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
               failures,
               ignored));
     }
-
-    sb.append("=======================================\n")
-        .append("Server side java.util.logging messages:\n")
-        .append(handler.getLogOutput());
 
     writer.println(sb);
   }

--- a/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
@@ -82,8 +82,8 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     LogEntryRecorder handler = new LogEntryRecorder();
+    Logger.getLogger("").addHandler(handler);
     try {
-      Logger.getLogger("").addHandler(handler);
       doGetHelper(req, resp);
     } finally {
       Logger.getLogger("").removeHandler(handler);

--- a/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
@@ -175,7 +175,6 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
               failures,
               ignored));
     }
-
     writer.println(sb);
   }
 

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -147,7 +147,7 @@ task runInteropTestRemote(dependsOn: 'appengineDeploy') {
             try {
                 def response = client.newCall(interopRequest).execute()
                 result = response.body().string()
-                logger.log(LogLevel.INFO, result)
+                project.println(result)
                 if (response.code() == 200) {
                     return
                 }

--- a/gae-interop-testing/gae-jdk8/build.gradle
+++ b/gae-interop-testing/gae-jdk8/build.gradle
@@ -147,6 +147,7 @@ task runInteropTestRemote(dependsOn: 'appengineDeploy') {
             try {
                 def response = client.newCall(interopRequest).execute()
                 result = response.body().string()
+                logger.log(LogLevel.INFO, result)
                 if (response.code() == 200) {
                     return
                 }
@@ -155,6 +156,6 @@ task runInteropTestRemote(dependsOn: 'appengineDeploy') {
                 logger.log(LogLevel.ERROR, "caught exception. will retry if possible", t)
             }
         }
-        throw new GradleException("Interop test failed:\nresponse: ${result}\nthrowable:${caught}")
+        throw new GradleException("Interop test failed:\nthrowable:${caught}")
     }
 }

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -78,8 +78,8 @@ public final class NettyClientInteropServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     LogEntryRecorder handler = new LogEntryRecorder();
+    Logger.getLogger("").addHandler(handler);
     try {
-      Logger.getLogger("").addHandler(handler);
       doGetHelper(req, resp);
     } finally {
       Logger.getLogger("").removeHandler(handler);

--- a/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk8/src/main/java/io/grpc/testing/integration/NettyClientInteropServlet.java
@@ -89,7 +89,7 @@ public final class NettyClientInteropServlet extends HttpServlet {
         .append(handler.getLogOutput());
   }
 
-  public void doGetHelper(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+  private void doGetHelper(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     resp.setContentType("text/plain");
     PrintWriter writer = resp.getWriter();
     writer.println("Test invoked at: ");


### PR DESCRIPTION
for jdk7 include the passing test names in the order they were run
for both, include the JUL log output