### PR TITLE
core: add LoadBalancer.Helper#createResolvingOobChannel()

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -551,9 +551,10 @@ public abstract class LoadBalancer {
     public abstract ManagedChannel createOobChannel(EquivalentAddressGroup eag, String authority);
 
     /**
-     * Updates the addresses used for connections in the {@code Channel}. This is supperior to
-     * {@link #createOobChannel} when the old and new addresses overlap, since the channel can
-     * continue using an existing connection.
+     * Updates the addresses used for connections in the {@code Channel} that was created by {@link
+     * #createOobChannel(EquivalentAddressGroup, String)}. This is supperior to {@link
+     * #createOobChannel(EquivalentAddressGroup, String)} when the old and new addresses overlap,
+     * since the channel can continue using an existing connection.
      *
      * @throws IllegalArgumentException if {@code channel} was not returned from {@link
      *     #createOobChannel}
@@ -561,6 +562,24 @@ public abstract class LoadBalancer {
      */
     public void updateOobChannelAddresses(ManagedChannel channel, EquivalentAddressGroup eag) {
       throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates an out-of-band channel for LoadBalancer's own RPC needs, e.g., talking to an external
+     * load-balancer service, that is specified by a target string.  See the documentation on
+     * {@link ManagedChannelBuilder#forTarget} for the format of a target string.
+     *
+     * <p>The target string will be resolved by a {@link NameResolver} created according to the
+     * target string.  The out-of-band channel doesn't have load-balancing. If multiple addresses
+     * are resolved for the target, the "pick_first" policy will be applied.
+     *
+     * <p>The LoadBalancer is responsible for closing unused OOB channels, and closing all OOB
+     * channels within {@link #shutdown}.
+     *
+     * <P>NOT IMPLEMENTED: this method is currently a stub and not yet implemented by gRPC.
+     */
+    public ManagedChannel createResolvingOobChannel(String target) {
+      throw new UnsupportedOperationException("Not implemented");
     }
 
     /**

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -570,13 +570,15 @@ public abstract class LoadBalancer {
      * {@link ManagedChannelBuilder#forTarget} for the format of a target string.
      *
      * <p>The target string will be resolved by a {@link NameResolver} created according to the
-     * target string.  The out-of-band channel doesn't have load-balancing. If multiple addresses
-     * are resolved for the target, the "pick_first" policy will be applied.
+     * target string.  The out-of-band channel doesn't have load-balancing.  If multiple addresses
+     * are resolved for the target, the first working address will be used.
      *
      * <p>The LoadBalancer is responsible for closing unused OOB channels, and closing all OOB
      * channels within {@link #shutdown}.
      *
      * <P>NOT IMPLEMENTED: this method is currently a stub and not yet implemented by gRPC.
+     *
+     * @since 1.20.0
      */
     public ManagedChannel createResolvingOobChannel(String target) {
       throw new UnsupportedOperationException("Not implemented");

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
@@ -60,6 +60,11 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
   }
 
   @Override
+  public ManagedChannel createResolvingOobChannel(String target) {
+    return delegate().createResolvingOobChannel(target);
+  }
+
+  @Override
   public void updateBalancingState(
       ConnectivityState newState, SubchannelPicker newPicker) {
     delegate().updateBalancingState(newState, newPicker);


### PR DESCRIPTION
This can be used by xds LoadBalancer to create a channel to the XDS
traffic director, as the service config will only specify the target
name of the balancer.

This PR only adds the interface to unblock the xds work.
Implementation would take some time thus will come later.

I selected a slightly different name from the original `createOobChannel()`
to signify their difference. I am open to naming it just `createOobChannel()`.