### PR TITLE
github/lock: Use reason "resolved", which is the default

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,3 +1,2 @@
 daysUntilLock: 365
 lockComment: false
-setLockReason: false


### PR DESCRIPTION
What the "reason" means was explained in
https://github.com/grpc/grpc-java/pull/4862#issuecomment-423662264 , and
it's probably fair to accept the default.