### PR TITLE
doc: update README because we have been requiring Java 7 (1.15.x backport)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 gRPC-Java - An RPC library and framework
 ========================================
 
-gRPC-Java works with JDK 6. gRPC-Java clients are supported on Android API
+gRPC-Java works with JDK 7. gRPC-Java clients are supported on Android API
 levels 14 and up (Ice Cream Sandwich and later). Deploying gRPC servers on an
 Android device is not supported.
 


### PR DESCRIPTION
This is a backport of #4819 