### PR TITLE
okhttp: settings acks back after apply settings before sending any data

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -1068,12 +1068,6 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           stopDelivery, null, null);
     }
 
-    /**
-     * Handles inbound {@code SETTINGS} frame. The changed settings are not finalized until {@code
-     * SETTINGS} acknowledgment frame is sent. Any writes due to update in settings must be sent
-     * after {@code SETTINGS} acknowledgment frame, otherwise it will cause a stream error ({@code
-     * RST_STREAM}).
-     */
     @Override
     public void settings(boolean clearPrevious, Settings settings) {
       boolean outboundWindowSizeIncreased = false;
@@ -1094,9 +1088,12 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           firstSettings = false;
         }
 
+        // The changed settings are not finalized until SETTINGS acknowledgment frame is sent. Any
+        // writes due to update in settings must be sent after SETTINGS acknowledgment frame,
+        // otherwise it will cause a stream error (RST_STREAM).
         frameWriter.ackSettings(settings);
 
-        // any pending bytes / streams frames must sent after ack settings.
+        // send any pending bytes / streams
         if (outboundWindowSizeIncreased) {
           outboundFlow.writeStreams();
         }

--- a/okhttp/src/main/java/io/grpc/okhttp/OutboundFlowController.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OutboundFlowController.java
@@ -47,8 +47,8 @@ class OutboundFlowController {
 
   /**
    * Adjusts outbound window size requested by peer. When window size is increased, it does not send
-   * any pending frames. Caller should send any pending frames after notify the peer about
-   * successful window size update.
+   * any pending frames. If this method returns {@code true}, the caller should call {@link
+   * #writeStreams()} after settings ack.
    *
    * <p>Must be called with holding transport lock.
    *

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -113,6 +114,7 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -752,6 +754,37 @@ public class OkHttpClientTransportTest {
     frameHandler().windowUpdate(3, HEADER_LENGTH + 20);
     verify(frameWriter, timeout(TIME_OUT_MS))
         .data(eq(false), eq(3), any(Buffer.class), eq(HEADER_LENGTH + 20));
+
+    stream.cancel(Status.CANCELLED);
+    listener.waitUntilStreamClosed();
+    shutdownAndVerify();
+  }
+
+  @Test
+  public void outboundFlowControlWithInitialWindowSizeChangeInMiddleOfStream() throws Exception {
+    initTransport();
+    MockStreamListener listener = new MockStreamListener();
+    OkHttpClientStream stream =
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    stream.start(listener);
+    int messageLength = 20;
+    setInitialWindowSize(HEADER_LENGTH + 10);
+    InputStream input = new ByteArrayInputStream(new byte[messageLength]);
+    stream.writeMessage(input);
+    stream.flush();
+    // part of the message can be sent.
+    verify(frameWriter, timeout(TIME_OUT_MS))
+        .data(eq(false), eq(3), any(Buffer.class), eq(HEADER_LENGTH + 10));
+    // Avoid connection flow control.
+    frameHandler().windowUpdate(0, HEADER_LENGTH + 10);
+
+    // Increase initial window size
+    setInitialWindowSize(HEADER_LENGTH + 20);
+
+    // It should ack the settings, then send remaining message.
+    InOrder inOrder = inOrder(frameWriter);
+    inOrder.verify(frameWriter).ackSettings(any(Settings.class));
+    inOrder.verify(frameWriter).data(eq(false), eq(3), any(Buffer.class), eq(10));
 
     stream.cancel(Status.CANCELLED);
     listener.waitUntilStreamClosed();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -776,11 +776,14 @@ public class OkHttpClientTransportTest {
     verify(frameWriter, timeout(TIME_OUT_MS))
         .data(eq(false), eq(3), any(Buffer.class), eq(HEADER_LENGTH + 10));
     // Avoid connection flow control.
-    frameHandler().windowUpdate(0, HEADER_LENGTH + 10);
+    frameHandler().windowUpdate(0, HEADER_LENGTH + 20);
 
     // Increase initial window size
     setInitialWindowSize(HEADER_LENGTH + 20);
 
+    // wait until pending frames sent (inOrder doesn't support timeout)
+    verify(frameWriter, timeout(TIME_OUT_MS).atLeastOnce())
+        .data(eq(false), eq(3), any(Buffer.class), eq(10));
     // It should ack the settings, then send remaining message.
     InOrder inOrder = inOrder(frameWriter);
     inOrder.verify(frameWriter).ackSettings(any(Settings.class));


### PR DESCRIPTION
settings acks back after apply settings before sending any data as a result of the change.
Resolves #4809 also, make #4816 the not flaky.