### PR TITLE
github/lock.yml: Lock GitHub issues after 90 days

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,2 +1,2 @@
-daysUntilLock: 365
+daysUntilLock: 90
 lockComment: false


### PR DESCRIPTION
The earlier year was just for testing. Things are working as we'd hope.
Choosing 90 days for now. If an issue is closed at the beginning of a
release cycle, that gives release cycle + 6 weeks to upgrade, which
seems plenty. Worst-case, is users open a new issue referencing the old
one they found.