### PR TITLE
alts: Fix ambiguous assertThat() in TsiFrameHandlerTest

### DIFF
--- a/alts/src/test/java/io/grpc/alts/internal/TsiFrameHandlerTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/TsiFrameHandlerTest.java
@@ -71,7 +71,7 @@ public class TsiFrameHandlerTest {
 
     channel.writeAndFlush(msg);
 
-    assertThat(channel.readOutbound()).isEqualTo(msg);
+    assertThat((Object) channel.readOutbound()).isEqualTo(msg);
     channel.close().sync();
     channel.checkException();
   }
@@ -115,7 +115,7 @@ public class TsiFrameHandlerTest {
     channel.close().sync();
 
     assertWithMessage("pending write should be flushed on close")
-        .that(channel.readOutbound()).isEqualTo(msg);
+        .that((Object) channel.readOutbound()).isEqualTo(msg);
     channel.checkException();
   }
 


### PR DESCRIPTION
Build failed internally:
```
ERROR: /google/src/cloud/zdapeng/copybara_181B7ACA96E2E83A27C4518F7ABC90FE_0/google3/third_party/java_src/grpc/alts/BUILD:69:1: Building third_party/java_src/grpc/alts/libalts_test_lib.jar (29 source files) failed (Exit 1) java failed: error executing command third_party/java/jdk/jdk11-k8/bin/java -Xms3072m -Xmx3072m '-XX:MaxGCPauseMillis=20000' -XX:+TieredCompilation '-XX:TieredStopAtLevel=1' -Xverify:none -Xss5m '-XX:ErrorFile=/dev/stderr' ... (remaining 16 argument(s) skipped).  [forge_remote_host=ikpa6]
[5 / 6] Building third_party/java_src/grpc/alts/libalts_test_lib.jar (29 source files); 10s forge

third_party/java_src/grpc/alts/src/test/java/io/grpc/alts/internal/TsiFrameHandlerTest.java:74: error: reference to assertThat is ambiguous
    assertThat(channel.readOutbound()).isEqualTo(msg);
    ^
  both method assertThat(Class<?>) in Truth and method assertThat(BigDecimal) in Truth match
third_party/java_src/grpc/alts/src/test/java/io/grpc/alts/internal/TsiFrameHandlerTest.java:118: error: reference to that is ambiguous
        .that(channel.readOutbound()).isEqualTo(msg);
        ^
  both method that(Table<?,?,?>) in StandardSubjectBuilder and method that(AtomicLongMap<?>) in StandardSubjectBuilder match
[5 / 6] Building third_party/java_src/grpc/alts/libalts_test_lib.jar (29 source files); 10s forge

Target //third_party/java_src/grpc/alts:alts_test_lib failed to build
[6 / 6] no action

Use --verbose_failures to see the command lines of failed build steps.
[6 / 6] no action

INFO: Elapsed time: 11.598s, Forge stats: 0/1 actions cached, 8.8s CPU used, 0.0s queue time, 0.0 MB ObjFS output (novel bytes: 0.0 MB), 0.0 MB local output, Critical Path: 10.79s, Remote (99.28% of the time): [queue: 0.05%, setup: 1.78%, process: 71.61%]
[6 / 6] no action

FAILED: Build did NOT complete successfully
```