### PR TITLE
core: add internal transport attribute ATTR_CLIENT_EAG_ATTRS

### DIFF
--- a/core/src/main/java/io/grpc/Grpc.java
+++ b/core/src/main/java/io/grpc/Grpc.java
@@ -55,6 +55,18 @@ public final class Grpc {
       Attributes.Key.create("ssl-session");
 
   /**
+   * Attribute key for the attributes of the {@link EquivalentAddressGroup} ({@link
+   * EquivalentAddressGroup#getAttributes}) that the transport's server address is from.  This is a
+   * client-side-only transport attribute, and available right after the transport is started.
+   *
+   * @since 1.20.0
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
+  @TransportAttr
+  public static final Attributes.Key<Attributes> TRANSPORT_ATTR_CLIENT_EAG_ATTRS =
+      Attributes.Key.create("client-eag-attrs");
+
+  /**
    * Annotation for transport attributes. It follows the annotation semantics defined
    * by {@link Attributes}.
    */

--- a/core/src/main/java/io/grpc/Grpc.java
+++ b/core/src/main/java/io/grpc/Grpc.java
@@ -55,18 +55,6 @@ public final class Grpc {
       Attributes.Key.create("ssl-session");
 
   /**
-   * Attribute key for the attributes of the {@link EquivalentAddressGroup} ({@link
-   * EquivalentAddressGroup#getAttributes}) that the transport's server address is from.  This is a
-   * client-side-only transport attribute, and available right after the transport is started.
-   *
-   * @since 1.20.0
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
-  @TransportAttr
-  public static final Attributes.Key<Attributes> TRANSPORT_ATTR_CLIENT_EAG_ATTRS =
-      Attributes.Key.create("client-eag-attrs");
-
-  /**
    * Annotation for transport attributes. It follows the annotation semantics defined
    * by {@link Attributes}.
    */

--- a/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java
@@ -202,7 +202,8 @@ public final class InProcessChannelBuilder extends
         throw new IllegalStateException("The transport factory is closed.");
       }
       return new InProcessTransport(
-          name, maxInboundMetadataSize, options.getAuthority(), options.getUserAgent());
+          name, maxInboundMetadataSize, options.getAuthority(), options.getUserAgent(),
+          options.getEagAttributes());
     }
 
     @Override

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -120,7 +120,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
     checkNotNull(eagAttrs, "eagAttrs");
     this.attributes = Attributes.newBuilder()
         .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
-        .set(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS, eagAttrs)
+        .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs)
         .build();
     logId = InternalLogId.allocate(getClass(), name);
   }

--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -94,9 +94,8 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
   private Set<InProcessStream> streams = new HashSet<>();
   @GuardedBy("this")
   private List<ServerStreamTracer.Factory> serverStreamTracerFactories;
-  private final Attributes attributes = Attributes.newBuilder()
-      .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
-      .build();
+  private final Attributes attributes;
+
   @GuardedBy("this")
   private final InUseStateAggregator<InProcessStream> inUseState =
       new InUseStateAggregator<InProcessStream>() {
@@ -112,11 +111,17 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       };
 
   public InProcessTransport(
-      String name, int maxInboundMetadataSize, String authority, String userAgent) {
+      String name, int maxInboundMetadataSize, String authority, String userAgent,
+      Attributes eagAttrs) {
     this.name = name;
     this.clientMaxInboundMetadataSize = maxInboundMetadataSize;
     this.authority = authority;
     this.userAgent = GrpcUtil.getGrpcUserAgent("inprocess", userAgent);
+    checkNotNull(eagAttrs, "eagAttrs");
+    this.attributes = Attributes.newBuilder()
+        .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
+        .set(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS, eagAttrs)
+        .build();
     logId = InternalLogId.allocate(getClass(), name);
   }
 

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -58,5 +58,14 @@ public final class GrpcAttributes {
   public static final Attributes.Key<SecurityLevel> ATTR_SECURITY_LEVEL =
       Attributes.Key.create("io.grpc.internal.GrpcAttributes.securityLevel");
 
+  /**
+   * Attribute key for the attributes of the {@link EquivalentAddressGroup} ({@link
+   * EquivalentAddressGroup#getAttributes}) that the transport's server address is from.  This is a
+   * client-side-only transport attribute, and available right after the transport is started.
+   */
+  @Grpc.TransportAttr
+  public static final Attributes.Key<Attributes> ATTR_CLIENT_EAG_ATTRS =
+      Attributes.Key.create("io.grpc.internal.GrpcAttributes.clientEagAttrs");
+
   private GrpcAttributes() {}
 }

--- a/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
+++ b/core/src/test/java/io/grpc/inprocess/InProcessTransportTest.java
@@ -58,7 +58,8 @@ public class InProcessTransportTest extends AbstractTransportTest {
   @Override
   protected ManagedClientTransport newClientTransport(InternalServer server) {
     return new InProcessTransport(
-        TRANSPORT_NAME, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, testAuthority(server), USER_AGENT);
+        TRANSPORT_NAME, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, testAuthority(server), USER_AGENT,
+        eagAttrs());
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -91,6 +91,12 @@ public abstract class AbstractTransportTest {
   private static final Attributes.Key<String> ADDITIONAL_TRANSPORT_ATTR_KEY =
       Attributes.Key.create("additional-attr");
 
+  private static final Attributes.Key<String> EAG_ATTR_KEY =
+      Attributes.Key.create("eag-attr");
+
+  private static final Attributes EAG_ATTRS =
+      Attributes.newBuilder().set(EAG_ATTR_KEY, "value").build();
+
   protected final TransportTracer.Factory fakeClockTransportTracer = new TransportTracer.Factory(
       new TimeProvider() {
         @Override
@@ -127,6 +133,10 @@ public abstract class AbstractTransportTest {
    */
   protected boolean sizesReported() {
     return true;
+  }
+
+  protected final Attributes eagAttrs() {
+    return EAG_ATTRS;
   }
 
   /**
@@ -724,7 +734,13 @@ public abstract class AbstractTransportTest {
     InOrder serverInOrder = inOrder(serverStreamTracerFactory);
     server.start(serverListener);
     client = newClientTransport(server);
+
     startTransport(client, mockClientTransportListener);
+
+    // This attribute is available right after transport is started
+    assertThat(((ConnectionClientTransport) client).getAttributes()
+        .get(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS)).isSameAs(EAG_ATTRS);
+
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     serverTransport = serverTransportListener.transport;
@@ -767,6 +783,10 @@ public abstract class AbstractTransportTest {
         serverStream.getAttributes().get(ADDITIONAL_TRANSPORT_ATTR_KEY));
     assertNotNull(serverStream.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
     assertNotNull(serverStream.getAttributes().get(Grpc.TRANSPORT_ATTR_LOCAL_ADDR));
+
+    // This attribute is still available when the transport is connected
+    assertThat(((ConnectionClientTransport) client).getAttributes()
+        .get(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS)).isSameAs(EAG_ATTRS);
 
     serverStream.request(1);
     assertTrue(clientStreamListener.awaitOnReadyAndDrain(TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractTransportTest.java
@@ -739,7 +739,7 @@ public abstract class AbstractTransportTest {
 
     // This attribute is available right after transport is started
     assertThat(((ConnectionClientTransport) client).getAttributes()
-        .get(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS)).isSameAs(EAG_ATTRS);
+        .get(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS)).isSameAs(EAG_ATTRS);
 
     MockServerTransportListener serverTransportListener
         = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -786,7 +786,7 @@ public abstract class AbstractTransportTest {
 
     // This attribute is still available when the transport is connected
     assertThat(((ConnectionClientTransport) client).getAttributes()
-        .get(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS)).isSameAs(EAG_ATTRS);
+        .get(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS)).isSameAs(EAG_ATTRS);
 
     serverStream.request(1);
     assertTrue(clientStreamListener.awaitOnReadyAndDrain(TIMEOUT_MS, TimeUnit.MILLISECONDS));

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -223,7 +223,8 @@ public final class CronetChannelBuilder extends
         SocketAddress addr, ClientTransportOptions options) {
       InetSocketAddress inetSocketAddr = (InetSocketAddress) addr;
       return new CronetClientTransport(streamFactory, inetSocketAddr, options.getAuthority(),
-          options.getUserAgent(), executor, maxMessageSize, alwaysUsePut, transportTracer);
+          options.getUserAgent(), options.getEagAttributes(), executor, maxMessageSize,
+          alwaysUsePut, transportTracer);
     }
 
     @Override

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -82,6 +82,7 @@ class CronetClientTransport implements ConnectionClientTransport {
       InetSocketAddress address,
       String authority,
       @Nullable String userAgent,
+      Attributes eagAttrs,
       Executor executor,
       int maxMessageSize,
       boolean alwaysUsePut,
@@ -97,6 +98,7 @@ class CronetClientTransport implements ConnectionClientTransport {
     this.transportTracer = Preconditions.checkNotNull(transportTracer, "transportTracer");
     this.attrs = Attributes.newBuilder()
         .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
+        .set(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS, eagAttrs)
         .build();
   }
 

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.Grpc;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientTransport.java
@@ -21,7 +21,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
-import io.grpc.Grpc;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalLogId;
 import io.grpc.Metadata;
@@ -99,7 +98,7 @@ class CronetClientTransport implements ConnectionClientTransport {
     this.transportTracer = Preconditions.checkNotNull(transportTracer, "transportTracer");
     this.attrs = Attributes.newBuilder()
         .set(GrpcAttributes.ATTR_SECURITY_LEVEL, SecurityLevel.PRIVACY_AND_INTEGRITY)
-        .set(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS, eagAttrs)
+        .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs)
         .build();
   }
 

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
-import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -91,7 +90,7 @@ public final class CronetClientTransportTest {
     Attributes attrs = transport.getAttributes();
     assertEquals(
         SecurityLevel.PRIVACY_AND_INTEGRITY, attrs.get(GrpcAttributes.ATTR_SECURITY_LEVEL));
-    assertEquals(EAG_ATTRS, attrs.get(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS));
+    assertEquals(EAG_ATTRS, attrs.get(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS));
   }
 
   @Test

--- a/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
+++ b/cronet/src/test/java/io/grpc/cronet/CronetClientTransportTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
+import io.grpc.Grpc;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.SecurityLevel;
@@ -51,6 +52,11 @@ import org.robolectric.RobolectricTestRunner;
 public final class CronetClientTransportTest {
 
   private static final String AUTHORITY = "test.example.com";
+  private static final Attributes.Key<String> EAG_ATTR_KEY =
+      Attributes.Key.create("eag-attr");
+
+  private static final Attributes EAG_ATTRS =
+      Attributes.newBuilder().set(EAG_ATTR_KEY, "value").build();
 
   private CronetClientTransport transport;
   @Mock private StreamBuilderFactory streamFactory;
@@ -69,6 +75,7 @@ public final class CronetClientTransportTest {
             new InetSocketAddress("localhost", 443),
             AUTHORITY,
             null,
+            EAG_ATTRS,
             executor,
             5000,
             false,
@@ -84,6 +91,7 @@ public final class CronetClientTransportTest {
     Attributes attrs = transport.getAttributes();
     assertEquals(
         SecurityLevel.PRIVACY_AND_INTEGRITY, attrs.get(GrpcAttributes.ATTR_SECURITY_LEVEL));
+    assertEquals(EAG_ATTRS, attrs.get(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS));
   }
 
   @Test

--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
@@ -24,13 +24,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import io.grpc.Attributes;
-import io.grpc.Grpc;
 import io.grpc.InternalChannelz;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.ClientTransport.PingCallback;
+import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.Http2Ping;
 import io.grpc.internal.InUseStateAggregator;
@@ -249,7 +249,7 @@ class NettyClientHandler extends AbstractNettyHandler {
     this.eagAttributes = eagAttributes;
     this.authority = authority;
     this.attributes = Attributes.newBuilder()
-        .set(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS, eagAttributes).build();
+        .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttributes).build();
 
     // Set the frame listener on the decoder.
     decoder().frameListener(new FrameListener());

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -546,7 +546,7 @@ public class NettyClientTransportTest {
     NettyClientTransport transport = newTransport(new NoopProtocolNegotiator());
     callMeMaybe(transport.start(clientTransportListener));
 
-    assertEquals(Attributes.EMPTY, transport.getAttributes());
+    assertNotNull(transport.getAttributes());
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyTransportTest.java
@@ -94,7 +94,8 @@ public class NettyTransportTest extends AbstractTransportTest {
     return clientFactory.newClientTransport(
         server.getListenSocketAddress(),
         new ClientTransportFactory.ClientTransportOptions()
-          .setAuthority(testAuthority(server)));
+          .setAuthority(testAuthority(server))
+          .setEagAttributes(eagAttrs()));
   }
 
   @org.junit.Ignore

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -561,6 +561,7 @@ public class OkHttpChannelBuilder extends
           inetSocketAddr,
           options.getAuthority(),
           options.getUserAgent(),
+          options.getEagAttributes(),
           executor,
           socketFactory,
           sslSocketFactory,

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -161,7 +161,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
   private int connectionUnacknowledgedBytesRead;
   private ClientFrameHandler clientFrameHandler;
   // Caution: Not synchronized, new value can only be safely read after the connection is complete.
-  private Attributes attributes = Attributes.EMPTY;
+  private Attributes attributes;
   /**
    * Indicates the transport is in go-away state: no new streams will be processed, but existing
    * streams may continue.
@@ -225,6 +225,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       InetSocketAddress address,
       String authority,
       @Nullable String userAgent,
+      Attributes eagAttrs,
       Executor executor,
       @Nullable SocketFactory socketFactory,
       @Nullable SSLSocketFactory sslSocketFactory,
@@ -257,6 +258,8 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     this.maxInboundMetadataSize = maxInboundMetadataSize;
     this.transportTracer = Preconditions.checkNotNull(transportTracer);
     this.logId = InternalLogId.allocate(getClass(), address.toString());
+    this.attributes = Attributes.newBuilder()
+        .set(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS, eagAttrs).build();
     initTransportTracer();
   }
 
@@ -547,8 +550,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
           asyncSink.becomeConnected(Okio.sink(sock), sock);
 
           // The return value of OkHttpTlsUpgrader.upgrade is an SSLSocket that has this info
-          attributes = Attributes
-              .newBuilder()
+          attributes = attributes.toBuilder()
               .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, sock.getRemoteSocketAddress())
               .set(Grpc.TRANSPORT_ATTR_LOCAL_ADDR, sock.getLocalSocketAddress())
               .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, sslSession)

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -259,7 +259,7 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
     this.transportTracer = Preconditions.checkNotNull(transportTracer);
     this.logId = InternalLogId.allocate(getClass(), address.toString());
     this.attributes = Attributes.newBuilder()
-        .set(Grpc.TRANSPORT_ATTR_CLIENT_EAG_ATTRS, eagAttrs).build();
+        .set(GrpcAttributes.ATTR_CLIENT_EAG_ATTRS, eagAttrs).build();
     initTransportTracer();
   }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpClientTransportTest.java
@@ -54,6 +54,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.InternalChannelz.SocketStats;
@@ -138,6 +139,7 @@ public class OkHttpClientTransportTest {
   private static final HttpConnectProxiedSocketAddress NO_PROXY = null;
   private static final int DEFAULT_START_STREAM_ID = 3;
   private static final int DEFAULT_MAX_INBOUND_METADATA_SIZE = Integer.MAX_VALUE;
+  private static final Attributes EAG_ATTRS = Attributes.EMPTY;
 
   @Rule public final Timeout globalTimeout = Timeout.seconds(10);
 
@@ -244,6 +246,7 @@ public class OkHttpClientTransportTest {
         address,
         "hostname",
         /*agent=*/ null,
+        EAG_ATTRS,
         executor,
         socketFactory,
         sslSocketFactory,
@@ -1534,6 +1537,7 @@ public class OkHttpClientTransportTest {
         new InetSocketAddress("host", 1234),
         "invalid_authority",
         "userAgent",
+        EAG_ATTRS,
         executor,
         socketFactory,
         sslSocketFactory,
@@ -1559,6 +1563,7 @@ public class OkHttpClientTransportTest {
         new InetSocketAddress("localhost", 0),
         "authority",
         "userAgent",
+        EAG_ATTRS,
         executor,
         socketFactory,
         sslSocketFactory,
@@ -1595,6 +1600,7 @@ public class OkHttpClientTransportTest {
             new InetSocketAddress("localhost", 0),
             "authority",
             "userAgent",
+            EAG_ATTRS,
             executor,
             socketFactory,
             sslSocketFactory,
@@ -1624,6 +1630,7 @@ public class OkHttpClientTransportTest {
         targetAddress,
         "authority",
         "userAgent",
+        EAG_ATTRS,
         executor,
         socketFactory,
         sslSocketFactory,
@@ -1679,6 +1686,7 @@ public class OkHttpClientTransportTest {
         targetAddress,
         "authority",
         "userAgent",
+        EAG_ATTRS,
         executor,
         socketFactory,
         sslSocketFactory,
@@ -1733,6 +1741,7 @@ public class OkHttpClientTransportTest {
         targetAddress,
         "authority",
         "userAgent",
+        EAG_ATTRS,
         executor,
         socketFactory,
         sslSocketFactory,

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpTransportTest.java
@@ -83,7 +83,8 @@ public class OkHttpTransportTest extends AbstractTransportTest {
     return clientFactory.newClientTransport(
         new InetSocketAddress("localhost", port),
         new ClientTransportFactory.ClientTransportOptions()
-          .setAuthority(testAuthority(server)));
+          .setAuthority(testAuthority(server))
+          .setEagAttributes(eagAttrs()));
   }
 
   @Override


### PR DESCRIPTION
This is needed for GRPCLB pick_first support, which needs to attach
tokens to headers, and the tokens are per server.  In pick_first, all
addresses are in a single Subchannel, thus the LoadBalancer needs to
know which backend is used for a new stream.