### PR TITLE
github/lock: Override some of the defaults before enabling

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,3 @@
+daysUntilLock: 365
+lockComment: false
+setLockReason: false


### PR DESCRIPTION
These are settings for the Lock app: https://github.com/apps/lock

We'll probably want to reduce the daysUntilLock to something lower, but
want to try it out first and a larger value will impact fewer issues.
365 is the default, but making it clear what setting we are using.

I disable the comment because I don't want notification noise. I disable
the resolved feature because I'm not quite sure what it is and I'm not
really looking for anything fancy.

The defaults can be found at
https://github.com/dessant/lock-threads/blob/master/src/schema.js