### PR TITLE
build.gradle: remove intellij workaround for gradle/issues/2315

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,6 @@ subprojects {
             }
         }
     }
-    // TODO(zpencer): remove when intellij 2017.2 is released
-    // https://github.com/gradle/gradle/issues/2315
-    idea.module.inheritOutputDirs = true
 
     group = "io.grpc"
     version = "1.15.0-SNAPSHOT" // CURRENT_GRPC_VERSION


### PR DESCRIPTION
This is no longer needed on recent versions of intellij.

Thank you @elharo for pointing this out.