### PR TITLE
Tweak interop client to be able use GoogleDefaultChannels on jwt and compute engine tests

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -267,7 +267,11 @@ public class TestServiceClient {
         break;
 
       case COMPUTE_ENGINE_CREDS:
-        tester.computeEngineCreds(defaultServiceAccount, oauthScope);
+        if ("google_default_credentials".equals(customCredentialsType)) {
+          tester.computeEngineCreds(defaultServiceAccount, oauthScope, true);
+        } else {
+          tester.computeEngineCreds(defaultServiceAccount, oauthScope, false);
+        }
         break;
 
       case SERVICE_ACCOUNT_CREDS: {
@@ -279,7 +283,11 @@ public class TestServiceClient {
 
       case JWT_TOKEN_CREDS: {
         FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));
-        tester.jwtTokenCreds(credentialsStream);
+        if ("google_default_credentials".equals(customCredentialsType)) {
+          tester.jwtTokenCreds(credentialsStream, true);
+        } else {
+          tester.jwtTokenCreds(credentialsStream, false);
+        }
         break;
       }
 


### PR DESCRIPTION
It would be nice to get the `GoogleDefaultCredentials` creds of all languages (C++, java, and go for now) running two cloud-to-prod-auth interop tests: `compute_engine_creds` and `jwt_token_creds`. The combination of running `compute_engine_creds` <i>on GCP</i> and `jwt_token_creds` from [outside of GCP](https://github.com/grpc/grpc/blob/master/tools/internal_ci/macos/grpc_interop_toprod.sh) exercises the fetching of the OAuth token from the metadata server when on GCP, and from a local file when ran outside of GCP.

This is just one idea for how to tweak the interop client to be able to run these tests