### PR TITLE
core: TimeProvider should not assume that the clock never changes

### DIFF
--- a/core/src/main/java/io/grpc/internal/TimeProvider.java
+++ b/core/src/main/java/io/grpc/internal/TimeProvider.java
@@ -27,12 +27,9 @@ public interface TimeProvider {
   long currentTimeNanos();
 
   TimeProvider SYSTEM_TIME_PROVIDER = new TimeProvider() {
-    final long offsetNanos =
-        TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis()) - System.nanoTime();
-
     @Override
     public long currentTimeNanos() {
-      return System.nanoTime() + offsetNanos;
+      return TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     }
   };
 }


### PR DESCRIPTION
We should reflect changes in the system clock.