### PR TITLE
travis.yml: Stop testing jdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ os:
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
   - openjdk11
 
 notifications:


### PR DESCRIPTION
JDK 11 is LTS and superceded JDK 9 and 10. Nobody should really be using JDK 9
(just like the already untested JDK 10) so let's not waste the CPU testing it.
As long as we support JDK 8 and 11 it is unlikely we break JDK 9, though.