### PR TITLE
core: suggest LoadBalancer.Helper.createSubChannel() to be called from SynchronizationContext

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -477,6 +477,10 @@ public abstract class LoadBalancer {
      * Subchannel, and can be accessed later through {@link Subchannel#getAttributes
      * Subchannel.getAttributes()}.
      *
+     * <p>It is recommended you call this method from the Synchronization Context, otherwise your
+     * logic around the creation may race with {@link #handleSubchannelState}.  See
+     * <a href="https://github.com/grpc/grpc-java/issues/5015">#5015</a> for more discussions.
+     *
      * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
      * Subchannels within {@link #shutdown}.
      *

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1026,6 +1026,14 @@ final class ManagedChannelImpl extends ManagedChannel implements
     @Override
     public AbstractSubchannel createSubchannel(
         List<EquivalentAddressGroup> addressGroups, Attributes attrs) {
+      try {
+        syncContext.throwIfNotInThisSynchronizationContext();
+      } catch (IllegalStateException e) {
+        logger.log(Level.WARNING,
+            "We sugguest you call createSubchannel() from SynchronizationContext."
+            + " Otherwise, it may race with handleSubchannelState()."
+            + " See https://github.com/grpc/grpc-java/issues/5015", e);
+      }
       checkNotNull(addressGroups, "addressGroups");
       checkNotNull(attrs, "attrs");
       // TODO(ejona): can we be even stricter? Like loadBalancer == null?


### PR DESCRIPTION
Because otherwise the user logic around Subchannel creation will
likely to race with handleSubchannelState().

Will log a warning if LoadBalancer.Helper.createSubChannel() is called
outside of the SynchronizationContext.

Adds SynchronizationContext.throwIfNotInThisSynchronizationContext()
to facilitate this warning.  It can also be used by LoadBalancer
implementations to make it a requirement.