### PR TITLE
bazel: ignore examples/ from root WORKSPACE

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+# examples has its own WORKSPACE. Ignore as part of this root WORKSPACE so that
+# we don't need to repeat dependencies.
+examples/


### PR DESCRIPTION
"bazel build ..." from the root will no longer build examples/. But
"cd examples; bazel build ..." still does.