### PR TITLE
Revert "examples: Add google mirrored maven central to examples pom.xml to deflake kokoro."

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -82,31 +82,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <!-- The google mirror is less flaky than maven central -->
-      <id>maven-central-google-mirror</id>
-      <name>Maven Central Google Mirror</name>
-      <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <releases>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <!-- The google mirror is less flaky than maven central -->
-      <id>maven-central-google-mirror</id>
-      <name>maven Central Google Mirror</name>
-      <url>https://maven-central.storage-download.googleapis.com/repos/central/data/</url>
-    </pluginRepository>
-  </pluginRepositories>
   <build>
     <extensions>
       <extension>


### PR DESCRIPTION
Reverts grpc/grpc-java#4813

make examples pom cleaner, also this issue can be fixed by configuring ~/.m2/settings.xml.
