### PR TITLE
core: disable SRV records lookup

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -90,7 +90,7 @@ final class DnsNameResolver extends NameResolver {
   private static final String JNDI_LOCALHOST_PROPERTY =
       System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_jndi_localhost", "false");
   private static final String JNDI_SRV_PROPERTY =
-      System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_grpclb", "true");
+      System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_grpclb", "false");
   private static final String JNDI_TXT_PROPERTY =
       System.getProperty("io.grpc.internal.DnsNameResolverProvider.enable_service_config", "false");
 


### PR DESCRIPTION
This effectively reverts c729a0f. This is necessary because #4602 is
not resolved.

-----

This change will only be applied to 1.17. 1.18 is receiving a behavior change
in #5129, but the behavior change is a bit too invasive for the release. In
addition it would have to be reimplemented due to changes to changes in
#4996 that prevent a clean backport merge.

CC @carl-mastrangelo 