### PR TITLE
cronet: avoid NPE in writeHeaders after transport shutdown

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -251,7 +251,7 @@ class CronetClientStream extends AbstractClientStream {
     @GuardedBy("lock")
     @Override
     protected void http2ProcessingFailed(Status status, boolean stopDelivery, Metadata trailers) {
-      Preconditions.checkNotNull(self.stream, "stream must not be null");
+      Preconditions.checkNotNull(stream, "stream must not be null");
       stream.cancel();
       transportReportStatus(status, stopDelivery, trailers);
     }
@@ -272,7 +272,7 @@ class CronetClientStream extends AbstractClientStream {
     @GuardedBy("lock")
     @Override
     public void bytesRead(int processedBytes) {
-      Preconditions.checkNotNull(self.stream, "stream must not be null");
+      Preconditions.checkNotNull(stream, "stream must not be null");
       bytesPendingProcess -= processedBytes;
       if (bytesPendingProcess == 0 && !readClosed) {
         if (Log.isLoggable(LOG_TAG, Log.VERBOSE)) {

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -251,9 +251,8 @@ class CronetClientStream extends AbstractClientStream {
     @GuardedBy("lock")
     @Override
     protected void http2ProcessingFailed(Status status, boolean stopDelivery, Metadata trailers) {
-      if (stream != null) {
-        stream.cancel();
-      }
+      Preconditions.checkNotNull(self.stream, "stream must not be null");
+      stream.cancel();
       transportReportStatus(status, stopDelivery, trailers);
     }
 
@@ -273,10 +272,8 @@ class CronetClientStream extends AbstractClientStream {
     @GuardedBy("lock")
     @Override
     public void bytesRead(int processedBytes) {
+      Preconditions.checkNotNull(self.stream, "stream must not be null");
       bytesPendingProcess -= processedBytes;
-      if (stream == null) {
-        return;
-      }
       if (bytesPendingProcess == 0 && !readClosed) {
         if (Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
           Log.v(LOG_TAG, "BidirectionalStream.read");
@@ -399,14 +396,10 @@ class CronetClientStream extends AbstractClientStream {
     public void onResponseHeadersReceived(BidirectionalStream stream, UrlResponseInfo info) {
       if (Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
         Log.v(LOG_TAG, "onResponseHeadersReceived. Header=" + info.getAllHeadersAsList());
+        Log.v(LOG_TAG, "BidirectionalStream.read");
       }
       reportHeaders(info.getAllHeadersAsList(), false);
-      if (stream != null) {
-        if (Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
-          Log.v(LOG_TAG, "BidirectionalStream.read");
-        }
-        stream.read(ByteBuffer.allocateDirect(READ_BUFFER_CAPACITY));
-      }
+      stream.read(ByteBuffer.allocateDirect(READ_BUFFER_CAPACITY));
     }
 
     @Override

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -121,4 +121,36 @@ public final class CronetClientTransportTest {
     // All streams are gone now.
     verify(clientTransportListener, times(1)).transportTerminated();
   }
+
+  @Test
+  public void startStreamAfterShutdown() throws Exception {
+    CronetClientStream stream =
+        transport.newStream(descriptor, new Metadata(), CallOptions.DEFAULT);
+    transport.shutdown();
+    BaseClientStreamListener listener = new BaseClientStreamListener();
+    stream.start(listener);
+
+    assertEquals(Status.UNAVAILABLE.getCode(), listener.status.getCode());
+  }
+
+  private static class BaseClientStreamListener implements ClientStreamListener {
+    private Status status;
+
+    @Override
+    public void messagesAvailable(MessageProducer producer) {}
+
+    @Override
+    public void onReady() {}
+
+    @Override
+    public void headersRead(Metadata headers) {}
+
+    @Override
+    public void closed(Status status, Metadata trailers) {}
+
+    @Override
+    public void closed(Status status, RpcProgress rpcProgress, Metadata trailers) {
+      this.status = status;
+    }
+  }
 }


### PR DESCRIPTION
This was discovered by an internal user. `AbstractClientStream#start` will call `#writeHeaders`, and if the transport is already shutdown, the invocation of `startCallback.run()` here will not set `streamFactory`.

@ejona86 I went with the "safe" route of just adding null-checks before access to `streamFactory` and `stream`, which made things much easier to (a) write, (b) feel confident about, and (hopefully) (c) review.