### PR TITLE
alts: Do not check protector if there are no bytes.

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/TsiFrameHandler.java
+++ b/alts/src/main/java/io/grpc/alts/internal/TsiFrameHandler.java
@@ -157,7 +157,6 @@ public final class TsiFrameHandler extends ByteToMessageDecoder implements Chann
 
   @Override
   public void flush(final ChannelHandlerContext ctx) throws GeneralSecurityException {
-    checkState(protector != null, "Cannot write frames while the TSI handshake is in progress");
     final ProtectedPromise aggregatePromise =
         new ProtectedPromise(ctx.channel(), ctx.executor(), pendingUnprotectedWrites.size());
 
@@ -169,6 +168,10 @@ public final class TsiFrameHandler extends ByteToMessageDecoder implements Chann
       // protection framing.
       return;
     }
+
+    // There is something to write, we need a frame protector now.
+    checkState(protector != null, "Cannot write frames while the TSI handshake is in progress");
+
     // Drain the unprotected writes.
     while (!pendingUnprotectedWrites.isEmpty()) {
       ByteBuf in = (ByteBuf) pendingUnprotectedWrites.current();


### PR DESCRIPTION
This should fix #5101. I'm not sure if the empty flush after the protector is released should happen.