### PR TITLE
core,grpclb: use better generics on service config

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -109,7 +109,7 @@ public abstract class LoadBalancer {
    * <p>{@link NameResolver}s should not produce this attribute.
    */
   @NameResolver.ResolutionResultAttr
-  public static final Attributes.Key<Map<String, Object>> ATTR_LOAD_BALANCING_CONFIG =
+  public static final Attributes.Key<Map<String, ?>> ATTR_LOAD_BALANCING_CONFIG =
       Attributes.Key.create("io.grpc.LoadBalancer.loadBalancingConfig");
 
   /**

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -217,7 +217,7 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
 
       List<LbConfig> lbConfigs = null;
       if (config != null) {
-        List<? extends Map<String, ?>> rawLbConfigs =
+        List<Map<String, ?>> rawLbConfigs =
             ServiceConfigUtil.getLoadBalancingConfigsFromServiceConfig(config);
         lbConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(rawLbConfigs);
       }

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -106,7 +106,7 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
             "Unexpected ATTR_LOAD_BALANCING_CONFIG from upstream: "
             + attributes.get(ATTR_LOAD_BALANCING_CONFIG));
       }
-      Map<String, Object> configMap = attributes.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
+      Map<String, ?> configMap = attributes.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
       PolicySelection selection;
       try {
         selection = decideLoadBalancerProvider(servers, configMap);
@@ -202,7 +202,7 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
      */
     @VisibleForTesting
     PolicySelection decideLoadBalancerProvider(
-        List<EquivalentAddressGroup> servers, @Nullable Map<String, Object> config)
+        List<EquivalentAddressGroup> servers, @Nullable Map<String, ?> config)
         throws PolicyException {
       // Check for balancer addresses
       boolean haveBalancerAddress = false;
@@ -217,7 +217,7 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
 
       List<LbConfig> lbConfigs = null;
       if (config != null) {
-        List<Map<String, Object>> rawLbConfigs =
+        List<? extends Map<String, ?>> rawLbConfigs =
             ServiceConfigUtil.getLoadBalancingConfigsFromServiceConfig(config);
         lbConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(rawLbConfigs);
       }
@@ -304,11 +304,11 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
   static final class PolicySelection {
     final LoadBalancerProvider provider;
     final List<EquivalentAddressGroup> serverList;
-    @Nullable final Map<String, Object> config;
+    @Nullable final Map<String, ?> config;
 
     PolicySelection(
         LoadBalancerProvider provider, List<EquivalentAddressGroup> serverList,
-        @Nullable Map<String, Object> config) {
+        @Nullable Map<String, ?> config) {
       this.provider = checkNotNull(provider, "provider");
       this.serverList = Collections.unmodifiableList(checkNotNull(serverList, "serverList"));
       this.config = config;

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -285,10 +285,9 @@ final class DnsNameResolver extends NameResolver {
 
       Attributes.Builder attrs = Attributes.newBuilder();
       if (!resolutionResults.txtRecords.isEmpty()) {
-        Map<String, Object> serviceConfig = null;
+        Map<String, ?> serviceConfig = null;
         try {
-          for (Map<String, Object> possibleConfig :
-              parseTxtResults(resolutionResults.txtRecords)) {
+          for (Map<String, ?> possibleConfig : parseTxtResults(resolutionResults.txtRecords)) {
             try {
               serviceConfig =
                   maybeChooseServiceConfig(possibleConfig, random, getLocalHostname());
@@ -406,23 +405,23 @@ final class DnsNameResolver extends NameResolver {
 
   @SuppressWarnings("unchecked")
   @VisibleForTesting
-  static List<Map<String, Object>> parseTxtResults(List<String> txtRecords) {
-    List<Map<String, Object>> serviceConfigs = new ArrayList<>();
+  static List<? extends Map<String, ?>> parseTxtResults(List<String> txtRecords) {
+    List<Map<String, ?>> serviceConfigs = new ArrayList<>();
     for (String txtRecord : txtRecords) {
       if (txtRecord.startsWith(SERVICE_CONFIG_PREFIX)) {
-        List<Map<String, Object>> choices;
+        List<? extends Map<String, ?>> choices;
         try {
           Object rawChoices = JsonParser.parse(txtRecord.substring(SERVICE_CONFIG_PREFIX.length()));
           if (!(rawChoices instanceof List)) {
             throw new IOException("wrong type " + rawChoices);
           }
-          List<Object> listChoices = (List<Object>) rawChoices;
+          List<?> listChoices = (List<?>) rawChoices;
           for (Object obj : listChoices) {
             if (!(obj instanceof Map)) {
               throw new IOException("wrong element type " + rawChoices);
             }
           }
-          choices = (List<Map<String, Object>>) (List<?>) listChoices;
+          choices = (List<? extends Map<String, ?>>) listChoices;
         } catch (IOException e) {
           logger.log(Level.WARNING, "Bad service config: " + txtRecord, e);
           continue;
@@ -436,8 +435,7 @@ final class DnsNameResolver extends NameResolver {
   }
 
   @Nullable
-  private static final Double getPercentageFromChoice(
-      Map<String, Object> serviceConfigChoice) {
+  private static final Double getPercentageFromChoice(Map<String, ?> serviceConfigChoice) {
     if (!serviceConfigChoice.containsKey(SERVICE_CONFIG_CHOICE_PERCENTAGE_KEY)) {
       return null;
     }
@@ -446,7 +444,7 @@ final class DnsNameResolver extends NameResolver {
 
   @Nullable
   private static final List<String> getClientLanguagesFromChoice(
-      Map<String, Object> serviceConfigChoice) {
+      Map<String, ?> serviceConfigChoice) {
     if (!serviceConfigChoice.containsKey(SERVICE_CONFIG_CHOICE_CLIENT_LANGUAGE_KEY)) {
       return null;
     }
@@ -455,8 +453,7 @@ final class DnsNameResolver extends NameResolver {
   }
 
   @Nullable
-  private static final List<String> getHostnamesFromChoice(
-      Map<String, Object> serviceConfigChoice) {
+  private static final List<String> getHostnamesFromChoice(Map<String, ?> serviceConfigChoice) {
     if (!serviceConfigChoice.containsKey(SERVICE_CONFIG_CHOICE_CLIENT_HOSTNAME_KEY)) {
       return null;
     }
@@ -499,8 +496,8 @@ final class DnsNameResolver extends NameResolver {
    */
   @Nullable
   @VisibleForTesting
-  static Map<String, Object> maybeChooseServiceConfig(
-      Map<String, Object> choice, Random random, String hostname) {
+  static Map<String, ?> maybeChooseServiceConfig(
+      Map<String, ?> choice, Random random, String hostname) {
     for (Entry<String, ?> entry : choice.entrySet()) {
       Verify.verify(SERVICE_CONFIG_CHOICE_KEYS.contains(entry.getKey()), "Bad key: %s", entry);
     }

--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -405,11 +405,11 @@ final class DnsNameResolver extends NameResolver {
 
   @SuppressWarnings("unchecked")
   @VisibleForTesting
-  static List<? extends Map<String, ?>> parseTxtResults(List<String> txtRecords) {
+  static List<Map<String, ?>> parseTxtResults(List<String> txtRecords) {
     List<Map<String, ?>> serviceConfigs = new ArrayList<>();
     for (String txtRecord : txtRecords) {
       if (txtRecord.startsWith(SERVICE_CONFIG_PREFIX)) {
-        List<? extends Map<String, ?>> choices;
+        List<Map<String, ?>> choices;
         try {
           Object rawChoices = JsonParser.parse(txtRecord.substring(SERVICE_CONFIG_PREFIX.length()));
           if (!(rawChoices instanceof List)) {
@@ -421,7 +421,7 @@ final class DnsNameResolver extends NameResolver {
               throw new IOException("wrong element type " + rawChoices);
             }
           }
-          choices = (List<? extends Map<String, ?>>) listChoices;
+          choices = (List<Map<String, ?>>) listChoices;
         } catch (IOException e) {
           logger.log(Level.WARNING, "Bad service config: " + txtRecord, e);
           continue;

--- a/core/src/main/java/io/grpc/internal/GrpcAttributes.java
+++ b/core/src/main/java/io/grpc/internal/GrpcAttributes.java
@@ -31,7 +31,7 @@ public final class GrpcAttributes {
    * Attribute key for service config.
    */
   @NameResolver.ResolutionResultAttr
-  public static final Attributes.Key<Map<String, Object>> NAME_RESOLVER_SERVICE_CONFIG =
+  public static final Attributes.Key<Map<String, ?>> NAME_RESOLVER_SERVICE_CONFIG =
       Attributes.Key.create("service-config");
 
   /**

--- a/core/src/main/java/io/grpc/internal/JsonParser.java
+++ b/core/src/main/java/io/grpc/internal/JsonParser.java
@@ -40,7 +40,7 @@ public final class JsonParser {
   private JsonParser() {}
 
   /**
-   * Parses a json string, returning either a {@code Map<String, Object>}, {@code List<Object>},
+   * Parses a json string, returning either a {@code Map<String, ?>}, {@code List<Object>},
    * {@code String}, {@code Double}, {@code Boolean}, or {@code null}.
    */
   @SuppressWarnings("unchecked")
@@ -77,7 +77,7 @@ public final class JsonParser {
     }
   }
 
-  private static Map<String, Object> parseJsonObject(JsonReader jr) throws IOException {
+  private static Map<String, ?> parseJsonObject(JsonReader jr) throws IOException {
     jr.beginObject();
     Map<String, Object> obj = new LinkedHashMap<>();
     while (jr.hasNext()) {
@@ -90,7 +90,7 @@ public final class JsonParser {
     return Collections.unmodifiableMap(obj);
   }
 
-  private static List<Object> parseJsonArray(JsonReader jr) throws IOException {
+  private static List<?> parseJsonArray(JsonReader jr) throws IOException {
     jr.beginArray();
     List<Object> array = new ArrayList<>();
     while (jr.hasNext()) {

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -237,7 +237,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
   @CheckForNull
   private Boolean haveBackends; // a flag for doing channel tracing when flipped
   @Nullable
-  private Map<String, Object> lastServiceConfig; // used for channel tracing when value changed
+  private Map<String, ?> lastServiceConfig; // used for channel tracing when value changed
 
   // One instance per channel.
   private final ChannelBufferMeter channelBufferUsed = new ChannelBufferMeter();
@@ -1296,8 +1296,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
         channelLogger.log(ChannelLogLevel.INFO, "Address resolved: {0}", servers);
         haveBackends = true;
       }
-      final Map<String, Object> serviceConfig =
-          config.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
+      final Map<String, ?> serviceConfig = config.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
       if (serviceConfig != null && !serviceConfig.equals(lastServiceConfig)) {
         channelLogger.log(ChannelLogLevel.INFO, "Service config changed");
         lastServiceConfig = serviceConfig;

--- a/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
@@ -73,14 +73,14 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
     this.maxHedgedAttemptsLimit = maxHedgedAttemptsLimit;
   }
 
-  void handleUpdate(@Nonnull Map<String, Object> serviceConfig) {
+  void handleUpdate(@Nonnull Map<String, ?> serviceConfig) {
     Map<String, MethodInfo> newServiceMethodConfigs = new HashMap<>();
     Map<String, MethodInfo> newServiceConfigs = new HashMap<>();
 
     // Try and do as much validation here before we swap out the existing configuration.  In case
     // the input is invalid, we don't want to lose the existing configuration.
 
-    List<Map<String, Object>> methodConfigs =
+    List<? extends Map<String, ?>> methodConfigs =
         ServiceConfigUtil.getMethodConfigFromServiceConfig(serviceConfig);
     if (methodConfigs == null) {
       logger.log(Level.FINE, "No method configs found, skipping");
@@ -88,16 +88,16 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
       return;
     }
 
-    for (Map<String, Object> methodConfig : methodConfigs) {
+    for (Map<String, ?> methodConfig : methodConfigs) {
       MethodInfo info = new MethodInfo(
           methodConfig, retryEnabled, maxRetryAttemptsLimit, maxHedgedAttemptsLimit);
 
-      List<Map<String, Object>> nameList =
+      List<? extends Map<String, ?>> nameList =
           ServiceConfigUtil.getNameListFromMethodConfig(methodConfig);
 
       checkArgument(
           nameList != null && !nameList.isEmpty(), "no names in method config %s", methodConfig);
-      for (Map<String, Object> name : nameList) {
+      for (Map<String, ?> name : nameList) {
         String serviceName = ServiceConfigUtil.getServiceFromName(name);
         checkArgument(!Strings.isNullOrEmpty(serviceName), "missing service name");
         String methodName = ServiceConfigUtil.getMethodFromName(name);
@@ -141,7 +141,7 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
      * @param retryEnabled when false, the argument maxRetryAttemptsLimit will have no effect.
      */
     MethodInfo(
-        Map<String, Object> methodConfig, boolean retryEnabled, int maxRetryAttemptsLimit,
+        Map<String, ?> methodConfig, boolean retryEnabled, int maxRetryAttemptsLimit,
         int maxHedgedAttemptsLimit) {
       timeoutNanos = ServiceConfigUtil.getTimeoutFromMethodConfig(methodConfig);
       waitForReady = ServiceConfigUtil.getWaitForReadyFromMethodConfig(methodConfig);
@@ -160,12 +160,12 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
             "maxOutboundMessageSize %s exceeds bounds", maxOutboundMessageSize);
       }
 
-      Map<String, Object> retryPolicyMap =
+      Map<String, ?> retryPolicyMap =
           retryEnabled ? ServiceConfigUtil.getRetryPolicyFromMethodConfig(methodConfig) : null;
       retryPolicy = retryPolicyMap == null
           ? RetryPolicy.DEFAULT : retryPolicy(retryPolicyMap, maxRetryAttemptsLimit);
 
-      Map<String, Object> hedgingPolicyMap =
+      Map<String, ?> hedgingPolicyMap =
           retryEnabled ? ServiceConfigUtil.getHedgingPolicyFromMethodConfig(methodConfig) : null;
       hedgingPolicy = hedgingPolicyMap == null
           ? HedgingPolicy.DEFAULT : hedgingPolicy(hedgingPolicyMap, maxHedgedAttemptsLimit);
@@ -201,7 +201,7 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
           .toString();
     }
 
-    private static RetryPolicy retryPolicy(Map<String, Object> retryPolicy, int maxAttemptsLimit) {
+    private static RetryPolicy retryPolicy(Map<String, ?> retryPolicy, int maxAttemptsLimit) {
       int maxAttempts = checkNotNull(
           ServiceConfigUtil.getMaxAttemptsFromRetryPolicy(retryPolicy),
           "maxAttempts cannot be empty");
@@ -249,7 +249,7 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
   }
 
   private static HedgingPolicy hedgingPolicy(
-      Map<String, Object> hedgingPolicy, int maxAttemptsLimit) {
+      Map<String, ?> hedgingPolicy, int maxAttemptsLimit) {
     int maxAttempts = checkNotNull(
         ServiceConfigUtil.getMaxAttemptsFromHedgingPolicy(hedgingPolicy),
         "maxAttempts cannot be empty");

--- a/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
@@ -80,7 +80,7 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
     // Try and do as much validation here before we swap out the existing configuration.  In case
     // the input is invalid, we don't want to lose the existing configuration.
 
-    List<? extends Map<String, ?>> methodConfigs =
+    List<Map<String, ?>> methodConfigs =
         ServiceConfigUtil.getMethodConfigFromServiceConfig(serviceConfig);
     if (methodConfigs == null) {
       logger.log(Level.FINE, "No method configs found, skipping");
@@ -92,7 +92,7 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
       MethodInfo info = new MethodInfo(
           methodConfig, retryEnabled, maxRetryAttemptsLimit, maxHedgedAttemptsLimit);
 
-      List<? extends Map<String, ?>> nameList =
+      List<Map<String, ?>> nameList =
           ServiceConfigUtil.getNameListFromMethodConfig(methodConfig);
 
       checkArgument(

--- a/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
@@ -243,7 +243,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static List<? extends Map<String, ?>> getNameListFromMethodConfig(
+  static List<Map<String, ?>> getNameListFromMethodConfig(
       Map<String, ?> methodConfig) {
     if (!methodConfig.containsKey(METHOD_CONFIG_NAME_KEY)) {
       return null;
@@ -294,7 +294,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static List<? extends Map<String, ?>> getMethodConfigFromServiceConfig(
+  static List<Map<String, ?>> getMethodConfigFromServiceConfig(
       Map<String, ?> serviceConfig) {
     if (!serviceConfig.containsKey(SERVICE_CONFIG_METHOD_CONFIG_KEY)) {
       return null;
@@ -307,7 +307,7 @@ public final class ServiceConfigUtil {
    */
   @SuppressWarnings("unchecked")
   @VisibleForTesting
-  public static List<? extends Map<String, ?>> getLoadBalancingConfigsFromServiceConfig(
+  public static List<Map<String, ?>> getLoadBalancingConfigsFromServiceConfig(
       Map<String, ?> serviceConfig) {
     /* schema as follows
     {
@@ -530,14 +530,14 @@ public final class ServiceConfigUtil {
   }
 
   @SuppressWarnings("unchecked")
-  private static List<? extends Map<String, ?>> checkObjectList(List<?> rawList) {
+  private static List<Map<String, ?>> checkObjectList(List<?> rawList) {
     for (int i = 0; i < rawList.size(); i++) {
       if (!(rawList.get(i) instanceof Map)) {
         throw new ClassCastException(
             String.format("value %s for idx %d in %s is not object", rawList.get(i), i, rawList));
       }
     }
-    return (List<? extends Map<String, ?>>) (List<?>) rawList;
+    return (List<Map<String, ?>>) rawList;
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
@@ -74,7 +74,7 @@ public final class ServiceConfigUtil {
    * Fetch the health-checked service name from service config. {@code null} if can't find one.
    */
   @Nullable
-  public static String getHealthCheckedServiceName(@Nullable Map<String, Object> serviceConfig) {
+  public static String getHealthCheckedServiceName(@Nullable Map<String, ?> serviceConfig) {
     String healthCheckKey = "healthCheckConfig";
     String serviceNameKey = "serviceName";
     if (serviceConfig == null || !serviceConfig.containsKey(healthCheckKey)) {
@@ -89,7 +89,7 @@ public final class ServiceConfigUtil {
       }
     }
     */
-    Map<String, Object> healthCheck = getObject(serviceConfig, healthCheckKey);
+    Map<String, ?> healthCheck = getObject(serviceConfig, healthCheckKey);
     if (!healthCheck.containsKey(serviceNameKey)) {
       return null;
     }
@@ -97,7 +97,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Throttle getThrottlePolicy(@Nullable Map<String, Object> serviceConfig) {
+  static Throttle getThrottlePolicy(@Nullable Map<String, ?> serviceConfig) {
     String retryThrottlingKey = "retryThrottling";
     if (serviceConfig == null || !serviceConfig.containsKey(retryThrottlingKey)) {
       return null;
@@ -122,7 +122,7 @@ public final class ServiceConfigUtil {
     }
     */
 
-    Map<String, Object> throttling = getObject(serviceConfig, retryThrottlingKey);
+    Map<String, ?> throttling = getObject(serviceConfig, retryThrottlingKey);
 
     float maxTokens = getDouble(throttling, "maxTokens").floatValue();
     float tokenRatio = getDouble(throttling, "tokenRatio").floatValue();
@@ -132,7 +132,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Integer getMaxAttemptsFromRetryPolicy(Map<String, Object> retryPolicy) {
+  static Integer getMaxAttemptsFromRetryPolicy(Map<String, ?> retryPolicy) {
     if (!retryPolicy.containsKey(RETRY_POLICY_MAX_ATTEMPTS_KEY)) {
       return null;
     }
@@ -140,7 +140,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Long getInitialBackoffNanosFromRetryPolicy(Map<String, Object> retryPolicy) {
+  static Long getInitialBackoffNanosFromRetryPolicy(Map<String, ?> retryPolicy) {
     if (!retryPolicy.containsKey(RETRY_POLICY_INITIAL_BACKOFF_KEY)) {
       return null;
     }
@@ -153,7 +153,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Long getMaxBackoffNanosFromRetryPolicy(Map<String, Object> retryPolicy) {
+  static Long getMaxBackoffNanosFromRetryPolicy(Map<String, ?> retryPolicy) {
     if (!retryPolicy.containsKey(RETRY_POLICY_MAX_BACKOFF_KEY)) {
       return null;
     }
@@ -166,7 +166,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Double getBackoffMultiplierFromRetryPolicy(Map<String, Object> retryPolicy) {
+  static Double getBackoffMultiplierFromRetryPolicy(Map<String, ?> retryPolicy) {
     if (!retryPolicy.containsKey(RETRY_POLICY_BACKOFF_MULTIPLIER_KEY)) {
       return null;
     }
@@ -174,7 +174,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static List<String> getRetryableStatusCodesFromRetryPolicy(Map<String, Object> retryPolicy) {
+  static List<String> getRetryableStatusCodesFromRetryPolicy(Map<String, ?> retryPolicy) {
     if (!retryPolicy.containsKey(RETRY_POLICY_RETRYABLE_STATUS_CODES_KEY)) {
       return null;
     }
@@ -182,7 +182,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Integer getMaxAttemptsFromHedgingPolicy(Map<String, Object> hedgingPolicy) {
+  static Integer getMaxAttemptsFromHedgingPolicy(Map<String, ?> hedgingPolicy) {
     if (!hedgingPolicy.containsKey(HEDGING_POLICY_MAX_ATTEMPTS_KEY)) {
       return null;
     }
@@ -190,7 +190,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Long getHedgingDelayNanosFromHedgingPolicy(Map<String, Object> hedgingPolicy) {
+  static Long getHedgingDelayNanosFromHedgingPolicy(Map<String, ?> hedgingPolicy) {
     if (!hedgingPolicy.containsKey(HEDGING_POLICY_HEDGING_DELAY_KEY)) {
       return null;
     }
@@ -203,7 +203,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static List<String> getNonFatalStatusCodesFromHedgingPolicy(Map<String, Object> hedgingPolicy) {
+  static List<String> getNonFatalStatusCodesFromHedgingPolicy(Map<String, ?> hedgingPolicy) {
     if (!hedgingPolicy.containsKey(HEDGING_POLICY_NON_FATAL_STATUS_CODES_KEY)) {
       return null;
     }
@@ -211,7 +211,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static String getServiceFromName(Map<String, Object> name) {
+  static String getServiceFromName(Map<String, ?> name) {
     if (!name.containsKey(NAME_SERVICE_KEY)) {
       return null;
     }
@@ -219,7 +219,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static String getMethodFromName(Map<String, Object> name) {
+  static String getMethodFromName(Map<String, ?> name) {
     if (!name.containsKey(NAME_METHOD_KEY)) {
       return null;
     }
@@ -227,7 +227,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Map<String, Object> getRetryPolicyFromMethodConfig(Map<String, Object> methodConfig) {
+  static Map<String, ?> getRetryPolicyFromMethodConfig(Map<String, ?> methodConfig) {
     if (!methodConfig.containsKey(METHOD_CONFIG_RETRY_POLICY_KEY)) {
       return null;
     }
@@ -235,7 +235,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Map<String, Object> getHedgingPolicyFromMethodConfig(Map<String, Object> methodConfig) {
+  static Map<String, ?> getHedgingPolicyFromMethodConfig(Map<String, ?> methodConfig) {
     if (!methodConfig.containsKey(METHOD_CONFIG_HEDGING_POLICY_KEY)) {
       return null;
     }
@@ -243,7 +243,8 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static List<Map<String, Object>> getNameListFromMethodConfig(Map<String, Object> methodConfig) {
+  static List<? extends Map<String, ?>> getNameListFromMethodConfig(
+      Map<String, ?> methodConfig) {
     if (!methodConfig.containsKey(METHOD_CONFIG_NAME_KEY)) {
       return null;
     }
@@ -256,7 +257,7 @@ public final class ServiceConfigUtil {
    * @return duration nanoseconds, or {@code null} if it isn't present.
    */
   @Nullable
-  static Long getTimeoutFromMethodConfig(Map<String, Object> methodConfig) {
+  static Long getTimeoutFromMethodConfig(Map<String, ?> methodConfig) {
     if (!methodConfig.containsKey(METHOD_CONFIG_TIMEOUT_KEY)) {
       return null;
     }
@@ -269,7 +270,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Boolean getWaitForReadyFromMethodConfig(Map<String, Object> methodConfig) {
+  static Boolean getWaitForReadyFromMethodConfig(Map<String, ?> methodConfig) {
     if (!methodConfig.containsKey(METHOD_CONFIG_WAIT_FOR_READY_KEY)) {
       return null;
     }
@@ -277,7 +278,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Integer getMaxRequestMessageBytesFromMethodConfig(Map<String, Object> methodConfig) {
+  static Integer getMaxRequestMessageBytesFromMethodConfig(Map<String, ?> methodConfig) {
     if (!methodConfig.containsKey(METHOD_CONFIG_MAX_REQUEST_MESSAGE_BYTES_KEY)) {
       return null;
     }
@@ -285,7 +286,7 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static Integer getMaxResponseMessageBytesFromMethodConfig(Map<String, Object> methodConfig) {
+  static Integer getMaxResponseMessageBytesFromMethodConfig(Map<String, ?> methodConfig) {
     if (!methodConfig.containsKey(METHOD_CONFIG_MAX_RESPONSE_MESSAGE_BYTES_KEY)) {
       return null;
     }
@@ -293,8 +294,8 @@ public final class ServiceConfigUtil {
   }
 
   @Nullable
-  static List<Map<String, Object>> getMethodConfigFromServiceConfig(
-      Map<String, Object> serviceConfig) {
+  static List<? extends Map<String, ?>> getMethodConfigFromServiceConfig(
+      Map<String, ?> serviceConfig) {
     if (!serviceConfig.containsKey(SERVICE_CONFIG_METHOD_CONFIG_KEY)) {
       return null;
     }
@@ -306,8 +307,8 @@ public final class ServiceConfigUtil {
    */
   @SuppressWarnings("unchecked")
   @VisibleForTesting
-  public static List<Map<String, Object>> getLoadBalancingConfigsFromServiceConfig(
-      Map<String, Object> serviceConfig) {
+  public static List<? extends Map<String, ?>> getLoadBalancingConfigsFromServiceConfig(
+      Map<String, ?> serviceConfig) {
     /* schema as follows
     {
       "loadBalancingConfig": {
@@ -325,11 +326,11 @@ public final class ServiceConfigUtil {
       "loadBalancingPolicy": "ROUND_ROBIN"  // The deprecated policy key
     }
     */
-    List<Map<String, Object>> lbConfigs = new ArrayList<>();
+    List<Map<String, ?>> lbConfigs = new ArrayList<>();
     if (serviceConfig.containsKey(SERVICE_CONFIG_LOAD_BALANCING_CONFIG_KEY)) {
-      List<Object> configs = getList(serviceConfig, SERVICE_CONFIG_LOAD_BALANCING_CONFIG_KEY);
+      List<?> configs = getList(serviceConfig, SERVICE_CONFIG_LOAD_BALANCING_CONFIG_KEY);
       for (Object config : configs) {
-        lbConfigs.add((Map<String, Object>) config);
+        lbConfigs.add((Map<String, ?>) config);
       }
     }
     if (lbConfigs.isEmpty()) {
@@ -338,7 +339,7 @@ public final class ServiceConfigUtil {
         String policy = getString(serviceConfig, SERVICE_CONFIG_LOAD_BALANCING_POLICY_KEY);
         // Convert the policy to a config, so that the caller can handle them in the same way.
         policy = policy.toLowerCase(Locale.ROOT);
-        Map<String, Object> fakeConfig =
+        Map<String, ?> fakeConfig =
             Collections.singletonMap(policy, (Object) Collections.emptyMap());
         lbConfigs.add(fakeConfig);
       }
@@ -353,9 +354,9 @@ public final class ServiceConfigUtil {
    */
   @SuppressWarnings("unchecked")
   public static LbConfig unwrapLoadBalancingConfig(Object lbConfig) {
-    Map<String, Object> map;
+    Map<String, ?> map;
     try {
-      map = (Map<String, Object>) lbConfig;
+      map = (Map<String, ?>) lbConfig;
     } catch (ClassCastException e) {
       ClassCastException ex = new ClassCastException("Invalid type. Config=" + lbConfig);
       ex.initCause(e);
@@ -366,10 +367,10 @@ public final class ServiceConfigUtil {
           "There are " + map.size() + " fields in a LoadBalancingConfig object. Exactly one"
           + " is expected. Config=" + lbConfig);
     }
-    Map.Entry<String, Object> entry = map.entrySet().iterator().next();
-    Map<String, Object> configValue;
+    Map.Entry<String, ?> entry = map.entrySet().iterator().next();
+    Map<String, ?> configValue;
     try {
-      configValue = (Map<String, Object>) entry.getValue();
+      configValue = (Map<String, ?>) entry.getValue();
     } catch (ClassCastException e) {
       ClassCastException ex =
           new ClassCastException("Invalid value type.  value=" + entry.getValue());
@@ -403,7 +404,7 @@ public final class ServiceConfigUtil {
    * Extracts the loadbalancer name from xds loadbalancer config.
    */
   public static String getBalancerNameFromXdsConfig(LbConfig xdsConfig) {
-    Map<String, Object> map = xdsConfig.getRawConfigValue();
+    Map<String, ?> map = xdsConfig.getRawConfigValue();
     return getString(map, XDS_CONFIG_BALANCER_NAME_KEY);
   }
 
@@ -412,7 +413,7 @@ public final class ServiceConfigUtil {
    */
   @Nullable
   public static List<LbConfig> getChildPolicyFromXdsConfig(LbConfig xdsConfig) {
-    Map<String, Object> map = xdsConfig.getRawConfigValue();
+    Map<String, ?> map = xdsConfig.getRawConfigValue();
     Object rawChildPolicies = map.get(XDS_CONFIG_CHILD_POLICY_KEY);
     if (rawChildPolicies != null) {
       return unwrapLoadBalancingConfigList(rawChildPolicies);
@@ -425,7 +426,7 @@ public final class ServiceConfigUtil {
    */
   @Nullable
   public static List<LbConfig> getFallbackPolicyFromXdsConfig(LbConfig xdsConfig) {
-    Map<String, Object> map = xdsConfig.getRawConfigValue();
+    Map<String, ?> map = xdsConfig.getRawConfigValue();
     Object rawFallbackPolicies = map.get(XDS_CONFIG_FALLBACK_POLICY_KEY);
     if (rawFallbackPolicies != null) {
       return unwrapLoadBalancingConfigList(rawFallbackPolicies);
@@ -438,7 +439,7 @@ public final class ServiceConfigUtil {
    */
   @Nullable
   public static String getStickinessMetadataKeyFromServiceConfig(
-      Map<String, Object> serviceConfig) {
+      Map<String, ?> serviceConfig) {
     if (!serviceConfig.containsKey(SERVICE_CONFIG_STICKINESS_METADATA_KEY)) {
       return null;
     }
@@ -449,11 +450,11 @@ public final class ServiceConfigUtil {
    * Gets a list from an object for the given key.
    */
   @SuppressWarnings("unchecked")
-  static List<Object> getList(Map<String, Object> obj, String key) {
+  static List<?> getList(Map<String, ?> obj, String key) {
     assert obj.containsKey(key);
     Object value = checkNotNull(obj.get(key), "no such key %s", key);
     if (value instanceof List) {
-      return (List<Object>) value;
+      return (List<?>) value;
     }
     throw new ClassCastException(
         String.format("value %s for key %s in %s is not List", value, key, obj));
@@ -463,11 +464,11 @@ public final class ServiceConfigUtil {
    * Gets an object from an object for the given key.
    */
   @SuppressWarnings("unchecked")
-  static Map<String, Object> getObject(Map<String, Object> obj, String key) {
+  static Map<String, ?> getObject(Map<String, ?> obj, String key) {
     assert obj.containsKey(key);
     Object value = checkNotNull(obj.get(key), "no such key %s", key);
     if (value instanceof Map) {
-      return (Map<String, Object>) value;
+      return (Map<String, ?>) value;
     }
     throw new ClassCastException(
         String.format("value %s for key %s in %s is not object", value, key, obj));
@@ -477,7 +478,7 @@ public final class ServiceConfigUtil {
    * Gets a double from an object for the given key.
    */
   @SuppressWarnings("unchecked")
-  static Double getDouble(Map<String, Object> obj, String key) {
+  static Double getDouble(Map<String, ?> obj, String key) {
     assert obj.containsKey(key);
     Object value = checkNotNull(obj.get(key), "no such key %s", key);
     if (value instanceof Double) {
@@ -491,7 +492,7 @@ public final class ServiceConfigUtil {
    * Gets a string from an object for the given key.
    */
   @SuppressWarnings("unchecked")
-  static String getString(Map<String, Object> obj, String key) {
+  static String getString(Map<String, ?> obj, String key) {
     assert obj.containsKey(key);
     Object value = checkNotNull(obj.get(key), "no such key %s", key);
     if (value instanceof String) {
@@ -505,7 +506,7 @@ public final class ServiceConfigUtil {
    * Gets a string from an object for the given index.
    */
   @SuppressWarnings("unchecked")
-  static String getString(List<Object> list, int i) {
+  static String getString(List<?> list, int i) {
     assert i >= 0 && i < list.size();
     Object value = checkNotNull(list.get(i), "idx %s in %s is null", i, list);
     if (value instanceof String) {
@@ -518,7 +519,7 @@ public final class ServiceConfigUtil {
   /**
    * Gets a boolean from an object for the given key.
    */
-  static Boolean getBoolean(Map<String, Object> obj, String key) {
+  static Boolean getBoolean(Map<String, ?> obj, String key) {
     assert obj.containsKey(key);
     Object value = checkNotNull(obj.get(key), "no such key %s", key);
     if (value instanceof Boolean) {
@@ -529,25 +530,25 @@ public final class ServiceConfigUtil {
   }
 
   @SuppressWarnings("unchecked")
-  private static List<Map<String, Object>> checkObjectList(List<Object> rawList) {
+  private static List<? extends Map<String, ?>> checkObjectList(List<?> rawList) {
     for (int i = 0; i < rawList.size(); i++) {
       if (!(rawList.get(i) instanceof Map)) {
         throw new ClassCastException(
             String.format("value %s for idx %d in %s is not object", rawList.get(i), i, rawList));
       }
     }
-    return (List<Map<String, Object>>) (List<?>) rawList;
+    return (List<? extends Map<String, ?>>) (List<?>) rawList;
   }
 
   @SuppressWarnings("unchecked")
-  static List<String> checkStringList(List<Object> rawList) {
+  static List<String> checkStringList(List<?> rawList) {
     for (int i = 0; i < rawList.size(); i++) {
       if (!(rawList.get(i) instanceof String)) {
         throw new ClassCastException(
             String.format("value %s for idx %d in %s is not string", rawList.get(i), i, rawList));
       }
     }
-    return (List<String>) (List<?>) rawList;
+    return (List<String>) rawList;
   }
 
   /**
@@ -687,9 +688,9 @@ public final class ServiceConfigUtil {
    */
   public static final class LbConfig {
     private final String policyName;
-    private final Map<String, Object> rawConfigValue;
+    private final Map<String, ?> rawConfigValue;
 
-    public LbConfig(String policyName, Map<String, Object> rawConfigValue) {
+    public LbConfig(String policyName, Map<String, ?> rawConfigValue) {
       this.policyName = checkNotNull(policyName, "policyName");
       this.rawConfigValue = checkNotNull(rawConfigValue, "rawConfigValue");
     }
@@ -698,7 +699,7 @@ public final class ServiceConfigUtil {
       return policyName;
     }
 
-    public Map<String, Object> getRawConfigValue() {
+    public Map<String, ?> getRawConfigValue() {
       return rawConfigValue;
     }
 

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -94,8 +94,7 @@ final class RoundRobinLoadBalancer extends LoadBalancer {
     Set<EquivalentAddressGroup> addedAddrs = setsDifference(latestAddrs, currentAddrs);
     Set<EquivalentAddressGroup> removedAddrs = setsDifference(currentAddrs, latestAddrs);
 
-    Map<String, Object> serviceConfig =
-        attributes.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
+    Map<String, ?> serviceConfig = attributes.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
     if (serviceConfig != null) {
       String stickinessMetadataKey =
           ServiceConfigUtil.getStickinessMetadataKeyFromServiceConfig(serviceConfig);

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -191,7 +191,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
   @Test
   public void handleResolvedAddressGroups_shutsDownOldBalancer() {
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("loadBalancingPolicy", "round_robin");
     Attributes serviceConfigAttrs =
         Attributes.newBuilder()
@@ -237,7 +237,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
   @Test
   public void handleResolvedAddressGroups_propagateLbConfigToDelegate() throws Exception {
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { \"setting1\": \"high\" } } ] }");
     Attributes serviceConfigAttrs =
         Attributes.newBuilder()
@@ -310,7 +310,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(helper);
 
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb\": { \"setting1\": \"high\" } } ] }");
     lb.handleResolvedAddressGroups(
         Collections.<EquivalentAddressGroup>emptyList(),
@@ -333,7 +333,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(helper);
 
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"test_lb2\": { \"setting1\": \"high\" } } ] }");
     lb.handleResolvedAddressGroups(
         Collections.<EquivalentAddressGroup>emptyList(),
@@ -345,7 +345,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
     verify(testLbBalancer2).handleResolvedAddressGroups(
         eq(Collections.<EquivalentAddressGroup>emptyList()), attrsCaptor.capture());
-    Map<String, Object> lbConfig =
+    Map<String, ?> lbConfig =
         attrsCaptor.getValue().get(LoadBalancer.ATTR_LOAD_BALANCING_CONFIG);
     assertThat(lbConfig).isEqualTo(Collections.<String, Object>singletonMap("setting1", "high"));
     assertThat(attrsCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
@@ -357,7 +357,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
       throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig = null;
+    Map<String, ?> serviceConfig = null;
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
     PolicySelection selection = lb.decideLoadBalancerProvider(servers, serviceConfig);
@@ -374,7 +374,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory("test_lb")
             .newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig = null;
+    Map<String, ?> serviceConfig = null;
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
     PolicySelection selection = lb.decideLoadBalancerProvider(servers, serviceConfig);
@@ -389,7 +389,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_oneBalancer_noServiceConfig_grpclb() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig = null;
+    Map<String, ?> serviceConfig = null;
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(
             new EquivalentAddressGroup(
@@ -407,7 +407,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_serviceConfigLbPolicy() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("loadBalancingPolicy", "round_robin");
     List<EquivalentAddressGroup> servers =
         Arrays.asList(
@@ -431,7 +431,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_serviceConfigLbConfig() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"round_robin\": {} } ] }");
     List<EquivalentAddressGroup> servers =
         Arrays.asList(
@@ -454,7 +454,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_grpclbConfigPropagated() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig(
             "{\"loadBalancingConfig\": ["
             + "{\"grpclb\": {\"childPolicy\": [ {\"pick_first\": {} } ] } }"
@@ -477,7 +477,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_policyUnavailButGrpclbAddressPresent() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig(
             "{\"loadBalancingConfig\": ["
             + "{\"unavail\": {} }"
@@ -506,7 +506,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(
             registry, GrpcUtil.DEFAULT_LB_POLICY).newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"grpclb\": {} } ] }");
     List<EquivalentAddressGroup> servers =
         Arrays.asList(
@@ -541,7 +541,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) new AutoConfiguredLoadBalancerFactory(
             registry, GrpcUtil.DEFAULT_LB_POLICY).newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"grpclb\": {} } ] }");
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(
@@ -562,7 +562,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_serviceConfigLbPolicyOverridesDefault() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("loadBalancingPolicy", "round_robin");
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
@@ -578,7 +578,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_serviceConfigLbConfigOverridesDefault() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"round_robin\": {\"setting1\": \"high\"} } ] }");
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
@@ -595,7 +595,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_serviceConfigLbPolicyFailsOnUnknown() {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("loadBalancingPolicy", "MAGIC_BALANCER");
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
@@ -612,7 +612,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_serviceConfigLbConfigFailsOnUnknown() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig("{\"loadBalancingConfig\": [ {\"magic_balancer\": {} } ] }");
     List<EquivalentAddressGroup> servers =
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
@@ -629,7 +629,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   public void decideLoadBalancerProvider_serviceConfigLbConfigSkipUnknown() throws Exception {
     AutoConfiguredLoadBalancer lb =
         (AutoConfiguredLoadBalancer) lbf.newLoadBalancer(new TestHelper());
-    Map<String, Object> serviceConfig =
+    Map<String, ?> serviceConfig =
         parseConfig(
             "{\"loadBalancingConfig\": [ {\"magic_balancer\": {} }, {\"round_robin\": {} } ] }");
     List<EquivalentAddressGroup> servers =
@@ -705,7 +705,7 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
     verifyNoMoreInteractions(channelLogger);
 
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("loadBalancingPolicy", "round_robin");
     lb.handleResolvedAddressGroups(servers,
         Attributes.newBuilder()
@@ -778,8 +778,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   @SuppressWarnings("unchecked")
-  private static Map<String, Object> parseConfig(String json) throws Exception {
-    return (Map<String, Object>) JsonParser.parse(json);
+  private static Map<String, ?> parseConfig(String json) throws Exception {
+    return (Map<String, ?>) JsonParser.parse(json);
   }
 
   private static class TestLoadBalancer extends ForwardingLoadBalancer {

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -93,7 +93,7 @@ public class DnsNameResolverTest {
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
-  private final Map<String, Object> serviceConfig = new LinkedHashMap<>();
+  private final Map<String, ?> serviceConfig = new LinkedHashMap<>();
 
   private static final int DEFAULT_PORT = 887;
   private final SynchronizationContext syncContext = new SynchronizationContext(
@@ -656,7 +656,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_clientLanguageMatchesJava() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> langs = new ArrayList<>();
+    List<String> langs = new ArrayList<>();
     langs.add("java");
     choice.put("clientLanguage", langs);
     choice.put("serviceConfig", serviceConfig);
@@ -667,7 +667,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_clientLanguageDoesntMatchGo() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> langs = new ArrayList<>();
+    List<String> langs = new ArrayList<>();
     langs.add("go");
     choice.put("clientLanguage", langs);
     choice.put("serviceConfig", serviceConfig);
@@ -678,7 +678,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_clientLanguageCaseInsensitive() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> langs = new ArrayList<>();
+    List<String> langs = new ArrayList<>();
     langs.add("JAVA");
     choice.put("clientLanguage", langs);
     choice.put("serviceConfig", serviceConfig);
@@ -689,7 +689,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_clientLanguageMatchesEmtpy() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> langs = new ArrayList<>();
+    List<String> langs = new ArrayList<>();
     choice.put("clientLanguage", langs);
     choice.put("serviceConfig", serviceConfig);
 
@@ -699,7 +699,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_clientLanguageMatchesMulti() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> langs = new ArrayList<>();
+    List<String> langs = new ArrayList<>();
     langs.add("go");
     langs.add("java");
     choice.put("clientLanguage", langs);
@@ -825,7 +825,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_hostnameMatches() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> hosts = new ArrayList<>();
+    List<String> hosts = new ArrayList<>();
     hosts.add("localhost");
     choice.put("clientHostname", hosts);
     choice.put("serviceConfig", serviceConfig);
@@ -836,7 +836,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_hostnameDoesntMatch() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> hosts = new ArrayList<>();
+    List<String> hosts = new ArrayList<>();
     hosts.add("localhorse");
     choice.put("clientHostname", hosts);
     choice.put("serviceConfig", serviceConfig);
@@ -847,7 +847,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_clientLanguageCaseSensitive() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> hosts = new ArrayList<>();
+    List<String> hosts = new ArrayList<>();
     hosts.add("LOCALHOST");
     choice.put("clientHostname", hosts);
     choice.put("serviceConfig", serviceConfig);
@@ -858,7 +858,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_hostnameMatchesEmtpy() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> hosts = new ArrayList<>();
+    List<String> hosts = new ArrayList<>();
     choice.put("clientHostname", hosts);
     choice.put("serviceConfig", serviceConfig);
 
@@ -868,7 +868,7 @@ public class DnsNameResolverTest {
   @Test
   public void maybeChooseServiceConfig_hostnameMatchesMulti() {
     Map<String, Object> choice = new LinkedHashMap<>();
-    List<Object> hosts = new ArrayList<>();
+    List<String> hosts = new ArrayList<>();
     hosts.add("localhorse");
     hosts.add("localhost");
     choice.put("clientHostname", hosts);
@@ -883,7 +883,7 @@ public class DnsNameResolverTest {
     txtRecords.add("some_record");
     txtRecords.add("_grpc_config=[]");
 
-    List<Map<String, Object>> results = DnsNameResolver.parseTxtResults(txtRecords);
+    List<? extends Map<String, ?>> results = DnsNameResolver.parseTxtResults(txtRecords);
 
     assertThat(results).isEmpty();
   }
@@ -898,7 +898,7 @@ public class DnsNameResolverTest {
       txtRecords.add("some_record");
       txtRecords.add("grpc_config={}");
 
-      List<Map<String, Object>> results = DnsNameResolver.parseTxtResults(txtRecords);
+      List<? extends Map<String, ?>> results = DnsNameResolver.parseTxtResults(txtRecords);
 
       assertThat(results).isEmpty();
     } finally {
@@ -916,7 +916,7 @@ public class DnsNameResolverTest {
       txtRecords.add("some_record");
       txtRecords.add("grpc_config=[\"bogus\"]");
 
-      List<Map<String, Object>> results = DnsNameResolver.parseTxtResults(txtRecords);
+      List<? extends Map<String, ?>> results = DnsNameResolver.parseTxtResults(txtRecords);
 
       assertThat(results).isEmpty();
     } finally {
@@ -936,7 +936,7 @@ public class DnsNameResolverTest {
       txtRecords.add("grpc_config=[{}, {}]"); // 2 records
       txtRecords.add("grpc_config=[{\"\":{}}]"); // 1 record
 
-      List<Map<String, Object>> results = DnsNameResolver.parseTxtResults(txtRecords);
+      List<? extends Map<String, ?>> results = DnsNameResolver.parseTxtResults(txtRecords);
 
       assertThat(results).hasSize(2 + 1);
     } finally {

--- a/core/src/test/java/io/grpc/internal/HedgingPolicyTest.java
+++ b/core/src/test/java/io/grpc/internal/HedgingPolicyTest.java
@@ -57,7 +57,7 @@ public class HedgingPolicyTest {
       assertTrue(serviceConfigObj instanceof Map);
 
       @SuppressWarnings("unchecked")
-      Map<String, Object> serviceConfig = (Map<String, Object>) serviceConfigObj;
+      Map<String, ?> serviceConfig = (Map<String, ?>) serviceConfigObj;
 
       ServiceConfigInterceptor serviceConfigInterceptor = new ServiceConfigInterceptor(
           /* retryEnabled = */ true, /* maxRetryAttemptsLimit = */ 3,
@@ -129,7 +129,7 @@ public class HedgingPolicyTest {
       assertTrue(serviceConfigObj instanceof Map);
 
       @SuppressWarnings("unchecked")
-      Map<String, Object> serviceConfig = (Map<String, Object>) serviceConfigObj;
+      Map<String, ?> serviceConfig = (Map<String, ?>) serviceConfigObj;
 
       ServiceConfigInterceptor serviceConfigInterceptor = new ServiceConfigInterceptor(
           /* retryEnabled = */ false, /* maxRetryAttemptsLimit = */ 3,

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -889,9 +889,9 @@ public class ManagedChannelImplTest {
     ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
     verify(mockLoadBalancer).handleResolvedAddressGroups(
         eq(ImmutableList.<EquivalentAddressGroup>of()), attrsCaptor.capture());
-    Map<String, Object> lbConfig =
+    Map<String, ?> lbConfig =
         attrsCaptor.getValue().get(LoadBalancer.ATTR_LOAD_BALANCING_CONFIG);
-    assertEquals(ImmutableMap.<String, Object>of("setting1", "high"), lbConfig);
+    assertEquals(ImmutableMap.<String, String>of("setting1", "high"), lbConfig);
     assertSame(
         serviceConfig, attrsCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG));
   }

--- a/core/src/test/java/io/grpc/internal/RetryPolicyTest.java
+++ b/core/src/test/java/io/grpc/internal/RetryPolicyTest.java
@@ -60,7 +60,7 @@ public class RetryPolicyTest {
       assertTrue(serviceConfigObj instanceof Map);
 
       @SuppressWarnings("unchecked")
-      Map<String, Object> serviceConfig = (Map<String, Object>) serviceConfigObj;
+      Map<String, ?> serviceConfig = (Map<String, ?>) serviceConfigObj;
 
       ServiceConfigInterceptor serviceConfigInterceptor = new ServiceConfigInterceptor(
           /* retryEnabled = */ true, /* maxRetryAttemptsLimit = */ 4,
@@ -138,7 +138,7 @@ public class RetryPolicyTest {
       assertTrue(serviceConfigObj instanceof Map);
 
       @SuppressWarnings("unchecked")
-      Map<String, Object> serviceConfig = (Map<String, Object>) serviceConfigObj;
+      Map<String, ?> serviceConfig = (Map<String, ?>) serviceConfigObj;
 
       ServiceConfigInterceptor serviceConfigInterceptor = new ServiceConfigInterceptor(
           /* retryEnabled = */ false, /* maxRetryAttemptsLimit = */ 4,
@@ -175,7 +175,7 @@ public class RetryPolicyTest {
       assertTrue(serviceConfigObj instanceof Map);
 
       @SuppressWarnings("unchecked")
-      Map<String, Object> serviceConfig = (Map<String, Object>) serviceConfigObj;
+      Map<String, ?> serviceConfig = (Map<String, ?>) serviceConfigObj;
       Throttle throttle = ServiceConfigUtil.getThrottlePolicy(serviceConfig);
 
       assertEquals(new Throttle(10f, 0.1f), throttle);

--- a/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/util/RoundRobinLoadBalancerTest.java
@@ -470,7 +470,7 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void stickinessEnabled_withStickyHeader() {
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("stickinessMetadataKey", "my-sticky-key");
     Attributes attributes = Attributes.newBuilder()
         .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, serviceConfig).build();
@@ -500,7 +500,7 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void stickinessEnabled_withDifferentStickyHeaders() {
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("stickinessMetadataKey", "my-sticky-key");
     Attributes attributes = Attributes.newBuilder()
         .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, serviceConfig).build();
@@ -545,7 +545,7 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void stickiness_goToTransientFailure_pick_backToReady() {
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("stickinessMetadataKey", "my-sticky-key");
     Attributes attributes = Attributes.newBuilder()
         .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, serviceConfig).build();
@@ -593,7 +593,7 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void stickiness_goToTransientFailure_backToReady_pick() {
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("stickinessMetadataKey", "my-sticky-key");
     Attributes attributes = Attributes.newBuilder()
         .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, serviceConfig).build();
@@ -647,7 +647,7 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void stickiness_oneSubchannelShutdown() {
-    Map<String, Object> serviceConfig = new HashMap<>();
+    Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put("stickinessMetadataKey", "my-sticky-key");
     Attributes attributes = Attributes.newBuilder()
         .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, serviceConfig).build();
@@ -703,14 +703,14 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void stickiness_resolveTwice_metadataKeyChanged() {
-    Map<String, Object> serviceConfig1 = new HashMap<>();
+    Map<String, String> serviceConfig1 = new HashMap<>();
     serviceConfig1.put("stickinessMetadataKey", "my-sticky-key1");
     Attributes attributes1 = Attributes.newBuilder()
         .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, serviceConfig1).build();
     loadBalancer.handleResolvedAddressGroups(servers, attributes1);
     Map<String, ?> stickinessMap1 = loadBalancer.getStickinessMapForTest();
 
-    Map<String, Object> serviceConfig2 = new HashMap<>();
+    Map<String, String> serviceConfig2 = new HashMap<>();
     serviceConfig2.put("stickinessMetadataKey", "my-sticky-key2");
     Attributes attributes2 = Attributes.newBuilder()
         .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, serviceConfig2).build();
@@ -722,7 +722,7 @@ public class RoundRobinLoadBalancerTest {
 
   @Test
   public void stickiness_resolveTwice_metadataKeyUnChanged() {
-    Map<String, Object> serviceConfig1 = new HashMap<>();
+    Map<String, String> serviceConfig1 = new HashMap<>();
     serviceConfig1.put("stickinessMetadataKey", "my-sticky-key1");
     Attributes attributes1 = Attributes.newBuilder()
         .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, serviceConfig1).build();

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -100,7 +100,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
 
     newLbAddressGroups = Collections.unmodifiableList(newLbAddressGroups);
     newBackendServers = Collections.unmodifiableList(newBackendServers);
-    Map<String, Object> rawLbConfigValue = attributes.get(ATTR_LOAD_BALANCING_CONFIG);
+    Map<String, ?> rawLbConfigValue = attributes.get(ATTR_LOAD_BALANCING_CONFIG);
     Mode newMode = retrieveModeFromLbConfig(rawLbConfigValue, helper.getChannelLogger());
     if (!mode.equals(newMode)) {
       mode = newMode;
@@ -112,7 +112,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
 
   @VisibleForTesting
   static Mode retrieveModeFromLbConfig(
-      @Nullable Map<String, Object> rawLbConfigValue, ChannelLogger channelLogger) {
+      @Nullable Map<String, ?> rawLbConfigValue, ChannelLogger channelLogger) {
     try {
       if (rawLbConfigValue == null) {
         return DEFAULT_MODE;

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -2170,8 +2170,8 @@ public class GrpclbLoadBalancerTest {
   }
 
   @SuppressWarnings("unchecked")
-  private static Map<String, Object> parseJsonObject(String json) throws Exception {
-    return (Map<String, Object>) JsonParser.parse(json);
+  private static Map<String, ?> parseJsonObject(String json) throws Exception {
+    return (Map<String, ?>) JsonParser.parse(json);
   }
 
   private static class ServerEntry {

--- a/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
@@ -169,7 +169,7 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
     @Override
     public void handleResolvedAddressGroups(
         List<EquivalentAddressGroup> servers, Attributes attributes) {
-      Map<String, Object> serviceConfig =
+      Map<String, ?> serviceConfig =
           attributes.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
       String serviceName = ServiceConfigUtil.getHealthCheckedServiceName(serviceConfig);
       helper.setHealthCheckedService(serviceName);

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -935,8 +935,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
 
   @Test
   public void getHealthCheckedServiceName_noHealthCheckConfig() {
-    assertThat(ServiceConfigUtil.getHealthCheckedServiceName(new HashMap<String, Object>()))
-        .isNull();
+    assertThat(ServiceConfigUtil.getHealthCheckedServiceName(new HashMap<String, Void>())).isNull();
   }
 
   @Test

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -52,7 +52,7 @@ final class XdsLoadBalancer extends LoadBalancer {
       Attributes.Key.create("io.grpc.xds.XdsLoadBalancer.stateInfo");
 
   private static final LbConfig DEFAULT_FALLBACK_POLICY =
-      new LbConfig("round_robin", ImmutableMap.<String, Object>of());
+      new LbConfig("round_robin", ImmutableMap.<String, Void>of());
 
   private final SubchannelStore subchannelStore;
   private final Helper helper;
@@ -89,7 +89,7 @@ final class XdsLoadBalancer extends LoadBalancer {
   @Override
   public void handleResolvedAddressGroups(
       List<EquivalentAddressGroup> servers, Attributes attributes) {
-    Map<String, Object> newRawLbConfig = checkNotNull(
+    Map<String, ?> newRawLbConfig = checkNotNull(
         attributes.get(ATTR_LOAD_BALANCING_CONFIG), "ATTR_LOAD_BALANCING_CONFIG not available");
     LbConfig newLbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(newRawLbConfig);
     fallbackPolicy = selectFallbackPolicy(newLbConfig, lbRegistry);

--- a/xds/src/test/java/io/grpc/xds/FallbackManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/FallbackManagerTest.java
@@ -106,7 +106,7 @@ public class FallbackManagerTest {
     doReturn(fakeClock.getScheduledExecutorService()).when(helper).getScheduledExecutorService();
     doReturn(channelLogger).when(helper).getChannelLogger();
     fallbackManager = new FallbackManager(helper, new SubchannelStoreImpl(), lbRegistry);
-    fallbackPolicy = new LbConfig("test_policy", new HashMap<String, Object>());
+    fallbackPolicy = new LbConfig("test_policy", new HashMap<String, Void>());
     lbRegistry.register(fakeLbProvider);
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
@@ -311,7 +311,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -328,7 +328,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig2 = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -352,7 +352,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -366,7 +366,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig2 = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -388,7 +388,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -404,7 +404,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig2 = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -426,7 +426,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -442,7 +442,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig2 = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -463,7 +463,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -477,7 +477,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig2 = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
@@ -588,7 +588,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"supported_1\" : { \"supported_1_option\" : \"yes\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     return Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
   }
 
@@ -600,7 +600,7 @@ public class XdsLoadBalancerTest {
         + "\"fallbackPolicy\" : [{\"unsupported\" : {}}, {\"supported_1\" : {\"key\" : \"val\"}}]"
         + "}}";
     @SuppressWarnings("unchecked")
-    Map<String, Object> lbConfig = (Map<String, Object>) JsonParser.parse(lbConfigRaw);
+    Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
     lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
 


### PR DESCRIPTION
The main difference is that `Map<String, ?>` is used as a return type instead of `Map<String, Object>`.  The reason for the change is that it more accurately represents what types can be put into a service config (which is nothing at all, it's immutable) while leaving the gettable types as Object.   This also avoids some internal double casting (like from `List -> List<?> -> List<Map<...>)`.

Effectively it increases the compile time safety by turning `put()` calls into errors.  