### PR TITLE
SECURITY.md: Don't suggest users to use Jetty ALPN

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,8 +53,8 @@ support or have 2% the performance of OpenSSL.
 
 We recommend most users use grpc-netty-shaded, which includes netty-tcnative on
 BoringSSL. It includes pre-built libraries for 64 bit Windows, OS X, and 64 bit
-Linux. For 32 bit Windows, Conscrypt may be an option. For all other platforms,
-Java 9+ is required.
+Linux. For 32 bit Windows, Conscrypt is an option. For all other platforms, Java
+9+ is required.
 
 For users of grpc-netty we recommend [netty-tcnative with
 BoringSSL](#tls-with-netty-tcnative-on-boringssl), although using the built-in
@@ -330,9 +330,9 @@ If you aren't using gRPC on Android devices, you are most likely using `grpc-net
 If you are developing for Android and have a dependency on `grpc-netty`, you should remove it as `grpc-netty` is unsupported on Android. Use `grpc-okhttp` instead.
 
 If you are on a 32-bit operating system, using Java 11+ may be the easiest
-solution, as ALPN was added to Java in Java 9. If on 32-bit Windows, Conscrypt
-may be an option. Otherwise you need to build your own 32-bit version of
-`netty-tcnative`.
+solution, as ALPN was added to Java in Java 9. If on 32-bit Windows, [Conscrypt
+is an option](#tls-with-conscrypt). Otherwise you need to build your own 32-bit
+version of `netty-tcnative`.
 
 If you are using `musl` libc (e.g., with Alpine Linux), then
 `netty-tcnative-boringssl-static` won't work. There are several alternatives:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -331,8 +331,9 @@ If you are developing for Android and have a dependency on `grpc-netty`, you sho
 
 If you are on a 32-bit operating system, using Java 11+ may be the easiest
 solution, as ALPN was added to Java in Java 9. If on 32-bit Windows, [Conscrypt
-is an option](#tls-with-conscrypt). Otherwise you need to build your own 32-bit
-version of `netty-tcnative`.
+is an option](#tls-with-conscrypt). Otherwise you need to [build your own 32-bit
+version of
+`netty-tcnative`](https://netty.io/wiki/forked-tomcat-native.html#wiki-h2-6).
 
 If you are using `musl` libc (e.g., with Alpine Linux), then
 `netty-tcnative-boringssl-static` won't work. There are several alternatives:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -329,7 +329,10 @@ If you aren't using gRPC on Android devices, you are most likely using `grpc-net
 
 If you are developing for Android and have a dependency on `grpc-netty`, you should remove it as `grpc-netty` is unsupported on Android. Use `grpc-okhttp` instead.
 
-If you are on a 32-bit operating system, or not on a [Transport Security supported platform](#transport-security-tls), you should use Jetty ALPN (and beware of potential issues), or you'll need to build your own 32-bit version of `netty-tcnative`.
+If you are on a 32-bit operating system, using Java 11+ may be the easiest
+solution, as ALPN was added to Java in Java 9. If on 32-bit Windows, Conscrypt
+may be an option. Otherwise you need to build your own 32-bit version of
+`netty-tcnative`.
 
 If you are using `musl` libc (e.g., with Alpine Linux), then
 `netty-tcnative-boringssl-static` won't work. There are several alternatives:


### PR DESCRIPTION
I fixed many of these elsewhere in the document via 4ba168f28, but I
didn't update the troubleshooting section previously.