### PR TITLE
core: Fix for issue #5142 (CallOptions mutability)

### DIFF
--- a/core/src/main/java/io/grpc/CallOptions.java
+++ b/core/src/main/java/io/grpc/CallOptions.java
@@ -326,7 +326,7 @@ public final class CallOptions {
       newOptions.customOptions[customOptions.length] = new Object[] {key, value};
     } else {
       // Replace an existing option
-      newOptions.customOptions[existingIdx][1] = value;
+      newOptions.customOptions[existingIdx] = new Object[] {key, value};
     }
 
     return newOptions;

--- a/core/src/test/java/io/grpc/CallOptionsTest.java
+++ b/core/src/test/java/io/grpc/CallOptionsTest.java
@@ -197,6 +197,17 @@ public class CallOptionsTest {
   }
 
   @Test
+  public void withOptionDoesNotMutateOriginal() {
+    CallOptions defaultOpt = CallOptions.DEFAULT;
+    CallOptions opt1 = defaultOpt.withOption(OPTION_1, "v1");
+    CallOptions opt2 = opt1.withOption(OPTION_1, "v2");
+
+    assertThat(defaultOpt.getOption(OPTION_1)).isEqualTo("default");
+    assertThat(opt1.getOption(OPTION_1)).isEqualTo("v1");
+    assertThat(opt2.getOption(OPTION_1)).isEqualTo("v2");
+  }
+
+  @Test
   public void withStreamTracerFactory() {
     CallOptions opts1 = CallOptions.DEFAULT.withStreamTracerFactory(tracerFactory1);
     CallOptions opts2 = opts1.withStreamTracerFactory(tracerFactory2);


### PR DESCRIPTION
Previously, overwriting an existing Key would cause the original CallOptions instance to also be mutated.

See #5142  

Also adds a regression test for this issue.