### PR TITLE
Add build support for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jdk:
   # processor based plugin.
   - oraclejdk8  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
   - oraclejdk9  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
-  - oraclejdk11
+  - openjdk11
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jdk:
   # processor based plugin.
   - oraclejdk8  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
   - oraclejdk9  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
+  - oraclejdk11
 
 notifications:
   email: false

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -32,6 +32,7 @@ dependencies {
         // prefer 20.0 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
     }
+    compileOnly libraries.javax_annotation
     runtime project(':grpc-grpclb')
     testCompile libraries.guava,
             libraries.guava_testlib,

--- a/build.gradle
+++ b/build.gradle
@@ -297,6 +297,10 @@ subprojects {
         }
     }
 
+    jacoco {
+        toolVersion = "0.8.2"
+    }
+
     checkstyle {
         configDir = file("$rootDir/buildscripts")
         toolVersion = "6.17"

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -130,11 +130,14 @@ configurations {
 
 dependencies {
     testCompile project(':grpc-protobuf'),
-            project(':grpc-stub')
+            project(':grpc-stub'),
+            libraries.javax_annotation
     testLiteCompile project(':grpc-protobuf-lite'),
-            project(':grpc-stub')
+            project(':grpc-stub'),
+            libraries.javax_annotation
     testNanoCompile project(':grpc-protobuf-nano'),
-            project(':grpc-stub')
+            project(':grpc-stub'),
+            libraries.javax_annotation
 }
 
 sourceSets {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -17,6 +17,9 @@ repositories {
     mavenLocal()
 }
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 // IMPORTANT: You probably want the non-SNAPSHOT version of gRPC. Make sure you
 // are looking at a tagged version of the example and not "master"!
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -41,6 +41,12 @@
       <version>${grpc.version}</version>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.2</version>
+      <scope>provided</scope> <!-- not needed at runtime -->
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <version>${grpc.version}</version>

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -96,6 +96,7 @@ public class ProtocolNegotiatorsTest {
     sslContext = GrpcSslContexts.forServer(serverCert, key)
         .ciphers(TestUtils.preferredTestCiphers(), SupportedCipherSuiteFilter.INSTANCE).build();
     engine = SSLContext.getDefault().createSSLEngine();
+    engine.setUseClientMode(true);
   }
 
   @Test

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compileOnly libraries.javax_annotation
     testCompile project(':grpc-testing'),
             libraries.netty_epoll // for DomainSocketAddress
+    testCompileOnly libraries.javax_annotation
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 


### PR DESCRIPTION
It appears everything was already working on Java 11, except
build-specific and testing issues. Updating to Netty 4.1.30 (#4940)
probably fixed the last true Java 11 incompatibility.

Fixes #4933