### PR TITLE
core: Improve error for Auto-LB configuration failure

### DIFF
--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -88,6 +88,10 @@ final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factory {
         Helper helper, @Nullable ChannelTracer channelTracer, @Nullable TimeProvider timeProvider) {
       this.helper = helper;
       delegateProvider = registry.getProvider(DEFAULT_POLICY);
+      if (delegateProvider == null) {
+        throw new IllegalStateException("Could not find LoadBalancer " + DEFAULT_POLICY
+            + ". The build probably threw away META-INF/services/io.grpc.LoadBalancerProvider");
+      }
       delegate = delegateProvider.newLoadBalancer(helper);
       this.channelTracer = channelTracer;
       this.timeProvider = timeProvider;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -347,8 +347,11 @@ final class ManagedChannelImpl extends ManagedChannel implements
       return;
     }
     logger.log(Level.FINE, "[{0}] Exiting idle mode", getLogId());
-    lbHelper = new LbHelperImpl(nameResolver);
+    LbHelperImpl lbHelper = new LbHelperImpl(nameResolver);
     lbHelper.lb = loadBalancerFactory.newLoadBalancer(lbHelper);
+    // Delay setting lbHelper until fully initialized, since loadBalancerFactory is user code and
+    // may throw. We don't want to confuse our state, even if we will enter panic mode.
+    this.lbHelper = lbHelper;
 
     NameResolverListenerImpl listener = new NameResolverListenerImpl(lbHelper);
     try {


### PR DESCRIPTION
The ManagedChannelImpl change prevents any LB initialization failure
from producing a useless exception like:
```
java.lang.NullPointerException
	at io.grpc.internal.ManagedChannelImpl.shutdownNameResolverAndLoadBalancer(ManagedChannelImpl.java:321)
	at io.grpc.internal.ManagedChannelImpl.panic(ManagedChannelImpl.java:738)
	at io.grpc.internal.ManagedChannelImpl$1.uncaughtException(ManagedChannelImpl.java:144)
```

Instead, now it will have the expected panic behavior of an INTERNAL
Status with a proper cause.

Since the NPE in AutoConfiguredLoadBalancerFactory wouldn't mean much to
users, it now has a more explicit message.