### PR TITLE
core: add option to fail tests that use Status.equals

### DIFF
--- a/core/src/main/java/io/grpc/Status.java
+++ b/core/src/main/java/io/grpc/Status.java
@@ -229,8 +229,7 @@ public final class Status {
   private static final String TEST_EQUALS_FAILURE_PROPERTY = "io.grpc.Status.failOnEqualsForTest";
   private static final boolean failOnEqualsForTest =
       Boolean.parseBoolean(System.getProperty(TEST_EQUALS_FAILURE_PROPERTY, "false"));
-
-
+  
   // Create the canonical list of Status instances indexed by their code values.
   private static final List<Status> STATUS_LIST = buildStatusList();
 


### PR DESCRIPTION
This is a small property to set when testing to ensure that Status matching is done correctly.  Calling equals on Status is not well defined, and makes test flaky when adding error messages.   I expect to turn this on in our unit tests, but not in production code.