### PR TITLE
kokoro: Reduce gradle workers on Mac to reduce flakes

### DIFF
--- a/buildscripts/kokoro/macos.cfg
+++ b/buildscripts/kokoro/macos.cfg
@@ -4,6 +4,14 @@
 build_file: "grpc-java/buildscripts/kokoro/unix.sh"
 timeout_mins: 45
 
+# We had problems with random tests timing out because it took seconds to do
+# trivial (ns) operations. The Mac machines have 2 cores with 4 logical
+# threads, so Gradle should be using 4 workers by default.
+env_vars {
+  key: "GRADLE_FLAGS"
+  value: "--max-workers=2"
+}
+
 # We always build mvn artifacts.
 action {
   define_artifacts {

--- a/buildscripts/kokoro/unix.sh
+++ b/buildscripts/kokoro/unix.sh
@@ -30,7 +30,7 @@ ARCH="$ARCH" buildscripts/make_dependencies.sh
 
 # Set properties via flags, do not pollute gradle.properties
 GRADLE_FLAGS="${GRADLE_FLAGS:-}"
-GRADLE_FLAGS+=" -PtargetArch=x86_$ARCH $GRADLE_FLAGS"
+GRADLE_FLAGS+=" -PtargetArch=x86_$ARCH"
 GRADLE_FLAGS+=" -Pcheckstyle.ignoreFailures=false"
 GRADLE_FLAGS+=" -PfailOnWarnings=true"
 GRADLE_FLAGS+=" -PerrorProne=true"


### PR DESCRIPTION
We've had a long run of test timeout failures on Mac with timeouts in
the seconds. Multiple of these haven't seemed like races, but simply
that the Mac machines were too slow. The most recent case for this is a
set of timeouts for
OkHttpTransportTest.earlyServerClose_serverFailure_withClientCancelOnListenerClosed
where it took over a second for a server stream to be created ("Timed
out waiting for server stream").

This commit reduces the number of workers to reduce the overall load,
hoping this lets tests complete within a reasonable amount of time.