### PR TITLE
services: allow config str to be passed into binlog object

### DIFF
--- a/services/src/main/java/io/grpc/services/BinaryLogProviderImpl.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogProviderImpl.java
@@ -38,6 +38,10 @@ class BinaryLogProviderImpl extends BinaryLogProvider {
     this(new TempFileSink(), System.getenv("GRPC_BINARY_LOG_CONFIG"));
   }
 
+  /**
+   * Deprecated and will be removed in a future version of gRPC.
+   */
+  @Deprecated
   public BinaryLogProviderImpl(BinaryLogSink sink) throws IOException {
     this(sink, System.getenv("GRPC_BINARY_LOG_CONFIG"));
   }
@@ -48,7 +52,7 @@ class BinaryLogProviderImpl extends BinaryLogProvider {
    * @param configStr config string to parse to determine logged methods and msg size limits.
    * @throws IOException if initialization failed.
    */
-  BinaryLogProviderImpl(BinaryLogSink sink, String configStr) throws IOException {
+  public BinaryLogProviderImpl(BinaryLogSink sink, String configStr) throws IOException {
     this.sink = Preconditions.checkNotNull(sink);
     try {
       factory = new BinlogHelper.FactoryImpl(sink, configStr);

--- a/services/src/main/java/io/grpc/services/BinaryLogs.java
+++ b/services/src/main/java/io/grpc/services/BinaryLogs.java
@@ -32,10 +32,21 @@ public final class BinaryLogs {
   }
 
   /**
-   * Creates a binary log with a custom {@link BinaryLogSink} for receiving the logged data.
+   * Deprecated and will be removed in a future version of gRPC.
    */
+  @Deprecated
   public static BinaryLog createBinaryLog(BinaryLogSink sink) throws IOException {
     return new BinaryLogProviderImpl(sink);
+  }
+
+  /**
+   * Creates a binary log with a custom {@link BinaryLogSink} for receiving the logged data,
+   * and a config string as defined by
+   * <a href="https://github.com/grpc/proposal/blob/master/A16-binary-logging.md">
+   *   A16-binary-logging</a>.
+   */
+  public static BinaryLog createBinaryLog(BinaryLogSink sink, String configStr) throws IOException {
+    return new BinaryLogProviderImpl(sink, configStr);
   }
 
   private BinaryLogs() {}


### PR DESCRIPTION
Do not require binlog str to be defined by env var.

This allows --flag=value styled configuration, which is more common
internally.