### PR TITLE
core,netty: refactor server builder

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -58,7 +58,7 @@ final class InProcessServer implements InternalServer {
 
   InProcessServer(
       InProcessServerBuilder builder,
-      List<ServerStreamTracer.Factory> streamTracerFactories) {
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories) {
     this.name = builder.name;
     this.schedulerPool = builder.schedulerPool;
     this.maxInboundMetadataSize = builder.maxInboundMetadataSize;

--- a/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessServerBuilder.java
@@ -146,7 +146,7 @@ public final class InProcessServerBuilder
 
   @Override
   protected InProcessServer buildTransportServer(
-      List<ServerStreamTracer.Factory> streamTracerFactories) {
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories) {
     return new InProcessServer(this, streamTracerFactories);
   }
 

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -27,7 +27,6 @@ import io.grpc.CompressorRegistry;
 import io.grpc.Context;
 import io.grpc.DecompressorRegistry;
 import io.grpc.HandlerRegistry;
-import io.grpc.Internal;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalNotifyOnServerBuild;
 import io.grpc.Server;
@@ -57,66 +56,38 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
     throw new UnsupportedOperationException("Subclass failed to hide static factory");
   }
 
+  // defaults
   private static final ObjectPool<? extends Executor> DEFAULT_EXECUTOR_POOL =
       SharedResourcePool.forResource(GrpcUtil.SHARED_CHANNEL_EXECUTOR);
-  private static final HandlerRegistry DEFAULT_FALLBACK_REGISTRY = new HandlerRegistry() {
-      @Override
-      public List<ServerServiceDefinition> getServices() {
-        return Collections.emptyList();
-      }
-
-      @Override
-      @Nullable
-      public ServerMethodDefinition<?, ?> lookupMethod(
-          String methodName, @Nullable String authority) {
-        return null;
-      }
-    };
+  private static final HandlerRegistry DEFAULT_FALLBACK_REGISTRY = new DefaultFallbackRegistry();
   private static final DecompressorRegistry DEFAULT_DECOMPRESSOR_REGISTRY =
       DecompressorRegistry.getDefaultInstance();
   private static final CompressorRegistry DEFAULT_COMPRESSOR_REGISTRY =
       CompressorRegistry.getDefaultInstance();
   private static final long DEFAULT_HANDSHAKE_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(120);
 
+  // mutable state
   final InternalHandlerRegistry.Builder registryBuilder =
       new InternalHandlerRegistry.Builder();
-
-  final List<ServerTransportFilter> transportFilters =
-      new ArrayList<>();
-
+  final List<ServerTransportFilter> transportFilters = new ArrayList<>();
   final List<ServerInterceptor> interceptors = new ArrayList<>();
-
-  private final List<InternalNotifyOnServerBuild> notifyOnBuildList =
-      new ArrayList<>();
-
-  private final List<ServerStreamTracer.Factory> streamTracerFactories =
-      new ArrayList<ServerStreamTracer.Factory>();
-
+  private final List<InternalNotifyOnServerBuild> notifyOnBuildList = new ArrayList<>();
+  private final List<ServerStreamTracer.Factory> streamTracerFactories = new ArrayList<>();
   HandlerRegistry fallbackRegistry = DEFAULT_FALLBACK_REGISTRY;
-
   ObjectPool<? extends Executor> executorPool = DEFAULT_EXECUTOR_POOL;
-
   DecompressorRegistry decompressorRegistry = DEFAULT_DECOMPRESSOR_REGISTRY;
-
   CompressorRegistry compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
-
   long handshakeTimeoutMillis = DEFAULT_HANDSHAKE_TIMEOUT_MILLIS;
-
-  @Nullable
-  private CensusStatsModule censusStatsOverride;
-
+  @Nullable private CensusStatsModule censusStatsOverride;
   private boolean statsEnabled = true;
   private boolean recordStartedRpcs = true;
   private boolean recordFinishedRpcs = true;
   private boolean recordRealTimeMetrics = false;
   private boolean tracingEnabled = true;
-
-  @Nullable
-  protected BinaryLog binlog;
-  protected TransportTracer.Factory transportTracerFactory = TransportTracer.getDefaultFactory();
-
-  protected InternalChannelz channelz = InternalChannelz.instance();
-  protected CallTracer.Factory callTracerFactory = CallTracer.getDefaultFactory();
+  @Nullable BinaryLog binlog;
+  TransportTracer.Factory transportTracerFactory = TransportTracer.getDefaultFactory();
+  InternalChannelz channelz = InternalChannelz.instance();
+  CallTracer.Factory callTracerFactory = CallTracer.getDefaultFactory();
 
   @Override
   public final T directExecutor() {
@@ -125,17 +96,13 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
 
   @Override
   public final T executor(@Nullable Executor executor) {
-    if (executor != null) {
-      this.executorPool = new FixedObjectPool<Executor>(executor);
-    } else {
-      this.executorPool = DEFAULT_EXECUTOR_POOL;
-    }
+    this.executorPool = executor != null ? new FixedObjectPool<>(executor) : DEFAULT_EXECUTOR_POOL;
     return thisT();
   }
 
   @Override
   public final T addService(ServerServiceDefinition service) {
-    registryBuilder.addService(service);
+    registryBuilder.addService(checkNotNull(service, "service"));
     return thisT();
   }
 
@@ -144,7 +111,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
     if (bindableService instanceof InternalNotifyOnServerBuild) {
       notifyOnBuildList.add((InternalNotifyOnServerBuild) bindableService);
     }
-    return addService(bindableService.bindService());
+    return addService(checkNotNull(bindableService, "bindableService").bindService());
   }
 
   @Override
@@ -155,7 +122,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
 
   @Override
   public final T intercept(ServerInterceptor interceptor) {
-    interceptors.add(interceptor);
+    interceptors.add(checkNotNull(interceptor, "interceptor"));
     return thisT();
   }
 
@@ -166,44 +133,32 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   }
 
   @Override
-  public final T fallbackHandlerRegistry(HandlerRegistry registry) {
-    if (registry != null) {
-      this.fallbackRegistry = registry;
-    } else {
-      this.fallbackRegistry = DEFAULT_FALLBACK_REGISTRY;
-    }
+  public final T fallbackHandlerRegistry(@Nullable HandlerRegistry registry) {
+    this.fallbackRegistry = registry != null ? registry : DEFAULT_FALLBACK_REGISTRY;
     return thisT();
   }
 
   @Override
-  public final T decompressorRegistry(DecompressorRegistry registry) {
-    if (registry != null) {
-      decompressorRegistry = registry;
-    } else {
-      decompressorRegistry = DEFAULT_DECOMPRESSOR_REGISTRY;
-    }
+  public final T decompressorRegistry(@Nullable DecompressorRegistry registry) {
+    this.decompressorRegistry = registry != null ? registry : DEFAULT_DECOMPRESSOR_REGISTRY;
     return thisT();
   }
 
   @Override
-  public final T compressorRegistry(CompressorRegistry registry) {
-    if (registry != null) {
-      compressorRegistry = registry;
-    } else {
-      compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
-    }
+  public final T compressorRegistry(@Nullable CompressorRegistry registry) {
+    this.compressorRegistry = registry != null ? registry : DEFAULT_COMPRESSOR_REGISTRY;
     return thisT();
   }
 
   @Override
   public final T handshakeTimeout(long timeout, TimeUnit unit) {
     checkArgument(timeout > 0, "handshake timeout is %s, but must be positive", timeout);
-    handshakeTimeoutMillis = unit.toMillis(timeout);
+    this.handshakeTimeoutMillis = checkNotNull(unit, "unit").toMillis(timeout);
     return thisT();
   }
 
   @Override
-  public final T setBinaryLog(BinaryLog binaryLog) {
+  public final T setBinaryLog(@Nullable BinaryLog binaryLog) {
     this.binlog = binaryLog;
     return thisT();
   }
@@ -212,8 +167,14 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
    * Override the default stats implementation.
    */
   @VisibleForTesting
-  protected T overrideCensusStatsModule(CensusStatsModule censusStats) {
+  protected final T overrideCensusStatsModule(@Nullable CensusStatsModule censusStats) {
     this.censusStatsOverride = censusStats;
+    return thisT();
+  }
+
+  @VisibleForTesting
+  public final T setTransportTracerFactory(TransportTracer.Factory transportTracerFactory) {
+    this.transportTracerFactory = transportTracerFactory;
     return thisT();
   }
 
@@ -221,7 +182,7 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
    * Disable or enable stats features.  Enabled by default.
    */
   protected void setStatsEnabled(boolean value) {
-    statsEnabled = value;
+    this.statsEnabled = value;
   }
 
   /**
@@ -256,10 +217,10 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   }
 
   @Override
-  public Server build() {
+  public final Server build() {
     ServerImpl server = new ServerImpl(
         this,
-        buildTransportServer(Collections.unmodifiableList(getTracerFactories())),
+        buildTransportServer(getTracerFactories()),
         Context.ROOT);
     for (InternalNotifyOnServerBuild notifyTarget : notifyOnBuildList) {
       notifyTarget.notifyOnBuild(server);
@@ -268,11 +229,10 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   }
 
   @VisibleForTesting
-  final List<ServerStreamTracer.Factory> getTracerFactories() {
-    ArrayList<ServerStreamTracer.Factory> tracerFactories =
-        new ArrayList<ServerStreamTracer.Factory>();
+  final List<? extends ServerStreamTracer.Factory> getTracerFactories() {
+    ArrayList<ServerStreamTracer.Factory> tracerFactories = new ArrayList<>(streamTracerFactories);
     if (statsEnabled) {
-      CensusStatsModule censusStats = this.censusStatsOverride;
+      CensusStatsModule censusStats = censusStatsOverride;
       if (censusStats == null) {
         censusStats = new CensusStatsModule(
             GrpcUtil.STOPWATCH_SUPPLIER, true, recordStartedRpcs, recordFinishedRpcs,
@@ -286,8 +246,16 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
               Tracing.getPropagationComponent().getBinaryFormat());
       tracerFactories.add(censusTracing.getServerTracerFactory());
     }
-    tracerFactories.addAll(streamTracerFactories);
-    return tracerFactories;
+    tracerFactories.trimToSize();
+    return Collections.unmodifiableList(tracerFactories);
+  }
+
+  protected final InternalChannelz getChannelz() {
+    return channelz;
+  }
+
+  protected final TransportTracer.Factory getTransportTracerFactory() {
+    return transportTracerFactory;
   }
 
   /**
@@ -297,13 +265,26 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
    *
    * @param streamTracerFactories an immutable list of stream tracer factories
    */
-  @Internal
   protected abstract io.grpc.internal.InternalServer buildTransportServer(
-      List<ServerStreamTracer.Factory> streamTracerFactories);
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories);
 
   private T thisT() {
     @SuppressWarnings("unchecked")
     T thisT = (T) this;
     return thisT;
+  }
+
+  private static final class DefaultFallbackRegistry extends HandlerRegistry {
+    @Override
+    public List<ServerServiceDefinition> getServices() {
+      return Collections.emptyList();
+    }
+
+    @Nullable
+    @Override
+    public ServerMethodDefinition<?, ?> lookupMethod(
+        String methodName, @Nullable String authority) {
+      return null;
+    }
   }
 }

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -64,7 +64,9 @@ public final class StatsTraceContext {
    * Factory method for the server-side.
    */
   public static StatsTraceContext newServerContext(
-      List<ServerStreamTracer.Factory> factories, String fullMethodName, Metadata headers) {
+      List<? extends ServerStreamTracer.Factory> factories,
+      String fullMethodName,
+      Metadata headers) {
     if (factories.isEmpty()) {
       return NOOP;
     }

--- a/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
@@ -47,31 +47,31 @@ public class AbstractServerImplBuilderTest {
   @Test
   public void getTracerFactories_default() {
     builder.addStreamTracerFactory(DUMMY_USER_TRACER);
-    List<ServerStreamTracer.Factory> factories = builder.getTracerFactories();
+    List<? extends ServerStreamTracer.Factory> factories = builder.getTracerFactories();
     assertEquals(3, factories.size());
-    assertThat(factories.get(0)).isInstanceOf(CensusStatsModule.ServerTracerFactory.class);
-    assertThat(factories.get(1)).isInstanceOf(CensusTracingModule.ServerTracerFactory.class);
-    assertThat(factories.get(2)).isSameAs(DUMMY_USER_TRACER);
+    assertThat(factories.get(0)).isSameAs(DUMMY_USER_TRACER);
+    assertThat(factories.get(1)).isInstanceOf(CensusStatsModule.ServerTracerFactory.class);
+    assertThat(factories.get(2)).isInstanceOf(CensusTracingModule.ServerTracerFactory.class);
   }
 
   @Test
   public void getTracerFactories_disableStats() {
     builder.addStreamTracerFactory(DUMMY_USER_TRACER);
     builder.setStatsEnabled(false);
-    List<ServerStreamTracer.Factory> factories = builder.getTracerFactories();
+    List<? extends ServerStreamTracer.Factory> factories = builder.getTracerFactories();
     assertEquals(2, factories.size());
-    assertThat(factories.get(0)).isInstanceOf(CensusTracingModule.ServerTracerFactory.class);
-    assertThat(factories.get(1)).isSameAs(DUMMY_USER_TRACER);
+    assertThat(factories.get(0)).isSameAs(DUMMY_USER_TRACER);
+    assertThat(factories.get(1)).isInstanceOf(CensusTracingModule.ServerTracerFactory.class);
   }
 
   @Test
   public void getTracerFactories_disableTracing() {
     builder.addStreamTracerFactory(DUMMY_USER_TRACER);
     builder.setTracingEnabled(false);
-    List<ServerStreamTracer.Factory> factories = builder.getTracerFactories();
+    List<? extends ServerStreamTracer.Factory> factories = builder.getTracerFactories();
     assertEquals(2, factories.size());
-    assertThat(factories.get(0)).isInstanceOf(CensusStatsModule.ServerTracerFactory.class);
-    assertThat(factories.get(1)).isSameAs(DUMMY_USER_TRACER);
+    assertThat(factories.get(0)).isSameAs(DUMMY_USER_TRACER);
+    assertThat(factories.get(1)).isInstanceOf(CensusStatsModule.ServerTracerFactory.class);
   }
 
   @Test
@@ -79,7 +79,7 @@ public class AbstractServerImplBuilderTest {
     builder.addStreamTracerFactory(DUMMY_USER_TRACER);
     builder.setTracingEnabled(false);
     builder.setStatsEnabled(false);
-    List<ServerStreamTracer.Factory> factories = builder.getTracerFactories();
+    List<? extends ServerStreamTracer.Factory> factories = builder.getTracerFactories();
     assertThat(factories).containsExactly(DUMMY_USER_TRACER);
   }
 
@@ -96,7 +96,7 @@ public class AbstractServerImplBuilderTest {
 
     @Override
     protected io.grpc.internal.InternalServer buildTransportServer(
-        List<ServerStreamTracer.Factory> streamTracerFactories) {
+        List<? extends ServerStreamTracer.Factory> streamTracerFactories) {
       throw new UnsupportedOperationException();
     }
 

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1412,7 +1412,7 @@ public class ServerImplTest {
 
   private static class Builder extends AbstractServerImplBuilder<Builder> {
     @Override protected InternalServer buildTransportServer(
-        List<ServerStreamTracer.Factory> streamTracerFactories) {
+        List<? extends ServerStreamTracer.Factory> streamTracerFactories) {
       throw new UnsupportedOperationException();
     }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServer.java
@@ -90,7 +90,7 @@ class NettyServer implements InternalServer, InternalWithLogId {
   private final boolean permitKeepAliveWithoutCalls;
   private final long permitKeepAliveTimeInNanos;
   private final ReferenceCounted eventLoopReferenceCounter = new EventLoopReferenceCounter();
-  private final List<ServerStreamTracer.Factory> streamTracerFactories;
+  private final List<? extends ServerStreamTracer.Factory> streamTracerFactories;
   private final TransportTracer.Factory transportTracerFactory;
   private final InternalChannelz channelz;
   // Only modified in event loop but safe to read any time. Set at startup and unset at shutdown.
@@ -102,7 +102,8 @@ class NettyServer implements InternalServer, InternalWithLogId {
       SocketAddress address, Class<? extends ServerChannel> channelType,
       Map<ChannelOption<?>, ?> channelOptions,
       @Nullable EventLoopGroup bossGroup, @Nullable EventLoopGroup workerGroup,
-      ProtocolNegotiator protocolNegotiator, List<ServerStreamTracer.Factory> streamTracerFactories,
+      ProtocolNegotiator protocolNegotiator,
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories,
       TransportTracer.Factory transportTracerFactory,
       int maxStreamsPerConnection, int flowControlWindow, int maxMessageSize, int maxHeaderListSize,
       long keepAliveTimeInNanos, long keepAliveTimeoutInNanos,

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -22,7 +22,6 @@ import static io.grpc.internal.GrpcUtil.DEFAULT_SERVER_KEEPALIVE_TIMEOUT_NANOS;
 import static io.grpc.internal.GrpcUtil.DEFAULT_SERVER_KEEPALIVE_TIME_NANOS;
 import static io.grpc.internal.GrpcUtil.SERVER_KEEPALIVE_TIME_NANOS_DISABLED;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.ExperimentalApi;
@@ -31,7 +30,6 @@ import io.grpc.ServerStreamTracer;
 import io.grpc.internal.AbstractServerImplBuilder;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.KeepAliveManager;
-import io.grpc.internal.TransportTracer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
@@ -69,8 +67,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
 
   private final SocketAddress address;
   private Class<? extends ServerChannel> channelType = NioServerSocketChannel.class;
-  private final Map<ChannelOption<?>, Object> channelOptions =
-      new HashMap<ChannelOption<?>, Object>();
+  private final Map<ChannelOption<?>, Object> channelOptions = new HashMap<>();
   @Nullable
   private EventLoopGroup bossEventLoopGroup;
   @Nullable
@@ -231,12 +228,6 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
   @Override
   protected void setStatsRecordRealTimeMetrics(boolean value) {
     super.setStatsRecordRealTimeMetrics(value);
-  }
-
-  @VisibleForTesting
-  NettyServerBuilder setTransportTracerFactory(TransportTracer.Factory transportTracerFactory) {
-    this.transportTracerFactory = transportTracerFactory;
-    return this;
   }
 
   /**
@@ -446,7 +437,7 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
   @Override
   @CheckReturnValue
   protected NettyServer buildTransportServer(
-      List<ServerStreamTracer.Factory> streamTracerFactories) {
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories) {
     ProtocolNegotiator negotiator = protocolNegotiator;
     if (negotiator == null) {
       negotiator = sslContext != null ? ProtocolNegotiators.serverTls(sslContext) :
@@ -455,12 +446,12 @@ public final class NettyServerBuilder extends AbstractServerImplBuilder<NettySer
 
     return new NettyServer(
         address, channelType, channelOptions, bossEventLoopGroup, workerEventLoopGroup,
-        negotiator, streamTracerFactories, transportTracerFactory,
+        negotiator, streamTracerFactories, getTransportTracerFactory(),
         maxConcurrentCallsPerConnection, flowControlWindow,
         maxMessageSize, maxHeaderListSize, keepAliveTimeInNanos, keepAliveTimeoutInNanos,
         maxConnectionIdleInNanos,
         maxConnectionAgeInNanos, maxConnectionAgeGraceInNanos,
-        permitKeepAliveWithoutCalls, permitKeepAliveTimeInNanos, channelz);
+        permitKeepAliveWithoutCalls, permitKeepAliveTimeInNanos, getChannelz());
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -108,7 +108,7 @@ class NettyServerHandler extends AbstractNettyHandler {
   private final long keepAliveTimeoutInNanos;
   private final long maxConnectionAgeInNanos;
   private final long maxConnectionAgeGraceInNanos;
-  private final List<ServerStreamTracer.Factory> streamTracerFactories;
+  private final List<? extends ServerStreamTracer.Factory> streamTracerFactories;
   private final TransportTracer transportTracer;
   private final KeepAliveEnforcer keepAliveEnforcer;
   /** Incomplete attributes produced by negotiator. */
@@ -132,7 +132,7 @@ class NettyServerHandler extends AbstractNettyHandler {
   static NettyServerHandler newHandler(
       ServerTransportListener transportListener,
       ChannelPromise channelUnused,
-      List<ServerStreamTracer.Factory> streamTracerFactories,
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories,
       TransportTracer transportTracer,
       int maxStreams,
       int flowControlWindow,
@@ -178,7 +178,7 @@ class NettyServerHandler extends AbstractNettyHandler {
       Http2FrameReader frameReader,
       Http2FrameWriter frameWriter,
       ServerTransportListener transportListener,
-      List<ServerStreamTracer.Factory> streamTracerFactories,
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories,
       TransportTracer transportTracer,
       int maxStreams,
       int flowControlWindow,
@@ -236,7 +236,7 @@ class NettyServerHandler extends AbstractNettyHandler {
       ChannelPromise channelUnused,
       final Http2Connection connection,
       ServerTransportListener transportListener,
-      List<ServerStreamTracer.Factory> streamTracerFactories,
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories,
       TransportTracer transportTracer,
       Http2ConnectionDecoder decoder,
       Http2ConnectionEncoder encoder,

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -75,14 +75,14 @@ class NettyServerTransport implements ServerTransport {
   private final long maxConnectionAgeGraceInNanos;
   private final boolean permitKeepAliveWithoutCalls;
   private final long permitKeepAliveTimeInNanos;
-  private final List<ServerStreamTracer.Factory> streamTracerFactories;
+  private final List<? extends ServerStreamTracer.Factory> streamTracerFactories;
   private final TransportTracer transportTracer;
 
   NettyServerTransport(
       Channel channel,
       ChannelPromise channelUnused,
       ProtocolNegotiator protocolNegotiator,
-      List<ServerStreamTracer.Factory> streamTracerFactories,
+      List<? extends ServerStreamTracer.Factory> streamTracerFactories,
       TransportTracer transportTracer,
       int maxStreams,
       int flowControlWindow,


### PR DESCRIPTION
This change:

* makes Census tracing factories at the end of the user added ones
* makes more vars in AbstractServerImplBuilder package private
* annotates methods in ASIB to be clearer
* simplifies several of the setters to be single line
* Makes the generics on the Tracer factories proper