### PR TITLE
travis: Remove sudo: false, as it is going away

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: java
 
 env:


### PR DESCRIPTION
This migrates us ahead of the forced migration, so if there are problems
the CI would still work while we work on them.

https://changelog.travis-ci.com/linux-builds-run-on-vms-by-default-77106