### PR TITLE
core: annotate Attributes key annotations as experimental API. (#4974) (1.16.x backport)

### DIFF
--- a/core/src/main/java/io/grpc/EquivalentAddressGroup.java
+++ b/core/src/main/java/io/grpc/EquivalentAddressGroup.java
@@ -136,6 +136,7 @@ public final class EquivalentAddressGroup {
    * Annotation for {@link EquivalentAddressGroup}'s attributes. It follows the annotation semantics
    * defined by {@link Attributes}.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4972")
   @Retention(RetentionPolicy.SOURCE)
   @Documented
   public @interface Attr {}

--- a/core/src/main/java/io/grpc/Grpc.java
+++ b/core/src/main/java/io/grpc/Grpc.java
@@ -58,6 +58,7 @@ public final class Grpc {
    * Annotation for transport attributes. It follows the annotation semantics defined
    * by {@link Attributes}.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4972")
   @Retention(RetentionPolicy.SOURCE)
   @Documented
   public @interface TransportAttr {}

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -129,6 +129,7 @@ public abstract class NameResolver {
    *
    * @since 1.0.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
   @ThreadSafe
   public interface Listener {
     /**
@@ -157,6 +158,7 @@ public abstract class NameResolver {
    * Annotation for name resolution result attributes. It follows the annotation semantics defined
    * by {@link Attributes}.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4972")
   @Retention(RetentionPolicy.SOURCE)
   @Documented
   public @interface ResolutionResultAttr {}


### PR DESCRIPTION
Also annotate NameResolver.Listener as experimental because
annotations of an outer class don't show in the javadoc page of its
inner classes.

This is a backport of #4974