### PR TITLE
Change http to https for security links

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ to gRPC and has weaker API guarantees than the core API under package `io.grpc`.
 gRPC comes with three Transport implementations:
 
 1. The Netty-based transport is the main transport implementation based on
-   [Netty](http://netty.io). It is for both the client and the server.
+   [Netty](https://netty.io). It is for both the client and the server.
 2. The OkHttp-based transport is a lightweight transport based on
-   [OkHttp](http://square.github.io/okhttp/). It is mainly for use on Android
+   [OkHttp](https://square.github.io/okhttp/). It is mainly for use on Android
    and is for client only.
 3. The in-process transport is for when a server is in the same process as the
    client. It is useful for testing, while also being safe for production use.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ Prerequisites
 If you haven't deployed artifacts to Maven Central before, you need to setup
 your OSSRH (OSS Repository Hosting) account.
 - Follow the instructions on [this
-  page](http://central.sonatype.org/pages/ossrh-guide.html) to set up an
+  page](https://central.sonatype.org/pages/ossrh-guide.html) to set up an
   account with OSSRH.
   - You only need to create the account, not set up a new project
   - Contact a gRPC maintainer to add your account after you have created it.
@@ -167,7 +167,7 @@ several sanity checks on the repository. If this completes successfully, the
 repository can then be `released`, which will begin the process of pushing the
 new artifacts to Maven Central (the staging repository will be destroyed in the
 process). You can see the complete process for releasing to Maven Central on the
-[OSSRH site](http://central.sonatype.org/pages/releasing-the-deployment.html).
+[OSSRH site](https://central.sonatype.org/pages/releasing-the-deployment.html).
 
 Build interop container image
 -----------------------------
@@ -179,7 +179,7 @@ releases. Generate one for the new release by following the
 Update README.md
 ----------------
 After waiting ~1 day and verifying that the release appears on [Maven
-Central](http://mvnrepository.com/), cherry-pick the commit that updated the
+Central](https://mvnrepository.com/), cherry-pick the commit that updated the
 README into the master branch and go through review process.
 
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ JDK support in Java 9+, [Conscrypt](#tls-with-conscrypt), and [netty-tcnative
 with OpenSSL](#tls-with-netty-tcnative-on-openssl) are other valid options.
 
 [Netty TCNative](https://github.com/netty/netty-tcnative) is a fork of
-[Apache Tomcat's tcnative](http://tomcat.apache.org/native-doc/) and is a JNI
+[Apache Tomcat's tcnative](https://tomcat.apache.org/native-doc/) and is a JNI
 wrapper around OpenSSL/BoringSSL/LibreSSL.
 
 We recommend BoringSSL for its simplicitly and low occurrence of security
@@ -252,7 +252,7 @@ of the other options due to a slow AES GCM implementation in Java.
 
 #### Configuring Jetty ALPN in Web Containers
 
-Some web containers, such as [Jetty](http://www.eclipse.org/jetty/documentation/current/jetty-classloading.html) restrict access to server classes for web applications. A gRPC client running within such a container must be properly configured to allow access to the ALPN classes. In Jetty, this is done by including a `WEB-INF/jetty-env.xml` file containing the following:
+Some web containers, such as [Jetty](https://www.eclipse.org/jetty/documentation/current/jetty-classloading.html) restrict access to server classes for web applications. A gRPC client running within such a container must be properly configured to allow access to the ALPN classes. In Jetty, this is done by including a `WEB-INF/jetty-env.xml` file containing the following:
 
 ```xml
 <?xml version="1.0"  encoding="ISO-8859-1"?>

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,7 +19,7 @@ The `C++` counterpart can be found at https://github.com/grpc/grpc/tree/master/t
 
 ## Visualizing the Latency Distribution
 
-The QPS client comes with the option `--save_histogram=FILE`, if set it serializes the histogram to `FILE` which can then be used with a plotter to visualize the latency distribution. The histogram is stored in the file format of [HdrHistogram](http://hdrhistogram.org/). That way it can be plotted very easily using a browser based tool like http://hdrhistogram.github.io/HdrHistogram/plotFiles.html. Simply upload the generated file and it will generate a beautiful graph for you. It also allows you to plot two or more histograms on the same surface in order two easily compare latency distributions.
+The QPS client comes with the option `--save_histogram=FILE`, if set it serializes the histogram to `FILE` which can then be used with a plotter to visualize the latency distribution. The histogram is stored in the file format of [HdrHistogram](https://hdrhistogram.org/). That way it can be plotted very easily using a browser based tool like https://hdrhistogram.github.io/HdrHistogram/plotFiles.html. Simply upload the generated file and it will generate a beautiful graph for you. It also allows you to plot two or more histograms on the same surface in order two easily compare latency distributions.
 
 ## JVM Options
 

--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/README.md
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/netty/README.md
@@ -16,7 +16,7 @@ ethernet interface with a packet delay of 0.1ms.
 Linux
 =====
 
-On Linux we can use [netem](http://www.linuxfoundation.org/collaborate/workgroups/networking/netem)  to shape the traffic appropriately.
+On Linux we can use [netem](https://www.linuxfoundation.org/collaborate/workgroups/networking/netem)  to shape the traffic appropriately.
 
 ```sh
 # Remove all traffic shaping from loopback

--- a/gae-interop-testing/README.md
+++ b/gae-interop-testing/README.md
@@ -8,7 +8,7 @@ Prerequisites
 ==========================
 
 - Install the Google Cloud SDK and ensure that `gcloud` is in the path
-- Set up an [App Engine app](http://appengine.google.com) with your
+- Set up an [App Engine app](https://appengine.google.com) with your
   choice of a PROJECT_ID.
 - Associate your `gcloud` environment with your app:
   ```bash


### PR DESCRIPTION
For security, we should change http into https links.

Co-Authored-By: Nguyen Van Trung [trungnvfet@outlook.com](mailto:trungnvfet@outlook.com)
Signed-off-by: Nguyen Quang Huy [huynq0911@gmail.com](mailto:huynq0911@gmail.com)