### PR TITLE
core: deprecate LoadBalancer.Helper#getNameResolverFactory

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -638,7 +638,11 @@ public abstract class LoadBalancer {
      * Returns the NameResolver of the channel.
      *
      * @since 1.2.0
+     *
+     * @deprecated this method will be deleted in a future release.  If you think it shouldn't be
+     *     deleted, please file an issue on <a href="https://github.com/grpc/grpc-java">github</a>.
      */
+    @Deprecated
     public abstract NameResolver.Factory getNameResolverFactory();
 
     /**

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1256,6 +1256,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       return ManagedChannelImpl.this.authority();
     }
 
+    @Deprecated
     @Override
     public NameResolver.Factory getNameResolverFactory() {
       return nameResolverFactory;

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
@@ -76,6 +76,7 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
     delegate().runSerialized(task);
   }
 
+  @Deprecated
   @Override
   public NameResolver.Factory getNameResolverFactory() {
     return delegate().getNameResolverFactory();

--- a/core/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/LoadBalancerTest.java
@@ -211,7 +211,9 @@ public class LoadBalancerTest {
       return null;
     }
 
-    @Override public NameResolver.Factory getNameResolverFactory() {
+    @Deprecated
+    @Override
+    public NameResolver.Factory getNameResolverFactory() {
       return null;
     }
 

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -1190,6 +1190,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
       return clock.getScheduledExecutorService();
     }
 
+    @Deprecated
     @Override
     public NameResolver.Factory getNameResolverFactory() {
       throw new AssertionError("Should not be called");


### PR DESCRIPTION
This was added for the potential use case of needing to resolve target
names (of the same scheme as the top-level channel's target's) in the
LoadBalancer.  Now actual use cases come up in xDS that we need to
resolve fully-qualified target strings with arbitrary schemes.  This
method has never been used and won't fit future uses because it's too
restrictive.