### PR TITLE
core: allow Java 7 source and bytecode

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,11 +1,5 @@
 description = 'gRPC: Core'
 
-// Workaround:
-// [Undefined reference (android-api-level-14-4.0_r4)] io.grpc.internal.(Rescheduler.java:87)
-//   >> Object java.util.Objects.requireNonNull(Object)
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-
 dependencies {
     compile project(':grpc-context'),
             libraries.gson,


### PR DESCRIPTION
(This PR is a follow-up for an issue identified in https://github.com/grpc/grpc-java/pull/4799 and should not be merged without that change)

javac can produce code that invokes Object.requireNonNull when instantiating
an inner class using a instance variable. See
https://bugs.openjdk.java.net/browse/JDK-8202137

@ejona86 From the linked bug, I don't see that there is an option here other than marking the inner class non-static. It's slightly unsettling that we apparently need animalsniffer to catch javac including code that isn't present on old Android devices; I haven't had time to check if the android build system would otherwise do something fancy here to avoid issues at runtime on older devices.

If this looks alright, do you want to cherry-pick this commit into https://github.com/grpc/grpc-java/pull/4799, or keep this as a stand-alone PR?