### PR TITLE
core: refactor flags in CensusStatsModule.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
-        opencensusVersion = '0.17.0'
+        opencensusVersion = '0.18.0'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
-        opencensusVersion = '0.18.0'
+        opencensusVersion = '0.17.0'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -432,12 +432,12 @@ public abstract class AbstractManagedChannelImplBuilder
       temporarilyDisableRetry = true;
       CensusStatsModule censusStats = this.censusStatsOverride;
       if (censusStats == null) {
-        censusStats = new CensusStatsModule(GrpcUtil.STOPWATCH_SUPPLIER, true);
+        censusStats = new CensusStatsModule(
+            GrpcUtil.STOPWATCH_SUPPLIER, true, recordStartedRpcs, recordFinishedRpcs);
       }
       // First interceptor runs last (see ClientInterceptors.intercept()), so that no
       // other interceptor can override the tracer factory we set in CallOptions.
-      effectiveInterceptors.add(
-          0, censusStats.getClientInterceptor(recordStartedRpcs, recordFinishedRpcs));
+      effectiveInterceptors.add(0, censusStats.getClientInterceptor());
     }
     if (tracingEnabled) {
       temporarilyDisableRetry = true;

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -265,10 +265,10 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
     if (statsEnabled) {
       CensusStatsModule censusStats = this.censusStatsOverride;
       if (censusStats == null) {
-        censusStats = new CensusStatsModule(GrpcUtil.STOPWATCH_SUPPLIER, true);
+        censusStats = new CensusStatsModule(
+            GrpcUtil.STOPWATCH_SUPPLIER, true, recordStartedRpcs, recordFinishedRpcs);
       }
-      tracerFactories.add(
-          censusStats.getServerTracerFactory(recordStartedRpcs, recordFinishedRpcs));
+      tracerFactories.add(censusStats.getServerTracerFactory());
     }
     if (tracingEnabled) {
       CensusTracingModule censusTracing =

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -414,7 +414,7 @@ public class AbstractManagedChannelImplBuilderTest {
               new FakeTagContextBinarySerializer(),
               new FakeStatsRecorder(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              true));
+              true, true, true));
     }
 
     Builder(SocketAddress directServerAddress, String authority) {
@@ -425,7 +425,7 @@ public class AbstractManagedChannelImplBuilderTest {
               new FakeTagContextBinarySerializer(),
               new FakeStatsRecorder(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              true));
+              true, true, true));
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
@@ -91,7 +91,7 @@ public class AbstractServerImplBuilderTest {
               new FakeTagContextBinarySerializer(),
               new FakeStatsRecorder(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              true));
+              true, true, true));
     }
 
     @Override

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -228,7 +228,7 @@ public abstract class AbstractInteropTest {
             tagContextBinarySerializer,
             serverStatsRecorder,
             GrpcUtil.STOPWATCH_SUPPLIER,
-            true));
+            true, true, true));
     try {
       server = builder.build().start();
     } catch (IOException ex) {
@@ -330,7 +330,8 @@ public abstract class AbstractInteropTest {
 
   protected final CensusStatsModule createClientCensusStatsModule() {
     return new CensusStatsModule(
-        tagger, tagContextBinarySerializer, clientStatsRecorder, GrpcUtil.STOPWATCH_SUPPLIER, true);
+        tagger, tagContextBinarySerializer, clientStatsRecorder, GrpcUtil.STOPWATCH_SUPPLIER,
+        true, true, true);
   }
 
   /**


### PR DESCRIPTION
There are currently three boolean flags, and there will be one more
soon.  Put them all in the top-level class instead of passing them as
arguments on lower levels.