### PR TITLE
all: Swap to Java 7 source and bytecode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ subprojects {
     group = "io.grpc"
     version = "1.15.0-SNAPSHOT" // CURRENT_GRPC_VERSION
 
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
 
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,11 @@
 description = 'gRPC: Core'
 
+// Workaround:
+// [Undefined reference (android-api-level-14-4.0_r4)] io.grpc.internal.(Rescheduler.java:87)
+//   >> Object java.util.Objects.requireNonNull(Object)
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
+
 dependencies {
     compile project(':grpc-context'),
             libraries.gson,

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,8 +16,8 @@
     <protoc.version>3.5.1-1</protoc.version>
     <netty.tcnative.version>2.0.7.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
   <dependencies>
     <dependency>

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,4 +1,11 @@
 description = "gRPC: OkHttp"
+
+// Workaround:
+//   Util.java:219: warning: [unchecked] Possible heap pollution from parameterized vararg type T
+// Need to verify the @SafeVarargs annotation is safe for Android
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
+
 dependencies {
     compile project(':grpc-core'),
             libraries.okhttp,


### PR DESCRIPTION
Core and OkHttp are left with Java 6 for the moment. Once we resolve
their issues they could be bumped as well.

Updates #3961

----

@ericgribkoff, could you help out with Core and OkHttp, figuring out how we can handle the incompatibility?