### PR TITLE
stub: disable exception if onCancelHandler set

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCallStreamObserver.java
@@ -39,12 +39,15 @@ public abstract class ServerCallStreamObserver<V> extends CallStreamObserver<V> 
   public abstract boolean isCancelled();
 
   /**
-   * Set a {@link Runnable} that will be called if the calls  {@link #isCancelled()} state
+   * Set a {@link Runnable} that will be called if the calls {@link #isCancelled()} state
    * changes from {@code false} to {@code true}. It is guaranteed that execution of the
    * {@link Runnable} are serialized with calls to the 'inbound' {@link StreamObserver}.
    *
-   * <p>Note that the handler may be called some time after {@link #isCancelled} has transitioned to
-   * {@code true} as other callbacks may still be executing in the 'inbound' observer.
+   * <p>Note that the handler may be called some time after {@link #isCancelled()} has transitioned
+   * to {@code true} as other callbacks may still be executing in the 'inbound' observer.
+   *
+   * <p>Setting the onCancelHandler will suppress the on-cancel exception thrown by
+   * {@link #onNext()}.
    *
    * @param onCancelHandler to call when client has cancelled the call.
    */

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -335,13 +335,13 @@ public final class ServerCalls {
         if (onCancelHandler == null) {
           throw Status.CANCELLED.withDescription("call already cancelled").asRuntimeException();
         }
-      } else {
-        if (!sentHeaders) {
-          call.sendHeaders(new Metadata());
-          sentHeaders = true;
-        }
-        call.sendMessage(response);
+        return;
       }
+      if (!sentHeaders) {
+        call.sendHeaders(new Metadata());
+        sentHeaders = true;
+      }
+      call.sendMessage(response);
     }
 
     @Override

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -331,7 +331,7 @@ public final class ServerCalls {
 
     @Override
     public void onNext(RespT response) {
-      if (cancelled) {
+      if (cancelled && onCancelHandler == null) {
         throw Status.CANCELLED.withDescription("call already cancelled").asRuntimeException();
       }
       if (!sentHeaders) {


### PR DESCRIPTION
This restrains a cancellation `Exception` when an `onCancelHandler` is set in `ServerCallStreamObserverImpl`. Fixes #5061.