### PR TITLE
Revert "core: promote CallCredentials API v2. (#4952)"

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Any;
 import io.grpc.Attributes;
+import io.grpc.CallCredentials;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz.OtherSecurity;
 import io.grpc.InternalChannelz.Security;
@@ -27,7 +28,6 @@ import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.alts.internal.RpcProtocolVersionsUtil.RpcVersionsCheckResult;
 import io.grpc.alts.internal.TsiHandshakeHandler.TsiHandshakeCompletionEvent;
-import io.grpc.internal.GrpcAttributes;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
 import io.grpc.netty.ProtocolNegotiator;
 import io.grpc.netty.ProtocolNegotiators.AbstractBufferingHandler;
@@ -146,7 +146,7 @@ public abstract class AltsProtocolNegotiator implements ProtocolNegotiator {
                     .set(ALTS_CONTEXT_KEY, altsContext)
                     .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
                     .set(Grpc.TRANSPORT_ATTR_LOCAL_ADDR, ctx.channel().localAddress())
-                    .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
+                    .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
                     .build(),
                 new Security(new OtherSecurity("alts", Any.pack(altsContext.context))));
           }

--- a/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
@@ -24,12 +24,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import io.grpc.Attributes;
+import io.grpc.CallCredentials;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
 import io.grpc.SecurityLevel;
 import io.grpc.alts.internal.TsiFrameProtector.Consumer;
 import io.grpc.alts.internal.TsiPeer.Property;
-import io.grpc.internal.GrpcAttributes;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -348,7 +348,7 @@ public class AltsProtocolNegotiatorTest {
         .isEqualTo("embedded");
     assertThat(grpcHandler.attrs.get(Grpc.TRANSPORT_ATTR_LOCAL_ADDR).toString())
         .isEqualTo("embedded");
-    assertThat(grpcHandler.attrs.get(GrpcAttributes.ATTR_SECURITY_LEVEL))
+    assertThat(grpcHandler.attrs.get(CallCredentials.ATTR_SECURITY_LEVEL))
         .isEqualTo(SecurityLevel.PRIVACY_AND_INTEGRITY);
   }
 

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -22,7 +22,7 @@ import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
-import io.grpc.CallCredentials;
+import io.grpc.CallCredentials2;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -46,7 +46,7 @@ import javax.annotation.Nullable;
 /**
  * Wraps {@link Credentials} as a {@link CallCredentials}.
  */
-final class GoogleAuthLibraryCallCredentials extends CallCredentials {
+final class GoogleAuthLibraryCallCredentials extends CallCredentials2 {
   private static final Logger log
       = Logger.getLogger(GoogleAuthLibraryCallCredentials.class.getName());
   private static final JwtHelper jwtHelper

--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -39,8 +39,8 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.CallCredentials.MetadataApplier;
+import io.grpc.CallCredentials2;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -393,7 +393,7 @@ public class GoogleAuthLibraryCallCredentialsTest {
     return savedPendingRunnables.size();
   }
 
-  private final class RequestInfoImpl extends CallCredentials.RequestInfo {
+  private final class RequestInfoImpl extends CallCredentials2.RequestInfo {
     final String authority;
     final SecurityLevel securityLevel;
 

--- a/core/src/main/java/io/grpc/CallCredentials2.java
+++ b/core/src/main/java/io/grpc/CallCredentials2.java
@@ -16,13 +16,69 @@
 
 package io.grpc;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.Executor;
+
 /**
  * The new interface for {@link CallCredentials}.
  *
- * @deprecated implementations should subclass {@link CallCredentials} instead. This name is part
- *             of a migration and will be deleted in the next release.
+ * <p>THIS CLASS NAME IS TEMPORARY and is part of a migration. This class will BE DELETED as it
+ * replaces {@link CallCredentials} in short-term.  THIS CLASS SHOULD ONLY BE REFERENCED BY
+ * IMPLEMENTIONS.  All consumers should still reference {@link CallCredentials}.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4901")
-@Deprecated
-public abstract class CallCredentials2 extends CallCredentials {
+public abstract class CallCredentials2 implements CallCredentials {
+  /**
+   * Pass the credential data to the given {@link CallCredentials.MetadataApplier}, which will
+   * propagate it to the request metadata.
+   *
+   * <p>It is called for each individual RPC, within the {@link Context} of the call, before the
+   * stream is about to be created on a transport. Implementations should not block in this
+   * method. If metadata is not immediately available, e.g., needs to be fetched from network, the
+   * implementation may give the {@code applier} to an asynchronous task which will eventually call
+   * the {@code applier}. The RPC proceeds only after the {@code applier} is called.
+   *
+   * @param requestInfo request-related information
+   * @param appExecutor The application thread-pool. It is provided to the implementation in case it
+   *        needs to perform blocking operations.
+   * @param applier The outlet of the produced headers. It can be called either before or after this
+   *        method returns.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
+  public abstract void applyRequestMetadata(
+      RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier);
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public final void applyRequestMetadata(
+      final MethodDescriptor<?, ?> method, final Attributes attrs,
+      Executor appExecutor, CallCredentials.MetadataApplier applier) {
+    final String authority = checkNotNull(attrs.get(ATTR_AUTHORITY), "authority");
+    final SecurityLevel securityLevel =
+        firstNonNull(attrs.get(ATTR_SECURITY_LEVEL), SecurityLevel.NONE);
+    RequestInfo requestInfo = new RequestInfo() {
+        @Override
+        public MethodDescriptor<?, ?> getMethodDescriptor() {
+          return method;
+        }
+
+        @Override
+        public SecurityLevel getSecurityLevel() {
+          return securityLevel;
+        }
+
+        @Override
+        public String getAuthority() {
+          return authority;
+        }
+
+        @Override
+        public Attributes getTransportAttrs() {
+          return attrs;
+        }
+      };
+    applyRequestMetadata(requestInfo, appExecutor, applier);
+  }
 }

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -21,13 +21,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
-import io.grpc.CallCredentials.RequestInfo;
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
-import io.grpc.internal.GrpcAttributes;
 import java.net.SocketAddress;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -74,38 +72,23 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public ClientStream newStream(
-        final MethodDescriptor<?, ?> method, Metadata headers, final CallOptions callOptions) {
+        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
       CallCredentials creds = callOptions.getCredentials();
       if (creds != null) {
-        final Attributes attrs = delegate.getAttributes();
         MetadataApplierImpl applier = new MetadataApplierImpl(
             delegate, method, headers, callOptions);
-        RequestInfo requestInfo = new RequestInfo() {
-            @Override
-            public MethodDescriptor<?, ?> getMethodDescriptor() {
-              return method;
-            }
-
-            @Override
-            public SecurityLevel getSecurityLevel() {
-              return firstNonNull(
-                  attrs.get(GrpcAttributes.ATTR_SECURITY_LEVEL), SecurityLevel.NONE);
-            }
-
-            @Override
-            public String getAuthority() {
-              return firstNonNull(callOptions.getAuthority(), authority);
-            }
-
-            @Override
-            public Attributes getTransportAttrs() {
-              return attrs;
-            }
-          };
+        Attributes.Builder effectiveAttrsBuilder = Attributes.newBuilder()
+            .set(CallCredentials.ATTR_AUTHORITY, authority)
+            .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
+            .setAll(delegate.getAttributes());
+        if (callOptions.getAuthority() != null) {
+          effectiveAttrsBuilder.set(CallCredentials.ATTR_AUTHORITY, callOptions.getAuthority());
+        }
         try {
-          creds.applyRequestMetadata(
-              requestInfo, firstNonNull(callOptions.getExecutor(), appExecutor), applier);
+          creds.applyRequestMetadata(method, effectiveAttrsBuilder.build(),
+              firstNonNull(callOptions.getExecutor(), appExecutor), applier);
         } catch (Throwable t) {
           applier.fail(Status.UNAUTHENTICATED
               .withDescription("Credentials should use fail() instead of throwing exceptions")

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -54,9 +54,10 @@ public final class GrpcAttributes {
    * The security level of the transport.  If it's not present, {@link SecurityLevel#NONE} should be
    * assumed.
    */
+  @SuppressWarnings("deprecation")
   @Grpc.TransportAttr
   public static final Attributes.Key<SecurityLevel> ATTR_SECURITY_LEVEL =
-      Attributes.Key.create("io.grpc.internal.GrpcAttributes.securityLevel");
+      io.grpc.CallCredentials.ATTR_SECURITY_LEVEL;
 
   private GrpcAttributes() {}
 }

--- a/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
@@ -29,8 +29,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.CallCredentials.MetadataApplier;
+import io.grpc.CallCredentials.RequestInfo;
+import io.grpc.CallCredentials2;
 import io.grpc.CallOptions;
 import io.grpc.IntegerMarshaller;
 import io.grpc.Metadata;
@@ -51,12 +52,11 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /**
- * Unit test for {@link CallCredentials} applying functionality implemented by {@link
+ * Unit test for {@link CallCredentials2} applying functionality implemented by {@link
  * CallCredentialsApplyingTransportFactory} and {@link MetadataApplierImpl}.
  */
 @RunWith(JUnit4.class)
-@Deprecated
-public class CallCredentialsApplyingTest {
+public class CallCredentials2ApplyingTest {
   @Mock
   private ClientTransportFactory mockTransportFactory;
 
@@ -67,7 +67,7 @@ public class CallCredentialsApplyingTest {
   private ClientStream mockStream;
 
   @Mock
-  private CallCredentials mockCreds;
+  private CallCredentials2 mockCreds;
 
   @Mock
   private Executor mockExecutor;
@@ -126,41 +126,40 @@ public class CallCredentialsApplyingTest {
 
     transport.newStream(method, origHeaders, callOptions);
 
-    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), attrsCaptor.capture(), same(mockExecutor),
-        any(MetadataApplier.class));
-    Attributes attrs = attrsCaptor.getValue();
-    assertSame(ATTR_VALUE, attrs.get(ATTR_KEY));
-    assertSame(AUTHORITY, attrs.get(CallCredentials.ATTR_AUTHORITY));
-    assertSame(SecurityLevel.NONE, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(
+        infoCaptor.capture(), same(mockExecutor), any(MetadataApplier.class));
+    RequestInfo info = infoCaptor.getValue();
+    assertSame(method, info.getMethodDescriptor());
+    assertSame(ATTR_VALUE, info.getTransportAttrs().get(ATTR_KEY));
+    assertSame(AUTHORITY, info.getAuthority());
+    assertSame(SecurityLevel.NONE, info.getSecurityLevel());
   }
 
   @Test
-  public void parameterPropagation_overrideByTransport() {
+  public void parameterPropagation_transportSetSecurityLevel() {
     Attributes transportAttrs = Attributes.newBuilder()
         .set(ATTR_KEY, ATTR_VALUE)
-        .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
-        .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
+        .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
         .build();
     when(mockTransport.getAttributes()).thenReturn(transportAttrs);
 
     transport.newStream(method, origHeaders, callOptions);
 
-    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), attrsCaptor.capture(), same(mockExecutor),
-        any(MetadataApplier.class));
-    Attributes attrs = attrsCaptor.getValue();
-    assertSame(ATTR_VALUE, attrs.get(ATTR_KEY));
-    assertEquals("transport-override-authority", attrs.get(CallCredentials.ATTR_AUTHORITY));
-    assertSame(SecurityLevel.INTEGRITY, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(
+        infoCaptor.capture(), same(mockExecutor), any(MetadataApplier.class));
+    RequestInfo info = infoCaptor.getValue();
+    assertSame(method, info.getMethodDescriptor());
+    assertSame(ATTR_VALUE, info.getTransportAttrs().get(ATTR_KEY));
+    assertSame(AUTHORITY, info.getAuthority());
+    assertSame(SecurityLevel.INTEGRITY, info.getSecurityLevel());
   }
 
   @Test
-  public void parameterPropagation_overrideByCallOptions() {
+  public void parameterPropagation_callOptionsSetAuthority() {
     Attributes transportAttrs = Attributes.newBuilder()
         .set(ATTR_KEY, ATTR_VALUE)
-        .set(CallCredentials.ATTR_AUTHORITY, "transport-override-authority")
-        .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.INTEGRITY)
         .build();
     when(mockTransport.getAttributes()).thenReturn(transportAttrs);
     Executor anotherExecutor = mock(Executor.class);
@@ -168,13 +167,14 @@ public class CallCredentialsApplyingTest {
     transport.newStream(method, origHeaders,
         callOptions.withAuthority("calloptions-authority").withExecutor(anotherExecutor));
 
-    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), attrsCaptor.capture(),
-        same(anotherExecutor), any(MetadataApplier.class));
-    Attributes attrs = attrsCaptor.getValue();
-    assertSame(ATTR_VALUE, attrs.get(ATTR_KEY));
-    assertEquals("calloptions-authority", attrs.get(CallCredentials.ATTR_AUTHORITY));
-    assertSame(SecurityLevel.INTEGRITY, attrs.get(CallCredentials.ATTR_SECURITY_LEVEL));
+    ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
+    verify(mockCreds).applyRequestMetadata(
+        infoCaptor.capture(), same(anotherExecutor), any(MetadataApplier.class));
+    RequestInfo info = infoCaptor.getValue();
+    assertSame(method, info.getMethodDescriptor());
+    assertSame(ATTR_VALUE, info.getTransportAttrs().get(ATTR_KEY));
+    assertEquals("calloptions-authority", info.getAuthority());
+    assertSame(SecurityLevel.NONE, info.getSecurityLevel());
   }
 
   @Test
@@ -182,7 +182,7 @@ public class CallCredentialsApplyingTest {
     final RuntimeException ex = new RuntimeException();
     when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
     doThrow(ex).when(mockCreds).applyRequestMetadata(
-        same(method), any(Attributes.class), same(mockExecutor), any(MetadataApplier.class));
+        any(RequestInfo.class), same(mockExecutor), any(MetadataApplier.class));
 
     FailingClientStream stream =
         (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
@@ -198,14 +198,14 @@ public class CallCredentialsApplyingTest {
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
-          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[3];
+          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[2];
           Metadata headers = new Metadata();
           headers.put(CREDS_KEY, CREDS_VALUE);
           applier.apply(headers);
           return null;
         }
-      }).when(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
-          same(mockExecutor), any(MetadataApplier.class));
+      }).when(mockCreds).applyRequestMetadata(
+          any(RequestInfo.class), same(mockExecutor), any(MetadataApplier.class));
 
     ClientStream stream = transport.newStream(method, origHeaders, callOptions);
 
@@ -222,12 +222,12 @@ public class CallCredentialsApplyingTest {
     doAnswer(new Answer<Void>() {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
-          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[3];
+          MetadataApplier applier = (MetadataApplier) invocation.getArguments()[2];
           applier.fail(error);
           return null;
         }
-      }).when(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
-          same(mockExecutor), any(MetadataApplier.class));
+      }).when(mockCreds).applyRequestMetadata(
+          any(RequestInfo.class), same(mockExecutor), any(MetadataApplier.class));
 
     FailingClientStream stream =
         (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
@@ -244,8 +244,8 @@ public class CallCredentialsApplyingTest {
     DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
 
     ArgumentCaptor<MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
-        same(mockExecutor), applierCaptor.capture());
+    verify(mockCreds).applyRequestMetadata(
+        any(RequestInfo.class), same(mockExecutor), applierCaptor.capture());
     verify(mockTransport, never()).newStream(method, origHeaders, callOptions);
 
     Metadata headers = new Metadata();
@@ -266,8 +266,8 @@ public class CallCredentialsApplyingTest {
     DelayedStream stream = (DelayedStream) transport.newStream(method, origHeaders, callOptions);
 
     ArgumentCaptor<MetadataApplier> applierCaptor = ArgumentCaptor.forClass(null);
-    verify(mockCreds).applyRequestMetadata(same(method), any(Attributes.class),
-        same(mockExecutor), applierCaptor.capture());
+    verify(mockCreds).applyRequestMetadata(
+        any(RequestInfo.class), same(mockExecutor), applierCaptor.capture());
 
     Status error = Status.FAILED_PRECONDITION.withDescription("channel not secure for creds");
     applierCaptor.getValue().fail(error);


### PR DESCRIPTION
This reverts commit ef8a84421d821e01185c289a4f1fb502a003c4f3.

Firebase is not yet ready to migrate to the new API. Will try again once we made the release and migrated them to CallCredentials2.