### PR TITLE
core: Place Nullable annotation before modifiers

### DIFF
--- a/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransportFactory.java
@@ -68,8 +68,8 @@ public interface ClientTransportFactory extends Closeable {
   public static final class ClientTransportOptions {
     private String authority = "unknown-authority";
     private Attributes eagAttributes = Attributes.EMPTY;
-    private @Nullable String userAgent;
-    private @Nullable HttpConnectProxiedSocketAddress connectProxiedSocketAddr;
+    @Nullable private String userAgent;
+    @Nullable private HttpConnectProxiedSocketAddress connectProxiedSocketAddr;
 
     public String getAuthority() {
       return authority;


### PR DESCRIPTION
Since Nullable is not a type annotation, it is normal to put it before any
modifiers (like "private"). This fixes a lint failure.