### PR TITLE
core: add ManagedChannelBuilder.defaultLoadBalancingPolicy()

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -121,9 +121,16 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
     return thisT();
   }
 
+  @Deprecated
   @Override
   public T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory) {
     delegate().loadBalancerFactory(loadBalancerFactory);
+    return thisT();
+  }
+
+  @Override
+  public T defaultLoadBalancingPolicy(String policy) {
+    delegate().defaultLoadBalancingPolicy(policy);
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -236,19 +236,23 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * @since 1.0.0
    */
   @Deprecated
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
   public abstract T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory);
 
   /**
    * Sets the default load-balancing policy that will be used if the service config doesn't specify
    * one.  If not set, the default will be the "pick_first" policy.
    *
-   * <p>This method is implemented by all stock channel builders that
-   * are shipped with gRPC, but may not be implemented by custom channel builders, in which case
-   * this method will throw.
+   * <p>Policy implementations are looked up in the
+   * {@link LoadBalancerRegistry#getDefaultRegistry default LoadBalancerRegistry}.
+   *
+   * <p>This method is implemented by all stock channel builders that are shipped with gRPC, but may
+   * not be implemented by custom channel builders, in which case this method will throw.
    *
    * @return this
    * @since 1.18.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
   public T defaultLoadBalancingPolicy(String policy) {
     throw new UnsupportedOperationException();
   }

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -228,11 +228,30 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    * are shipped with gRPC, but may not be implemented by custom channel builders, in which case
    * this method will throw.
    *
+   * @deprecated this method disables service-config-based policy selection, and may cause problems
+   *             if NameResolver returns GRPCLB balancer addresses but a non-GRPCLB LoadBalancer
+   *             is passed in here.  Use {@link #defaultLoadBalancingPolicy} instead.
+   *
    * @return this
    * @since 1.0.0
    */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
+  @Deprecated
   public abstract T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory);
+
+  /**
+   * Sets the default load-balancing policy that will be used if the service config doesn't specify
+   * one.  If not set, the default will be the "pick_first" policy.
+   *
+   * <p>This method is implemented by all stock channel builders that
+   * are shipped with gRPC, but may not be implemented by custom channel builders, in which case
+   * this method will throw.
+   *
+   * @return this
+   * @since 1.18.0
+   */
+  public T defaultLoadBalancingPolicy(String policy) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Enables full-stream decompression of inbound streams. This will cause the channel's outbound

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -114,8 +114,9 @@ public abstract class AbstractManagedChannelImplBuilder
   @Nullable
   String authorityOverride;
 
-
   @Nullable LoadBalancer.Factory loadBalancerFactory;
+
+  String defaultLbPolicy = GrpcUtil.DEFAULT_LB_POLICY;
 
   boolean fullStreamDecompression;
 
@@ -236,12 +237,23 @@ public abstract class AbstractManagedChannelImplBuilder
     return thisT();
   }
 
+  @Deprecated
   @Override
   public final T loadBalancerFactory(LoadBalancer.Factory loadBalancerFactory) {
     Preconditions.checkState(directServerAddress == null,
         "directServerAddress is set (%s), which forbids the use of LoadBalancer.Factory",
         directServerAddress);
     this.loadBalancerFactory = loadBalancerFactory;
+    return thisT();
+  }
+
+  @Override
+  public final T defaultLoadBalancingPolicy(String policy) {
+    Preconditions.checkState(directServerAddress == null,
+        "directServerAddress is set (%s), which forbids the use of load-balancing policy",
+        directServerAddress);
+    Preconditions.checkArgument(policy != null, "policy cannot be null");
+    this.defaultLbPolicy = policy;
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -43,19 +43,20 @@ import javax.annotation.Nullable;
 
 @VisibleForTesting
 public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factory {
-  private static final String DEFAULT_POLICY = "pick_first";
   private static final Logger logger =
       Logger.getLogger(AutoConfiguredLoadBalancerFactory.class.getName());
 
   private final LoadBalancerRegistry registry;
+  private final String defaultPolicy;
 
-  public AutoConfiguredLoadBalancerFactory() {
-    this(LoadBalancerRegistry.getDefaultRegistry());
+  public AutoConfiguredLoadBalancerFactory(String defaultPolicy) {
+    this(LoadBalancerRegistry.getDefaultRegistry(), defaultPolicy);
   }
 
   @VisibleForTesting
-  AutoConfiguredLoadBalancerFactory(LoadBalancerRegistry registry) {
+  AutoConfiguredLoadBalancerFactory(LoadBalancerRegistry registry, String defaultPolicy) {
     this.registry = checkNotNull(registry, "registry");
+    this.defaultPolicy = checkNotNull(defaultPolicy, "defaultPolicy");
   }
 
   @Override
@@ -87,10 +88,11 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
 
     AutoConfiguredLoadBalancer(Helper helper) {
       this.helper = helper;
-      delegateProvider = registry.getProvider(DEFAULT_POLICY);
+      delegateProvider = registry.getProvider(defaultPolicy);
       if (delegateProvider == null) {
-        throw new IllegalStateException("Could not find LoadBalancer " + DEFAULT_POLICY
-            + ". The build probably threw away META-INF/services/io.grpc.LoadBalancerProvider");
+        throw new IllegalStateException("Could not find policy '" + defaultPolicy
+            + "'. Make sure its implementation is either registered to LoadBalancerRegistry or"
+            + " included in META-INF/services/io.grpc.LoadBalancerProvider from your jar files.");
       }
       delegate = delegateProvider.newLoadBalancer(helper);
     }
@@ -222,9 +224,11 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
       }
       roundRobinDueToGrpclbDepMissing = false;
 
+      List<Map<String, Object>> lbConfigs = null;
       if (config != null) {
-        List<Map<String, Object>> lbConfigs =
-            ServiceConfigUtil.getLoadBalancingConfigsFromServiceConfig(config);
+        lbConfigs = ServiceConfigUtil.getLoadBalancingConfigsFromServiceConfig(config);
+      }
+      if (lbConfigs != null && !lbConfigs.isEmpty()) {
         LinkedHashSet<String> policiesTried = new LinkedHashSet<>();
         for (Map<String, Object> lbConfig : lbConfigs) {
           if (lbConfig.size() != 1) {
@@ -250,7 +254,7 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
             "None of " + policiesTried + " specified by Service Config are available.");
       }
       return new PolicySelection(
-          getProviderOrThrow(DEFAULT_POLICY, "using default policy"), servers, null);
+          getProviderOrThrow(defaultPolicy, "using default policy"), servers, null);
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -249,6 +249,11 @@ public final class GrpcUtil {
   };
 
   /**
+   * The very default load-balancing policy.
+   */
+  public static final String DEFAULT_LB_POLICY = "pick_first";
+
+  /**
    * RPCs created on the Channel returned by {@link io.grpc.LoadBalancer.Subchannel#asChannel}
    * will have this option with value {@code true}.  They will be treated differently from
    * the ones created by application.

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -542,7 +542,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
         "Channel for '" + target + "'");
     channelLogger = new ChannelLoggerImpl(channelTracer, timeProvider);
     if (builder.loadBalancerFactory == null) {
-      this.loadBalancerFactory = new AutoConfiguredLoadBalancerFactory();
+      this.loadBalancerFactory = new AutoConfiguredLoadBalancerFactory(builder.defaultLbPolicy);
     } else {
       this.loadBalancerFactory = builder.loadBalancerFactory;
     }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -127,6 +127,7 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
+  @Deprecated
   public void loadBalancerFactory_normal() {
     LoadBalancer.Factory loadBalancerFactory = mock(LoadBalancer.Factory.class);
     assertEquals(builder, builder.loadBalancerFactory(loadBalancerFactory));
@@ -134,6 +135,7 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test
+  @Deprecated
   public void loadBalancerFactory_null() {
     LoadBalancer.Factory defaultValue = builder.loadBalancerFactory;
     builder.loadBalancerFactory(mock(LoadBalancer.Factory.class));
@@ -142,8 +144,30 @@ public class AbstractManagedChannelImplBuilderTest {
   }
 
   @Test(expected = IllegalStateException.class)
+  @Deprecated
   public void loadBalancerFactory_notAllowedWithDirectAddress() {
     directAddressBuilder.loadBalancerFactory(mock(LoadBalancer.Factory.class));
+  }
+
+  @Test
+  public void defaultLoadBalancingPolicy_default() {
+    assertEquals(builder.defaultLbPolicy, "pick_first");
+  }
+
+  @Test
+  public void defaultLoadBalancingPolicy_normal() {
+    assertEquals(builder, builder.defaultLoadBalancingPolicy("magic_balancer"));
+    assertEquals("magic_balancer", builder.defaultLbPolicy);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void defaultLoadBalancingPolicy_null() {
+    builder.defaultLoadBalancingPolicy(null);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void defaultLoadBalancingPolicy_notAllowedWithDirectAddress() {
+    directAddressBuilder.defaultLoadBalancingPolicy("magic_balancer");
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -74,7 +74,8 @@ import org.mockito.ArgumentCaptor;
  */
 @RunWith(JUnit4.class)
 public class AutoConfiguredLoadBalancerFactoryTest {
-  private final AutoConfiguredLoadBalancerFactory lbf = new AutoConfiguredLoadBalancerFactory();
+  private final AutoConfiguredLoadBalancerFactory lbf =
+      new AutoConfiguredLoadBalancerFactory(GrpcUtil.DEFAULT_LB_POLICY);
 
   private final ChannelLogger channelLogger = mock(ChannelLogger.class);
   private final LoadBalancer testLbBalancer = mock(LoadBalancer.class);
@@ -105,6 +106,16 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
     assertThat(lb.getDelegateProvider()).isInstanceOf(PickFirstLoadBalancerProvider.class);
     assertThat(lb.getDelegate().getClass().getName()).contains("PickFirst");
+  }
+
+  @Test
+  public void defaultIsConfigurable() {
+    AutoConfiguredLoadBalancer lb =
+        (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory("test_lb")
+        .newLoadBalancer(new TestHelper());
+
+    assertThat(lb.getDelegateProvider()).isSameAs(testLbBalancerProvider);
+    assertThat(lb.getDelegate()).isSameAs(testLbBalancer);
   }
 
   @Test
@@ -286,8 +297,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
         }
       };
     AutoConfiguredLoadBalancer lb =
-        (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(registry)
-            .newLoadBalancer(helper);
+        (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(
+            registry, GrpcUtil.DEFAULT_LB_POLICY).newLoadBalancer(helper);
 
     lb.handleResolvedAddressGroups(servers, Attributes.EMPTY);
 
@@ -307,6 +318,23 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     PolicySelection selection = lb.decideLoadBalancerProvider(servers, serviceConfig);
 
     assertThat(selection.provider).isInstanceOf(PickFirstLoadBalancerProvider.class);
+    assertThat(selection.serverList).isEqualTo(servers);
+    assertThat(selection.config).isNull();
+    verifyZeroInteractions(channelLogger);
+  }
+
+  @Test
+  public void decideLoadBalancerProvider_noBalancerAddresses_noServiceConfig_customDefault()
+      throws Exception {
+    AutoConfiguredLoadBalancer lb =
+        (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory("test_lb")
+            .newLoadBalancer(new TestHelper());
+    Map<String, Object> serviceConfig = null;
+    List<EquivalentAddressGroup> servers =
+        Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
+    PolicySelection selection = lb.decideLoadBalancerProvider(servers, serviceConfig);
+
+    assertThat(selection.provider).isSameAs(testLbBalancerProvider);
     assertThat(selection.serverList).isEqualTo(servers);
     assertThat(selection.config).isNull();
     verifyZeroInteractions(channelLogger);
@@ -376,8 +404,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     registry.register(new PickFirstLoadBalancerProvider());
     registry.register(new FakeRoundRobinLoadBalancerProvider());
     AutoConfiguredLoadBalancer lb =
-        (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(registry)
-            .newLoadBalancer(new TestHelper());
+        (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(
+            registry, GrpcUtil.DEFAULT_LB_POLICY).newLoadBalancer(new TestHelper());
     Map<String, Object> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"round_robin\": {} } ] }");
     List<EquivalentAddressGroup> servers =
@@ -411,8 +439,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     registry.register(new PickFirstLoadBalancerProvider());
     registry.register(new FakeRoundRobinLoadBalancerProvider());
     AutoConfiguredLoadBalancer lb =
-        (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(registry)
-            .newLoadBalancer(new TestHelper());
+        (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(
+            registry, GrpcUtil.DEFAULT_LB_POLICY).newLoadBalancer(new TestHelper());
     Map<String, Object> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"round_robin\": {} } ] }");
     List<EquivalentAddressGroup> servers =
@@ -560,7 +588,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
       }
     };
 
-    LoadBalancer lb = new AutoConfiguredLoadBalancerFactory().newLoadBalancer(helper);
+    LoadBalancer lb = new AutoConfiguredLoadBalancerFactory(GrpcUtil.DEFAULT_LB_POLICY)
+        .newLoadBalancer(helper);
     lb.handleResolvedAddressGroups(servers, Attributes.EMPTY);
 
     verifyNoMoreInteractions(channelLogger);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -196,7 +196,7 @@ public class ManagedChannelImplTest {
   private ArgumentCaptor<CallOptions> callOptionsCaptor;
   @Mock
   private LoadBalancer mockLoadBalancer;
-  private LoadBalancerProvider mockLoadBalancerProvider =
+  private final LoadBalancerProvider mockLoadBalancerProvider =
       mock(LoadBalancerProvider.class, delegatesTo(new LoadBalancerProvider() {
           @Override
           public LoadBalancer newLoadBalancer(Helper helper) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
@@ -80,6 +81,8 @@ import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -159,6 +162,7 @@ public class ManagedChannelImplTest {
           .setAuthority(AUTHORITY)
           .setUserAgent(USER_AGENT);
   private static final String TARGET = "fake://" + SERVICE_NAME;
+  private static final String MOCK_POLICY_NAME = "mock_lb";
   private URI expectedUri;
   private final SocketAddress socketAddress =
       new SocketAddress() {
@@ -191,9 +195,29 @@ public class ManagedChannelImplTest {
   @Captor
   private ArgumentCaptor<CallOptions> callOptionsCaptor;
   @Mock
-  private LoadBalancer.Factory mockLoadBalancerFactory;
-  @Mock
   private LoadBalancer mockLoadBalancer;
+  private LoadBalancerProvider mockLoadBalancerProvider =
+      mock(LoadBalancerProvider.class, delegatesTo(new LoadBalancerProvider() {
+          @Override
+          public LoadBalancer newLoadBalancer(Helper helper) {
+            return mockLoadBalancer;
+          }
+
+          @Override
+          public boolean isAvailable() {
+            return true;
+          }
+
+          @Override
+          public int getPriority() {
+            return 999;
+          }
+
+          @Override
+          public String getPolicyName() {
+            return MOCK_POLICY_NAME;
+          }
+        }));
 
   @Captor
   private ArgumentCaptor<ConnectivityStateInfo> stateInfoCaptor;
@@ -248,7 +272,7 @@ public class ManagedChannelImplTest {
       assertEquals(numExpectedTasks, timer.numPendingTasks());
 
       ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
-      verify(mockLoadBalancerFactory).newLoadBalancer(helperCaptor.capture());
+      verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
       helper = helperCaptor.getValue();
     }
   }
@@ -256,8 +280,8 @@ public class ManagedChannelImplTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
+    LoadBalancerRegistry.getDefaultRegistry().register(mockLoadBalancerProvider);
     expectedUri = new URI(TARGET);
-    when(mockLoadBalancerFactory.newLoadBalancer(any(Helper.class))).thenReturn(mockLoadBalancer);
     transports = TestUtils.captureTransports(mockTransportFactory);
     when(mockTransportFactory.getScheduledExecutorService())
         .thenReturn(timer.getScheduledExecutorService());
@@ -267,7 +291,7 @@ public class ManagedChannelImplTest {
 
     channelBuilder = new ChannelBuilder()
         .nameResolverFactory(new FakeNameResolverFactory.Builder(expectedUri).build())
-        .loadBalancerFactory(mockLoadBalancerFactory)
+        .defaultLoadBalancingPolicy(MOCK_POLICY_NAME)
         .userAgent(USER_AGENT)
         .idleTimeout(AbstractManagedChannelImplBuilder.IDLE_MODE_MAX_TIMEOUT_DAYS, TimeUnit.DAYS);
     channelBuilder.executorPool = executorPool;
@@ -287,6 +311,11 @@ public class ManagedChannelImplTest {
       channel.shutdownNow();
       channel = null;
     }
+  }
+
+  @After
+  public void cleanUp() {
+    LoadBalancerRegistry.getDefaultRegistry().deregister(mockLoadBalancerProvider);
   }
 
   @Test
@@ -523,7 +552,7 @@ public class ManagedChannelImplTest {
     assertTrue(channel.isShutdown());
     assertFalse(channel.isTerminated());
     assertEquals(1, nameResolverFactory.resolvers.size());
-    verify(mockLoadBalancerFactory).newLoadBalancer(any(Helper.class));
+    verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
 
     // Further calls should fail without going to the transport
     ClientCall<String, Integer> call3 = channel.newCall(method, CallOptions.DEFAULT);
@@ -602,7 +631,7 @@ public class ManagedChannelImplTest {
     createChannel();
 
     FakeNameResolverFactory.FakeNameResolver resolver = nameResolverFactory.resolvers.get(0);
-    verify(mockLoadBalancerFactory).newLoadBalancer(any(Helper.class));
+    verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
     verify(mockLoadBalancer).handleResolvedAddressGroups(
         eq(Arrays.asList(addressGroup)), eq(Attributes.EMPTY));
 
@@ -803,7 +832,7 @@ public class ManagedChannelImplTest {
     createChannel();
 
     // LoadBalancer received the error
-    verify(mockLoadBalancerFactory).newLoadBalancer(any(Helper.class));
+    verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
     verify(mockLoadBalancer).handleNameResolutionError(statusCaptor.capture());
     Status status = statusCaptor.getValue();
     assertSame(Status.Code.UNAVAILABLE, status.getCode());
@@ -822,7 +851,7 @@ public class ManagedChannelImplTest {
     channelBuilder.nameResolverFactory(nameResolverFactory);
     createChannel();
 
-    verify(mockLoadBalancerFactory).newLoadBalancer(any(Helper.class));
+    verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
     doThrow(ex).when(mockLoadBalancer).handleResolvedAddressGroups(
         Matchers.<List<EquivalentAddressGroup>>anyObject(), any(Attributes.class));
 
@@ -1727,18 +1756,18 @@ public class ManagedChannelImplTest {
     createChannel();
 
     assertEquals(IDLE, channel.getState(false));
-    verify(mockLoadBalancerFactory, never()).newLoadBalancer(any(Helper.class));
+    verify(mockLoadBalancerProvider, never()).newLoadBalancer(any(Helper.class));
 
     // call getState() with requestConnection = true
     assertEquals(IDLE, channel.getState(true));
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
-    verify(mockLoadBalancerFactory).newLoadBalancer(helperCaptor.capture());
+    verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
 
     helper.updateBalancingState(CONNECTING, mockPicker);
     assertEquals(CONNECTING, channel.getState(false));
     assertEquals(CONNECTING, channel.getState(true));
-    verifyNoMoreInteractions(mockLoadBalancerFactory);
+    verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
   }
 
   @Test
@@ -1746,12 +1775,12 @@ public class ManagedChannelImplTest {
     channelBuilder.nameResolverFactory(
         new FakeNameResolverFactory.Builder(expectedUri).setResolvedAtStart(false).build());
     createChannel();
-    verify(mockLoadBalancerFactory).newLoadBalancer(any(Helper.class));
+    verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
 
     helper.updateBalancingState(IDLE, mockPicker);
 
     assertEquals(IDLE, channel.getState(true));
-    verifyNoMoreInteractions(mockLoadBalancerFactory);
+    verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
     verify(mockPicker).requestConnection();
   }
 
@@ -1863,7 +1892,7 @@ public class ManagedChannelImplTest {
     channelBuilder.idleTimeout(idleTimeoutMillis, TimeUnit.MILLISECONDS);
     createChannel();
 
-    verify(mockLoadBalancerFactory).newLoadBalancer(any(Helper.class));
+    verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
     assertEquals(1, nameResolverFactory.resolvers.size());
     FakeNameResolverFactory.FakeNameResolver resolver = nameResolverFactory.resolvers.remove(0);
 
@@ -1909,7 +1938,7 @@ public class ManagedChannelImplTest {
     verifyPanicMode(panicReason);
 
     // No new resolver or balancer are created
-    verifyNoMoreInteractions(mockLoadBalancerFactory);
+    verifyNoMoreInteractions(mockLoadBalancerProvider);
     assertEquals(0, nameResolverFactory.resolvers.size());
 
     // A misbehaving balancer that calls updateBalancingState() after it's shut down will not be
@@ -2006,7 +2035,7 @@ public class ManagedChannelImplTest {
 
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     // Two times of requesting connection will create loadBalancer twice.
-    verify(mockLoadBalancerFactory, times(2)).newLoadBalancer(helperCaptor.capture());
+    verify(mockLoadBalancerProvider, times(2)).newLoadBalancer(helperCaptor.capture());
     Helper helper2 = helperCaptor.getValue();
 
     // Updating on the old helper (whose balancer has been shutdown) does not change the channel
@@ -2055,7 +2084,7 @@ public class ManagedChannelImplTest {
 
     // Get the helper created on exiting idle
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
-    verify(mockLoadBalancerFactory, times(2)).newLoadBalancer(helperCaptor.capture());
+    verify(mockLoadBalancerProvider, times(2)).newLoadBalancer(helperCaptor.capture());
     Helper helper2 = helperCaptor.getValue();
 
     // Establish a connection
@@ -2123,7 +2152,7 @@ public class ManagedChannelImplTest {
 
     // enterIdle() will restart the delayed call by exiting idle. This creates a new helper.
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
-    verify(mockLoadBalancerFactory, times(2)).newLoadBalancer(helperCaptor.capture());
+    verify(mockLoadBalancerProvider, times(2)).newLoadBalancer(helperCaptor.capture());
     Helper helper2 = helperCaptor.getValue();
 
     // Establish a connection
@@ -2528,7 +2557,7 @@ public class ManagedChannelImplTest {
     createChannel();
 
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(null);
-    verify(mockLoadBalancerFactory).newLoadBalancer(helperCaptor.capture());
+    verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
 
     assertEquals(IDLE, getStats(channel).state);
@@ -2818,10 +2847,11 @@ public class ManagedChannelImplTest {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, new Metadata());
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
-    verify(mockLoadBalancerFactory).newLoadBalancer(helperCaptor.capture());
+    verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
     verify(mockLoadBalancer)
-        .handleResolvedAddressGroups(nameResolverFactory.servers, attributesWithRetryPolicy);
+        .handleResolvedAddressGroups(
+            eq(nameResolverFactory.servers), same(attributesWithRetryPolicy));
 
     // simulating request connection and then transport ready after resolved address
     Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
@@ -2914,7 +2944,7 @@ public class ManagedChannelImplTest {
     ClientCall<String, Integer> call = channel.newCall(method, CallOptions.DEFAULT);
     call.start(mockCallListener, new Metadata());
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
-    verify(mockLoadBalancerFactory).newLoadBalancer(helperCaptor.capture());
+    verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
     verify(mockLoadBalancer)
         .handleResolvedAddressGroups(nameResolverFactory.servers, attributesWithRetryPolicy);
@@ -3035,9 +3065,7 @@ public class ManagedChannelImplTest {
       }
     }
 
-    ManagedChannel mychannel = new CustomBuilder()
-        .nameResolverFactory(factory)
-        .loadBalancerFactory(new AutoConfiguredLoadBalancerFactory()).build();
+    ManagedChannel mychannel = new CustomBuilder().nameResolverFactory(factory).build();
 
     ClientCall<Void, Void> call1 =
         mychannel.newCall(TestMethodDescriptors.voidMethod(), CallOptions.DEFAULT);


### PR DESCRIPTION
ManagedChannelBuilder.loadBalancingFactory() overrides the proper
policy selection logic implemented in AutoConfiguredLoadBalancer, thus
has problems in cases where NameResolver returns balancer addresses,
because custom LoadBalancers normally don't differentiate between
normal server addresses with balancer addresses.  The policy selection
logic will filter out balancer addresses.