### PR TITLE
interop-testing: Disable flaky ProxyTest.smallLatency

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/ProxyTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/ProxyTest.java
@@ -61,6 +61,7 @@ public class ProxyTest {
   }
 
   @Test
+  @org.junit.Ignore // flaky. latency commonly too high
   public void smallLatency() throws Exception {
     server = new Server();
     int serverPort = server.init();


### PR DESCRIPTION
Fixing the flakiness is tracked in #2951. The current flakiness is ~3/8
fail.