### PR TITLE
Downgrade to Guava 25.1 (v1.18.x backport)

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile (libraries.google_auth_oauth2_http) {
         // prefer 3.0.2 from libraries instead of 1.3.9
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 20.0 from libraries instead of 19.0
+        // prefer 25.1 from libraries instead of 19.0
         exclude group: 'com.google.guava', module: 'guava'
     }
     compileOnly libraries.javax_annotation

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,9 @@ subprojects {
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         nettyVersion = '4.1.32.Final'
-        guavaVersion = '26.0-android'
+        // Temporarily use a slightly older version of Guava. Will want to bump
+        // to 27.0.1+ with grpc 1.19 or 1.20 for the listenablefuture dep changes.
+        guavaVersion = '25.1-android'
         protobufVersion = '3.5.1'
         protocVersion = '3.5.1-1'
         protobufNanoVersion = '3.0.0-alpha-5'
@@ -191,6 +193,7 @@ subprojects {
         }
         libraries = [
             animalsniffer_annotations: "org.codehaus.mojo:animal-sniffer-annotations:1.17",
+            checker_compat_qual: "org.checkerframework:checker-compat-qual:2.5.2",
             errorprone: "com.google.errorprone:error_prone_annotations:2.2.0",
             gson: "com.google.code.gson:gson:2.7",
             guava: "com.google.guava:guava:${guavaVersion}",

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,28 +6,24 @@ dependencies {
             libraries.errorprone,
             libraries.jsr305,
             libraries.animalsniffer_annotations
+    // Brought in by Guava, but Proguard fails with 2.0.0. So we bump it to 2.5.2
+    compile libraries.checker_compat_qual
     compile (libraries.guava) {
         // prefer 2.2.0 from libraries instead of 2.1.3
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+        // prefer 2.5.2 from libraries instead of 2.0.0
+        exclude group: 'org.checkerframework', module: 'checker-compat-qual'
         // prefer 1.17 from libraries instead of 1.14
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }
     compile (libraries.opencensus_api) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
         // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
     }
     compile (libraries.opencensus_contrib_grpc_metrics) {
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
         // we'll always be more up-to-date
         exclude group: 'io.grpc', module: 'grpc-context'
-        // prefer 20.0 from libraries instead of 19.0
+        // prefer 25.1 from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
     }
 

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -14,11 +14,13 @@ description = 'gRPC: Protobuf Lite'
 dependencies {
     compile project(':grpc-core'),
             libraries.protobuf_lite
+    // Brought in by Guava, but Proguard fails with 2.0.0. So we bump it to 2.5.2
+    compile libraries.checker_compat_qual
     compile (libraries.guava) {
         // prefer 2.2.0 from libraries instead of 2.1.3
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+        // prefer 2.5.2 from libraries instead of 2.0.0
+        exclude group: 'org.checkerframework', module: 'checker-compat-qual'
         // prefer 1.17 from libraries instead of 1.14
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }

--- a/protobuf-nano/build.gradle
+++ b/protobuf-nano/build.gradle
@@ -12,11 +12,13 @@ description = 'gRPC: Protobuf Nano'
 dependencies {
     compile project(':grpc-core'),
             libraries.protobuf_nano
+    // Brought in by Guava, but Proguard fails with 2.0.0. So we bump it to 2.5.2
+    compile libraries.checker_compat_qual
     compile (libraries.guava) {
         // prefer 2.2.0 from libraries instead of 2.1.3
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+        // prefer 2.5.2 from libraries instead of 2.0.0
+        exclude group: 'org.checkerframework', module: 'checker-compat-qual'
         // prefer 1.17 from libraries instead of 1.14
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -11,11 +11,13 @@ buildscript {
 dependencies {
     compile project(':grpc-core'),
             libraries.protobuf
+    // Brought in by Guava, but Proguard fails with 2.0.0. So we bump it to 2.5.2
+    compile libraries.checker_compat_qual
     compile (libraries.guava) {
         // prefer 2.2.0 from libraries instead of 2.1.3
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 3.0.2 from libraries instead of 3.0.1
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+        // prefer 2.5.2 from libraries instead of 2.0.0
+        exclude group: 'org.checkerframework', module: 'checker-compat-qual'
         // prefer 1.17 from libraries instead of 1.14
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -158,8 +158,8 @@ def com_google_errorprone_error_prone_annotations():
 def com_google_guava():
     native.maven_jar(
         name = "com_google_guava_guava",
-        artifact = "com.google.guava:guava:26.0-android",
-        sha1 = "ef69663836b339db335fde0df06fb3cd84e3742b",
+        artifact = "com.google.guava:guava:25.1-android",
+        sha1 = "bdaab946ca5ad20253502d873ba0c3313d141036",
     )
 
 def com_google_j2objc_j2objc_annotations():


### PR DESCRIPTION
This is temporary for the 1.18 release to give users a bit more time to
get past the breaking changes to Beta APIs in Guava 26.

Fixes #5166

-----

This is a backport of #5196