### PR TITLE
gae-interop-testing: disable timeoutOnSleepingServer

### DIFF
--- a/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
+++ b/gae-interop-testing/gae-jdk7/src/main/java/io/grpc/testing/integration/OkHttpClientInteropServlet.java
@@ -222,5 +222,10 @@ public final class OkHttpClientInteropServlet extends HttpServlet {
     @Ignore
     @Override
     public void specialStatusMessage() {}
+
+    // grpc-java/issues/4626: this test has become flakey on GAE JDK7
+    @Ignore
+    @Override
+    public void timeoutOnSleepingServer() {}
   }
 }


### PR DESCRIPTION
The test is flakey and we have exhausted the obvious clues. Since the
impact of this is likely low, let's `@Ignore` it.

See #4626