### PR TITLE
core: add LoadBalancer.canHandleEmptyAddressListFromNameResolution()

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -169,6 +169,20 @@ public abstract class LoadBalancer {
   public abstract void shutdown();
 
   /**
+   * Whether this LoadBalancer can handle empty address group list to be passed to {@link
+   * #handleResolvedAddressGroups}.  The default implementation returns {@code false}, meaning that
+   * if the NameResolver returns an empty list, the Channel will turn that into an error and call
+   * {@link #handleNameResolutionError}.  LoadBalancers that want to accept empty lists should
+   * override this method and return {@code true}.
+   *
+   * <p>This method should always return a constant value.  It's not specified when this will be
+   * called.
+   */
+  public boolean canHandleEmptyAddressListFromNameResolution() {
+    return false;
+  }
+
+  /**
    * The main balancing logic.  It <strong>must be thread-safe</strong>. Typically it should only
    * synchronize on its own state, and avoid synchronizing with the LoadBalancer's state.
    *

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -111,7 +111,6 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
       try {
         selection = decideLoadBalancerProvider(servers, configMap);
       } catch (PolicyException e) {
-        System.err.println("XXX: " + e);
         Status s = Status.INTERNAL.withDescription(e.getMessage());
         helper.updateBalancingState(ConnectivityState.TRANSIENT_FAILURE, new FailingPicker(s));
         delegate.shutdown();

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1257,11 +1257,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
 
     @Override
     public void onAddresses(final List<EquivalentAddressGroup> servers, final Attributes config) {
-      if (servers.isEmpty()) {
-        onError(Status.UNAVAILABLE.withDescription(
-            "Name resolver " + resolver + " returned an empty list"));
-        return;
-      }
       channelLogger.log(
           ChannelLogLevel.DEBUG, "Resolved address: {0}, config={1}", servers, config);
 
@@ -1300,7 +1295,12 @@ final class ManagedChannelImpl extends ManagedChannel implements
             }
           }
 
-          helper.lb.handleResolvedAddressGroups(servers, config);
+          if (servers.isEmpty() && !helper.lb.canHandleEmptyAddressListFromNameResolution()) {
+            onError(Status.UNAVAILABLE.withDescription(
+                    "Name resolver " + resolver + " returned an empty list"));
+          } else {
+            helper.lb.handleResolvedAddressGroups(servers, config);
+          }
         }
       }
 

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -58,6 +58,11 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   }
 
   @Override
+  public boolean canHandleEmptyAddressListFromNameResolution() {
+    return delegate().canHandleEmptyAddressListFromNameResolution();
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }


### PR DESCRIPTION
Currently ManagedChannelImpl will interpret empty address list from
NameResolver as an error, and LoadBalancer will NEVER receive an empty
list from handleResolvedAddressGroups().  There is a case in the
request-routing design where a LoadBalancer only receives service
config with which it constructs children NameResolver/LoadBalancer
pairs, thus no address is expected at this level.

canHandleEmptyAddressListFromNameResolution() is a signal to Channel
(and to the parent LoadBalancer in case of hierachical LoadBalancers)
about whether it accepts empty address lists.  The default is false,
which is the current behavior.

The logic is currently duplicated in ManagedChannelImpl and
AutoConfiguredLoadBalancer.  The one in ManagedChannelImpl will be
removed once we delete ManagedChannelBuilder.loadBalancerFactory() as
AutoConfiguredLoadBalancer will always be the top-level LoadBalancer
by then.