### PR TITLE
Bump Jetty ALPN to 2.0.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ subprojects {
             math: 'org.apache.commons:commons-math3:3.6',
 
             // Jetty ALPN dependencies
-            jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.7'
+            jetty_alpn_agent: 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.9'
         ]
     }
 


### PR DESCRIPTION
This adds support for Java 1.8.0_191 and 192