### PR TITLE
Revert "core: Update gRPC to use span kind and raw full method. (#5328)"

### DIFF
--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -72,7 +72,6 @@ import io.opencensus.trace.EndSpanOptions;
 import io.opencensus.trace.MessageEvent;
 import io.opencensus.trace.MessageEvent.Type;
 import io.opencensus.trace.Span;
-import io.opencensus.trace.Span.Kind;
 import io.opencensus.trace.SpanBuilder;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Tracer;
@@ -295,14 +294,12 @@ public class CensusModulesTest {
 
     if (nonDefaultContext) {
       verify(tracer).spanBuilderWithExplicitParent(
-          eq("package1.service2/method3"), same(fakeClientParentSpan));
+          eq("Sent.package1.service2.method3"), same(fakeClientParentSpan));
       verify(spyClientSpanBuilder).setRecordEvents(eq(true));
-      verify(spyClientSpanBuilder).setSpanKind(eq(Kind.CLIENT));
     } else {
       verify(tracer).spanBuilderWithExplicitParent(
-          eq("package1.service2/method3"), isNull(Span.class));
+          eq("Sent.package1.service2.method3"), isNull(Span.class));
       verify(spyClientSpanBuilder).setRecordEvents(eq(true));
-      verify(spyClientSpanBuilder).setSpanKind(eq(Kind.CLIENT));
     }
     verify(spyClientSpan, never()).end(any(EndSpanOptions.class));
 
@@ -500,7 +497,7 @@ public class CensusModulesTest {
     ClientStreamTracer clientStreamTracer =
         callTracer.newClientStreamTracer(CallOptions.DEFAULT, headers);
     verify(tracer).spanBuilderWithExplicitParent(
-        eq("package1.service2/method3"), isNull(Span.class));
+        eq("Sent.package1.service2.method3"), isNull(Span.class));
     verify(spyClientSpan, never()).end(any(EndSpanOptions.class));
 
     clientStreamTracer.outboundMessage(0);
@@ -607,9 +604,8 @@ public class CensusModulesTest {
     CensusTracingModule.ClientCallTracer callTracer =
         censusTracing.newClientCallTracer(fakeClientParentSpan, method);
     verify(tracer).spanBuilderWithExplicitParent(
-        eq("package1.service2/method3"), same(fakeClientParentSpan));
+        eq("Sent.package1.service2.method3"), same(fakeClientParentSpan));
     verify(spyClientSpanBuilder).setRecordEvents(eq(true));
-    verify(spyClientSpanBuilder).setSpanKind(eq(Kind.CLIENT));
 
     callTracer.callEnded(Status.DEADLINE_EXCEEDED.withDescription("3 seconds"));
     verify(spyClientSpan).end(
@@ -784,9 +780,8 @@ public class CensusModulesTest {
     verify(mockTracingPropagationHandler).toByteArray(same(fakeClientSpanContext));
     verifyNoMoreInteractions(mockTracingPropagationHandler);
     verify(tracer).spanBuilderWithExplicitParent(
-        eq("package1.service2/method3"), same(fakeClientParentSpan));
+        eq("Sent.package1.service2.method3"), same(fakeClientParentSpan));
     verify(spyClientSpanBuilder).setRecordEvents(eq(true));
-    verify(spyClientSpanBuilder).setSpanKind(eq(Kind.CLIENT));
     verifyNoMoreInteractions(tracer);
     assertTrue(headers.containsKey(censusTracing.tracingHeader));
 
@@ -795,9 +790,8 @@ public class CensusModulesTest {
             method.getFullMethodName(), headers);
     verify(mockTracingPropagationHandler).fromByteArray(same(binarySpanContext));
     verify(tracer).spanBuilderWithRemoteParent(
-        eq("package1.service2/method3"), same(spyClientSpan.getContext()));
+        eq("Recv.package1.service2.method3"), same(spyClientSpan.getContext()));
     verify(spyServerSpanBuilder).setRecordEvents(eq(true));
-    verify(spyServerSpanBuilder).setSpanKind(eq(Kind.SERVER));
 
     Context filteredContext = serverTracer.filterContext(Context.ROOT);
     assertSame(spyServerSpan, ContextUtils.CONTEXT_SPAN_KEY.get(filteredContext));
@@ -867,10 +861,8 @@ public class CensusModulesTest {
     censusTracing.getServerTracerFactory().newServerStreamTracer(
         method.getFullMethodName(), headers);
     verify(tracer).spanBuilderWithRemoteParent(
-        eq("package1.service2/method3"), isNull(SpanContext.class));
+        eq("Recv.package1.service2.method3"), isNull(SpanContext.class));
     verify(spyServerSpanBuilder).setRecordEvents(eq(true));
-    verify(spyServerSpanBuilder).setSpanKind(eq(Kind.SERVER));
-
   }
 
   @Test
@@ -1021,9 +1013,8 @@ public class CensusModulesTest {
         tracerFactory.newServerStreamTracer(method.getFullMethodName(), new Metadata());
     verifyZeroInteractions(mockTracingPropagationHandler);
     verify(tracer).spanBuilderWithRemoteParent(
-        eq("package1.service2/method3"), isNull(SpanContext.class));
+        eq("Recv.package1.service2.method3"), isNull(SpanContext.class));
     verify(spyServerSpanBuilder).setRecordEvents(eq(true));
-    verify(spyServerSpanBuilder).setSpanKind(eq(Kind.SERVER));
 
     Context filteredContext = serverStreamTracer.filterContext(Context.ROOT);
     assertSame(spyServerSpan, ContextUtils.CONTEXT_SPAN_KEY.get(filteredContext));
@@ -1117,6 +1108,15 @@ public class CensusModulesTest {
       assertEquals(grpcCode.toString(), tracingStatus.getCanonicalCode().toString());
       assertEquals(grpcStatus.getDescription(), tracingStatus.getDescription());
     }
+  }
+
+
+  @Test
+  public void generateTraceSpanName() {
+    assertEquals(
+        "Sent.io.grpc.Foo", CensusTracingModule.generateTraceSpanName(false, "io.grpc/Foo"));
+    assertEquals(
+        "Recv.io.grpc.Bar", CensusTracingModule.generateTraceSpanName(true, "io.grpc/Bar"));
   }
 
   private static void assertNoServerContent(StatsTestUtils.MetricsRecord record) {


### PR DESCRIPTION
This reverts commit d47379947ff010b478ce9513c3d1778f49482db4.

This caused test failures internally, where gRPC failed with
"IllegalArgumentException: Invalid trace name". Not only was this
failure unexpected, it was also weird that it failed with an
IllegalArgumentException instead of the normal StatusRuntimeException.

CC @zhangkun83 @bogdandrutu 