### PR TITLE
core: Remove incorrect usages of VisibleForTesting

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -77,7 +77,6 @@ public abstract class AbstractManagedChannelImplBuilder
   /**
    * An idle timeout smaller than this would be capped to it.
    */
-  @VisibleForTesting
   static final long IDLE_MODE_MIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(1);
 
   private static final ObjectPool<? extends Executor> DEFAULT_EXECUTOR_POOL =

--- a/core/src/main/java/io/grpc/internal/ProxySocketAddress.java
+++ b/core/src/main/java/io/grpc/internal/ProxySocketAddress.java
@@ -16,7 +16,6 @@
 
 package io.grpc.internal;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.net.SocketAddress;
 
@@ -29,7 +28,6 @@ final class ProxySocketAddress extends SocketAddress {
   private final SocketAddress address;
   private final ProxyParameters proxyParameters;
 
-  @VisibleForTesting
   ProxySocketAddress(SocketAddress address, ProxyParameters proxyParameters) {
     this.address = Preconditions.checkNotNull(address);
     this.proxyParameters = Preconditions.checkNotNull(proxyParameters);


### PR DESCRIPTION
The visibility is (correctly) used in non-testing scenarios.