### PR TITLE
core,okhttp,testing: add proguard flags

### DIFF
--- a/core/proguard.flags
+++ b/core/proguard.flags
@@ -1,0 +1,2 @@
+# Needed for DNS resolution.  Present in OpenJDK, but not Android
+-dontwarn javax.naming.**

--- a/okhttp/proguard.flags
+++ b/okhttp/proguard.flags
@@ -1,0 +1,2 @@
+-dontnote io.grpc.okhttp.internal.Platform
+-dontnote io.grpc.okhttp.OkHttpProtocolNegotiator

--- a/testing/proguard.flags
+++ b/testing/proguard.flags
@@ -1,0 +1,4 @@
+# Sorry if this file messes you up.  Proguard makes it really difficult to find out where the 
+# classes if complains about come from, leading to seemingly impossible warnings to arise.
+-dontwarn org.hamcrest.**
+-dontwarn android.test.**


### PR DESCRIPTION
@ericgribkoff  had suggesting these flags files could live in OSS, and in the scope of #5422 it seems there would be some use of them.  

Currently these have no effect, but they serve as references we can point people to.  Also, these match the internal copies (in content and file path).