### PR TITLE
core: use SynchronizationContext.schedule() for NameResolver refresh

### DIFF
--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -175,7 +175,8 @@ public class ManagedChannelImplTest {
       new FakeClock.TaskFilter() {
         @Override
         public boolean shouldAccept(Runnable command) {
-          return command instanceof ManagedChannelImpl.NameResolverRefresh;
+          return command.toString().contains(
+              ManagedChannelImpl.NameResolverRefresh.class.getName());
         }
       };
 


### PR DESCRIPTION
This also fixes the bug where NameResolverRefresh is not run from
syncContext if run from ScheduledExecutorService.