### PR TITLE
core: do not lose status when RST_STREAM with NO_ERROR received

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -240,7 +240,7 @@ public abstract class AbstractClientStream extends AbstractStream
      * #listenerClosed} because there may still be messages buffered to deliver to the application.
      */
     private boolean statusReported;
-    /** True if the status to report (set via {@link #transportReportStatus}) is OK. */
+    /** True if the status reported (set via {@link #transportReportStatus}) is OK. */
     private boolean statusReportedIsOk;
 
     protected TransportState(

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -241,7 +241,7 @@ public abstract class AbstractClientStream extends AbstractStream
      */
     private boolean statusReported;
     /** True if the status to report (set via {@link #transportReportStatus}) is OK. */
-    private boolean statusToReportIsOk;
+    private boolean statusReportedIsOk;
 
     protected TransportState(
         int maxMessageSize,
@@ -271,7 +271,7 @@ public abstract class AbstractClientStream extends AbstractStream
     public void deframerClosed(boolean hasPartialMessage) {
       checkState(statusReported, "status should have been reported on deframer closed");
       deframerClosed = true;
-      if (statusToReportIsOk && hasPartialMessage) {
+      if (statusReportedIsOk && hasPartialMessage) {
         transportReportStatus(
             Status.INTERNAL.withDescription("Encountered end-of-stream mid-frame"),
             true,
@@ -431,7 +431,7 @@ public abstract class AbstractClientStream extends AbstractStream
         return;
       }
       statusReported = true;
-      statusToReportIsOk = status.isOk();
+      statusReportedIsOk = status.isOk();
       onStreamDeallocated();
 
       if (deframerClosed) {

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -339,6 +339,24 @@ public class AbstractClientStreamTest {
   }
 
   @Test
+  public void statusOkFollowedByRstStreamNoError() {
+    AbstractClientStream stream =
+        new BaseAbstractClientStream(allocator, statsTraceCtx, transportTracer);
+    stream.start(mockListener);
+    stream.transportState().deframe(ReadableBuffers.wrap(new byte[] {0, 0, 0, 0, 1, 1}));
+    stream.transportState().inboundTrailersReceived(new Metadata(), Status.OK);
+    Status status = Status.INTERNAL.withDescription("rst___stream");
+    // Simulate getting a reset
+    stream.transportState().transportReportStatus(status, false /*stop delivery*/, new Metadata());
+    stream.transportState().requestMessagesFromDeframer(1);
+
+    ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+    verify(mockListener)
+        .closed(statusCaptor.capture(), any(RpcProgress.class), any(Metadata.class));
+    assertSame(Status.Code.OK, statusCaptor.getValue().getCode());
+  }
+
+  @Test
   public void trailerOkWithTruncatedMessage() {
     AbstractClientStream stream =
         new BaseAbstractClientStream(allocator, statsTraceCtx, transportTracer);

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -353,7 +353,7 @@ public class AbstractClientStreamTest {
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(mockListener)
         .closed(statusCaptor.capture(), any(RpcProgress.class), any(Metadata.class));
-    assertSame(Status.Code.OK, statusCaptor.getValue().getCode());
+    assertTrue(statusCaptor.getValue().isOk());
   }
 
   @Test

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -483,6 +483,27 @@ public class OkHttpClientTransportTest {
     shutdownAndVerify();
   }
 
+
+  @Test
+  public void receiveResetNoError() throws Exception {
+    initTransport();
+    MockStreamListener listener = new MockStreamListener();
+    OkHttpClientStream stream =
+        clientTransport.newStream(method, new Metadata(), CallOptions.DEFAULT);
+    stream.start(listener);
+    assertContainStream(3);
+    frameHandler().headers(false, false, 3, 0, grpcResponseHeaders(), HeadersMode.HTTP_20_HEADERS);
+    Buffer buffer = createMessageFrame("a message");
+    frameHandler().data(false, 3, buffer, (int) buffer.size());
+    frameHandler().headers(true, true, 3, 0, grpcResponseTrailers(), HeadersMode.HTTP_20_HEADERS);
+    frameHandler().rstStream(3, ErrorCode.NO_ERROR);
+    stream.request(1);
+    listener.waitUntilStreamClosed();
+
+    assertThat(listener.status.getCode()).isEqualTo(Code.OK);
+    shutdownAndVerify();
+  }
+
   @Test
   public void cancelStream() throws Exception {
     initTransport();

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -500,7 +500,7 @@ public class OkHttpClientTransportTest {
     stream.request(1);
     listener.waitUntilStreamClosed();
 
-    assertThat(listener.status.getCode()).isEqualTo(Code.OK);
+    assertTrue(listener.status.isOk());
     shutdownAndVerify();
   }
 


### PR DESCRIPTION
The current behavior (RST_STREAM w/ NO_ERROR results in client seeing INTERNAL error, even if gRPC status code was already sent in trailing headers) seems to have been introduced in https://github.com/grpc/grpc-java/pull/4485. The added call to `transportReportStatus` within `deframerClosed` would have no effect when `statusReported` had already been set to true upon receipt of the rst stream.