### PR TITLE
okhttp: use java 7, avoid compiler varargs warning

### DIFF
--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,11 +1,5 @@
 description = "gRPC: OkHttp"
 
-// Workaround:
-//   Util.java:219: warning: [unchecked] Possible heap pollution from parameterized vararg type T
-// Need to verify the @SafeVarargs annotation is safe for Android
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-
 dependencies {
     compile project(':grpc-core'),
             libraries.okhttp,

--- a/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Util.java
+++ b/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Util.java
@@ -216,7 +216,7 @@ public final class Util {
   }
 
   /** Returns an immutable list containing {@code elements}. */
-  public static <T> List<T> immutableList(T... elements) {
+  public static <T> List<T> immutableList(T[] elements) {
     return Collections.unmodifiableList(Arrays.asList(elements.clone()));
   }
 


### PR DESCRIPTION
Leaving the method as-is seems to require both of the following annotations:

```
@SafeVarargs
@SuppressWarnings("varargs")
```

Rather than doing this (`@SafeVarargs` may or may not be fine for Android pre-API 19, didn't dig into it fully), it seems easier to just change the method signature to accept an array instead of varargs. The utility function is only used in two places, `io.grpc.okhttp.internal.ConnectionSpec#cipherSuites` and `io.grpc.okhttp.internal.ConnectionSpec#tlsVersions`.