### PR TITLE
xds: do not upload archives for xds for now

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -371,7 +371,7 @@ subprojects {
             snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/', configureAuth)
         }
     }
-    uploadArchives.onlyIf { !name.contains("grpc-gae-interop-testing") }
+    uploadArchives.onlyIf { !name.contains("grpc-gae-interop-testing") && !name.contains("grpc-xds") }
 
     [
         install.repositories.mavenInstaller,


### PR DESCRIPTION
During 1.18 release, I found xds directory was uploaded to Sonatype, so I had to manually delete it before releasing to maven central. This needs backport to v1.18.x branch in case for future patches v1.18.1+.