### PR TITLE
Update net.ltgt.errorprone plugin and Error Prone, enable Error Prone on JDK 10, and JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,8 @@ os:
   - linux
 
 jdk:
-  # net.ltgt.errorprone supports jdk8 and jdk9, but has problems with jdk10
-  # For jdk10, we need to switch over to using net.ltgt.errorprone-javacplugin,
-  # and likely update to the latest com.google.errorprone:error_prone_core.
-  # We have decided not to make our build.gradle support both plugins, so when
-  # we finally move off of jdk8 and jdk9 we will need use the javac annotation
-  # processor based plugin.
-  - oraclejdk8  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
-  - oraclejdk9  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
+  - oraclejdk8
+  - oraclejdk9
   - oraclejdk10
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ jdk:
   - oraclejdk8
   - oraclejdk9
   - oraclejdk10
+  - oraclejdk11
 
 notifications:
   email: false

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -32,6 +32,7 @@ dependencies {
         // prefer 20.0 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
     }
+    compileOnly libraries.javax_annotation
     runtime project(':grpc-grpclb')
     testCompile libraries.guava,
             libraries.guava_testlib,

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -45,13 +45,15 @@ dependencies {
 
 configureProtoCompilation()
 
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 [compileJava, compileTestJava].each() {
-    // ALTS retuns a lot of futures that we mostly don't care about.
     // protobuf calls valueof. Will be fixed in next release (google/protobuf#4046)
     it.options.compilerArgs += [
-        "-Xlint:-deprecation",
-        "-Xep:FutureReturnValueIgnored:OFF"
+        "-Xlint:-deprecation"
     ]
+    // ALTS returns a lot of futures that we mostly don't care about.
+    it.options.errorprone.check("FutureReturnValueIgnored", CheckSeverity.OFF)
 }
 
 javadoc { exclude 'io/grpc/alts/internal/**' }

--- a/alts/src/test/java/io/grpc/alts/internal/FakeTsiHandshaker.java
+++ b/alts/src/test/java/io/grpc/alts/internal/FakeTsiHandshaker.java
@@ -172,6 +172,7 @@ public class FakeTsiHandshaker implements TsiHandshaker {
       ByteBuffer messageBytes = frameParser.getRawFrame();
       int offset = AltsFraming.getFramingOverhead();
       int length = messageBytes.limit() - offset;
+      @SuppressWarnings("ByteBufferBackingArray") // ByteBuffer is created using allocate()
       String message = new String(messageBytes.array(), offset, length, UTF_8);
       logger.log(Level.FINE, "Read message: {0}", message);
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.6"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
@@ -41,6 +41,9 @@ repositories {
 }
 
 dependencies {
+    errorprone 'com.google.errorprone:error_prone_core:2.3.1'
+    errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
+
     implementation 'io.grpc:grpc-core:1.17.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     testImplementation 'io.grpc:grpc-okhttp:1.17.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ repositories {
 }
 
 dependencies {
-    errorprone 'com.google.errorprone:error_prone_core:2.3.1'
+    errorprone 'com.google.errorprone:error_prone_core:2.3.2'
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
     implementation 'io.grpc:grpc-core:1.17.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -36,9 +36,11 @@ dependencies {
     compileOnly libraries.javax_annotation
 }
 
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 compileJava {
     // The Control.Void protobuf clashes
-    options.compilerArgs += ["-Xep:JavaLangClash:OFF"]
+    options.errorprone.check("JavaLangClash", CheckSeverity.OFF)
 }
 
 configureProtoCompilation()

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -111,14 +111,14 @@ public class AsyncServer {
               Class.forName("io.netty.channel.epoll.EpollServerSocketChannel");
           boss =
               (EventLoopGroup)
-                  (groupClass
+                  groupClass
                       .getConstructor(int.class, ThreadFactory.class)
-                      .newInstance(1, tf));
+                      .newInstance(1, tf);
           worker =
               (EventLoopGroup)
-                  (groupClass
+                  groupClass
                       .getConstructor(int.class, ThreadFactory.class)
-                      .newInstance(0, tf));
+                      .newInstance(0, tf);
           channelType = channelClass;
           break;
         } catch (Exception e) {
@@ -134,14 +134,14 @@ public class AsyncServer {
               Class.forName("io.netty.channel.epoll.EpollServerDomainSocketChannel");
           boss =
               (EventLoopGroup)
-                  (groupClass
+                  groupClass
                       .getConstructor(int.class, ThreadFactory.class)
-                      .newInstance(1, tf));
+                      .newInstance(1, tf);
           worker =
               (EventLoopGroup)
-                  (groupClass
+                  groupClass
                       .getConstructor(int.class, ThreadFactory.class)
-                      .newInstance(0, tf));
+                      .newInstance(0, tf);
           channelType = channelClass;
           break;
         } catch (Exception e) {

--- a/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/qps/AsyncServer.java
@@ -76,6 +76,7 @@ public class AsyncServer {
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
+      @SuppressWarnings("CatchAndPrintStackTrace")
       public void run() {
         try {
           System.out.println("QPS Server shutting down");

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ subprojects {
     apply plugin: "signing"
     apply plugin: "jacoco"
 
+    jacoco {
+      toolVersion = "0.8.2"
+    }
+
     apply plugin: "me.champeau.gradle.jmh"
     apply plugin: "com.google.osdetector"
     // The plugin only has an effect if a signature is specified

--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,13 @@ buildscript {
         classpath "com.diffplug.spotless:spotless-plugin-gradle:3.13.0"
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.5'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
-        classpath 'net.ltgt.gradle:gradle-apt-plugin:0.13'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
         classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.5"
         classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.2.5'
     }
 }
+
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 subprojects {
     apply plugin: "checkstyle"
@@ -26,24 +27,23 @@ subprojects {
     apply plugin: "com.google.osdetector"
     // The plugin only has an effect if a signature is specified
     apply plugin: "ru.vyarus.animalsniffer"
+
+    apply plugin: "net.ltgt.errorprone"
     // jdk10 not supported by errorprone: https://github.com/google/error-prone/issues/860
     if (!JavaVersion.current().isJava10Compatible() &&
         rootProject.properties.get('errorProne', true)) {
-        apply plugin: "net.ltgt.errorprone"
-        apply plugin: "net.ltgt.apt"
-
         dependencies {
-            // The ErrorProne plugin defaults to the latest, which would break our
-            // build if error prone releases a new version with a new check
-            errorprone 'com.google.errorprone:error_prone_core:2.2.0'
-            apt 'com.google.guava:guava-beta-checker:1.0'
+            errorprone 'com.google.errorprone:error_prone_core:2.3.1'
+            errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
+
+            annotationProcessor 'com.google.guava:guava-beta-checker:1.0'
         }
     } else {
-        // Remove per-project error-prone checker config
+        // Disable Error Prone
         allprojects {
             afterEvaluate { project ->
                 project.tasks.withType(JavaCompile) {
-                    options.compilerArgs.removeAll { it.startsWith("-Xep") }
+                    options.errorprone.enabled = false
                 }
             }
         }
@@ -83,11 +83,11 @@ subprojects {
 
     compileTestJava {
         // serialVersionUID is basically guaranteed to be useless in our tests
-        // LinkedList doesn't hurt much in tests and has lots of usages
         options.compilerArgs += [
-            "-Xlint:-serial",
-            "-Xep:JdkObsolete:OFF"
+            "-Xlint:-serial"
         ]
+        // LinkedList doesn't hurt much in tests and has lots of usages
+        options.errorprone.check("JdkObsolete", CheckSeverity.OFF)
     }
 
     jar.manifest {
@@ -184,8 +184,8 @@ subprojects {
                 // https://github.com/google/protobuf/issues/2718
                 it.options.compilerArgs += [
                     "-Xlint:-cast",
-                    "-XepExcludedPaths:.*/src/generated/[^/]+/java/.*",
                 ]
+                it.options.errorprone.excludedPaths = ".*/src/generated/[^/]+/java/.*"
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,9 @@ subprojects {
     apply plugin: "ru.vyarus.animalsniffer"
 
     apply plugin: "net.ltgt.errorprone"
-    // jdk10 not supported by errorprone: https://github.com/google/error-prone/issues/860
-    if (!JavaVersion.current().isJava10Compatible() &&
-        rootProject.properties.get('errorProne', true)) {
+    if (rootProject.properties.get('errorProne', true)) {
         dependencies {
-            errorprone 'com.google.errorprone:error_prone_core:2.3.1'
+            errorprone 'com.google.errorprone:error_prone_core:2.3.2'
             errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
             annotationProcessor 'com.google.guava:guava-beta-checker:1.0'

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -131,10 +131,13 @@ configurations {
 dependencies {
     testCompile project(':grpc-protobuf'),
             project(':grpc-stub')
+    testCompileOnly libraries.javax_annotation
     testLiteCompile project(':grpc-protobuf-lite'),
             project(':grpc-stub')
+    testLiteCompileOnly libraries.javax_annotation
     testNanoCompile project(':grpc-protobuf-nano'),
             project(':grpc-stub')
+    testNanoCompileOnly libraries.javax_annotation
 }
 
 sourceSets {

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -148,9 +148,9 @@ sourceSets {
 
 compileTestJava {
     options.compilerArgs += [
-        "-Xlint:-cast",
-        "-XepExcludedPaths:.*/build/generated/source/proto/.*",
+        "-Xlint:-cast"
     ]
+    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
 compileTestLiteJava {
@@ -161,10 +161,12 @@ compileTestLiteJava {
         "-Xlint:-unchecked",
         "-Xlint:-fallthrough"
     ]
+    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
 compileTestNanoJava {
     options.compilerArgs = compileTestJava.options.compilerArgs
+    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
 protobuf {

--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -672,7 +672,7 @@ public final class Metadata {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Key)) {
         return false;
       }
       Key<?> key = (Key<?>) o;

--- a/core/src/test/java/io/grpc/MetadataTest.java
+++ b/core/src/test/java/io/grpc/MetadataTest.java
@@ -77,7 +77,7 @@ public class MetadataTest {
     Fish cat = new Fish("cat");
     Metadata metadata = new Metadata();
 
-    assertEquals(null, metadata.get(KEY));
+    assertNull(metadata.get(KEY));
     metadata.put(KEY, lance);
     assertEquals(Arrays.asList(lance), Lists.newArrayList(metadata.getAll(KEY)));
     assertEquals(lance, metadata.get(KEY));
@@ -99,8 +99,8 @@ public class MetadataTest {
     assertEquals(Arrays.asList(lance, lance), Lists.newArrayList(metadata.getAll(KEY)));
 
     assertEquals(Arrays.asList(lance, lance), Lists.newArrayList(metadata.removeAll(KEY)));
-    assertEquals(null, metadata.getAll(KEY));
-    assertEquals(null, metadata.get(KEY));
+    assertNull(metadata.getAll(KEY));
+    assertNull(metadata.get(KEY));
   }
 
   @Test
@@ -110,16 +110,16 @@ public class MetadataTest {
 
     metadata.put(KEY, lance);
     metadata.discardAll(KEY);
-    assertEquals(null, metadata.getAll(KEY));
-    assertEquals(null, metadata.get(KEY));
+    assertNull(metadata.getAll(KEY));
+    assertNull(metadata.get(KEY));
   }
 
   @Test
   public void discardAll_empty() {
     Metadata metadata = new Metadata();
     metadata.discardAll(KEY);
-    assertEquals(null, metadata.getAll(KEY));
-    assertEquals(null, metadata.get(KEY));
+    assertNull(metadata.getAll(KEY));
+    assertNull(metadata.get(KEY));
   }
 
   @Test
@@ -334,7 +334,7 @@ public class MetadataTest {
     }
   }
 
-  private static class Fish {
+  private static final class Fish {
     private String name;
 
     private Fish(String name) {

--- a/core/src/test/java/io/grpc/ServerServiceDefinitionTest.java
+++ b/core/src/test/java/io/grpc/ServerServiceDefinitionTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import org.junit.Rule;
@@ -44,9 +45,9 @@ public class ServerServiceDefinitionTest {
       .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, "method2"))
       .build();
   private ServerCallHandler<String, Integer> methodHandler1
-      = new NoopServerCallHandler<String, Integer>();
+      = new NoopServerCallHandler<>();
   private ServerCallHandler<String, Integer> methodHandler2
-      = new NoopServerCallHandler<String, Integer>();
+      = new NoopServerCallHandler<>();
   private ServerMethodDefinition<String, Integer> methodDef1
         = ServerMethodDefinition.create(method1, methodHandler1);
   private ServerMethodDefinition<String, Integer> methodDef2
@@ -61,7 +62,7 @@ public class ServerServiceDefinitionTest {
         .build();
     assertSame(sd, ssd.getServiceDescriptor());
     assertEquals(Collections.<MethodDescriptor<?, ?>>emptyList(),
-        ssd.getServiceDescriptor().getMethods());
+        new ArrayList<>(ssd.getServiceDescriptor().getMethods()));
   }
 
   @Test
@@ -128,17 +129,17 @@ public class ServerServiceDefinitionTest {
         .build();
     assertEquals(serviceName, ssd.getServiceDescriptor().getName());
 
-    HashSet<MethodDescriptor<?, ?>> goldenMethods = new HashSet<MethodDescriptor<?, ?>>();
+    HashSet<MethodDescriptor<?, ?>> goldenMethods = new HashSet<>();
     goldenMethods.add(method1);
     goldenMethods.add(method2);
     assertEquals(goldenMethods,
-        new HashSet<MethodDescriptor<?, ?>>(ssd.getServiceDescriptor().getMethods()));
+        new HashSet<>(ssd.getServiceDescriptor().getMethods()));
 
     HashSet<ServerMethodDefinition<?, ?>> goldenMethodDefs
-        = new HashSet<ServerMethodDefinition<?, ?>>();
+        = new HashSet<>();
     goldenMethodDefs.add(methodDef1);
     goldenMethodDefs.add(methodDef2);
-    assertEquals(goldenMethodDefs, new HashSet<ServerMethodDefinition<?, ?>>(ssd.getMethods()));
+    assertEquals(goldenMethodDefs, new HashSet<>(ssd.getMethods()));
   }
 
   @Test
@@ -146,9 +147,9 @@ public class ServerServiceDefinitionTest {
     ServerServiceDefinition ssd = ServerServiceDefinition.builder(serviceName)
         .build();
     assertEquals(Collections.<MethodDescriptor<?, ?>>emptyList(),
-        ssd.getServiceDescriptor().getMethods());
+        new ArrayList<>(ssd.getServiceDescriptor().getMethods()));
     assertEquals(Collections.<ServerMethodDefinition<?, ?>>emptySet(),
-        new HashSet<ServerMethodDefinition<?, ?>>(ssd.getMethods()));
+        new HashSet<>(ssd.getMethods()));
   }
 
   private static class NoopServerCallHandler<ReqT, RespT>

--- a/core/src/test/java/io/grpc/ServiceDescriptorTest.java
+++ b/core/src/test/java/io/grpc/ServiceDescriptorTest.java
@@ -60,7 +60,7 @@ public class ServiceDescriptorTest {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("method");
 
-    new ServiceDescriptor("name", (Collections.<MethodDescriptor<?, ?>>singletonList(null)));
+    new ServiceDescriptor("name", Collections.<MethodDescriptor<?, ?>>singletonList(null));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -479,6 +479,7 @@ public class DelayedClientTransportTest {
 
     doAnswer(new Answer<PickResult>() {
         @Override
+        @SuppressWarnings("CatchAndPrintStackTrace")
         public PickResult answer(InvocationOnMock invocation) throws Throwable {
           if (nextPickShouldWait.compareAndSet(true, false)) {
             try {

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -35,7 +35,6 @@ import io.grpc.CompressorRegistry;
 import io.grpc.Context;
 import io.grpc.DecompressorRegistry;
 import io.grpc.InternalChannelz.ServerStats;
-import io.grpc.InternalChannelz.ServerStats.Builder;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
@@ -106,7 +105,7 @@ public class ServerCallImplTest {
 
   private void callTracer0(Status status) {
     CallTracer tracer = CallTracer.getDefaultFactory().create();
-    Builder beforeBuilder = new Builder();
+    ServerStats.Builder beforeBuilder = new ServerStats.Builder();
     tracer.updateBuilder(beforeBuilder);
     ServerStats before = beforeBuilder.build();
     assertEquals(0, before.callsStarted);
@@ -122,7 +121,7 @@ public class ServerCallImplTest {
     // end: required boilerplate
 
     call.close(status, new Metadata());
-    Builder afterBuilder = new Builder();
+    ServerStats.Builder afterBuilder = new ServerStats.Builder();
     tracer.updateBuilder(afterBuilder);
     ServerStats after = afterBuilder.build();
     assertEquals(1, after.callsStarted);

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -27,6 +27,9 @@ def nettyTcNativeVersion = '2.0.7.Final'
 def protobufVersion = '3.5.1'
 def protocVersion = '3.5.1-1'
 
+sourceCompatibility = 8
+targetCompatibility = 8
+
 dependencies {
     compile "com.google.api.grpc:proto-google-common-protos:1.0.0"
     compile "io.grpc:grpc-alts:${grpcVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -70,6 +70,13 @@
       <version>${protobuf.version}</version>
     </dependency>
     <dependency>
+      <!-- JDK 11 no longer have javax.annotation.Generated -->
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -163,7 +163,7 @@ final class GrpclbState {
   }
 
   void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState) {
-    if (newState.getState() == SHUTDOWN || !(subchannels.values().contains(subchannel))) {
+    if (newState.getState() == SHUTDOWN || !subchannels.values().contains(subchannel)) {
       return;
     }
     if (newState.getState() == IDLE) {

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -38,9 +38,11 @@ dependencies {
 
 configureProtoCompilation()
 
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 compileJava {
     // This isn't a library; it can use beta APIs
-    it.options.compilerArgs += ["-Xep:BetaApi:OFF"]
+    options.errorprone.check("BetaApi", CheckSeverity.OFF)
 }
 
 test {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -862,10 +862,7 @@ public abstract class AbstractInteropTest {
     StreamObserver<StreamingOutputCallRequest> requestStream = asyncStub.halfDuplexCall(recorder);
 
     final int numRequests = 10;
-    List<StreamingOutputCallRequest> requests =
-        new ArrayList<>(numRequests);
     for (int ix = numRequests; ix > 0; --ix) {
-      requests.add(request);
       requestStream.onNext(request);
     }
     requestStream.onCompleted();
@@ -1029,11 +1026,7 @@ public abstract class AbstractInteropTest {
         stub.fullDuplexCall(recorder);
 
     final int numRequests = 10;
-    List<StreamingOutputCallRequest> requests =
-        new ArrayList<>(numRequests);
-
     for (int ix = numRequests; ix > 0; --ix) {
-      requests.add(request);
       requestStream.onNext(request);
     }
     requestStream.onCompleted();

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -55,6 +55,7 @@ public class TestServiceClient {
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
+      @SuppressWarnings("CatchAndPrintStackTrace")
       public void run() {
         System.out.println("Shutting down");
         try {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.java
@@ -245,6 +245,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
     private Throwable failure;
     private Runnable dispatchTask = new Runnable() {
       @Override
+      @SuppressWarnings("CatchAndPrintStackTrace")
       public void run() {
         try {
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceServer.java
@@ -48,6 +48,7 @@ public class TestServiceServer {
         .addShutdownHook(
             new Thread() {
               @Override
+              @SuppressWarnings("CatchAndPrintStackTrace")
               public void run() {
                 try {
                   System.out.println("Shutting down");

--- a/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/NettyFlowControlTest.java
@@ -131,7 +131,7 @@ public class NettyFlowControlTest {
   private void doTest(int bandwidth, int latency) throws InterruptedException {
 
     int streamSize = 1 * 1024 * 1024;
-    long expectedWindow = (latency * (bandwidth / TimeUnit.SECONDS.toMillis(1)));
+    long expectedWindow = latency * (bandwidth / TimeUnit.SECONDS.toMillis(1));
 
     TestServiceGrpc.TestServiceStub stub = TestServiceGrpc.newStub(channel);
     StreamingOutputCallRequest.Builder builder = StreamingOutputCallRequest.newBuilder()
@@ -147,7 +147,7 @@ public class NettyFlowControlTest {
     int lastWindow = observer.waitFor();
 
     // deal with cases that either don't cause a window update or hit max window
-    expectedWindow = Math.min(MAX_WINDOW, (Math.max(expectedWindow, REGULAR_WINDOW)));
+    expectedWindow = Math.min(MAX_WINDOW, Math.max(expectedWindow, REGULAR_WINDOW));
 
     // Range looks large, but this allows for only one extra/missed window update
     // (one extra update causes a 2x difference and one missed update causes a .5x difference)

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -13,11 +13,11 @@ dependencies {
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 [compileJava, compileTestJava].each() {
     // Netty retuns a lot of futures that we mostly don't care about.
-    it.options.compilerArgs += [
-        "-Xep:FutureReturnValueIgnored:OFF"
-    ]
+    it.options.errorprone.check("FutureReturnValueIgnored", CheckSeverity.OFF)
 }
 
 javadoc {

--- a/netty/src/jmh/java/io/grpc/netty/InboundHeadersBenchmark.java
+++ b/netty/src/jmh/java/io/grpc/netty/InboundHeadersBenchmark.java
@@ -18,7 +18,6 @@ package io.grpc.netty;
 
 import static io.grpc.netty.Utils.CONTENT_TYPE_HEADER;
 import static io.grpc.netty.Utils.TE_TRAILERS;
-import static io.netty.util.AsciiString.of;
 
 import io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2RequestHeaders;
 import io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2ResponseHeaders;
@@ -53,33 +52,33 @@ public class InboundHeadersBenchmark {
   private static void setupRequestHeaders() {
     requestHeaders = new AsciiString[18];
     int i = 0;
-    requestHeaders[i++] = of(":method");
-    requestHeaders[i++] = of("POST");
-    requestHeaders[i++] = of(":scheme");
-    requestHeaders[i++] = of("http");
-    requestHeaders[i++] = of(":path");
-    requestHeaders[i++] = of("/google.pubsub.v2.PublisherService/CreateTopic");
-    requestHeaders[i++] = of(":authority");
-    requestHeaders[i++] = of("pubsub.googleapis.com");
-    requestHeaders[i++] = of("te");
-    requestHeaders[i++] = of("trailers");
-    requestHeaders[i++] = of("grpc-timeout");
-    requestHeaders[i++] = of("1S");
-    requestHeaders[i++] = of("content-type");
-    requestHeaders[i++] = of("application/grpc+proto");
-    requestHeaders[i++] = of("grpc-encoding");
-    requestHeaders[i++] = of("gzip");
-    requestHeaders[i++] = of("authorization");
-    requestHeaders[i] = of("Bearer y235.wef315yfh138vh31hv93hv8h3v");
+    requestHeaders[i++] = AsciiString.of(":method");
+    requestHeaders[i++] = AsciiString.of("POST");
+    requestHeaders[i++] = AsciiString.of(":scheme");
+    requestHeaders[i++] = AsciiString.of("http");
+    requestHeaders[i++] = AsciiString.of(":path");
+    requestHeaders[i++] = AsciiString.of("/google.pubsub.v2.PublisherService/CreateTopic");
+    requestHeaders[i++] = AsciiString.of(":authority");
+    requestHeaders[i++] = AsciiString.of("pubsub.googleapis.com");
+    requestHeaders[i++] = AsciiString.of("te");
+    requestHeaders[i++] = AsciiString.of("trailers");
+    requestHeaders[i++] = AsciiString.of("grpc-timeout");
+    requestHeaders[i++] = AsciiString.of("1S");
+    requestHeaders[i++] = AsciiString.of("content-type");
+    requestHeaders[i++] = AsciiString.of("application/grpc+proto");
+    requestHeaders[i++] = AsciiString.of("grpc-encoding");
+    requestHeaders[i++] = AsciiString.of("gzip");
+    requestHeaders[i++] = AsciiString.of("authorization");
+    requestHeaders[i] = AsciiString.of("Bearer y235.wef315yfh138vh31hv93hv8h3v");
   }
 
   private static void setupResponseHeaders() {
     responseHeaders = new AsciiString[4];
     int i = 0;
-    responseHeaders[i++] = of(":status");
-    responseHeaders[i++] = of("200");
-    responseHeaders[i++] = of("grpc-encoding");
-    responseHeaders[i] = of("gzip");
+    responseHeaders[i++] = AsciiString.of(":status");
+    responseHeaders[i++] = AsciiString.of("200");
+    responseHeaders[i++] = AsciiString.of("grpc-encoding");
+    responseHeaders[i] = AsciiString.of("gzip");
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
+++ b/netty/src/main/java/io/grpc/netty/CancelServerStreamCommand.java
@@ -24,7 +24,7 @@ import io.grpc.Status;
 /**
  * Command sent from a Netty server stream to the handler to cancel the stream.
  */
-class CancelServerStreamCommand extends WriteQueue.AbstractQueuedCommand {
+final class CancelServerStreamCommand extends WriteQueue.AbstractQueuedCommand {
   private final NettyServerStream.TransportState stream;
   private final Status reason;
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -365,7 +365,7 @@ class NettyServerHandler extends AbstractNettyHandler {
 
   private void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers)
       throws Http2Exception {
-    if (!teWarningLogged && !TE_TRAILERS.equals(headers.get(TE_HEADER))) {
+    if (!teWarningLogged && !TE_TRAILERS.contentEquals(headers.get(TE_HEADER))) {
       logger.warning(String.format("Expected header TE: %s, but %s is received. This means "
               + "some intermediate proxy may not support trailers",
           TE_TRAILERS, headers.get(TE_HEADER)));
@@ -405,7 +405,7 @@ class NettyServerHandler extends AbstractNettyHandler {
         return;
       }
 
-      if (!HTTP_METHOD.equals(headers.method())) {
+      if (!HTTP_METHOD.contentEquals(headers.method())) {
         respondWithHttpError(ctx, streamId, 405, Status.Code.INTERNAL,
             String.format("Method '%s' is not supported", headers.method()));
         return;

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -25,7 +25,7 @@ import io.netty.channel.ChannelPromise;
 /**
  * Command sent from the transport to the Netty channel to send a GRPC frame to the remote endpoint.
  */
-class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.QueuedCommand {
+final class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.QueuedCommand {
   private final StreamIdHolder stream;
   private final boolean endStream;
 

--- a/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendResponseHeadersCommand.java
@@ -24,7 +24,7 @@ import io.netty.handler.codec.http2.Http2Headers;
 /**
  * Command sent from the transport to the Netty channel to send response headers to the client.
  */
-class SendResponseHeadersCommand extends WriteQueue.AbstractQueuedCommand {
+final class SendResponseHeadersCommand extends WriteQueue.AbstractQueuedCommand {
   private final StreamIdHolder stream;
   private final Http2Headers headers;
   private final Status status;

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
@@ -42,6 +42,7 @@ import org.junit.runners.JUnit4;
  * Tests for {@link GrpcHttp2HeadersUtils}.
  */
 @RunWith(JUnit4.class)
+@SuppressWarnings({ "BadImport", "UndefinedEquals" }) // AsciiString.of and AsciiString.equals
 public class GrpcHttp2HeadersUtilsTest {
 
   private static final SensitivityDetector NEVER_SENSITIVE = new SensitivityDetector() {

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2InboundHeadersTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2InboundHeadersTest.java
@@ -36,6 +36,7 @@ import org.junit.runners.JUnit4;
  * Tests for {@link GrpcHttp2RequestHeaders} and {@link GrpcHttp2ResponseHeaders}.
  */
 @RunWith(JUnit4.class)
+@SuppressWarnings({ "BadImport", "UndefinedEquals" }) // AsciiString.of and AsciiString.equals
 public class GrpcHttp2InboundHeadersTest {
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/UtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/UtilsTest.java
@@ -107,6 +107,7 @@ public class UtilsTest {
   }
 
   @Test
+  @SuppressWarnings("UndefinedEquals") // AsciiString.equals
   public void convertServerHeaders_sanitizes() {
     Metadata metaData = new Metadata();
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -336,18 +336,21 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     Preconditions.checkNotNull(method, "method");
     Preconditions.checkNotNull(headers, "headers");
     StatsTraceContext statsTraceCtx = StatsTraceContext.newClientContext(callOptions, headers);
-    return new OkHttpClientStream(
-        method,
-        headers,
-        frameWriter,
-        OkHttpClientTransport.this,
-        outboundFlow,
-        lock,
-        maxMessageSize,
-        defaultAuthority,
-        userAgent,
-        statsTraceCtx,
-        transportTracer);
+    // FIXME: it is likely wrong to pass the transportTracer here as it'll exit the lock's scope
+    synchronized (lock) {
+      return new OkHttpClientStream(
+          method,
+          headers,
+          frameWriter,
+          OkHttpClientTransport.this,
+          outboundFlow,
+          lock,
+          maxMessageSize,
+          defaultAuthority,
+          userAgent,
+          statsTraceCtx,
+          transportTracer);
+    }
   }
 
   @GuardedBy("lock")

--- a/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/OkHostnameVerifier.java
+++ b/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/OkHostnameVerifier.java
@@ -168,13 +168,13 @@ public final class OkHostnameVerifier implements HostnameVerifier {
   private boolean verifyHostName(String hostName, String pattern) {
     // Basic sanity checks
     // Check length == 0 instead of .isEmpty() to support Java 5.
-    if ((hostName == null) || (hostName.length() == 0) || (hostName.startsWith("."))
-        || (hostName.endsWith(".."))) {
+    if (hostName == null || hostName.length() == 0 || hostName.startsWith(".")
+        || hostName.endsWith("..")) {
       // Invalid domain name
       return false;
     }
-    if ((pattern == null) || (pattern.length() == 0) || (pattern.startsWith("."))
-        || (pattern.endsWith(".."))) {
+    if (pattern == null || pattern.length() == 0 || pattern.startsWith(".")
+        || pattern.endsWith("..")) {
       // Invalid pattern/domain name
       return false;
     }
@@ -215,7 +215,7 @@ public final class OkHostnameVerifier implements HostnameVerifier {
     //    sub.test.example.com.
     // 3. Wildcard patterns for single-label domain names are not permitted.
 
-    if ((!pattern.startsWith("*.")) || (pattern.indexOf('*', 1) != -1)) {
+    if (!pattern.startsWith("*.") || pattern.indexOf('*', 1) != -1) {
       // Asterisk (*) is only permitted in the left-most domain name label and must be the only
       // character in that label
       return false;
@@ -243,8 +243,8 @@ public final class OkHostnameVerifier implements HostnameVerifier {
 
     // Check that asterisk did not match across domain name labels.
     int suffixStartIndexInHostName = hostName.length() - suffix.length();
-    if ((suffixStartIndexInHostName > 0)
-        && (hostName.lastIndexOf('.', suffixStartIndexInHostName - 1) != -1)) {
+    if (suffixStartIndexInHostName > 0
+        && hostName.lastIndexOf('.', suffixStartIndexInHostName - 1) != -1) {
       // Asterisk is matching across domain name labels -- not permitted.
       return false;
     }

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -34,9 +34,9 @@ compileTestJava {
     options.compilerArgs += [
         "-Xlint:-rawtypes",
         "-Xlint:-unchecked",
-        "-Xlint:-fallthrough",
-        "-XepExcludedPaths:.*/build/generated/source/proto/.*"
+        "-Xlint:-fallthrough"
     ]
+    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
 protobuf {

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     compile libraries.re2j
 
     compileOnly libraries.javax_annotation
+    testCompileOnly libraries.javax_annotation
     testCompile project(':grpc-testing'),
             libraries.netty_epoll // for DomainSocketAddress
     signature "org.codehaus.mojo.signature:java17:1.0@signature"

--- a/services/src/main/java/io/grpc/services/BinlogHelper.java
+++ b/services/src/main/java/io/grpc/services/BinlogHelper.java
@@ -57,7 +57,6 @@ import io.grpc.binarylog.v1.Address.Type;
 import io.grpc.binarylog.v1.GrpcLogEntry;
 import io.grpc.binarylog.v1.GrpcLogEntry.EventType;
 import io.grpc.binarylog.v1.Message;
-import io.grpc.binarylog.v1.Message.Builder;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -255,7 +254,7 @@ final class BinlogHelper {
       if (marshaller != BYTEARRAY_MARSHALLER) {
         throw new IllegalStateException("Expected the BinaryLog's ByteArrayMarshaller");
       }
-      MaybeTruncated<Builder> pair = createMessageProto((byte[]) message, maxMessageBytes);
+      MaybeTruncated<Message.Builder> pair = createMessageProto((byte[]) message, maxMessageBytes);
       GrpcLogEntry.Builder entryBuilder = newTimestampedBuilder()
           .setSequenceIdWithinCall(seq)
           .setType(eventType)

--- a/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
+++ b/services/src/main/java/io/grpc/services/ChannelzProtoUtil.java
@@ -58,7 +58,6 @@ import io.grpc.channelz.v1.Server;
 import io.grpc.channelz.v1.ServerData;
 import io.grpc.channelz.v1.ServerRef;
 import io.grpc.channelz.v1.Socket;
-import io.grpc.channelz.v1.Socket.Builder;
 import io.grpc.channelz.v1.SocketData;
 import io.grpc.channelz.v1.SocketOption;
 import io.grpc.channelz.v1.SocketOptionLinger;
@@ -174,7 +173,7 @@ final class ChannelzProtoUtil {
 
   static Socket toSocket(InternalInstrumented<SocketStats> obj) {
     SocketStats socketStats = getFuture(obj.getStats());
-    Builder builder = Socket.newBuilder()
+    Socket.Builder builder = Socket.newBuilder()
         .setRef(toSocketRef(obj))
         .setLocal(toAddress(socketStats.local));
     if (socketStats.security != null) {

--- a/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/ProtoReflectionServiceTest.java
@@ -66,9 +66,9 @@ public class ProtoReflectionServiceTest {
   private MutableHandlerRegistry handlerRegistry = new MutableHandlerRegistry();
   private BindableService reflectionService;
   private ServerServiceDefinition dynamicService =
-      (new DynamicServiceGrpc.DynamicServiceImplBase() {}).bindService();
+      new DynamicServiceGrpc.DynamicServiceImplBase() {}.bindService();
   private ServerServiceDefinition anotherDynamicService =
-      (new AnotherDynamicServiceGrpc.AnotherDynamicServiceImplBase() {}).bindService();
+      new AnotherDynamicServiceGrpc.AnotherDynamicServiceImplBase() {}.bindService();
   private Server server;
   private ManagedChannel channel;
   private ServerReflectionGrpc.ServerReflectionStub stub;


### PR DESCRIPTION
Note that the update of Error Prone past 2.3.1 adds a lot of warnings, and emits an error related to `GuardedBy` (I changed the code to please Error Prone, and added a FIXME because I think Error Prone is right, and the change is not a real fix).