### PR TITLE
core: include what name resolver was used when it fails

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1252,7 +1252,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
     @Override
     public void onAddresses(final List<EquivalentAddressGroup> servers, final Attributes config) {
       if (servers.isEmpty()) {
-        onError(Status.UNAVAILABLE.withDescription("NameResolver returned an empty list"));
+        onError(Status.UNAVAILABLE.withDescription(
+            "Name resolver " + helper.nr + " returned an empty list"));
         return;
       }
       if (logger.isLoggable(Level.FINE)) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -759,7 +759,7 @@ public class ManagedChannelImplTest {
 
   @Test
   public void nameResolverReturnsEmptySubLists() {
-    String errorDescription = "NameResolver returned an empty list";
+    String errorDescription = "returned an empty list";
 
     // Pass a FakeNameResolverFactory with an empty list
     createChannel();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -51,6 +51,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
@@ -769,7 +770,7 @@ public class ManagedChannelImplTest {
     verify(mockLoadBalancer).handleNameResolutionError(statusCaptor.capture());
     Status status = statusCaptor.getValue();
     assertSame(Status.Code.UNAVAILABLE, status.getCode());
-    assertEquals(errorDescription, status.getDescription());
+    Truth.assertThat(status.getDescription()).contains(errorDescription);
   }
 
   @Test


### PR DESCRIPTION
(I think this will always be non-null, but I am not certain)