### PR TITLE
core: add CallCredentials2 and deprecate CallCredentials' old interface

### DIFF
--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -40,11 +40,15 @@ public interface CallCredentials {
    * The security level of the transport. It is guaranteed to be present in the {@code attrs} passed
    * to {@link #applyRequestMetadata}. It is by default {@link SecurityLevel#NONE} but can be
    * overridden by the transport.
+   *
+   * @deprecated transport implementations should use {@code
+   * io.grpc.internal.GrpcAttributes.ATTR_SECURITY_LEVEL} instead.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   @Grpc.TransportAttr
+  @Deprecated
   public static final Key<SecurityLevel> ATTR_SECURITY_LEVEL =
-      Key.create("io.grpc.CallCredentials.securityLevel");
+      Key.create("io.grpc.internal.GrpcAttributes.securityLevel");
 
   /**
    * The authority string used to authenticate the server. Usually it's the server's host name. It
@@ -54,6 +58,7 @@ public interface CallCredentials {
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   @Grpc.TransportAttr
+  @Deprecated
   public static final Key<String> ATTR_AUTHORITY = Key.create("io.grpc.CallCredentials.authority");
 
   /**
@@ -75,6 +80,7 @@ public interface CallCredentials {
    *        method returns.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
+  @Deprecated
   void applyRequestMetadata(
       MethodDescriptor<?, ?> method, Attributes attrs,
       Executor appExecutor, MetadataApplier applier);
@@ -92,16 +98,16 @@ public interface CallCredentials {
    * <p>Exactly one of its methods must be called to make the RPC proceed.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  public interface MetadataApplier {
+  public abstract class MetadataApplier {
     /**
      * Called when headers are successfully generated. They will be merged into the original
      * headers.
      */
-    void apply(Metadata headers);
+    public abstract void apply(Metadata headers);
 
     /**
      * Called when there has been an error when preparing the headers. This will fail the RPC.
      */
-    void fail(Status status);
+    public abstract void fail(Status status);
   }
 }

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -112,4 +112,31 @@ public interface CallCredentials {
      */
     public abstract void fail(Status status);
   }
+
+  /**
+   * The request-related information passed to {@code CallCredentials2.applyRequestMetadata()}.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
+  public abstract static class RequestInfo {
+    /**
+     * The method descriptor of this RPC.
+     */
+    public abstract MethodDescriptor<?, ?> getMethodDescriptor();
+
+    /**
+     * The security level on the transport.
+     */
+    public abstract SecurityLevel getSecurityLevel();
+
+    /**
+     * Returns the authority string used to authenticate the server for this call.
+     */
+    public abstract String getAuthority();
+
+    /**
+     * Returns the transport attributes.
+     */
+    @Grpc.TransportAttr
+    public abstract Attributes getTransportAttrs();
+  }
 }

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -100,7 +100,7 @@ public interface CallCredentials {
    * <p>Exactly one of its methods must be called to make the RPC proceed.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  public abstract class MetadataApplier {
+  public abstract static class MetadataApplier {
     /**
      * Called when headers are successfully generated. They will be merged into the original
      * headers.

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -78,6 +78,8 @@ public interface CallCredentials {
    *        needs to perform blocking operations.
    * @param applier The outlet of the produced headers. It can be called either before or after this
    *        method returns.
+   *
+   * @deprecated implement {@link CallCredentials2} instead.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
   @Deprecated

--- a/core/src/main/java/io/grpc/CallCredentials2.java
+++ b/core/src/main/java/io/grpc/CallCredentials2.java
@@ -24,9 +24,11 @@ import java.util.concurrent.Executor;
 /**
  * The new interface for {@link CallCredentials}.
  *
- * <p>THIS CLASS IS MEANT TO BE REFERENCED BY IMPLEMENTIONS ONLY.  All users should reference {@link
- * CallCredentials}.
+ * <p>THIS CLASS NAME IS TEMPORARY and is part of a migration. This class will BE DELETED as it
+ * replaces {@link CallCredentials} in short-term.  THIS CLASS SHOULD ONLY BE REFERENCED BY
+ * IMPLEMENTIONS.  All consumers should still reference {@link CallCredentials}.
  */
+@Internal
 public abstract class CallCredentials2 implements CallCredentials {
   /**
    * Pass the credential data to the given {@link CallCredentials.MetadataApplier}, which will

--- a/core/src/main/java/io/grpc/CallCredentials2.java
+++ b/core/src/main/java/io/grpc/CallCredentials2.java
@@ -81,31 +81,4 @@ public abstract class CallCredentials2 implements CallCredentials {
       };
     applyRequestMetadata(requestInfo, appExecutor, applier);
   }
-
-  /**
-   * The request-related information passed to {@link #applyRequestMetadata}.
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  public abstract static class RequestInfo {
-    /**
-     * The method descriptor of this RPC.
-     */
-    public abstract MethodDescriptor<?, ?> getMethodDescriptor();
-
-    /**
-     * The security level on the transport.
-     */
-    public abstract SecurityLevel getSecurityLevel();
-
-    /**
-     * Returns the authority string used to authenticate the server for this call.
-     */
-    public abstract String getAuthority();
-
-    /**
-     * Returns the transport attributes.
-     */
-    @Grpc.TransportAttr
-    public abstract Attributes getTransportAttrs();
-  }
 }

--- a/core/src/main/java/io/grpc/CallCredentials2.java
+++ b/core/src/main/java/io/grpc/CallCredentials2.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.Executor;
+
+/**
+ * The new interface for {@link CallCredentials}.
+ *
+ * <p>THIS CLASS IS MEANT TO BE REFERENCED BY IMPLEMENTIONS ONLY.  All users should reference {@link
+ * Credentials}.
+ */
+public abstract class CallCredentials2 implements CallCredentials {
+  /**
+   * Pass the credential data to the given {@link CallCredentials.MetadataApplier}, which will
+   * propagate it to the request metadata.
+   *
+   * <p>It is called for each individual RPC, within the {@link Context} of the call, before the
+   * stream is about to be created on a transport. Implementations should not block in this
+   * method. If metadata is not immediately available, e.g., needs to be fetched from network, the
+   * implementation may give the {@code applier} to an asynchronous task which will eventually call
+   * the {@code applier}. The RPC proceeds only after the {@code applier} is called.
+   *
+   * @param requestInfo request-related information
+   * @param appExecutor The application thread-pool. It is provided to the implementation in case it
+   *        needs to perform blocking operations.
+   * @param applier The outlet of the produced headers. It can be called either before or after this
+   *        method returns.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
+  public abstract void applyRequestMetadata(
+      RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier);
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public final void applyRequestMetadata(
+      final MethodDescriptor<?, ?> method, final Attributes attrs,
+      Executor appExecutor, CallCredentials.MetadataApplier applier) {
+    final String authority = checkNotNull(attrs.get(ATTR_AUTHORITY), "authority");
+    final SecurityLevel securityLevel =
+        firstNonNull(attrs.get(ATTR_SECURITY_LEVEL), SecurityLevel.NONE);
+    RequestInfo requestInfo = new RequestInfo() {
+        @Override
+        public MethodDescriptor<?, ?> getMethodDescriptor() {
+          return method;
+        }
+
+        @Override
+        public SecurityLevel getSecurityLevel() {
+          return securityLevel;
+        }
+
+        @Override
+        public String getAuthority() {
+          return authority;
+        }
+
+        @Override
+        public Attributes getTransportAttrs() {
+          return attrs;
+        }
+      };
+    applyRequestMetadata(requestInfo, appExecutor, applier);
+  }
+
+  /**
+   * The request-related information passed to {@link #applyRequestMetadata}.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
+  public abstract static class RequestInfo {
+    /**
+     * The method descriptor of this RPC.
+     */
+    public abstract MethodDescriptor<?, ?> getMethodDescriptor();
+
+    /**
+     * The security level on the transport.
+     */
+    public abstract SecurityLevel getSecurityLevel();
+
+    /**
+     * Returns the authority string used to authenticate the server for this call.
+     */
+    public abstract String getAuthority();
+
+    /**
+     * Returns the transport attributes.
+     */
+    @Grpc.TransportAttr
+    public abstract Attributes getTransportAttrs();
+  }
+}

--- a/core/src/main/java/io/grpc/CallCredentials2.java
+++ b/core/src/main/java/io/grpc/CallCredentials2.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executor;
  * replaces {@link CallCredentials} in short-term.  THIS CLASS SHOULD ONLY BE REFERENCED BY
  * IMPLEMENTIONS.  All consumers should still reference {@link CallCredentials}.
  */
-@Internal
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/4901")
 public abstract class CallCredentials2 implements CallCredentials {
   /**
    * Pass the credential data to the given {@link CallCredentials.MetadataApplier}, which will

--- a/core/src/main/java/io/grpc/CallCredentials2.java
+++ b/core/src/main/java/io/grpc/CallCredentials2.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Executor;
  * The new interface for {@link CallCredentials}.
  *
  * <p>THIS CLASS IS MEANT TO BE REFERENCED BY IMPLEMENTIONS ONLY.  All users should reference {@link
- * Credentials}.
+ * CallCredentials}.
  */
 public abstract class CallCredentials2 implements CallCredentials {
   /**

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -24,7 +24,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Compressor;
 import io.grpc.Deadline;
@@ -41,6 +40,7 @@ import io.grpc.Status;
 import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ConnectionClientTransport;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.NoopClientStream;
@@ -91,7 +91,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   @GuardedBy("this")
   private List<ServerStreamTracer.Factory> serverStreamTracerFactories;
   private final Attributes attributes = Attributes.newBuilder()
-      .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
+      .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
       .build();
 
   public InProcessTransport(String name, String authority, String userAgent) {

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -72,6 +72,7 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public ClientStream newStream(
         MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
       CallCredentials creds = callOptions.getCredentials();

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -18,7 +18,9 @@ package io.grpc.internal;
 
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.Grpc;
 import io.grpc.NameResolver;
+import io.grpc.SecurityLevel;
 import java.util.Map;
 
 /**
@@ -47,6 +49,15 @@ public final class GrpcAttributes {
   @EquivalentAddressGroup.Attr
   public static final Attributes.Key<Boolean> ATTR_LB_PROVIDED_BACKEND =
       Attributes.Key.create("io.grpc.grpclb.lbProvidedBackend");
+
+  /**
+   * The security level of the transport.  If it's not present, {@link SecurityLevel#NONE} should be
+   * assumed.
+   */
+  @SuppressWarnings("deprecation")
+  @Grpc.TransportAttr
+  public static final Attributes.Key<SecurityLevel> ATTR_SECURITY_LEVEL =
+      io.grpc.CallCredentials.ATTR_SECURITY_LEVEL;
 
   private GrpcAttributes() {}
 }

--- a/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
+++ b/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
@@ -29,7 +29,7 @@ import io.grpc.Status;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
-final class MetadataApplierImpl implements MetadataApplier {
+final class MetadataApplierImpl extends MetadataApplier {
   private final ClientTransport transport;
   private final MethodDescriptor<?, ?> method;
   private final Metadata origHeaders;

--- a/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
@@ -30,8 +30,8 @@ import static org.mockito.Mockito.when;
 
 import io.grpc.Attributes;
 import io.grpc.CallCredentials.MetadataApplier;
+import io.grpc.CallCredentials.RequestInfo;
 import io.grpc.CallCredentials2;
-import io.grpc.CallCredentials2.RequestInfo;
 import io.grpc.CallOptions;
 import io.grpc.IntegerMarshaller;
 import io.grpc.Metadata;

--- a/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
@@ -29,8 +29,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.CallCredentials.MetadataApplier;
+import io.grpc.CallCredentials2;
+import io.grpc.CallCredentials2.RequestInfo;
 import io.grpc.CallOptions;
 import io.grpc.IntegerMarshaller;
 import io.grpc.Metadata;
@@ -51,12 +52,11 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /**
- * Unit test for {@link CallCredentials} applying functionality implemented by {@link
+ * Unit test for {@link CallCredentials2} applying functionality implemented by {@link
  * CallCredentialsApplyingTransportFactory} and {@link MetadataApplierImpl}.
  */
 @RunWith(JUnit4.class)
-@Deprecated
-public class CallCredentialsApplyingTest {
+public class CallCredentials2ApplyingTest {
   @Mock
   private ClientTransportFactory mockTransportFactory;
 
@@ -67,7 +67,7 @@ public class CallCredentialsApplyingTest {
   private ClientStream mockStream;
 
   @Mock
-  private CallCredentials mockCreds;
+  private CallCredentials2 mockCreds;
 
   @Mock
   private Executor mockExecutor;
@@ -126,41 +126,41 @@ public class CallCredentialsApplyingTest {
 
     transport.newStream(method, origHeaders, callOptions);
 
-    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), attrsCaptor.capture(), same(mockExecutor),
-        any(MetadataApplier.class));
-    Attributes attrs = attrsCaptor.getValue();
-    assertSame(ATTR_VALUE, attrs.get(ATTR_KEY));
-    assertSame(AUTHORITY, attrs.get(CallCredentials.ATTR_AUTHORITY));
-    assertSame(SecurityLevel.NONE, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(
+        infoCaptor.capture(), same(mockExecutor), any(MetadataApplier.class));
+    RequestInfo info = infoCaptor.getValue();
+    assertSame(method, info.getMethodDescriptor());
+    Attributes attrs = info.getTransportAttrs();
+    assertSame(ATTR_VALUE, info.getTransportAttrs().get(ATTR_KEY));
+    assertSame(AUTHORITY, info.getAuthority());
+    assertSame(SecurityLevel.NONE, info.getSecurityLevel());
   }
 
   @Test
-  public void parameterPropagation_overrideByTransport() {
+  public void parameterPropagation_transportSetSecurityLevel() {
     Attributes transportAttrs = Attributes.newBuilder()
         .set(ATTR_KEY, ATTR_VALUE)
-        .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
-        .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
+        .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
         .build();
     when(mockTransport.getAttributes()).thenReturn(transportAttrs);
 
     transport.newStream(method, origHeaders, callOptions);
 
-    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), attrsCaptor.capture(), same(mockExecutor),
-        any(MetadataApplier.class));
-    Attributes attrs = attrsCaptor.getValue();
-    assertSame(ATTR_VALUE, attrs.get(ATTR_KEY));
-    assertEquals("transport-override-authority", attrs.get(CallCredentials.ATTR_AUTHORITY));
-    assertSame(SecurityLevel.INTEGRITY, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(
+        infoCaptor.capture(), same(mockExecutor), any(MetadataApplier.class));
+    RequestInfo info = infoCaptor.getValue();
+    assertSame(method, info.getMethodDescriptor());
+    assertSame(ATTR_VALUE, info.getTransportAttrs().get(ATTR_KEY));
+    assertSame(AUTHORITY, info.getAuthority());
+    assertSame(SecurityLevel.INTEGRITY, info.getSecurityLevel());
   }
 
   @Test
-  public void parameterPropagation_overrideByCallOptions() {
+  public void parameterPropagation_callOptionsSetAuthority() {
     Attributes transportAttrs = Attributes.newBuilder()
         .set(ATTR_KEY, ATTR_VALUE)
-        .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
-        .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
         .build();
     when(mockTransport.getAttributes()).thenReturn(transportAttrs);
     Executor anotherExecutor = mock(Executor.class);
@@ -168,13 +168,14 @@ public class CallCredentialsApplyingTest {
     transport.newStream(method, origHeaders,
         callOptions.withAuthority("calloptions-authority").withExecutor(anotherExecutor));
 
-    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), attrsCaptor.capture(),
-        same(anotherExecutor), any(MetadataApplier.class));
-    Attributes attrs = attrsCaptor.getValue();
-    assertSame(ATTR_VALUE, attrs.get(ATTR_KEY));
-    assertEquals("calloptions-authority", attrs.get(CallCredentials.ATTR_AUTHORITY));
-    assertSame(SecurityLevel.INTEGRITY, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(
+        infoCaptor.capture(), same(anotherExecutor), any(MetadataApplier.class));
+    RequestInfo info = infoCaptor.getValue();
+    assertSame(method, info.getMethodDescriptor());
+    assertSame(ATTR_VALUE, info.getTransportAttrs().get(ATTR_KEY));
+    assertEquals("calloptions-authority", info.getAuthority());
+    assertSame(SecurityLevel.NONE, info.getSecurityLevel());
   }
 
   @Test
@@ -182,7 +183,7 @@ public class CallCredentialsApplyingTest {
     final RuntimeException ex = new RuntimeException();
     when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
     doThrow(ex).when(mockCreds).applyRequestMetadata(
-        same(method), any(Attributes.class), same(mockExecutor), any(MetadataApplier.class));
+        any(RequestInfo.class), same(mockExecutor), any(MetadataApplier.class));
 
     FailingClientStream stream =
         (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
@@ -198,14 +199,14 @@ public class CallCredentialsApplyingTest {
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
-          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[3];
+          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[2];
           Metadata headers = new Metadata();
           headers.put(CREDS_KEY, CREDS_VALUE);
           applier.apply(headers);
           return null;
         }
-      }).when(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
-          same(mockExecutor), any(MetadataApplier.class));
+      }).when(mockCreds).applyRequestMetadata(
+          any(RequestInfo.class), same(mockExecutor), any(MetadataApplier.class));
 
     ClientStream stream = transport.newStream(method, origHeaders, callOptions);
 
@@ -222,12 +223,12 @@ public class CallCredentialsApplyingTest {
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
-          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[3];
+          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[2];
           applier.fail(error);
           return null;
         }
-      }).when(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
-          same(mockExecutor), any(MetadataApplier.class));
+      }).when(mockCreds).applyRequestMetadata(
+          any(RequestInfo.class), same(mockExecutor), any(MetadataApplier.class));
 
     FailingClientStream stream =
         (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
@@ -244,8 +245,8 @@ public class CallCredentialsApplyingTest {
     DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
 
     ArgumentCaptor<MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
-        same(mockExecutor), applierCaptor.capture());
+    verify(mockCreds).applyRequestMetadata(
+        any(RequestInfo.class), same(mockExecutor), applierCaptor.capture());
     verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
 
     Metadata headers = new Metadata();
@@ -266,8 +267,8 @@ public class CallCredentialsApplyingTest {
     DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
 
     ArgumentCaptor<MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
-        same(mockExecutor), applierCaptor.capture());
+    verify(mockCreds).applyRequestMetadata(
+        any(RequestInfo.class), same(mockExecutor), applierCaptor.capture());
 
     Status error = Status.FAILED_PRECONDITION.withDescription("channel not secure for creds");
     applierCaptor.getValue().fail(error);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1388,6 +1388,7 @@ public class ManagedChannelImplTest {
    * propagated to newStream() and applyRequestMetadata().
    */
   @Test
+  @SuppressWarnings("deprecation")
   public void informationPropagatedToNewStreamAndCallCredentials() {
     createChannel();
     CallOptions callOptions = CallOptions.DEFAULT.withCallCredentials(creds);
@@ -1401,7 +1402,7 @@ public class ManagedChannelImplTest {
           credsApplyContexts.add(Context.current());
           return null;
         }
-      }).when(creds).applyRequestMetadata(
+      }).when(creds).applyRequestMetadata(  // TODO(zhangkun83): remove suppression of deprecations
           any(MethodDescriptor.class), any(Attributes.class), any(Executor.class),
           any(MetadataApplier.class));
 

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
@@ -31,6 +30,7 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.cronet.CronetChannelBuilder.StreamBuilderFactory;
 import io.grpc.internal.ConnectionClientTransport;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.StatsTraceContext;
 import io.grpc.internal.TransportTracer;
@@ -95,8 +95,7 @@ class CronetClientTransport implements ConnectionClientTransport {
     this.streamFactory = Preconditions.checkNotNull(streamFactory, "streamFactory");
     this.transportTracer = Preconditions.checkNotNull(transportTracer, "transportTracer");
     this.attrs = Attributes.newBuilder()
-        .set(CallCredentials.ATTR_AUTHORITY, authority)
-        .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
+        .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
         .build();
   }
 

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -33,6 +33,7 @@ import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.cronet.CronetChannelBuilder.StreamBuilderFactory;
 import io.grpc.internal.ClientStreamListener;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ManagedClientTransport;
 import io.grpc.internal.TransportTracer;
 import io.grpc.testing.TestMethodDescriptors;
@@ -82,9 +83,8 @@ public final class CronetClientTransportTest {
   @Test
   public void transportAttributes() {
     Attributes attrs = transport.getAttributes();
-    assertEquals(AUTHORITY, attrs.get(CallCredentials.ATTR_AUTHORITY));
     assertEquals(
-        SecurityLevel.PRIVACY_AND_INTEGRITY, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+        SecurityLevel.PRIVACY_AND_INTEGRITY, attrs.get(GrpcAttributes.ATTR_SECURITY_LEVEL));
   }
 
   @Test

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -22,12 +22,12 @@ import static io.grpc.netty.GrpcSslContexts.NEXT_PROTOCOL_VERSIONS;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.Grpc;
 import io.grpc.Internal;
 import io.grpc.InternalChannelz;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
@@ -651,7 +651,7 @@ public final class ProtocolNegotiators {
                 Attributes.newBuilder()
                     .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, session)
                     .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
-                    .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
+                    .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
                     .build(),
                 new InternalChannelz.Security(new InternalChannelz.Tls(session)));
             writeBufferedAndRemove(ctx);
@@ -699,7 +699,7 @@ public final class ProtocolNegotiators {
           Attributes
               .newBuilder()
               .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
-              .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
+              .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
               .build(),
           /*securityInfo=*/ null);
       super.channelActive(ctx);
@@ -742,7 +742,7 @@ public final class ProtocolNegotiators {
             Attributes
                 .newBuilder()
                 .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
-                .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
+                .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
                 .build(),
             /*securityInfo=*/ null);
       } else if (evt == HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_REJECTED) {

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -31,7 +31,6 @@ import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.internal.http.StatusLine;
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
@@ -46,6 +45,7 @@ import io.grpc.Status.Code;
 import io.grpc.StatusException;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.ConnectionClientTransport;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
 import io.grpc.internal.KeepAliveManager;
@@ -485,7 +485,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
               .newBuilder()
               .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, sock.getRemoteSocketAddress())
               .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, sslSession)
-              .set(CallCredentials.ATTR_SECURITY_LEVEL,
+              .set(GrpcAttributes.ATTR_SECURITY_LEVEL,
                   sslSession == null ? SecurityLevel.NONE : SecurityLevel.PRIVACY_AND_INTEGRITY)
               .build();
         } catch (StatusException e) {

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -44,7 +44,6 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Grpc;
@@ -59,6 +58,7 @@ import io.grpc.internal.ClientStream;
 import io.grpc.internal.ClientStreamListener;
 import io.grpc.internal.ClientTransport;
 import io.grpc.internal.ConnectionClientTransport;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.IoUtils;
 import io.grpc.internal.ManagedClientTransport;
@@ -346,7 +346,7 @@ public abstract class AbstractTransportTest {
     verify(mockClientTransportListener, timeout(TIMEOUT_MS)).transportReady();
 
     assertNotNull("security level should be set in client attributes",
-        connectionClient.getAttributes().get(CallCredentials.ATTR_SECURITY_LEVEL));
+        connectionClient.getAttributes().get(GrpcAttributes.ATTR_SECURITY_LEVEL));
   }
 
   @Test


### PR DESCRIPTION
This is the first step of introducing the 2nd edition of CallCredentials API (#4901)

Security level and authority are parameters required to be passed to
applyRequestMetadata(). This change wraps them, along with
MethodDescriptor and the transport attributes to RequestInfo, which is
more clear to the implementers.

ATTR_SECURITY_LEVEL is moved to the internal GrpcAttributes and
annotated as TransportAttr, because transports are required to set it,
but no user is actually reading them from
{Client,Server}Call.getAttributes().

ATTR_AUTHORITY is removed, because no transport is overriding it.

All involved interfaces are changed to abstract classes, as this will
make further API changes smoother.
