### PR TITLE
netty: Allow specifying a ProtocolNegotatior directly to Channels

### DIFF
--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -63,6 +63,18 @@ public final class InternalNettyChannelBuilder {
     builder.setDynamicParamsFactory(factory);
   }
 
+  /** A class that provides a Netty handler to control protocol negotiation. */
+  public interface ProtocolNegotiator extends io.grpc.netty.ProtocolNegotiator {}
+
+  /**
+   * Sets the {@link ProtocolNegotiator} to be used. Overrides any specified negotiation type and
+   * {@code SslContext}.
+   */
+  public static void setProtocolNegotiator(
+      NettyChannelBuilder builder, ProtocolNegotiator protocolNegotiator) {
+    builder.protocolNegotiator(protocolNegotiator);
+  }
+
   public static void setStatsEnabled(NettyChannelBuilder builder, boolean value) {
     builder.setStatsEnabled(value);
   }

--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -64,15 +64,16 @@ public final class InternalNettyChannelBuilder {
   }
 
   /** A class that provides a Netty handler to control protocol negotiation. */
-  public interface ProtocolNegotiator extends io.grpc.netty.ProtocolNegotiator {}
+  public interface ProtocolNegotiatorFactory
+      extends NettyChannelBuilder.ProtocolNegotiatorFactory {}
 
   /**
-   * Sets the {@link ProtocolNegotiator} to be used. Overrides any specified negotiation type and
-   * {@code SslContext}.
+   * Sets the {@link ProtocolNegotiatorFactory} to be used. Overrides any specified negotiation type
+   * and {@code SslContext}.
    */
-  public static void setProtocolNegotiator(
-      NettyChannelBuilder builder, ProtocolNegotiator protocolNegotiator) {
-    builder.protocolNegotiator(protocolNegotiator);
+  public static void setProtocolNegotiatorFactory(
+      NettyChannelBuilder builder, ProtocolNegotiatorFactory protocolNegotiator) {
+    builder.protocolNegotiatorFactory(protocolNegotiator);
   }
 
   public static void setStatsEnabled(NettyChannelBuilder builder, boolean value) {


### PR DESCRIPTION
This will be the replacement for TransportCreationParamsFilterFactory
and matches what used to be done and what is done on server-side.