### PR TITLE
netty: finalize deprecating of maxMessageSize in NettyChannelBuilder.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -202,17 +202,6 @@ public final class NettyChannelBuilder
   }
 
   /**
-   * Sets the max message size.
-   *
-   * @deprecated Use {@link #maxInboundMessageSize} instead
-   */
-  @Deprecated
-  public NettyChannelBuilder maxMessageSize(int maxMessageSize) {
-    maxInboundMessageSize(maxMessageSize);
-    return this;
-  }
-
-  /**
    * Sets the maximum size of header list allowed to be received. This is cumulative size of the
    * headers with some overhead, as defined for
    * <a href="http://httpwg.org/specs/rfc7540.html#rfc.section.6.5.2">


### PR DESCRIPTION
some internally referenced codes are migrated to maxInboundMessageSize.
Resolves #2507
