### PR TITLE
Downgrade to Guava 25.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,9 @@ subprojects {
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         nettyVersion = '4.1.32.Final'
-        guavaVersion = '26.0-android'
+        // Temporarily use a slightly older version of Guava. Will want to bump
+        // to 27.0.1+ with grpc 1.19 or 1.20 for the listenablefuture dep changes.
+        guavaVersion = '25.1-android'
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -158,8 +158,8 @@ def com_google_errorprone_error_prone_annotations():
 def com_google_guava():
     native.maven_jar(
         name = "com_google_guava_guava",
-        artifact = "com.google.guava:guava:26.0-android",
-        sha1 = "ef69663836b339db335fde0df06fb3cd84e3742b",
+        artifact = "com.google.guava:guava:25.1-android",
+        sha1 = "bdaab946ca5ad20253502d873ba0c3313d141036",
     )
 
 def com_google_j2objc_j2objc_annotations():


### PR DESCRIPTION
This is temporary for the 1.18 release to give users a bit more time to
get past the breaking changes to Beta APIs in Guava 26.

Fixes #5166