### PR TITLE
POC: bounded Attribute keys

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -19,6 +19,7 @@ package io.grpc.alts.internal;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Any;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.Grpc;
@@ -41,18 +42,11 @@ import io.netty.util.AsciiString;
  */
 public abstract class AltsProtocolNegotiator implements ProtocolNegotiator {
 
-  private static final Attributes.Key<TsiPeer> TSI_PEER_KEY = Attributes.Key.create("TSI_PEER");
-  private static final Attributes.Key<AltsAuthContext> ALTS_CONTEXT_KEY =
-      Attributes.Key.create("ALTS_CONTEXT_KEY");
+  public static final AttributeMap.Key<Grpc.TransportAttr, TsiPeer> TSI_PEER_KEY =
+      AttributeMap.Key.define("TSI_PEER");
+  public static final AttributeMap.Key<Grpc.TransportAttr, AltsAuthContext> ALTS_CONTEXT_KEY =
+      AttributeMap.Key.define("ALTS_CONTEXT_KEY");
   private static final AsciiString scheme = AsciiString.of("https");
-
-  public static Attributes.Key<TsiPeer> getTsiPeerAttributeKey() {
-    return TSI_PEER_KEY;
-  }
-
-  public static Attributes.Key<AltsAuthContext> getAltsAuthContextAttributeKey() {
-    return ALTS_CONTEXT_KEY;
-  }
 
   /** Creates a negotiator used for ALTS. */
   public static AltsProtocolNegotiator create(final TsiHandshakerFactory handshakerFactory) {
@@ -120,7 +114,7 @@ public abstract class AltsProtocolNegotiator implements ProtocolNegotiator {
               fail(ctx, Status.UNAVAILABLE.withDescription(errorMessage).asRuntimeException());
             }
             grpcHandler.handleProtocolNegotiationCompleted(
-                Attributes.newBuilder()
+                AttributeMap.<Grpc.TransportAttr>newBuilder()
                     .set(TSI_PEER_KEY, altsEvt.peer())
                     .set(ALTS_CONTEXT_KEY, altsContext)
                     .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())

--- a/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.Grpc;
@@ -339,9 +340,9 @@ public class AltsProtocolNegotiatorTest {
   public void peerPropagated() throws Exception {
     doHandshake();
 
-    assertThat(grpcHandler.attrs.get(AltsProtocolNegotiator.getTsiPeerAttributeKey()))
+    assertThat(grpcHandler.attrs.get(AltsProtocolNegotiator.TSI_PEER_KEY))
         .isEqualTo(mockedTsiPeer);
-    assertThat(grpcHandler.attrs.get(AltsProtocolNegotiator.getAltsAuthContextAttributeKey()))
+    assertThat(grpcHandler.attrs.get(AltsProtocolNegotiator.ALTS_CONTEXT_KEY))
         .isEqualTo(mockedAltsContext);
     assertThat(grpcHandler.attrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR).toString())
         .isEqualTo("embedded");
@@ -394,7 +395,7 @@ public class AltsProtocolNegotiatorTest {
   }
 
   private final class CapturingGrpcHttp2ConnectionHandler extends GrpcHttp2ConnectionHandler {
-    private Attributes attrs;
+    private AttributeMap<Grpc.TransportAttr> attrs;
 
     private CapturingGrpcHttp2ConnectionHandler(
         Http2ConnectionDecoder decoder,
@@ -405,7 +406,7 @@ public class AltsProtocolNegotiatorTest {
 
     @Override
     public void handleProtocolNegotiationCompleted(
-        Attributes attrs, InternalChannelz.Security securityInfo) {
+        AttributeMap<Grpc.TransportAttr> attrs, InternalChannelz.Security securityInfo) {
       // If we are added to the pipeline, we need to remove ourselves.  The HTTP2 handler
       channel.pipeline().remove(this);
       this.attrs = attrs;

--- a/core/src/main/java/io/grpc/AttributeMap.java
+++ b/core/src/main/java/io/grpc/AttributeMap.java
@@ -31,11 +31,11 @@ import javax.annotation.concurrent.Immutable;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1764")
 @Immutable
-public class AttributeMap<AT> {
+public final class AttributeMap<AT> {
 
   // TODO(zhangkun83): to be accessible from Attributes only.
   // Make this private after Attributes is deleted.
-  final Map<Key<AT, ?>, Object> data;
+  final Map<Key<? super AT, ?>, Object> data;
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   private static final AttributeMap EMPTY =
@@ -46,7 +46,7 @@ public class AttributeMap<AT> {
     return EMPTY;
   }
 
-  private AttributeMap(Map<Key<AT, ?>, Object> data) {
+  private AttributeMap(Map<Key<? super AT, ?>, Object> data) {
     assert data != null;
     this.data = Collections.unmodifiableMap(data);
   }
@@ -56,11 +56,11 @@ public class AttributeMap<AT> {
    */
   @SuppressWarnings("unchecked")
   @Nullable
-  public final <T> T get(Key<AT, T> key) {
+  public final <T> T get(Key<? super AT, T> key) {
     return (T) data.get(key);
   }
 
-  Set<Key<AT, ?>> keysForTest() {
+  Set<Key<? super AT, ?>> keysForTest() {
     return data.keySet();
   }
 
@@ -144,7 +144,7 @@ public class AttributeMap<AT> {
     if (data.size() != that.data.size()) {
       return false;
     }
-    for (Entry<Key<AT, ?>, Object> e : data.entrySet()) {
+    for (Entry<Key<? super AT, ?>, Object> e : data.entrySet()) {
       if (!that.data.containsKey(e.getKey())) {
         return false;
       }
@@ -167,7 +167,7 @@ public class AttributeMap<AT> {
   @Override
   public int hashCode() {
     int hashCode = 0;
-    for (Entry<Key<AT, ?>, Object> e : data.entrySet()) {
+    for (Entry<Key<? super AT, ?>, Object> e : data.entrySet()) {
       hashCode += Objects.hashCode(e.getKey(), e.getValue());
     }
     return hashCode;
@@ -178,26 +178,26 @@ public class AttributeMap<AT> {
    */
   public static final class Builder<AT> {
     private AttributeMap<AT> base;
-    private Map<Key<AT, ?>, Object> newdata;
+    private Map<Key<? super AT, ?>, Object> newdata;
 
     private Builder(AttributeMap<AT> base) {
       assert base != null;
       this.base = base;
     }
 
-    private Map<Key<AT, ?>, Object> data(int size) {
+    private Map<Key<? super AT, ?>, Object> data(int size) {
       if (newdata == null) {
-        newdata = new IdentityHashMap<Key<AT, ?>, Object>(size);
+        newdata = new IdentityHashMap<Key<? super AT, ?>, Object>(size);
       }
       return newdata;
     }
 
-    public <T> Builder<AT> set(Key<AT, T> key, T value) {
+    public <T> Builder<AT> set(Key<? super AT, T> key, T value) {
       data(1).put(key, value);
       return this;
     }
 
-    public <T> Builder<AT> setAll(AttributeMap<AT> other) {
+    public <T> Builder<AT> setAll(AttributeMap<? super AT> other) {
       data(other.data.size()).putAll(other.data);
       return this;
     }
@@ -207,7 +207,7 @@ public class AttributeMap<AT> {
      */
     public AttributeMap<AT> build() {
       if (newdata != null) {
-        for (Entry<Key<AT, ?>, Object> entry : base.data.entrySet()) {
+        for (Entry<Key<? super AT, ?>, Object> entry : base.data.entrySet()) {
           if (!newdata.containsKey(entry.getKey())) {
             newdata.put(entry.getKey(), entry.getValue());
           }

--- a/core/src/main/java/io/grpc/AttributeMap.java
+++ b/core/src/main/java/io/grpc/AttributeMap.java
@@ -37,10 +37,11 @@ public class AttributeMap<AT> {
   // Make this private after Attributes is deleted.
   final Map<Key<AT, ?>, Object> data;
 
-  @SuppressWarnings("rawtypes")
+  @SuppressWarnings({"rawtypes", "unchecked"})
   private static final AttributeMap EMPTY =
       new AttributeMap(Collections.<Key<?, ?>, Object>emptyMap());
 
+  @SuppressWarnings("unchecked")
   public static <AT> AttributeMap<AT> getEmptyInstance() {
     return EMPTY;
   }
@@ -60,14 +61,20 @@ public class AttributeMap<AT> {
   }
 
   Set<Key<AT, ?>> keysForTest() {
-    return Collections.unmodifiableSet(data.keySet());
+    return data.keySet();
   }
 
   /**
    * Create a new builder.
    */
-  public static <AT extends AttributeMap> Builder<AT> newBuilder() {
+  @SuppressWarnings("unchecked")
+  public static <AT> Builder<AT> newBuilder() {
     return new Builder<AT>((AttributeMap<AT>) EMPTY);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static <AT> AttributeMap<AT> fromAttributes(Attributes attrs) {
+    return new AttributeMap(attrs.data);
   }
 
   /**
@@ -125,6 +132,7 @@ public class AttributeMap<AT> {
    * @return true if the given object is a {@link AttributeMap} equal attributes.
    */
   @Override
+  @SuppressWarnings("rawtypes")
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -184,12 +192,12 @@ public class AttributeMap<AT> {
       return newdata;
     }
 
-    public <T> Builder set(Key<AT, T> key, T value) {
+    public <T> Builder<AT> set(Key<AT, T> key, T value) {
       data(1).put(key, value);
       return this;
     }
 
-    public <T> Builder setAll(AttributeMap<AT> other) {
+    public <T> Builder<AT> setAll(AttributeMap<AT> other) {
       data(other.data.size()).putAll(other.data);
       return this;
     }
@@ -204,7 +212,7 @@ public class AttributeMap<AT> {
             newdata.put(entry.getKey(), entry.getValue());
           }
         }
-        base = new AttributeMap(newdata);
+        base = new AttributeMap<AT>(newdata);
         newdata = null;
       }
       return base;

--- a/core/src/main/java/io/grpc/AttributeMap.java
+++ b/core/src/main/java/io/grpc/AttributeMap.java
@@ -35,7 +35,7 @@ public final class AttributeMap<AT> {
 
   // TODO(zhangkun83): to be accessible from Attributes only.
   // Make this private after Attributes is deleted.
-  final Map<Key<? super AT, ?>, Object> data;
+  final Map<Key<? extends AT, ?>, Object> data;
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   private static final AttributeMap EMPTY =
@@ -46,7 +46,7 @@ public final class AttributeMap<AT> {
     return EMPTY;
   }
 
-  private AttributeMap(Map<Key<? super AT, ?>, Object> data) {
+  private AttributeMap(Map<Key<? extends AT, ?>, Object> data) {
     assert data != null;
     this.data = Collections.unmodifiableMap(data);
   }
@@ -56,11 +56,11 @@ public final class AttributeMap<AT> {
    */
   @SuppressWarnings("unchecked")
   @Nullable
-  public final <T> T get(Key<? super AT, T> key) {
+  public final <T> T get(Key<? extends AT, T> key) {
     return (T) data.get(key);
   }
 
-  Set<Key<? super AT, ?>> keysForTest() {
+  Set<Key<? extends AT, ?>> keysForTest() {
     return data.keySet();
   }
 
@@ -144,7 +144,7 @@ public final class AttributeMap<AT> {
     if (data.size() != that.data.size()) {
       return false;
     }
-    for (Entry<Key<? super AT, ?>, Object> e : data.entrySet()) {
+    for (Entry<Key<? extends AT, ?>, Object> e : data.entrySet()) {
       if (!that.data.containsKey(e.getKey())) {
         return false;
       }
@@ -167,7 +167,7 @@ public final class AttributeMap<AT> {
   @Override
   public int hashCode() {
     int hashCode = 0;
-    for (Entry<Key<? super AT, ?>, Object> e : data.entrySet()) {
+    for (Entry<Key<? extends AT, ?>, Object> e : data.entrySet()) {
       hashCode += Objects.hashCode(e.getKey(), e.getValue());
     }
     return hashCode;
@@ -178,26 +178,26 @@ public final class AttributeMap<AT> {
    */
   public static final class Builder<AT> {
     private AttributeMap<AT> base;
-    private Map<Key<? super AT, ?>, Object> newdata;
+    private Map<Key<? extends AT, ?>, Object> newdata;
 
     private Builder(AttributeMap<AT> base) {
       assert base != null;
       this.base = base;
     }
 
-    private Map<Key<? super AT, ?>, Object> data(int size) {
+    private Map<Key<? extends AT, ?>, Object> data(int size) {
       if (newdata == null) {
-        newdata = new IdentityHashMap<Key<? super AT, ?>, Object>(size);
+        newdata = new IdentityHashMap<Key<? extends AT, ?>, Object>(size);
       }
       return newdata;
     }
 
-    public <T> Builder<AT> set(Key<? super AT, T> key, T value) {
+    public <T> Builder<AT> set(Key<? extends AT, T> key, T value) {
       data(1).put(key, value);
       return this;
     }
 
-    public <T> Builder<AT> setAll(AttributeMap<? super AT> other) {
+    public <T> Builder<AT> setAll(AttributeMap<? extends AT> other) {
       data(other.data.size()).putAll(other.data);
       return this;
     }
@@ -207,7 +207,7 @@ public final class AttributeMap<AT> {
      */
     public AttributeMap<AT> build() {
       if (newdata != null) {
-        for (Entry<Key<? super AT, ?>, Object> entry : base.data.entrySet()) {
+        for (Entry<Key<? extends AT, ?>, Object> entry : base.data.entrySet()) {
           if (!newdata.containsKey(entry.getKey())) {
             newdata.put(entry.getKey(), entry.getValue());
           }

--- a/core/src/main/java/io/grpc/AttributeMap.java
+++ b/core/src/main/java/io/grpc/AttributeMap.java
@@ -33,15 +33,21 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class AttributeMap<AT> {
 
-  private final Map<Key<AT, ?>, Object> data;
+  // TODO(zhangkun83): to be accessible from Attributes only.
+  // Make this private after Attributes is deleted.
+  final Map<Key<AT, ?>, Object> data;
 
   @SuppressWarnings("rawtypes")
-  public static final AttributeMap EMPTY =
+  private static final AttributeMap EMPTY =
       new AttributeMap(Collections.<Key<?, ?>, Object>emptyMap());
+
+  public static <AT> AttributeMap<AT> getEmptyInstance() {
+    return EMPTY;
+  }
 
   private AttributeMap(Map<Key<AT, ?>, Object> data) {
     assert data != null;
-    this.data = data;
+    this.data = Collections.unmodifiableMap(data);
   }
 
   /**
@@ -49,7 +55,7 @@ public class AttributeMap<AT> {
    */
   @SuppressWarnings("unchecked")
   @Nullable
-  public final <AT, T> T get(Key<AT, T> key) {
+  public final <T> T get(Key<AT, T> key) {
     return (T) data.get(key);
   }
 

--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -33,17 +33,16 @@ import javax.annotation.concurrent.Immutable;
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1764")
 @Immutable
-@Deprecated
 public final class Attributes {
 
-  private final Map<AttributeMap.Key<?, ?>, Object> data;
+  final Map<AttributeMap.Key<?, ?>, Object> data;
 
   public static final Attributes EMPTY =
       new Attributes(Collections.<AttributeMap.Key<?, ?>, Object>emptyMap());
 
   private Attributes(Map<AttributeMap.Key<?, ?>, Object> data) {
     assert data != null;
-    this.data = data;
+    this.data = Collections.unmodifiableMap(data);
   }
 
   /**
@@ -56,7 +55,7 @@ public final class Attributes {
   }
 
   Set<AttributeMap.Key<?, ?>> keysForTest() {
-    return Collections.unmodifiableSet(data.keySet());
+    return data.keySet();
   }
 
   /**
@@ -85,6 +84,7 @@ public final class Attributes {
     return new Builder(this);
   }
 
+  @SuppressWarnings("unchecked")
   public static Attributes fromAttributeMap(AttributeMap<?> am) {
     return new Attributes((Map<AttributeMap.Key<?, ?>, Object>) am.data);
   }
@@ -115,7 +115,6 @@ public final class Attributes {
      * @param <T> Key type
      * @return Key object
      */
-    @Deprecated
     public static <T> Key<T> create(String debugString) {
       return new Key<T>(debugString);
     }

--- a/core/src/main/java/io/grpc/Attributes.java
+++ b/core/src/main/java/io/grpc/Attributes.java
@@ -51,7 +51,7 @@ public final class Attributes {
    */
   @SuppressWarnings("unchecked")
   @Nullable
-  public <T> T get(Key<T> key) {
+  public <T> T get(AttributeMap.Key<?, T> key) {
     return (T) data.get(key);
   }
 
@@ -83,6 +83,10 @@ public final class Attributes {
    */
   public Builder toBuilder() {
     return new Builder(this);
+  }
+
+  public static Attributes fromAttributeMap(AttributeMap<?> am) {
+    return new Attributes((Map<AttributeMap.Key<?, ?>, Object>) am.data);
   }
 
   @Immutable
@@ -194,7 +198,7 @@ public final class Attributes {
       return newdata;
     }
 
-    public <T> Builder set(Key<T> key, T value) {
+    public <T> Builder set(AttributeMap.Key<?, T> key, T value) {
       data(1).put(key, value);
       return this;
     }

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -16,7 +16,9 @@
 
 package io.grpc;
 
+import io.grpc.AttributeMap;
 import io.grpc.Attributes.Key;
+import io.grpc.Grpc;
 import java.util.concurrent.Executor;
 
 /**
@@ -42,8 +44,8 @@ public interface CallCredentials {
    * overridden by the transport.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  public static final Key<SecurityLevel> ATTR_SECURITY_LEVEL =
-      Key.create("io.grpc.CallCredentials.securityLevel");
+  public static final AttributeMap.Key<Grpc.TransportAttr, SecurityLevel> ATTR_SECURITY_LEVEL =
+      AttributeMap.Key.define("io.grpc.CallCredentials.securityLevel");
 
   /**
    * The authority string used to authenticate the server. Usually it's the server's host name. It

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -269,6 +269,10 @@ public abstract class ClientCall<ReqT, RespT> {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2607")
   public Attributes getAttributes() {
-    return Attributes.EMPTY;
+    return Attributes.fromAttributeMap(getTransportAttributes());
+  }
+
+  public AttributeMap<Grpc.TransportAttr> getTransportAttributes() {
+    return AttributeMap.getEmptyInstance();
   }
 }

--- a/core/src/main/java/io/grpc/ClientCall.java
+++ b/core/src/main/java/io/grpc/ClientCall.java
@@ -268,11 +268,12 @@ public abstract class ClientCall<ReqT, RespT> {
    * @throws IllegalStateException (optional) if called before permitted
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/2607")
+  @Deprecated
   public Attributes getAttributes() {
-    return Attributes.fromAttributeMap(getTransportAttributes());
+    return Attributes.fromAttributeMap(getTransportAttrs());
   }
 
-  public AttributeMap<Grpc.TransportAttr> getTransportAttributes() {
+  public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
     return AttributeMap.getEmptyInstance();
   }
 }

--- a/core/src/main/java/io/grpc/Grpc.java
+++ b/core/src/main/java/io/grpc/Grpc.java
@@ -31,8 +31,8 @@ public final class Grpc {
    * Attribute key for the remote address of a transport.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
-  public static final Attributes.Key<SocketAddress> TRANSPORT_ATTR_REMOTE_ADDR =
-          Attributes.Key.create("remote-addr");
+  public static final AttributeMap.Key<TransportAttr, SocketAddress> TRANSPORT_ATTR_REMOTE_ADDR =
+          AttributeMap.Key.define("remote-addr");
 
   /**
    * Attribute key for SSL session of a transport.
@@ -40,4 +40,7 @@ public final class Grpc {
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
   public static final Attributes.Key<SSLSession> TRANSPORT_ATTR_SSL_SESSION =
           Attributes.Key.create("ssl-session");
+
+  @ExperimentalApi("TODO")
+  public static final class TransportAttr {}
 }

--- a/core/src/main/java/io/grpc/Grpc.java
+++ b/core/src/main/java/io/grpc/Grpc.java
@@ -38,9 +38,12 @@ public final class Grpc {
    * Attribute key for SSL session of a transport.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
-  public static final Attributes.Key<SSLSession> TRANSPORT_ATTR_SSL_SESSION =
-          Attributes.Key.create("ssl-session");
+  public static final AttributeMap.Key<TransportAttr, SSLSession> TRANSPORT_ATTR_SSL_SESSION =
+          AttributeMap.Key.define("ssl-session");
 
+  /**
+   * The marker type for transport attribute keys.
+   */
   @ExperimentalApi("TODO")
   public static final class TransportAttr {}
 }

--- a/core/src/main/java/io/grpc/PartialForwardingClientCall.java
+++ b/core/src/main/java/io/grpc/PartialForwardingClientCall.java
@@ -17,6 +17,8 @@
 package io.grpc;
 
 import com.google.common.base.MoreObjects;
+import io.grpc.AttributeMap;
+import io.grpc.Grpc;
 import javax.annotation.Nullable;
 
 /**
@@ -55,8 +57,14 @@ abstract class PartialForwardingClientCall<ReqT, RespT> extends ClientCall<ReqT,
   }
 
   @Override
+  @Deprecated
   public Attributes getAttributes() {
     return delegate().getAttributes();
+  }
+
+  @Override
+  public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
+    return delegate().getTransportAttrs();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -23,7 +23,9 @@ import static java.lang.Math.max;
 import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
+import io.grpc.AttributeMap;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Compressor;
@@ -127,13 +129,15 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
     }
     return new Runnable() {
       @Override
-      @SuppressWarnings("deprecation")
       public void run() {
         synchronized (InProcessTransport.this) {
-          Attributes serverTransportAttrs = Attributes.newBuilder()
-              .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, new InProcessSocketAddress(name))
-              .build();
-          serverStreamAttributes = serverTransportListener.transportReady(serverTransportAttrs);
+          AttributeMap<Grpc.TransportAttr> serverTransportAttrs =
+              AttributeMap.<Grpc.TransportAttr>newBuilder()
+                  .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, new InProcessSocketAddress(name))
+                  .build();
+          serverStreamAttributes =
+              Attributes.fromAttributeMap(
+                  serverTransportListener.transportReady(serverTransportAttrs));
           clientTransportListener.transportReady();
         }
       }
@@ -228,8 +232,8 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   }
 
   @Override
-  public Attributes getAttributes() {
-    return attributes;
+  public AttributeMap<Grpc.TransportAttr> getAttributes() {
+    return AttributeMap.fromAttributes(attributes);
   }
 
   @Override
@@ -659,8 +663,8 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       }
 
       @Override
-      public Attributes getAttributes() {
-        return Attributes.EMPTY;
+      public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
+        return AttributeMap.getEmptyInstance();
       }
 
       @Override

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -81,7 +81,7 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
         Attributes.Builder effectiveAttrsBuilder = Attributes.newBuilder()
             .set(CallCredentials.ATTR_AUTHORITY, authority)
             .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
-            .setAll(delegate.getAttributes());
+            .setAll(Attributes.fromAttributeMap(delegate.getAttributes()));
         if (callOptions.getAuthority() != null) {
           effectiveAttrsBuilder.set(CallCredentials.ATTR_AUTHORITY, callOptions.getAuthority());
         }

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -30,7 +30,7 @@ import static java.lang.Math.max;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import io.grpc.Attributes;
+import io.grpc.AttributeMap;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Codec;
@@ -41,6 +41,7 @@ import io.grpc.Context.CancellationListener;
 import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.InternalDecompressorRegistry;
+import io.grpc.Grpc;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -448,11 +449,11 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
   }
 
   @Override
-  public Attributes getAttributes() {
+  public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
     if (stream != null) {
-      return stream.getAttributes();
+      return stream.getTransportAttrs();
     }
-    return Attributes.EMPTY;
+    return AttributeMap.getEmptyInstance();
   }
 
   private void closeObserver(Listener<RespT> observer, Status status, Metadata trailers) {

--- a/core/src/main/java/io/grpc/internal/ClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ClientStream.java
@@ -16,9 +16,10 @@
 
 package io.grpc.internal;
 
-import io.grpc.Attributes;
+import io.grpc.AttributeMap;
 import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
+import io.grpc.Grpc;
 import io.grpc.Status;
 import javax.annotation.Nonnull;
 
@@ -94,7 +95,7 @@ public interface ClientStream extends Stream {
   void setDeadline(@Nonnull Deadline deadline);
 
   /**
-   * Attributes that the stream holds at the current moment.
+   * Transport attributes that the stream holds at the current moment.
    */
-  Attributes getAttributes();
+  AttributeMap<Grpc.TransportAttr> getTransportAttrs();
 }

--- a/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
@@ -16,7 +16,8 @@
 
 package io.grpc.internal;
 
-import io.grpc.Attributes;
+import io.grpc.AttributeMap;
+import io.grpc.Grpc;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -28,5 +29,5 @@ public interface ConnectionClientTransport extends ManagedClientTransport {
    * Returns a set of attributes, which may vary depending on the state of the transport. The keys
    * should define in what states they will be present.
    */
-  Attributes getAttributes();
+  AttributeMap<Grpc.TransportAttr> getAttributes();
 }

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -20,11 +20,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.grpc.Attributes;
+import io.grpc.AttributeMap;
 import io.grpc.Compressor;
 import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
+import io.grpc.Grpc;
 import io.grpc.Status;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -212,9 +213,9 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
-  public Attributes getAttributes() {
+  public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
     checkState(passThrough, "Called getAttributes before attributes are ready");
-    return realStream.getAttributes();
+    return realStream.getTransportAttrs();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStream.java
@@ -17,10 +17,11 @@
 package io.grpc.internal;
 
 import com.google.common.base.MoreObjects;
-import io.grpc.Attributes;
+import io.grpc.AttributeMap;
 import io.grpc.Compressor;
 import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
+import io.grpc.Grpc;
 import io.grpc.Status;
 import java.io.InputStream;
 
@@ -103,8 +104,8 @@ abstract class ForwardingClientStream implements ClientStream {
   }
 
   @Override
-  public Attributes getAttributes() {
-    return delegate().getAttributes();
+  public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
+    return delegate().getTransportAttrs();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingConnectionClientTransport.java
@@ -18,8 +18,9 @@ package io.grpc.internal;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.grpc.Attributes;
+import io.grpc.AttributeMap;
 import io.grpc.CallOptions;
+import io.grpc.Grpc;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -60,7 +61,7 @@ abstract class ForwardingConnectionClientTransport implements ConnectionClientTr
   }
 
   @Override
-  public Attributes getAttributes() {
+  public AttributeMap<Grpc.TransportAttr> getAttributes() {
     return delegate().getAttributes();
   }
 

--- a/core/src/main/java/io/grpc/internal/NoopClientStream.java
+++ b/core/src/main/java/io/grpc/internal/NoopClientStream.java
@@ -16,10 +16,11 @@
 
 package io.grpc.internal;
 
-import io.grpc.Attributes;
+import io.grpc.AttributeMap;
 import io.grpc.Compressor;
 import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
+import io.grpc.Grpc;
 import io.grpc.Status;
 import java.io.InputStream;
 import javax.annotation.Nonnull;
@@ -37,8 +38,8 @@ public class NoopClientStream implements ClientStream {
   public void start(ClientStreamListener listener) {}
 
   @Override
-  public Attributes getAttributes() {
-    return Attributes.EMPTY;
+  public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
+    return AttributeMap.getEmptyInstance();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -21,12 +21,13 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
-import io.grpc.Attributes;
+import io.grpc.AttributeMap;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Compressor;
 import io.grpc.Deadline;
 import io.grpc.DecompressorRegistry;
+import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -502,11 +503,11 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   }
 
   @Override
-  public final Attributes getAttributes() {
+  public final AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
     if (state.winningSubstream != null) {
-      return state.winningSubstream.stream.getAttributes();
+      return state.winningSubstream.stream.getTransportAttrs();
     }
-    return Attributes.EMPTY;
+    return AttributeMap.getEmptyInstance();
   }
 
   private static Random random = new Random();

--- a/core/src/main/java/io/grpc/internal/ServerTransportListener.java
+++ b/core/src/main/java/io/grpc/internal/ServerTransportListener.java
@@ -16,7 +16,8 @@
 
 package io.grpc.internal;
 
-import io.grpc.Attributes;
+import io.grpc.AttributeMap;
+import io.grpc.Grpc;
 import io.grpc.Metadata;
 
 /**
@@ -40,7 +41,7 @@ public interface ServerTransportListener {
    *
    * @return the effective transport attributes that is used as the basis of call attributes
    */
-  Attributes transportReady(Attributes attributes);
+  AttributeMap<Grpc.TransportAttr> transportReady(AttributeMap<Grpc.TransportAttr> attributes);
 
   /**
    * The transport completed shutting down. All resources have been released.

--- a/core/src/test/java/io/grpc/AttributeMapTest.java
+++ b/core/src/test/java/io/grpc/AttributeMapTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link AttributeMap}. */
+@RunWith(JUnit4.class)
+public class AttributeMapTest {
+  private static interface TransAttr {}
+  private static interface TlsTransAttr extends TransAttr {}
+
+  private static final AttributeMap.Key<TransAttr, String> ADDR_KEY =
+      AttributeMap.Key.define("addr");
+
+  private static final AttributeMap.Key<TransAttr, String> HOST_KEY =
+      AttributeMap.Key.define("host");
+
+  private static final AttributeMap.Key<TlsTransAttr, String> TLS_KEY =
+      AttributeMap.Key.define("tls");
+
+  @Test
+  public void buildAttributes() {
+    AttributeMap<TransAttr> attrs =
+        AttributeMap.<TransAttr>newBuilder().set(ADDR_KEY, "8.8.8.8").build();
+    assertSame("8.8.8.8", attrs.get(ADDR_KEY));
+    assertThat(attrs.keysForTest()).hasSize(1);
+  }
+
+  @Test
+  public void duplicates() {
+    AttributeMap<TransAttr> attrs = AttributeMap.<TransAttr>newBuilder()
+        .set(ADDR_KEY, "8.8.8.8")
+        .set(ADDR_KEY, "8.8.8.7")
+        .set(HOST_KEY, "google.com")
+        .build();
+    assertThat(attrs.get(ADDR_KEY)).isEqualTo("8.8.8.7");
+    assertThat(attrs.keysForTest()).hasSize(2);
+  }
+
+  @Test
+  public void keyHirarchy() {
+    // Because TlsTransAttr extends TransAttr, an AttributeMap<TransAttr> can contain
+    // both Key<TransAttr, ?> and Key<TlsTransAttr, ?>
+    AttributeMap<TransAttr> attrs = AttributeMap.<TransAttr>newBuilder()
+        .set(ADDR_KEY, "8.8.8.8")
+        .set(ADDR_KEY, "8.8.8.7")
+        .set(TLS_KEY, "gibberish")
+        .build();
+    assertThat(attrs.get(ADDR_KEY)).isEqualTo("8.8.8.7");
+    assertThat(attrs.get(TLS_KEY)).isEqualTo("gibberish");
+    assertThat(attrs.keysForTest()).hasSize(2);
+
+    AttributeMap<TlsTransAttr> tlsAttrs = AttributeMap.<TlsTransAttr>newBuilder()
+        .set(TLS_KEY, "gibberish again")
+        // .set(ADDR_KEY, "8.8.8.8")  // won't compile
+        .build();
+
+    attrs = attrs.toBuilder().setAll(tlsAttrs).build();
+    assertThat(attrs.get(TLS_KEY)).isEqualTo("gibberish again");
+
+    // tlsAttrs = tlsAttrs.toBuilder().setAll(attrs).build();  // won't compile
+  }
+
+  @Test
+  public void toBuilder() {
+    AttributeMap<TransAttr> attrs = AttributeMap.<TransAttr>newBuilder()
+        .set(ADDR_KEY, "8.8.8.8")
+        .build()
+        .toBuilder()
+        .set(ADDR_KEY, "8.8.8.7")
+        .set(HOST_KEY, "I'm not a duplicate")
+        .build();
+    assertThat(attrs.get(ADDR_KEY)).isEqualTo("8.8.8.7");
+    assertThat(attrs.keysForTest()).hasSize(2);
+  }
+
+  @Test
+  public void empty() {
+    assertThat(AttributeMap.getEmptyInstance().keysForTest()).isEmpty();
+  }
+
+  @Test
+  public void valueEquality() {
+    class EqualObject {
+      @Override public boolean equals(Object o) {
+        return o instanceof EqualObject;
+      }
+
+      @Override public int hashCode() {
+        return 42;
+      }
+    }
+
+    AttributeMap.Key<TransAttr, EqualObject> key = AttributeMap.Key.define("ints");
+    EqualObject v1 = new EqualObject();
+    EqualObject v2 = new EqualObject();
+
+    assertNotSame(v1, v2);
+    assertEquals(v1, v2);
+
+    AttributeMap<TransAttr> attr1 = AttributeMap.<TransAttr>newBuilder().set(key, v1).build();
+    AttributeMap<TransAttr> attr2 = AttributeMap.<TransAttr>newBuilder().set(key, v2).build();
+
+    assertEquals(attr1, attr2);
+    assertEquals(attr1.hashCode(), attr2.hashCode());
+  }
+}

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -33,9 +33,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.Codec;
 import io.grpc.Deadline;
+import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -504,8 +506,8 @@ public class AbstractClientStreamTest {
     public void setMaxOutboundMessageSize(int maxSize) {}
 
     @Override
-    public Attributes getAttributes() {
-      return Attributes.EMPTY;
+    public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
+      return AttributeMap.getEmptyInstance();
     }
   }
 

--- a/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentialsApplyingTest.java
@@ -28,10 +28,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallOptions;
+import io.grpc.Grpc;
 import io.grpc.IntegerMarshaller;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -121,7 +123,8 @@ public class CallCredentialsApplyingTest {
   @Test
   public void parameterPropagation_base() {
     Attributes transportAttrs = Attributes.newBuilder().set(ATTR_KEY, ATTR_VALUE).build();
-    when(mockTransport.getAttributes()).thenReturn(transportAttrs);
+    when(mockTransport.getAttributes()).thenReturn(
+        AttributeMap.<Grpc.TransportAttr>fromAttributes(transportAttrs));
 
     transport.newStream(method, origHeaders, callOptions);
 
@@ -141,7 +144,8 @@ public class CallCredentialsApplyingTest {
         .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
         .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
         .build();
-    when(mockTransport.getAttributes()).thenReturn(transportAttrs);
+    when(mockTransport.getAttributes()).thenReturn(
+        AttributeMap.<Grpc.TransportAttr>fromAttributes(transportAttrs));
 
     transport.newStream(method, origHeaders, callOptions);
 
@@ -161,7 +165,8 @@ public class CallCredentialsApplyingTest {
         .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
         .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
         .build();
-    when(mockTransport.getAttributes()).thenReturn(transportAttrs);
+    when(mockTransport.getAttributes()).thenReturn(
+        AttributeMap.<Grpc.TransportAttr>fromAttributes(transportAttrs));
     Executor anotherExecutor = mock(Executor.class);
 
     transport.newStream(method, origHeaders,
@@ -179,7 +184,8 @@ public class CallCredentialsApplyingTest {
   @Test
   public void credentialThrows() {
     final RuntimeException ex = new RuntimeException();
-    when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
+    when(mockTransport.getAttributes()).thenReturn(
+        AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
     doThrow(ex).when(mockCreds).applyRequestMetadata(
         same(method), any(Attributes.class), same(mockExecutor), any(MetadataApplier.class));
 
@@ -193,7 +199,8 @@ public class CallCredentialsApplyingTest {
 
   @Test
   public void applyMetadata_inline() {
-    when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
+    when(mockTransport.getAttributes()).thenReturn(
+        AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -217,7 +224,8 @@ public class CallCredentialsApplyingTest {
   @Test
   public void fail_inline() {
     final Status error = Status.FAILED_PRECONDITION.withDescription("channel not secure for creds");
-    when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
+    when(mockTransport.getAttributes()).thenReturn(
+        AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -237,7 +245,8 @@ public class CallCredentialsApplyingTest {
 
   @Test
   public void applyMetadata_delayed() {
-    when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
+    when(mockTransport.getAttributes()).thenReturn(
+        AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
 
     // Will call applyRequestMetadata(), which is no-op.
     DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
@@ -259,7 +268,8 @@ public class CallCredentialsApplyingTest {
 
   @Test
   public void fail_delayed() {
-    when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
+    when(mockTransport.getAttributes()).thenReturn(
+        AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
 
     // Will call applyRequestMetadata(), which is no-op.
     DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);

--- a/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ClientCallImplTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.Attributes.Key;
 import io.grpc.CallOptions;
@@ -49,6 +50,7 @@ import io.grpc.Context;
 import io.grpc.Deadline;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
+import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
@@ -935,15 +937,16 @@ public class ClientCallImplTest {
     ClientCallImpl<Void, Void> call = new ClientCallImpl<Void, Void>(
         method, MoreExecutors.directExecutor(), baseCallOptions, provider,
         deadlineCancellationExecutor, channelCallTracer, false /* retryEnabled */);
-    Attributes attrs =
-        Attributes.newBuilder().set(Key.<String>create("fake key"), "fake value").build();
-    when(stream.getAttributes()).thenReturn(attrs);
+    AttributeMap<Grpc.TransportAttr> attrs =
+        AttributeMap.<Grpc.TransportAttr>newBuilder().set(
+            AttributeMap.Key.<Grpc.TransportAttr, String>define("fake key"), "fake value").build();
+    when(stream.getTransportAttrs()).thenReturn(attrs);
 
-    assertNotEquals(attrs, call.getAttributes());
+    assertNotEquals(attrs, call.getTransportAttrs());
 
     call.start(callListener, new Metadata());
 
-    assertEquals(attrs, call.getAttributes());
+    assertEquals(attrs, call.getTransportAttrs());
   }
 
   private static void assertTimeoutBetween(long timeout, long from, long to) {

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -31,10 +31,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.Attributes.Key;
 import io.grpc.Codec;
 import io.grpc.DecompressorRegistry;
+import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.internal.testing.SingleMessageProducer;
@@ -180,22 +182,23 @@ public class DelayedStreamTest {
   }
 
   @Test
-  public void setStream_getAttributes() {
-    Attributes attributes =
-        Attributes.newBuilder().set(Key.<String>create("fakeKey"), "fakeValue").build();
-    when(realStream.getAttributes()).thenReturn(attributes);
+  public void setStream_getTransportAttrs() {
+    AttributeMap<Grpc.TransportAttr> attributes =
+        AttributeMap.<Grpc.TransportAttr>newBuilder().set(
+            AttributeMap.Key.<Grpc.TransportAttr, String>define("fakeKey"), "fakeValue").build();
+    when(realStream.getTransportAttrs()).thenReturn(attributes);
 
     stream.start(listener);
 
     try {
-      stream.getAttributes(); // expect to throw IllegalStateException, otherwise fail()
+      stream.getTransportAttrs(); // expect to throw IllegalStateException, otherwise fail()
       fail();
     } catch (IllegalStateException expected) {
       // ignore
     }
 
     stream.setStream(realStream);
-    assertEquals(attributes, stream.getAttributes());
+    assertEquals(attributes, stream.getTransportAttrs());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ForwardingClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingClientStreamTest.java
@@ -23,11 +23,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.Compressor;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.ForwardingTestUtil;
+import io.grpc.Grpc;
 import io.grpc.Status;
 import java.io.IOException;
 import java.io.InputStream;
@@ -148,9 +150,9 @@ public class ForwardingClientStreamTest {
   }
 
   @Test
-  public void getAttributesTest() {
-    Attributes attr = Attributes.newBuilder().build();
-    when(mock.getAttributes()).thenReturn(attr);
-    assertSame(attr, forward.getAttributes());
+  public void getTransportAttrsTest() {
+    AttributeMap<Grpc.TransportAttr> attr = AttributeMap.<Grpc.TransportAttr>newBuilder().build();
+    when(mock.getTransportAttrs()).thenReturn(attr);
+    assertSame(attr, forward.getTransportAttrs());
   }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -54,6 +54,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.BinaryLog;
 import io.grpc.CallCredentials;
@@ -68,6 +69,7 @@ import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.Grpc;
 import io.grpc.IntegerMarshaller;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalChannelz.ChannelStats;
@@ -1423,7 +1425,7 @@ public class ManagedChannelImplTest {
         .newClientTransport(same(socketAddress), eq(clientTransportOptions));
     MockClientTransportInfo transportInfo = transports.poll();
     final ConnectionClientTransport transport = transportInfo.transport;
-    when(transport.getAttributes()).thenReturn(Attributes.EMPTY);
+    when(transport.getAttributes()).thenReturn(AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
     doAnswer(new Answer<ClientStream>() {
         @Override
         public ClientStream answer(InvocationOnMock in) throws Throwable {

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.BinaryLog;
 import io.grpc.Channel;
@@ -408,7 +409,7 @@ public class ServerImplTest {
     createAndStartServer();
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-    transportListener.transportReady(Attributes.EMPTY);
+    transportListener.transportReady(AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
     Metadata requestHeaders = new Metadata();
     StatsTraceContext statsTraceCtx =
         StatsTraceContext.newServerContext(
@@ -435,7 +436,7 @@ public class ServerImplTest {
     createAndStartServer();
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-    transportListener.transportReady(Attributes.EMPTY);
+    transportListener.transportReady(AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
     Metadata requestHeaders = new Metadata();
     requestHeaders.put(MESSAGE_ENCODING_KEY, decompressorName);
     StatsTraceContext statsTraceCtx =
@@ -488,7 +489,7 @@ public class ServerImplTest {
             }).build());
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-    transportListener.transportReady(Attributes.EMPTY);
+    transportListener.transportReady(AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
 
     Metadata requestHeaders = new Metadata();
     requestHeaders.put(metadataKey, "value");
@@ -623,10 +624,11 @@ public class ServerImplTest {
     createAndStartServer();
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-    Attributes transportAttrs = transportListener.transportReady(Attributes.newBuilder()
+    AttributeMap<Grpc.TransportAttr> transportAttrs = transportListener.transportReady(
+        AttributeMap.<Grpc.TransportAttr>newBuilder()
         .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, remoteAddr).build());
 
-    assertEquals(expectedTransportAttrs, transportAttrs);
+    assertEquals(expectedTransportAttrs, Attributes.fromAttributeMap(transportAttrs));
 
     server.shutdown();
     server.awaitTermination();
@@ -695,7 +697,7 @@ public class ServerImplTest {
 
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-    transportListener.transportReady(Attributes.EMPTY);
+    transportListener.transportReady(AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
 
     Metadata requestHeaders = new Metadata();
     StatsTraceContext statsTraceCtx =
@@ -740,7 +742,7 @@ public class ServerImplTest {
             }).build());
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-    transportListener.transportReady(Attributes.EMPTY);
+    transportListener.transportReady(AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
 
     Metadata requestHeaders = new Metadata();
     StatsTraceContext statsTraceCtx =
@@ -902,7 +904,7 @@ public class ServerImplTest {
             }).build());
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-    transportListener.transportReady(Attributes.EMPTY);
+    transportListener.transportReady(AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
 
     Metadata requestHeaders = new Metadata();
     StatsTraceContext statsTraceCtx =
@@ -968,7 +970,7 @@ public class ServerImplTest {
             }).build());
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-    transportListener.transportReady(Attributes.EMPTY);
+    transportListener.transportReady(AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
     Metadata requestHeaders = new Metadata();
     StatsTraceContext statsTraceCtx =
         StatsTraceContext.newServerContext(streamTracerFactories, "Waitier/serve", requestHeaders);
@@ -1074,7 +1076,7 @@ public class ServerImplTest {
 
     ServerTransportListener transportListener
         = transportServer.registerNewServerTransport(new SimpleServerTransport());
-    transportListener.transportReady(Attributes.EMPTY);
+    transportListener.transportReady(AttributeMap.<Grpc.TransportAttr>getEmptyInstance());
     Metadata requestHeaders = new Metadata();
     StatsTraceContext statsTraceCtx =
         StatsTraceContext.newServerContext(streamTracerFactories, "Waiter/serve", requestHeaders);

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2ConnectionHandler.java
@@ -16,7 +16,9 @@
 
 package io.grpc.netty;
 
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
+import io.grpc.Grpc;
 import io.grpc.Internal;
 import io.grpc.InternalChannelz;
 import io.netty.channel.ChannelPromise;
@@ -45,18 +47,6 @@ public abstract class GrpcHttp2ConnectionHandler extends Http2ConnectionHandler 
   }
 
   /**
-   * Same as {@link #handleProtocolNegotiationCompleted(
-   *   Attributes, io.grpc.InternalChannelz.Security)}
-   * but with no {@link io.grpc.InternalChannelz.Security}.
-   *
-   * @deprecated Use the two argument method instead.
-   */
-  @Deprecated
-  public void handleProtocolNegotiationCompleted(Attributes attrs) {
-    handleProtocolNegotiationCompleted(attrs, /*securityInfo=*/ null);
-  }
-
-  /**
    * Triggered on protocol negotiation completion.
    *
    * <p>It must me called after negotiation is completed but before given handler is added to the
@@ -66,7 +56,7 @@ public abstract class GrpcHttp2ConnectionHandler extends Http2ConnectionHandler 
    * @param securityInfo informs channelz about the security protocol.
    */
   public void handleProtocolNegotiationCompleted(
-      Attributes attrs, InternalChannelz.Security securityInfo) {
+      AttributeMap<Grpc.TransportAttr> attrs, InternalChannelz.Security securityInfo) {
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -23,7 +23,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
+import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -106,7 +108,7 @@ class NettyClientHandler extends AbstractNettyHandler {
   private final String authority;
   private WriteQueue clientWriteQueue;
   private Http2Ping ping;
-  private Attributes attributes = Attributes.EMPTY;
+  private AttributeMap<Grpc.TransportAttr> attributes = AttributeMap.getEmptyInstance();
   private InternalChannelz.Security securityInfo;
 
   static NettyClientHandler newHandler(
@@ -283,10 +285,9 @@ class NettyClientHandler extends AbstractNettyHandler {
   }
 
   /**
-   * The protocol negotiation attributes, available once the protocol negotiation completes;
-   * otherwise returns {@code Attributes.EMPTY}.
+   * The protocol negotiation attributes, available once the protocol negotiation completes.
    */
-  Attributes getAttributes() {
+  AttributeMap<Grpc.TransportAttr> getAttributes() {
     return attributes;
   }
 
@@ -426,7 +427,7 @@ class NettyClientHandler extends AbstractNettyHandler {
 
   @Override
   public void handleProtocolNegotiationCompleted(
-      Attributes attributes, InternalChannelz.Security securityInfo) {
+      AttributeMap<Grpc.TransportAttr> attributes, InternalChannelz.Security securityInfo) {
     this.attributes = attributes;
     this.securityInfo = securityInfo;
     super.handleProtocolNegotiationCompleted(attributes, securityInfo);

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -23,7 +23,9 @@ import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 
 import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
+import io.grpc.Grpc;
 import io.grpc.InternalKnownTransport;
 import io.grpc.InternalMethodDescriptor;
 import io.grpc.Metadata;
@@ -102,7 +104,7 @@ class NettyClientStream extends AbstractClientStream {
   }
 
   @Override
-  public Attributes getAttributes() {
+  public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
     return state.handler.getAttributes();
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -24,8 +24,10 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.Grpc;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -316,7 +318,7 @@ class NettyClientTransport implements ConnectionClientTransport {
   }
 
   @Override
-  public Attributes getAttributes() {
+  public AttributeMap<Grpc.TransportAttr> getAttributes() {
     return handler.getAttributes();
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -30,7 +30,9 @@ import static io.netty.handler.codec.http2.DefaultHttp2LocalFlowController.DEFAU
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
+import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalMetadata;
 import io.grpc.InternalStatus;
@@ -112,7 +114,7 @@ class NettyServerHandler extends AbstractNettyHandler {
   private final TransportTracer transportTracer;
   private final KeepAliveEnforcer keepAliveEnforcer;
   /** Incomplete attributes produced by negotiator. */
-  private Attributes negotiationAttributes;
+  private AttributeMap<Grpc.TransportAttr> negotiationAttributes;
   private InternalChannelz.Security securityInfo;
   /** Completed attributes produced by transportReady. */
   private Attributes attributes;
@@ -507,7 +509,7 @@ class NettyServerHandler extends AbstractNettyHandler {
 
   @Override
   public void handleProtocolNegotiationCompleted(
-      Attributes attrs, InternalChannelz.Security securityInfo) {
+      AttributeMap<Grpc.TransportAttr> attrs, InternalChannelz.Security securityInfo) {
     negotiationAttributes = attrs;
     this.securityInfo = securityInfo;
   }
@@ -711,7 +713,8 @@ class NettyServerHandler extends AbstractNettyHandler {
         firstSettings = false;
         // Delay transportReady until we see the client's HTTP handshake, for coverage with
         // handshakeTimeout
-        attributes = transportListener.transportReady(negotiationAttributes);
+        attributes =
+            Attributes.fromAttributeMap(transportListener.transportReady(negotiationAttributes));
       }
     }
 

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -21,6 +21,7 @@ import static io.grpc.netty.GrpcSslContexts.NEXT_PROTOCOL_VERSIONS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.Grpc;
@@ -88,7 +89,7 @@ public final class ProtocolNegotiators {
           @Override
           public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
             // Set sttributes before replace to be sure we pass it before accepting any requests.
-            handler.handleProtocolNegotiationCompleted(Attributes.newBuilder()
+            handler.handleProtocolNegotiationCompleted(AttributeMap.<Grpc.TransportAttr>newBuilder()
                 .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
                 .build(),
                 /*securityInfo=*/ null);
@@ -154,7 +155,7 @@ public final class ProtocolNegotiators {
             // Successfully negotiated the protocol.
             // Notify about completion and pass down SSLSession in attributes.
             grpcHandler.handleProtocolNegotiationCompleted(
-                Attributes.newBuilder()
+                AttributeMap.<Grpc.TransportAttr>newBuilder()
                     .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, session)
                     .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
                     .build(),
@@ -648,7 +649,7 @@ public final class ProtocolNegotiators {
             // Successfully negotiated the protocol.
             // Notify about completion and pass down SSLSession in attributes.
             grpcHandler.handleProtocolNegotiationCompleted(
-                Attributes.newBuilder()
+                AttributeMap.<Grpc.TransportAttr>newBuilder()
                     .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, session)
                     .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
                     .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
@@ -696,8 +697,8 @@ public final class ProtocolNegotiators {
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
       writeBufferedAndRemove(ctx);
       handler.handleProtocolNegotiationCompleted(
-          Attributes
-              .newBuilder()
+          AttributeMap
+              .<Grpc.TransportAttr>newBuilder()
               .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
               .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
               .build(),
@@ -739,8 +740,8 @@ public final class ProtocolNegotiators {
       if (evt == HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_SUCCESSFUL) {
         writeBufferedAndRemove(ctx);
         grpcHandler.handleProtocolNegotiationCompleted(
-            Attributes
-                .newBuilder()
+            AttributeMap
+                .<Grpc.TransportAttr>newBuilder()
                 .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
                 .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
                 .build(),

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.fail;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Grpc;
@@ -507,7 +508,7 @@ public class NettyClientTransportTest {
     NettyClientTransport transport = newTransport(new NoopProtocolNegotiator());
     callMeMaybe(transport.start(clientTransportListener));
 
-    assertEquals(Attributes.EMPTY, transport.getAttributes());
+    assertEquals(AttributeMap.<Grpc.TransportAttr>getEmptyInstance(), transport.getAttributes());
   }
 
   @Test
@@ -534,8 +535,8 @@ public class NettyClientTransportTest {
     Rpc rpc = new Rpc(transport).halfClose();
     rpc.waitForResponse();
 
-    assertNotNull(rpc.stream.getAttributes().get(Grpc.TRANSPORT_ATTR_SSL_SESSION));
-    assertEquals(address, rpc.stream.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
+    assertNotNull(rpc.stream.getTransportAttrs().get(Grpc.TRANSPORT_ATTR_SSL_SESSION));
+    assertEquals(address, rpc.stream.getTransportAttrs().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
   }
 
   @Test
@@ -768,7 +769,8 @@ public class NettyClientTransportTest {
         }
 
         @Override
-        public Attributes transportReady(Attributes transportAttrs) {
+        public AttributeMap<Grpc.TransportAttr> transportReady(
+            AttributeMap<Grpc.TransportAttr> transportAttrs) {
           return transportAttrs;
         }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -21,7 +21,9 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.grpc.internal.ClientStreamListener.RpcProgress.PROCESSED;
 
 import com.google.common.io.BaseEncoding;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
+import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -58,7 +60,7 @@ class OkHttpClientStream extends AbstractClientStream {
   private volatile int id = ABSENT_ID;
   private final TransportState state;
   private final Sink sink = new Sink();
-  private final Attributes attributes;
+  private final AttributeMap<Grpc.TransportAttr> attributes;
 
   private boolean useGet = false;
 
@@ -127,7 +129,7 @@ class OkHttpClientStream extends AbstractClientStream {
   }
 
   @Override
-  public Attributes getAttributes() {
+  public AttributeMap<Grpc.TransportAttr> getTransportAttrs() {
     return attributes;
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -30,6 +30,7 @@ import com.squareup.okhttp.Credentials;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.internal.http.StatusLine;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
@@ -157,7 +158,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   private int connectionUnacknowledgedBytesRead;
   private ClientFrameHandler clientFrameHandler;
   // Caution: Not synchronized, new value can only be safely read after the connection is complete.
-  private Attributes attributes = Attributes.EMPTY;
+  private AttributeMap<Grpc.TransportAttr> attributes = AttributeMap.getEmptyInstance();
   /**
    * Indicates the transport is in go-away state: no new streams will be processed, but existing
    * streams may continue.
@@ -481,8 +482,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           source = Okio.buffer(Okio.source(sock));
           sink = Okio.buffer(Okio.sink(sock));
           // The return value of OkHttpTlsUpgrader.upgrade is an SSLSocket that has this info
-          attributes = Attributes
-              .newBuilder()
+          attributes = AttributeMap
+              .<Grpc.TransportAttr>newBuilder()
               .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, sock.getRemoteSocketAddress())
               .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, sslSession)
               .set(CallCredentials.ATTR_SECURITY_LEVEL,
@@ -701,7 +702,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   }
 
   @Override
-  public Attributes getAttributes() {
+  public AttributeMap<Grpc.TransportAttr> getAttributes() {
     return attributes;
   }
 

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -43,6 +43,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.AttributeMap;
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
@@ -98,8 +99,8 @@ import org.mockito.Matchers;
 public abstract class AbstractTransportTest {
   private static final int TIMEOUT_MS = 1000;
 
-  private static final Attributes.Key<String> ADDITIONAL_TRANSPORT_ATTR_KEY =
-      Attributes.Key.create("additional-attr");
+  private static final AttributeMap.Key<Grpc.TransportAttr, String> ADDITIONAL_TRANSPORT_ATTR_KEY =
+      AttributeMap.Key.define("additional-attr");
 
   protected final TransportTracer.Factory fakeClockTransportTracer = new TransportTracer.Factory(
       new TimeProvider() {
@@ -1715,7 +1716,8 @@ public abstract class AbstractTransportTest {
         = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     ServerStream serverStream = serverStreamCreation.stream;
 
-    SocketAddress serverAddress = clientStream.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
+    SocketAddress serverAddress =
+        clientStream.getTransportAttrs().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
     SocketAddress clientAddress = serverStream.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
 
     SocketStats clientSocketStats = client.getStats().get();
@@ -1862,8 +1864,9 @@ public abstract class AbstractTransportTest {
     }
 
     @Override
-    public Attributes transportReady(Attributes attributes) {
-      return Attributes.newBuilder()
+    public AttributeMap<Grpc.TransportAttr> transportReady(
+        AttributeMap<Grpc.TransportAttr> attributes) {
+      return AttributeMap.<Grpc.TransportAttr>newBuilder()
           .setAll(attributes)
           .set(ADDITIONAL_TRANSPORT_ATTR_KEY, "additional attribute value")
           .build();


### PR DESCRIPTION
Introduced `AttributeMap` to replace `Attributes`. The Key has an additional type parameter, which `AttributeMap` has too, so that each Key is bound with a certain `AttributeMap` passed on certain interfaces. This makes attribute keys more manageable and prevent misusing.

`ClientCall.getAttributes()` will be replaced by `ClientCall.getTransportAttrs()`. If there is a need for passing per-Call attributes, we can easily add `ClientCall.getCallAttrs()`.

`Attributes` is changed to be compatible with `AttributeMap.Key`. `Attributes` and `AttributeMap` can be converted back and forth. This allows non-breaking migration. Once `AttributeMap` is used and `Attributes` have been deprecated on all APIs, we can mark `Attributes` as deprecated.