### PR TITLE
core: fix lint

### DIFF
--- a/core/src/test/java/io/grpc/SynchronizationContextTest.java
+++ b/core/src/test/java/io/grpc/SynchronizationContextTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.internal;
+package io.grpc;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertSame;
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
+import io.grpc.internal.FakeClock;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/core/src/test/java/io/grpc/internal/FakeClock.java
+++ b/core/src/test/java/io/grpc/internal/FakeClock.java
@@ -81,7 +81,6 @@ public final class FakeClock {
   public class ScheduledTask extends AbstractFuture<Void> implements ScheduledFuture<Void> {
     public final Runnable command;
     public final long dueTimeNanos;
-    private boolean hasRun;
 
     ScheduledTask(long dueTimeNanos, Runnable command) {
       this.dueTimeNanos = dueTimeNanos;
@@ -244,7 +243,6 @@ public final class FakeClock {
       }
       ScheduledTask task;
       while ((task = dueTasks.poll()) != null) {
-        task.hasRun = true;
         task.command.run();
         task.complete();
         count++;


### PR DESCRIPTION
This PR changes the package name for `io/grpc/SynchronizationContextTest` to `io.grpc` and removes an unused `hasRun` private field added to `FakeClock` in https://github.com/grpc/grpc-java/pull/4971.