### PR TITLE
compiler: propegate -fstack-protector flag to linker

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -103,7 +103,7 @@ model {
                     // Link other (system) libraries dynamically.
                     // Clang under OSX doesn't support these options.
                     linker.args "-Wl,-Bstatic", "-lprotoc", "-lprotobuf", "-static-libgcc",
-                            "-static-libstdc++",
+                            "-static-libstdc++", "-fstack-protector",
                             "-Wl,-Bdynamic", "-lpthread", "-s"
                 }
                 addEnvArgs("LDFLAGS", linker.args)


### PR DESCRIPTION
On Illumos / SmartOS / Solaris the '-fstack-protector' needs to be propegated to the linker in order for the build to succeed.

This commit improves gRPC to allow the gRPC compiler to be used on Illumos, SmartOS and Solaris.