### PR TITLE
core: allow ClientStreamTracer to intercept trailers.

### DIFF
--- a/core/src/main/java/io/grpc/ClientStreamTracer.java
+++ b/core/src/main/java/io/grpc/ClientStreamTracer.java
@@ -37,6 +37,15 @@ public abstract class ClientStreamTracer extends StreamTracer {
   }
 
   /**
+   * Trailing metadata has been received from the server.
+   *
+   * @param trailers the mutable trailing metadata.  Modifications to it will be seen by
+   *                 interceptors and the application.
+   */
+  public void inboundTrailers(Metadata trailers) {
+  }
+
+  /**
    * Factory class for {@link ClientStreamTracer}.
    */
   public abstract static class Factory {

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -426,6 +426,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
         }
         if (clientReceiveQueue.isEmpty() && clientNotifyStatus != null) {
           closed = true;
+          clientStream.statsTraceCtx.clientInboundTrailers(clientNotifyTrailers);
           clientStream.statsTraceCtx.streamClosed(clientNotifyStatus);
           clientStreamListener.closed(clientNotifyStatus, clientNotifyTrailers);
         }
@@ -535,6 +536,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
           }
           if (clientReceiveQueue.isEmpty()) {
             closed = true;
+            clientStream.statsTraceCtx.clientInboundTrailers(trailers);
             clientStream.statsTraceCtx.streamClosed(clientStatus);
             clientStreamListener.closed(clientStatus, trailers);
           } else {

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -388,6 +388,7 @@ public abstract class AbstractClientStream extends AbstractStream
         return;
       }
       this.trailers = trailers;
+      statsTraceCtx.clientInboundTrailers(trailers);
       trailerStatus = status;
       closeDeframer(false);
     }

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -111,6 +111,17 @@ public final class StatsTraceContext {
   }
 
   /**
+   * See {@link ClientStreamTracer#inboundTrailers}.  For client-side only.
+   *
+   * <p>Called from abstract stream implementations.
+   */
+  public void clientInboundTrailers(Metadata trailers) {
+    for (StreamTracer tracer : tracers) {
+      ((ClientStreamTracer) tracer).inboundTrailers(trailers);
+    }
+  }
+
+  /**
    * See {@link ServerStreamTracer#filterContext}.  For server-side only.
    *
    * <p>Called from {@link io.grpc.internal.ServerImpl}.

--- a/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestStreamTracer.java
@@ -94,6 +94,7 @@ public interface TestStreamTracer {
     protected final LinkedBlockingQueue<String> outboundEvents = new LinkedBlockingQueue<String>();
     protected final LinkedBlockingQueue<String> inboundEvents = new LinkedBlockingQueue<String>();
     protected final AtomicReference<Status> streamClosedStatus = new AtomicReference<Status>();
+    protected final AtomicReference<Throwable> streamClosedStack = new AtomicReference<Throwable>();
     protected final CountDownLatch streamClosed = new CountDownLatch(1);
     protected final AtomicBoolean failDuplicateCallbacks = new AtomicBoolean(true);
 
@@ -154,9 +155,10 @@ public interface TestStreamTracer {
 
     @Override
     public void streamClosed(Status status) {
+      streamClosedStack.compareAndSet(null, new Throwable("first call"));
       if (!streamClosedStatus.compareAndSet(null, status)) {
         if (failDuplicateCallbacks.get()) {
-          throw new AssertionError("streamClosed called more than once");
+          throw new AssertionError("streamClosed called more than once", streamClosedStack.get());
         }
       } else {
         streamClosed.countDown();


### PR DESCRIPTION
This would allow LoadBalancers to intercept trailers which could carry
load information.