### PR TITLE
core: record real-time metrics to OpenCensus (updated to 1.18.0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
-        opencensusVersion = '0.17.0'
+        opencensusVersion = '0.18.0'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
-        opencensusVersion = '0.18.0'
+        opencensusVersion = '0.17.0'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -165,6 +165,7 @@ public abstract class AbstractManagedChannelImplBuilder
   private boolean statsEnabled = true;
   private boolean recordStartedRpcs = true;
   private boolean recordFinishedRpcs = true;
+  private boolean recordRealTimeMetrics = false;
   private boolean tracingEnabled = true;
 
   @Nullable
@@ -384,6 +385,14 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   /**
+   * Disable or enable real-time metrics recording.  Effective only if {@link #setStatsEnabled} is
+   * set to true.  Disabled by default.
+   */
+  protected void setStatsRecordRealTimeMetrics(boolean value) {
+    recordRealTimeMetrics = value;
+  }
+
+  /**
    * Disable or enable tracing features.  Enabled by default.
    *
    * <p>For the current release, calling {@code setTracingEnabled(true)} may have a side effect that
@@ -433,7 +442,8 @@ public abstract class AbstractManagedChannelImplBuilder
       CensusStatsModule censusStats = this.censusStatsOverride;
       if (censusStats == null) {
         censusStats = new CensusStatsModule(
-            GrpcUtil.STOPWATCH_SUPPLIER, true, recordStartedRpcs, recordFinishedRpcs);
+            GrpcUtil.STOPWATCH_SUPPLIER, true, recordStartedRpcs, recordFinishedRpcs,
+            recordRealTimeMetrics);
       }
       // First interceptor runs last (see ClientInterceptors.intercept()), so that no
       // other interceptor can override the tracer factory we set in CallOptions.

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -432,12 +432,12 @@ public abstract class AbstractManagedChannelImplBuilder
       temporarilyDisableRetry = true;
       CensusStatsModule censusStats = this.censusStatsOverride;
       if (censusStats == null) {
-        censusStats = new CensusStatsModule(GrpcUtil.STOPWATCH_SUPPLIER, true);
+        censusStats = new CensusStatsModule(
+            GrpcUtil.STOPWATCH_SUPPLIER, true, recordStartedRpcs, recordFinishedRpcs);
       }
       // First interceptor runs last (see ClientInterceptors.intercept()), so that no
       // other interceptor can override the tracer factory we set in CallOptions.
-      effectiveInterceptors.add(
-          0, censusStats.getClientInterceptor(recordStartedRpcs, recordFinishedRpcs));
+      effectiveInterceptors.add(0, censusStats.getClientInterceptor());
     }
     if (tracingEnabled) {
       temporarilyDisableRetry = true;

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -265,10 +265,10 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
     if (statsEnabled) {
       CensusStatsModule censusStats = this.censusStatsOverride;
       if (censusStats == null) {
-        censusStats = new CensusStatsModule(GrpcUtil.STOPWATCH_SUPPLIER, true);
+        censusStats = new CensusStatsModule(
+            GrpcUtil.STOPWATCH_SUPPLIER, true, recordStartedRpcs, recordFinishedRpcs);
       }
-      tracerFactories.add(
-          censusStats.getServerTracerFactory(recordStartedRpcs, recordFinishedRpcs));
+      tracerFactories.add(censusStats.getServerTracerFactory());
     }
     if (tracingEnabled) {
       CensusTracingModule censusTracing =

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -108,6 +108,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   private boolean statsEnabled = true;
   private boolean recordStartedRpcs = true;
   private boolean recordFinishedRpcs = true;
+  private boolean recordRealTimeMetrics = false;
   private boolean tracingEnabled = true;
 
   @Nullable
@@ -240,6 +241,14 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   }
 
   /**
+   * Disable or enable real-time metrics recording.  Effective only if {@link #setStatsEnabled} is
+   * set to true.  Disabled by default.
+   */
+  protected void setStatsRecordRealTimeMetrics(boolean value) {
+    recordRealTimeMetrics = value;
+  }
+
+  /**
    * Disable or enable tracing features.  Enabled by default.
    */
   protected void setTracingEnabled(boolean value) {
@@ -266,7 +275,8 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
       CensusStatsModule censusStats = this.censusStatsOverride;
       if (censusStats == null) {
         censusStats = new CensusStatsModule(
-            GrpcUtil.STOPWATCH_SUPPLIER, true, recordStartedRpcs, recordFinishedRpcs);
+            GrpcUtil.STOPWATCH_SUPPLIER, true, recordStartedRpcs, recordFinishedRpcs,
+            recordRealTimeMetrics);
       }
       tracerFactories.add(censusStats.getServerTracerFactory());
     }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -414,7 +414,7 @@ public class AbstractManagedChannelImplBuilderTest {
               new FakeTagContextBinarySerializer(),
               new FakeStatsRecorder(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              true, true, true));
+              true, true, true, true));
     }
 
     Builder(SocketAddress directServerAddress, String authority) {
@@ -425,7 +425,7 @@ public class AbstractManagedChannelImplBuilderTest {
               new FakeTagContextBinarySerializer(),
               new FakeStatsRecorder(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              true, true, true));
+              true, true, true, true));
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -414,7 +414,7 @@ public class AbstractManagedChannelImplBuilderTest {
               new FakeTagContextBinarySerializer(),
               new FakeStatsRecorder(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              true));
+              true, true, true));
     }
 
     Builder(SocketAddress directServerAddress, String authority) {
@@ -425,7 +425,7 @@ public class AbstractManagedChannelImplBuilderTest {
               new FakeTagContextBinarySerializer(),
               new FakeStatsRecorder(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              true));
+              true, true, true));
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
@@ -91,7 +91,7 @@ public class AbstractServerImplBuilderTest {
               new FakeTagContextBinarySerializer(),
               new FakeStatsRecorder(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              true, true, true));
+              true, true, true, true));
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
@@ -91,7 +91,7 @@ public class AbstractServerImplBuilderTest {
               new FakeTagContextBinarySerializer(),
               new FakeStatsRecorder(),
               GrpcUtil.STOPWATCH_SUPPLIER,
-              true));
+              true, true, true));
     }
 
     @Override

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -228,7 +228,7 @@ public abstract class AbstractInteropTest {
             tagContextBinarySerializer,
             serverStatsRecorder,
             GrpcUtil.STOPWATCH_SUPPLIER,
-            true));
+            true, true, true));
     try {
       server = builder.build().start();
     } catch (IOException ex) {
@@ -330,7 +330,8 @@ public abstract class AbstractInteropTest {
 
   protected final CensusStatsModule createClientCensusStatsModule() {
     return new CensusStatsModule(
-        tagger, tagContextBinarySerializer, clientStatsRecorder, GrpcUtil.STOPWATCH_SUPPLIER, true);
+        tagger, tagContextBinarySerializer, clientStatsRecorder, GrpcUtil.STOPWATCH_SUPPLIER,
+        true, true, true);
   }
 
   /**

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -228,7 +228,7 @@ public abstract class AbstractInteropTest {
             tagContextBinarySerializer,
             serverStatsRecorder,
             GrpcUtil.STOPWATCH_SUPPLIER,
-            true, true, true));
+            true, true, true, false /* real-time metrics */));
     try {
       server = builder.build().start();
     } catch (IOException ex) {
@@ -331,7 +331,7 @@ public abstract class AbstractInteropTest {
   protected final CensusStatsModule createClientCensusStatsModule() {
     return new CensusStatsModule(
         tagger, tagContextBinarySerializer, clientStatsRecorder, GrpcUtil.STOPWATCH_SUPPLIER,
-        true, true, true);
+        true, true, true, false /* real-time metrics */);
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -62,6 +62,10 @@ public final class InternalNettyChannelBuilder {
     builder.setStatsRecordStartedRpcs(value);
   }
 
+  public static void setStatsRecordRealTimeMetrics(NettyChannelBuilder builder, boolean value) {
+    builder.setStatsRecordRealTimeMetrics(value);
+  }
+
   public static ClientTransportFactory buildTransportFactory(NettyChannelBuilder builder) {
     return builder.buildTransportFactory();
   }

--- a/netty/src/main/java/io/grpc/netty/InternalNettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyServerBuilder.java
@@ -33,6 +33,10 @@ public final class InternalNettyServerBuilder {
     builder.setStatsRecordStartedRpcs(value);
   }
 
+  public static void setStatsRecordRealTimeMetrics(NettyServerBuilder builder, boolean value) {
+    builder.setStatsRecordRealTimeMetrics(value);
+  }
+
   public static void setTracingEnabled(NettyServerBuilder builder, boolean value) {
     builder.setTracingEnabled(value);
   }

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -471,6 +471,11 @@ public final class NettyChannelBuilder
     super.setStatsRecordStartedRpcs(value);
   }
 
+  @Override
+  protected void setStatsRecordRealTimeMetrics(boolean value) {
+    super.setStatsRecordRealTimeMetrics(value);
+  }
+
   @VisibleForTesting
   NettyChannelBuilder setTransportTracerFactory(TransportTracer.Factory transportTracerFactory) {
     this.transportTracerFactory = transportTracerFactory;

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -228,6 +228,11 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
     super.setStatsRecordStartedRpcs(value);
   }
 
+  @Override
+  protected void setStatsRecordRealTimeMetrics(boolean value) {
+    super.setStatsRecordRealTimeMetrics(value);
+  }
+
   @VisibleForTesting
   NettyServerBuilder setTransportTracerFactory(TransportTracer.Factory transportTracerFactory) {
     this.transportTracerFactory = transportTracerFactory;

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -302,15 +302,15 @@ def io_netty_transport():
 def io_opencensus_api():
     native.maven_jar(
         name = "io_opencensus_opencensus_api",
-        artifact = "io.opencensus:opencensus-api:0.17.0",
-        sha1 = "0b9c91321f9c9f20f3a4627bfd9e3097164f85e6",
+        artifact = "io.opencensus:opencensus-api:0.18.0",
+        sha1 = "b89a8f8dfd1e1e0d68d83c82a855624814b19a6e",
     )
 
 def io_opencensus_grpc_metrics():
     native.maven_jar(
         name = "io_opencensus_opencensus_contrib_grpc_metrics",
-        artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.17.0",
-        sha1 = "4b82972073361704f57fa2107910242f1143df25",
+        artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.18.0",
+        sha1 = "8e90fab2930b6a0e67dab48911b9c936470d43dd",
     )
 
 def javax_annotation():


### PR DESCRIPTION
Real-time metrics are total sent/received bytes and messages per
method, and are updated as the events occur rather than at the end of
RPCs.

/cc @songy23 