### PR TITLE
alts: Remove usage of TransportCreationParamsFilterFactory

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -29,7 +29,7 @@ import io.grpc.Status;
 import io.grpc.alts.internal.RpcProtocolVersionsUtil.RpcVersionsCheckResult;
 import io.grpc.alts.internal.TsiHandshakeHandler.TsiHandshakeCompletionEvent;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
-import io.grpc.netty.InternalNettyChannelBuilder.ProtocolNegotiator;
+import io.grpc.netty.ProtocolNegotiator;
 import io.grpc.netty.ProtocolNegotiators.AbstractBufferingHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;

--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -29,7 +29,7 @@ import io.grpc.Status;
 import io.grpc.alts.internal.RpcProtocolVersionsUtil.RpcVersionsCheckResult;
 import io.grpc.alts.internal.TsiHandshakeHandler.TsiHandshakeCompletionEvent;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
-import io.grpc.netty.ProtocolNegotiator;
+import io.grpc.netty.InternalNettyChannelBuilder.ProtocolNegotiator;
 import io.grpc.netty.ProtocolNegotiators.AbstractBufferingHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;

--- a/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
@@ -19,14 +19,14 @@ package io.grpc.alts.internal;
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
-import io.grpc.netty.ProtocolNegotiator;
+import io.grpc.netty.InternalNettyChannelBuilder.ProtocolNegotiator;
 import io.grpc.netty.ProtocolNegotiators;
 import io.netty.handler.ssl.SslContext;
 
 /** A client-side GPRC {@link ProtocolNegotiator} for Google Default Channel. */
 public final class GoogleDefaultProtocolNegotiator implements ProtocolNegotiator {
-  private final ProtocolNegotiator altsProtocolNegotiator;
-  private final ProtocolNegotiator tlsProtocolNegotiator;
+  private final io.grpc.netty.ProtocolNegotiator altsProtocolNegotiator;
+  private final io.grpc.netty.ProtocolNegotiator tlsProtocolNegotiator;
 
   public GoogleDefaultProtocolNegotiator(TsiHandshakerFactory altsFactory, SslContext sslContext) {
     altsProtocolNegotiator = AltsProtocolNegotiator.create(altsFactory);
@@ -35,7 +35,8 @@ public final class GoogleDefaultProtocolNegotiator implements ProtocolNegotiator
 
   @VisibleForTesting
   GoogleDefaultProtocolNegotiator(
-      ProtocolNegotiator altsProtocolNegotiator, ProtocolNegotiator tlsProtocolNegotiator) {
+      io.grpc.netty.ProtocolNegotiator altsProtocolNegotiator,
+      io.grpc.netty.ProtocolNegotiator tlsProtocolNegotiator) {
     this.altsProtocolNegotiator = altsProtocolNegotiator;
     this.tlsProtocolNegotiator = tlsProtocolNegotiator;
   }

--- a/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
@@ -19,14 +19,14 @@ package io.grpc.alts.internal;
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
-import io.grpc.netty.InternalNettyChannelBuilder.ProtocolNegotiator;
+import io.grpc.netty.ProtocolNegotiator;
 import io.grpc.netty.ProtocolNegotiators;
 import io.netty.handler.ssl.SslContext;
 
 /** A client-side GPRC {@link ProtocolNegotiator} for Google Default Channel. */
 public final class GoogleDefaultProtocolNegotiator implements ProtocolNegotiator {
-  private final io.grpc.netty.ProtocolNegotiator altsProtocolNegotiator;
-  private final io.grpc.netty.ProtocolNegotiator tlsProtocolNegotiator;
+  private final ProtocolNegotiator altsProtocolNegotiator;
+  private final ProtocolNegotiator tlsProtocolNegotiator;
 
   public GoogleDefaultProtocolNegotiator(TsiHandshakerFactory altsFactory, SslContext sslContext) {
     altsProtocolNegotiator = AltsProtocolNegotiator.create(altsFactory);
@@ -35,8 +35,8 @@ public final class GoogleDefaultProtocolNegotiator implements ProtocolNegotiator
 
   @VisibleForTesting
   GoogleDefaultProtocolNegotiator(
-      io.grpc.netty.ProtocolNegotiator altsProtocolNegotiator,
-      io.grpc.netty.ProtocolNegotiator tlsProtocolNegotiator) {
+      ProtocolNegotiator altsProtocolNegotiator,
+      ProtocolNegotiator tlsProtocolNegotiator) {
     this.altsProtocolNegotiator = altsProtocolNegotiator;
     this.tlsProtocolNegotiator = tlsProtocolNegotiator;
   }

--- a/alts/src/test/java/io/grpc/alts/AltsChannelBuilderTest.java
+++ b/alts/src/test/java/io/grpc/alts/AltsChannelBuilderTest.java
@@ -21,9 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import io.grpc.alts.internal.AltsClientOptions;
 import io.grpc.alts.internal.AltsProtocolNegotiator;
 import io.grpc.alts.internal.TransportSecurityCommon.RpcProtocolVersions;
-import io.grpc.netty.InternalNettyChannelBuilder.TransportCreationParamsFilterFactory;
 import io.grpc.netty.ProtocolNegotiator;
-import java.net.InetSocketAddress;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,22 +34,18 @@ public final class AltsChannelBuilderTest {
     AltsChannelBuilder builder =
         AltsChannelBuilder.forTarget("localhost:8080").enableUntrustedAltsForTesting();
 
-    TransportCreationParamsFilterFactory tcpfFactory = builder.getTcpfFactoryForTest();
+    ProtocolNegotiator protocolNegotiator = builder.getProtocolNegotiatorForTest();
     AltsClientOptions altsClientOptions = builder.getAltsClientOptionsForTest();
 
-    assertThat(tcpfFactory).isNull();
+    assertThat(protocolNegotiator).isNull();
     assertThat(altsClientOptions).isNull();
 
     builder.build();
 
-    tcpfFactory = builder.getTcpfFactoryForTest();
+    protocolNegotiator = builder.getProtocolNegotiatorForTest();
     altsClientOptions = builder.getAltsClientOptionsForTest();
 
-    assertThat(tcpfFactory).isNotNull();
-    ProtocolNegotiator protocolNegotiator =
-        tcpfFactory
-            .create(new InetSocketAddress(8080), "fakeAuthority", "fakeUserAgent", null)
-            .getProtocolNegotiator();
+    assertThat(protocolNegotiator).isNotNull();
     assertThat(protocolNegotiator).isInstanceOf(AltsProtocolNegotiator.class);
 
     assertThat(altsClientOptions).isNotNull();

--- a/alts/src/test/java/io/grpc/alts/GoogleDefaultChannelBuilderTest.java
+++ b/alts/src/test/java/io/grpc/alts/GoogleDefaultChannelBuilderTest.java
@@ -19,9 +19,7 @@ package io.grpc.alts;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.grpc.alts.internal.GoogleDefaultProtocolNegotiator;
-import io.grpc.netty.InternalNettyChannelBuilder.TransportCreationParamsFilterFactory;
 import io.grpc.netty.ProtocolNegotiator;
-import java.net.InetSocketAddress;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,12 +31,7 @@ public final class GoogleDefaultChannelBuilderTest {
   public void buildsNettyChannel() throws Exception {
     GoogleDefaultChannelBuilder builder = GoogleDefaultChannelBuilder.forTarget("localhost:8080");
 
-    TransportCreationParamsFilterFactory tcpfFactory = builder.getTcpfFactoryForTest();
-    assertThat(tcpfFactory).isNotNull();
-    ProtocolNegotiator protocolNegotiator =
-        tcpfFactory
-            .create(new InetSocketAddress(8080), "fakeAuthority", "fakeUserAgent", null)
-            .getProtocolNegotiator();
+    ProtocolNegotiator protocolNegotiator = builder.getProtocolNegotiatorForTest();
     assertThat(protocolNegotiator).isInstanceOf(GoogleDefaultProtocolNegotiator.class);
   }
 }

--- a/alts/src/test/java/io/grpc/alts/GoogleDefaultChannelBuilderTest.java
+++ b/alts/src/test/java/io/grpc/alts/GoogleDefaultChannelBuilderTest.java
@@ -30,6 +30,7 @@ public final class GoogleDefaultChannelBuilderTest {
   @Test
   public void buildsNettyChannel() throws Exception {
     GoogleDefaultChannelBuilder builder = GoogleDefaultChannelBuilder.forTarget("localhost:8080");
+    builder.build();
 
     ProtocolNegotiator protocolNegotiator = builder.getProtocolNegotiatorForTest();
     assertThat(protocolNegotiator).isInstanceOf(GoogleDefaultProtocolNegotiator.class);


### PR DESCRIPTION
Provide a ProtocolNegotiator directly instead.
TransportCreationParamsFilterFactory is being removed.

-----

~The first two commits are just dependencies. This depends on #4835 and #4855~ Those are merged. Rebased.

CC @jiangtaoli2016 