### PR TITLE
interop-testing:  Add GoogleDefaultCreds test case for java

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1712,7 +1712,7 @@ public abstract class AbstractInteropTest {
     oauth2AuthToken(jsonKey, credentialsStream, oauthScope);
   }
 
-  /** Sends an unary rpc with "google default credentials" */
+  /** Sends an unary rpc with "google default credentials". */
   public void googleDefaultCredentials(String defaultServiceAccount)
       throws Exception {
     final SimpleRequest request = SimpleRequest.newBuilder()

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1712,6 +1712,27 @@ public abstract class AbstractInteropTest {
     oauth2AuthToken(jsonKey, credentialsStream, oauthScope);
   }
 
+  /** Sends an unary rpc with "google default credentials" */
+  public void googleDefaultCredentials(String defaultServiceAccount)
+      throws Exception {
+    final SimpleRequest request = SimpleRequest.newBuilder()
+        .setFillUsername(true)
+        .setResponseSize(314159)
+        .setPayload(Payload.newBuilder()
+            .setBody(ByteString.copyFrom(new byte[271828])))
+        .build();
+
+    final SimpleResponse response = blockingStub.unaryCall(request);
+    assertEquals(defaultServiceAccount, response.getUsername());
+
+    final SimpleResponse goldenResponse = SimpleResponse.newBuilder()
+        .setUsername(defaultServiceAccount)
+        .setPayload(Payload.newBuilder()
+            .setBody(ByteString.copyFrom(new byte[314159])))
+        .build();
+    assertResponse(goldenResponse, response);
+  }
+
   protected static void assertSuccess(StreamRecorder<?> recorder) {
     if (recorder.getError() != null) {
       throw new AssertionError(recorder.getError());

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1713,16 +1713,16 @@ public abstract class AbstractInteropTest {
   }
 
   /** Sends an unary rpc with "google default credentials". */
-  public void googleDefaultCredentials(String defaultServiceAccount)
-      throws Exception {
+  public void googleDefaultCredentials(
+      String defaultServiceAccount,
+      TestServiceGrpc.TestServiceBlockingStub googleDefaultStub) throws Exception {
     final SimpleRequest request = SimpleRequest.newBuilder()
         .setFillUsername(true)
         .setResponseSize(314159)
         .setPayload(Payload.newBuilder()
             .setBody(ByteString.copyFrom(new byte[271828])))
         .build();
-
-    final SimpleResponse response = blockingStub.unaryCall(request);
+    final SimpleResponse response = googleDefaultStub.unaryCall(request);
     assertEquals(defaultServiceAccount, response.getUsername());
 
     final SimpleResponse goldenResponse = SimpleResponse.newBuilder()

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -42,6 +42,8 @@ public enum TestCases {
   JWT_TOKEN_CREDS("JWT-based auth"),
   OAUTH2_AUTH_TOKEN("raw oauth2 access token auth"),
   PER_RPC_CREDS("per rpc raw oauth2 access token auth"),
+  GOOGLE_DEFAULT_CREDENTIALS(
+      "google default credentials, i.e. GoogleManagedChannel based auth"),
   CUSTOM_METADATA("unary and full duplex calls with metadata"),
   STATUS_CODE_AND_MESSAGE("request error code and message"),
   SPECIAL_STATUS_MESSAGE("special characters in status message"),

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -16,6 +16,9 @@
 
 package io.grpc.testing.integration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Files;
 import io.grpc.ManagedChannel;
@@ -301,6 +304,13 @@ public class TestServiceClient {
         String jsonKey = Files.asCharSource(new File(serviceAccountKeyFile), UTF_8).read();
         FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));
         tester.perRpcCreds(jsonKey, credentialsStream, oauthScope);
+        break;
+      }
+
+      case GOOGLE_DEFAULT_CREDENTIALS: {
+        assertNotNull(customCredentialsType);
+        assertEquals(customCredentialsType, "google_default_credentials");
+        tester.googleDefaultCredentials(defaultServiceAccount);
         break;
       }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -308,9 +308,14 @@ public class TestServiceClient {
       }
 
       case GOOGLE_DEFAULT_CREDENTIALS: {
-        assertNotNull(customCredentialsType);
-        assertEquals(customCredentialsType, "google_default_credentials");
-        tester.googleDefaultCredentials(defaultServiceAccount);
+        ManagedChannel channel = GoogleDefaultChannelBuilder.forAddress(serverHost, serverPort).build();
+        try {
+          TestServiceGrpc.TestServiceBlockingStub googleDefaultStub =
+              TestServiceGrpc.newBlockingStub(channel);
+          tester.googleDefaultCredentials(defaultServiceAccount, googleDefaultStub);
+        } finally {
+          channel.shutdownNow();
+        }
         break;
       }
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -16,9 +16,6 @@
 
 package io.grpc.testing.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Files;
 import io.grpc.ManagedChannel;
@@ -308,7 +305,8 @@ public class TestServiceClient {
       }
 
       case GOOGLE_DEFAULT_CREDENTIALS: {
-        ManagedChannel channel = GoogleDefaultChannelBuilder.forAddress(serverHost, serverPort).build();
+        ManagedChannel channel = GoogleDefaultChannelBuilder.forAddress(
+            serverHost, serverPort).build();
         try {
           TestServiceGrpc.TestServiceBlockingStub googleDefaultStub =
               TestServiceGrpc.newBlockingStub(channel);

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
@@ -56,6 +56,7 @@ public class TestCasesTest {
       "jwt_token_creds",
       "oauth2_auth_token",
       "per_rpc_creds",
+      "google_default_credentials",
       "custom_metadata",
       "status_code_and_message",
       "special_status_message",


### PR DESCRIPTION
This PR adds the [google default credentials](https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#google_default_credentials) test case for Java. As follow up, will also need to add thist into `run_interop_tests.py` on GCE linux and also on mac.