### PR TITLE
core/services: test/debug friendlier

### DIFF
--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -35,7 +35,8 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factory {
+@VisibleForTesting
+public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factory {
   private static final String DEFAULT_POLICY = "pick_first";
 
   private static final LoadBalancerRegistry registry = LoadBalancerRegistry.getDefaultRegistry();
@@ -62,7 +63,7 @@ final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factory {
 
 
   @VisibleForTesting
-  static final class AutoConfiguredLoadBalancer extends LoadBalancer {
+  public static final class AutoConfiguredLoadBalancer extends LoadBalancer {
     private final Helper helper;
     private LoadBalancer delegate;
     private LoadBalancerProvider delegateProvider;
@@ -125,7 +126,7 @@ final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factory {
     }
 
     @VisibleForTesting
-    LoadBalancer getDelegate() {
+    public LoadBalancer getDelegate() {
       return delegate;
     }
 

--- a/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
@@ -86,7 +86,7 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
     HelperImpl wrappedHelper = new HelperImpl(helper);
     LoadBalancer delegateBalancer = delegateFactory.newLoadBalancer(wrappedHelper);
     wrappedHelper.init(delegateBalancer);
-    return new LoadBalancerImpl(wrappedHelper, delegateBalancer);
+    return new HealthCheckingLoadBalancer(wrappedHelper, delegateBalancer);
   }
 
   private final class HelperImpl extends ForwardingLoadBalancerHelper {
@@ -144,13 +144,13 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
     }
   }
 
-  private static final class LoadBalancerImpl extends ForwardingLoadBalancer {
+  private static final class HealthCheckingLoadBalancer extends ForwardingLoadBalancer {
     final LoadBalancer delegate;
     final HelperImpl helper;
     final SynchronizationContext syncContext;
     final ScheduledExecutorService timerService;
 
-    LoadBalancerImpl(HelperImpl helper, LoadBalancer delegate) {
+    HealthCheckingLoadBalancer(HelperImpl helper, LoadBalancer delegate) {
       this.helper = checkNotNull(helper, "helper");
       this.syncContext = checkNotNull(helper.getSynchronizationContext(), "syncContext");
       this.timerService = checkNotNull(helper.getScheduledExecutorService(), "timerService");


### PR DESCRIPTION
Raise visibility of AutoConfiguredLoadBalancerFactory as internal
tests need to access it from a different package.

Rename HealthCheckingLoadBalancerFactory.LoadBalancerImpl to
*.HealthCheckingLoadBalancer so that its toString() output is more
informative.