### PR TITLE
Fix copy pasta error in method comment

### DIFF
--- a/core/src/main/java/io/grpc/StatusException.java
+++ b/core/src/main/java/io/grpc/StatusException.java
@@ -30,7 +30,7 @@ public class StatusException extends Exception {
   private final boolean fillInStackTrace;
 
   /**
-   * Constructs an exception with both a status.  See also {@link Status#asException()}.
+   * Constructs an exception with a status.  See also {@link Status#asException()}.
    *
    * @since 1.0.0
    */


### PR DESCRIPTION
"Constructs an exception with both a status." -> "Constructs an exception with a status."