### PR TITLE
StreamObservers: make sure onComplete only gets called once from onReadyHandler

### DIFF
--- a/stub/src/main/java/io/grpc/stub/StreamObservers.java
+++ b/stub/src/main/java/io/grpc/stub/StreamObservers.java
@@ -44,12 +44,15 @@ public final class StreamObservers {
     Preconditions.checkNotNull(target, "target");
 
     final class FlowControllingOnReadyHandler implements Runnable {
+      private boolean completed;
+
       @Override
       public void run() {
         while (target.isReady() && source.hasNext()) {
           target.onNext(source.next());
         }
-        if (!source.hasNext()) {
+        if (!source.hasNext() && !completed) {
+          completed = true;
           target.onCompleted();
         }
       }

--- a/stub/src/main/java/io/grpc/stub/StreamObservers.java
+++ b/stub/src/main/java/io/grpc/stub/StreamObservers.java
@@ -48,14 +48,17 @@ public final class StreamObservers {
 
       @Override
       public void run() {
-        if (!completed) {
-          while (target.isReady() && source.hasNext()) {
-            target.onNext(source.next());
-          }
-          if (!source.hasNext()) {
-            completed = true;
-            target.onCompleted();
-          }
+        if (completed) {
+          return;
+        }
+
+        while (target.isReady() && source.hasNext()) {
+          target.onNext(source.next());
+        }
+
+        if (!source.hasNext()) {
+          completed = true;
+          target.onCompleted();
         }
       }
     }

--- a/stub/src/main/java/io/grpc/stub/StreamObservers.java
+++ b/stub/src/main/java/io/grpc/stub/StreamObservers.java
@@ -48,12 +48,14 @@ public final class StreamObservers {
 
       @Override
       public void run() {
-        while (target.isReady() && source.hasNext()) {
-          target.onNext(source.next());
-        }
-        if (!source.hasNext() && !completed) {
-          completed = true;
-          target.onCompleted();
+        if (!completed) {
+          while (target.isReady() && source.hasNext()) {
+            target.onNext(source.next());
+          }
+          if (!source.hasNext()) {
+            completed = true;
+            target.onCompleted();
+          }
         }
       }
     }


### PR DESCRIPTION
re: #4558

I encountered the same issue as @biran0079 was seeing where `onReady` was getting called again after `onComplete` had already been called, resulting in an exception because the channel had already been half closed. This simply tracks whether the stream has previously been completed and refuses to call `onComplete`.

I opted not to make this thread-safe because it seems like many of these interfaces are generally not thread-safe (and AFAICT this will only get called from one thread).