### PR TITLE
services: add BUILD.bazel

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -200,7 +200,7 @@ def com_google_re2j():
     native.maven_jar(
         name = "com_google_re2j",
         artifact = "com.google.re2j:re2j:1.2",
-        sha1 = "499d5e041f962fefd0f245a9325e8125608ebb54",
+        sha1 = "4361eed4abe6f84d982cbb26749825f285996dd2",
     )
 
 def com_google_truth_truth():

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -1,0 +1,24 @@
+java_library(
+    name = "services",
+    srcs = glob([
+        "src/main/java/io/grpc/**/*.java",
+        "src/generated/main/**/*.java",
+    ]),
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//context",
+        "//core",
+        "//core:internal",
+        "//core:util",
+        "//protobuf",
+        "//stub",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@javax_annotation_javax_annotation_api//jar",
+        "@com_google_re2j//jar",
+    ],
+)

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -1,11 +1,50 @@
+package(default_visibility = ["//visibility:public"])
+
 java_library(
-    name = "services",
-    srcs = glob([
-        "src/main/java/io/grpc/**/*.java",
-        "src/generated/main/**/*.java",
-    ]),
-    visibility = [
-        "//visibility:public",
+    name = "binarylog",
+    srcs = [
+        "src/main/java/io/grpc/services/BinaryLogProvider.java",
+        "src/main/java/io/grpc/services/BinaryLogProviderImpl.java",
+        "src/main/java/io/grpc/services/BinaryLogSink.java",
+        "src/main/java/io/grpc/services/BinlogHelper.java",
+        "src/main/java/io/grpc/services/InetAddressUtil.java",
+        "src/main/java/io/grpc/services/TempFileSink.java",
+    ],
+    deps = [
+        "//context",
+        "//core",
+        "//services/src/main/proto/grpc/binlog/v1:binarylog_java_proto",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@com_google_re2j//jar",
+    ],
+)
+
+java_library(
+    name = "channelz",
+    srcs = [
+        "src/main/java/io/grpc/services/ChannelzProtoUtil.java",
+        "src/main/java/io/grpc/services/ChannelzService.java",
+    ],
+    deps = [
+        "//context",
+        "//core",
+        "//services/src/main/proto/grpc/channelz/v1:channelz_grpc",
+        "//services/src/main/proto/grpc/channelz/v1:channelz_java_proto",
+        "//stub",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+    ],
+)
+
+java_library(
+    name = "reflection",
+    srcs = [
+        "src/main/java/io/grpc/protobuf/services/ProtoReflectionService.java",
     ],
     deps = [
         "//context",
@@ -13,12 +52,14 @@ java_library(
         "//core:internal",
         "//core:util",
         "//protobuf",
+        "//services/src/main/proto/io/grpc/reflection/v1alpha:reflection_grpc",
+        "//services/src/main/proto/io/grpc/reflection/v1alpha:reflection_java_proto",
         "//stub",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_guava_guava//jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
-        "@javax_annotation_javax_annotation_api//jar",
         "@com_google_re2j//jar",
+        "@javax_annotation_javax_annotation_api//jar",
     ],
 )

--- a/services/src/main/proto/grpc/binlog/v1/BUILD.bazel
+++ b/services/src/main/proto/grpc/binlog/v1/BUILD.bazel
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "binarylog_proto",
+    srcs = [
+        "binarylog.proto",
+    ],
+    deps = [
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+java_proto_library(
+    name = "binarylog_java_proto",
+    deps = [":binarylog_proto"],
+)

--- a/services/src/main/proto/grpc/channelz/v1/BUILD.bazel
+++ b/services/src/main/proto/grpc/channelz/v1/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//:java_grpc_library.bzl", "java_grpc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "channelz_proto",
+    srcs = [
+        "channelz.proto",
+    ],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+java_proto_library(
+    name = "channelz_java_proto",
+    deps = [":channelz_proto"],
+)
+
+java_grpc_library(
+    name = "channelz_grpc",
+    srcs = [":channelz_proto"],
+    deps = [":channelz_java_proto"],
+)

--- a/services/src/main/proto/grpc/health/v1/BUILD.bazel
+++ b/services/src/main/proto/grpc/health/v1/BUILD.bazel
@@ -1,0 +1,9 @@
+proto_library(
+    name = "health_proto",
+    srcs = [
+        "health.proto",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/services/src/main/proto/io/grpc/reflection/v1alpha/BUILD.bazel
+++ b/services/src/main/proto/io/grpc/reflection/v1alpha/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//:java_grpc_library.bzl", "java_grpc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "reflection_proto",
+    srcs = [
+        "reflection.proto",
+    ],
+)
+
+java_proto_library(
+    name = "reflection_java_proto",
+    deps = [":reflection_proto"],
+)
+
+java_grpc_library(
+    name = "reflection_grpc",
+    srcs = [
+        ":reflection_proto",
+    ],
+    deps = [":reflection_java_proto"],
+)


### PR DESCRIPTION
At HEAD, the java sources in services/ are not accessible from any bazel target. Most top-level directories have both a BUILD.bazel and a build.gradle, but services/ has only build.gradle.

(Note that https://github.com/grpc/grpc-java/pull/5183 must be merged before this can be merged, to fix the re2j jar.)