### PR TITLE
core: normalize log statement callsite

### DIFF
--- a/core/src/main/java/io/grpc/internal/ChannelTracer.java
+++ b/core/src/main/java/io/grpc/internal/ChannelTracer.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -121,7 +122,13 @@ final class ChannelTracer {
 
   void logOnly(Level logLevel, String msg) {
     if (logger.isLoggable(logLevel)) {
-      logger.log(logLevel, "[" + logId + "] " + msg);
+      LogRecord lr = new LogRecord(logLevel, "[" + logId + "] " + msg);
+      // No resource bundle as gRPC is not localized.
+      lr.setLoggerName(logger.getName());
+      lr.setSourceClassName(ChannelLogger.class.getName());
+      // Both logger methods are called log in ChannelLogger.
+      lr.setSourceMethodName("log");
+      logger.log(lr);
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/ChannelTracer.java
+++ b/core/src/main/java/io/grpc/internal/ChannelTracer.java
@@ -125,7 +125,7 @@ final class ChannelTracer {
       LogRecord lr = new LogRecord(logLevel, "[" + logId + "] " + msg);
       // No resource bundle as gRPC is not localized.
       lr.setLoggerName(logger.getName());
-      lr.setSourceClassName(ChannelLogger.class.getName());
+      lr.setSourceClassName(logger.getName());
       // Both logger methods are called log in ChannelLogger.
       lr.setSourceMethodName("log");
       logger.log(lr);


### PR DESCRIPTION
Make the "logged" method be consistent, and refer to the public logging class name and method.  This makes the log statements return the same class name used to set the log level.  

Before:

```
190306 13:29:39.290:D 1 [io.grpc.internal.ChannelTracer.logOnly] [Channel<1>: (localhost:10000)] Channel for 'localhost:10000' created
190306 13:29:39.414:D 1 [io.grpc.internal.ChannelTracer.logOnly] [Channel<1>: (localhost:10000)] Exiting idle mode
190306 13:29:39.622:D 17 [io.grpc.internal.ChannelTracer.logOnly] [Channel<1>: (localhost:10000)] Resolved address: [[[/127.0.0.1:10000]/{}]], config={}
190306 13:29:39.623:D 17 [io.grpc.internal.ChannelTracer.logOnly] [Channel<1>: (localhost:10000)] Address resolved: [[[/127.0.0.1:10000]/{}]]
190306 13:29:39.624:D 17 [io.grpc.internal.ChannelTracer.logOnly] [Subchannel<3>] Subchannel for [[[/127.0.0.1:10000]/{}]] created
```

After:

```
190306 13:49:15.654:D 1 [io.grpc.ChannelLogger.log] [Channel<1>: (localhost:10000)] Channel for 'localhost:10000' created
190306 13:49:15.772:D 1 [io.grpc.ChannelLogger.log] [Channel<1>: (localhost:10000)] Exiting idle mode
190306 13:49:15.995:D 18 [io.grpc.ChannelLogger.log] [Channel<1>: (localhost:10000)] Resolved address: [[[/127.0.0.1:10000]/{}]], config={}
190306 13:49:15.995:D 18 [io.grpc.ChannelLogger.log] [Channel<1>: (localhost:10000)] Address resolved: [[[/127.0.0.1:10000]/{}]]
190306 13:49:15.997:D 18 [io.grpc.ChannelLogger.log] [Subchannel<3>] Subchannel for [[[/127.0.0.1:10000]/{}]] created
190306 13:49:15.999:D 18 [io.grpc.ChannelLogger.log] [Channel<1>: (localhost:10000)] Child Subchannel created
```