### PR TITLE
cronet: report statsTraceCtx.clientOutboundHeaders()

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -65,6 +65,7 @@ class CronetClientStream extends AbstractClientStream {
   private static final String LOG_TAG = "grpc-java-cronet";
   private final String url;
   private final String userAgent;
+  private final StatsTraceContext statsTraceCtx;
   private final Executor executor;
   private final Metadata headers;
   private final CronetClientTransport transport;
@@ -98,6 +99,7 @@ class CronetClientStream extends AbstractClientStream {
         method.isSafe());
     this.url = Preconditions.checkNotNull(url, "url");
     this.userAgent = Preconditions.checkNotNull(userAgent, "userAgent");
+    this.statsTraceCtx = Preconditions.checkNotNull(statsTraceCtx, "statsTraceCtx");
     this.executor = Preconditions.checkNotNull(executor, "executor");
     this.headers = Preconditions.checkNotNull(headers, "headers");
     this.transport = Preconditions.checkNotNull(transport, "transport");
@@ -374,6 +376,7 @@ class CronetClientStream extends AbstractClientStream {
         // Now that the stream is ready, call the listener's onReady callback if
         // appropriate.
         state.onStreamAllocated();
+        statsTraceCtx.clientOutboundHeaders();
         state.streamReady = true;
         state.writeAllPendingData();
       }


### PR DESCRIPTION
This brings Cronet client's stats reporting inline with InProcess, Netty, and OkHttp.

This was caught by AbstractInteropTest#assertClientStatsTrace when running the interop tests with a Cronet transport.