### PR TITLE
core: DnsNameResolver caches refresh

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -130,7 +130,7 @@ final class DnsNameResolver extends NameResolver {
   private final String host;
   private final int port;
   private final Resource<ExecutorService> executorResource;
-  private final long networkAddressCacheTtlNanoSeconds;
+  private final long networkAddressCacheTtlNanos;
   private final Stopwatch stopwatch;
   @GuardedBy("this")
   private boolean shutdown;
@@ -168,7 +168,7 @@ final class DnsNameResolver extends NameResolver {
     }
     this.proxyDetector = proxyDetector;
     this.stopwatch = Preconditions.checkNotNull(stopwatch, "stopwatch");
-    this.networkAddressCacheTtlNanoSeconds = getNetworkAddressCacheTtlNanoSeconds();
+    this.networkAddressCacheTtlNanos = getNetworkAddressCacheTtlNanos();
   }
 
   @Override
@@ -199,9 +199,9 @@ final class DnsNameResolver extends NameResolver {
             return;
           }
           boolean resourceRefreshRequired = cachedResolutionResults == null
-              || networkAddressCacheTtlNanoSeconds == 0
-              || (networkAddressCacheTtlNanoSeconds > 0
-                  && stopwatch.elapsed(TimeUnit.NANOSECONDS) >= networkAddressCacheTtlNanoSeconds);
+              || networkAddressCacheTtlNanos == 0
+              || (networkAddressCacheTtlNanos > 0
+                  && stopwatch.elapsed(TimeUnit.NANOSECONDS) > networkAddressCacheTtlNanos);
           if (!resourceRefreshRequired) {
             return;
           }
@@ -235,7 +235,7 @@ final class DnsNameResolver extends NameResolver {
             resolutionResults =
                 resolveAll(addressResolver, resourceResolver, enableSrv, enableTxt, host);
             cachedResolutionResults = resolutionResults;
-            if (networkAddressCacheTtlNanoSeconds > 0) {
+            if (networkAddressCacheTtlNanos > 0) {
               stopwatch.reset().start();
             }
           } catch (Exception e) {
@@ -285,7 +285,7 @@ final class DnsNameResolver extends NameResolver {
     };
 
   /** Returns value of network address cache ttl property. */
-  private static long getNetworkAddressCacheTtlNanoSeconds() {
+  private static long getNetworkAddressCacheTtlNanos() {
     String cacheTtlPropertyValue = System.getProperty(NETWORKADDRESS_CACHE_TTL_PROPERTY);
     long cacheTtl = DEFAULT_NETWORK_CACHE_TTL_SECONDS;
     if (cacheTtlPropertyValue != null) {

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -17,6 +17,7 @@
 package io.grpc.internal;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import io.grpc.Attributes;
 import io.grpc.NameResolverProvider;
 import java.net.URI;
@@ -52,7 +53,8 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
           name,
           params,
           GrpcUtil.SHARED_CHANNEL_EXECUTOR,
-          GrpcUtil.getDefaultProxyDetector());
+          GrpcUtil.getDefaultProxyDetector(),
+          Stopwatch.createUnstarted());
     } else {
       return null;
     }

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -315,7 +315,7 @@ public class DnsNameResolverTest {
     assertAnswerMatches(answer1, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
-    fakeTicker.advance(ttl, TimeUnit.SECONDS);
+    fakeTicker.advance(ttl + 1, TimeUnit.SECONDS);
     resolver.refresh();
     assertEquals(1, fakeExecutor.runDueTasks());
     verify(mockListener, times(2)).onAddresses(resultCaptor.capture(), any(Attributes.class));
@@ -357,7 +357,7 @@ public class DnsNameResolverTest {
     assertAnswerMatches(answer1, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
-    fakeTicker.advance(DnsNameResolver.DEFAULT_NETWORK_CACHE_TTL_SECONDS - 1, TimeUnit.SECONDS);
+    fakeTicker.advance(DnsNameResolver.DEFAULT_NETWORK_CACHE_TTL_SECONDS, TimeUnit.SECONDS);
     resolver.refresh();
     assertEquals(1, fakeExecutor.runDueTasks());
     verifyNoMoreInteractions(mockListener);


### PR DESCRIPTION
DnsNameResolver caches refresh using java system property networkaddress.cache.ttl.

Resolves #4745