### PR TITLE
netty,alts: hide ProtocolNegotiator behind an accessor, and...

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiator.java
@@ -20,9 +20,11 @@ import com.google.common.annotations.VisibleForTesting;
 import io.grpc.alts.internal.AltsProtocolNegotiator.LazyChannel;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
+import io.grpc.netty.InternalProtocolNegotiator.ProtocolNegotiator;
 import io.grpc.netty.InternalProtocolNegotiators;
-import io.grpc.netty.ProtocolNegotiator;
+import io.netty.channel.ChannelHandler;
 import io.netty.handler.ssl.SslContext;
+import io.netty.util.AsciiString;
 
 /** A client-side GPRC {@link ProtocolNegotiator} for Google Default Channel. */
 public final class GoogleDefaultProtocolNegotiator implements ProtocolNegotiator {
@@ -38,6 +40,12 @@ public final class GoogleDefaultProtocolNegotiator implements ProtocolNegotiator
     tlsProtocolNegotiator = InternalProtocolNegotiators.tls(sslContext);
   }
 
+  @Override
+  public AsciiString scheme() {
+    assert tlsProtocolNegotiator.scheme().equals(altsProtocolNegotiator.scheme());
+    return tlsProtocolNegotiator.scheme();
+  }
+
   @VisibleForTesting
   GoogleDefaultProtocolNegotiator(
       ProtocolNegotiator altsProtocolNegotiator, ProtocolNegotiator tlsProtocolNegotiator) {
@@ -46,7 +54,7 @@ public final class GoogleDefaultProtocolNegotiator implements ProtocolNegotiator
   }
 
   @Override
-  public Handler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {
+  public ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {
     if (grpcHandler.getEagAttributes().get(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY) != null
         || grpcHandler.getEagAttributes().get(GrpcAttributes.ATTR_LB_PROVIDED_BACKEND) != null) {
       return altsProtocolNegotiator.newHandler(grpcHandler);

--- a/alts/src/test/java/io/grpc/alts/AltsChannelBuilderTest.java
+++ b/alts/src/test/java/io/grpc/alts/AltsChannelBuilderTest.java
@@ -19,7 +19,7 @@ package io.grpc.alts;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.grpc.alts.internal.AltsProtocolNegotiator;
-import io.grpc.netty.ProtocolNegotiator;
+import io.grpc.netty.InternalProtocolNegotiator.ProtocolNegotiator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/alts/src/test/java/io/grpc/alts/GoogleDefaultChannelBuilderTest.java
+++ b/alts/src/test/java/io/grpc/alts/GoogleDefaultChannelBuilderTest.java
@@ -19,7 +19,7 @@ package io.grpc.alts;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.grpc.alts.internal.GoogleDefaultProtocolNegotiator;
-import io.grpc.netty.ProtocolNegotiator;
+import io.grpc.netty.InternalProtocolNegotiator.ProtocolNegotiator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
@@ -25,8 +25,7 @@ import static org.mockito.Mockito.when;
 import io.grpc.Attributes;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
-import io.grpc.netty.ProtocolNegotiator;
-import io.grpc.netty.ProtocolNegotiator.Handler;
+import io.grpc.netty.InternalProtocolNegotiator.ProtocolNegotiator;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,7 +51,7 @@ public final class GoogleDefaultProtocolNegotiatorTest {
         Attributes.newBuilder().set(GrpcAttributes.ATTR_LB_PROVIDED_BACKEND, true).build();
     GrpcHttp2ConnectionHandler mockHandler = mock(GrpcHttp2ConnectionHandler.class);
     when(mockHandler.getEagAttributes()).thenReturn(eagAttributes);
-    Handler handler = googleProtocolNegotiator.newHandler(mockHandler);
+    googleProtocolNegotiator.newHandler(mockHandler);
     verify(altsProtocolNegotiator, times(1)).newHandler(mockHandler);
     verify(tlsProtocolNegotiator, never()).newHandler(mockHandler);
   }
@@ -62,7 +61,7 @@ public final class GoogleDefaultProtocolNegotiatorTest {
     Attributes eagAttributes = Attributes.EMPTY;
     GrpcHttp2ConnectionHandler mockHandler = mock(GrpcHttp2ConnectionHandler.class);
     when(mockHandler.getEagAttributes()).thenReturn(eagAttributes);
-    Handler handler = googleProtocolNegotiator.newHandler(mockHandler);
+    googleProtocolNegotiator.newHandler(mockHandler);
     verify(altsProtocolNegotiator, never()).newHandler(mockHandler);
     verify(tlsProtocolNegotiator, times(1)).newHandler(mockHandler);
   }

--- a/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/InternalNettyChannelBuilder.java
@@ -39,7 +39,11 @@ public final class InternalNettyChannelBuilder {
 
   /** A class that provides a Netty handler to control protocol negotiation. */
   public interface ProtocolNegotiatorFactory
-      extends NettyChannelBuilder.ProtocolNegotiatorFactory {}
+      extends NettyChannelBuilder.ProtocolNegotiatorFactory {
+
+    @Override
+    InternalProtocolNegotiator.ProtocolNegotiator buildProtocolNegotiator();
+  }
 
   /**
    * Sets the {@link ProtocolNegotiatorFactory} to be used. Overrides any specified negotiation type

--- a/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiator.java
+++ b/netty/src/main/java/io/grpc/netty/InternalProtocolNegotiator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+/**
+ * Internal accessor for {@link ProtocolNegotiator}.
+ */
+public final class InternalProtocolNegotiator {
+
+  private InternalProtocolNegotiator() {}
+
+  public interface ProtocolNegotiator extends io.grpc.netty.ProtocolNegotiator {}
+}

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiator.java
@@ -16,25 +16,18 @@
 
 package io.grpc.netty;
 
-import io.grpc.Internal;
 import io.netty.channel.ChannelHandler;
 import io.netty.util.AsciiString;
 
 /**
- * A class that provides a Netty handler to control protocol negotiation.
+ * An class that provides a Netty handler to control protocol negotiation.
  */
-@Internal
-public interface ProtocolNegotiator {
+interface ProtocolNegotiator {
 
   /**
-   * The Netty handler to control the protocol negotiation.
+   * The HTTP/2 scheme to be used when sending {@code HEADERS}.
    */
-  interface Handler extends ChannelHandler {
-    /**
-     * The HTTP/2 scheme to be used when sending {@code HEADERS}.
-     */
-    AsciiString scheme();
-  }
+  AsciiString scheme();
 
   /**
    * Creates a new handler to control the protocol negotiation. Once the negotiation has completed
@@ -42,7 +35,7 @@ public interface ProtocolNegotiator {
    * grpcHandler.onHandleProtocolNegotiationCompleted()} at certain point if the negotiation has
    * completed successfully.
    */
-  Handler newHandler(GrpcHttp2ConnectionHandler grpcHandler);
+  ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHandler);
 
   /**
    * Releases resources held by this negotiator. Called when the Channel transitions to terminated.

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -65,6 +65,7 @@ import io.grpc.netty.NettyChannelBuilder.LocalSocketPicker;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.local.LocalChannel;
@@ -851,15 +852,9 @@ public class NettyClientTransportTest {
     }
   }
 
-  private static class NoopHandler extends ProtocolNegotiators.AbstractBufferingHandler
-      implements ProtocolNegotiator.Handler {
+  private static class NoopHandler extends ProtocolNegotiators.AbstractBufferingHandler {
     public NoopHandler(GrpcHttp2ConnectionHandler grpcHandler) {
       super(grpcHandler);
-    }
-
-    @Override
-    public AsciiString scheme() {
-      return Utils.HTTP;
     }
   }
 
@@ -868,9 +863,14 @@ public class NettyClientTransportTest {
     NoopHandler handler;
 
     @Override
-    public Handler newHandler(final GrpcHttp2ConnectionHandler grpcHandler) {
+    public ChannelHandler newHandler(final GrpcHttp2ConnectionHandler grpcHandler) {
       this.grpcHandler = grpcHandler;
       return handler = new NoopHandler(grpcHandler);
+    }
+
+    @Override
+    public AsciiString scheme() {
+      return Utils.HTTP;
     }
 
     @Override


### PR DESCRIPTION
...and move the `close()` method to ProtocolNegotiator rather than Handler.  

Since this is a breaking change (for people who ignored our `@Internal` annotations), I wanted to make both changes in the same PR so as to fix them both at the same time.   