### PR TITLE
Add ManagedChannelBuilder/ServerBuilder.maxInboundMetadataSize

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -158,6 +158,12 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
+  public T maxInboundMetadataSize(int max) {
+    delegate().maxInboundMetadataSize(max);
+    return thisT();
+  }
+
+  @Override
   public T keepAliveTime(long keepAliveTime, TimeUnit timeUnit) {
     delegate().keepAliveTime(keepAliveTime, timeUnit);
     return thisT();

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -306,6 +306,28 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
+   * Sets the maximum size of metadata allowed to be received. {@code Integer.MAX_VALUE} disables
+   * the enforcement. The default is implementation-dependent, but is not generally less than 8 KiB
+   * and may be unlimited.
+   *
+   * <p>This is cumulative size of the metadata. The precise calculation is
+   * implementation-dependent, but implementations are encouraged to follow the calculation used for
+   * <a href="http://httpwg.org/specs/rfc7540.html#rfc.section.6.5.2">
+   * HTTP/2's SETTINGS_MAX_HEADER_LIST_SIZE</a>. It sums the bytes from each entry's key and value,
+   * plus 32 bytes of overhead per entry.
+   *
+   * @param bytes the maximum size of received metadata
+   * @return this
+   * @throws IllegalArgumentException if bytes is non-positive
+   * @since 1.17.0
+   */
+  public T maxInboundMetadataSize(int bytes) {
+    Preconditions.checkArgument(bytes > 0, "maxInboundMetadataSize must be > 0");
+    // intentional noop rather than throw, this method is only advisory.
+    return thisT();
+  }
+
+  /**
    * Sets the time without read activity before sending a keepalive ping. An unreasonably small
    * value might be increased, and {@code Long.MAX_VALUE} nano seconds or an unreasonably large
    * value will disable keepalive. Defaults to infinite.

--- a/core/src/main/java/io/grpc/ServerBuilder.java
+++ b/core/src/main/java/io/grpc/ServerBuilder.java
@@ -226,6 +226,28 @@ public abstract class ServerBuilder<T extends ServerBuilder<T>> {
   }
 
   /**
+   * Sets the maximum size of metadata allowed to be received. {@code Integer.MAX_VALUE} disables
+   * the enforcement. The default is implementation-dependent, but is not generally less than 8 KiB
+   * and may be unlimited.
+   *
+   * <p>This is cumulative size of the metadata. The precise calculation is
+   * implementation-dependent, but implementations are encouraged to follow the calculation used for
+   * <a href="http://httpwg.org/specs/rfc7540.html#rfc.section.6.5.2">
+   * HTTP/2's SETTINGS_MAX_HEADER_LIST_SIZE</a>. It sums the bytes from each entry's key and value,
+   * plus 32 bytes of overhead per entry.
+   *
+   * @param bytes the maximum size of received metadata
+   * @return this
+   * @throws IllegalArgumentException if bytes is non-positive
+   * @since 1.17.0
+   */
+  public T maxInboundMetadataSize(int bytes) {
+    Preconditions.checkArgument(bytes > 0, "maxInboundMetadataSize must be > 0");
+    // intentional noop rather than throw, this method is only advisory.
+    return thisT();
+  }
+
+  /**
    * Sets the BinaryLog object that this server should log to. The server does not take
    * ownership of the object, and users are responsible for calling {@link BinaryLog#close()}.
    *

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -160,6 +160,7 @@ public final class InProcessChannelBuilder extends
    * @throws IllegalArgumentException if bytes is non-positive
    * @since 1.17.0
    */
+  @Override
   public InProcessChannelBuilder maxInboundMetadataSize(int bytes) {
     checkArgument(bytes > 0, "maxInboundMetadataSize must be > 0");
     this.maxInboundMetadataSize = bytes;

--- a/core/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -44,6 +44,7 @@ final class InProcessServer implements InternalServer {
   }
 
   private final String name;
+  private final int maxInboundMetadataSize;
   private final List<ServerStreamTracer.Factory> streamTracerFactories;
   private ServerListener listener;
   private boolean shutdown;
@@ -56,10 +57,11 @@ final class InProcessServer implements InternalServer {
   private ScheduledExecutorService scheduler;
 
   InProcessServer(
-      String name, ObjectPool<ScheduledExecutorService> schedulerPool,
+      InProcessServerBuilder builder,
       List<ServerStreamTracer.Factory> streamTracerFactories) {
-    this.name = name;
-    this.schedulerPool = schedulerPool;
+    this.name = builder.name;
+    this.schedulerPool = builder.schedulerPool;
+    this.maxInboundMetadataSize = builder.maxInboundMetadataSize;
     this.streamTracerFactories =
         Collections.unmodifiableList(checkNotNull(streamTracerFactories, "streamTracerFactories"));
   }
@@ -110,6 +112,10 @@ final class InProcessServer implements InternalServer {
 
   ObjectPool<ScheduledExecutorService> getScheduledExecutorServicePool() {
     return schedulerPool;
+  }
+
+  int getMaxInboundMetadataSize() {
+    return maxInboundMetadataSize;
   }
 
   List<ServerStreamTracer.Factory> getStreamTracerFactories() {

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -137,6 +137,7 @@ public final class InProcessServerBuilder
    * @throws IllegalArgumentException if bytes is non-positive
    * @since 1.17.0
    */
+  @Override
   public InProcessServerBuilder maxInboundMetadataSize(int bytes) {
     Preconditions.checkArgument(bytes > 0, "maxInboundMetadataSize must be > 0");
     this.maxInboundMetadataSize = bytes;

--- a/core/src/test/java/io/grpc/ForwardingChannelBuilderTest.java
+++ b/core/src/test/java/io/grpc/ForwardingChannelBuilderTest.java
@@ -50,7 +50,17 @@ public class ForwardingChannelBuilderTest {
         ManagedChannelBuilder.class,
         mockDelegate,
         testChannelBuilder,
-        Collections.<Method>emptyList());
+        Collections.<Method>emptyList(),
+        new ForwardingTestUtil.ArgumentProvider() {
+          @Override
+          public Object get(Method method, int argPos, Class<?> clazz) {
+            if (method.getName().equals("maxInboundMetadataSize")) {
+              assertThat(argPos).isEqualTo(0);
+              return 1; // an arbitrary positive number
+            }
+            return null;
+          }
+        });
   }
 
   @Test
@@ -66,6 +76,9 @@ public class ForwardingChannelBuilderTest {
       Object[] args = new Object[argTypes.length];
       for (int i = 0; i < argTypes.length; i++) {
         args[i] = Defaults.defaultValue(argTypes[i]);
+      }
+      if (method.getName().equals("maxInboundMetadataSize")) {
+        args[0] = 1; // an arbitrary positive number
       }
 
       Object returnedValue = method.invoke(testChannelBuilder, args);

--- a/core/src/test/java/io/grpc/ForwardingTestUtil.java
+++ b/core/src/test/java/io/grpc/ForwardingTestUtil.java
@@ -53,7 +53,7 @@ public final class ForwardingTestUtil {
         delegateClass, mockDelegate, forwarder, skippedMethods,
         new ArgumentProvider() {
           @Override
-          public Object get(Class<?> clazz) {
+          public Object get(Method method, int argPos, Class<?> clazz) {
             return null;
           }
         });
@@ -89,7 +89,7 @@ public final class ForwardingTestUtil {
       Class<?>[] argTypes = method.getParameterTypes();
       Object[] args = new Object[argTypes.length];
       for (int i = 0; i < argTypes.length; i++) {
-        if ((args[i] = argProvider.get(argTypes[i])) == null) {
+        if ((args[i] = argProvider.get(method, i, argTypes[i])) == null) {
           args[i] = Defaults.defaultValue(argTypes[i]);
         }
       }
@@ -129,6 +129,6 @@ public final class ForwardingTestUtil {
      * @return a value to be passed as an argument.  If {@code null}, {@link Default#defaultValue}
      *         will be used.
      */
-    @Nullable Object get(Class<?> clazz);
+    @Nullable Object get(Method method, int argPos, Class<?> clazz);
   }
 }

--- a/core/src/test/java/io/grpc/inprocess/InProcessServerTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessServerTest.java
@@ -19,12 +19,10 @@ package io.grpc.inprocess;
 import com.google.common.truth.Truth;
 import io.grpc.ServerStreamTracer;
 import io.grpc.internal.FakeClock;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ObjectPool;
 import io.grpc.internal.ServerListener;
 import io.grpc.internal.ServerTransport;
 import io.grpc.internal.ServerTransportListener;
-import io.grpc.internal.SharedResourcePool;
 import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Test;
@@ -33,12 +31,12 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class InProcessServerTest {
+  private InProcessServerBuilder builder = InProcessServerBuilder.forName("name");
 
   @Test
   public void getPort_notStarted() throws Exception {
     InProcessServer s =
-        new InProcessServer("name", SharedResourcePool.forResource(GrpcUtil.TIMER_SERVICE),
-            Collections.<ServerStreamTracer.Factory>emptyList());
+        new InProcessServer(builder, Collections.<ServerStreamTracer.Factory>emptyList());
 
     Truth.assertThat(s.getPort()).isEqualTo(-1);
   }
@@ -63,8 +61,9 @@ public class InProcessServerTest {
     }
 
     RefCountingObjectPool pool = new RefCountingObjectPool();
+    builder.schedulerPool = pool;
     InProcessServer s =
-        new InProcessServer("name", pool, Collections.<ServerStreamTracer.Factory>emptyList());
+        new InProcessServer(builder, Collections.<ServerStreamTracer.Factory>emptyList());
     Truth.assertThat(pool.count).isEqualTo(0);
     s.start(new ServerListener() {
       @Override public ServerTransportListener transportCreated(ServerTransport transport) {

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -20,7 +20,6 @@ import io.grpc.ServerStreamTracer;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.SharedResourcePool;
 import io.grpc.internal.testing.AbstractTransportTest;
 import java.util.List;
 import org.junit.Ignore;
@@ -37,9 +36,10 @@ public class InProcessTransportTest extends AbstractTransportTest {
 
   @Override
   protected InternalServer newServer(List<ServerStreamTracer.Factory> streamTracerFactories) {
-    return new InProcessServer(
-        TRANSPORT_NAME,
-        SharedResourcePool.forResource(GrpcUtil.TIMER_SERVICE), streamTracerFactories);
+    InProcessServerBuilder builder = InProcessServerBuilder
+        .forName(TRANSPORT_NAME)
+        .maxInboundMetadataSize(GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE);
+    return new InProcessServer(builder, streamTracerFactories);
   }
 
   @Override
@@ -55,7 +55,8 @@ public class InProcessTransportTest extends AbstractTransportTest {
 
   @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
-    return new InProcessTransport(TRANSPORT_NAME, testAuthority(server), USER_AGENT);
+    return new InProcessTransport(
+        TRANSPORT_NAME, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, testAuthority(server), USER_AGENT);
   }
 
   @Override
@@ -71,22 +72,4 @@ public class InProcessTransportTest extends AbstractTransportTest {
   public void socketStats() throws Exception {
     // test does not apply to in-process
   }
-
-  // not yet implemented
-  @Test
-  @Ignore
-  @Override
-  public void serverChecksInboundMetadataSize() {}
-
-  // not yet implemented
-  @Test
-  @Ignore
-  @Override
-  public void clientChecksInboundMetadataSize_header() {}
-
-  // not yet implemented
-  @Test
-  @Ignore
-  @Override
-  public void clientChecksInboundMetadataSize_trailer() {}
 }

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -71,4 +71,22 @@ public class InProcessTransportTest extends AbstractTransportTest {
   public void socketStats() throws Exception {
     // test does not apply to in-process
   }
+
+  // not yet implemented
+  @Test
+  @Ignore
+  @Override
+  public void serverChecksInboundMetadataSize() {}
+
+  // not yet implemented
+  @Test
+  @Ignore
+  @Override
+  public void clientChecksInboundMetadataSize_header() {}
+
+  // not yet implemented
+  @Test
+  @Ignore
+  @Override
+  public void clientChecksInboundMetadataSize_trailer() {}
 }

--- a/core/src/test/java/io/grpc/util/ForwardingLoadBalancerHelperTest.java
+++ b/core/src/test/java/io/grpc/util/ForwardingLoadBalancerHelperTest.java
@@ -52,7 +52,7 @@ public class ForwardingLoadBalancerHelperTest {
         Collections.<Method>emptyList(),
         new ForwardingTestUtil.ArgumentProvider() {
           @Override
-          public Object get(Class<?> clazz) {
+          public Object get(Method method, int argPos, Class<?> clazz) {
             if (clazz.equals(EquivalentAddressGroup.class)) {
               return new EquivalentAddressGroup(Arrays.asList(mockAddr));
             } else if (clazz.equals(List.class)) {

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -217,10 +217,29 @@ public final class NettyChannelBuilder
    * headers with some overhead, as defined for
    * <a href="http://httpwg.org/specs/rfc7540.html#rfc.section.6.5.2">
    * HTTP/2's SETTINGS_MAX_HEADER_LIST_SIZE</a>. The default is 8 KiB.
+   *
+   * @deprecated Use {@link #maxInboundMetadataSize} instead
    */
+  @Deprecated
   public NettyChannelBuilder maxHeaderListSize(int maxHeaderListSize) {
-    checkArgument(maxHeaderListSize > 0, "maxHeaderListSize must be > 0");
-    this.maxHeaderListSize = maxHeaderListSize;
+    return maxInboundMetadataSize(maxHeaderListSize);
+  }
+
+  /**
+   * Sets the maximum size of metadata allowed to be received. This is cumulative size of the
+   * entries with some overhead, as defined for
+   * <a href="http://httpwg.org/specs/rfc7540.html#rfc.section.6.5.2">
+   * HTTP/2's SETTINGS_MAX_HEADER_LIST_SIZE</a>. The default is 8 KiB.
+   *
+   * @param bytes the maximum size of received metadata
+   * @return this
+   * @throws IllegalArgumentException if bytes is non-positive
+   * @since 1.17.0
+   */
+  @Override
+  public NettyChannelBuilder maxInboundMetadataSize(int bytes) {
+    checkArgument(bytes > 0, "maxInboundMetadataSize must be > 0");
+    this.maxHeaderListSize = bytes;
     return this;
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -281,10 +281,29 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
    * headers with some overhead, as defined for
    * <a href="http://httpwg.org/specs/rfc7540.html#rfc.section.6.5.2">
    * HTTP/2's SETTINGS_MAX_HEADER_LIST_SIZE</a>. The default is 8 KiB.
+   *
+   * @deprecated Use {@link #maxInboundMetadataSize} instead
    */
+  @Deprecated
   public NettyServerBuilder maxHeaderListSize(int maxHeaderListSize) {
-    checkArgument(maxHeaderListSize > 0, "maxHeaderListSize must be > 0");
-    this.maxHeaderListSize = maxHeaderListSize;
+    return maxInboundMetadataSize(maxHeaderListSize);
+  }
+
+  /**
+   * Sets the maximum size of metadata allowed to be received. This is cumulative size of the
+   * entries with some overhead, as defined for
+   * <a href="http://httpwg.org/specs/rfc7540.html#rfc.section.6.5.2">
+   * HTTP/2's SETTINGS_MAX_HEADER_LIST_SIZE</a>. The default is 8 KiB.
+   *
+   * @param bytes the maximum size of received metadata
+   * @return this
+   * @throws IllegalArgumentException if bytes is non-positive
+   * @since 1.17.0
+   */
+  @Override
+  public NettyServerBuilder maxInboundMetadataSize(int bytes) {
+    checkArgument(bytes > 0, "maxInboundMetadataSize must be > 0");
+    this.maxHeaderListSize = bytes;
     return this;
   }
 

--- a/netty/src/test/java/io/grpc/netty/NettyServerBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerBuilderTest.java
@@ -78,11 +78,11 @@ public class NettyServerBuilderTest {
   }
 
   @Test
-  public void failIfMaxHeaderListSizeNegative() {
+  public void failIfMaxInboundMetadataSizeNonPositive() {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("maxHeaderListSize must be > 0");
+    thrown.expectMessage("maxInboundMetadataSize must be > 0");
 
-    builder.maxHeaderListSize(0);
+    builder.maxInboundMetadataSize(0);
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -97,4 +97,11 @@ public class NettyTransportTest extends AbstractTransportTest {
         new ClientTransportFactory.ClientTransportOptions()
           .setAuthority(testAuthority(server)));
   }
+
+  @org.junit.Ignore
+  @org.junit.Test
+  @Override
+  public void clientChecksInboundMetadataSize_trailer() throws Exception {
+    // Server-side is flaky due to https://github.com/netty/netty/pull/8332
+  }
 }

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -419,6 +419,7 @@ public class OkHttpChannelBuilder extends
    * @throws IllegalArgumentException if bytes is non-positive
    * @since 1.17.0
    */
+  @Override
   public OkHttpChannelBuilder maxInboundMetadataSize(int bytes) {
     Preconditions.checkArgument(bytes > 0, "maxInboundMetadataSize must be > 0");
     this.maxInboundMetadataSize = bytes;

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -135,6 +135,7 @@ public class OkHttpClientTransportTest {
   private static final String NO_USER = null;
   private static final String NO_PW = null;
   private static final int DEFAULT_START_STREAM_ID = 3;
+  private static final int DEFAULT_MAX_INBOUND_METADATA_SIZE = Integer.MAX_VALUE;
 
   @Rule public final Timeout globalTimeout = Timeout.seconds(10);
 
@@ -245,6 +246,7 @@ public class OkHttpClientTransportTest {
         INITIAL_WINDOW_SIZE,
         NO_PROXY,
         tooManyPingsRunnable,
+        DEFAULT_MAX_INBOUND_METADATA_SIZE,
         transportTracer);
     String s = clientTransport.toString();
     assertTrue("Unexpected: " + s, s.contains("OkHttpClientTransport"));
@@ -1518,6 +1520,7 @@ public class OkHttpClientTransportTest {
         INITIAL_WINDOW_SIZE,
         NO_PROXY,
         tooManyPingsRunnable,
+        DEFAULT_MAX_INBOUND_METADATA_SIZE,
         transportTracer);
 
     String host = clientTransport.getOverridenHost();
@@ -1541,6 +1544,7 @@ public class OkHttpClientTransportTest {
         INITIAL_WINDOW_SIZE,
         NO_PROXY,
         tooManyPingsRunnable,
+        DEFAULT_MAX_INBOUND_METADATA_SIZE,
         new TransportTracer());
 
     ManagedClientTransport.Listener listener = mock(ManagedClientTransport.Listener.class);
@@ -1573,6 +1577,7 @@ public class OkHttpClientTransportTest {
         new ProxyParameters(
             (InetSocketAddress) serverSocket.getLocalSocketAddress(), NO_USER, NO_PW),
         tooManyPingsRunnable,
+        DEFAULT_MAX_INBOUND_METADATA_SIZE,
         transportTracer);
     clientTransport.start(transportListener);
 
@@ -1624,6 +1629,7 @@ public class OkHttpClientTransportTest {
         new ProxyParameters(
             (InetSocketAddress) serverSocket.getLocalSocketAddress(), NO_USER, NO_PW),
         tooManyPingsRunnable,
+        DEFAULT_MAX_INBOUND_METADATA_SIZE,
         transportTracer);
     clientTransport.start(transportListener);
 
@@ -1674,6 +1680,7 @@ public class OkHttpClientTransportTest {
         new ProxyParameters(
             (InetSocketAddress) serverSocket.getLocalSocketAddress(), NO_USER, NO_PW),
         tooManyPingsRunnable,
+        DEFAULT_MAX_INBOUND_METADATA_SIZE,
         transportTracer);
     clientTransport.start(transportListener);
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -98,4 +98,16 @@ public class OkHttpTransportTest extends AbstractTransportTest {
   protected boolean haveTransportTracer() {
     return true;
   }
+
+  // not yet implemented
+  @Override
+  @org.junit.Test
+  @org.junit.Ignore
+  public void clientChecksInboundMetadataSize_header() {}
+
+  // not yet implemented
+  @Override
+  @org.junit.Test
+  @org.junit.Ignore
+  public void clientChecksInboundMetadataSize_trailer() {}
 }

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -20,6 +20,7 @@ import io.grpc.ServerStreamTracer;
 import io.grpc.internal.AccessProtectedHack;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.FakeClock;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.testing.AbstractTransportTest;
@@ -41,6 +42,7 @@ public class OkHttpTransportTest extends AbstractTransportTest {
           .forAddress("localhost", 0)
           .usePlaintext()
           .setTransportTracerFactory(fakeClockTransportTracer)
+          .maxInboundMetadataSize(GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE)
           .buildTransportFactory();
 
   @After
@@ -99,15 +101,10 @@ public class OkHttpTransportTest extends AbstractTransportTest {
     return true;
   }
 
-  // not yet implemented
   @Override
   @org.junit.Test
   @org.junit.Ignore
-  public void clientChecksInboundMetadataSize_header() {}
-
-  // not yet implemented
-  @Override
-  @org.junit.Test
-  @org.junit.Ignore
-  public void clientChecksInboundMetadataSize_trailer() {}
+  public void clientChecksInboundMetadataSize_trailer() {
+    // Server-side is flaky due to https://github.com/netty/netty/pull/8332
+  }
 }


### PR DESCRIPTION
Support was added to InProcess and OkHttp transports. As mentioned
in #4567 OkHttp will not actually limit the memory used.

This API was a minor rename to the pre-existing Netty API,
so has already undergone API review and thus is not ExperimentalApi.

In adding transport tests I discovered Netty's behavior for trailers is
broken causing the stream to be orphaned and the client to hang. I have
verified this is fixed by https://github.com/netty/netty/pull/8332 .

The commits will remain separate when merging. They may help during
review, but probably aren't too necessary.

Fixes #4050 and #4567.

CC @garrettjonesgoogle 