### PR TITLE
BROKEN on Windows: Avoid using Jetty ALPN

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,19 +51,6 @@ for reviewers:
   Project maintainers are obligated to squash those commits into one when
   merging.
 
-## Running tests
-
-### Jetty ALPN setup for IntelliJ
-
-The tests in interop-testing project require jetty-alpn agent running in the background
-otherwise they'll fail. Here are instructions on how to setup IntellJ IDEA to enable running
-those tests in IDE:
-
-* Settings -> Build Tools -> Gradle -> Runner -> select Gradle Test Runner
-* View -> Tool Windows -> Gradle -> Edit Run Configuration -> Defaults -> JUnit -> Before lauch -> + -> Run Gradle task, enter the task in the build.gradle that sets the javaagent.
-
-Step 1 must be taken, otherwise by the default JUnit Test Runner running a single test in IDE will trigger all the tests.
-
 ## Guidelines for Pull Requests
 How to get your contributions merged smoothly and quickly.
  

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -37,7 +37,7 @@ dependencies {
             libraries.netty_epoll,
             libraries.math
     compileOnly libraries.javax_annotation
-    alpnagent libraries.jetty_alpn_agent
+    runtime libraries.conscrypt
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity
@@ -59,9 +59,6 @@ def vmArgs = [
 task qps_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.benchmarks.qps.AsyncClient"
     applicationName = "qps_client"
-    defaultJvmOpts = [
-        "-javaagent:" + configurations.alpnagent.asPath
-    ].plus(vmArgs)
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
 }
@@ -69,9 +66,6 @@ task qps_client(type: CreateStartScripts) {
 task openloop_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.benchmarks.qps.OpenLoopClient"
     applicationName = "openloop_client"
-    defaultJvmOpts = [
-        "-javaagent:" + configurations.alpnagent.asPath
-    ].plus(vmArgs)
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
 }
@@ -86,9 +80,6 @@ task qps_server(type: CreateStartScripts) {
 task benchmark_worker(type: CreateStartScripts) {
     mainClassName = "io.grpc.benchmarks.driver.LoadWorker"
     applicationName = "benchmark_worker"
-    defaultJvmOpts = [
-        "-javaagent:" + configurations.alpnagent.asPath
-    ].plus(vmArgs)
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
 }

--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
@@ -24,6 +24,7 @@ import io.grpc.benchmarks.proto.Control.ClientArgs;
 import io.grpc.benchmarks.proto.Control.ServerArgs;
 import io.grpc.benchmarks.proto.Control.ServerArgs.ArgtypeCase;
 import io.grpc.benchmarks.proto.WorkerServiceGrpc;
+import io.grpc.internal.testing.TestUtils;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -107,6 +108,10 @@ public class LoadWorker {
               + "\n    Port to start load servers on. Defaults to any available port");
       System.exit(1);
     }
+
+    // Let Netty or OkHttp use Conscrypt if it is available.
+    TestUtils.installConscryptIfAvailable();
+
     LoadWorker loadWorker = new LoadWorker(driverPort, serverPort);
     loadWorker.start();
     loadWorker.driverServer.awaitTermination();

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncClient.java
@@ -44,6 +44,7 @@ import io.grpc.benchmarks.proto.BenchmarkServiceGrpc.BenchmarkServiceStub;
 import io.grpc.benchmarks.proto.Messages.Payload;
 import io.grpc.benchmarks.proto.Messages.SimpleRequest;
 import io.grpc.benchmarks.proto.Messages.SimpleResponse;
+import io.grpc.internal.testing.TestUtils;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
 import java.util.List;
@@ -303,6 +304,8 @@ public class AsyncClient {
    * checkstyle complains if there is no javadoc comment here.
    */
   public static void main(String... args) throws Exception {
+    // Let Netty or OkHttp use Conscrypt if it is available.
+    TestUtils.installConscryptIfAvailable();
     ClientConfiguration.Builder configBuilder = ClientConfiguration.newBuilder(
         ADDRESS, CHANNELS, OUTSTANDING_RPCS, CLIENT_PAYLOAD, SERVER_PAYLOAD,
         TLS, TESTCA, TRANSPORT, DURATION, WARMUP_DURATION, DIRECTEXECUTOR,

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -54,6 +54,8 @@ public class AsyncServer {
    * checkstyle complains if there is no javadoc comment here.
    */
   public static void main(String... args) throws Exception {
+    // Let Netty or OkHttp use Conscrypt if it is available.
+    TestUtils.installConscryptIfAvailable();
     new AsyncServer().run(args);
   }
 

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/OpenLoopClient.java
@@ -37,6 +37,7 @@ import io.grpc.Status;
 import io.grpc.benchmarks.proto.BenchmarkServiceGrpc;
 import io.grpc.benchmarks.proto.Messages.SimpleRequest;
 import io.grpc.benchmarks.proto.Messages.SimpleResponse;
+import io.grpc.internal.testing.TestUtils;
 import io.grpc.stub.StreamObserver;
 import java.util.Random;
 import java.util.concurrent.Callable;
@@ -63,6 +64,8 @@ public class OpenLoopClient {
    * Comment for checkstyle.
    */
   public static void main(String... args) throws Exception {
+    // Let Netty or OkHttp use Conscrypt if it is available.
+    TestUtils.installConscryptIfAvailable();
     ClientConfiguration.Builder configBuilder = ClientConfiguration.newBuilder(
         ADDRESS, TARGET_QPS, CLIENT_PAYLOAD, SERVER_PAYLOAD, TLS,
         TESTCA, TRANSPORT, DURATION, SAVE_HISTOGRAM, FLOW_CONTROL_WINDOW);

--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,6 @@ subprojects {
         ]
     }
 
-    // Define a separate configuration for managing the dependency on Jetty ALPN agent.
     configurations {
         compile {
             // Detect Maven Enforcer's dependencyConvergence failures. We only

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -9,10 +9,6 @@ plugins {
 description = "gRPC: Integration Testing"
 startScripts.enabled = false
 
-configurations {
-    alpnagent
-}
-
 dependencies {
     compile project(':grpc-alts'),
             project(':grpc-auth'),
@@ -28,10 +24,10 @@ dependencies {
     compileOnly libraries.javax_annotation
     runtime libraries.opencensus_impl,
             libraries.netty_tcnative,
-            project(':grpc-grpclb')
+            project(':grpc-grpclb'),
+            libraries.conscrypt // for OkHttp
     testCompile project(':grpc-context').sourceSets.test.output,
             libraries.mockito
-    alpnagent libraries.jetty_alpn_agent
 }
 
 configureProtoCompilation()
@@ -43,27 +39,14 @@ compileJava {
     options.errorprone.check("BetaApi", CheckSeverity.OFF)
 }
 
-test {
-    // For the automated tests, use Jetty ALPN.
-    jvmArgs "-javaagent:" + configurations.alpnagent.asPath
-}
-
 // For the generated scripts, use Netty tcnative (i.e. OpenSSL).
 // Note that OkHttp currently only supports ALPN, so OpenSSL version >= 1.0.2 is required.
 
 task test_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.TestServiceClient"
     applicationName = "test-client"
-    defaultJvmOpts = [
-        "-javaagent:JAVAAGENT_APP_HOME" + configurations.alpnagent.singleFile.name
-    ]
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + configurations.runtime
-    dependencies { runtime configurations.alpnagent }
-    doLast {
-        unixScript.text = unixScript.text.replace('JAVAAGENT_APP_HOME', '\$APP_HOME/lib/')
-        windowsScript.text = windowsScript.text.replace('JAVAAGENT_APP_HOME', '%APP_HOME%\\lib\\')
-    }
 }
 
 task test_server(type: CreateStartScripts) {


### PR DESCRIPTION
We still want Netty to test that it continues working with Jetty ALPN,
but otherwise we don't want to use it.

Fixes #2266