### PR TITLE
core: stop catching exceptions from NameResolver.start()

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -363,12 +363,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
     this.lbHelper = lbHelper;
 
     NameResolverListenerImpl listener = new NameResolverListenerImpl(lbHelper, nameResolver);
-    try {
-      nameResolver.start(listener);
-      nameResolverStarted = true;
-    } catch (Throwable t) {
-      listener.onError(Status.fromThrowable(t));
-    }
+    nameResolver.start(listener);
+    nameResolverStarted = true;
   }
 
   // Must be run from syncContext


### PR DESCRIPTION
It's not supposed to throw. Any exception from it should be considered
a bug and deserves a panic.