### PR TITLE
core: Add "fake" dependency on Guava's failureaccess

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -7,6 +7,7 @@ java_library(
     deps = [
         "//context",
         "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_failureaccess//jar",  # future transitive dep of Guava. See #5214
         "@com_google_guava_guava//jar",
         "@com_google_j2objc_j2objc_annotations//jar",
     ],
@@ -34,8 +35,8 @@ java_library(
         "src/main/java/io/grpc/internal/*.java",
     ]),
     resources = glob([
-            "src/bazel-internal/resources/**",
-        ]),
+        "src/bazel-internal/resources/**",
+    ]),
     visibility = ["//:__subpackages__"],
     deps = [
         ":core",
@@ -57,8 +58,8 @@ java_library(
         "src/main/java/io/grpc/util/*.java",
     ]),
     resources = glob([
-            "src/bazel-util/resources/**",
-        ]),
+        "src/bazel-util/resources/**",
+    ]),
     visibility = ["//visibility:public"],
     deps = [
         ":core",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -11,6 +11,7 @@ def grpc_java_repositories(
         omit_com_google_code_gson = False,
         omit_com_google_errorprone_error_prone_annotations = False,
         omit_com_google_guava = False,
+        omit_com_google_guava_failureaccess = False,
         omit_com_google_j2objc_j2objc_annotations = False,
         omit_com_google_protobuf = False,
         omit_com_google_protobuf_java = False,
@@ -52,6 +53,8 @@ def grpc_java_repositories(
         com_google_errorprone_error_prone_annotations()
     if not omit_com_google_guava:
         com_google_guava()
+    if not omit_com_google_guava_failureaccess:
+        com_google_guava_failureaccess()
     if not omit_com_google_j2objc_j2objc_annotations:
         com_google_j2objc_j2objc_annotations()
     if not omit_com_google_protobuf:
@@ -174,6 +177,16 @@ def com_google_guava():
         artifact = "com.google.guava:guava:26.0-android",
         server_urls = ["http://central.maven.org/maven2"],
         artifact_sha256 = "1d044ebb866ef08b7d04e998b4260c9b52fab6e6d6b68d207859486bb3686cd5",
+        licenses = ["notice"],  # Apache 2.0
+    )
+
+def com_google_guava_failureaccess():
+    # Not needed until Guava 27.0, but including now to ease upgrading of users. See #5214
+    jvm_maven_import_external(
+        name = "com_google_guava_failureaccess",
+        artifact = "com.google.guava:failureaccess:1.0.1",
+        server_urls = ["http://central.maven.org/maven2"],
+        artifact_sha256 = "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
         licenses = ["notice"],  # Apache 2.0
     )
 


### PR DESCRIPTION
This allows users to upgrade to newer versions of Guava without breaking
the build due to missing transitive dependencies. Without it, when
increasing the Guava version to 27.0+ you see errors like:

```
stub/src/main/java/io/grpc/stub/ClientCalls.java:487: error: cannot access InternalFutureFailureAccess
  private static final class GrpcFuture<RespT> extends AbstractFuture<RespT> {
                       ^
  class file for com.google.common.util.concurrent.internal.InternalFutureFailureAccess not found
```

Note that using a runtime_dep does not fix the compilation error.

Long-term we will want our users to migrate to
jvm_maven_import_external. However, if we use it ourselves, it will
effectively require our users to use it immediately themselves. It has
low penetration today, including lack of usage by tools like
johnynek/bazel-deps.

Fixes #5214

------

CC @pgr0ss . This is intended for the v1.19.0 release.