### PR TITLE
Lint fixes

### DIFF
--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -78,7 +78,6 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats> {
   private final CallTracer callsTracer;
   private final ChannelTracer channelTracer;
   private final ChannelLogger channelLogger;
-  private final TimeProvider timeProvider;
 
   // File-specific convention: methods without GuardedBy("lock") MUST NOT be called under the lock.
   private final Object lock = new Object();
@@ -184,7 +183,6 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats> {
     this.channelz = channelz;
     this.callsTracer = callsTracer;
     this.channelTracer = Preconditions.checkNotNull(channelTracer, "channelTracer");
-    this.timeProvider = Preconditions.checkNotNull(timeProvider, "timeProvider");
     this.logId = Preconditions.checkNotNull(logId, "logId");
     this.channelLogger = new ChannelLoggerImpl(channelTracer, timeProvider);
   }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -109,8 +109,6 @@ import org.mockito.stubbing.Answer;
 /** Unit tests for {@link GrpclbLoadBalancer}. */
 @RunWith(JUnit4.class)
 public class GrpclbLoadBalancerTest {
-  private static final Attributes.Key<String> RESOLUTION_ATTR =
-      Attributes.Key.create("resolution-attr");
   private static final String SERVICE_AUTHORITY = "api.google.com";
 
   // The tasks are wrapped by SynchronizationContext, so we can't compare the types

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -72,13 +72,13 @@ import io.grpc.internal.ServiceConfigUtil;
 import io.grpc.stub.StreamObserver;
 import java.net.SocketAddress;
 import java.text.MessageFormat;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1068,7 +1068,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
 
   private static class HealthImpl extends HealthGrpc.HealthImplBase {
     boolean checkCalled;
-    final Deque<ServerSideCall> calls = new LinkedList<ServerSideCall>();
+    final Queue<ServerSideCall> calls = new ArrayDeque<ServerSideCall>();
 
     @Override
     public void check(HealthCheckRequest request,


### PR DESCRIPTION
Remove unused variables and prefer ArrayDeque to LinkedList. The swap to
Queue from Deque was just to make it more obvious what the usage was,
since the original swap to Deque was to avoid the same LinkedList lint
violation (3d51756d).