### PR TITLE
buildscripts: Use full SHA for protobuf download

### DIFF
--- a/buildscripts/build_docker.sh
+++ b/buildscripts/build_docker.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 readonly proto_dir="$(mktemp -d protobuf.XXXXXX)"
 # Download an unreleased SHA to include TLS 1.2 support:
 # https://github.com/google/protobuf/pull/4879
-wget -O - https://github.com/google/protobuf/archive/61476b8e.tar.gz | tar xz -C "$proto_dir"
+wget -O - https://github.com/google/protobuf/archive/61476b8e74357ea875f71bb321874ca4530b7d50.tar.gz | tar xz -C "$proto_dir"
 
 docker build -t protoc-artifacts "$proto_dir"/protobuf-61476b8e74357ea875f71bb321874ca4530b7d50/protoc-artifacts
 rm -r "$proto_dir"


### PR DESCRIPTION
Github used to produce tars with the full SHA in the folder name.
However, now they are providing tars with just as much SHA as was in the
initial request. This coincides with a change in its services:

Before:
Resolving github.com... 192.30.253.113, 192.30.253.112
Connecting to github.com|192.30.253.113|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://github-production-release-asset-2e65be.s3.amazonaws.com/23357588/88f90e58-e598-11e7-9263-ef8b1fb345b8?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20180817%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20180817T190158Z&X-Amz-Expires=300&X-Amz-Signature=b684e1ead24a96764fd1f29ac5eb1df693d47c5fe86962088aee2ccfb8e4e72a&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B%20filename%3Dprotobuf-all-3.5.1.tar.gz&response-content-type=application%2Foctet-stream [following]

As of 2:00 PM PT today:
Resolving github.com (github.com)... 192.30.253.113, 192.30.253.112
Connecting to github.com (github.com)|192.30.253.113|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/google/protobuf/tar.gz/61476b8e [following]

Note that repositories.bzl isn't impacted because it already specified
the full SHA.