### PR TITLE
Auth: Make IOException non retriable

### DIFF
--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -135,16 +135,11 @@ final class GoogleAuthLibraryCallCredentials extends CallCredentials2 {
 
       @Override
       public void onFailure(Throwable e) {
-        if (e instanceof IOException) {
-          // Since it's an I/O failure, let the call be retried with UNAVAILABLE.
-          applier.fail(Status.UNAVAILABLE
-              .withDescription("Credentials failed to obtain metadata")
-              .withCause(e));
-        } else {
-          applier.fail(Status.UNAUTHENTICATED
-              .withDescription("Failed computing credential metadata")
-              .withCause(e));
-        }
+        // There are so many IOException that are not retriable. Also most of the network based operation
+        // are retried in their respective library, others are mostly not retriable. Also retrying
+        // IOException causes more undeterministic behaviour in rpc with retries and higher total timeout.
+        applier.fail(Status.UNAUTHENTICATED.withDescription("Failed computing credential metadata")
+            .withCause(e));
       }
     });
   }

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -135,7 +135,7 @@ final class GoogleAuthLibraryCallCredentials extends CallCredentials2 {
 
       @Override
       public void onFailure(Throwable e) {
-        // There are so many IOException that are not retriable. Also most of the network based operation
+        // There are so many IOException that are not retriable. Also most of the network based operations
         // are retried in their respective library, others are mostly not retriable. Also retrying
         // IOException causes more undeterministic behaviour in rpc with retries and higher total timeout.
         applier.fail(Status.UNAUTHENTICATED.withDescription("Failed computing credential metadata")

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -28,7 +28,6 @@ import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.StatusException;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -135,9 +134,10 @@ final class GoogleAuthLibraryCallCredentials extends CallCredentials2 {
 
       @Override
       public void onFailure(Throwable e) {
-        // There are so many IOException that are not retriable. Also most of the network based operations
-        // are retried in their respective library, others are mostly not retriable. Also retrying
-        // IOException causes more undeterministic behaviour in rpc with retries and higher total timeout.
+        // There are so many IOException that are not retriable. Also most of the network based
+        // operations are retried in their respective library, others are mostly not retriable.
+        // Also retrying IOException causes more undeterministic behaviour in rpc with retries and
+        // higher total timeout.
         applier.fail(Status.UNAUTHENTICATED.withDescription("Failed computing credential metadata")
             .withCause(e));
       }

--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -195,7 +195,7 @@ public class GoogleAuthLibraryCallCredentialsTest {
     verify(credentials).getRequestMetadata(eq(expectedUri));
     verify(applier).fail(statusCaptor.capture());
     Status status = statusCaptor.getValue();
-    assertEquals(Status.Code.UNAVAILABLE, status.getCode());
+    assertEquals(Status.Code.UNAUTHENTICATED, status.getCode());
     assertEquals(exception, status.getCause());
   }
 


### PR DESCRIPTION
Fix [#3573](https://github.com/googleapis/google-cloud-java/issues/3573) Making IOException non retriable. Since most of Auth implementation based on network are already retrying for common problems and there are more IOException that are not retriable.