### PR TITLE
alts: Use absolute domain name for metadata server

### DIFF
--- a/alts/src/main/java/io/grpc/alts/HandshakerServiceChannel.java
+++ b/alts/src/main/java/io/grpc/alts/HandshakerServiceChannel.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 final class HandshakerServiceChannel {
 
   static final Resource<Channel> SHARED_HANDSHAKER_CHANNEL =
-      new ChannelResource("metadata.google.internal:8080");
+      new ChannelResource("metadata.google.internal.:8080");
 
   /** Returns a resource of handshaker service channel for testing only. */
   static Resource<Channel> getHandshakerChannelForTesting(String handshakerAddress) {

--- a/alts/src/test/java/io/grpc/alts/HandshakerServiceChannelTest.java
+++ b/alts/src/test/java/io/grpc/alts/HandshakerServiceChannelTest.java
@@ -61,7 +61,7 @@ public final class HandshakerServiceChannelTest {
     resource = HandshakerServiceChannel.SHARED_HANDSHAKER_CHANNEL;
     Channel channel = resource.create();
     try {
-      assertThat(channel.authority()).isEqualTo("metadata.google.internal:8080");
+      assertThat(channel.authority()).isEqualTo("metadata.google.internal.:8080");
     } finally {
       resource.close(channel);
     }


### PR DESCRIPTION
This avoids using the search domains when not on GCE, which prevents
useless DNS requests.

This is the Java equivalent of grpc/grpc#17598

---

CC @apolcyn 