### PR TITLE
travis.yml: Fix protobuf compilation caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ notifications:
 
 cache:
   directories:
-    - /tmp/protobuf-*
+    - /tmp/protobuf-cache
     - /tmp/gradle-caches-modules-2
     - /tmp/gradle-wrapper
 

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -8,7 +8,7 @@ PROTOBUF_VERSION=3.5.1
 # ARCH is 64 bit unless otherwise specified.
 ARCH="${ARCH:-64}"
 DOWNLOAD_DIR=/tmp/source
-INSTALL_DIR="/tmp/protobuf-$PROTOBUF_VERSION/$(uname -s)-$(uname -p)-x86_$ARCH"
+INSTALL_DIR="/tmp/protobuf-cache/$PROTOBUF_VERSION/$(uname -s)-$(uname -p)-x86_$ARCH"
 mkdir -p $DOWNLOAD_DIR
 
 # Start with a sane default


### PR DESCRIPTION
Wildcard apparently doesn't work... silently. Move versions into their
own directory so we can use a hard-coded string in the travis
configuration.