### PR TITLE
core/grpclb: propagation and parsing of grpclb config

### DIFF
--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -257,9 +257,7 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
             LoadBalancerProvider provider = registry.getProvider(policy);
             if (provider == null) {
               policiesTried.add(policy);
-            }
-
-            if (provider != null) {
+            } else {
               if (!policiesTried.isEmpty()) {
                 // Before returning, log all previously tried policies
                 helper.getChannelLogger().log(

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -270,11 +270,10 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
               backendAddrs, null);
         }
         return new PolicySelection(grpclbProvider, servers, null);
-      } else {
-        // No balancer address this time.  If balancer address shows up later, we want to make sure
-        // the warning is logged one more time.
-        roundRobinDueToGrpclbDepMissing = false;
       }
+      // No balancer address this time.  If balancer address shows up later, we want to make sure
+      // the warning is logged one more time.
+      roundRobinDueToGrpclbDepMissing = false;
 
       // No config nor balancer address. Use default.
       return new PolicySelection(

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -404,41 +404,49 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @Test
-  public void decideLoadBalancerProvider_grpclbOverridesServiceConfigLbPolicy() throws Exception {
+  public void decideLoadBalancerProvider_serviceConfigLbPolicy() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
     Map<String, Object> serviceConfig = new HashMap<>();
     serviceConfig.put("loadBalancingPolicy", "round_robin");
     List<EquivalentAddressGroup> servers =
-        Collections.singletonList(
+        Arrays.asList(
             new EquivalentAddressGroup(
                 new SocketAddress(){},
-                Attributes.newBuilder().set(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY, "ok").build()));
+                Attributes.newBuilder().set(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY, "ok").build()),
+            new EquivalentAddressGroup(
+                new SocketAddress(){}));
+    List<EquivalentAddressGroup> backends = Arrays.asList(servers.get(1));
     PolicySelection selection = lb.decideLoadBalancerProvider(servers, serviceConfig);
 
-    assertThat(selection.provider).isInstanceOf(GrpclbLoadBalancerProvider.class);
-    assertThat(selection.serverList).isEqualTo(servers);
-    assertThat(selection.config).isNull();
+    assertThat(selection.provider.getClass().getName()).isEqualTo(
+        "io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider");
+    assertThat(selection.serverList).isEqualTo(backends);
+    assertThat(selection.config).isEqualTo(Collections.<String, Object>emptyMap());
     verifyZeroInteractions(channelLogger);
   }
 
   @SuppressWarnings("unchecked")
   @Test
-  public void decideLoadBalancerProvider_grpclbOverridesServiceConfigLbConfig() throws Exception {
+  public void decideLoadBalancerProvider_serviceConfigLbConfig() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
     Map<String, Object> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"round_robin\": {} } ] }");
     List<EquivalentAddressGroup> servers =
-        Collections.singletonList(
+        Arrays.asList(
             new EquivalentAddressGroup(
                 new SocketAddress(){},
-                Attributes.newBuilder().set(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY, "ok").build()));
+                Attributes.newBuilder().set(GrpcAttributes.ATTR_LB_ADDR_AUTHORITY, "ok").build()),
+            new EquivalentAddressGroup(
+                new SocketAddress(){}));
+    List<EquivalentAddressGroup> backends = Arrays.asList(servers.get(1));
     PolicySelection selection = lb.decideLoadBalancerProvider(servers, serviceConfig);
 
-    assertThat(selection.provider).isInstanceOf(GrpclbLoadBalancerProvider.class);
-    assertThat(selection.serverList).isEqualTo(servers);
-    assertThat(selection.config).isNull();
+    assertThat(selection.provider.getClass().getName()).isEqualTo(
+        "io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider");
+    assertThat(selection.serverList).isEqualTo(backends);
+    assertThat(selection.config).isEqualTo(Collections.<String, Object>emptyMap());
     verifyZeroInteractions(channelLogger);
   }
 
@@ -449,7 +457,6 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     Map<String, Object> serviceConfig =
         parseConfig(
             "{\"loadBalancingConfig\": ["
-            + "{\"test_lb\": {} },"
             + "{\"grpclb\": {\"childPolicy\": [ {\"pick_first\": {} } ] } }"
             + "] }");
     List<EquivalentAddressGroup> servers =
@@ -471,14 +478,14 @@ public class AutoConfiguredLoadBalancerFactoryTest {
       throws Exception {
     LoadBalancerRegistry registry = new LoadBalancerRegistry();
     registry.register(new PickFirstLoadBalancerProvider());
-    LoadBalancerProvider fakeRondRobinProvider =
+    LoadBalancerProvider fakeRoundRobinProvider =
         new FakeLoadBalancerProvider("round_robin", testLbBalancer);
-    registry.register(fakeRondRobinProvider);
+    registry.register(fakeRoundRobinProvider);
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(
             registry, GrpcUtil.DEFAULT_LB_POLICY).newLoadBalancer(new TestHelper());
     Map<String, Object> serviceConfig =
-        parseConfig("{\"loadBalancingConfig\": [ {\"round_robin\": {} } ] }");
+        parseConfig("{\"loadBalancingConfig\": [ {\"grpclb\": {} } ] }");
     List<EquivalentAddressGroup> servers =
         Arrays.asList(
             new EquivalentAddressGroup(
@@ -487,7 +494,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
             new EquivalentAddressGroup(new SocketAddress(){}));
     PolicySelection selection = lb.decideLoadBalancerProvider(servers, serviceConfig);
 
-    assertThat(selection.provider).isSameAs(fakeRondRobinProvider);
+    assertThat(selection.provider).isSameAs(fakeRoundRobinProvider);
     assertThat(selection.config).isNull();
     verify(channelLogger).log(
         eq(ChannelLogLevel.ERROR),
@@ -496,7 +503,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     // Called for the second time, the warning is only logged once
     selection = lb.decideLoadBalancerProvider(servers, serviceConfig);
 
-    assertThat(selection.provider).isSameAs(fakeRondRobinProvider);
+    assertThat(selection.provider).isSameAs(fakeRoundRobinProvider);
     // Balancer addresses are filtered out in the server list passed to round_robin
     assertThat(selection.serverList).containsExactly(servers.get(1));
     assertThat(selection.config).isNull();
@@ -513,7 +520,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
         (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(
             registry, GrpcUtil.DEFAULT_LB_POLICY).newLoadBalancer(new TestHelper());
     Map<String, Object> serviceConfig =
-        parseConfig("{\"loadBalancingConfig\": [ {\"round_robin\": {} } ] }");
+        parseConfig("{\"loadBalancingConfig\": [ {\"grpclb\": {} } ] }");
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(
             new EquivalentAddressGroup(

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -104,33 +104,34 @@ class GrpclbLoadBalancer extends LoadBalancer {
   static Mode retrieveModeFromLbConfig(
       @Nullable Map<String, Object> rawLbConfigValue, ChannelLogger channelLogger) {
     try {
-      if (rawLbConfigValue != null) {
-        Object rawChildPolicies = rawLbConfigValue.get("childPolicy");
-        if (rawChildPolicies != null) {
-          List<LbConfig> childPolicies =
-              ServiceConfigUtil.unwrapLoadBalancingConfigList(rawChildPolicies);
-          for (LbConfig childPolicy : childPolicies) {
-            String childPolicyName = childPolicy.getPolicyName();
-            switch (childPolicyName) {
-              case "round_robin":
-                return Mode.ROUND_ROBIN;
-              case "pick_first":
-                return Mode.PICK_FIRST;
-              default:
-                channelLogger.log(
-                    ChannelLogLevel.DEBUG,
-                    "grpclb ignoring unsupported child policy " + childPolicyName);
-            }
-          }
+      if (rawLbConfigValue == null) {
+        return DEFAULT_MODE;
+      }
+      Object rawChildPolicies = rawLbConfigValue.get("childPolicy");
+      if (rawChildPolicies == null) {
+        return DEFAULT_MODE;
+      }
+      List<LbConfig> childPolicies =
+          ServiceConfigUtil.unwrapLoadBalancingConfigList(rawChildPolicies);
+      for (LbConfig childPolicy : childPolicies) {
+        String childPolicyName = childPolicy.getPolicyName();
+        switch (childPolicyName) {
+          case "round_robin":
+            return Mode.ROUND_ROBIN;
+          case "pick_first":
+            return Mode.PICK_FIRST;
+          default:
+            channelLogger.log(
+                ChannelLogLevel.DEBUG,
+                "grpclb ignoring unsupported child policy " + childPolicyName);
         }
       }
-      return DEFAULT_MODE;
     } catch (RuntimeException e) {
       channelLogger.log(ChannelLogLevel.WARNING, "Bad grpclb config, using " + DEFAULT_MODE);
       logger.log(
           Level.WARNING, "Bad grpclb config: " + rawLbConfigValue + ", using " + DEFAULT_MODE, e);
-      return DEFAULT_MODE;
     }
+    return DEFAULT_MODE;
   }
 
   private void resetStates() {

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -20,16 +20,24 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Attributes;
+import io.grpc.ChannelLogger;
+import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.Status;
+import io.grpc.grpclb.GrpclbState.Mode;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.GrpcAttributes;
+import io.grpc.internal.ServiceConfigUtil;
+import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.internal.TimeProvider;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
@@ -39,7 +47,10 @@ import javax.annotation.Nullable;
  * or round-robin balancer.
  */
 class GrpclbLoadBalancer extends LoadBalancer {
+  private static final Mode DEFAULT_MODE = Mode.ROUND_ROBIN;
+  private static final Logger logger = Logger.getLogger(GrpclbLoadBalancer.class.getName());
 
+  private final Helper helper;
   private final SubchannelPool subchannelPool;
 
   // All mutable states in this class are mutated ONLY from Channel Executor
@@ -51,7 +62,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
       SubchannelPool subchannelPool,
       TimeProvider time,
       BackoffPolicy.Provider backoffPolicyProvider) {
-    checkNotNull(helper, "helper");
+    this.helper = checkNotNull(helper, "helper");
     checkNotNull(time, "time provider");
     checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
     this.subchannelPool = checkNotNull(subchannelPool, "subchannelPool");
@@ -84,7 +95,42 @@ class GrpclbLoadBalancer extends LoadBalancer {
 
     newLbAddressGroups = Collections.unmodifiableList(newLbAddressGroups);
     newBackendServers = Collections.unmodifiableList(newBackendServers);
-    grpclbState.handleAddresses(newLbAddressGroups, newBackendServers);
+    Map<String, Object> rawLbConfigValue = attributes.get(ATTR_LOAD_BALANCING_CONFIG);
+    Mode newMode = retrieveModeFromLbConfig(rawLbConfigValue, helper.getChannelLogger());
+    grpclbState.handleAddresses(newLbAddressGroups, newBackendServers, newMode);
+  }
+
+  @VisibleForTesting
+  static Mode retrieveModeFromLbConfig(
+      @Nullable Map<String, Object> rawLbConfigValue, ChannelLogger channelLogger) {
+    try {
+      if (rawLbConfigValue != null) {
+        Object rawChildPolicies = rawLbConfigValue.get("childPolicy");
+        if (rawChildPolicies != null) {
+          List<LbConfig> childPolicies =
+              ServiceConfigUtil.unwrapLoadBalancingConfigList(rawChildPolicies);
+          for (LbConfig childPolicy : childPolicies) {
+            String childPolicyName = childPolicy.getPolicyName();
+            switch (childPolicyName) {
+              case "round_robin":
+                return Mode.ROUND_ROBIN;
+              case "pick_first":
+                return Mode.PICK_FIRST;
+              default:
+                channelLogger.log(
+                    ChannelLogLevel.DEBUG,
+                    "grpclb ignoring unsupported child policy " + childPolicyName);
+            }
+          }
+        }
+      }
+      return DEFAULT_MODE;
+    } catch (RuntimeException e) {
+      channelLogger.log(ChannelLogLevel.WARNING, "Bad grpclb config, using " + DEFAULT_MODE);
+      logger.log(
+          Level.WARNING, "Bad grpclb config: " + rawLbConfigValue + ", using " + DEFAULT_MODE, e);
+      return DEFAULT_MODE;
+    }
   }
 
   private void resetStates() {

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -102,6 +102,11 @@ final class GrpclbState {
       }
     };
 
+  static enum Mode {
+    ROUND_ROBIN,
+    PICK_FIRST,
+  }
+
   private final String serviceName;
   private final Helper helper;
   private final SynchronizationContext syncContext;
@@ -134,6 +139,7 @@ final class GrpclbState {
   @Nullable
   private LbStream lbStream;
   private Map<EquivalentAddressGroup, Subchannel> subchannels = Collections.emptyMap();
+  private Mode mode;
 
   // Has the same size as the round-robin list from the balancer.
   // A drop entry from the round-robin list becomes a DropEntry here.
@@ -176,7 +182,8 @@ final class GrpclbState {
    * not yet connected.
    */
   void handleAddresses(
-      List<LbAddressGroup> newLbAddressGroups, List<EquivalentAddressGroup> newBackendServers) {
+      List<LbAddressGroup> newLbAddressGroups, List<EquivalentAddressGroup> newBackendServers,
+      Mode mode) {
     if (newLbAddressGroups.isEmpty()) {
       propagateError(Status.UNAVAILABLE.withDescription(
               "NameResolver returned no LB address while asking for GRPCLB"));

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -22,6 +22,7 @@ import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.SHUTDOWN;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
+import static io.grpc.grpclb.GrpclbLoadBalancer.retrieveModeFromLbConfig;
 import static io.grpc.grpclb.GrpclbState.BUFFER_ENTRY;
 import static io.grpc.grpclb.GrpclbState.DROP_PICK_RESULT;
 import static org.junit.Assert.assertEquals;
@@ -67,12 +68,14 @@ import io.grpc.SynchronizationContext;
 import io.grpc.grpclb.GrpclbState.BackendEntry;
 import io.grpc.grpclb.GrpclbState.DropEntry;
 import io.grpc.grpclb.GrpclbState.ErrorEntry;
+import io.grpc.grpclb.GrpclbState.Mode;
 import io.grpc.grpclb.GrpclbState.RoundRobinPicker;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcAttributes;
+import io.grpc.internal.JsonParser;
 import io.grpc.lb.v1.ClientStats;
 import io.grpc.lb.v1.ClientStatsPerToken;
 import io.grpc.lb.v1.InitialLoadBalanceRequest;
@@ -91,6 +94,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.junit.After;
@@ -1587,6 +1591,68 @@ public class GrpclbLoadBalancerTest {
     verify(helper, times(4)).refreshNameResolution();
   }
 
+  @Test
+  public void retrieveModeFromLbConfig_pickFirst() throws Exception {
+    String lbConfig = "{\"childPolicy\" : [{\"pick_first\" : {}}, {\"round_robin\" : {}}]}";
+
+    Mode mode = retrieveModeFromLbConfig(parseJsonObject(lbConfig), channelLogger);
+    assertThat(logs).isEmpty();
+    assertThat(mode).isEqualTo(Mode.PICK_FIRST);
+  }
+
+  @Test
+  public void retrieveModeFromLbConfig_roundRobin() throws Exception {
+    String lbConfig = "{\"childPolicy\" : [{\"round_robin\" : {}}, {\"pick_first\" : {}}]}";
+
+    Mode mode = retrieveModeFromLbConfig(parseJsonObject(lbConfig), channelLogger);
+    assertThat(logs).isEmpty();
+    assertThat(mode).isEqualTo(Mode.ROUND_ROBIN);
+  }
+
+  @Test
+  public void retrieveModeFromLbConfig_nullConfigUseRoundRobin() throws Exception {
+    Mode mode = retrieveModeFromLbConfig(null, channelLogger);
+    assertThat(logs).isEmpty();
+    assertThat(mode).isEqualTo(Mode.ROUND_ROBIN);
+  }
+
+  @Test
+  public void retrieveModeFromLbConfig_emptyConfigUseRoundRobin() throws Exception {
+    String lbConfig = "{}";
+
+    Mode mode = retrieveModeFromLbConfig(parseJsonObject(lbConfig), channelLogger);
+    assertThat(logs).isEmpty();
+    assertThat(mode).isEqualTo(Mode.ROUND_ROBIN);
+  }
+
+  @Test
+  public void retrieveModeFromLbConfig_emptyChildPolicyUseRoundRobin() throws Exception {
+    String lbConfig = "{\"childPolicy\" : []}";
+
+    Mode mode = retrieveModeFromLbConfig(parseJsonObject(lbConfig), channelLogger);
+    assertThat(logs).isEmpty();
+    assertThat(mode).isEqualTo(Mode.ROUND_ROBIN);
+  }
+
+  @Test
+  public void retrieveModeFromLbConfig_unsupportedChildPolicyUseRoundRobin()
+      throws Exception {
+    String lbConfig = "{\"childPolicy\" : [ {\"nonono\" : {}} ]}";
+
+    Mode mode = retrieveModeFromLbConfig(parseJsonObject(lbConfig), channelLogger);
+    assertThat(logs).containsExactly("DEBUG: grpclb ignoring unsupported child policy nonono");
+    assertThat(mode).isEqualTo(Mode.ROUND_ROBIN);
+  }
+
+  @Test
+  public void retrieveModeFromLbConfig_skipUnsupportedChildPolicy() throws Exception {
+    String lbConfig = "{\"childPolicy\" : [ {\"nono\" : {}}, {\"pick_first\" : {} } ]}";
+
+    Mode mode = retrieveModeFromLbConfig(parseJsonObject(lbConfig), channelLogger);
+    assertThat(logs).containsExactly("DEBUG: grpclb ignoring unsupported child policy nono");
+    assertThat(mode).isEqualTo(Mode.PICK_FIRST);
+  }
+
   private void deliverSubchannelState(
       final Subchannel subchannel, final ConnectivityStateInfo newState) {
     syncContext.execute(new Runnable() {
@@ -1675,6 +1741,11 @@ public class GrpclbLoadBalancerTest {
     return LoadBalanceResponse.newBuilder()
         .setServerList(serverListBuilder.build())
         .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> parseJsonObject(String json) throws Exception {
+    return (Map<String, Object>) JsonParser.parse(json);
   }
 
   private static class ServerEntry {

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -1653,6 +1653,15 @@ public class GrpclbLoadBalancerTest {
     assertThat(mode).isEqualTo(Mode.PICK_FIRST);
   }
 
+  @Test
+  public void retrieveModeFromLbConfig_badConfigDefaultToRoundRobin() throws Exception {
+    String lbConfig = "{\"childPolicy\" : {}}";
+
+    Mode mode = retrieveModeFromLbConfig(parseJsonObject(lbConfig), channelLogger);
+    assertThat(logs).containsExactly("WARNING: Bad grpclb config, using ROUND_ROBIN");
+    assertThat(mode).isEqualTo(Mode.ROUND_ROBIN);
+  }
+
   private void deliverSubchannelState(
       final Subchannel subchannel, final ConnectivityStateInfo newState) {
     syncContext.execute(new Runnable() {


### PR DESCRIPTION
Make sure the config for grpclb is passed to the `GrpclbLoadBalancer`, which will support two child policies -- "round_robin" (default) and "pick_first".

Previously the presence of balancer addresses would dictate "grpclb" policy, despite of the service config. Service config will now take precedence instead.

Implement config parsing logic in `GrpclbLoadBalancer`. Per offline discussions with @markdroth and @ejona86, we will ignore configuration errors for now. The more appropriate [config error handling](https://github.com/grpc/proposal/pull/100) is upcoming.