### PR TITLE
Update google-auth-library-java to 0.13.0

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -27,10 +27,10 @@ dependencies {
             libraries.lang,
             libraries.protobuf
     compile (libraries.google_auth_oauth2_http) {
-        // prefer 3.0.2 from libraries instead of 1.3.9
-        exclude group: 'com.google.code.findbugs', module: 'jsr305'
-        // prefer 20.0 from libraries instead of 19.0
+        // prefer 26.0-android from libraries instead of 25.1-android
         exclude group: 'com.google.guava', module: 'guava'
+        // prefer 0.19.2 from libraries instead of 0.18.0
+        exclude group: 'io.opencensus', module: 'opencensus-api'
     }
     compileOnly libraries.javax_annotation
     runtime project(':grpc-grpclb')

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ subprojects {
         javaPluginPath = "$rootDir/compiler/build/exe/java_plugin/$protocPluginBaseName$exeSuffix"
 
         nettyVersion = '4.1.32.Final'
-        googleauthVersion = '0.9.0'
+        googleauthVersion = '0.13.0'
         guavaVersion = '26.0-android'
         protobufVersion = '3.6.1'
         protocVersion = protobufVersion


### PR DESCRIPTION
0.13.0 is the latest version.

This honestly doesn't do much since any user of our auth API will be
depending on the library themselves (we only depend on the interface; no
implementation). But getting past 0.9.1 may encourage our users to use a
newer version with better JWT handling and 0.9.1 was released 10 months
ago, so we're overdue for an update.

Fixes #4700

----

CC @elharo

Note that this did not make the cut for the 1.19 release. It could easily be backported, but I'm not sure there's much point.