### PR TITLE
core: Trim trailing dot from SRV hostnames

### DIFF
--- a/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
+++ b/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
@@ -86,7 +86,7 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
     if (unavailabilityCause() != null) {
       return null;
     }
-    return new JndiResourceResolver();
+    return new JndiResourceResolver(new JndiRecordFetcher());
   }
 
   @Nullable
@@ -96,21 +96,31 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
   }
 
   @VisibleForTesting
+  interface RecordFetcher {
+    List<String> getAllRecords(String recordType, String name) throws NamingException;
+  }
+
+  @VisibleForTesting
   static final class JndiResourceResolver implements DnsNameResolver.ResourceResolver {
     private static final Logger logger =
         Logger.getLogger(JndiResourceResolver.class.getName());
 
     private static final Pattern whitespace = Pattern.compile("\\s+");
 
+    private final RecordFetcher recordFetcher;
+
+    public JndiResourceResolver(RecordFetcher recordFetcher) {
+      this.recordFetcher = recordFetcher;
+    }
+
     @Override
     public List<String> resolveTxt(String serviceConfigHostname) throws NamingException {
-      checkAvailable();
       if (logger.isLoggable(Level.FINER)) {
         logger.log(
             Level.FINER, "About to query TXT records for {0}", new Object[]{serviceConfigHostname});
       }
       List<String> serviceConfigRawTxtRecords =
-          getAllRecords("TXT", "dns:///" + serviceConfigHostname);
+          recordFetcher.getAllRecords("TXT", "dns:///" + serviceConfigHostname);
       if (logger.isLoggable(Level.FINER)) {
         logger.log(
             Level.FINER, "Found {0} TXT records", new Object[]{serviceConfigRawTxtRecords.size()});
@@ -126,13 +136,12 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
     @Override
     public List<EquivalentAddressGroup> resolveSrv(
         AddressResolver addressResolver, String grpclbHostname) throws Exception {
-      checkAvailable();
       if (logger.isLoggable(Level.FINER)) {
         logger.log(
             Level.FINER, "About to query SRV records for {0}", new Object[]{grpclbHostname});
       }
       List<String> grpclbSrvRecords =
-          getAllRecords("SRV", "dns:///" + grpclbHostname);
+          recordFetcher.getAllRecords("SRV", "dns:///" + grpclbHostname);
       if (logger.isLoggable(Level.FINER)) {
         logger.log(
             Level.FINER, "Found {0} SRV records", new Object[]{grpclbSrvRecords.size()});
@@ -144,14 +153,23 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
       for (String srvRecord : grpclbSrvRecords) {
         try {
           SrvRecord record = parseSrvRecord(srvRecord);
+          // SRV requires the host name to be absolute
+          if (!record.host.endsWith(".")) {
+            throw new RuntimeException("Returned SRV host does not end in period: " + record.host);
+          }
 
+          // Strip trailing dot for appearance's sake. It _should_ be fine either way, but most
+          // people expect to see it without the dot.
+          String authority = record.host.substring(0, record.host.length() - 1);
+          // But we want to use the trailing dot for the IP lookup. The dot makes the name absolute
+          // instead of relative and so will avoid the search list like that in resolv.conf.
           List<? extends InetAddress> addrs = addressResolver.resolveAddress(record.host);
           List<SocketAddress> sockaddrs = new ArrayList<>(addrs.size());
           for (InetAddress addr : addrs) {
             sockaddrs.add(new InetSocketAddress(addr, record.port));
           }
           Attributes attrs = Attributes.newBuilder()
-              .set(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY, record.host)
+              .set(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY, authority)
               .build();
           balancerAddresses.add(
               new EquivalentAddressGroup(Collections.unmodifiableList(sockaddrs), attrs));
@@ -176,8 +194,7 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
       return Collections.unmodifiableList(balancerAddresses);
     }
 
-    @VisibleForTesting
-    static final class SrvRecord {
+    private static final class SrvRecord {
       SrvRecord(String host, int port) {
         this.host = host;
         this.port = port;
@@ -187,17 +204,50 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
       final int port;
     }
 
-    @VisibleForTesting
     @SuppressWarnings("BetaApi") // Verify is only kinda beta
-    static SrvRecord parseSrvRecord(String rawRecord) {
+    private static SrvRecord parseSrvRecord(String rawRecord) {
       String[] parts = whitespace.split(rawRecord);
       Verify.verify(parts.length == 4, "Bad SRV Record: %s", rawRecord);
       return new SrvRecord(parts[3], Integer.parseInt(parts[2]));
     }
 
-    @IgnoreJRERequirement
-    private static List<String> getAllRecords(String recordType, String name)
-        throws NamingException {
+    /**
+     * Undo the quoting done in {@link com.sun.jndi.dns.ResourceRecord#decodeTxt}.
+     */
+    @VisibleForTesting
+    static String unquote(String txtRecord) {
+      StringBuilder sb = new StringBuilder(txtRecord.length());
+      boolean inquote = false;
+      for (int i = 0; i < txtRecord.length(); i++) {
+        char c = txtRecord.charAt(i);
+        if (!inquote) {
+          if (c == ' ') {
+            continue;
+          } else if (c == '"') {
+            inquote = true;
+            continue;
+          }
+        } else {
+          if (c == '"') {
+            inquote = false;
+            continue;
+          } else if (c == '\\') {
+            c = txtRecord.charAt(++i);
+            assert c == '"' || c == '\\';
+          }
+        }
+        sb.append(c);
+      }
+      return sb.toString();
+    }
+  }
+
+  @VisibleForTesting
+  @IgnoreJRERequirement
+  static final class JndiRecordFetcher implements RecordFetcher {
+    @Override
+    public List<String> getAllRecords(String recordType, String name) throws NamingException {
+      checkAvailable();
       String[] rrType = new String[]{recordType};
       List<String> records = new ArrayList<>();
 
@@ -237,7 +287,6 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
       return records;
     }
 
-    @IgnoreJRERequirement
     private static void closeThenThrow(NamingEnumeration<?> namingEnumeration, NamingException e)
         throws NamingException {
       try {
@@ -248,7 +297,6 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
       throw e;
     }
 
-    @IgnoreJRERequirement
     private static void closeThenThrow(DirContext ctx, NamingException e) throws NamingException {
       try {
         ctx.close();
@@ -256,36 +304,6 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
         // ignore
       }
       throw e;
-    }
-
-    /**
-     * Undo the quoting done in {@link com.sun.jndi.dns.ResourceRecord#decodeTxt}.
-     */
-    @VisibleForTesting
-    static String unquote(String txtRecord) {
-      StringBuilder sb = new StringBuilder(txtRecord.length());
-      boolean inquote = false;
-      for (int i = 0; i < txtRecord.length(); i++) {
-        char c = txtRecord.charAt(i);
-        if (!inquote) {
-          if (c == ' ') {
-            continue;
-          } else if (c == '"') {
-            inquote = true;
-            continue;
-          }
-        } else {
-          if (c == '"') {
-            inquote = false;
-            continue;
-          } else if (c == '\\') {
-            c = txtRecord.charAt(++i);
-            assert c == '"' || c == '\\';
-          }
-        }
-        sb.append(c);
-      }
-      return sb.toString();
     }
 
     private static void checkAvailable() {


### PR DESCRIPTION
The trailing dot denotes the hostname to be absolute. It is fine to
leave, but removing it makes the authority match the more common form
and hopefully reduces confusion.

This happens to works around SNI failures caused when using gRPC-LB,
since SNI prohibits the trailing dot. However, that is not the reason
for this change as we have to support users directly providing a
hostname with the trailing dot anyway (and doing so is not hard).

See #4912 

---

This is fundamentally a 4 line change, but with more changes to make it testable.