### PR TITLE
repositories.bzl: correct re2j sha.

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -200,7 +200,7 @@ def com_google_re2j():
     native.maven_jar(
         name = "com_google_re2j",
         artifact = "com.google.re2j:re2j:1.2",
-        sha1 = "499d5e041f962fefd0f245a9325e8125608ebb54",
+        sha1 = "4361eed4abe6f84d982cbb26749825f285996dd2",
     )
 
 def com_google_truth_truth():


### PR DESCRIPTION
The fundamental issue is that the SHA-1 sums for the GitHub and Maven jars for re2j are different. (see https://github.com/google/re2j/issues/83 for discussion.) the SHA used at grpc-java HEAD corresponds to the re2j GitHub jar, but the target itself refers to the re2j Maven jar.

The reason no one has noticed is that `@com_google_re2j//jar` is not actually used as a dependency in any bazel target in this repo. This will change once the services/ directory becomes a bazel package. (the source files in services/ do depend on re2j.)