### PR TITLE
buildscripts: disable gae jdk7 test

### DIFF
--- a/buildscripts/kokoro/gae-interop.sh
+++ b/buildscripts/kokoro/gae-interop.sh
@@ -43,9 +43,6 @@ set -e
 # Deploy and test the real app (jdk8)
 ./gradlew $GRADLE_FLAGS -DgaeDeployVersion="$KOKORO_GAE_APP_VERSION" :grpc-gae-interop-testing-jdk8:runInteropTestRemote
 
-# Deploy and test the real app (jdk7)
-./gradlew $GRADLE_FLAGS -DgaeDeployVersion="$KOKORO_GAE_APP_VERSION" :grpc-gae-interop-testing-jdk7:runInteropTestRemote
-
 set +e
 echo "Cleaning out stale deploys from previous runs, it is ok if this part fails"
 


### PR DESCRIPTION
The test has become very flakey recently. With GAE jdk7 going away
completely in early 2019, let's disable running the test in CI.