### PR TITLE
okhttp: error in frame handler closes with INTERNAL

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -1011,9 +1011,9 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       } catch (Throwable t) {
         // TODO(madongfly): Send the exception message to the server.
         startGoAway(
-            0, 
-            ErrorCode.PROTOCOL_ERROR, 
-            Status.UNAVAILABLE.withDescription("error in frame handler").withCause(t));
+            0,
+            ErrorCode.PROTOCOL_ERROR,
+            Status.INTERNAL.withDescription("error in frame handler").withCause(t));
       } finally {
         try {
           frameReader.close();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -301,9 +301,9 @@ public class OkHttpClientTransportTest {
     listener2.waitUntilStreamClosed();
 
     assertEquals(0, activeStreamCount());
-    assertEquals(Status.UNAVAILABLE.getCode(), listener1.status.getCode());
+    assertEquals(Status.INTERNAL.getCode(), listener1.status.getCode());
     assertEquals(NETWORK_ISSUE_MESSAGE, listener1.status.getCause().getMessage());
-    assertEquals(Status.UNAVAILABLE.getCode(), listener2.status.getCode());
+    assertEquals(Status.INTERNAL.getCode(), listener2.status.getCode());
     assertEquals(NETWORK_ISSUE_MESSAGE, listener2.status.getCause().getMessage());
     verify(transportListener, timeout(TIME_OUT_MS)).transportShutdown(isA(Status.class));
     verify(transportListener, timeout(TIME_OUT_MS)).transportTerminated();
@@ -329,7 +329,7 @@ public class OkHttpClientTransportTest {
     listener.waitUntilStreamClosed();
 
     assertEquals(0, activeStreamCount());
-    assertEquals(Status.UNAVAILABLE.getCode(), listener.status.getCode());
+    assertEquals(Status.INTERNAL.getCode(), listener.status.getCode());
     assertEquals(ERROR_MESSAGE, listener.status.getCause().getMessage());
     verify(transportListener, timeout(TIME_OUT_MS)).transportShutdown(isA(Status.class));
     verify(transportListener, timeout(TIME_OUT_MS)).transportTerminated();


### PR DESCRIPTION
This is intended to convert errors thrown in the KeepAliveManager to a more appropriate error status. It will also catch exceptions from `io.grpc.okhttp.internal.framed.FrameReader#nextFrame`, for which INTERNAL also seems like an appropriate status code.