### PR TITLE
core: android use smaller(2s) DNS cache TTL

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -95,13 +95,16 @@ final class DnsNameResolver extends NameResolver {
    *
    * <p>Default value is -1 (cache forever) if security manager is installed. If security manager is
    * not installed, the ttl value is {@code null} which falls back to {@link
-   * #DEFAULT_NETWORK_CACHE_TTL_SECONDS gRPC default value}.
+   * #DEFAULT_NETWORK_CACHE_TTL_SECONDS gRPC default value} or {@link
+   * #DEFAULT_ANDROID_NETWORK_CACHE_TTL_SECONDS android default value}.
    */
   @VisibleForTesting
   static final String NETWORKADDRESS_CACHE_TTL_PROPERTY = "networkaddress.cache.ttl";
   /** Default DNS cache duration if network cache ttl value is not specified ({@code null}). */
   @VisibleForTesting
   static final long DEFAULT_NETWORK_CACHE_TTL_SECONDS = 30;
+  @VisibleForTesting
+  static final long DEFAULT_ANDROID_NETWORK_CACHE_TTL_SECONDS = 2;
 
   @VisibleForTesting
   static boolean enableJndi = Boolean.parseBoolean(JNDI_PROPERTY);
@@ -132,6 +135,7 @@ final class DnsNameResolver extends NameResolver {
   private final Resource<ExecutorService> executorResource;
   private final long networkAddressCacheTtlNanos;
   private final Stopwatch stopwatch;
+  private final boolean isAndroid;
   @GuardedBy("this")
   private boolean shutdown;
   @GuardedBy("this")
@@ -144,7 +148,7 @@ final class DnsNameResolver extends NameResolver {
 
   DnsNameResolver(@Nullable String nsAuthority, String name, Attributes params,
       Resource<ExecutorService> executorResource, ProxyDetector proxyDetector,
-      Stopwatch stopwatch) {
+      Stopwatch stopwatch, boolean isAndroid) {
     // TODO: if a DNS server is provided as nsAuthority, use it.
     // https://www.captechconsulting.com/blogs/accessing-the-dusty-corners-of-dns-with-java
     this.executorResource = executorResource;
@@ -169,6 +173,7 @@ final class DnsNameResolver extends NameResolver {
     this.proxyDetector = proxyDetector;
     this.stopwatch = Preconditions.checkNotNull(stopwatch, "stopwatch");
     this.networkAddressCacheTtlNanos = getNetworkAddressCacheTtlNanos();
+    this.isAndroid = isAndroid;
   }
 
   @Override
@@ -285,9 +290,10 @@ final class DnsNameResolver extends NameResolver {
     };
 
   /** Returns value of network address cache ttl property. */
-  private static long getNetworkAddressCacheTtlNanos() {
+  private long getNetworkAddressCacheTtlNanos() {
     String cacheTtlPropertyValue = System.getProperty(NETWORKADDRESS_CACHE_TTL_PROPERTY);
-    long cacheTtl = DEFAULT_NETWORK_CACHE_TTL_SECONDS;
+    long cacheTtl =
+        isAndroid ? DEFAULT_ANDROID_NETWORK_CACHE_TTL_SECONDS : DEFAULT_NETWORK_CACHE_TTL_SECONDS;
     if (cacheTtlPropertyValue != null) {
       try {
         cacheTtl = Long.parseLong(cacheTtlPropertyValue);

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -135,7 +135,6 @@ final class DnsNameResolver extends NameResolver {
   private final Resource<ExecutorService> executorResource;
   private final long networkAddressCacheTtlNanos;
   private final Stopwatch stopwatch;
-  private final boolean isAndroid;
   @GuardedBy("this")
   private boolean shutdown;
   @GuardedBy("this")
@@ -172,8 +171,7 @@ final class DnsNameResolver extends NameResolver {
     }
     this.proxyDetector = proxyDetector;
     this.stopwatch = Preconditions.checkNotNull(stopwatch, "stopwatch");
-    this.networkAddressCacheTtlNanos = getNetworkAddressCacheTtlNanos();
-    this.isAndroid = isAndroid;
+    this.networkAddressCacheTtlNanos = getNetworkAddressCacheTtlNanos(isAndroid);
   }
 
   @Override
@@ -290,7 +288,7 @@ final class DnsNameResolver extends NameResolver {
     };
 
   /** Returns value of network address cache ttl property. */
-  private long getNetworkAddressCacheTtlNanos() {
+  private static long getNetworkAddressCacheTtlNanos(boolean isAndroid) {
     String cacheTtlPropertyValue = System.getProperty(NETWORKADDRESS_CACHE_TTL_PROPERTY);
     long cacheTtl =
         isAndroid ? DEFAULT_ANDROID_NETWORK_CACHE_TTL_SECONDS : DEFAULT_NETWORK_CACHE_TTL_SECONDS;

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -19,6 +19,7 @@ package io.grpc.internal;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import io.grpc.Attributes;
+import io.grpc.InternalServiceProviders;
 import io.grpc.NameResolverProvider;
 import java.net.URI;
 
@@ -54,7 +55,8 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
           params,
           GrpcUtil.SHARED_CHANNEL_EXECUTOR,
           GrpcUtil.getDefaultProxyDetector(),
-          Stopwatch.createUnstarted());
+          Stopwatch.createUnstarted(),
+          InternalServiceProviders.isAndroid(getClass().getClassLoader()));
     } else {
       return null;
     }

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -112,7 +112,13 @@ public class DnsNameResolverTest {
   private String networkaddressCacheTtlPropertyValue;
 
   private DnsNameResolver newResolver(String name, int port) {
-    return newResolver(name, port, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted());
+    return
+        newResolver(name, port, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(), false);
+  }
+
+  private DnsNameResolver newResolver(String name, int port, boolean isAndroid) {
+    return newResolver(
+        name, port, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(), isAndroid);
   }
 
   private DnsNameResolver newResolver(
@@ -120,13 +126,23 @@ public class DnsNameResolverTest {
       int port,
       ProxyDetector proxyDetector,
       Stopwatch stopwatch) {
+    return newResolver(name, port, proxyDetector, stopwatch, false);
+  }
+
+  private DnsNameResolver newResolver(
+      String name,
+      int port,
+      ProxyDetector proxyDetector,
+      Stopwatch stopwatch,
+      boolean isAndroid) {
     DnsNameResolver dnsResolver = new DnsNameResolver(
         null,
         name,
         Attributes.newBuilder().set(NameResolver.Factory.PARAMS_DEFAULT_PORT, port).build(),
         fakeExecutorResource,
         proxyDetector,
-        stopwatch);
+        stopwatch,
+        isAndroid);
     return dnsResolver;
   }
 
@@ -199,12 +215,16 @@ public class DnsNameResolverTest {
 
   @Test
   public void resolve_neverCache() throws Exception {
+    resolve_neverCache(false);
+  }
+
+  private void resolve_neverCache(boolean isAndroid) throws Exception {
     System.setProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY, "0");
     final List<InetAddress> answer1 = createAddressList(2);
     final List<InetAddress> answer2 = createAddressList(1);
     String name = "foo.googleapis.com";
 
-    DnsNameResolver resolver = newResolver(name, 81);
+    DnsNameResolver resolver = newResolver(name, 81, isAndroid);
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(Matchers.anyString())).thenReturn(answer1).thenReturn(answer2);
     resolver.setAddressResolver(mockResolver);
@@ -227,14 +247,28 @@ public class DnsNameResolverTest {
   }
 
   @Test
+  public void resolve_androidNeverCache() throws Exception {
+    resolve_neverCache(false);
+  }
+
+  @Test
   public void resolve_cacheForever() throws Exception {
+    resolve_cacheForever(false);
+  }
+
+  private void resolve_cacheForever(boolean isAndroid) throws Exception {
     System.setProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY, "-1");
     final List<InetAddress> answer1 = createAddressList(2);
     String name = "foo.googleapis.com";
     FakeTicker fakeTicker = new FakeTicker();
 
     DnsNameResolver resolver =
-        newResolver(name, 81, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(fakeTicker));
+        newResolver(
+            name,
+            81,
+            GrpcUtil.NOOP_PROXY_DETECTOR,
+            Stopwatch.createUnstarted(fakeTicker),
+            isAndroid);
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(Matchers.anyString()))
         .thenReturn(answer1)
@@ -260,7 +294,16 @@ public class DnsNameResolverTest {
   }
 
   @Test
+  public void resolve_androidCacheForever() throws Exception {
+    resolve_cacheForever(true);
+  }
+
+  @Test
   public void resolve_usingCache() throws Exception {
+    resolve_usingCache(false);
+  }
+
+  private void resolve_usingCache(boolean isAndroid) throws Exception {
     long ttl = 60;
     System.setProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY, Long.toString(ttl));
     final List<InetAddress> answer = createAddressList(2);
@@ -268,7 +311,12 @@ public class DnsNameResolverTest {
     FakeTicker fakeTicker = new FakeTicker();
 
     DnsNameResolver resolver =
-        newResolver(name, 81, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(fakeTicker));
+        newResolver(
+            name,
+            81,
+            GrpcUtil.NOOP_PROXY_DETECTOR,
+            Stopwatch.createUnstarted(fakeTicker),
+            isAndroid);
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(Matchers.anyString()))
         .thenReturn(answer)
@@ -295,7 +343,16 @@ public class DnsNameResolverTest {
   }
 
   @Test
+  public void resolve_androidUsingCache() throws Exception {
+    resolve_usingCache(true);
+  }
+
+  @Test
   public void resolve_cacheExpired() throws Exception {
+    resolve_cacheExpired(false);
+  }
+
+  private void resolve_cacheExpired(boolean isAndroid) throws Exception {
     long ttl = 60;
     System.setProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY, Long.toString(ttl));
     final List<InetAddress> answer1 = createAddressList(2);
@@ -304,7 +361,12 @@ public class DnsNameResolverTest {
     FakeTicker fakeTicker = new FakeTicker();
 
     DnsNameResolver resolver =
-        newResolver(name, 81, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(fakeTicker));
+        newResolver(
+            name,
+            81,
+            GrpcUtil.NOOP_PROXY_DETECTOR,
+            Stopwatch.createUnstarted(fakeTicker),
+            isAndroid);
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(Matchers.anyString())).thenReturn(answer1).thenReturn(answer2);
     resolver.setAddressResolver(mockResolver);
@@ -328,25 +390,47 @@ public class DnsNameResolverTest {
   }
 
   @Test
+  public void resolve_androidCacheExpired() throws Exception {
+    resolve_cacheExpired(false);
+  }
+
+  @Test
   public void resolve_invalidTtlPropertyValue() throws Exception {
     System.setProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY, "not_a_number");
-    resolveDefaultValue();
+    resolveDefaultValue(false);
+  }
+
+  @Test
+  public void resolve_androidInvalidTtlPropertyValue() throws Exception {
+    System.setProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY, "not_a_number");
+    resolveDefaultValue(false);
   }
 
   @Test
   public void resolve_noPropertyValue() throws Exception {
     System.clearProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY);
-    resolveDefaultValue();
+    resolveDefaultValue(false);
   }
 
-  private void resolveDefaultValue() throws Exception {
+  @Test
+  public void resolve_androidNoPropertyValue() throws Exception {
+    System.clearProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY);
+    resolveDefaultValue(false);
+  }
+
+  private void resolveDefaultValue(boolean isAndroid) throws Exception {
     final List<InetAddress> answer1 = createAddressList(2);
     final List<InetAddress> answer2 = createAddressList(1);
     String name = "foo.googleapis.com";
     FakeTicker fakeTicker = new FakeTicker();
 
     DnsNameResolver resolver =
-        newResolver(name, 81, GrpcUtil.NOOP_PROXY_DETECTOR, Stopwatch.createUnstarted(fakeTicker));
+        newResolver(
+            name,
+            81,
+            GrpcUtil.NOOP_PROXY_DETECTOR,
+            Stopwatch.createUnstarted(fakeTicker),
+            isAndroid);
     AddressResolver mockResolver = mock(AddressResolver.class);
     when(mockResolver.resolveAddress(Matchers.anyString())).thenReturn(answer1).thenReturn(answer2);
     resolver.setAddressResolver(mockResolver);
@@ -357,7 +441,11 @@ public class DnsNameResolverTest {
     assertAnswerMatches(answer1, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
-    fakeTicker.advance(DnsNameResolver.DEFAULT_NETWORK_CACHE_TTL_SECONDS, TimeUnit.SECONDS);
+    long defaultTtl =
+        isAndroid
+            ? DnsNameResolver.DEFAULT_ANDROID_NETWORK_CACHE_TTL_SECONDS
+            : DnsNameResolver.DEFAULT_NETWORK_CACHE_TTL_SECONDS;
+    fakeTicker.advance(defaultTtl, TimeUnit.SECONDS);
     resolver.refresh();
     assertEquals(1, fakeExecutor.runDueTasks());
     verifyNoMoreInteractions(mockListener);

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -248,7 +248,7 @@ public class DnsNameResolverTest {
 
   @Test
   public void resolve_androidNeverCache() throws Exception {
-    resolve_neverCache(false);
+    resolve_neverCache(true);
   }
 
   @Test
@@ -391,7 +391,7 @@ public class DnsNameResolverTest {
 
   @Test
   public void resolve_androidCacheExpired() throws Exception {
-    resolve_cacheExpired(false);
+    resolve_cacheExpired(true);
   }
 
   @Test
@@ -403,7 +403,7 @@ public class DnsNameResolverTest {
   @Test
   public void resolve_androidInvalidTtlPropertyValue() throws Exception {
     System.setProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY, "not_a_number");
-    resolveDefaultValue(false);
+    resolveDefaultValue(true);
   }
 
   @Test
@@ -415,7 +415,7 @@ public class DnsNameResolverTest {
   @Test
   public void resolve_androidNoPropertyValue() throws Exception {
     System.clearProperty(DnsNameResolver.NETWORKADDRESS_CACHE_TTL_PROPERTY);
-    resolveDefaultValue(false);
+    resolveDefaultValue(true);
   }
 
   private void resolveDefaultValue(boolean isAndroid) throws Exception {


### PR DESCRIPTION
Use smaller DNS cache TTL (2s) for android device, this value default on android. For more detail see #4942.

Resolves #4942 