### PR TITLE
core,netty,testing: Support dup headers joined with commas

### DIFF
--- a/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
+++ b/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
@@ -139,7 +139,7 @@ public final class TransportFrameUtil {
           continue;
         }
         byte[] decodedVal =
-          BaseEncoding.base64().decode(new String(value, prevIdx, idx - prevIdx, US_ASCII));
+            BaseEncoding.base64().decode(new String(value, prevIdx, idx - prevIdx, US_ASCII));
         prevIdx = idx + 1;
         headerList.add(key);
         headerList.add(decodedVal);

--- a/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
+++ b/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Utility functions for transport layer framing.
@@ -89,10 +90,13 @@ public final class TransportFrameUtil {
    * metadata marshallers. It decodes the Base64-encoded binary headers.  This function modifies
    * the headers in place.  By modifying the input array.
    *
+   * <p>Warning: it may mutate the content of the argument.
+   *
    * @param http2Headers the interleaved keys and values of HTTP/2-compliant headers
    * @return the interleaved keys and values in the raw serialized format
    */
   @SuppressWarnings("BetaApi") // BaseEncoding is stable in Guava 20.0
+  @CheckReturnValue
   public static byte[][] toRawSerializedHeaders(byte[][] http2Headers) {
     List<byte[]> dupHeaders = null; // lazily allocate once ',' is found
     for (int i = 0; i < http2Headers.length; i += 2) {

--- a/core/src/test/java/io/grpc/internal/TransportFrameUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportFrameUtilTest.java
@@ -19,11 +19,14 @@ package io.grpc.internal;
 import static com.google.common.base.Charsets.US_ASCII;
 import static com.google.common.base.Charsets.UTF_8;
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+import static io.grpc.Metadata.BINARY_BYTE_MARSHALLER;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.Iterables;
 import com.google.common.io.BaseEncoding;
 import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
@@ -59,6 +62,7 @@ public class TransportFrameUtilTest {
   private static final Key<String> BINARY_STRING = Key.of("string-bin", UTF8_STRING_MARSHALLER);
   private static final Key<String> BINARY_STRING_WITHOUT_SUFFIX =
       Key.of("string", ASCII_STRING_MARSHALLER);
+  private static final Key<byte[]> BINARY_BYTES = Key.of("bytes-bin", BINARY_BYTE_MARSHALLER);
 
   @Test
   public void testToHttp2Headers() {
@@ -97,6 +101,25 @@ public class TransportFrameUtilTest {
     assertEquals(COMPLIANT_ASCII_STRING, recoveredHeaders.get(PLAIN_STRING));
     assertEquals(NONCOMPLIANT_ASCII_STRING, recoveredHeaders.get(BINARY_STRING));
     assertNull(recoveredHeaders.get(BINARY_STRING_WITHOUT_SUFFIX));
+  }
+
+  @Test
+  public void dupBinHeadersWithComma() {
+    byte[][] http2Headers = new byte[][] {
+        BINARY_BYTES.name().getBytes(US_ASCII),
+        "BaS,e6,,4+,padding==".getBytes(US_ASCII)};
+    byte[][] rawSerialized = TransportFrameUtil.toRawSerializedHeaders(http2Headers);
+    Metadata recoveredHeaders = InternalMetadata.newMetadata(rawSerialized);
+    byte[][] values = Iterables.toArray(recoveredHeaders.getAll(BINARY_BYTES), byte[].class);
+
+    assertTrue(Arrays.deepEquals(
+        new byte[][] {
+            BaseEncoding.base64().decode("BaS"),
+            BaseEncoding.base64().decode("e6"),
+            BaseEncoding.base64().decode(""),
+            BaseEncoding.base64().decode("4+"),
+            BaseEncoding.base64().decode("padding")},
+        values));
   }
 
   private static void assertContains(byte[][] headers, byte[] key, byte[] value) {

--- a/core/src/test/java/io/grpc/internal/TransportFrameUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/TransportFrameUtilTest.java
@@ -107,7 +107,11 @@ public class TransportFrameUtilTest {
   public void dupBinHeadersWithComma() {
     byte[][] http2Headers = new byte[][] {
         BINARY_BYTES.name().getBytes(US_ASCII),
-        "BaS,e6,,4+,padding==".getBytes(US_ASCII)};
+        "BaS,e6,,4+,padding==".getBytes(US_ASCII),
+        BINARY_BYTES.name().getBytes(US_ASCII),
+        "more".getBytes(US_ASCII),
+        BINARY_BYTES.name().getBytes(US_ASCII),
+        "".getBytes(US_ASCII)};
     byte[][] rawSerialized = TransportFrameUtil.toRawSerializedHeaders(http2Headers);
     Metadata recoveredHeaders = InternalMetadata.newMetadata(rawSerialized);
     byte[][] values = Iterables.toArray(recoveredHeaders.getAll(BINARY_BYTES), byte[].class);
@@ -118,7 +122,9 @@ public class TransportFrameUtilTest {
             BaseEncoding.base64().decode("e6"),
             BaseEncoding.base64().decode(""),
             BaseEncoding.base64().decode("4+"),
-            BaseEncoding.base64().decode("padding")},
+            BaseEncoding.base64().decode("padding"),
+            BaseEncoding.base64().decode("more"),
+            BaseEncoding.base64().decode("")},
         values));
   }
 

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -72,9 +72,6 @@ class Utils {
   public static final Resource<EventLoopGroup> DEFAULT_WORKER_EVENT_LOOP_GROUP =
       new DefaultEventLoopGroupResource(0, "grpc-default-worker-ELG");
 
-  @VisibleForTesting
-  static boolean validateHeaders = false;
-
   public static Metadata convertHeaders(Http2Headers http2Headers) {
     if (http2Headers instanceof GrpcHttp2InboundHeaders) {
       GrpcHttp2InboundHeaders h = (GrpcHttp2InboundHeaders) http2Headers;

--- a/netty/src/main/java/io/grpc/netty/Utils.java
+++ b/netty/src/main/java/io/grpc/netty/Utils.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Common utility methods.
@@ -80,6 +81,7 @@ class Utils {
     return InternalMetadata.newMetadata(convertHeadersToArray(http2Headers));
   }
 
+  @CheckReturnValue
   private static byte[][] convertHeadersToArray(Http2Headers http2Headers) {
     // The Netty AsciiString class is really just a wrapper around a byte[] and supports
     // arbitrary binary data, not just ASCII.

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
@@ -61,8 +61,6 @@ public class GrpcHttp2HeadersUtilsTest {
     }
   };
 
-  private static final Key<byte[]> BINARY_BYTES = Key.of("bytes-bin", BINARY_BYTE_MARSHALLER);
-
   private ByteBuf encodedHeaders;
 
   @After
@@ -138,10 +136,11 @@ public class GrpcHttp2HeadersUtilsTest {
 
   @Test
   public void dupBinHeadersWithComma() {
+    Key<byte[]> key = Key.of("bytes-bin", BINARY_BYTE_MARSHALLER);
     Http2Headers http2Headers = new GrpcHttp2RequestHeaders(1);
-    http2Headers.add(AsciiString.of(BINARY_BYTES.name()), AsciiString.of("BaS,e6,,4+,padding=="));
+    http2Headers.add(AsciiString.of("bytes-bin"), AsciiString.of("BaS,e6,,4+,padding=="));
     Metadata recoveredHeaders = Utils.convertHeaders(http2Headers);
-    byte[][] values = Iterables.toArray(recoveredHeaders.getAll(BINARY_BYTES), byte[].class);
+    byte[][] values = Iterables.toArray(recoveredHeaders.getAll(key), byte[].class);
 
     assertTrue(Arrays.deepEquals(
         new byte[][] {

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
@@ -16,13 +16,20 @@
 
 package io.grpc.netty;
 
+import static io.grpc.Metadata.BINARY_BYTE_MARSHALLER;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE;
 import static io.netty.util.AsciiString.of;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.Iterables;
+import com.google.common.io.BaseEncoding;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
 import io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2ClientHeadersDecoder;
+import io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2RequestHeaders;
 import io.grpc.netty.GrpcHttp2HeadersUtils.GrpcHttp2ServerHeadersDecoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -33,6 +40,8 @@ import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2HeadersDecoder;
 import io.netty.handler.codec.http2.Http2HeadersEncoder;
 import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
+import io.netty.util.AsciiString;
+import java.util.Arrays;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +60,8 @@ public class GrpcHttp2HeadersUtilsTest {
       return false;
     }
   };
+
+  private static final Key<byte[]> BINARY_BYTES = Key.of("bytes-bin", BINARY_BYTE_MARSHALLER);
 
   private ByteBuf encodedHeaders;
 
@@ -123,6 +134,23 @@ public class GrpcHttp2HeadersUtilsTest {
     Http2Headers decodedHeaders = decoder.decodeHeaders(3 /* randomly chosen */, encodedHeaders);
     assertEquals(0, decodedHeaders.size());
     assertThat(decodedHeaders.toString(), containsString("[]"));
+  }
+
+  @Test
+  public void dupBinHeadersWithComma() {
+    Http2Headers http2Headers = new GrpcHttp2RequestHeaders(1);
+    http2Headers.add(AsciiString.of(BINARY_BYTES.name()), AsciiString.of("BaS,e6,,4+,padding=="));
+    Metadata recoveredHeaders = Utils.convertHeaders(http2Headers);
+    byte[][] values = Iterables.toArray(recoveredHeaders.getAll(BINARY_BYTES), byte[].class);
+
+    assertTrue(Arrays.deepEquals(
+        new byte[][] {
+            BaseEncoding.base64().decode("BaS"),
+            BaseEncoding.base64().decode("e6"),
+            BaseEncoding.base64().decode(""),
+            BaseEncoding.base64().decode("4+"),
+            BaseEncoding.base64().decode("padding")},
+        values));
   }
 
   private static void assertContainsKeyAndValue(String str, CharSequence key, CharSequence value) {

--- a/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/GrpcHttp2HeadersUtilsTest.java
@@ -137,8 +137,10 @@ public class GrpcHttp2HeadersUtilsTest {
   @Test
   public void dupBinHeadersWithComma() {
     Key<byte[]> key = Key.of("bytes-bin", BINARY_BYTE_MARSHALLER);
-    Http2Headers http2Headers = new GrpcHttp2RequestHeaders(1);
+    Http2Headers http2Headers = new GrpcHttp2RequestHeaders(2);
     http2Headers.add(AsciiString.of("bytes-bin"), AsciiString.of("BaS,e6,,4+,padding=="));
+    http2Headers.add(AsciiString.of("bytes-bin"), AsciiString.of("more"));
+    http2Headers.add(AsciiString.of("bytes-bin"), AsciiString.of(""));
     Metadata recoveredHeaders = Utils.convertHeaders(http2Headers);
     byte[][] values = Iterables.toArray(recoveredHeaders.getAll(key), byte[].class);
 
@@ -148,7 +150,9 @@ public class GrpcHttp2HeadersUtilsTest {
             BaseEncoding.base64().decode("e6"),
             BaseEncoding.base64().decode(""),
             BaseEncoding.base64().decode("4+"),
-            BaseEncoding.base64().decode("padding")},
+            BaseEncoding.base64().decode("padding"),
+            BaseEncoding.base64().decode("more"),
+            BaseEncoding.base64().decode("")},
         values));
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/Utils.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/Utils.java
@@ -29,6 +29,7 @@ import java.net.SocketException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Common utility methods for OkHttp transport.
@@ -51,6 +52,7 @@ class Utils {
     return InternalMetadata.newMetadata(convertHeadersToArray(http2Headers));
   }
 
+  @CheckReturnValue
   private static byte[][] convertHeadersToArray(List<Header> http2Headers) {
     byte[][] headerValues = new byte[http2Headers.size() * 2][];
     int i = 0;

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -722,6 +722,7 @@ public abstract class AbstractTransportTest {
     clientHeaders.put(asciiKey, "dupvalue");
     clientHeaders.put(asciiKey, "dupvalue");
     clientHeaders.put(binaryKey, "äbinaryclient");
+    clientHeaders.put(binaryKey, "dup,value");
     Metadata clientHeadersCopy = new Metadata();
 
     clientHeadersCopy.merge(clientHeaders);
@@ -790,14 +791,13 @@ public abstract class AbstractTransportTest {
     serverHeaders.put(asciiKey, "dupvalue");
     serverHeaders.put(asciiKey, "dupvalue");
     serverHeaders.put(binaryKey, "äbinaryserver");
+    serverHeaders.put(binaryKey, "dup,value");
     Metadata serverHeadersCopy = new Metadata();
     serverHeadersCopy.merge(serverHeaders);
     serverStream.writeHeaders(serverHeaders);
     Metadata headers = clientStreamListener.headers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     assertNotNull(headers);
-    assertEquals(
-        Lists.newArrayList(serverHeadersCopy.getAll(asciiKey)),
-        Lists.newArrayList(headers.getAll(asciiKey)));
+    assertAsciiMetadataValuesEqual(serverHeadersCopy.getAll(asciiKey),headers.getAll(asciiKey));
     assertEquals(
         Lists.newArrayList(serverHeadersCopy.getAll(binaryKey)),
         Lists.newArrayList(headers.getAll(binaryKey)));
@@ -842,6 +842,7 @@ public abstract class AbstractTransportTest {
     trailers.put(asciiKey, "dupvalue");
     trailers.put(asciiKey, "dupvalue");
     trailers.put(binaryKey, "äbinarytrailers");
+    trailers.put(binaryKey, "dup,value");
     serverStream.close(status, trailers);
     assertNull(serverStreamTracer1.nextInboundEvent());
     assertNull(serverStreamTracer1.nextOutboundEvent());
@@ -855,9 +856,8 @@ public abstract class AbstractTransportTest {
     assertNull(clientStreamTracer1.nextOutboundEvent());
     assertEquals(status.getCode(), clientStreamStatus.getCode());
     assertEquals(status.getDescription(), clientStreamStatus.getDescription());
-    assertEquals(
-        Lists.newArrayList(trailers.getAll(asciiKey)),
-        Lists.newArrayList(clientStreamTrailers.getAll(asciiKey)));
+    assertAsciiMetadataValuesEqual(
+        trailers.getAll(asciiKey), clientStreamTrailers.getAll(asciiKey));
     assertEquals(
         Lists.newArrayList(trailers.getAll(binaryKey)),
         Lists.newArrayList(clientStreamTrailers.getAll(binaryKey)));
@@ -881,6 +881,18 @@ public abstract class AbstractTransportTest {
     ServerStream serverStream = serverStreamCreation.stream;
 
     assertEquals(testAuthority(server), serverStream.getAuthority());
+  }
+
+  private void assertAsciiMetadataValuesEqual(Iterable<String> expected, Iterable<String> actural) {
+    StringBuilder sbExpected = new StringBuilder();
+    for (String str : expected) {
+      sbExpected.append(str).append(",");
+    }
+    StringBuilder sbActual = new StringBuilder();
+    for (String str : actural) {
+      sbActual.append(str).append(",");
+    }
+    assertEquals(sbExpected.toString(), sbActual.toString());
   }
 
   @Test

--- a/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
+++ b/testing/src/main/java/io/grpc/internal/testing/AbstractTransportTest.java
@@ -797,7 +797,7 @@ public abstract class AbstractTransportTest {
     serverStream.writeHeaders(serverHeaders);
     Metadata headers = clientStreamListener.headers.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     assertNotNull(headers);
-    assertAsciiMetadataValuesEqual(serverHeadersCopy.getAll(asciiKey),headers.getAll(asciiKey));
+    assertAsciiMetadataValuesEqual(serverHeadersCopy.getAll(asciiKey), headers.getAll(asciiKey));
     assertEquals(
         Lists.newArrayList(serverHeadersCopy.getAll(binaryKey)),
         Lists.newArrayList(headers.getAll(binaryKey)));


### PR DESCRIPTION
Following the [spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) on duplicate header names:

**Custom-Metadata** header order is not guaranteed to be preserved except for values with duplicate header names. Duplicate header names may have their values joined with "," as the delimiter and be considered semantically equivalent. Implementations must split Binary-Headers on "," before decoding the Base64-encoded values.
