### PR TITLE
Rename source jar outputs to avoid conflicts with java_common.compile

### DIFF
--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -3,7 +3,7 @@
 set -exu -o pipefail
 cat /VERSION
 
-use_bazel.sh 0.22.0
+use_bazel.sh 0.23.1
 bazel version
 
 cd github/grpc-java

--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -20,15 +20,17 @@ def _java_rpc_library_impl(ctx):
     if flavor == "normal":
         flavor = ""
 
+    srcjar = ctx.actions.declare_file("%s-proto-gensrc.jar" % ctx.label.name)
+
     args = ctx.actions.args()
     args.add(ctx.executable._java_plugin.path, format = "--plugin=protoc-gen-grpc-java=%s")
-    args.add("--grpc-java_out={0}:{1}".format(flavor, ctx.outputs.srcjar.path))
+    args.add("--grpc-java_out={0}:{1}".format(flavor, srcjar.path))
     args.add_all(includes, map_each = _create_include_path)
     args.add_all(srcs, map_each = _path_ignoring_repository)
 
     ctx.action(
         inputs = depset([ctx.executable._java_plugin] + srcs, transitive = [includes]),
-        outputs = [ctx.outputs.srcjar],
+        outputs = [srcjar],
         executable = ctx.executable._protoc,
         arguments = [args],
     )
@@ -39,7 +41,8 @@ def _java_rpc_library_impl(ctx):
         ctx,
         java_toolchain = ctx.attr._java_toolchain,
         host_javabase = ctx.attr._host_javabase,
-        source_jars = [ctx.outputs.srcjar],
+        source_jars = [srcjar],
+        output_source_jar = ctx.outputs.srcjar,
         output = ctx.outputs.jar,
         deps = [
             java_common.make_non_strict(deps_java_info),


### PR DESCRIPTION
More information: https://github.com/bazelbuild/bazel/issues/5824