### PR TITLE
android-interop-testing: put google() repo first (1.16.x backport)

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -16,9 +16,9 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         mavenLocal()
         jcenter()
-        google()
     }
 }
 


### PR DESCRIPTION
This is a backport of #4993

CC @ericgribkoff 