### PR TITLE
travis: Use default Maven settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - LD_LIBRARY_PATH=/tmp/protobuf/lib
 
 before_install:
+  - rm ~/.m2/settings.xml || true # Avoid repository.apache.org, which has QPS limits and is useless
   - mkdir -p $HOME/.gradle/caches &&
     ln -s /tmp/gradle-caches-modules-2 $HOME/.gradle/caches/modules-2
   - mkdir -p $HOME/.gradle &&


### PR DESCRIPTION
Throw away Travis-CI's custom Maven settings, because they are causing
massive CI failures when Maven slows to a crawl/hangs because of
failures contaicting repository.apache.org.

Travis-CI's settings includes repo.maven.apache.org, oss.sonatype
(releases and snapshots), and repository.apache.org (releases and
snapshots). Now we will just be using Maven's default, which may just
be repo.maven.apache.org.