### PR TITLE
services: fix channelz javadoc lint for reference not found

### DIFF
--- a/services/src/main/java/io/grpc/services/ChannelzService.java
+++ b/services/src/main/java/io/grpc/services/ChannelzService.java
@@ -61,7 +61,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
     this.maxPageSize = maxPageSize;
   }
 
-  /** Returns top level channel aka {@link io.grpc.internal.ManagedChannelImpl}. */
+  /** Returns top level channel aka {@link io.grpc.ManagedChannel}. */
   @Override
   public void getTopChannels(
       GetTopChannelsRequest request, StreamObserver<GetTopChannelsResponse> responseObserver) {
@@ -72,7 +72,7 @@ public final class ChannelzService extends ChannelzGrpc.ChannelzImplBase {
     responseObserver.onCompleted();
   }
 
-  /** Returns a top level channel aka {@link io.grpc.internal.ManagedChannelImpl}. */
+  /** Returns a top level channel aka {@link io.grpc.ManagedChannel}. */
   @Override
   public void getChannel(
       GetChannelRequest request, StreamObserver<GetChannelResponse> responseObserver) {


### PR DESCRIPTION
Referring to the public abstract class seems to be OK, but referring
to the package private impl trips the linter.