### PR TITLE
Remove old BetaApi failure suppressions

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsChannelCrypter.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsChannelCrypter.java
@@ -54,7 +54,6 @@ final class AltsChannelCrypter implements ChannelCrypterNetty {
     return COUNTER_LENGTH;
   }
 
-  @SuppressWarnings("BetaApi") // verify is stable in Guava
   @Override
   public void encrypt(ByteBuf outBuf, List<ByteBuf> plainBufs) throws GeneralSecurityException {
     checkArgument(outBuf.nioBufferCount() == 1);
@@ -93,7 +92,6 @@ final class AltsChannelCrypter implements ChannelCrypterNetty {
     decrypt(out, cipherTextAndTag);
   }
 
-  @SuppressWarnings("BetaApi") // verify is stable in Guava
   @Override
   public void decrypt(ByteBuf out, ByteBuf ciphertextAndTag) throws GeneralSecurityException {
     int bytesRead = ciphertextAndTag.readableBytes();

--- a/alts/src/main/java/io/grpc/alts/internal/AltsTsiFrameProtector.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsTsiFrameProtector.java
@@ -128,7 +128,6 @@ public final class AltsTsiFrameProtector implements TsiFrameProtector {
       }
     }
 
-    @SuppressWarnings("BetaApi") // verify is stable in Guava
     private ByteBuf handleUnprotected(List<ByteBuf> unprotectedBufs, ByteBufAllocator alloc)
         throws GeneralSecurityException {
       long unprotectedBytes = 0;
@@ -270,7 +269,6 @@ public final class AltsTsiFrameProtector implements TsiFrameProtector {
       state = DeframerState.READ_PROTECTED_PAYLOAD;
     }
 
-    @SuppressWarnings("BetaApi") // verify is stable in Guava
     private ByteBuf handlePayload(ByteBufAllocator alloc) throws GeneralSecurityException {
       int requiredCiphertextBytes = requiredProtectedBytes - suffixBytes;
       int firstFrameUnprotectedLen = requiredCiphertextBytes;

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -184,7 +184,6 @@ final class GoogleAuthLibraryCallCredentials extends CallCredentials2 {
     }
   }
 
-  @SuppressWarnings("BetaApi") // BaseEncoding is stable in Guava 20.0
   private static Metadata toHeaders(@Nullable Map<String, List<String>> metadata) {
     Metadata headers = new Metadata();
     if (metadata != null) {

--- a/core/src/main/java/io/grpc/Metadata.java
+++ b/core/src/main/java/io/grpc/Metadata.java
@@ -457,7 +457,6 @@ public final class Metadata {
     }
   }
 
-  @SuppressWarnings("BetaApi") // BaseEncoding is stable in Guava 20.0
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("Metadata(");

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -506,7 +506,6 @@ final class DnsNameResolver extends NameResolver {
    * @return The service config object or {@code null} if this choice does not apply.
    */
   @Nullable
-  @SuppressWarnings("BetaApi") // Verify isn't all that beta
   @VisibleForTesting
   static Map<String, Object> maybeChooseServiceConfig(
       Map<String, Object> choice, Random random, String hostname) {

--- a/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
+++ b/core/src/main/java/io/grpc/internal/JndiResourceResolverFactory.java
@@ -204,7 +204,6 @@ final class JndiResourceResolverFactory implements DnsNameResolver.ResourceResol
       final int port;
     }
 
-    @SuppressWarnings("BetaApi") // Verify is only kinda beta
     private static SrvRecord parseSrvRecord(String rawRecord) {
       String[] parts = whitespace.split(rawRecord);
       Verify.verify(parts.length == 4, "Bad SRV Record: %s", rawRecord);

--- a/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
@@ -201,7 +201,6 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
           .toString();
     }
 
-    @SuppressWarnings("BetaApi") // Verify is stabilized since Guava v24.0
     private static RetryPolicy retryPolicy(Map<String, Object> retryPolicy, int maxAttemptsLimit) {
       int maxAttempts = checkNotNull(
           ServiceConfigUtil.getMaxAttemptsFromRetryPolicy(retryPolicy),
@@ -249,7 +248,6 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
     }
   }
 
-  @SuppressWarnings("BetaApi") // Verify is stabilized since Guava v24.0
   private static HedgingPolicy hedgingPolicy(
       Map<String, Object> hedgingPolicy, int maxAttemptsLimit) {
     int maxAttempts = checkNotNull(
@@ -284,7 +282,6 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
   static final CallOptions.Key<HedgingPolicy.Provider> HEDGING_POLICY_KEY =
       CallOptions.Key.create("internal-hedging-policy");
 
-  @SuppressWarnings("BetaApi") // Verify is stabilized since Guava v24.0
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
       final MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {

--- a/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
+++ b/core/src/main/java/io/grpc/internal/TransportFrameUtil.java
@@ -47,7 +47,6 @@ public final class TransportFrameUtil {
    *
    * @return the interleaved keys and values.
    */
-  @SuppressWarnings("BetaApi") // BaseEncoding is stable in Guava 20.0
   public static byte[][] toHttp2Headers(Metadata headers) {
     byte[][] serializedHeaders = InternalMetadata.serialize(headers);
     // TODO(carl-mastrangelo): eventually remove this once all callers are updated.
@@ -97,7 +96,6 @@ public final class TransportFrameUtil {
    * @param http2Headers the interleaved keys and values of HTTP/2-compliant headers
    * @return the interleaved keys and values in the raw serialized format
    */
-  @SuppressWarnings("BetaApi") // BaseEncoding is stable in Guava 20.0
   @CheckReturnValue
   public static byte[][] toRawSerializedHeaders(byte[][] http2Headers) {
     for (int i = 0; i < http2Headers.length; i += 2) {

--- a/netty/src/main/java/io/grpc/netty/GrpcHttp2HeadersUtils.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcHttp2HeadersUtils.java
@@ -101,7 +101,6 @@ class GrpcHttp2HeadersUtils {
       values = new AsciiString[numHeadersGuess];
     }
 
-    @SuppressWarnings("BetaApi") // BaseEncoding is stable in Guava 20.0
     protected Http2Headers add(AsciiString name, AsciiString value) {
       byte[] nameBytes = bytes(name);
       byte[] valueBytes;

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -114,7 +114,6 @@ class NettyClientStream extends AbstractClientStream {
   }
 
   private class Sink implements AbstractClientStream.Sink {
-    @SuppressWarnings("BetaApi") // BaseEncoding is stable in Guava 20.0
     @Override
     public void writeHeaders(Metadata headers, byte[] requestPayload) {
       // Convert the headers into Netty HTTP/2 headers.

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -139,7 +139,6 @@ class OkHttpClientStream extends AbstractClientStream {
   }
 
   class Sink implements AbstractClientStream.Sink {
-    @SuppressWarnings("BetaApi") // BaseEncoding is stable in Guava 20.0
     @Override
     public void writeHeaders(Metadata metadata, byte[] payload) {
       String defaultPath = "/" + method.getFullMethodName();

--- a/testing/src/main/java/io/grpc/testing/GrpcCleanupRule.java
+++ b/testing/src/main/java/io/grpc/testing/GrpcCleanupRule.java
@@ -74,7 +74,7 @@ public final class GrpcCleanupRule implements TestRule {
    *
    * @return this
    */
-  @SuppressWarnings("BetaApi") // Stopwatch.createUnstarted(Ticker ticker) is not Beta. Test only.
+  @SuppressWarnings("BetaApi") // Test only.
   @VisibleForTesting
   GrpcCleanupRule setTicker(Ticker ticker) {
     this.stopwatch = Stopwatch.createUnstarted(ticker);


### PR DESCRIPTION
We've been on newer versions of Guava for a while now; these no longer
do anything.

Reworded the comment for Stopwatch.createUnstarted(), because it is not
safe (it doesn't matter if the method isn't marked Beta; you have to use
Ticker), except for the fact it is only used in our tests.

----

I've confirmed this is compatible with #5196.