### PR TITLE
core: finalize convenient overrides on LoadBalancer.Helper and Subchannel.

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -462,12 +462,9 @@ public abstract class LoadBalancer {
      * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
      * Subchannels within {@link #shutdown}.
      *
-     * <p>The default implementation calls {@link #createSubchannel(List, Attributes)}.
-     * Implementations should not override this method.
-     *
      * @since 1.2.0
      */
-    public Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
+    public final Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
       Preconditions.checkNotNull(addrs, "addrs");
       return createSubchannel(Collections.singletonList(addrs), attrs);
     }
@@ -493,14 +490,11 @@ public abstract class LoadBalancer {
      * {@link #createSubchannel} when the new and old addresses overlap, since the subchannel can
      * continue using an existing connection.
      *
-     * <p>The default implementation calls {@link #updateSubchannelAddresses(
-     * LoadBalancer.Subchannel, List)}. Implementations should not override this method.
-     *
      * @throws IllegalArgumentException if {@code subchannel} was not returned from {@link
      *     #createSubchannel}
      * @since 1.4.0
      */
-    public void updateSubchannelAddresses(
+    public final void updateSubchannelAddresses(
         Subchannel subchannel, EquivalentAddressGroup addrs) {
       Preconditions.checkNotNull(addrs, "addrs");
       updateSubchannelAddresses(subchannel, Collections.singletonList(addrs));
@@ -625,14 +619,11 @@ public abstract class LoadBalancer {
      * Returns the addresses that this Subchannel is bound to. The default implementation calls
      * getAllAddresses().
      *
-     * <p>The default implementation calls {@link #getAllAddresses()}. Implementations should not
-     * override this method.
-     *
      * @throws IllegalStateException if this subchannel has more than one EquivalentAddressGroup.
      *     Use getAllAddresses() instead
      * @since 1.2.0
      */
-    public EquivalentAddressGroup getAddresses() {
+    public final EquivalentAddressGroup getAddresses() {
       List<EquivalentAddressGroup> groups = getAllAddresses();
       Preconditions.checkState(groups.size() == 1, "Does not have exactly one group");
       return groups.get(0);

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -454,13 +454,8 @@ public abstract class LoadBalancer {
   @ThreadSafe
   public abstract static class Helper {
     /**
-     * Creates a Subchannel, which is a logical connection to the given group of addresses which are
-     * considered equivalent.  The {@code attrs} are custom attributes associated with this
-     * Subchannel, and can be accessed later through {@link Subchannel#getAttributes
-     * Subchannel.getAttributes()}.
-     *
-     * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
-     * Subchannels within {@link #shutdown}.
+     * Equivalent to {@link #createSubchannel(List, Attributes)} with the given single {@code
+     * EquivalentAddressGroup}.
      *
      * @since 1.2.0
      */
@@ -486,12 +481,9 @@ public abstract class LoadBalancer {
     }
 
     /**
-     * Replaces the existing addresses used with {@code subchannel}. This method is superior to
-     * {@link #createSubchannel} when the new and old addresses overlap, since the subchannel can
-     * continue using an existing connection.
+     * Equivalent to {@link #updateSubchannelAddresses(io.grpc.LoadBalancer.Subchannel, List)} with
+     * the given single {@code EquivalentAddressGroup}.
      *
-     * @throws IllegalArgumentException if {@code subchannel} was not returned from {@link
-     *     #createSubchannel}
      * @since 1.4.0
      */
     public final void updateSubchannelAddresses(
@@ -616,11 +608,12 @@ public abstract class LoadBalancer {
     public abstract void requestConnection();
 
     /**
-     * Returns the addresses that this Subchannel is bound to. The default implementation calls
-     * getAllAddresses().
+     * Returns the addresses that this Subchannel is bound to.  This can be called only if
+     * the Subchannel has only one {@link EquivalentAddressGroup}.  Under the hood it calls
+     * {@link #getAllAddresses}.
      *
      * @throws IllegalStateException if this subchannel has more than one EquivalentAddressGroup.
-     *     Use getAllAddresses() instead
+     *         Use {@link #getAllAddresses} instead
      * @since 1.2.0
      */
     public final EquivalentAddressGroup getAddresses() {

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
@@ -36,19 +36,8 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
   protected abstract LoadBalancer.Helper delegate();
 
   @Override
-  public Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
-    return delegate().createSubchannel(addrs, attrs);
-  }
-
-  @Override
   public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
     return delegate().createSubchannel(addrs, attrs);
-  }
-
-  @Override
-  public void updateSubchannelAddresses(
-      Subchannel subchannel, EquivalentAddressGroup addrs) {
-    delegate().updateSubchannelAddresses(subchannel, addrs);
   }
 
   @Override

--- a/core/src/test/java/io/grpc/PickFirstLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/PickFirstLoadBalancerTest.java
@@ -84,7 +84,7 @@ public class PickFirstLoadBalancerTest {
       socketAddresses.add(addr);
     }
 
-    when(mockSubchannel.getAddresses()).thenThrow(new UnsupportedOperationException());
+    when(mockSubchannel.getAllAddresses()).thenThrow(new UnsupportedOperationException());
     when(mockHelper.createSubchannel(
         anyListOf(EquivalentAddressGroup.class), any(Attributes.class)))
         .thenReturn(mockSubchannel);

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -222,7 +222,7 @@ public class GrpclbLoadBalancerTest {
           Subchannel subchannel = mock(Subchannel.class);
           EquivalentAddressGroup eag = (EquivalentAddressGroup) invocation.getArguments()[0];
           Attributes attrs = (Attributes) invocation.getArguments()[1];
-          when(subchannel.getAddresses()).thenReturn(eag);
+          when(subchannel.getAllAddresses()).thenReturn(Arrays.asList(eag));
           when(subchannel.getAttributes()).thenReturn(attrs);
           mockSubchannels.add(subchannel);
           subchannelTracker.add(subchannel);
@@ -262,6 +262,7 @@ public class GrpclbLoadBalancerTest {
   }
 
   @After
+  @SuppressWarnings("unchecked")
   public void tearDown() {
     try {
       if (balancer != null) {
@@ -285,7 +286,7 @@ public class GrpclbLoadBalancerTest {
         verify(subchannel, never()).shutdown();
       }
       verify(helper, never())
-          .createSubchannel(any(EquivalentAddressGroup.class), any(Attributes.class));
+          .createSubchannel(any(List.class), any(Attributes.class));
       // No timer should linger after shutdown
       assertThat(fakeClock.getPendingTasks()).isEmpty();
     } finally {


### PR DESCRIPTION
Those overrides are kept for backward compatibility and convenience
for callers.  Documentation already says implementations should not
override them.  Making them final reduces confusion around which
override should be verified in tests and be overridden in forwarding
classes, thus prevents bugs caused by such confusion.