### PR TITLE
bazel: update to new ProtoInfo provider

### DIFF
--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -2,6 +2,8 @@
 
 set -exu -o pipefail
 cat /VERSION
+
+use_bazel.sh 0.22.0
 bazel version
 
 cd github/grpc-java

--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -14,8 +14,8 @@ def _java_rpc_library_impl(ctx):
         print(("in srcs attribute of {0}: Proto source with label {1} should be in " +
                "same package as consuming rule").format(ctx.label, ctx.attr.srcs[0].label))
 
-    srcs = ctx.attr.srcs[0].proto.direct_sources
-    includes = ctx.attr.srcs[0].proto.transitive_imports
+    srcs = ctx.attr.srcs[0][ProtoInfo].direct_sources
+    includes = ctx.attr.srcs[0][ProtoInfo].transitive_imports
     flavor = ctx.attr.flavor
     if flavor == "normal":
         flavor = ""
@@ -53,7 +53,7 @@ _java_rpc_library = rule(
         "srcs": attr.label_list(
             mandatory = True,
             non_empty = True,
-            providers = ["proto"],
+            providers = [ProtoInfo],
         ),
         "deps": attr.label_list(
             mandatory = True,


### PR DESCRIPTION
This is part of #5383. As Bazel 0.22.0 is the only supported version
now, use this in the Kokoro build.