### PR TITLE
Revert "core: DnsNameResolver caches refresh (#4812)" (1.15.x backport)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ jdk:
   # processor based plugin.
   - oraclejdk8  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
   - oraclejdk9  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
-  - oraclejdk10
 
 notifications:
   email: false

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Stopwatch;
 import com.google.common.base.Verify;
 import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
@@ -43,7 +42,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -90,19 +88,6 @@ final class DnsNameResolver extends NameResolver {
   private static final String JNDI_TXT_PROPERTY =
       System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_service_config", "false");
 
-  /**
-   * Java networking system properties name for caching DNS result.
-   *
-   * <p>Default value is -1 (cache forever) if security manager is installed. If security manager is
-   * not installed, the ttl value is {@code null} which falls back to {@link
-   * #DEFAULT_NETWORK_CACHE_TTL_SECONDS gRPC default value}.
-   */
-  @VisibleForTesting
-  static final String NETWORKADDRESS_CACHE_TTL_PROPERTY = "networkaddress.cache.ttl";
-  /** Default DNS cache duration if network cache ttl value is not specified ({@code null}). */
-  @VisibleForTesting
-  static final long DEFAULT_NETWORK_CACHE_TTL_SECONDS = 30;
-
   @VisibleForTesting
   static boolean enableJndi = Boolean.parseBoolean(JNDI_PROPERTY);
   @VisibleForTesting
@@ -130,8 +115,6 @@ final class DnsNameResolver extends NameResolver {
   private final String host;
   private final int port;
   private final Resource<ExecutorService> executorResource;
-  private final long networkAddressCacheTtlNanos;
-  private final Stopwatch stopwatch;
   @GuardedBy("this")
   private boolean shutdown;
   @GuardedBy("this")
@@ -140,11 +123,10 @@ final class DnsNameResolver extends NameResolver {
   private boolean resolving;
   @GuardedBy("this")
   private Listener listener;
-  private ResolutionResults cachedResolutionResults;
 
   DnsNameResolver(@Nullable String nsAuthority, String name, Attributes params,
-      Resource<ExecutorService> executorResource, ProxyDetector proxyDetector,
-      Stopwatch stopwatch) {
+      Resource<ExecutorService> executorResource,
+      ProxyDetector proxyDetector) {
     // TODO: if a DNS server is provided as nsAuthority, use it.
     // https://www.captechconsulting.com/blogs/accessing-the-dusty-corners-of-dns-with-java
     this.executorResource = executorResource;
@@ -167,8 +149,6 @@ final class DnsNameResolver extends NameResolver {
       port = nameUri.getPort();
     }
     this.proxyDetector = proxyDetector;
-    this.stopwatch = Preconditions.checkNotNull(stopwatch, "stopwatch");
-    this.networkAddressCacheTtlNanos = getNetworkAddressCacheTtlNanos();
   }
 
   @Override
@@ -196,13 +176,6 @@ final class DnsNameResolver extends NameResolver {
         Listener savedListener;
         synchronized (DnsNameResolver.this) {
           if (shutdown) {
-            return;
-          }
-          boolean resourceRefreshRequired = cachedResolutionResults == null
-              || networkAddressCacheTtlNanos == 0
-              || (networkAddressCacheTtlNanos > 0
-                  && stopwatch.elapsed(TimeUnit.NANOSECONDS) > networkAddressCacheTtlNanos);
-          if (!resourceRefreshRequired) {
             return;
           }
           savedListener = listener;
@@ -234,10 +207,6 @@ final class DnsNameResolver extends NameResolver {
             }
             resolutionResults =
                 resolveAll(addressResolver, resourceResolver, enableSrv, enableTxt, host);
-            cachedResolutionResults = resolutionResults;
-            if (networkAddressCacheTtlNanos > 0) {
-              stopwatch.reset().start();
-            }
           } catch (Exception e) {
             savedListener.onError(
                 Status.UNAVAILABLE.withDescription("Unable to resolve host " + host).withCause(e));
@@ -283,23 +252,6 @@ final class DnsNameResolver extends NameResolver {
         }
       }
     };
-
-  /** Returns value of network address cache ttl property. */
-  private static long getNetworkAddressCacheTtlNanos() {
-    String cacheTtlPropertyValue = System.getProperty(NETWORKADDRESS_CACHE_TTL_PROPERTY);
-    long cacheTtl = DEFAULT_NETWORK_CACHE_TTL_SECONDS;
-    if (cacheTtlPropertyValue != null) {
-      try {
-        cacheTtl = Long.parseLong(cacheTtlPropertyValue);
-      } catch (NumberFormatException e) {
-        logger.log(
-            Level.WARNING,
-            "Property({0}) valid is not valid number format({1}), fall back to default({2})",
-            new Object[] {NETWORKADDRESS_CACHE_TTL_PROPERTY, cacheTtlPropertyValue, cacheTtl});
-      }
-    }
-    return cacheTtl > 0 ? TimeUnit.SECONDS.toNanos(cacheTtl) : cacheTtl;
-  }
 
   @GuardedBy("this")
   private void resolve() {

--- a/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolverProvider.java
@@ -17,7 +17,6 @@
 package io.grpc.internal;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Stopwatch;
 import io.grpc.Attributes;
 import io.grpc.NameResolverProvider;
 import java.net.URI;
@@ -53,8 +52,7 @@ public final class DnsNameResolverProvider extends NameResolverProvider {
           name,
           params,
           GrpcUtil.SHARED_CHANNEL_EXECUTOR,
-          GrpcUtil.getDefaultProxyDetector(),
-          Stopwatch.createUnstarted());
+          GrpcUtil.getDefaultProxyDetector());
     } else {
       return null;
     }


### PR DESCRIPTION
This reverts commit 189991012bbff42b975c51045c32efceaa07f462.