### PR TITLE
buildscripts: Update net.ltgt.errorprone to 0.6 and enable Error Prone on JDK 10+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,8 @@ os:
   - linux
 
 jdk:
-  # net.ltgt.errorprone supports jdk8 and jdk9, but has problems with jdk10
-  # For jdk10, we need to switch over to using net.ltgt.errorprone-javacplugin,
-  # and likely update to the latest com.google.errorprone:error_prone_core.
-  # We have decided not to make our build.gradle support both plugins, so when
-  # we finally move off of jdk8 and jdk9 we will need use the javac annotation
-  # processor based plugin.
-  - oraclejdk8  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
-  - oraclejdk9  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
+  - oraclejdk8
+  - oraclejdk9
   - openjdk11
 
 notifications:

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -46,13 +46,15 @@ dependencies {
 
 configureProtoCompilation()
 
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 [compileJava, compileTestJava].each() {
-    // ALTS retuns a lot of futures that we mostly don't care about.
     // protobuf calls valueof. Will be fixed in next release (google/protobuf#4046)
     it.options.compilerArgs += [
-        "-Xlint:-deprecation",
-        "-Xep:FutureReturnValueIgnored:OFF"
+        "-Xlint:-deprecation"
     ]
+    // ALTS returns a lot of futures that we mostly don't care about.
+    it.options.errorprone.check("FutureReturnValueIgnored", CheckSeverity.OFF)
 }
 
 javadoc { exclude 'io/grpc/alts/internal/**' }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.6"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
@@ -41,6 +41,9 @@ repositories {
 }
 
 dependencies {
+    errorprone 'com.google.errorprone:error_prone_core:2.3.2'
+    errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
+
     implementation 'io.grpc:grpc-core:1.18.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     testImplementation 'io.grpc:grpc-okhttp:1.18.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -36,9 +36,11 @@ dependencies {
     compileOnly libraries.javax_annotation
 }
 
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 compileJava {
     // The Control.Void protobuf clashes
-    options.compilerArgs += ["-Xep:JavaLangClash:OFF"]
+    options.errorprone.check("JavaLangClash", CheckSeverity.OFF)
 }
 
 configureProtoCompilation()

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,8 @@ subprojects {
     apply plugin: "ru.vyarus.animalsniffer"
 
     apply plugin: "net.ltgt.errorprone"
-    if (rootProject.properties.get('errorProne', true)) {
+    if (rootProject.properties.get('errorProne', true).toBoolean()) {
+
         dependencies {
             errorprone 'com.google.errorprone:error_prone_core:2.3.2'
             errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,13 @@ buildscript {
         classpath "com.diffplug.spotless:spotless-plugin-gradle:3.13.0"
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.5'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
         classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.5"
         classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.2.5'
     }
 }
+
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 subprojects {
     apply plugin: "checkstyle"
@@ -25,23 +27,21 @@ subprojects {
     apply plugin: "com.google.osdetector"
     // The plugin only has an effect if a signature is specified
     apply plugin: "ru.vyarus.animalsniffer"
-    // jdk10 not supported by errorprone: https://github.com/google/error-prone/issues/860
-    if (!JavaVersion.current().isJava10Compatible() &&
-        rootProject.properties.get('errorProne', true)) {
-        apply plugin: "net.ltgt.errorprone"
 
+    apply plugin: "net.ltgt.errorprone"
+    if (rootProject.properties.get('errorProne', true)) {
         dependencies {
-            // The ErrorProne plugin defaults to the latest, which would break our
-            // build if error prone releases a new version with a new check
             errorprone 'com.google.errorprone:error_prone_core:2.3.2'
+            errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
+
             annotationProcessor 'com.google.guava:guava-beta-checker:1.0'
         }
     } else {
-        // Remove per-project error-prone checker config
+        // Disable Error Prone
         allprojects {
             afterEvaluate { project ->
                 project.tasks.withType(JavaCompile) {
-                    options.compilerArgs.removeAll { it.startsWith("-Xep") }
+                    options.errorprone.enabled = false
                 }
             }
         }
@@ -78,11 +78,11 @@ subprojects {
 
     compileTestJava {
         // serialVersionUID is basically guaranteed to be useless in our tests
-        // LinkedList doesn't hurt much in tests and has lots of usages
         options.compilerArgs += [
-            "-Xlint:-serial",
-            "-Xep:JdkObsolete:OFF"
+            "-Xlint:-serial"
         ]
+        // LinkedList doesn't hurt much in tests and has lots of usages
+        options.errorprone.check("JdkObsolete", CheckSeverity.OFF)
     }
 
     jar.manifest {
@@ -179,8 +179,8 @@ subprojects {
                 // https://github.com/google/protobuf/issues/2718
                 it.options.compilerArgs += [
                     "-Xlint:-cast",
-                    "-XepExcludedPaths:.*/src/generated/[^/]+/java/.*",
                 ]
+                it.options.errorprone.excludedPaths = ".*/src/generated/[^/]+/java/.*"
             }
         }
 

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -33,7 +33,7 @@ GRADLE_FLAGS="${GRADLE_FLAGS:-}"
 GRADLE_FLAGS+=" -PtargetArch=x86_$ARCH $GRADLE_FLAGS"
 GRADLE_FLAGS+=" -Pcheckstyle.ignoreFailures=false"
 GRADLE_FLAGS+=" -PfailOnWarnings=true"
-GRADLE_FLAGS+=" -PerrorProne=true"
+GRADLE_FLAGS+=" -PerrorProne=false"
 GRADLE_FLAGS+=" -Dorg.gradle.parallel=true"
 export GRADLE_OPTS="-Xmx512m"
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -151,9 +151,9 @@ sourceSets {
 
 compileTestJava {
     options.compilerArgs += [
-        "-Xlint:-cast",
-        "-XepExcludedPaths:.*/build/generated/source/proto/.*",
+        "-Xlint:-cast"
     ]
+    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
 compileTestLiteJava {
@@ -164,10 +164,12 @@ compileTestLiteJava {
         "-Xlint:-unchecked",
         "-Xlint:-fallthrough"
     ]
+    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
 compileTestNanoJava {
     options.compilerArgs = compileTestJava.options.compilerArgs
+    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
 protobuf {

--- a/core/src/main/java/io/grpc/internal/ChannelTracer.java
+++ b/core/src/main/java/io/grpc/internal/ChannelTracer.java
@@ -63,7 +63,8 @@ final class ChannelTracer {
     checkNotNull(description, "description");
     this.logId = checkNotNull(logId, "logId");
     if (maxEvents > 0) {
-      events = new ArrayDeque<Event>() {
+      @SuppressWarnings("serial")
+      Collection<Event> events = new ArrayDeque<Event>() {
           @GuardedBy("lock")
           @Override
           public boolean add(Event event) {
@@ -74,6 +75,7 @@ final class ChannelTracer {
             return super.add(event);
           }
         };
+      this.events = events;
     } else {
       events = null;
     }

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -38,9 +38,11 @@ dependencies {
 
 configureProtoCompilation()
 
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 compileJava {
     // This isn't a library; it can use beta APIs
-    it.options.compilerArgs += ["-Xep:BetaApi:OFF"]
+    options.errorprone.check("BetaApi", CheckSeverity.OFF)
 }
 
 test {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1780,6 +1780,7 @@ public abstract class AbstractInteropTest {
   /**
    * Wrapper around {@link Mockito#verify}, to keep log spam down on failure.
    */
+  @SuppressWarnings("serial")
   private static <T> T verify(T mock, VerificationMode mode) {
     try {
       return Mockito.verify(mock, mode);
@@ -1801,6 +1802,7 @@ public abstract class AbstractInteropTest {
   /**
    * Wrapper around {@link Mockito#verify}, to keep log spam down on failure.
    */
+  @SuppressWarnings("serial")
   private static void verifyNoMoreInteractions(Object... mocks) {
     try {
       Mockito.verifyNoMoreInteractions(mocks);

--- a/netty/build.gradle
+++ b/netty/build.gradle
@@ -13,11 +13,11 @@ dependencies {
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 [compileJava, compileTestJava].each() {
     // Netty retuns a lot of futures that we mostly don't care about.
-    it.options.compilerArgs += [
-        "-Xep:FutureReturnValueIgnored:OFF"
-    ]
+    it.options.errorprone.check("FutureReturnValueIgnored", CheckSeverity.OFF)
 }
 
 javadoc {

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -34,9 +34,9 @@ compileTestJava {
     options.compilerArgs += [
         "-Xlint:-rawtypes",
         "-Xlint:-unchecked",
-        "-Xlint:-fallthrough",
-        "-XepExcludedPaths:.*/build/generated/source/proto/.*"
+        "-Xlint:-fallthrough"
     ]
+    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
 }
 
 protobuf {


### PR DESCRIPTION
Grabbed #4980 to triage the [Macos failure of it](https://source.cloud.google.com/results/invocations/9609e259-8a83-4f1e-bc71-8c8633ea3122)