### PR TITLE
grpclb: more useful debug logs.

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/BackendAddressGroup.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/BackendAddressGroup.java
@@ -39,4 +39,9 @@ final class BackendAddressGroup {
   String getToken() {
     return token;
   }
+
+  @Override
+  public String toString() {
+    return "[addrs=" + addresses + " token=" + token + "]";
+  }
 }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -344,6 +344,8 @@ final class GrpclbState {
   private void useRoundRobinLists(
       List<DropEntry> newDropList, List<BackendAddressGroup> newBackendAddrList,
       @Nullable GrpclbClientLoadRecorder loadRecorder) {
+    logger.log(Level.FINE, "[{0}] Using round-robin list: {1}, droplist={2}",
+         new Object[] {logId, newBackendAddrList, newDropList});
     HashMap<EquivalentAddressGroup, Subchannel> newSubchannelMap =
         new HashMap<EquivalentAddressGroup, Subchannel>();
     List<BackendEntry> newBackendList = new ArrayList<BackendEntry>();
@@ -540,7 +542,7 @@ final class GrpclbState {
       if (closed) {
         return;
       }
-      logger.log(Level.FINE, "[{0}] Got an LB response: {1}", new Object[] {logId, response});
+      logger.log(Level.FINER, "[{0}] Got an LB response: {1}", new Object[] {logId, response});
 
       LoadBalanceResponseTypeCase typeCase = response.getLoadBalanceResponseTypeCase();
       if (!initialResponseReceived) {


### PR DESCRIPTION
The addresses from the string dump of the LoadBalanceResponse proto is
in binary format and not human-readable.  We will log the
BackendAddressGroups when using a new list from the balancer.  The
original logging of LoadBalanceResponse is downgraded to FINER level.