### PR TITLE
services: fix callbacks not being forwarded in binlog interceptors

### DIFF
--- a/services/src/main/java/io/grpc/services/BinlogHelper.java
+++ b/services/src/main/java/io/grpc/services/BinlogHelper.java
@@ -486,6 +486,7 @@ final class BinlogHelper {
                 seq.getAndIncrement(),
                 GrpcLogEntry.Logger.LOGGER_CLIENT,
                 callId);
+            super.halfClose();
           }
 
           @Override
@@ -590,6 +591,7 @@ final class BinlogHelper {
                 seq.getAndIncrement(),
                 GrpcLogEntry.Logger.LOGGER_SERVER,
                 callId);
+            super.onCancel();
           }
         };
       }


### PR DESCRIPTION
The callback must be forwarded otherwise the RPC hangs.