### PR TITLE
 buildscript: Add CI for kotlin non-android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - ./gradlew assemble generateTestProto install
   - pushd examples && ./gradlew build && popd
   - pushd examples && mvn verify && popd
+  - pushd examples/example-kotlin && ./gradlew build && popd
 
 before_script:
   - test -z "$(git status --porcelain)" || (git status && echo Error Working directory is not clean. Forget to commit generated files? && false)

--- a/examples/example-kotlin/android/helloworld/build.gradle
+++ b/examples/example-kotlin/android/helloworld/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.3.10'
 
     repositories {
         google()

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile "io.grpc:grpc-netty-shaded:${grpcVersion}"
     compile "io.grpc:grpc-protobuf:${grpcVersion}"
     compile "io.grpc:grpc-stub:${grpcVersion}"
-    // compileOnly "javax.annotation:javax.annotation-api:1.2"
+    compileOnly "javax.annotation:javax.annotation-api:1.2"
 
     testCompile "io.grpc:grpc-testing:${grpcVersion}" // gRCP testing utilities
     testCompile "junit:junit:4.12"

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'application'
 
 
 buildscript {
-    ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.3.10'
 
     repositories {
         mavenCentral()
@@ -43,6 +43,7 @@ dependencies {
     compile "io.grpc:grpc-netty-shaded:${grpcVersion}"
     compile "io.grpc:grpc-protobuf:${grpcVersion}"
     compile "io.grpc:grpc-stub:${grpcVersion}"
+    // compileOnly "javax.annotation:javax.annotation-api:1.2"
 
     testCompile "io.grpc:grpc-testing:${grpcVersion}" // gRCP testing utilities
     testCompile "junit:junit:4.12"


### PR DESCRIPTION
- add CI for kotlin non-android
- bump kotlin version to fix kotlin compiler issue on jdk11
- add javax.annotation dep to fix kotlin build on jdk 9 & 11

Fixes #4725