### PR TITLE
android-interop-testing: put google() repo first

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -16,9 +16,9 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         mavenLocal()
         jcenter()
-        google()
     }
 }
 


### PR DESCRIPTION
This should fix a build issue we're seeing where a transitive dependency is not being pulled in properly from the google() repository when building an Android target. A successful build (e.g., [this one](https://source.cloud.google.com/results/invocations/877dd72a-cd1a-4926-b5b1-d2c93fb8c2a8/log)) is fetching com/android/tools/* packages from the google() repository. The failing jobs are trying to get Android related jars, including lint-gradle-api, from bintray instead. 

This brings our android-interop-test build file in line with our other android builds and places the google() repository at the head of the ordered list.