### PR TITLE
netty: Initialize ProtocolNegotiators eagerly

### DIFF
--- a/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
@@ -144,7 +144,7 @@ public final class GoogleDefaultChannelBuilder
           "%s must be a InetSocketAddress",
           serverAddress);
       final GoogleDefaultProtocolNegotiator negotiator =
-          new GoogleDefaultProtocolNegotiator(altsHandshakerFactory, sslContext, authority);
+          new GoogleDefaultProtocolNegotiator(altsHandshakerFactory, sslContext);
       return new TransportCreationParamsFilter() {
         @Override
         public SocketAddress getTargetServerAddress() {

--- a/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
@@ -28,10 +28,9 @@ public final class GoogleDefaultProtocolNegotiator implements ProtocolNegotiator
   private final ProtocolNegotiator altsProtocolNegotiator;
   private final ProtocolNegotiator tlsProtocolNegotiator;
 
-  public GoogleDefaultProtocolNegotiator(
-      TsiHandshakerFactory altsFactory, SslContext sslContext, String authority) {
+  public GoogleDefaultProtocolNegotiator(TsiHandshakerFactory altsFactory, SslContext sslContext) {
     altsProtocolNegotiator = AltsProtocolNegotiator.create(altsFactory);
-    tlsProtocolNegotiator = ProtocolNegotiators.tls(sslContext, authority);
+    tlsProtocolNegotiator = ProtocolNegotiators.tls(sslContext);
   }
 
   @VisibleForTesting

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
@@ -84,4 +84,13 @@ public abstract class GrpcHttp2ConnectionHandler extends Http2ConnectionHandler 
   public Attributes getEagAttributes() {
     return Attributes.EMPTY;
   }
+
+  /**
+   * Returns the authority of the server. Only available on the client-side.
+   *
+   * @throws UnsupportedOperationException if on server-side
+   */
+  public String getAuthority() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -70,6 +70,7 @@ class NettyClientTransport implements ConnectionClientTransport {
   private final Class<? extends Channel> channelType;
   private final EventLoopGroup group;
   private final ProtocolNegotiator negotiator;
+  private final String authorityString;
   private final AsciiString authority;
   private final AsciiString userAgent;
   private final int flowControlWindow;
@@ -111,6 +112,7 @@ class NettyClientTransport implements ConnectionClientTransport {
     this.keepAliveTimeNanos = keepAliveTimeNanos;
     this.keepAliveTimeoutNanos = keepAliveTimeoutNanos;
     this.keepAliveWithoutCalls = keepAliveWithoutCalls;
+    this.authorityString = authority;
     this.authority = new AsciiString(authority);
     this.userAgent = new AsciiString(GrpcUtil.getGrpcUserAgent("netty", userAgent));
     this.tooManyPingsRunnable =
@@ -197,7 +199,8 @@ class NettyClientTransport implements ConnectionClientTransport {
         GrpcUtil.STOPWATCH_SUPPLIER,
         tooManyPingsRunnable,
         transportTracer,
-        eagAttributes);
+        eagAttributes,
+        authorityString);
     NettyHandlerSettings.setAutoWindow(handler);
 
     negotiationHandler = negotiator.newHandler(handler);

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -139,65 +139,57 @@ public class NettyChannelBuilderTest {
   }
 
   @Test
-  public void createProtocolNegotiator_plaintext() {
-    ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiator(
-        "authority",
+  public void createProtocolNegotiatorByType_plaintext() {
+    ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiatorByType(
         NegotiationType.PLAINTEXT,
-        noSslContext,
-        noProxy);
+        noSslContext);
     // just check that the classes are the same, and that negotiator is not null.
     assertTrue(negotiator instanceof ProtocolNegotiators.PlaintextNegotiator);
   }
 
   @Test
-  public void createProtocolNegotiator_plaintextUpgrade() {
-    ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiator(
-        "authority",
+  public void createProtocolNegotiatorByType_plaintextUpgrade() {
+    ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiatorByType(
         NegotiationType.PLAINTEXT_UPGRADE,
-        noSslContext,
-        noProxy);
+        noSslContext);
     // just check that the classes are the same, and that negotiator is not null.
     assertTrue(negotiator instanceof ProtocolNegotiators.PlaintextUpgradeNegotiator);
   }
 
   @Test
-  public void createProtocolNegotiator_tlsWithNoContext() {
+  public void createProtocolNegotiatorByType_tlsWithNoContext() {
     thrown.expect(NullPointerException.class);
-    NettyChannelBuilder.createProtocolNegotiator(
-        "authority:1234",
+    NettyChannelBuilder.createProtocolNegotiatorByType(
         NegotiationType.TLS,
-        noSslContext,
-        noProxy);
+        noSslContext);
   }
 
   @Test
-  public void createProtocolNegotiator_tlsWithClientContext() throws SSLException {
-    ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiator(
-        "authority:1234",
+  public void createProtocolNegotiatorByType_tlsWithClientContext() throws SSLException {
+    ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiatorByType(
         NegotiationType.TLS,
-        GrpcSslContexts.forClient().build(),
-        noProxy);
+        GrpcSslContexts.forClient().build());
 
     assertTrue(negotiator instanceof ProtocolNegotiators.TlsNegotiator);
     ProtocolNegotiators.TlsNegotiator n = (TlsNegotiator) negotiator;
+    ProtocolNegotiators.HostPort hostPort = n.parseAuthority("authority:1234");
 
-    assertEquals("authority", n.getHost());
-    assertEquals(1234, n.getPort());
+    assertEquals("authority", hostPort.host);
+    assertEquals(1234, hostPort.port);
   }
 
   @Test
-  public void createProtocolNegotiator_tlsWithAuthorityFallback() throws SSLException {
-    ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiator(
-        "bad_authority",
+  public void createProtocolNegotiatorByType_tlsWithAuthorityFallback() throws SSLException {
+    ProtocolNegotiator negotiator = NettyChannelBuilder.createProtocolNegotiatorByType(
         NegotiationType.TLS,
-        GrpcSslContexts.forClient().build(),
-        noProxy);
+        GrpcSslContexts.forClient().build());
 
     assertTrue(negotiator instanceof ProtocolNegotiators.TlsNegotiator);
     ProtocolNegotiators.TlsNegotiator n = (TlsNegotiator) negotiator;
+    ProtocolNegotiators.HostPort hostPort = n.parseAuthority("bad_authority");
 
-    assertEquals("bad_authority", n.getHost());
-    assertEquals(-1, n.getPort());
+    assertEquals("bad_authority", hostPort.host);
+    assertEquals(-1, hostPort.port);
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -722,7 +722,8 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
         stopwatchSupplier,
         tooManyPingsRunnable,
         transportTracer,
-        Attributes.EMPTY);
+        Attributes.EMPTY,
+        "someauthority");
   }
 
   @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -293,7 +293,7 @@ public class NettyClientTransportTest {
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE)
         .keyManager(clientCert, clientKey)
         .build();
-    ProtocolNegotiator negotiator = ProtocolNegotiators.tls(clientContext, authority);
+    ProtocolNegotiator negotiator = ProtocolNegotiators.tls(clientContext);
     final NettyClientTransport transport = newTransport(negotiator);
     callMeMaybe(transport.start(clientTransportListener));
 
@@ -573,7 +573,7 @@ public class NettyClientTransportTest {
     File caCert = TestUtils.loadCert("ca.pem");
     SslContext clientContext = GrpcSslContexts.forClient().trustManager(caCert)
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
-    return ProtocolNegotiators.tls(clientContext, authority);
+    return ProtocolNegotiators.tls(clientContext);
   }
 
   private NettyClientTransport newTransport(ProtocolNegotiator negotiator) {


### PR DESCRIPTION
This simplifies the construction paradigm and leads to the eventual
removal of TransportCreationParamsFilterFactory. The eventual end goal
is to be able to shut down ProtocolNegotiators as is necessary for ALTS.

The only reason the initialization was delayed was for 'authority', so
we now plumb the authority through GrpcHttp2ConnectionHandler.