### PR TITLE
examples: Add google mirrored maven central to examples pom.xml to deflake kokoro.

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -90,6 +90,19 @@
       <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>Maven-central-google-mirror</id>
+      <name>Maven Central Google Mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
+    </pluginRepository>
+  </pluginRepositories>
   <build>
     <extensions>
       <extension>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -85,7 +85,7 @@
   <repositories>
     <repository>
       <snapshots><enabled>false</enabled></snapshots>
-      <id>Maven-central-google-mirror</id>
+      <id>maven-central-google-mirror</id>
       <name>Maven Central Google Mirror</name>
       <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
     </repository>
@@ -98,8 +98,8 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>Maven-central-google-mirror</id>
-      <name>Maven Central Google Mirror</name>
+      <id>maven-central-google-mirror</id>
+      <name>maven Central Google Mirror</name>
       <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
     </pluginRepository>
   </pluginRepositories>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -85,7 +85,7 @@
   <repositories>
     <repository>
       <snapshots><enabled>false</enabled></snapshots>
-      <id>maven-central-google-mirror</id>
+      <id>Maven-central-google-mirror</id>
       <name>Maven Central Google Mirror</name>
       <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
     </repository>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -84,7 +84,10 @@
   </dependencies>
   <repositories>
     <repository>
-      <snapshots><enabled>false</enabled></snapshots>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <!-- The google mirror is less flaky than maven central -->
       <id>maven-central-google-mirror</id>
       <name>Maven Central Google Mirror</name>
       <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
@@ -98,6 +101,7 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+      <!-- The google mirror is less flaky than maven central -->
       <id>maven-central-google-mirror</id>
       <name>maven Central Google Mirror</name>
       <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -82,6 +82,14 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <repositories>
+    <repository>
+      <snapshots><enabled>false</enabled></snapshots>
+      <id>maven-central-google-mirror</id>
+      <name>Maven Central Google Mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
+    </repository>
+  </repositories>
   <build>
     <extensions>
       <extension>


### PR DESCRIPTION
error message:

cmd: mvn verify
Downloading from central: https://repo.maven.apache.org/maven2/kr/motd/maven/os-maven-plugin/1.5.0.Final/os-maven-plugin-1.5.0.Final.pom
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Unresolveable build extension: Plugin kr.motd.maven:os-maven-plugin:1.5.0.Final or one of its dependencies could not be resolved: Failed to read artifact descriptor for kr.motd.maven:os-maven-plugin:jar:1.5.0.Final @ 
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project io.grpc:examples:1.16.0-SNAPSHOT (/home/travis/build/grpc/grpc-java/examples/pom.xml) has 1 error
[ERROR]     Unresolveable build extension: Plugin kr.motd.maven:os-maven-plugin:1.5.0.Final or one of its dependencies could not be resolved: Failed to read artifact descriptor for kr.motd.maven:os-maven-plugin:jar:1.5.0.Final: Could not transfer artifact kr.motd.maven:os-maven-plugin:pom:1.5.0.Final from/to central (https://repo.maven.apache.org/maven2): Access denied to: https://repo.maven.apache.org/maven2/kr/motd/maven/os-maven-plugin/1.5.0.Final/os-maven-plugin-1.5.0.Final.pom , ReasonPhrase:Forbidden. -> [Help 2]