### PR TITLE
all: prepend internal classes with Internal

### DIFF
--- a/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
+++ b/core/src/jmh/java/io/grpc/internal/ChannelzBenchmark.java
@@ -17,11 +17,11 @@
 package io.grpc.internal;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ServerStats;
 import io.grpc.InternalChannelz.SocketStats;
-import io.grpc.LogId;
+import io.grpc.InternalInstrumented;
+import io.grpc.InternalLogId;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -43,13 +43,13 @@ public class ChannelzBenchmark {
 
   public InternalChannelz channelz = new InternalChannelz();
 
-  public Instrumented<ServerStats> serverToRemove;
+  public InternalInstrumented<ServerStats> serverToRemove;
 
-  public Instrumented<ServerStats> serverToAdd;
+  public InternalInstrumented<ServerStats> serverToAdd;
 
-  public Instrumented<ServerStats> serverForServerSocket;
-  public Instrumented<SocketStats> serverSocketToAdd;
-  public Instrumented<SocketStats> serverSocketToRemove;
+  public InternalInstrumented<ServerStats> serverForServerSocket;
+  public InternalInstrumented<SocketStats> serverSocketToAdd;
+  public InternalInstrumented<SocketStats> serverSocketToRemove;
 
   /**
    * Javadoc.
@@ -76,11 +76,11 @@ public class ChannelzBenchmark {
   private void populate(int count) {
     for (int i = 0; i < count; i++) {
       // for addNavigable / removeNavigable
-      Instrumented<ServerStats> srv = create();
+      InternalInstrumented<ServerStats> srv = create();
       channelz.addServer(srv);
 
       // for add / remove
-      Instrumented<SocketStats> sock = create();
+      InternalInstrumented<SocketStats> sock = create();
       channelz.addClientSocket(sock);
 
       // for addServerSocket / removeServerSocket
@@ -130,9 +130,9 @@ public class ChannelzBenchmark {
     channelz.removeServerSocket(serverForServerSocket, serverSocketToRemove);
   }
 
-  private static <T> Instrumented<T> create() {
-    return new Instrumented<T>() {
-      final LogId id = LogId.allocate("fake-tag");
+  private static <T> InternalInstrumented<T> create() {
+    return new InternalInstrumented<T>() {
+      final InternalLogId id = InternalLogId.allocate("fake-tag");
 
       @Override
       public ListenableFuture<T> getStats() {
@@ -140,7 +140,7 @@ public class ChannelzBenchmark {
       }
 
       @Override
-      public LogId getLogId() {
+      public InternalLogId getLogId() {
         return id;
       }
     };

--- a/core/src/main/java/io/grpc/InternalInstrumented.java
+++ b/core/src/main/java/io/grpc/InternalInstrumented.java
@@ -25,7 +25,7 @@ import com.google.common.util.concurrent.ListenableFuture;
  * support instrumentation, then the future will return a {@code null}.
  */
 @Internal
-public interface Instrumented<T> extends WithLogId {
+public interface InternalInstrumented<T> extends InternalWithLogId {
 
   /**
    * Returns the stats object.

--- a/core/src/main/java/io/grpc/InternalLogId.java
+++ b/core/src/main/java/io/grpc/InternalLogId.java
@@ -24,15 +24,15 @@ import java.util.concurrent.atomic.AtomicLong;
  *<p>An object that has an ID that is unique within the JVM, primarily for debug logging.
  */
 @Internal
-public final class LogId {
+public final class InternalLogId {
   private static final AtomicLong idAlloc = new AtomicLong();
 
   /**
    * @param tag a loggable tag associated with this tag. The ID that is allocated is guaranteed
    *            to be unique and increasing, irrespective of the tag.
    */
-  public static LogId allocate(String tag) {
-    return new LogId(tag, getNextId());
+  public static InternalLogId allocate(String tag) {
+    return new InternalLogId(tag, getNextId());
   }
 
   static long getNextId() {
@@ -42,7 +42,7 @@ public final class LogId {
   private final String tag;
   private final long id;
 
-  protected LogId(String tag, long id) {
+  protected InternalLogId(String tag, long id) {
     this.tag = tag;
     this.id = id;
   }

--- a/core/src/main/java/io/grpc/InternalWithLogId.java
+++ b/core/src/main/java/io/grpc/InternalWithLogId.java
@@ -22,7 +22,7 @@ package io.grpc;
  * <p>A loggable ID, unique for the duration of the program.
  */
 @Internal
-public interface WithLogId {
+public interface InternalWithLogId {
   /**
    * Returns an ID that is primarily used in debug logs. It usually contains the class name and a
    * numeric ID that is unique among the instances.
@@ -30,5 +30,5 @@ public interface WithLogId {
    * <p>The subclasses of this interface usually want to include the log ID in their {@link
    * #toString} results.
    */
-  LogId getLogId();
+  InternalLogId getLogId();
 }

--- a/core/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -19,8 +19,8 @@ package io.grpc.inprocess;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalInstrumented;
 import io.grpc.ServerStreamTracer;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ObjectPool;
@@ -80,7 +80,7 @@ final class InProcessServer implements InternalServer {
   }
 
   @Override
-  public List<Instrumented<SocketStats>> getListenSockets() {
+  public List<InternalInstrumented<SocketStats>> getListenSockets() {
     return Collections.emptyList();
   }
 

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -32,7 +32,7 @@ import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz.SocketStats;
-import io.grpc.LogId;
+import io.grpc.InternalLogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -71,7 +71,7 @@ import javax.annotation.concurrent.ThreadSafe;
 final class InProcessTransport implements ServerTransport, ConnectionClientTransport {
   private static final Logger log = Logger.getLogger(InProcessTransport.class.getName());
 
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final String name;
   private final String authority;
   private final String userAgent;
@@ -223,7 +223,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 

--- a/core/src/main/java/io/grpc/internal/AbstractSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/AbstractSubchannel.java
@@ -17,8 +17,8 @@
 package io.grpc.internal;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz.ChannelStats;
+import io.grpc.InternalInstrumented;
 import io.grpc.LoadBalancer;
 import javax.annotation.Nullable;
 
@@ -39,5 +39,5 @@ abstract class AbstractSubchannel extends LoadBalancer.Subchannel {
    * unit tests.
    */
   @VisibleForTesting
-  abstract Instrumented<ChannelStats> getInternalSubchannel();
+  abstract InternalInstrumented<ChannelStats> getInternalSubchannel();
 }

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -17,8 +17,8 @@
 package io.grpc.internal;
 
 import io.grpc.CallOptions;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalInstrumented;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import java.util.concurrent.Executor;
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * are expected to execute quickly.
  */
 @ThreadSafe
-public interface ClientTransport extends Instrumented<SocketStats> {
+public interface ClientTransport extends InternalInstrumented<SocketStats> {
 
   /**
    * Creates a new stream for sending messages to a remote end-point.

--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -22,10 +22,10 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -48,7 +48,7 @@ import javax.annotation.concurrent.GuardedBy;
  * thus the delayed transport stops owning the stream.
  */
 final class DelayedClientTransport implements ManagedClientTransport {
-  private final LogId lodId = LogId.allocate(getClass().getName());
+  private final InternalLogId lodId = InternalLogId.allocate(getClass().getName());
 
   private final Object lock = new Object();
 
@@ -339,7 +339,7 @@ final class DelayedClientTransport implements ManagedClientTransport {
 
   // TODO(carl-mastrangelo): remove this once the Subchannel change is in.
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return lodId;
   }
 

--- a/core/src/main/java/io/grpc/internal/FailingClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/FailingClientTransport.java
@@ -22,7 +22,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
 import io.grpc.InternalChannelz.SocketStats;
-import io.grpc.LogId;
+import io.grpc.InternalLogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -66,7 +66,7 @@ class FailingClientTransport implements ClientTransport {
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     throw new UnsupportedOperationException("Not a real transport");
   }
 }

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -21,7 +21,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.InternalChannelz.SocketStats;
-import io.grpc.LogId;
+import io.grpc.InternalLogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -55,7 +55,7 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return delegate().getLogId();
   }
 

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -30,11 +30,11 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalLogId;
 import io.grpc.InternalMetadata;
 import io.grpc.InternalMetadata.TrustedAsciiMarshaller;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.Subchannel;
-import io.grpc.LogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -689,7 +689,7 @@ public final class GrpcUtil {
         }
 
         @Override
-        public LogId getLogId() {
+        public InternalLogId getLogId() {
           return transport.getLogId();
         }
 

--- a/core/src/main/java/io/grpc/internal/InternalServer.java
+++ b/core/src/main/java/io/grpc/internal/InternalServer.java
@@ -16,8 +16,8 @@
 
 package io.grpc.internal;
 
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalInstrumented;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
@@ -54,5 +54,5 @@ public interface InternalServer {
   /**
    * Returns the listen sockets of this server. May return an empty list but never returns null.
    */
-  List<Instrumented<SocketStats>> getListenSockets();
+  List<InternalInstrumented<SocketStats>> getListenSockets();
 }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -35,15 +35,15 @@ import io.grpc.CallOptions;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ChannelStats;
 import io.grpc.InternalChannelz.ChannelTrace;
-import io.grpc.LogId;
+import io.grpc.InternalInstrumented;
+import io.grpc.InternalLogId;
+import io.grpc.InternalWithLogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.WithLogId;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -63,10 +63,10 @@ import javax.annotation.concurrent.ThreadSafe;
  * Transports for a single {@link SocketAddress}.
  */
 @ThreadSafe
-final class InternalSubchannel implements Instrumented<ChannelStats> {
+final class InternalSubchannel implements InternalInstrumented<ChannelStats> {
   private static final Logger log = Logger.getLogger(InternalSubchannel.class.getName());
 
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final String authority;
   private final String userAgent;
   private final BackoffPolicy.Provider backoffPolicyProvider;
@@ -489,7 +489,7 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 
@@ -500,10 +500,10 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
     ChannelStats.Builder builder = new ChannelStats.Builder();
 
     List<EquivalentAddressGroup> addressGroupsSnapshot;
-    List<WithLogId> transportsSnapshot;
+    List<InternalWithLogId> transportsSnapshot;
     synchronized (lock) {
       addressGroupsSnapshot = addressIndex.getGroups();
-      transportsSnapshot = new ArrayList<WithLogId>(transports);
+      transportsSnapshot = new ArrayList<InternalWithLogId>(transports);
     }
 
     builder.setTarget(addressGroupsSnapshot.toString()).setState(getState());

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -44,21 +44,21 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
 import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ChannelStats;
 import io.grpc.InternalChannelz.ChannelTrace;
+import io.grpc.InternalInstrumented;
+import io.grpc.InternalLogId;
+import io.grpc.InternalWithLogId;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LogId;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.NameResolver;
 import io.grpc.Status;
-import io.grpc.WithLogId;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 import io.grpc.internal.RetriableStream.ChannelBufferMeter;
 import io.grpc.internal.RetriableStream.Throttle;
@@ -86,7 +86,8 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /** A communication channel for making outgoing RPCs. */
 @ThreadSafe
-final class ManagedChannelImpl extends ManagedChannel implements Instrumented<ChannelStats> {
+final class ManagedChannelImpl extends ManagedChannel implements
+    InternalInstrumented<ChannelStats> {
   static final Logger logger = Logger.getLogger(ManagedChannelImpl.class.getName());
 
   // Matching this pattern means the target string is a URI target or at least intended to be one.
@@ -112,7 +113,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
   static final Status SUBCHANNEL_SHUTDOWN_STATUS =
       Status.UNAVAILABLE.withDescription("Subchannel shutdown invoked");
 
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final String target;
   private final NameResolver.Factory nameResolverFactory;
   private final Attributes nameResolverParams;
@@ -307,7 +308,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
           channelTracer.updateBuilder(builder);
         }
         builder.setTarget(target).setState(channelStateManager.getState());
-        List<WithLogId> children = new ArrayList<WithLogId>();
+        List<InternalWithLogId> children = new ArrayList<InternalWithLogId>();
         children.addAll(subchannels);
         children.addAll(oobChannels);
         builder.setSubchannels(children);
@@ -318,7 +319,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 
@@ -1389,7 +1390,7 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
     }
 
     @Override
-    Instrumented<ChannelStats> getInternalSubchannel() {
+    InternalInstrumented<ChannelStats> getInternalSubchannel() {
       return subchannel;
     }
 

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -30,21 +30,21 @@ import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ChannelStats;
 import io.grpc.InternalChannelz.ChannelTrace;
+import io.grpc.InternalInstrumented;
+import io.grpc.InternalLogId;
+import io.grpc.InternalWithLogId;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LogId;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.WithLogId;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 import java.util.Collections;
 import java.util.List;
@@ -63,14 +63,14 @@ import javax.annotation.concurrent.ThreadSafe;
  * to its own RPC needs.
  */
 @ThreadSafe
-final class OobChannel extends ManagedChannel implements Instrumented<ChannelStats> {
+final class OobChannel extends ManagedChannel implements InternalInstrumented<ChannelStats> {
   private static final Logger log = Logger.getLogger(OobChannel.class.getName());
 
   private InternalSubchannel subchannel;
   private AbstractSubchannel subchannelImpl;
   private SubchannelPicker subchannelPicker;
 
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final String authority;
   private final DelayedClientTransport delayedTransport;
   private final InternalChannelz channelz;
@@ -154,7 +154,7 @@ final class OobChannel extends ManagedChannel implements Instrumented<ChannelSta
         }
 
         @Override
-        Instrumented<ChannelStats> getInternalSubchannel() {
+        InternalInstrumented<ChannelStats> getInternalSubchannel() {
           return subchannel;
         }
 
@@ -299,13 +299,13 @@ final class OobChannel extends ManagedChannel implements Instrumented<ChannelSta
     builder
         .setTarget(authority)
         .setState(subchannel.getState())
-        .setSubchannels(Collections.<WithLogId>singletonList(subchannel));
+        .setSubchannels(Collections.<InternalWithLogId>singletonList(subchannel));
     ret.set(builder.build());
     return ret;
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -36,11 +36,11 @@ import io.grpc.Context;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.HandlerRegistry;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ServerStats;
+import io.grpc.InternalInstrumented;
+import io.grpc.InternalLogId;
 import io.grpc.InternalServerInterceptors;
-import io.grpc.LogId;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
@@ -78,11 +78,11 @@ import javax.annotation.concurrent.GuardedBy;
  * <p>Starting the server starts the underlying transport for servicing requests. Stopping the
  * server stops servicing new requests and waits for all connections to terminate.
  */
-public final class ServerImpl extends io.grpc.Server implements Instrumented<ServerStats> {
+public final class ServerImpl extends io.grpc.Server implements InternalInstrumented<ServerStats> {
   private static final Logger log = Logger.getLogger(ServerImpl.class.getName());
   private static final ServerStreamListener NOOP_LISTENER = new NoopListener();
 
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final ObjectPool<? extends Executor> executorPool;
   /** Executor for application processing. Safe to read after {@link #start()}. */
   private Executor executor;
@@ -570,7 +570,7 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 

--- a/core/src/main/java/io/grpc/internal/ServerTransport.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransport.java
@@ -16,13 +16,13 @@
 
 package io.grpc.internal;
 
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalInstrumented;
 import io.grpc.Status;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** An inbound connection. */
-public interface ServerTransport extends Instrumented<SocketStats> {
+public interface ServerTransport extends InternalInstrumented<SocketStats> {
   /**
    * Initiates an orderly shutdown of the transport. Existing streams continue, but new streams will
    * eventually begin failing. New streams "eventually" begin failing because shutdown may need to

--- a/core/src/test/java/io/grpc/InternalChannelzTest.java
+++ b/core/src/test/java/io/grpc/InternalChannelzTest.java
@@ -55,7 +55,7 @@ public final class InternalChannelzTest {
 
   @Test
   public void getRootChannels_onePage() {
-    Instrumented<ChannelStats> root1 = create();
+    InternalInstrumented<ChannelStats> root1 = create();
     channelz.addRootChannel(root1);
     RootChannelList page = channelz.getRootChannels(/*fromId=*/ 0, /*maxPageSize=*/ 1);
     assertTrue(page.end);
@@ -64,8 +64,8 @@ public final class InternalChannelzTest {
 
   @Test
   public void getRootChannels_onePage_multi() {
-    Instrumented<ChannelStats> root1 = create();
-    Instrumented<ChannelStats> root2 = create();
+    InternalInstrumented<ChannelStats> root1 = create();
+    InternalInstrumented<ChannelStats> root2 = create();
     channelz.addRootChannel(root1);
     channelz.addRootChannel(root2);
     RootChannelList page = channelz.getRootChannels(/*fromId=*/ 0, /*maxPageSize=*/ 2);
@@ -75,8 +75,8 @@ public final class InternalChannelzTest {
 
   @Test
   public void getRootChannels_paginate() {
-    Instrumented<ChannelStats> root1 = create();
-    Instrumented<ChannelStats> root2 = create();
+    InternalInstrumented<ChannelStats> root1 = create();
+    InternalInstrumented<ChannelStats> root2 = create();
     channelz.addRootChannel(root1);
     channelz.addRootChannel(root2);
     RootChannelList page1 = channelz.getRootChannels(/*fromId=*/ 0, /*maxPageSize=*/ 1);
@@ -90,7 +90,7 @@ public final class InternalChannelzTest {
 
   @Test
   public void getRootChannels_remove() {
-    Instrumented<ChannelStats> root1 = create();
+    InternalInstrumented<ChannelStats> root1 = create();
     channelz.addRootChannel(root1);
     channelz.removeRootChannel(root1);
     RootChannelList page = channelz.getRootChannels(/*fromId=*/ 0, /*maxPageSize=*/ 1);
@@ -100,7 +100,7 @@ public final class InternalChannelzTest {
 
   @Test
   public void getRootChannels_addAfterLastPage() {
-    Instrumented<ChannelStats> root1 = create();
+    InternalInstrumented<ChannelStats> root1 = create();
     {
       channelz.addRootChannel(root1);
       RootChannelList page1 = channelz.getRootChannels(/*fromId=*/ 0, /*maxPageSize=*/ 1);
@@ -108,7 +108,7 @@ public final class InternalChannelzTest {
       assertThat(page1.channels).containsExactly(root1);
     }
 
-    Instrumented<ChannelStats> root2 = create();
+    InternalInstrumented<ChannelStats> root2 = create();
     {
       channelz.addRootChannel(root2);
       RootChannelList page2
@@ -127,7 +127,7 @@ public final class InternalChannelzTest {
 
   @Test
   public void getServers_onePage() {
-    Instrumented<ServerStats> server1 = create();
+    InternalInstrumented<ServerStats> server1 = create();
     channelz.addServer(server1);
     ServerList page = channelz.getServers(/*fromId=*/ 0, /*maxPageSize=*/ 1);
     assertTrue(page.end);
@@ -136,8 +136,8 @@ public final class InternalChannelzTest {
 
   @Test
   public void getServers_onePage_multi() {
-    Instrumented<ServerStats> server1 = create();
-    Instrumented<ServerStats> server2 = create();
+    InternalInstrumented<ServerStats> server1 = create();
+    InternalInstrumented<ServerStats> server2 = create();
     channelz.addServer(server1);
     channelz.addServer(server2);
     ServerList page = channelz.getServers(/*fromId=*/ 0, /*maxPageSize=*/ 2);
@@ -147,8 +147,8 @@ public final class InternalChannelzTest {
 
   @Test
   public void getServers_paginate() {
-    Instrumented<ServerStats> server1 = create();
-    Instrumented<ServerStats> server2 = create();
+    InternalInstrumented<ServerStats> server1 = create();
+    InternalInstrumented<ServerStats> server2 = create();
     channelz.addServer(server1);
     channelz.addServer(server2);
     ServerList page1 = channelz.getServers(/*fromId=*/ 0, /*maxPageSize=*/ 1);
@@ -162,7 +162,7 @@ public final class InternalChannelzTest {
 
   @Test
   public void getServers_remove() {
-    Instrumented<ServerStats> server1 = create();
+    InternalInstrumented<ServerStats> server1 = create();
     channelz.addServer(server1);
     channelz.removeServer(server1);
     ServerList page = channelz.getServers(/*fromId=*/ 0, /*maxPageSize=*/ 1);
@@ -172,7 +172,7 @@ public final class InternalChannelzTest {
 
   @Test
   public void getServers_addAfterLastPage() {
-    Instrumented<ServerStats> server1 = create();
+    InternalInstrumented<ServerStats> server1 = create();
     {
       channelz.addServer(server1);
       ServerList page = channelz.getServers(/*fromId=*/ 0, /*maxPageSize=*/ 1);
@@ -180,7 +180,7 @@ public final class InternalChannelzTest {
       assertThat(page.servers).containsExactly(server1);
     }
 
-    Instrumented<ServerStats> server2 = create();
+    InternalInstrumented<ServerStats> server2 = create();
     {
       channelz.addServer(server2);
       ServerList page
@@ -192,7 +192,7 @@ public final class InternalChannelzTest {
 
   @Test
   public void getChannel() {
-    Instrumented<ChannelStats> root = create();
+    InternalInstrumented<ChannelStats> root = create();
     assertNull(channelz.getChannel(id(root)));
 
     channelz.addRootChannel(root);
@@ -205,7 +205,7 @@ public final class InternalChannelzTest {
 
   @Test
   public void getSubchannel() {
-    Instrumented<ChannelStats> sub = create();
+    InternalInstrumented<ChannelStats> sub = create();
     assertNull(channelz.getSubchannel(id(sub)));
 
     channelz.addSubchannel(sub);
@@ -218,7 +218,7 @@ public final class InternalChannelzTest {
 
   @Test
   public void getSocket() {
-    Instrumented<SocketStats> socket = create();
+    InternalInstrumented<SocketStats> socket = create();
     assertNull(channelz.getSocket(id(socket)));
 
     channelz.addClientSocket(socket);
@@ -235,10 +235,10 @@ public final class InternalChannelzTest {
 
   @Test
   public void serverSocket() {
-    Instrumented<ServerStats> server = create();
+    InternalInstrumented<ServerStats> server = create();
     channelz.addServer(server);
 
-    Instrumented<SocketStats> socket = create();
+    InternalInstrumented<SocketStats> socket = create();
     assertEmptyServerSocketsPage(id(server), id(socket));
 
     channelz.addServerSocket(server, socket);
@@ -254,11 +254,11 @@ public final class InternalChannelzTest {
 
   @Test
   public void serverSocket_eachServerSeparate() {
-    Instrumented<ServerStats> server1 = create();
-    Instrumented<ServerStats> server2 = create();
+    InternalInstrumented<ServerStats> server1 = create();
+    InternalInstrumented<ServerStats> server2 = create();
 
-    Instrumented<SocketStats> socket1 = create();
-    Instrumented<SocketStats> socket2 = create();
+    InternalInstrumented<SocketStats> socket1 = create();
+    InternalInstrumented<SocketStats> socket2 = create();
 
     channelz.addServer(server1);
     channelz.addServer(server2);
@@ -301,16 +301,16 @@ public final class InternalChannelzTest {
     assertThat(emptyPage.sockets).isEmpty();
   }
 
-  private static <T> Instrumented<T> create() {
-    return new Instrumented<T>() {
-      final LogId id = LogId.allocate("fake-tag");
+  private static <T> InternalInstrumented<T> create() {
+    return new InternalInstrumented<T>() {
+      final InternalLogId id = InternalLogId.allocate("fake-tag");
       @Override
       public ListenableFuture<T> getStats() {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public LogId getLogId() {
+      public InternalLogId getLogId() {
         return id;
       }
     };

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -42,8 +42,8 @@ import io.grpc.Attributes;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.InternalChannelz;
+import io.grpc.InternalWithLogId;
 import io.grpc.Status;
-import io.grpc.WithLogId;
 import io.grpc.internal.InternalSubchannel.CallTracingTransport;
 import io.grpc.internal.InternalSubchannel.Index;
 import io.grpc.internal.TestUtils.MockClientTransportInfo;
@@ -983,7 +983,7 @@ public class InternalSubchannelTest {
     createInternalSubchannel(addr);
     internalSubchannel.obtainActiveTransport();
 
-    WithLogId registeredTransport
+    InternalWithLogId registeredTransport
         = Iterables.getOnlyElement(internalSubchannel.getStats().get().sockets);
     MockClientTransportInfo actualTransport = Iterables.getOnlyElement(transports);
     assertEquals(actualTransport.transport.getLogId(), registeredTransport.getLogId());

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -68,11 +68,11 @@ import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.Instrumented;
 import io.grpc.IntegerMarshaller;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ChannelStats;
 import io.grpc.InternalChannelz.ChannelTrace;
+import io.grpc.InternalInstrumented;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
@@ -2950,7 +2950,7 @@ public class ManagedChannelImplTest {
   }
 
   private static ChannelStats getStats(
-      Instrumented<ChannelStats> instrumented) throws Exception {
+      InternalInstrumented<ChannelStats> instrumented) throws Exception {
     return instrumented.getStats().get();
   }
 

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -54,13 +54,13 @@ import io.grpc.Compressor;
 import io.grpc.Context;
 import io.grpc.Grpc;
 import io.grpc.HandlerRegistry;
-import io.grpc.Instrumented;
 import io.grpc.IntegerMarshaller;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ServerSocketsList;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalInstrumented;
+import io.grpc.InternalLogId;
 import io.grpc.InternalServerInterceptors;
-import io.grpc.LogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
@@ -1364,7 +1364,7 @@ public class ServerImplTest {
     }
 
     @Override
-    public List<Instrumented<SocketStats>> getListenSockets() {
+    public List<InternalInstrumented<SocketStats>> getListenSockets() {
       return Collections.emptyList();
     }
 
@@ -1380,7 +1380,7 @@ public class ServerImplTest {
 
   private class SimpleServerTransport implements ServerTransport {
     ServerTransportListener listener;
-    LogId id = LogId.allocate(getClass().getName());
+    InternalLogId id = InternalLogId.allocate(getClass().getName());
 
     @Override
     public void shutdown() {
@@ -1393,7 +1393,7 @@ public class ServerImplTest {
     }
 
     @Override
-    public LogId getLogId() {
+    public InternalLogId getLogId() {
       return id;
     }
 

--- a/core/src/test/java/io/grpc/internal/TestUtils.java
+++ b/core/src/test/java/io/grpc/internal/TestUtils.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.grpc.CallOptions;
-import io.grpc.LogId;
+import io.grpc.InternalLogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import java.net.SocketAddress;
@@ -75,7 +75,7 @@ final class TestUtils {
       @Override
       public ConnectionClientTransport answer(InvocationOnMock invocation) throws Throwable {
         final ConnectionClientTransport mockTransport = mock(ConnectionClientTransport.class);
-        when(mockTransport.getLogId()).thenReturn(LogId.allocate("mocktransport"));
+        when(mockTransport.getLogId()).thenReturn(InternalLogId.allocate("mocktransport"));
         when(mockTransport.newStream(
                 any(MethodDescriptor.class), any(Metadata.class), any(CallOptions.class)))
             .thenReturn(mock(ClientStream.class));

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -23,7 +23,7 @@ import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.InternalChannelz.SocketStats;
-import io.grpc.LogId;
+import io.grpc.InternalLogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.GuardedBy;
  * A cronet-based {@link ConnectionClientTransport} implementation.
  */
 class CronetClientTransport implements ConnectionClientTransport {
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final InetSocketAddress address;
   private final String authority;
   private final String userAgent;
@@ -231,7 +231,7 @@ class CronetClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -22,10 +22,10 @@ import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Attributes;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.InternalLogId;
+import io.grpc.InternalWithLogId;
 import io.grpc.LoadBalancer;
-import io.grpc.LogId;
 import io.grpc.Status;
-import io.grpc.WithLogId;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ObjectPool;
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
-
 import javax.annotation.Nullable;
 
 /**
@@ -43,9 +42,9 @@ import javax.annotation.Nullable;
  * <p>Optionally, when requested by the naming system, will delegate the work to a local pick-first
  * or round-robin balancer.
  */
-class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
+class GrpclbLoadBalancer extends LoadBalancer implements InternalWithLogId {
 
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final SubchannelPool subchannelPool;
   private final ObjectPool<ScheduledExecutorService> timerServicePool;
 
@@ -73,7 +72,7 @@ class GrpclbLoadBalancer extends LoadBalancer implements WithLogId {
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -33,12 +33,12 @@ import io.grpc.Attributes;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LogId;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -49,8 +49,8 @@ import io.grpc.lb.v1.ClientStats;
 import io.grpc.lb.v1.InitialLoadBalanceRequest;
 import io.grpc.lb.v1.InitialLoadBalanceResponse;
 import io.grpc.lb.v1.LoadBalanceRequest;
-import io.grpc.lb.v1.LoadBalanceResponse.LoadBalanceResponseTypeCase;
 import io.grpc.lb.v1.LoadBalanceResponse;
+import io.grpc.lb.v1.LoadBalanceResponse.LoadBalanceResponseTypeCase;
 import io.grpc.lb.v1.LoadBalancerGrpc;
 import io.grpc.lb.v1.Server;
 import io.grpc.lb.v1.ServerList;
@@ -105,7 +105,7 @@ final class GrpclbState {
       }
     };
 
-  private final LogId logId;
+  private final InternalLogId logId;
   private final String serviceName;
   private final Helper helper;
   private final SubchannelPool subchannelPool;
@@ -152,7 +152,7 @@ final class GrpclbState {
       TimeProvider time,
       ScheduledExecutorService timerService,
       BackoffPolicy.Provider backoffPolicyProvider,
-      LogId logId) {
+      InternalLogId logId) {
     this.helper = checkNotNull(helper, "helper");
     this.subchannelPool = checkNotNull(subchannelPool, "subchannelPool");
     this.time = checkNotNull(time, "time provider");

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
@@ -45,8 +45,9 @@ public abstract class GrpcHttp2ConnectionHandler extends Http2ConnectionHandler 
   }
 
   /**
-   * Same as {@link #handleProtocolNegotiationCompleted(Attributes, InternalChannelz.Security)}
-   * but with no {@link InternalChannelz.Security}.
+   * Same as {@link #handleProtocolNegotiationCompleted(
+   *   Attributes, io.grpc.InternalChannelz.Security)}
+   * but with no {@link io.grpc.InternalChannelz.Security}.
    *
    * @deprecated Use the two argument method instead.
    */

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -27,7 +27,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.InternalChannelz.SocketStats;
-import io.grpc.LogId;
+import io.grpc.InternalLogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -64,7 +64,7 @@ import javax.annotation.Nullable;
  */
 class NettyClientTransport implements ConnectionClientTransport {
   private static final Logger log = Logger.getLogger(NettyServerTransport.class.getName());
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final Map<ChannelOption<?>, ?> channelOptions;
   private final SocketAddress address;
   private final Class<? extends Channel> channelType;
@@ -310,7 +310,7 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.InternalChannelz.SocketStats;
-import io.grpc.LogId;
+import io.grpc.InternalLogId;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
 import io.grpc.internal.ServerTransport;
@@ -55,7 +55,7 @@ class NettyServerTransport implements ServerTransport {
       "Connection reset by peer",
       "An existing connection was forcibly closed by the remote host");
 
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   private final Channel channel;
   private final ChannelPromise channelUnused;
   private final ProtocolNegotiator protocolNegotiator;
@@ -162,7 +162,7 @@ class NettyServerTransport implements ServerTransport {
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyServerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerTest.java
@@ -24,9 +24,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import com.google.common.util.concurrent.SettableFuture;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalInstrumented;
 import io.grpc.ServerStreamTracer;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerTransport;
@@ -212,7 +212,7 @@ public class NettyServerTest {
     });
     assertThat(ns.getPort()).isGreaterThan(0);
 
-    Instrumented<SocketStats> listenSocket = getOnlyElement(ns.getListenSockets());
+    InternalInstrumented<SocketStats> listenSocket = getOnlyElement(ns.getListenSockets());
     assertSame(listenSocket, channelz.getSocket(id(listenSocket)));
 
     // very basic sanity check of the contents

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -36,7 +36,7 @@ import io.grpc.CallOptions;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.SocketStats;
-import io.grpc.LogId;
+import io.grpc.InternalLogId;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
@@ -144,7 +144,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   private AsyncFrameWriter frameWriter;
   private OutboundFlowController outboundFlow;
   private final Object lock = new Object();
-  private final LogId logId = LogId.allocate(getClass().getName());
+  private final InternalLogId logId = InternalLogId.allocate(getClass().getName());
   @GuardedBy("lock")
   private int nextStreamId;
   @GuardedBy("lock")
@@ -629,7 +629,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   }
 
   @Override
-  public LogId getLogId() {
+  public InternalLogId getLogId() {
     return logId;
   }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -55,9 +55,9 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.CallOptions;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalChannelz.TransportStats;
+import io.grpc.InternalInstrumented;
 import io.grpc.InternalStatus;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -2037,7 +2037,7 @@ public class OkHttpClientTransportTest {
     }
   }
 
-  private static TransportStats getTransportStats(Instrumented<SocketStats> obj)
+  private static TransportStats getTransportStats(InternalInstrumented<SocketStats> obj)
       throws ExecutionException, InterruptedException {
     return obj.getStats().get().data;
   }

--- a/services/src/main/java/io/grpc/services/ChannelzService.java
+++ b/services/src/main/java/io/grpc/services/ChannelzService.java
@@ -18,12 +18,12 @@ package io.grpc.services;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ExperimentalApi;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ChannelStats;
 import io.grpc.InternalChannelz.ServerList;
 import io.grpc.InternalChannelz.ServerSocketsList;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalInstrumented;
 import io.grpc.ServerInterceptors;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.Status;
@@ -92,7 +92,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
   @Override
   public void getChannel(
       GetChannelRequest request, StreamObserver<GetChannelResponse> responseObserver) {
-    Instrumented<ChannelStats> s = channelz.getRootChannel(request.getChannelId());
+    InternalInstrumented<ChannelStats> s = channelz.getRootChannel(request.getChannelId());
     if (s == null) {
       responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
       return;
@@ -120,7 +120,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
   @Override
   public void getSubchannel(
       GetSubchannelRequest request, StreamObserver<GetSubchannelResponse> responseObserver) {
-    Instrumented<ChannelStats> s = channelz.getSubchannel(request.getSubchannelId());
+    InternalInstrumented<ChannelStats> s = channelz.getSubchannel(request.getSubchannelId());
     if (s == null) {
       responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
       return;
@@ -138,7 +138,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
   @Override
   public void getSocket(
       GetSocketRequest request, StreamObserver<GetSocketResponse> responseObserver) {
-    Instrumented<SocketStats> s = channelz.getSocket(request.getSocketId());
+    InternalInstrumented<SocketStats> s = channelz.getSocket(request.getSocketId());
     if (s == null) {
       responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
       return;

--- a/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
+++ b/services/src/test/java/io/grpc/services/ChannelzProtoUtilTest.java
@@ -32,7 +32,6 @@ import com.google.protobuf.Message;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
 import io.grpc.ConnectivityState;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ChannelStats;
 import io.grpc.InternalChannelz.ChannelTrace.Event;
@@ -43,7 +42,8 @@ import io.grpc.InternalChannelz.ServerSocketsList;
 import io.grpc.InternalChannelz.ServerStats;
 import io.grpc.InternalChannelz.SocketOptions;
 import io.grpc.InternalChannelz.SocketStats;
-import io.grpc.WithLogId;
+import io.grpc.InternalInstrumented;
+import io.grpc.InternalWithLogId;
 import io.grpc.channelz.v1.Address;
 import io.grpc.channelz.v1.Address.OtherAddress;
 import io.grpc.channelz.v1.Address.TcpIpAddress;
@@ -538,7 +538,7 @@ public final class ChannelzProtoUtilTest {
 
     // 1 listen socket
     server.serverStats = toBuilder(server.serverStats)
-        .setListenSockets(ImmutableList.<Instrumented<SocketStats>>of(listenSocket))
+        .setListenSockets(ImmutableList.<InternalInstrumented<SocketStats>>of(listenSocket))
         .build();
     assertEquals(
         serverProto
@@ -552,7 +552,7 @@ public final class ChannelzProtoUtilTest {
     SocketRef otherListenSocketRef = ChannelzProtoUtil.toSocketRef(otherListenSocket);
     server.serverStats = toBuilder(server.serverStats)
         .setListenSockets(
-            ImmutableList.<Instrumented<SocketStats>>of(listenSocket, otherListenSocket))
+            ImmutableList.<InternalInstrumented<SocketStats>>of(listenSocket, otherListenSocket))
         .build();
     assertEquals(
         serverProto
@@ -573,7 +573,7 @@ public final class ChannelzProtoUtilTest {
     assertEquals(channelProto, ChannelzProtoUtil.toChannel(channel));
 
     channel.stats = toBuilder(channel.stats)
-        .setSubchannels(ImmutableList.<WithLogId>of(subchannel))
+        .setSubchannels(ImmutableList.<InternalWithLogId>of(subchannel))
         .build();
 
     assertEquals(
@@ -585,7 +585,7 @@ public final class ChannelzProtoUtilTest {
 
     TestChannel otherSubchannel = new TestChannel();
     channel.stats = toBuilder(channel.stats)
-        .setSubchannels(ImmutableList.<WithLogId>of(subchannel, otherSubchannel))
+        .setSubchannels(ImmutableList.<InternalWithLogId>of(subchannel, otherSubchannel))
         .build();
     assertEquals(
         channelProto
@@ -611,7 +611,7 @@ public final class ChannelzProtoUtilTest {
   @Test
   public void toSubchannel_socketChildren() throws Exception {
     subchannel.stats = toBuilder(subchannel.stats)
-        .setSockets(ImmutableList.<WithLogId>of(socket))
+        .setSockets(ImmutableList.<InternalWithLogId>of(socket))
         .build();
 
     assertEquals(
@@ -622,7 +622,7 @@ public final class ChannelzProtoUtilTest {
 
     TestSocket otherSocket = new TestSocket();
     subchannel.stats = toBuilder(subchannel.stats)
-        .setSockets(ImmutableList.<WithLogId>of(socket, otherSocket))
+        .setSockets(ImmutableList.<InternalWithLogId>of(socket, otherSocket))
         .build();
     assertEquals(
         subchannelProto
@@ -637,7 +637,7 @@ public final class ChannelzProtoUtilTest {
   public void toSubchannel_subchannelChildren() throws Exception {
     TestChannel subchannel1 = new TestChannel();
     subchannel.stats = toBuilder(subchannel.stats)
-        .setSubchannels(ImmutableList.<WithLogId>of(subchannel1))
+        .setSubchannels(ImmutableList.<InternalWithLogId>of(subchannel1))
         .build();
     assertEquals(
         subchannelProto.toBuilder()
@@ -647,7 +647,7 @@ public final class ChannelzProtoUtilTest {
 
     TestChannel subchannel2 = new TestChannel();
     subchannel.stats = toBuilder(subchannel.stats)
-        .setSubchannels(ImmutableList.<WithLogId>of(subchannel1, subchannel2))
+        .setSubchannels(ImmutableList.<InternalWithLogId>of(subchannel1, subchannel2))
         .build();
     assertEquals(
         subchannelProto
@@ -664,7 +664,8 @@ public final class ChannelzProtoUtilTest {
     assertEquals(
         GetTopChannelsResponse.newBuilder().setEnd(true).build(),
         ChannelzProtoUtil.toGetTopChannelResponse(
-            new RootChannelList(Collections.<Instrumented<ChannelStats>>emptyList(), true)));
+            new RootChannelList(
+                Collections.<InternalInstrumented<ChannelStats>>emptyList(), true)));
 
     // 1 result, paginated
     assertEquals(
@@ -673,7 +674,8 @@ public final class ChannelzProtoUtilTest {
             .addChannel(channelProto)
             .build(),
         ChannelzProtoUtil.toGetTopChannelResponse(
-            new RootChannelList(ImmutableList.<Instrumented<ChannelStats>>of(channel), false)));
+            new RootChannelList(
+                ImmutableList.<InternalInstrumented<ChannelStats>>of(channel), false)));
 
     // 1 result, end
     assertEquals(
@@ -683,7 +685,8 @@ public final class ChannelzProtoUtilTest {
             .setEnd(true)
             .build(),
         ChannelzProtoUtil.toGetTopChannelResponse(
-            new RootChannelList(ImmutableList.<Instrumented<ChannelStats>>of(channel), true)));
+            new RootChannelList(
+                ImmutableList.<InternalInstrumented<ChannelStats>>of(channel), true)));
 
     // 2 results, end
     TestChannel channel2 = new TestChannel();
@@ -696,7 +699,7 @@ public final class ChannelzProtoUtilTest {
             .build(),
         ChannelzProtoUtil.toGetTopChannelResponse(
             new RootChannelList(
-                ImmutableList.<Instrumented<ChannelStats>>of(channel, channel2), true)));
+                ImmutableList.<InternalInstrumented<ChannelStats>>of(channel, channel2), true)));
   }
 
   @Test
@@ -705,7 +708,7 @@ public final class ChannelzProtoUtilTest {
     assertEquals(
         GetServersResponse.getDefaultInstance(),
         ChannelzProtoUtil.toGetServersResponse(
-            new ServerList(Collections.<Instrumented<ServerStats>>emptyList(), false)));
+            new ServerList(Collections.<InternalInstrumented<ServerStats>>emptyList(), false)));
 
     // 1 result, paginated
     assertEquals(
@@ -714,7 +717,7 @@ public final class ChannelzProtoUtilTest {
             .addServer(serverProto)
             .build(),
         ChannelzProtoUtil.toGetServersResponse(
-            new ServerList(ImmutableList.<Instrumented<ServerStats>>of(server), false)));
+            new ServerList(ImmutableList.<InternalInstrumented<ServerStats>>of(server), false)));
 
     // 1 result, end
     assertEquals(
@@ -724,7 +727,7 @@ public final class ChannelzProtoUtilTest {
             .setEnd(true)
             .build(),
         ChannelzProtoUtil.toGetServersResponse(
-            new ServerList(ImmutableList.<Instrumented<ServerStats>>of(server), true)));
+            new ServerList(ImmutableList.<InternalInstrumented<ServerStats>>of(server), true)));
 
     TestServer server2 = new TestServer();
     // 2 results, end
@@ -736,7 +739,8 @@ public final class ChannelzProtoUtilTest {
             .setEnd(true)
             .build(),
         ChannelzProtoUtil.toGetServersResponse(
-            new ServerList(ImmutableList.<Instrumented<ServerStats>>of(server, server2), true)));
+            new ServerList(
+                ImmutableList.<InternalInstrumented<ServerStats>>of(server, server2), true)));
   }
 
   @Test
@@ -745,7 +749,7 @@ public final class ChannelzProtoUtilTest {
     assertEquals(
         GetServerSocketsResponse.getDefaultInstance(),
         ChannelzProtoUtil.toGetServerSocketsResponse(
-            new ServerSocketsList(Collections.<WithLogId>emptyList(), false)));
+            new ServerSocketsList(Collections.<InternalWithLogId>emptyList(), false)));
 
     // 1 result, paginated
     assertEquals(
@@ -754,7 +758,7 @@ public final class ChannelzProtoUtilTest {
             .addSocketRef(socketRef)
             .build(),
         ChannelzProtoUtil.toGetServerSocketsResponse(
-            new ServerSocketsList(ImmutableList.<WithLogId>of(socket), false)));
+            new ServerSocketsList(ImmutableList.<InternalWithLogId>of(socket), false)));
 
     // 1 result, end
     assertEquals(
@@ -764,7 +768,7 @@ public final class ChannelzProtoUtilTest {
             .setEnd(true)
             .build(),
         ChannelzProtoUtil.toGetServerSocketsResponse(
-            new ServerSocketsList(ImmutableList.<WithLogId>of(socket), true)));
+            new ServerSocketsList(ImmutableList.<InternalWithLogId>of(socket), true)));
 
     TestSocket socket2 = new TestSocket();
     // 2 results, end
@@ -776,7 +780,7 @@ public final class ChannelzProtoUtilTest {
             .setEnd(true)
             .build(),
         ChannelzProtoUtil.toGetServerSocketsResponse(
-            new ServerSocketsList(ImmutableList.<WithLogId>of(socket, socket2), true)));
+            new ServerSocketsList(ImmutableList.<InternalWithLogId>of(socket, socket2), true)));
   }
 
   @Test

--- a/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
+++ b/services/src/test/java/io/grpc/services/ChannelzTestHelper.java
@@ -20,7 +20,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.ConnectivityState;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ChannelStats;
 import io.grpc.InternalChannelz.Security;
@@ -28,8 +27,9 @@ import io.grpc.InternalChannelz.ServerStats;
 import io.grpc.InternalChannelz.SocketOptions;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalChannelz.TransportStats;
-import io.grpc.LogId;
-import io.grpc.WithLogId;
+import io.grpc.InternalInstrumented;
+import io.grpc.InternalLogId;
+import io.grpc.InternalWithLogId;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
@@ -40,8 +40,8 @@ import java.util.Collections;
  */
 final class ChannelzTestHelper {
 
-  static final class TestSocket implements Instrumented<SocketStats> {
-    private final LogId id = LogId.allocate("socket");
+  static final class TestSocket implements InternalInstrumented<SocketStats> {
+    private final InternalLogId id = InternalLogId.allocate("socket");
     TransportStats transportStats = new TransportStats(
         /*streamsStarted=*/ 1,
         /*lastLocalStreamCreatedTimeNanos=*/ 2,
@@ -75,7 +75,7 @@ final class ChannelzTestHelper {
     }
 
     @Override
-    public LogId getLogId() {
+    public InternalLogId getLogId() {
       return id;
     }
 
@@ -87,8 +87,8 @@ final class ChannelzTestHelper {
     }
   }
 
-  static final class TestListenSocket implements Instrumented<SocketStats> {
-    private final LogId id = LogId.allocate("listensocket");
+  static final class TestListenSocket implements InternalInstrumented<SocketStats> {
+    private final InternalLogId id = InternalLogId.allocate("listensocket");
     SocketAddress listenAddress = new InetSocketAddress("10.0.0.1", 1234);
 
     @Override
@@ -105,7 +105,7 @@ final class ChannelzTestHelper {
     }
 
     @Override
-    public LogId getLogId() {
+    public InternalLogId getLogId() {
       return id;
     }
 
@@ -117,14 +117,14 @@ final class ChannelzTestHelper {
     }
   }
 
-  static final class TestServer implements Instrumented<ServerStats> {
-    private final LogId id = LogId.allocate("server");
+  static final class TestServer implements InternalInstrumented<ServerStats> {
+    private final InternalLogId id = InternalLogId.allocate("server");
     ServerStats serverStats = new ServerStats(
         /*callsStarted=*/ 1,
         /*callsSucceeded=*/ 2,
         /*callsFailed=*/ 3,
         /*lastCallStartedNanos=*/ 4,
-        Collections.<Instrumented<SocketStats>>emptyList());
+        Collections.<InternalInstrumented<SocketStats>>emptyList());
 
     @Override
     public ListenableFuture<ServerStats> getStats() {
@@ -134,7 +134,7 @@ final class ChannelzTestHelper {
     }
 
     @Override
-    public LogId getLogId() {
+    public InternalLogId getLogId() {
       return id;
     }
 
@@ -146,8 +146,8 @@ final class ChannelzTestHelper {
     }
   }
 
-  static final class TestChannel implements Instrumented<ChannelStats> {
-    private final LogId id = LogId.allocate("channel-or-subchannel");
+  static final class TestChannel implements InternalInstrumented<ChannelStats> {
+    private final InternalLogId id = InternalLogId.allocate("channel-or-subchannel");
 
     ChannelStats stats = new ChannelStats.Builder()
         .setTarget("sometarget")
@@ -156,8 +156,8 @@ final class ChannelzTestHelper {
         .setCallsSucceeded(2)
         .setCallsFailed(3)
         .setLastCallStartedNanos(4)
-        .setSubchannels(Collections.<WithLogId>emptyList())
-        .setSockets(Collections.<WithLogId>emptyList())
+        .setSubchannels(Collections.<InternalWithLogId>emptyList())
+        .setSockets(Collections.<InternalWithLogId>emptyList())
         .build();
 
     @Override
@@ -168,7 +168,7 @@ final class ChannelzTestHelper {
     }
 
     @Override
-    public LogId getLogId() {
+    public InternalLogId getLogId() {
       return id;
     }
 

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -48,9 +48,9 @@ import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Grpc;
-import io.grpc.Instrumented;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalChannelz.TransportStats;
+import io.grpc.InternalInstrumented;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
@@ -2043,7 +2043,7 @@ public abstract class AbstractTransportTest {
     }
   }
 
-  private static TransportStats getTransportStats(Instrumented<SocketStats> socket)
+  private static TransportStats getTransportStats(InternalInstrumented<SocketStats> socket)
       throws ExecutionException, InterruptedException {
     return socket.getStats().get().data;
   }


### PR DESCRIPTION
This is a safer way to hide the classes, because they will not appear
in public targets for some build configurations.