### PR TITLE
Workaround Bazel 0.23 incompatibility (v1.19.x version)

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -91,7 +91,7 @@ _java_rpc_library = rule(
     fragments = ["java"],
     outputs = {
         "jar": "lib%{name}.jar",
-        "srcjar": "lib%{name}-src.jar",
+        "srcjar": "lib%{name}-source.jar",
     },
     provides = [JavaInfo],
     implementation = _java_rpc_library_impl,


### PR DESCRIPTION
--incompatible_generate_javacommon_source_jar was introduced in 0.22 and became
default in 0.23, but there isn't a way to support the old and new way at the
same time.

We generate a srcjar with the same lib${name}-src.jar, but now
java_common.compile is also producing a srcjar with that same name and causes a
conflict. This requires us to choose a different name for our srcjar, but any
existing users of the srcjar will break if on 0.22 and earlier (excepting they
specify the incompatible flag in 0.22) as the file name referenced is no longer
available. For such users, they will need to change their grpc version at the
same time as changing their Bazel version.

See #5395 and #5412

-----

Note that this is against v1.19.x and not master. Note also it differs from the solution performed on master in #5395 since that requires Bazel 0.23.

CC @cushon