### PR TITLE
services: use Durations.toNanos instead of Duration.getNanos

### DIFF
--- a/services/src/test/java/io/grpc/services/BinlogHelperTest.java
+++ b/services/src/test/java/io/grpc/services/BinlogHelperTest.java
@@ -966,7 +966,8 @@ public final class BinlogHelperTest {
         eq(CALL_ID),
         isNull(SocketAddress.class));
     verifyNoMoreInteractions(mockSinkWriter);
-    assertThat(TimeUnit.SECONDS.toNanos(1) - timeoutCaptor.getValue().getNanos())
+    Duration timeout = timeoutCaptor.getValue();
+    assertThat(TimeUnit.SECONDS.toNanos(1) - Durations.toNanos(timeout))
         .isAtMost(TimeUnit.MILLISECONDS.toNanos(250));
   }
 


### PR DESCRIPTION
getNanos will return the fractional nanos of the duration, which is
not the same as toNanos for durations larger than 1s.