### PR TITLE
core: add stackless variants for asException and use it throughout

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -117,7 +117,9 @@ public abstract class AltsProtocolNegotiator implements ProtocolNegotiator {
                       + RpcProtocolVersionsUtil.getRpcProtocolVersions().toString()
                       + "are not compatible with peer Rpc Protocol Versions "
                       + altsContext.getPeerRpcVersions().toString();
-              fail(ctx, Status.UNAVAILABLE.withDescription(errorMessage).asRuntimeException());
+              fail(
+                  ctx,
+                  Status.UNAVAILABLE.withDescription(errorMessage).asStacklessRuntimeException());
             }
             grpcHandler.handleProtocolNegotiationCompleted(
                 Attributes.newBuilder()
@@ -139,7 +141,7 @@ public abstract class AltsProtocolNegotiator implements ProtocolNegotiator {
     }
 
     private static RuntimeException unavailableException(String msg, Throwable cause) {
-      return Status.UNAVAILABLE.withCause(cause).withDescription(msg).asRuntimeException();
+      return Status.UNAVAILABLE.withCause(cause).withDescription(msg).asStacklessRuntimeException();
     }
   }
 }

--- a/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
+++ b/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
@@ -97,7 +97,8 @@ public final class ClientAuthInterceptor implements ClientInterceptor {
   private URI serviceUri(Channel channel, MethodDescriptor<?, ?> method) throws StatusException {
     String authority = channel.authority();
     if (authority == null) {
-      throw Status.UNAUTHENTICATED.withDescription("Channel has no authority").asException();
+      throw Status.UNAUTHENTICATED.withDescription("Channel has no authority")
+          .asStacklessException();
     }
     // Always use HTTPS, by definition.
     final String scheme = "https";
@@ -108,7 +109,7 @@ public final class ClientAuthInterceptor implements ClientInterceptor {
       uri = new URI(scheme, authority, path, null, null);
     } catch (URISyntaxException e) {
       throw Status.UNAUTHENTICATED.withDescription("Unable to construct service URI for auth")
-          .withCause(e).asException();
+          .withCause(e).asStacklessException();
     }
     // The default port must not be present. Alternative ports should be present.
     if (uri.getPort() == defaultPort) {
@@ -124,7 +125,7 @@ public final class ClientAuthInterceptor implements ClientInterceptor {
     } catch (URISyntaxException e) {
       throw Status.UNAUTHENTICATED.withDescription(
             "Unable to construct service URI after removing port")
-          .withCause(e).asException();
+          .withCause(e).asStacklessException();
     }
   }
 
@@ -133,7 +134,7 @@ public final class ClientAuthInterceptor implements ClientInterceptor {
       return credentials.getRequestMetadata(uri);
     } catch (IOException e) {
       throw Status.UNAUTHENTICATED.withDescription("Unable to get request metadata").withCause(e)
-          .asException();
+          .asStacklessException();
     }
   }
 

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -172,7 +172,7 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
       uri = new URI(scheme, authority, path, null, null);
     } catch (URISyntaxException e) {
       throw Status.UNAUTHENTICATED.withDescription("Unable to construct service URI for auth")
-          .withCause(e).asException();
+          .withCause(e).asStacklessException();
     }
     // The default port must not be present. Alternative ports should be present.
     if (uri.getPort() == defaultPort) {
@@ -186,8 +186,8 @@ final class GoogleAuthLibraryCallCredentials implements CallCredentials {
       return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), -1 /* port */,
           uri.getPath(), uri.getQuery(), uri.getFragment());
     } catch (URISyntaxException e) {
-      throw Status.UNAUTHENTICATED.withDescription(
-           "Unable to construct service URI after removing port").withCause(e).asException();
+      throw Status.UNAUTHENTICATED.withCause(e).withDescription(
+           "Unable to construct service URI after removing port").asStacklessException();
     }
   }
 

--- a/benchmarks/src/main/java/io/grpc/benchmarks/Utils.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/Utils.java
@@ -249,7 +249,8 @@ public final class Utils {
   public static SimpleResponse makeResponse(SimpleRequest request) {
     if (request.getResponseSize() > 0) {
       if (!Messages.PayloadType.COMPRESSABLE.equals(request.getResponseType())) {
-        throw Status.INTERNAL.augmentDescription("Error creating payload.").asRuntimeException();
+        throw Status.INTERNAL.augmentDescription("Error creating payload.")
+            .asStacklessRuntimeException();
       }
 
       ByteString body = ByteString.copyFrom(new byte[request.getResponseSize()]);

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadClient.java
@@ -208,7 +208,7 @@ class LoadClient {
         default: {
           throw Status.UNIMPLEMENTED.withDescription(
               "Unknown payload case " + config.getPayloadConfig().getPayloadCase().name())
-              .asRuntimeException();
+              .asStacklessRuntimeException();
         }
       }
       if (r == null) {

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
@@ -149,11 +149,12 @@ public class LoadWorker {
             } else {
               responseObserver.onError(Status.ALREADY_EXISTS
                   .withDescription("Server already started")
-                  .asRuntimeException());
+                  .asStacklessRuntimeException());
             }
           } catch (Throwable t) {
             log.log(Level.WARNING, "Error running server", t);
-            responseObserver.onError(Status.INTERNAL.withCause(t).asException());
+            responseObserver.onError(Status.INTERNAL.withDescription("Error running server")
+                .withCause(t).asStacklessRuntimeException());
             // Shutdown server if we can
             onCompleted();
           }
@@ -201,11 +202,12 @@ public class LoadWorker {
             } else {
               responseObserver.onError(Status.ALREADY_EXISTS
                   .withDescription("Client already started")
-                  .asRuntimeException());
+                  .asStacklessRuntimeException());
             }
           } catch (Throwable t) {
             log.log(Level.WARNING, "Error running client", t);
-            responseObserver.onError(Status.INTERNAL.withCause(t).asException());
+            responseObserver.onError(Status.INTERNAL.withDescription("Error running client")
+                .withCause(t).asStacklessRuntimeException());
             // Shutdown the client if we can
             onCompleted();
           }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -275,7 +275,7 @@ public class AsyncServer {
           } else {
             responseObserver.onError(
                 Status.FAILED_PRECONDITION
-                    .withDescription("never received any requests").asException());
+                    .withDescription("never received any requests").asStacklessRuntimeException());
           }
         }
       };

--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -513,6 +513,15 @@ public final class Status {
    * Convert this {@link Status} to a {@link RuntimeException}. Use {@link #fromThrowable}
    * to recover this {@link Status} instance when the returned exception is in the causal chain.
    */
+  @ExperimentalApi("FIXME")
+  public StatusRuntimeException asStacklessRuntimeException() {
+    return new StatusRuntimeException(this, /*trailers=*/ null, /*fillInStackTrace=*/ false);
+  }
+
+  /**
+   * Convert this {@link Status} to a {@link RuntimeException}. Use {@link #fromThrowable}
+   * to recover this {@link Status} instance when the returned exception is in the causal chain.
+   */
   public StatusRuntimeException asRuntimeException() {
     return new StatusRuntimeException(this);
   }
@@ -524,6 +533,15 @@ public final class Status {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4683")
   public StatusRuntimeException asRuntimeException(@Nullable Metadata trailers) {
     return new StatusRuntimeException(this, trailers);
+  }
+
+  /**
+   * Convert this {@link Status} to an {@link Exception}. Use {@link #fromThrowable}
+   * to recover this {@link Status} instance when the returned exception is in the causal chain.
+   */
+  @ExperimentalApi("FIXME")
+  public StatusException asStacklessException() {
+    return new StatusException(this, /*trailers=*/ null, /*fillInStackTrace=*/ false);
   }
 
   /**

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -167,7 +167,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       executor.execute(new Runnable() {
         @Override
         public void run() {
-          callback.onFailure(shutdownStatus.asRuntimeException());
+          callback.onFailure(shutdownStatus.asStacklessRuntimeException());
         }
       });
     } else {

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -308,7 +308,7 @@ public abstract class AbstractClientStream extends AbstractStream
               Status.INTERNAL
                   .withDescription(
                       String.format("Can't find full stream decompressor for %s", streamEncoding))
-                  .asRuntimeException());
+                  .asStacklessRuntimeException());
           return;
         }
       }
@@ -320,7 +320,7 @@ public abstract class AbstractClientStream extends AbstractStream
           deframeFailed(
               Status.INTERNAL
                   .withDescription(String.format("Can't find decompressor for %s", messageEncoding))
-                  .asRuntimeException());
+                  .asStacklessRuntimeException());
           return;
         } else if (decompressor != Codec.Identity.NONE) {
           if (compressedStream) {
@@ -328,7 +328,7 @@ public abstract class AbstractClientStream extends AbstractStream
                 Status.INTERNAL
                     .withDescription(
                         String.format("Full stream and gRPC message encoding cannot both be set"))
-                    .asRuntimeException());
+                    .asStacklessRuntimeException());
             return;
           }
           setDecompressor(decompressor);

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -235,7 +235,7 @@ public abstract class AbstractServerStream extends AbstractStream
           deframeFailed(
               Status.INTERNAL
                   .withDescription("Encountered end-of-stream mid-frame")
-                  .asRuntimeException());
+                  .asStacklessRuntimeException());
           deframerClosedTask = null;
           return;
         }

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -52,7 +52,7 @@ class FailingClientTransport implements ClientTransport {
   public void ping(final PingCallback callback, Executor executor) {
     executor.execute(new Runnable() {
         @Override public void run() {
-          callback.onFailure(error.asException());
+          callback.onFailure(error.asStacklessRuntimeException());
         }
       });
   }

--- a/core/src/main/java/io/grpc/internal/KeepAliveManager.java
+++ b/core/src/main/java/io/grpc/internal/KeepAliveManager.java
@@ -272,7 +272,7 @@ public class KeepAliveManager {
         @Override
         public void onFailure(Throwable cause) {
           transport.shutdownNow(Status.UNAVAILABLE.withDescription(
-              "Keepalive failed. The connection is likely gone"));
+              "Keepalive failed. The connection is likely gone").withCause(cause));
         }
       }, MoreExecutors.directExecutor());
     }

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -374,7 +374,7 @@ public class MessageDeframer implements Closeable, Deframer {
     if ((type & RESERVED_MASK) != 0) {
       throw Status.INTERNAL.withDescription(
           "gRPC frame header malformed: reserved bits not zero")
-          .asRuntimeException();
+          .asStacklessRuntimeException();
     }
     compressedFlag = (type & COMPRESSED_FLAG_MASK) != 0;
 
@@ -384,7 +384,7 @@ public class MessageDeframer implements Closeable, Deframer {
       throw Status.RESOURCE_EXHAUSTED.withDescription(
           String.format("gRPC message exceeds maximum size %d: %d",
               maxInboundMessageSize, requiredLength))
-          .asRuntimeException();
+          .asStacklessRuntimeException();
     }
 
     currentMessageSeqNo++;
@@ -421,7 +421,7 @@ public class MessageDeframer implements Closeable, Deframer {
     if (decompressor == Codec.Identity.NONE) {
       throw Status.INTERNAL.withDescription(
           "Can't decode compressed gRPC message as compression not configured")
-          .asRuntimeException();
+          .asStacklessRuntimeException();
     }
 
     try {
@@ -514,7 +514,7 @@ public class MessageDeframer implements Closeable, Deframer {
       if (count > maxMessageSize) {
         throw Status.RESOURCE_EXHAUSTED.withDescription(String.format(
                 "Compressed gRPC message exceeds maximum size %d: %d bytes read",
-                maxMessageSize, count)).asRuntimeException();
+                maxMessageSize, count)).asStacklessRuntimeException();
       }
     }
   }

--- a/core/src/main/java/io/grpc/internal/MessageFramer.java
+++ b/core/src/main/java/io/grpc/internal/MessageFramer.java
@@ -144,17 +144,17 @@ public class MessageFramer implements Framer {
       throw Status.INTERNAL
           .withDescription("Failed to frame message")
           .withCause(e)
-          .asRuntimeException();
+          .asStacklessRuntimeException();
     } catch (RuntimeException e) {
       throw Status.INTERNAL
           .withDescription("Failed to frame message")
           .withCause(e)
-          .asRuntimeException();
+          .asStacklessRuntimeException();
     }
 
     if (messageLength != -1 && written != messageLength) {
       String err = String.format("Message length inaccurate %s != %s", written, messageLength);
-      throw Status.INTERNAL.withDescription(err).asRuntimeException();
+      throw Status.INTERNAL.withDescription(err).asStacklessRuntimeException();
     }
     statsTraceCtx.outboundUncompressedSize(written);
     statsTraceCtx.outboundWireSize(currentMessageWireSize);
@@ -172,7 +172,7 @@ public class MessageFramer implements Framer {
       throw Status.RESOURCE_EXHAUSTED
           .withDescription(
               String.format("message too large %d > %d", written , maxOutboundMessageSize))
-          .asRuntimeException();
+          .asStacklessRuntimeException();
     }
     writeBufferChain(bufferChain, false);
     return written;
@@ -192,7 +192,7 @@ public class MessageFramer implements Framer {
       throw Status.RESOURCE_EXHAUSTED
           .withDescription(
               String.format("message too large %d > %d", written , maxOutboundMessageSize))
-          .asRuntimeException();
+          .asStacklessRuntimeException();
     }
 
     writeBufferChain(bufferChain, true);
@@ -215,7 +215,7 @@ public class MessageFramer implements Framer {
       throw Status.RESOURCE_EXHAUSTED
           .withDescription(
               String.format("message too large %d > %d", messageLength , maxOutboundMessageSize))
-          .asRuntimeException();
+          .asStacklessRuntimeException();
     }
     ByteBuffer header = ByteBuffer.wrap(headerScratch);
     header.put(UNCOMPRESSED);

--- a/core/src/test/java/io/grpc/ContextsTest.java
+++ b/core/src/test/java/io/grpc/ContextsTest.java
@@ -193,7 +193,8 @@ public class ContextsTest {
   @Test
   public void statusFromCancelled_returnStatusAsSetOnCtx() {
     Context.CancellableContext cancellableContext = Context.current().withCancellation();
-    cancellableContext.cancel(Status.DEADLINE_EXCEEDED.withDescription("foo bar").asException());
+    cancellableContext.cancel(
+        Status.DEADLINE_EXCEEDED.withDescription("foo bar").asStacklessException());
     Status status = statusFromCancelled(cancellableContext);
     assertNotNull(status);
     assertEquals(Status.Code.DEADLINE_EXCEEDED, status.getCode());
@@ -242,7 +243,7 @@ public class ContextsTest {
   @Test
   public void statusFromCancelled_StatusUnknownShouldWork() {
     Context.CancellableContext cancellableContext = Context.current().withCancellation();
-    Exception e = Status.UNKNOWN.asException();
+    Exception e = Status.UNKNOWN.asStacklessRuntimeException();
     cancellableContext.cancel(e);
     assertTrue(cancellableContext.isCancelled());
 

--- a/core/src/test/java/io/grpc/StatusTest.java
+++ b/core/src/test/java/io/grpc/StatusTest.java
@@ -32,12 +32,15 @@ public class StatusTest {
 
   @Test
   public void verifyExceptionMessage() {
-    assertEquals("UNKNOWN", Status.UNKNOWN.asRuntimeException().getMessage());
+    assertEquals("UNKNOWN", Status.UNKNOWN.asStacklessRuntimeException().getMessage());
     assertEquals("CANCELLED: This is a test",
-        Status.CANCELLED.withDescription("This is a test").asRuntimeException().getMessage());
-    assertEquals("UNKNOWN", Status.UNKNOWN.asException().getMessage());
+        Status.CANCELLED
+            .withDescription("This is a test")
+            .asStacklessRuntimeException()
+            .getMessage());
+    assertEquals("UNKNOWN", Status.UNKNOWN.asStacklessException().getMessage());
     assertEquals("CANCELLED: This is a test",
-        Status.CANCELLED.withDescription("This is a test").asException().getMessage());
+        Status.CANCELLED.withDescription("This is a test").asStacklessException().getMessage());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -732,7 +732,7 @@ public class ServerImplTest {
               public ServerCall.Listener<String> startCall(
                   ServerCall<String, Integer> call,
                   Metadata headers) {
-                throw status.asRuntimeException();
+                throw status.asStacklessRuntimeException();
               }
             }).build());
     ServerTransportListener transportListener

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -98,7 +98,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
       obs.onError(Status.UNIMPLEMENTED
           .withDescription("compression not supported.")
           .withCause(e)
-          .asRuntimeException());
+          .asStacklessRuntimeException());
       return;
     }
 
@@ -119,7 +119,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
     if (req.hasResponseStatus()) {
       obs.onError(Status.fromCodeValue(req.getResponseStatus().getCode())
           .withDescription(req.getResponseStatus().getMessage())
-          .asRuntimeException());
+          .asStacklessRuntimeException());
       return;
     }
 
@@ -182,7 +182,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
           dispatcher.cancel();
           dispatcher.onError(Status.fromCodeValue(request.getResponseStatus().getCode())
               .withDescription(request.getResponseStatus().getMessage())
-              .asRuntimeException());
+              .asStacklessRuntimeException());
           return;
         }
         dispatcher.enqueue(toChunkQueue(request));

--- a/netty/src/main/java/io/grpc/netty/ClientTransportLifecycleManager.java
+++ b/netty/src/main/java/io/grpc/netty/ClientTransportLifecycleManager.java
@@ -49,7 +49,7 @@ final class ClientTransportLifecycleManager {
     }
     transportShutdown = true;
     shutdownStatus = s;
-    shutdownThrowable = s.asException();
+    shutdownThrowable = s.asStacklessRuntimeException();
     listener.transportShutdown(s);
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -125,7 +125,7 @@ class NettyClientTransport implements ConnectionClientTransport {
       executor.execute(new Runnable() {
         @Override
         public void run() {
-          callback.onFailure(statusExplainingWhyTheChannelIsNull.asException());
+          callback.onFailure(statusExplainingWhyTheChannelIsNull.asStacklessRuntimeException());
         }
       });
       return;
@@ -137,7 +137,7 @@ class NettyClientTransport implements ConnectionClientTransport {
       public void operationComplete(ChannelFuture future) throws Exception {
         if (!future.isSuccess()) {
           Status s = statusFromFailedFuture(future);
-          Http2Ping.notifyFailed(callback, executor, s.asException());
+          Http2Ping.notifyFailed(callback, executor, s.asStacklessRuntimeException());
         }
       }
     };

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -356,7 +356,7 @@ public final class ProtocolNegotiators {
   }
 
   private static RuntimeException unavailableException(String msg) {
-    return Status.UNAVAILABLE.withDescription(msg).asRuntimeException();
+    return Status.UNAVAILABLE.withDescription(msg).asStacklessRuntimeException();
   }
 
   @VisibleForTesting

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -55,7 +55,6 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.Attributes;
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.StatusException;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.ClientTransport;
@@ -606,9 +605,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     handler().channelInactive(ctx());
     // ping failed on channel going inactive
     assertEquals(1, callback.invocationCount);
-    assertTrue(callback.failureCause instanceof StatusException);
-    assertEquals(Status.Code.UNAVAILABLE,
-        ((StatusException) callback.failureCause).getStatus().getCode());
+    assertEquals(Status.Code.UNAVAILABLE, Status.fromThrowable(callback.failureCause).getCode());
     // A failed ping is still counted
     assertEquals(1, transportTracer.getStats().keepAlivesSent);
   }

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -324,7 +324,7 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
     // Verify the stream was closed.
     ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
     verify(streamListener).closed(captor.capture());
-    assertEquals(e, captor.getValue().asException().getCause());
+    assertEquals(e, captor.getValue().getCause());
     assertEquals(Code.UNKNOWN, captor.getValue().getCode());
   }
 

--- a/netty/src/test/java/io/grpc/netty/UtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/UtilsTest.java
@@ -54,7 +54,7 @@ public class UtilsTest {
   @Test
   public void testStatusFromThrowable() {
     Status s = Status.CANCELLED.withDescription("msg");
-    assertSame(s, Utils.statusFromThrowable(new Exception(s.asException())));
+    assertSame(s, Utils.statusFromThrowable(new Exception(s.asStacklessRuntimeException())));
     Throwable t;
     t = new ConnectTimeoutException("msg");
     assertStatusEquals(Status.UNAVAILABLE.withCause(t), Utils.statusFromThrowable(t));

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -61,7 +61,6 @@ import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.Status;
 import io.grpc.Status.Code;
-import io.grpc.StatusException;
 import io.grpc.internal.AbstractStream;
 import io.grpc.internal.Channelz.SocketStats;
 import io.grpc.internal.Channelz.TransportStats;
@@ -1338,16 +1337,14 @@ public class OkHttpClientTransportTest {
     clientTransport.shutdown(SHUTDOWN_REASON);
     // ping failed on channel shutdown
     assertEquals(1, callback.invocationCount);
-    assertTrue(callback.failureCause instanceof StatusException);
-    assertSame(SHUTDOWN_REASON, ((StatusException) callback.failureCause).getStatus());
+    assertSame(SHUTDOWN_REASON, Status.fromThrowable(callback.failureCause));
 
     // now that handler is in terminal state, all future pings fail immediately
     callback = new PingCallbackImpl();
     clientTransport.ping(callback, MoreExecutors.directExecutor());
     assertEquals(1, getTransportStats(clientTransport).keepAlivesSent);
     assertEquals(1, callback.invocationCount);
-    assertTrue(callback.failureCause instanceof StatusException);
-    assertSame(SHUTDOWN_REASON, ((StatusException) callback.failureCause).getStatus());
+    assertSame(SHUTDOWN_REASON, Status.fromThrowable(callback.failureCause));
     shutdownAndVerify();
   }
 
@@ -1362,18 +1359,14 @@ public class OkHttpClientTransportTest {
     clientTransport.onException(new IOException());
     // ping failed on error
     assertEquals(1, callback.invocationCount);
-    assertTrue(callback.failureCause instanceof StatusException);
-    assertEquals(Status.Code.UNAVAILABLE,
-        ((StatusException) callback.failureCause).getStatus().getCode());
+    assertEquals(Status.Code.UNAVAILABLE, Status.fromThrowable(callback.failureCause).getCode());
 
     // now that handler is in terminal state, all future pings fail immediately
     callback = new PingCallbackImpl();
     clientTransport.ping(callback, MoreExecutors.directExecutor());
     assertEquals(1, getTransportStats(clientTransport).keepAlivesSent);
     assertEquals(1, callback.invocationCount);
-    assertTrue(callback.failureCause instanceof StatusException);
-    assertEquals(Status.Code.UNAVAILABLE,
-        ((StatusException) callback.failureCause).getStatus().getCode());
+    assertEquals(Status.Code.UNAVAILABLE, Status.fromThrowable(callback.failureCause).getCode());
     shutdownAndVerify();
   }
 

--- a/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
+++ b/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
@@ -215,7 +215,7 @@ public final class ProtoLiteUtils {
         return parseFrom(cis);
       } catch (InvalidProtocolBufferException ipbe) {
         throw Status.INTERNAL.withDescription("Invalid protobuf byte sequence")
-            .withCause(ipbe).asRuntimeException();
+            .withCause(ipbe).asStacklessRuntimeException();
       }
     }
 

--- a/protobuf-nano/src/main/java/io/grpc/protobuf/nano/NanoUtils.java
+++ b/protobuf-nano/src/main/java/io/grpc/protobuf/nano/NanoUtils.java
@@ -69,7 +69,7 @@ public final class NanoUtils {
         return message;
       } catch (IOException ipbe) {
         throw Status.INTERNAL.withDescription("Failed parsing nano proto message").withCause(ipbe)
-            .asRuntimeException();
+            .asStacklessRuntimeException();
       }
     }
 

--- a/protobuf/src/test/java/io/grpc/protobuf/StatusProtoTest.java
+++ b/protobuf/src/test/java/io/grpc/protobuf/StatusProtoTest.java
@@ -129,8 +129,8 @@ public class StatusProtoTest {
   public void fromThrowable_shouldReturnNullIfTrailersAreNull() {
     Status status = Status.fromCodeValue(0);
 
-    assertNull(StatusProto.fromThrowable(status.asRuntimeException()));
-    assertNull(StatusProto.fromThrowable(status.asException()));
+    assertNull(StatusProto.fromThrowable(status.asStacklessRuntimeException()));
+    assertNull(StatusProto.fromThrowable(status.asStacklessException()));
   }
 
   @Test

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -460,13 +460,13 @@ final class ChannelzProtoUtil {
         throw Status.UNIMPLEMENTED
             .withDescription("The entity's stats can not be retrieved. "
                 + "If this is an InProcessTransport this is expected.")
-            .asRuntimeException();
+            .asStacklessRuntimeException();
       }
       return ret;
     } catch (InterruptedException e) {
-      throw Status.INTERNAL.withCause(e).asRuntimeException();
+      throw Status.INTERNAL.withCause(e).asStacklessRuntimeException();
     } catch (ExecutionException e) {
-      throw Status.INTERNAL.withCause(e).asRuntimeException();
+      throw Status.INTERNAL.withCause(e).asStacklessRuntimeException();
     }
   }
 }

--- a/services/src/main/java/io/grpc/services/ChannelzService.java
+++ b/services/src/main/java/io/grpc/services/ChannelzService.java
@@ -94,7 +94,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
       GetChannelRequest request, StreamObserver<GetChannelResponse> responseObserver) {
     Instrumented<ChannelStats> s = channelz.getRootChannel(request.getChannelId());
     if (s == null) {
-      responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
+      responseObserver.onError(Status.NOT_FOUND.asStacklessRuntimeException());
       return;
     }
 
@@ -122,7 +122,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
       GetSubchannelRequest request, StreamObserver<GetSubchannelResponse> responseObserver) {
     Instrumented<ChannelStats> s = channelz.getSubchannel(request.getSubchannelId());
     if (s == null) {
-      responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
+      responseObserver.onError(Status.NOT_FOUND.asStacklessRuntimeException());
       return;
     }
 
@@ -140,7 +140,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
       GetSocketRequest request, StreamObserver<GetSocketResponse> responseObserver) {
     Instrumented<SocketStats> s = channelz.getSocket(request.getSocketId());
     if (s == null) {
-      responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
+      responseObserver.onError(Status.NOT_FOUND.asStacklessRuntimeException());
       return;
     }
 
@@ -158,7 +158,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
     ServerSocketsList serverSockets
         = channelz.getServerSockets(request.getServerId(), request.getStartSocketId(), maxPageSize);
     if (serverSockets == null) {
-      responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
+      responseObserver.onError(Status.NOT_FOUND.asStacklessRuntimeException());
       return;
     }
 

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -133,7 +133,7 @@ public final class ClientCalls {
           throw Status.CANCELLED
               .withDescription("Call was interrupted")
               .withCause(e)
-              .asRuntimeException();
+              .asStacklessRuntimeException();
         }
       }
       return getUnchecked(responseFuture);
@@ -209,7 +209,7 @@ public final class ClientCalls {
       throw Status.CANCELLED
           .withDescription("Call was interrupted")
           .withCause(e)
-          .asRuntimeException();
+          .asStacklessRuntimeException();
     } catch (ExecutionException e) {
       throw toStatusRuntimeException(e.getCause());
     }
@@ -235,7 +235,7 @@ public final class ClientCalls {
       cause = cause.getCause();
     }
     return Status.UNKNOWN.withDescription("unexpected exception").withCause(t)
-        .asRuntimeException();
+        .asStacklessRuntimeException();
   }
 
   /**
@@ -415,7 +415,7 @@ public final class ClientCalls {
       if (firstResponseReceived && !streamingResponse) {
         throw Status.INTERNAL
             .withDescription("More than one responses received for unary or client-streaming call")
-            .asRuntimeException();
+            .asStacklessRuntimeException();
       }
       firstResponseReceived = true;
       observer.onNext(message);
@@ -463,7 +463,7 @@ public final class ClientCalls {
     public void onMessage(RespT value) {
       if (this.value != null) {
         throw Status.INTERNAL.withDescription("More than one value received for unary call")
-            .asRuntimeException();
+            .asStacklessRuntimeException();
       }
       this.value = value;
     }
@@ -567,7 +567,8 @@ public final class ClientCalls {
           last = waitForNext();
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
-          throw Status.CANCELLED.withDescription("interrupted").withCause(ie).asRuntimeException();
+          throw Status.CANCELLED.withDescription("interrupted").withCause(ie)
+              .asStacklessRuntimeException();
         }
       }
       if (last instanceof StatusRuntimeException) {

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -269,7 +269,7 @@ public final class ServerCalls {
           requestObserver.onError(
               Status.CANCELLED
                   .withDescription("cancelled before receiving half close")
-                  .asRuntimeException());
+                  .asStacklessRuntimeException());
         }
       }
 
@@ -332,7 +332,8 @@ public final class ServerCalls {
     @Override
     public void onNext(RespT response) {
       if (cancelled) {
-        throw Status.CANCELLED.withDescription("call already cancelled").asRuntimeException();
+        throw Status.CANCELLED.withDescription("call already cancelled")
+            .asStacklessRuntimeException();
       }
       if (!sentHeaders) {
         call.sendHeaders(new Metadata());
@@ -353,7 +354,8 @@ public final class ServerCalls {
     @Override
     public void onCompleted() {
       if (cancelled) {
-        throw Status.CANCELLED.withDescription("call already cancelled").asRuntimeException();
+        throw Status.CANCELLED.withDescription("call already cancelled")
+            .asStacklessRuntimeException();
       } else {
         call.close(Status.OK, new Metadata());
       }
@@ -406,7 +408,7 @@ public final class ServerCalls {
     responseObserver.onError(Status.UNIMPLEMENTED
         .withDescription(String.format("Method %s is unimplemented",
             methodDescriptor.getFullMethodName()))
-        .asRuntimeException());
+        .asStacklessRuntimeException());
   }
 
   /**

--- a/stub/src/main/java/io/grpc/stub/StreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/StreamObserver.java
@@ -60,9 +60,10 @@ public interface StreamObserver<V>  {
    *
    * <p>{@code t} should be a {@link io.grpc.StatusException} or {@link
    * io.grpc.StatusRuntimeException}, but other {@code Throwable} types are possible. Callers should
-   * generally convert from a {@link io.grpc.Status} via {@link io.grpc.Status#asException()} or
-   * {@link io.grpc.Status#asRuntimeException()}. Implementations should generally convert to a
-   * {@code Status} via {@link io.grpc.Status#fromThrowable(Throwable)}.
+   * generally convert from a {@link io.grpc.Status} via
+   * {@link io.grpc.Status#asStacklessException()} or
+   * {@link io.grpc.Status#asStacklessRuntimeException()}. Implementations should generally convert
+   * to a {@code Status} via {@link io.grpc.Status#fromThrowable(Throwable)}.
    *
    * @param t the error occurred on the stream
    */

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -1003,7 +1003,8 @@ public abstract class AbstractTransportTest {
       public void closed(Status status, Metadata trailers) {
         super.closed(status, trailers);
         // This simulates the blocking calls which can trigger clientStream.cancel().
-        clientStream.cancel(Status.CANCELLED.withCause(status.asRuntimeException()));
+        clientStream.cancel(Status.CANCELLED.withDescription("closed")
+            .withCause(status.asStacklessRuntimeException()));
       }
 
       @Override
@@ -1011,7 +1012,8 @@ public abstract class AbstractTransportTest {
           Status status, RpcProgress rpcProgress, Metadata trailers) {
         super.closed(status, rpcProgress, trailers);
         // This simulates the blocking calls which can trigger clientStream.cancel().
-        clientStream.cancel(Status.CANCELLED.withCause(status.asRuntimeException()));
+        clientStream.cancel(Status.CANCELLED.withDescription("closed")
+            .withCause(status.asStacklessRuntimeException()));
       }
     };
     clientStream.start(clientStreamListener);


### PR DESCRIPTION
I tried my best to chase each of these exceptions to see where they were consumed.   The only *serious* change in API is at the stub level, where stackless Runtime exceptions are now used.  This makes most RPC Exceptions purely expose the message, code, and cause.

Key changes:

* Add `asStacklessException` and `asStacklessRuntimeException`  
* Swap nearly all in gRPC usages to these methods.  Some places were not swapped (like in StatusProto) as the API contract is not so clear here.
* Tests updated to unwrap the exception, rather than cast.  
* Avoid using StatusException in favor of StatusRuntimeException.    