### PR TITLE
netty: add a proxy handler

### DIFF
--- a/core/src/main/java/io/grpc/Grpc.java
+++ b/core/src/main/java/io/grpc/Grpc.java
@@ -47,6 +47,14 @@ public final class Grpc {
       Attributes.Key.create("local-addr");
 
   /**
+   * Attribute key for the proxied remote address of a transport.
+   */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")
+  @TransportAttr
+  public static final Attributes.Key<SocketAddress> TRANSPORT_ATTR_PROXIED_REMOTE_ADDR =
+      Attributes.Key.create("proxy-remote-addr");
+
+  /**
    * Attribute key for SSL session of a transport.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1710")


### PR DESCRIPTION
New Pieces:

* Added an Http connect proxy.  
* Record the target proxy address in an attribute key (in the new handler)
* Added docs about new protocol negotiator style

Missing pieces:

* New handler is not wired up, ProxiedSocketAddress is not changed

Where this is going:

Each negotiator in ProtocolNegotiators will insert ClientHttpProxyHandler before WaitUntilActiveHandler.  This will make each negotiator capable of handling proxy addresses, (but not yet required to handle them).  This will remove the chaining of the ProxyProtocolNegotiator.  The motivation is that these new style negotiators expect to be have total knowledge of the handlers that will be added.  The handlers are composable, rather than the negotiators.

The new attributed is currently used for testing, but will eventually be represented in the Channelz data.  I don't expect this will have any use to applications, so we could remove it from the attributes, if desired.