### PR TITLE
Bazel services + grpc_proto dependency

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -268,6 +268,7 @@ def com_squareup_okio():
     )
 
 def io_grpc_grpc_proto():
+    # DO NOT SUBMIT: Need PR to go in first so this can be updated -- https://github.com/grpc/grpc-proto/pull/44
     http_archive(
         name = "io_grpc_grpc_proto",
         sha256 = "64a2cf675e38d4e8ef340432a5b701b079c769fb7f8b59a58c26df04fb53aa6a",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -21,6 +21,7 @@ def grpc_java_repositories(
         omit_com_google_truth_truth = False,
         omit_com_squareup_okhttp = False,
         omit_com_squareup_okio = False,
+        omit_io_grpc_grpc_proto = False,
         omit_io_netty_buffer = False,
         omit_io_netty_common = False,
         omit_io_netty_transport = False,
@@ -73,6 +74,8 @@ def grpc_java_repositories(
         com_squareup_okhttp()
     if not omit_com_squareup_okio:
         com_squareup_okio()
+    if not omit_io_grpc_grpc_proto:
+        io_grpc_grpc_proto()
     if not omit_io_netty_buffer:
         io_netty_buffer()
     if not omit_io_netty_common:
@@ -262,6 +265,14 @@ def com_squareup_okio():
         server_urls = ["http://central.maven.org/maven2"],
         artifact_sha256 = "734269c3ebc5090e3b23566db558f421f0b4027277c79ad5d176b8ec168bb850",
         licenses = ["notice"],  # Apache 2.0
+    )
+
+def io_grpc_grpc_proto():
+    http_archive(
+        name = "io_grpc_grpc_proto",
+        sha256 = "64a2cf675e38d4e8ef340432a5b701b079c769fb7f8b59a58c26df04fb53aa6a",
+        strip_prefix = "grpc-proto-f9af5e19f738a84b9fd9d78e380a9a352ab5ad34",
+        urls = ["https://github.com/grpc/grpc-proto/archive/f9af5e19f738a84b9fd9d78e380a9a352ab5ad34.zip"],
     )
 
 def io_netty_buffer():

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -268,12 +268,11 @@ def com_squareup_okio():
     )
 
 def io_grpc_grpc_proto():
-    # DO NOT SUBMIT: Need PR to go in first so this can be updated -- https://github.com/grpc/grpc-proto/pull/44
     http_archive(
         name = "io_grpc_grpc_proto",
-        sha256 = "64a2cf675e38d4e8ef340432a5b701b079c769fb7f8b59a58c26df04fb53aa6a",
-        strip_prefix = "grpc-proto-f9af5e19f738a84b9fd9d78e380a9a352ab5ad34",
-        urls = ["https://github.com/grpc/grpc-proto/archive/f9af5e19f738a84b9fd9d78e380a9a352ab5ad34.zip"],
+        sha256 = "df184b7bef52f5dfdcf7f2f8bc35086285f4e0f36413d09a500f0a8a51e8288b",
+        strip_prefix = "grpc-proto-e9d128ddadb204e89cfa4e73c454510a22394b33",
+        urls = ["https://github.com/grpc/grpc-proto/archive/e9d128ddadb204e89cfa4e73c454510a22394b33.zip"],
     )
 
 def io_netty_buffer():

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -270,9 +270,9 @@ def com_squareup_okio():
 def io_grpc_grpc_proto():
     http_archive(
         name = "io_grpc_grpc_proto",
-        sha256 = "df184b7bef52f5dfdcf7f2f8bc35086285f4e0f36413d09a500f0a8a51e8288b",
-        strip_prefix = "grpc-proto-e9d128ddadb204e89cfa4e73c454510a22394b33",
-        urls = ["https://github.com/grpc/grpc-proto/archive/e9d128ddadb204e89cfa4e73c454510a22394b33.zip"],
+        sha256 = "873f3fdec7ed052f899aef83fc897926729713d96d7ccdb2df22843dc702ef3a",
+        strip_prefix = "grpc-proto-96ecba6941c67b1da2af598330c60cf9b0336051",
+        urls = ["https://github.com/grpc/grpc-proto/archive/96ecba6941c67b1da2af598330c60cf9b0336051.zip"],
     )
 
 def io_netty_buffer():

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -1,0 +1,84 @@
+load("//:java_grpc_library.bzl", "java_grpc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "binarylog",
+    srcs = [
+        "src/main/java/io/grpc/services/BinaryLogProvider.java",
+        "src/main/java/io/grpc/services/BinaryLogProviderImpl.java",
+        "src/main/java/io/grpc/services/BinaryLogSink.java",
+        "src/main/java/io/grpc/services/BinlogHelper.java",
+        "src/main/java/io/grpc/services/InetAddressUtil.java",
+        "src/main/java/io/grpc/services/TempFileSink.java",
+    ],
+    deps = [
+        "//context",
+        "//core",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@com_google_re2j//jar",
+        "@io_grpc_grpc_proto//:binarylog_v1_java_proto",
+    ],
+)
+
+java_library(
+    name = "channelz",
+    srcs = [
+        "src/main/java/io/grpc/services/ChannelzProtoUtil.java",
+        "src/main/java/io/grpc/services/ChannelzService.java",
+    ],
+    deps = [
+        ":_channelz_java_grpc",
+        "//context",
+        "//core",
+        "//stub",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@io_grpc_grpc_proto//:channelz_java_proto",
+    ],
+)
+
+java_library(
+    name = "reflection",
+    srcs = [
+        "src/main/java/io/grpc/protobuf/services/ProtoReflectionService.java",
+    ],
+    deps = [
+        ":_reflection_java_grpc",
+        "//context",
+        "//core",
+        "//core:internal",
+        "//core:util",
+        "//protobuf",
+        "//stub",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
+        "@com_google_re2j//jar",
+        "@io_grpc_grpc_proto//:reflection_java_proto_deprecated",
+        "@javax_annotation_javax_annotation_api//jar",
+    ],
+)
+
+# These shouldn't be here, but this is better than having
+# a circular dependency on grpc-proto and grpc-java.
+
+java_grpc_library(
+    name = "_reflection_java_grpc",
+    srcs = ["@io_grpc_grpc_proto//:reflection_proto_deprecated"],
+    visibility = ["//visibility:private"],
+    deps = ["@io_grpc_grpc_proto//:reflection_java_proto_deprecated"],
+)
+
+java_grpc_library(
+    name = "_channelz_java_grpc",
+    srcs = ["@io_grpc_grpc_proto//:channelz_proto"],
+    visibility = ["//visibility:private"],
+    deps = ["@io_grpc_grpc_proto//:channelz_java_proto"],
+)

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -20,7 +20,7 @@ java_library(
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@com_google_re2j//jar",
-        "@io_grpc_grpc_proto//:binarylog_v1_java_proto",
+        "@io_grpc_grpc_proto//:binarylog_java_proto",
     ],
 )
 


### PR DESCRIPTION
Got tired of waiting on https://github.com/grpc/grpc-java/pull/5184/, so I forked and also did the integration with grpc-proto.

This PR should not be merged until https://github.com/grpc/grpc-proto/pull/44 has been merged, as we depend on the newly added java proto rules.
 
Manually tested, everything builds.