### PR TITLE
alts: Fix SHARED_HANDSHAKER_CHANNEL after first close

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -34,7 +34,9 @@ dependencies {
     }
     compileOnly libraries.javax_annotation
     runtime project(':grpc-grpclb')
-    testCompile libraries.guava,
+    testCompile project(':grpc-testing'),
+            project(':grpc-testing-proto'),
+            libraries.guava,
             libraries.guava_testlib,
             libraries.junit,
             libraries.mockito,

--- a/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
@@ -56,7 +56,7 @@ public final class AltsChannelBuilder extends ForwardingChannelBuilder<AltsChann
   private final NettyChannelBuilder delegate;
   private final ImmutableList.Builder<String> targetServiceAccountsBuilder =
       ImmutableList.builder();
-  private ObjectPool<ManagedChannel> handshakerChannelPool =
+  private ObjectPool<Channel> handshakerChannelPool =
       SharedResourcePool.forResource(HandshakerServiceChannel.SHARED_HANDSHAKER_CHANNEL);
   private boolean enableUntrustedAlts;
 
@@ -102,10 +102,10 @@ public final class AltsChannelBuilder extends ForwardingChannelBuilder<AltsChann
 
   /** Sets a new handshaker service address for testing. */
   public AltsChannelBuilder setHandshakerAddressForTesting(String handshakerAddress) {
-    // Instead of using the default shared channel to the handshaker service, create a fix object
-    // pool of handshaker service channel for testing.
-    handshakerChannelPool =
-        HandshakerServiceChannel.getHandshakerChannelPoolForTesting(handshakerAddress);
+    // Instead of using the default shared channel to the handshaker service, create a separate
+    // resource to the test address.
+    handshakerChannelPool = SharedResourcePool.forResource(
+        HandshakerServiceChannel.getHandshakerChannelForTesting(handshakerAddress));
     return this;
   }
 

--- a/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
@@ -17,11 +17,11 @@
 package io.grpc.alts;
 
 import io.grpc.BindableService;
+import io.grpc.Channel;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.ExperimentalApi;
 import io.grpc.HandlerRegistry;
-import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -59,7 +59,7 @@ public final class AltsServerBuilder extends ServerBuilder<AltsServerBuilder> {
 
   private static final Logger logger = Logger.getLogger(AltsServerBuilder.class.getName());
   private final NettyServerBuilder delegate;
-  private ObjectPool<ManagedChannel> handshakerChannelPool =
+  private ObjectPool<Channel> handshakerChannelPool =
       SharedResourcePool.forResource(HandshakerServiceChannel.SHARED_HANDSHAKER_CHANNEL);
   private boolean enableUntrustedAlts;
 
@@ -90,10 +90,10 @@ public final class AltsServerBuilder extends ServerBuilder<AltsServerBuilder> {
 
   /** Sets a new handshaker service address for testing. */
   public AltsServerBuilder setHandshakerAddressForTesting(String handshakerAddress) {
-    // Instead of using the default shared channel to the handshaker service, create a fix object
-    // pool of handshaker service channel for testing.
-    handshakerChannelPool =
-        HandshakerServiceChannel.getHandshakerChannelPoolForTesting(handshakerAddress);
+    // Instead of using the default shared channel to the handshaker service, create a separate
+    // resource to the test address.
+    handshakerChannelPool = SharedResourcePool.forResource(
+        HandshakerServiceChannel.getHandshakerChannelForTesting(handshakerAddress));
     return this;
   }
 

--- a/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/GoogleDefaultChannelBuilder.java
@@ -24,7 +24,6 @@ import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ForwardingChannelBuilder;
-import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -104,7 +103,7 @@ public final class GoogleDefaultChannelBuilder
               // Used the shared grpc channel to connecting to the ALTS handshaker service.
               // TODO: Release the channel if it is not used.
               // https://github.com/grpc/grpc-java/issues/4755.
-              ManagedChannel channel =
+              Channel channel =
                   SharedResourceHolder.get(HandshakerServiceChannel.SHARED_HANDSHAKER_CHANNEL);
               AltsClientOptions handshakerOptions =
                   new AltsClientOptions.Builder()

--- a/alts/src/test/java/io/grpc/alts/HandshakerServiceChannelTest.java
+++ b/alts/src/test/java/io/grpc/alts/HandshakerServiceChannelTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.alts;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.grpc.Channel;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.internal.SharedResourceHolder.Resource;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.testing.protobuf.SimpleRequest;
+import io.grpc.testing.protobuf.SimpleResponse;
+import io.grpc.testing.protobuf.SimpleServiceGrpc;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class HandshakerServiceChannelTest {
+  @Rule
+  public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  private Server server = grpcCleanup.register(
+      ServerBuilder.forPort(0)
+        .addService(new SimpleServiceGrpc.SimpleServiceImplBase() {
+          @Override
+          public void unaryRpc(SimpleRequest request, StreamObserver<SimpleResponse> so) {
+            so.onNext(SimpleResponse.getDefaultInstance());
+            so.onCompleted();
+          }
+        })
+        .build());
+  private Resource<Channel> resource;
+
+  @Before
+  public void setUp() throws Exception {
+    server.start();
+    resource =
+        HandshakerServiceChannel.getHandshakerChannelForTesting("localhost:" + server.getPort());
+  }
+
+  @Test
+  public void sharedChannel_authority() {
+    resource = HandshakerServiceChannel.SHARED_HANDSHAKER_CHANNEL;
+    Channel channel = resource.create();
+    try {
+      assertThat(channel.authority()).isEqualTo("metadata.google.internal:8080");
+    } finally {
+      resource.close(channel);
+    }
+  }
+
+  @Test
+  public void resource_works() {
+    Channel channel = resource.create();
+    try {
+      // Do an RPC to verify that the channel actually works
+      doRpc(channel);
+    } finally {
+      resource.close(channel);
+    }
+  }
+
+  @Test
+  public void resource_lifecycleTwice() {
+    Channel channel = resource.create();
+    try {
+      doRpc(channel);
+    } finally {
+      resource.close(channel);
+    }
+    channel = resource.create();
+    try {
+      doRpc(channel);
+    } finally {
+      resource.close(channel);
+    }
+  }
+
+  private void doRpc(Channel channel) {
+    SimpleServiceGrpc.newBlockingStub(channel).unaryRpc(SimpleRequest.getDefaultInstance());
+  }
+}


### PR DESCRIPTION
Since the Resource shared the executor service between invocations, but
didn't null it out on shutdown, it could bring up a new channel with a
terminated event loop. The channel would then proceed to panic on usage.

I noticed this problem while looking into what was necessary for #4755.