### PR TITLE
travis: Drop testing for Java 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ jdk:
   # processor based plugin.
   - oraclejdk8  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
   - oraclejdk9  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
-  - oraclejdk10
 
 notifications:
   email: false


### PR DESCRIPTION
oracle10 is failing during setup with:
The command "bash install-jdk.sh -F 10 -L BCL --target $JAVA_HOME --workspace ${TRAVIS_HOME}/.cache/install-jdk" failed and exited with 8 during .

We should be adding support for Java 11 and dropping Java 9-10 anyway,
since Java 9-10 are unsupported.