### PR TITLE
core: permanently store authority at channel creation

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -159,6 +159,10 @@ final class ManagedChannelImpl extends ManagedChannel implements
   // Only null after channel is terminated. Must be assigned from the channelExecutor.
   private NameResolver nameResolver;
 
+  // Set when the NameResolver is initially created. When we create a new NameResolver for the same
+  // target, the new instance must have the same value.
+  private final String cachedAuthority;
+
   // Must be accessed from the channelExecutor.
   private boolean nameResolverStarted;
 
@@ -552,6 +556,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
     this.nameResolverFactory = builder.getNameResolverFactory();
     this.nameResolverParams = checkNotNull(builder.getNameResolverParams(), "nameResolverParams");
     this.nameResolver = getNameResolver(target, nameResolverFactory, nameResolverParams);
+    this.cachedAuthority = checkNotNull(nameResolver.getServiceAuthority(), "serviceAuthority");
     this.timeProvider = checkNotNull(timeProvider, "timeProvider");
     maxTraceEvents = builder.maxTraceEvents;
     if (maxTraceEvents > 0) {
@@ -798,7 +803,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
 
   @Override
   public String authority() {
-    return interceptorChannel.authority();
+    return checkNotNull(cachedAuthority, "cachedAuthority");
   }
 
   private Executor getCallExecutor(CallOptions callOptions) {
@@ -828,8 +833,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
 
     @Override
     public String authority() {
-      String authority = nameResolver.getServiceAuthority();
-      return checkNotNull(authority, "authority");
+      return checkNotNull(cachedAuthority, "cachedAuthority");
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -2801,6 +2801,14 @@ public class ManagedChannelImplTest {
     mychannel.shutdownNow();
   }
 
+  @Test
+  public void getAuthorityAfterShutdown() {
+    createChannel();
+    assertEquals(SERVICE_NAME, channel.authority());
+    channel.shutdownNow();
+    assertEquals(SERVICE_NAME, channel.authority());
+  }
+
   private static final class ChannelBuilder
       extends AbstractManagedChannelImplBuilder<ChannelBuilder> {
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -2802,10 +2802,10 @@ public class ManagedChannelImplTest {
   }
 
   @Test
-  public void getAuthorityAfterShutdown() {
+  public void getAuthorityAfterShutdown() throws Exception {
     createChannel();
     assertEquals(SERVICE_NAME, channel.authority());
-    channel.shutdownNow();
+    channel.shutdownNow().awaitTermination(1, TimeUnit.SECONDS);
     assertEquals(SERVICE_NAME, channel.authority());
   }
 


### PR DESCRIPTION
Getting the authority must not rely on the name resolver being
non-null, because that can trivially happen if the channel is shut
down.