### PR TITLE
netty: Remove TransportCreationParamsFilterFactory and add ProtocolNegotiator.close

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -61,6 +61,11 @@ public abstract class AltsProtocolNegotiator implements ProtocolNegotiator {
                     handshakerFactory.newHandshaker(grpcHandler.getAuthority()))),
             new TsiFrameHandler());
       }
+
+      @Override
+      public void close() {
+        // TODO(jiangtaoli2016): release resources
+      }
     };
   }
 
@@ -74,6 +79,11 @@ public abstract class AltsProtocolNegotiator implements ProtocolNegotiator {
             grpcHandler,
             new TsiHandshakeHandler(new NettyTsiHandshaker(handshakerFactory.newHandshaker(null))),
             new TsiFrameHandler());
+      }
+
+      @Override
+      public void close() {
+        // TODO(jiangtaoli2016): release resources
       }
     };
   }

--- a/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
@@ -49,4 +49,10 @@ public final class GoogleDefaultProtocolNegotiator implements ProtocolNegotiator
       return tlsProtocolNegotiator.newHandler(grpcHandler);
     }
   }
+
+  @Override
+  public void close() {
+    altsProtocolNegotiator.close();
+    tlsProtocolNegotiator.close();
+  }
 }

--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -18,8 +18,6 @@ package io.grpc.netty;
 
 import io.grpc.Internal;
 import io.grpc.internal.ClientTransportFactory;
-import io.grpc.internal.ProxyParameters;
-import java.net.SocketAddress;
 
 /**
  * Internal {@link NettyChannelBuilder} accessor.  This is intended for usage internal to the gRPC
@@ -37,30 +35,6 @@ public final class InternalNettyChannelBuilder {
   public static void overrideAuthorityChecker(
       NettyChannelBuilder channelBuilder, OverrideAuthorityChecker authorityChecker) {
     channelBuilder.overrideAuthorityChecker(authorityChecker);
-  }
-
-  /**
-   * Interface to create netty dynamic parameters.
-   */
-  public interface TransportCreationParamsFilterFactory
-      extends NettyChannelBuilder.TransportCreationParamsFilterFactory {
-    @Override
-    TransportCreationParamsFilter create(
-        SocketAddress targetServerAddress, String authority, String userAgent,
-        ProxyParameters proxy);
-  }
-
-  /**
-   * {@link TransportCreationParamsFilter} are those that may depend on late-known information about
-   * a client transport.  This interface can be used to dynamically alter params based on the
-   * params of {@code ClientTransportFactory#newClientTransport}.
-   */
-  public interface TransportCreationParamsFilter
-      extends NettyChannelBuilder.TransportCreationParamsFilter {}
-
-  public static void setDynamicTransportParamsFactory(
-      NettyChannelBuilder builder, TransportCreationParamsFilterFactory factory) {
-    builder.setDynamicParamsFactory(factory);
   }
 
   /** A class that provides a Netty handler to control protocol negotiation. */

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -526,6 +526,7 @@ public final class NettyChannelBuilder
       }
       closed = true;
 
+      protocolNegotiator.close();
       if (usingSharedGroup) {
         SharedResourceHolder.release(Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP, group);
       }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
@@ -43,4 +43,11 @@ public interface ProtocolNegotiator {
    * completed successfully.
    */
   Handler newHandler(GrpcHttp2ConnectionHandler grpcHandler);
+
+  /**
+   * Releases resources held by this negotiator. Called when the Channel transitions to terminated.
+   * Is currently only supported on client-side; server-side protocol negotiators will not see this
+   * method called.
+   */
+  void close();
 }

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -104,6 +104,9 @@ public final class ProtocolNegotiators {
 
         return new PlaintextHandler();
       }
+
+      @Override
+      public void close() {}
     };
   }
 
@@ -117,6 +120,9 @@ public final class ProtocolNegotiators {
       public Handler newHandler(GrpcHttp2ConnectionHandler handler) {
         return new ServerTlsHandler(sslContext, handler);
       }
+
+      @Override
+      public void close() {}
     };
   }
 
@@ -206,6 +212,13 @@ public final class ProtocolNegotiators {
         }
         return new BufferUntilProxyTunnelledHandler(
             proxyHandler, negotiator.newHandler(http2Handler));
+      }
+
+      // This method is not normally called, because we use httpProxy on a per-connection basis in
+      // NettyChannelBuilder. Instead, we expect `negotiator' to be closed by NettyTransportFactory.
+      @Override
+      public void close() {
+        negotiator.close();
       }
     }
 
@@ -310,6 +323,9 @@ public final class ProtocolNegotiators {
       };
       return new BufferUntilTlsNegotiatedHandler(sslBootstrap, handler);
     }
+
+    @Override
+    public void close() {}
   }
 
   /** A tuple of (host, port). */
@@ -341,6 +357,9 @@ public final class ProtocolNegotiators {
           new HttpClientUpgradeHandler(httpClientCodec, upgradeCodec, 1000);
       return new BufferingHttp2UpgradeHandler(upgrader, handler);
     }
+
+    @Override
+    public void close() {}
   }
 
   /**
@@ -357,6 +376,9 @@ public final class ProtocolNegotiators {
     public Handler newHandler(GrpcHttp2ConnectionHandler handler) {
       return new BufferUntilChannelActiveHandler(handler);
     }
+
+    @Override
+    public void close() {}
   }
 
   private static RuntimeException unavailableException(String msg) {

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -821,5 +821,8 @@ public class NettyClientTransportTest {
       this.grpcHandler = grpcHandler;
       return handler = new NoopHandler(grpcHandler);
     }
+
+    @Override
+    public void close() {}
   }
 }


### PR DESCRIPTION
There's two commits here that are easiest to review separately. Removing the FilterFactory was necessary to have a clear lifecycle of the ProtocolNegotiator.

@jiangtaoli2016, after this is merged you can plumb cleanup login in ALTS.

After this is approved but before merging I'll add the necessary close() internally, to make the sync easy.