### PR TITLE
examples: fix the logger name to match actual class

### DIFF
--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonClient.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonClient.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
  * https://groups.google.com/forum/#!forum/grpc-io
  */
 public final class HelloJsonClient {
-  private static final Logger logger = Logger.getLogger(HelloWorldClient.class.getName());
+  private static final Logger logger = Logger.getLogger(HelloJsonClient.class.getName());
 
   private final ManagedChannel channel;
   private final HelloJsonStub blockingStub;

--- a/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
+++ b/examples/src/main/java/io/grpc/examples/advanced/HelloJsonServer.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
  * https://groups.google.com/forum/#!forum/grpc-io
  */
 public class HelloJsonServer {
-  private static final Logger logger = Logger.getLogger(HelloWorldServer.class.getName());
+  private static final Logger logger = Logger.getLogger(HelloJsonServer.class.getName());
 
   private Server server;
 


### PR DESCRIPTION
package name:  **examples/src/main/java/io/grpc/examples/advanced**

Fix the **Logger.getLogger** class name typo