### PR TITLE
interop-testing: add very_large_request case to test client

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -49,7 +49,8 @@ public enum TestCases {
   UNIMPLEMENTED_SERVICE("call an unimplemented RPC service"),
   CANCEL_AFTER_BEGIN("cancel stream after starting it"),
   CANCEL_AFTER_FIRST_RESPONSE("cancel on first response"),
-  TIMEOUT_ON_SLEEPING_SERVER("timeout before receiving a response");
+  TIMEOUT_ON_SLEEPING_SERVER("timeout before receiving a response"),
+  VERY_LARGE_REQUEST("very large request");
 
   private final String description;
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -336,6 +336,11 @@ public class TestServiceClient {
         break;
       }
 
+      case VERY_LARGE_REQUEST: {
+        tester.veryLargeRequest();
+        break;
+      }
+
       default:
         throw new IllegalArgumentException("Unknown test case: " + testCase);
     }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
@@ -69,7 +69,8 @@ public class TestCasesTest {
     // additional test cases
     String[] additionalTestCases = {
       "client_compressed_unary_noprobe",
-      "client_compressed_streaming_noprobe"
+      "client_compressed_streaming_noprobe",
+      "very_large_request"
     };
 
     assertEquals(testCases.length + additionalTestCases.length, TestCases.values().length);


### PR DESCRIPTION
This was shown by https://github.com/grpc/grpc-java/issues/4809 to be a useful test. This change makes it easier to reproduce issues by running the test case manually with the interop client.