### PR TITLE
benchmarks: driverServer graceful shutdown

### DIFF
--- a/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
+++ b/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java
@@ -251,7 +251,7 @@ public class LoadWorker {
         log.log(Level.INFO, "Received quitWorker request.");
         responseObserver.onNext(Control.Void.getDefaultInstance());
         responseObserver.onCompleted();
-        driverServer.shutdownNow();
+        driverServer.shutdown();
       } catch (Throwable t) {
         log.log(Level.WARNING, "Error during shutdown", t);
       }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/17101.

According to the docs the `shutdownNow()` kills all the inflight calls (including quitWorker method) before they can finish and hence the C++ benchmark driver reports `driver.cc:550]  Worker 0 could not be properly quit because Received RST_STREAM with error code 8`  (I misinterpreted the msg earlier, the error code 8 seems to mean "cancelled" according to http/2 spec).

Before I was able to reproduce reliably locally and after this change, I'm unable to reproduce, so I assume it fixes the problem.