### PR TITLE
config stats and tracing at InProcessChannelBuilder

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -128,6 +128,16 @@ public final class InProcessChannelBuilder extends
     return this;
   }
 
+  @Override
+  public void setStatsEnabled(boolean value) {
+    super.setStatsEnabled(value);
+  }
+
+  @Override
+  public void setTracingEnabled(boolean value) {
+    super.setTracingEnabled(value);
+  }
+
   /**
    * Provides a custom scheduled executor service.
    *


### PR DESCRIPTION
make `setStatsEnabled` and `setTracingEnabled` public to support test retry feature