### PR TITLE
okhttp: add socketFactory method to channel builder

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -160,6 +160,8 @@ public class OkHttpChannelBuilder extends
 
   /**
    * Override the default {@link SocketFactory} used to create sockets.
+   *
+   * @since 1.20.0
    */
   public final OkHttpChannelBuilder socketFactory(@Nullable SocketFactory socketFactory) {
     this.socketFactory = socketFactory;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -159,7 +159,8 @@ public class OkHttpChannelBuilder extends
   }
 
   /**
-   * Override the default {@link SocketFactory} used to create sockets.
+   * Override the default {@link SocketFactory} used to create sockets. If the socket factory is not
+   * set, the value of {@link SocketFactory#getDefault} will be used.
    *
    * @since 1.20.0
    */

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -49,6 +49,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.net.SocketFactory;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -120,6 +121,7 @@ public class OkHttpChannelBuilder extends
   private Executor transportExecutor;
   private ScheduledExecutorService scheduledExecutorService;
 
+  private SocketFactory socketFactory;
   private SSLSocketFactory sslSocketFactory;
   private HostnameVerifier hostnameVerifier;
   private ConnectionSpec connectionSpec = INTERNAL_DEFAULT_CONNECTION_SPEC;
@@ -153,6 +155,14 @@ public class OkHttpChannelBuilder extends
    */
   public final OkHttpChannelBuilder transportExecutor(@Nullable Executor transportExecutor) {
     this.transportExecutor = transportExecutor;
+    return this;
+  }
+
+  /**
+   * Override the default {@link SocketFactory} used to create sockets.
+   */
+  public final OkHttpChannelBuilder socketFactory(@Nullable SocketFactory socketFactory) {
+    this.socketFactory = socketFactory;
     return this;
   }
 
@@ -397,10 +407,21 @@ public class OkHttpChannelBuilder extends
   @Internal
   protected final ClientTransportFactory buildTransportFactory() {
     boolean enableKeepAlive = keepAliveTimeNanos != KEEPALIVE_TIME_NANOS_DISABLED;
-    return new OkHttpTransportFactory(transportExecutor, scheduledExecutorService,
-        createSocketFactory(), hostnameVerifier, connectionSpec, maxInboundMessageSize(),
-        enableKeepAlive, keepAliveTimeNanos, keepAliveTimeoutNanos, flowControlWindow,
-        keepAliveWithoutCalls, maxInboundMetadataSize, transportTracerFactory);
+    return new OkHttpTransportFactory(
+        transportExecutor,
+        scheduledExecutorService,
+        socketFactory,
+        createSslSocketFactory(),
+        hostnameVerifier,
+        connectionSpec,
+        maxInboundMessageSize(),
+        enableKeepAlive,
+        keepAliveTimeNanos,
+        keepAliveTimeoutNanos,
+        flowControlWindow,
+        keepAliveWithoutCalls,
+        maxInboundMetadataSize,
+        transportTracerFactory);
   }
 
   @Override
@@ -417,7 +438,7 @@ public class OkHttpChannelBuilder extends
 
   @VisibleForTesting
   @Nullable
-  SSLSocketFactory createSocketFactory() {
+  SSLSocketFactory createSslSocketFactory() {
     switch (negotiationType) {
       case TLS:
         try {
@@ -463,8 +484,8 @@ public class OkHttpChannelBuilder extends
     private final boolean usingSharedExecutor;
     private final boolean usingSharedScheduler;
     private final TransportTracer.Factory transportTracerFactory;
-    @Nullable
-    private final SSLSocketFactory socketFactory;
+    @Nullable private final SocketFactory socketFactory;
+    @Nullable private final SSLSocketFactory sslSocketFactory;
     @Nullable
     private final HostnameVerifier hostnameVerifier;
     private final ConnectionSpec connectionSpec;
@@ -478,9 +499,11 @@ public class OkHttpChannelBuilder extends
     private final ScheduledExecutorService timeoutService;
     private boolean closed;
 
-    private OkHttpTransportFactory(Executor executor,
+    private OkHttpTransportFactory(
+        Executor executor,
         @Nullable ScheduledExecutorService timeoutService,
-        @Nullable SSLSocketFactory socketFactory,
+        @Nullable SocketFactory socketFactory,
+        @Nullable SSLSocketFactory sslSocketFactory,
         @Nullable HostnameVerifier hostnameVerifier,
         ConnectionSpec connectionSpec,
         int maxMessageSize,
@@ -495,6 +518,7 @@ public class OkHttpChannelBuilder extends
       this.timeoutService = usingSharedScheduler
           ? SharedResourceHolder.get(GrpcUtil.TIMER_SERVICE) : timeoutService;
       this.socketFactory = socketFactory;
+      this.sslSocketFactory = sslSocketFactory;
       this.hostnameVerifier = hostnameVerifier;
       this.connectionSpec = connectionSpec;
       this.maxMessageSize = maxMessageSize;
@@ -536,6 +560,7 @@ public class OkHttpChannelBuilder extends
           options.getUserAgent(),
           executor,
           socketFactory,
+          sslSocketFactory,
           hostnameVerifier,
           connectionSpec,
           maxMessageSize,

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -160,7 +160,7 @@ public class OkHttpChannelBuilder extends
 
   /**
    * Override the default {@link SocketFactory} used to create sockets. If the socket factory is not
-   * set, the value of {@link SocketFactory#getDefault} will be used.
+   * set or set to null, a default one will be used.
    *
    * @since 1.20.0
    */

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -487,7 +487,7 @@ public class OkHttpChannelBuilder extends
     private final boolean usingSharedExecutor;
     private final boolean usingSharedScheduler;
     private final TransportTracer.Factory transportTracerFactory;
-    @Nullable private final SocketFactory socketFactory;
+    private final SocketFactory socketFactory;
     @Nullable private final SSLSocketFactory sslSocketFactory;
     @Nullable
     private final HostnameVerifier hostnameVerifier;

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -86,6 +86,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+import javax.net.SocketFactory;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
@@ -175,6 +176,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   private boolean stopped;
   @GuardedBy("lock")
   private boolean hasStream;
+  private SocketFactory socketFactory;
   private SSLSocketFactory sslSocketFactory;
   private HostnameVerifier hostnameVerifier;
   private Socket socket;
@@ -219,12 +221,21 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   Runnable connectingCallback;
   SettableFuture<Void> connectedFuture;
 
-  OkHttpClientTransport(InetSocketAddress address, String authority, @Nullable String userAgent,
-      Executor executor, @Nullable SSLSocketFactory sslSocketFactory,
-      @Nullable HostnameVerifier hostnameVerifier, ConnectionSpec connectionSpec,
-      int maxMessageSize, int initialWindowSize,
+  OkHttpClientTransport(
+      InetSocketAddress address,
+      String authority,
+      @Nullable String userAgent,
+      Executor executor,
+      @Nullable SocketFactory socketFactory,
+      @Nullable SSLSocketFactory sslSocketFactory,
+      @Nullable HostnameVerifier hostnameVerifier,
+      ConnectionSpec connectionSpec,
+      int maxMessageSize,
+      int initialWindowSize,
       @Nullable HttpConnectProxiedSocketAddress proxiedAddr,
-      Runnable tooManyPingsRunnable, int maxInboundMetadataSize, TransportTracer transportTracer) {
+      Runnable tooManyPingsRunnable,
+      int maxInboundMetadataSize,
+      TransportTracer transportTracer) {
     this.address = Preconditions.checkNotNull(address, "address");
     this.defaultAuthority = authority;
     this.maxMessageSize = maxMessageSize;
@@ -234,6 +245,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     // Client initiated streams are odd, server initiated ones are even. Server should not need to
     // use it. We start clients at 3 to avoid conflicting with HTTP negotiation.
     nextStreamId = 3;
+    this.socketFactory = socketFactory;
     this.sslSocketFactory = sslSocketFactory;
     this.hostnameVerifier = hostnameVerifier;
     this.connectionSpec = Preconditions.checkNotNull(connectionSpec, "connectionSpec");
@@ -506,7 +518,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
         SSLSession sslSession = null;
         try {
           if (proxiedAddr == null) {
-            sock = new Socket(address.getAddress(), address.getPort());
+            sock = socketFactoryToUse().createSocket(address.getAddress(), address.getPort());
           } else {
             if (proxiedAddr.getProxyAddress() instanceof InetSocketAddress) {
               sock = createHttpProxySocket(
@@ -584,9 +596,10 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       Socket sock;
       // The proxy address may not be resolved
       if (proxyAddress.getAddress() != null) {
-        sock = new Socket(proxyAddress.getAddress(), proxyAddress.getPort());
+        sock = socketFactoryToUse().createSocket(proxyAddress.getAddress(), proxyAddress.getPort());
       } else {
-        sock = new Socket(proxyAddress.getHostName(), proxyAddress.getPort());
+        sock =
+            socketFactoryToUse().createSocket(proxyAddress.getHostName(), proxyAddress.getPort());
       }
       sock.setTcpNoDelay(true);
 
@@ -637,6 +650,14 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     } catch (IOException e) {
       throw Status.UNAVAILABLE.withDescription("Failed trying to connect with proxy").withCause(e)
           .asException();
+    }
+  }
+
+  private SocketFactory socketFactoryToUse() {
+    if (socketFactory != null) {
+      return socketFactory;
+    } else {
+      return SocketFactory.getDefault();
     }
   }
 
@@ -769,6 +790,11 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   @VisibleForTesting
   ClientFrameHandler getHandler() {
     return clientFrameHandler;
+  }
+
+  @VisibleForTesting
+  SocketFactory getSocketFactory() {
+    return socketFactory;
   }
 
   @VisibleForTesting

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -27,8 +27,11 @@ import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.net.SocketFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -125,10 +128,10 @@ public class OkHttpChannelBuilderTest {
   @Test
   public void usePlaintextCreatesNullSocketFactory() {
     OkHttpChannelBuilder builder = OkHttpChannelBuilder.forAddress("host", 1234);
-    assertNotNull(builder.createSocketFactory());
+    assertNotNull(builder.createSslSocketFactory());
 
     builder.usePlaintext();
-    assertNull(builder.createSocketFactory());
+    assertNull(builder.createSslSocketFactory());
   }
 
   @Test
@@ -159,5 +162,56 @@ public class OkHttpChannelBuilderTest {
 
     clientTransportFactory.close();
   }
-}
 
+  @Test
+  public void socketFactory_default() {
+    OkHttpChannelBuilder builder = OkHttpChannelBuilder.forTarget("foo");
+    ClientTransportFactory transportFactory = builder.buildTransportFactory();
+    OkHttpClientTransport transport =
+        (OkHttpClientTransport)
+            transportFactory.newClientTransport(
+                new InetSocketAddress(5678), new ClientTransportFactory.ClientTransportOptions());
+
+    assertNull("socketFactory should be null", transport.getSocketFactory());
+
+    transportFactory.close();
+  }
+
+  @Test
+  public void socketFactory_custom() {
+    SocketFactory socketFactory =
+        new SocketFactory() {
+          @Override
+          public Socket createSocket(String s, int i) {
+            return null;
+          }
+
+          @Override
+          public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) {
+            return null;
+          }
+
+          @Override
+          public Socket createSocket(InetAddress inetAddress, int i) {
+            return null;
+          }
+
+          @Override
+          public Socket createSocket(
+              InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) {
+            return null;
+          }
+        };
+    OkHttpChannelBuilder builder =
+        OkHttpChannelBuilder.forTarget("foo").socketFactory(socketFactory);
+    ClientTransportFactory transportFactory = builder.buildTransportFactory();
+    OkHttpClientTransport transport =
+        (OkHttpClientTransport)
+            transportFactory.newClientTransport(
+                new InetSocketAddress(5678), new ClientTransportFactory.ClientTransportOptions());
+
+    assertSame(socketFactory, transport.getSocketFactory());
+
+    transportFactory.close();
+  }
+}

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelBuilderTest.java
@@ -172,7 +172,7 @@ public class OkHttpChannelBuilderTest {
             transportFactory.newClientTransport(
                 new InetSocketAddress(5678), new ClientTransportFactory.ClientTransportOptions());
 
-    assertNull("socketFactory should be null", transport.getSocketFactory());
+    assertSame(SocketFactory.getDefault(), transport.getSocketFactory());
 
     transportFactory.close();
   }


### PR DESCRIPTION
This is mainly aimed at allowing Android users to force the OkHttp channel to use a particular network, via providing a socket factory obtained from [`android.net.Network#getSocketFactory()`](https://developer.android.com/reference/android/net/Network.html#getSocketFactory()). The corresponding feature request from an internal user is at b/119564668.