### PR TITLE
core: Fix typo in RoundRobinLoadBalancerFactory's deprecation warning

### DIFF
--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancerFactory.java
@@ -27,7 +27,7 @@ import io.grpc.LoadBalancerRegistry;
  * A {@link LoadBalancer} that provides round-robin load balancing mechanism over the
  * addresses.
  *
- * @deprecated use {@link io.grpc.LoadBalancerRegistry#getProvider} with "round-robin" policy.  This
+ * @deprecated use {@link io.grpc.LoadBalancerRegistry#getProvider} with "round_robin" policy.  This
  *             class will be deleted soon.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")


### PR DESCRIPTION
> ````java
> * @deprecated use {@link io.grpc.LoadBalancerRegistry#getProvider} with "round-robin" policy.  This
> *             class will be deleted soon.
> [...]
> LoadBalancerRegistry.getDefaultRegistry().getProvider("round_robin")
> ````

The name of the policy and the mentioned policy in the deprecation warning does not match.