### PR TITLE
core: promote the new API in CallCredentials2

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Any;
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz.OtherSecurity;
 import io.grpc.InternalChannelz.Security;
@@ -28,6 +27,7 @@ import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.alts.internal.RpcProtocolVersionsUtil.RpcVersionsCheckResult;
 import io.grpc.alts.internal.TsiHandshakeHandler.TsiHandshakeCompletionEvent;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
 import io.grpc.netty.ProtocolNegotiator;
 import io.grpc.netty.ProtocolNegotiators.AbstractBufferingHandler;
@@ -161,7 +161,7 @@ public abstract class AltsProtocolNegotiator implements ProtocolNegotiator {
                     .set(ALTS_CONTEXT_KEY, altsContext)
                     .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, ctx.channel().remoteAddress())
                     .set(Grpc.TRANSPORT_ATTR_LOCAL_ADDR, ctx.channel().localAddress())
-                    .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
+                    .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
                     .build(),
                 new Security(new OtherSecurity("alts", Any.pack(altsContext.context))));
           }

--- a/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/AltsProtocolNegotiatorTest.java
@@ -24,12 +24,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import io.grpc.Attributes;
-import io.grpc.CallCredentials;
 import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
 import io.grpc.SecurityLevel;
 import io.grpc.alts.internal.TsiFrameProtector.Consumer;
 import io.grpc.alts.internal.TsiPeer.Property;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -348,7 +348,7 @@ public class AltsProtocolNegotiatorTest {
         .isEqualTo("embedded");
     assertThat(grpcHandler.attrs.get(Grpc.TRANSPORT_ATTR_LOCAL_ADDR).toString())
         .isEqualTo("embedded");
-    assertThat(grpcHandler.attrs.get(CallCredentials.ATTR_SECURITY_LEVEL))
+    assertThat(grpcHandler.attrs.get(GrpcAttributes.ATTR_SECURITY_LEVEL))
         .isEqualTo(SecurityLevel.PRIVACY_AND_INTEGRITY);
   }
 

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -22,7 +22,7 @@ import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
-import io.grpc.CallCredentials2;
+import io.grpc.CallCredentials;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -46,7 +46,7 @@ import javax.annotation.Nullable;
 /**
  * Wraps {@link Credentials} as a {@link CallCredentials}.
  */
-final class GoogleAuthLibraryCallCredentials extends CallCredentials2 {
+final class GoogleAuthLibraryCallCredentials extends CallCredentials {
   private static final Logger log
       = Logger.getLogger(GoogleAuthLibraryCallCredentials.class.getName());
   private static final JwtHelper jwtHelper

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -22,7 +22,6 @@ import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
-import io.grpc.CallCredentials2;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -48,7 +47,7 @@ import javax.annotation.Nullable;
  */
 // TODO(zhangkun83): remove the suppression after we change the base class to CallCredential
 @SuppressWarnings("deprecation")
-final class GoogleAuthLibraryCallCredentials extends CallCredentials2 {
+final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials2 {
   private static final Logger log
       = Logger.getLogger(GoogleAuthLibraryCallCredentials.class.getName());
   private static final JwtHelper jwtHelper

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -22,7 +22,7 @@ import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
-import io.grpc.CallCredentials;
+import io.grpc.CallCredentials2;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -46,7 +46,9 @@ import javax.annotation.Nullable;
 /**
  * Wraps {@link Credentials} as a {@link CallCredentials}.
  */
-final class GoogleAuthLibraryCallCredentials extends CallCredentials {
+// TODO(zhangkun83): remove the suppression after we change the base class to CallCredential
+@SuppressWarnings("deprecation")
+final class GoogleAuthLibraryCallCredentials extends CallCredentials2 {
   private static final Logger log
       = Logger.getLogger(GoogleAuthLibraryCallCredentials.class.getName());
   private static final JwtHelper jwtHelper

--- a/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
+++ b/auth/src/test/java/io/grpc/auth/GoogleAuthLibraryCallCredentialsTest.java
@@ -39,8 +39,8 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 import io.grpc.Attributes;
-import io.grpc.CallCredentials2;
-import io.grpc.CallCredentials2.MetadataApplier;
+import io.grpc.CallCredentials;
+import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -393,7 +393,7 @@ public class GoogleAuthLibraryCallCredentialsTest {
     return savedPendingRunnables.size();
   }
 
-  private final class RequestInfoImpl extends CallCredentials2.RequestInfo {
+  private final class RequestInfoImpl extends CallCredentials.RequestInfo {
     final String authority;
     final SecurityLevel securityLevel;
 

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executor;
  * response = stub.withCallCredentials(creds).bar(request);
  * </pre>
  *
- * <p>The contents and nature of this interface (and whether it remains an interface) is
+ * <p>The contents and nature of this class (and whether it remains an abstract class) is
  * experimental, in that it can change. However, we are guaranteeing stability for the
  * <em>name</em>. That is, we are guaranteeing stability for code to be returned a reference and
  * pass that reference to gRPC for usage. However, code may not call or implement the {@code

--- a/core/src/main/java/io/grpc/CallCredentials.java
+++ b/core/src/main/java/io/grpc/CallCredentials.java
@@ -35,83 +35,31 @@ import java.util.concurrent.Executor;
  * pass that reference to gRPC for usage. However, code may not call or implement the {@code
  * CallCredentials} itself if it wishes to only use stable APIs.
  */
-public interface CallCredentials {
-  /**
-   * The security level of the transport. It is guaranteed to be present in the {@code attrs} passed
-   * to {@link #applyRequestMetadata}. It is by default {@link SecurityLevel#NONE} but can be
-   * overridden by the transport.
-   *
-   * @deprecated transport implementations should use {@code
-   * io.grpc.internal.GrpcAttributes.ATTR_SECURITY_LEVEL} instead.
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  @Grpc.TransportAttr
-  @Deprecated
-  public static final Key<SecurityLevel> ATTR_SECURITY_LEVEL =
-      Key.create("io.grpc.internal.GrpcAttributes.securityLevel");
-
-  /**
-   * The authority string used to authenticate the server. Usually it's the server's host name. It
-   * is guaranteed to be present in the {@code attrs} passed to {@link #applyRequestMetadata}. It is
-   * by default from the channel, but can be overridden by the transport and {@link
-   * io.grpc.CallOptions} with increasing precedence.
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  @Grpc.TransportAttr
-  @Deprecated
-  public static final Key<String> ATTR_AUTHORITY = Key.create("io.grpc.CallCredentials.authority");
-
-  /**
-   * Pass the credential data to the given {@link MetadataApplier}, which will propagate it to
-   * the request metadata.
-   *
-   * <p>It is called for each individual RPC, within the {@link Context} of the call, before the
-   * stream is about to be created on a transport. Implementations should not block in this
-   * method. If metadata is not immediately available, e.g., needs to be fetched from network, the
-   * implementation may give the {@code applier} to an asynchronous task which will eventually call
-   * the {@code applier}. The RPC proceeds only after the {@code applier} is called.
-   *
-   * @param method The method descriptor of this RPC
-   * @param attrs Additional attributes from the transport, along with the keys defined in this
-   *        interface (i.e. the {@code ATTR_*} fields) which are guaranteed to be present.
-   * @param appExecutor The application thread-pool. It is provided to the implementation in case it
-   *        needs to perform blocking operations.
-   * @param applier The outlet of the produced headers. It can be called either before or after this
-   *        method returns.
-   *
-   * @deprecated implement {@link CallCredentials2} instead.
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  @Deprecated
-  void applyRequestMetadata(
-      MethodDescriptor<?, ?> method, Attributes attrs,
-      Executor appExecutor, MetadataApplier applier);
-
+public abstract class CallCredentials {
   /**
    * Should be a noop but never called; tries to make it clearer to implementors that they may break
    * in the future.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  void thisUsesUnstableApi();
+  public abstract void thisUsesUnstableApi();
 
   /**
    * The outlet of the produced headers. Not thread-safe.
    *
    * <p>Exactly one of its methods must be called to make the RPC proceed.
    */
-  @Deprecated
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  public interface MetadataApplier {
+  public abstract class MetadataApplier {
     /**
      * Called when headers are successfully generated. They will be merged into the original
      * headers.
      */
-    void apply(Metadata headers);
+    public abstract void apply(Metadata headers);
 
     /**
      * Called when there has been an error when preparing the headers. This will fail the RPC.
      */
-    void fail(Status status);
+    public abstract void fail(Status status);
   }
 
   /**

--- a/core/src/main/java/io/grpc/CallCredentials2.java
+++ b/core/src/main/java/io/grpc/CallCredentials2.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Executor;
  * IMPLEMENTIONS.  All consumers should still reference {@link CallCredentials}.
  */
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4901")
-public abstract class CallCredentials2 implements CallCredentials {
+public abstract class CallCredentials2 extends CallCredentials {
   /**
    * Pass the credential data to the given {@link CallCredentials.MetadataApplier}, which will
    * propagate it to the request metadata.
@@ -47,39 +47,15 @@ public abstract class CallCredentials2 implements CallCredentials {
    *        method returns.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
+  @Deprecated
   public abstract void applyRequestMetadata(
       RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier);
 
   @Override
-  @SuppressWarnings("deprecation")
   public final void applyRequestMetadata(
-      final MethodDescriptor<?, ?> method, final Attributes attrs,
-      Executor appExecutor, final CallCredentials.MetadataApplier applier) {
-    final String authority = checkNotNull(attrs.get(ATTR_AUTHORITY), "authority");
-    final SecurityLevel securityLevel =
-        firstNonNull(attrs.get(ATTR_SECURITY_LEVEL), SecurityLevel.NONE);
-    RequestInfo requestInfo = new RequestInfo() {
-        @Override
-        public MethodDescriptor<?, ?> getMethodDescriptor() {
-          return method;
-        }
-
-        @Override
-        public SecurityLevel getSecurityLevel() {
-          return securityLevel;
-        }
-
-        @Override
-        public String getAuthority() {
-          return authority;
-        }
-
-        @Override
-        public Attributes getTransportAttrs() {
-          return attrs;
-        }
-      };
-    MetadataApplier applierAdapter = new MetadataApplier() {
+      RequestInfo requestInfo, Executor appExecutor,
+      final CallCredentials.MetadataApplier applier) {
+    applyRequestMetadata(requestInfo, appExecutor, new MetadataApplier() {
         @Override
         public void apply(Metadata headers) {
           applier.apply(headers);
@@ -89,11 +65,10 @@ public abstract class CallCredentials2 implements CallCredentials {
         public void fail(Status status) {
           applier.fail(status);
         }
-      };
-    applyRequestMetadata(requestInfo, appExecutor, applierAdapter);
+      });
   }
 
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  @SuppressWarnings("deprecation")
-  public abstract static class MetadataApplier implements CallCredentials.MetadataApplier {}
+  @Deprecated
+  public abstract static class MetadataApplier extends CallCredentials.MetadataApplier {}
 }

--- a/core/src/main/java/io/grpc/CallCredentials2.java
+++ b/core/src/main/java/io/grpc/CallCredentials2.java
@@ -16,9 +16,6 @@
 
 package io.grpc;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.concurrent.Executor;
 
 /**
@@ -31,8 +28,8 @@ import java.util.concurrent.Executor;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4901")
 public abstract class CallCredentials2 extends CallCredentials {
   /**
-   * Pass the credential data to the given {@link CallCredentials.MetadataApplier}, which will
-   * propagate it to the request metadata.
+   * Pass the credential data to the given {@link MetadataApplier}, which will propagate it to the
+   * request metadata.
    *
    * <p>It is called for each individual RPC, within the {@link Context} of the call, before the
    * stream is about to be created on a transport. Implementations should not block in this

--- a/core/src/main/java/io/grpc/CallCredentials2.java
+++ b/core/src/main/java/io/grpc/CallCredentials2.java
@@ -22,9 +22,13 @@ import java.util.concurrent.Executor;
  * The new interface for {@link CallCredentials}.
  *
  * <p>THIS CLASS NAME IS TEMPORARY and is part of a migration. This class will BE DELETED as it
- * replaces {@link CallCredentials} in short-term.  THIS CLASS SHOULD ONLY BE REFERENCED BY
- * IMPLEMENTIONS.  All consumers should still reference {@link CallCredentials}.
+ * replaces {@link CallCredentials} in short-term.  THIS CLASS IS ONLY REFERENCED BY IMPLEMENTIONS.
+ * All consumers should be always referencing {@link CallCredentials}.
+ *
+ * @deprecated the new interface has been promoted into {@link CallCredentials}.  Implementations
+ *             should switch back to "{@code extends CallCredentials}".
  */
+@Deprecated
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4901")
 public abstract class CallCredentials2 extends CallCredentials {
   /**
@@ -44,7 +48,6 @@ public abstract class CallCredentials2 extends CallCredentials {
    *        method returns.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  @Deprecated
   public abstract void applyRequestMetadata(
       RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier);
 
@@ -66,6 +69,5 @@ public abstract class CallCredentials2 extends CallCredentials {
   }
 
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-  @Deprecated
   public abstract static class MetadataApplier extends CallCredentials.MetadataApplier {}
 }

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -74,11 +74,35 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
     @Override
     @SuppressWarnings("deprecation")
     public ClientStream newStream(
-        MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+        final MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
       CallCredentials creds = callOptions.getCredentials();
       if (creds != null) {
         MetadataApplierImpl applier = new MetadataApplierImpl(
             delegate, method, headers, callOptions);
+        RequestInfo requestInfo = new RequestInfo() {
+            @Override
+            public MethodDescriptor<?, ?> getMethodDescriptor() {
+              return method;
+            }
+
+            @Override
+            public SecurityLevel getSecurityLevel() {
+              // TODO(zhangkun83): get from GrpcAttributes.ATTR_SECURITY_LEVEL out of the delegate's
+              // attributes.
+              return securityLevel;
+            }
+
+            @Override
+            public String getAuthority() {
+              return authority;
+            }
+
+            @Override
+            public Attributes getTransportAttrs() {
+              // TODO(zhangkun83): get from delegate attributes
+              return attrs;
+            }
+          };
         Attributes.Builder effectiveAttrsBuilder = Attributes.newBuilder()
             .set(CallCredentials.ATTR_AUTHORITY, authority)
             .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)

--- a/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/CallCredentialsApplyingTransportFactory.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
+import io.grpc.CallCredentials.RequestInfo;
 import io.grpc.CallOptions;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -74,7 +75,7 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
     @Override
     @SuppressWarnings("deprecation")
     public ClientStream newStream(
-        final MethodDescriptor<?, ?> method, Metadata headers, CallOptions callOptions) {
+        final MethodDescriptor<?, ?> method, Metadata headers, final CallOptions callOptions) {
       CallCredentials creds = callOptions.getCredentials();
       if (creds != null) {
         MetadataApplierImpl applier = new MetadataApplierImpl(
@@ -87,32 +88,24 @@ final class CallCredentialsApplyingTransportFactory implements ClientTransportFa
 
             @Override
             public SecurityLevel getSecurityLevel() {
-              // TODO(zhangkun83): get from GrpcAttributes.ATTR_SECURITY_LEVEL out of the delegate's
-              // attributes.
-              return securityLevel;
+              return firstNonNull(
+                  delegate.getAttributes().get(GrpcAttributes.ATTR_SECURITY_LEVEL),
+                  SecurityLevel.NONE);
             }
 
             @Override
             public String getAuthority() {
-              return authority;
+              return firstNonNull(callOptions.getAuthority(), authority);
             }
 
             @Override
             public Attributes getTransportAttrs() {
-              // TODO(zhangkun83): get from delegate attributes
-              return attrs;
+              return delegate.getAttributes();
             }
           };
-        Attributes.Builder effectiveAttrsBuilder = Attributes.newBuilder()
-            .set(CallCredentials.ATTR_AUTHORITY, authority)
-            .set(CallCredentials.ATTR_SECURITY_LEVEL, SecurityLevel.NONE)
-            .setAll(delegate.getAttributes());
-        if (callOptions.getAuthority() != null) {
-          effectiveAttrsBuilder.set(CallCredentials.ATTR_AUTHORITY, callOptions.getAuthority());
-        }
         try {
-          creds.applyRequestMetadata(method, effectiveAttrsBuilder.build(),
-              firstNonNull(callOptions.getExecutor(), appExecutor), applier);
+          creds.applyRequestMetadata(
+              requestInfo, firstNonNull(callOptions.getExecutor(), appExecutor), applier);
         } catch (Throwable t) {
           applier.fail(Status.UNAUTHENTICATED
               .withDescription("Credentials should use fail() instead of throwing exceptions")

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -54,10 +54,9 @@ public final class GrpcAttributes {
    * The security level of the transport.  If it's not present, {@link SecurityLevel#NONE} should be
    * assumed.
    */
-  @SuppressWarnings("deprecation")
   @Grpc.TransportAttr
   public static final Attributes.Key<SecurityLevel> ATTR_SECURITY_LEVEL =
-      io.grpc.CallCredentials.ATTR_SECURITY_LEVEL;
+      Attributes.Key.create("io.grpc.internal.GrpcAttributes.securityLevel");
 
   private GrpcAttributes() {}
 }

--- a/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
+++ b/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import io.grpc.CallCredentials2.MetadataApplier;
+import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.Metadata;

--- a/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
+++ b/core/src/test/java/io/grpc/internal/CallCredentials2ApplyingTest.java
@@ -29,9 +29,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.grpc.Attributes;
+import io.grpc.CallCredentials.MetadataApplier;
 import io.grpc.CallCredentials.RequestInfo;
-import io.grpc.CallCredentials2;
-import io.grpc.CallCredentials2.MetadataApplier;
 import io.grpc.CallOptions;
 import io.grpc.IntegerMarshaller;
 import io.grpc.Metadata;
@@ -55,6 +54,7 @@ import org.mockito.stubbing.Answer;
  * Unit test for {@link CallCredentials2} applying functionality implemented by {@link
  * CallCredentialsApplyingTransportFactory} and {@link MetadataApplierImpl}.
  */
+@SuppressWarnings("deprecation")
 @RunWith(JUnit4.class)
 public class CallCredentials2ApplyingTest {
   @Mock
@@ -67,7 +67,7 @@ public class CallCredentials2ApplyingTest {
   private ClientStream mockStream;
 
   @Mock
-  private CallCredentials2 mockCreds;
+  private io.grpc.CallCredentials2 mockCreds;
 
   @Mock
   private Executor mockExecutor;
@@ -128,7 +128,8 @@ public class CallCredentials2ApplyingTest {
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(
-        infoCaptor.capture(), same(mockExecutor), any(MetadataApplier.class));
+        infoCaptor.capture(), same(mockExecutor),
+        any(io.grpc.CallCredentials2.MetadataApplier.class));
     RequestInfo info = infoCaptor.getValue();
     assertSame(method, info.getMethodDescriptor());
     assertSame(ATTR_VALUE, info.getTransportAttrs().get(ATTR_KEY));
@@ -148,7 +149,8 @@ public class CallCredentials2ApplyingTest {
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(
-        infoCaptor.capture(), same(mockExecutor), any(MetadataApplier.class));
+        infoCaptor.capture(), same(mockExecutor),
+        any(io.grpc.CallCredentials2.MetadataApplier.class));
     RequestInfo info = infoCaptor.getValue();
     assertSame(method, info.getMethodDescriptor());
     assertSame(ATTR_VALUE, info.getTransportAttrs().get(ATTR_KEY));
@@ -169,7 +171,8 @@ public class CallCredentials2ApplyingTest {
 
     ArgumentCaptor<RequestInfo> infoCaptor = ArgumentCaptor.forClass(null);
     verify(mockCreds).applyRequestMetadata(
-        infoCaptor.capture(), same(anotherExecutor), any(MetadataApplier.class));
+        infoCaptor.capture(), same(anotherExecutor),
+        any(io.grpc.CallCredentials2.MetadataApplier.class));
     RequestInfo info = infoCaptor.getValue();
     assertSame(method, info.getMethodDescriptor());
     assertSame(ATTR_VALUE, info.getTransportAttrs().get(ATTR_KEY));
@@ -182,7 +185,8 @@ public class CallCredentials2ApplyingTest {
     final RuntimeException ex = new RuntimeException();
     when(mockTransport.getAttributes()).thenReturn(Attributes.EMPTY);
     doThrow(ex).when(mockCreds).applyRequestMetadata(
-        any(RequestInfo.class), same(mockExecutor), any(MetadataApplier.class));
+        any(RequestInfo.class), same(mockExecutor),
+        any(io.grpc.CallCredentials2.MetadataApplier.class));
 
     FailingClientStream stream =
         (FailingClientStream) transport.newStream(method, origHeaders, callOptions);
@@ -205,7 +209,8 @@ public class CallCredentials2ApplyingTest {
           return null;
         }
       }).when(mockCreds).applyRequestMetadata(
-          any(RequestInfo.class), same(mockExecutor), any(MetadataApplier.class));
+          any(RequestInfo.class), same(mockExecutor),
+          any(io.grpc.CallCredentials2.MetadataApplier.class));
 
     ClientStream stream = transport.newStream(method, origHeaders, callOptions);
 
@@ -227,7 +232,8 @@ public class CallCredentials2ApplyingTest {
           return null;
         }
       }).when(mockCreds).applyRequestMetadata(
-          any(RequestInfo.class), same(mockExecutor), any(MetadataApplier.class));
+          any(RequestInfo.class), same(mockExecutor),
+          any(io.grpc.CallCredentials2.MetadataApplier.class));
 
     FailingClientStream stream =
         (FailingClientStream) transport.newStream(method, origHeaders, callOptions);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1674,7 +1674,6 @@ public class ManagedChannelImplTest {
    * propagated to newStream() and applyRequestMetadata().
    */
   @Test
-  @SuppressWarnings("deprecation")
   public void informationPropagatedToNewStreamAndCallCredentials() {
     createChannel();
     CallOptions callOptions = CallOptions.DEFAULT.withCallCredentials(creds);
@@ -1688,7 +1687,7 @@ public class ManagedChannelImplTest {
           credsApplyContexts.add(Context.current());
           return null;
         }
-      }).when(creds).applyRequestMetadata(  // TODO(zhangkun83): remove suppression of deprecations
+      }).when(creds).applyRequestMetadata(
           any(RequestInfo.class), any(Executor.class), any(CallCredentials.MetadataApplier.class));
 
     // First call will be on delayed transport.  Only newCall() is run within the expected context,


### PR DESCRIPTION
This is the 3rd step of #4901

- The deprecated `CC.applyRequestMetadata(... Attributes ...)` is now **replaced** by the new API `CC.applyRequestMetadata(... CC.MetadataApplier ...)` transformed from `CC2.applyRequestMetadata(... CC2.MetadataApplier ...)`.
- The Attributes keys in `CallCredentials` were deprecated, and now deleted.
- The deprecated interface `CC.MetadataApplier` is **replaced** by an equivalent abstract class.
- `CallCredentials2` is now marked as deprecated, while keeping its interface intact so that it won't break current implementations that are still on `CallCredentials2`.
- From this point on, implementations should do a one-line change from `extends CallCredentials2` to `extends CallCredentials`
- `GoogleAuthLibraryCallCredentials` is kept as `CallCredentials2` for now, as there is an internal consumer that expects it to be `CallCredentials2`.

/cc @njhill 