### PR TITLE
buildscripts: Reduce verbosity of protobuf builds

### DIFF
--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -36,7 +36,7 @@ if "%PLATFORM%" == "X64" (
   SET CMAKE_VSARCH=
 )
 cmake -Dprotobuf_BUILD_TESTS=OFF -G "Visual Studio %VisualStudioVersion:~0,2%%CMAKE_VSARCH%" .. || exit /b 1
-msbuild /maxcpucount /p:Configuration=Release libprotoc.vcxproj || exit /b 1
+msbuild /maxcpucount /p:Configuration=Release /verbosity:minimal libprotoc.vcxproj || exit /b 1
 call extract_includes.bat || exit /b 1
 popd
 goto :eof

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -35,7 +35,7 @@ else
     --prefix="$INSTALL_DIR"
   # the same source dir is used for 32 and 64 bit builds, so we need to clean stale data first
   make clean
-  make -j$NUM_CPU
+  make V=0 -j$NUM_CPU
   make install
   popd
 fi


### PR DESCRIPTION
A substantial portion of our build logs are just compiling protobuf.
This reduces the noise while still keeping most of the useful
information.