### PR TITLE
Upgrade to Protobuf 3.7.0

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -44,7 +44,7 @@ For Linux, Mac and MinGW:
 ```
 $ git clone https://github.com/google/protobuf.git
 $ cd protobuf
-$ git checkout v3.6.1
+$ git checkout v3.7.0
 $ ./autogen.sh
 $ ./configure
 $ make
@@ -83,16 +83,16 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew publishToMavenLocal ^
-    -PvcProtobufInclude=C:\path\to\protobuf-3.6.1\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.6.1\vsprojects\Release ^
+    -PvcProtobufInclude=C:\path\to\protobuf-3.7.0\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf-3.7.0\vsprojects\Release ^
     -PtargetArch=x86_32
 ```
 
 Since specifying those properties every build is bothersome, you can instead
 create ``<project-root>\gradle.properties`` with contents like:
 ```
-vcProtobufInclude=C:\\path\\to\\protobuf-3.6.1\\src
-vcProtobufLibs=C:\\path\\to\\protobuf-3.6.1\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf-3.7.0\\src
+vcProtobufLibs=C:\\path\\to\\protobuf-3.7.0\\vsprojects\\Release
 targetArch=x86_32
 ```
 

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -39,7 +39,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.6.1' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.20.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
         nettyVersion = '4.1.32.Final'
         googleauthVersion = '0.13.0'
         guavaVersion = '26.0-android'
-        protobufVersion = '3.6.1'
+        protobufVersion = '3.7.0'
         protocVersion = protobufVersion
         protobufNanoVersion = '3.0.0-alpha-5'
         opencensusVersion = '0.19.2'
@@ -192,7 +192,7 @@ subprojects {
         libraries = [
             android_annotations: "com.google.android:annotations:4.1.1.4",
             animalsniffer_annotations: "org.codehaus.mojo:animal-sniffer-annotations:1.17",
-            errorprone: "com.google.errorprone:error_prone_annotations:2.2.0",
+            errorprone: "com.google.errorprone:error_prone_annotations:2.3.2",
             gson: "com.google.code.gson:gson:2.7",
             guava: "com.google.guava:guava:${guavaVersion}",
             hpack: 'com.twitter:hpack:0.10.1',

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-set PROTOBUF_VER=3.6.1
+set PROTOBUF_VER=3.7.0
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,7 +3,7 @@
 # Build protoc
 set -evux -o pipefail
 
-PROTOBUF_VERSION=3.6.1
+PROTOBUF_VERSION=3.7.0
 
 # ARCH is 64 bit unless otherwise specified.
 ARCH="${ARCH:-64}"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ dependencies {
             libraries.android_annotations,
             libraries.animalsniffer_annotations
     compile (libraries.guava) {
-        // prefer 2.2.0 from libraries instead of 2.1.3
+        // prefer 2.3.2 from libraries instead of 2.1.3
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         // prefer 3.0.2 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.6.1' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.20.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -26,7 +26,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.6.1' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.20.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.20.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.6.1'
+def protobufVersion = '3.7.0'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.20.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.6.1'
+def protocVersion = '3.7.0'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.20.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.6.1'
+def protobufVersion = '3.7.0'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.20.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.6.1</protobuf.version>
+    <protobuf.version>3.7.0</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.6.1' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.20.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.6.1' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
     }

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // updating the version in our release process.
 def grpcVersion = '1.20.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.20.Final'
-def protocVersion = '3.6.1'
+def protocVersion = '3.7.0'
 
 dependencies {
     implementation "io.grpc:grpc-netty:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.20.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.6.1</protoc.version>
+    <protoc.version>3.7.0</protoc.version>
     <netty.tcnative.version>2.0.20.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.20.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.6.1</protobuf.version>
-    <protoc.version>3.6.1</protoc.version>
+    <protobuf.version>3.7.0</protobuf.version>
+    <protoc.version>3.7.0</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -14,8 +14,10 @@ dependencies {
             project(':grpc-stub'),
             libraries.protobuf
     compile (libraries.protobuf_util) {
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
+        // prefer 2.3.2 from libraries instead of 2.1.3 from guava
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // prefer 1.17 from libraries instead of 1.14 from guava
+        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }
     compileOnly libraries.javax_annotation
     testCompile libraries.truth,

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile project(':grpc-core'),
             libraries.protobuf_lite
     compile (libraries.guava) {
-        // prefer 2.2.0 from libraries instead of 2.1.3
+        // prefer 2.3.2 from libraries instead of 2.1.3
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         // prefer 3.0.2 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'

--- a/protobuf-nano/build.gradle
+++ b/protobuf-nano/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compile project(':grpc-core'),
             libraries.protobuf_nano
     compile (libraries.guava) {
-        // prefer 2.2.0 from libraries instead of 2.1.3
+        // prefer 2.3.2 from libraries instead of 2.1.3
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         // prefer 3.0.2 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'

--- a/protobuf/build.gradle
+++ b/protobuf/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compile project(':grpc-core'),
             libraries.protobuf
     compile (libraries.guava) {
-        // prefer 2.2.0 from libraries instead of 2.1.3
+        // prefer 2.3.2 from libraries instead of 2.1.3
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         // prefer 3.0.2 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -4,6 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 
 def grpc_java_repositories(
+        omit_bazel_skylib = False,
         omit_com_google_android_annotations = False,
         omit_com_google_api_grpc_google_common_protos = False,
         omit_com_google_auth_google_auth_library_credentials = False,
@@ -37,9 +38,12 @@ def grpc_java_repositories(
         omit_io_opencensus_grpc_metrics = False,
         omit_javax_annotation = False,
         omit_junit_junit = False,
+        omit_net_zlib = False,
         omit_org_apache_commons_lang3 = False,
         omit_org_codehaus_mojo_animal_sniffer_annotations = False):
     """Imports dependencies for grpc-java."""
+    if not omit_bazel_skylib:
+        bazel_skylib()
     if not omit_com_google_android_annotations:
         com_google_android_annotations()
     if not omit_com_google_api_grpc_google_common_protos:
@@ -106,6 +110,8 @@ def grpc_java_repositories(
         javax_annotation()
     if not omit_junit_junit:
         junit_junit()
+    if not omit_net_zlib:
+        net_zlib()
     if not omit_org_apache_commons_lang3:
         org_apache_commons_lang3()
     if not omit_org_codehaus_mojo_animal_sniffer_annotations:
@@ -118,6 +124,22 @@ def grpc_java_repositories(
     native.bind(
         name = "gson",
         actual = "@com_google_code_gson_gson//jar",
+    )
+    native.bind(
+        name = "zlib",
+        actual = "@net_zlib//:zlib",
+    )
+    native.bind(
+        name = "error_prone_annotations",
+        actual = "@com_google_errorprone_error_prone_annotations//jar",
+    )
+
+def bazel_skylib():
+    http_archive(
+        name = "bazel_skylib",
+        sha256 = "bce240a0749dfc52fab20dce400b4d5cf7c28b239d64f8fd1762b3c9470121d8",
+        strip_prefix = "bazel-skylib-0.7.0",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.7.0.zip"],
     )
 
 def com_google_android_annotations():
@@ -177,9 +199,9 @@ def com_google_code_gson():
 def com_google_errorprone_error_prone_annotations():
     jvm_maven_import_external(
         name = "com_google_errorprone_error_prone_annotations",
-        artifact = "com.google.errorprone:error_prone_annotations:2.2.0",
+        artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
         server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "6ebd22ca1b9d8ec06d41de8d64e0596981d9607b42035f9ed374f9de271a481a",
+        artifact_sha256 = "357cd6cfb067c969226c442451502aee13800a24e950fdfde77bcdb4565a668d",
         licenses = ["notice"],  # Apache 2.0
     )
 
@@ -217,9 +239,10 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "d6618d117698132dadf0f830b762315807dc424ba36ab9183f1f436008a2fdb6",
-        strip_prefix = "protobuf-3.6.1.2",
-        urls = ["https://github.com/google/protobuf/archive/v3.6.1.2.zip"],
+        sha256 = "8955eb28f9c6db71d013bfe8255e485837d473db8a5786f6a017e40934f304a7",
+        strip_prefix = "protobuf-4b9a5df4e8ba2066794da56598ad2905dc42051e",
+        # This is v3.7.0 with a Bazel compilation failure fix
+        urls = ["https://github.com/google/protobuf/archive/4b9a5df4e8ba2066794da56598ad2905dc42051e.zip"],
     )
 
 def com_google_protobuf_javalite():
@@ -410,6 +433,15 @@ def junit_junit():
         server_urls = ["http://central.maven.org/maven2"],
         artifact_sha256 = "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
         licenses = ["notice"],  # EPL 1.0
+    )
+
+def net_zlib():
+    http_archive(
+        name = "net_zlib",
+        build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        strip_prefix = "zlib-1.2.11",
+        urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
     )
 
 def org_apache_commons_lang3():

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -21,8 +21,10 @@ dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub')
     compile (libraries.protobuf_util) {
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
+        // prefer 2.3.2 from libraries instead of 2.1.3 from guava
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // prefer 1.17 from libraries instead of 1.14 from guava
+        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }
     compile libraries.re2j
 

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -26,8 +26,10 @@ dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub')
     compile (libraries.protobuf_util) {
-        // prefer 20.0 from libraries instead of 19.0
-        exclude group: 'com.google.guava', module: 'guava'
+        // prefer 2.3.2 from libraries instead of 2.1.3 from guava
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        // prefer 1.17 from libraries instead of 1.14 from guava
+        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
     }
 
     testCompile project(':grpc-core').sourceSets.test.output


### PR DESCRIPTION
This version of Protobuf works with Bazel's
--incompatible_disable_deprecated_attr_params. It also avoids a noisy
reflective access warning in JDK 9+ (nothing was broken before; the warning was
overzealous).

Fixes #5383