### PR TITLE
testing: Move AbstractTransportTest to core to avoid Truth dep

### DIFF
--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -18,10 +18,10 @@ package io.grpc.inprocess;
 
 import com.google.common.collect.ImmutableList;
 import io.grpc.ServerStreamTracer;
+import io.grpc.internal.AbstractTransportTest;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.testing.AbstractTransportTest;
 import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.internal.testing;
+package io.grpc.internal;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.truth.Truth.assertThat;
@@ -55,22 +55,8 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerStreamTracer;
 import io.grpc.Status;
-import io.grpc.internal.ClientStream;
-import io.grpc.internal.ClientStreamListener;
-import io.grpc.internal.ClientTransport;
-import io.grpc.internal.ConnectionClientTransport;
-import io.grpc.internal.GrpcAttributes;
-import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.InternalServer;
-import io.grpc.internal.IoUtils;
-import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.ServerListener;
-import io.grpc.internal.ServerStream;
-import io.grpc.internal.ServerStreamListener;
-import io.grpc.internal.ServerTransport;
-import io.grpc.internal.ServerTransportListener;
-import io.grpc.internal.TimeProvider;
-import io.grpc.internal.TransportTracer;
+import io.grpc.internal.testing.TestClientStreamTracer;
+import io.grpc.internal.testing.TestServerStreamTracer;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -17,11 +17,11 @@
 package io.grpc.netty;
 
 import io.grpc.ServerStreamTracer;
+import io.grpc.internal.AbstractTransportTest;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.testing.AbstractTransportTest;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -17,13 +17,13 @@
 package io.grpc.okhttp;
 
 import io.grpc.ServerStreamTracer;
+import io.grpc.internal.AbstractTransportTest;
 import io.grpc.internal.AccessProtectedHack;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.InternalServer;
 import io.grpc.internal.ManagedClientTransport;
-import io.grpc.internal.testing.AbstractTransportTest;
 import io.grpc.netty.NettyServerBuilder;
 import java.net.InetSocketAddress;
 import java.util.List;

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -8,13 +8,6 @@ dependencies {
         // prefer 1.3 from JUnit instead of 1.1
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-    // Use compileOnly to avoid dependencyConvergence problem with the Guava
-    // pulled in via Truth, for users that don't use Truth. Truth requires a
-    // more up-to-date Guava than we support elsewhere, which would trigger
-    // convergence failures in tests that only our users could resolve. Using
-    // compileOnly means only users using Truth would have the problem and
-    // they'd have to resolve it like normal anyway.
-    compileOnly libraries.truth
 
     testCompile project(':grpc-testing-proto'),
             project(':grpc-core').sourceSets.test.output


### PR DESCRIPTION
Fixes #5301 

----

CC @elharo @suztomo. This will be present in v1.20.