### PR TITLE
Interop-testing: implement compute engine channel creds test case in Java

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1660,6 +1660,26 @@ public abstract class AbstractInteropTest {
     assertResponse(goldenResponse, response);
   }
 
+  /** Sends an unary rpc with ComputeEngineChannelBuilder. */
+  public void computeEngineChannelCredentials(
+      String defaultServiceAccount,
+      TestServiceGrpc.TestServiceBlockingStub computeEngineStub) throws Exception {
+    final SimpleRequest request = SimpleRequest.newBuilder()
+        .setFillUsername(true)
+        .setResponseSize(314159)
+        .setPayload(Payload.newBuilder()
+        .setBody(ByteString.copyFrom(new byte[271828])))
+        .build();
+    final SimpleResponse response = computeEngineStub.unaryCall(request);
+    assertEquals(defaultServiceAccount, response.getUsername());
+    final SimpleResponse goldenResponse = SimpleResponse.newBuilder()
+        .setUsername(defaultServiceAccount)
+        .setPayload(Payload.newBuilder()
+        .setBody(ByteString.copyFrom(new byte[314159])))
+        .build();
+    assertResponse(goldenResponse, response);
+  }
+
   /** Test JWT-based auth. */
   public void jwtTokenCreds(InputStream serviceAccountJson) throws Exception {
     final SimpleRequest request = SimpleRequest.newBuilder()

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -38,6 +38,7 @@ public enum TestCases {
   PING_PONG("full-duplex ping-pong streaming"),
   EMPTY_STREAM("A stream that has zero-messages in both directions"),
   COMPUTE_ENGINE_CREDS("large_unary with service_account auth"),
+  COMPUTE_ENGINE_CHANNEL_CREDENTIALS("large unary with compute engine channel builder"),
   SERVICE_ACCOUNT_CREDS("large_unary with compute engine auth"),
   JWT_TOKEN_CREDS("JWT-based auth"),
   OAUTH2_AUTH_TOKEN("raw oauth2 access token auth"),

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -278,6 +278,19 @@ public class TestServiceClient {
         tester.computeEngineCreds(defaultServiceAccount, oauthScope);
         break;
 
+      case COMPUTE_ENGINE_CHANNEL_CREDENTIALS: {
+        ManagedChannel channel = ComputeEngineChannelBuilder.forAddress(
+            serverHost, serverPort).build();
+        try {
+          TestServiceGrpc.TestServiceBlockingStub computeEngineStub =
+              TestServiceGrpc.newBlockingStub(channel);
+          tester.computeEngineChannelCredentials(defaultServiceAccount, computeEngineStub);
+        } finally {
+          channel.shutdownNow();
+        }
+        break;
+      }
+
       case SERVICE_ACCOUNT_CREDS: {
         String jsonKey = Files.asCharSource(new File(serviceAccountKeyFile), UTF_8).read();
         FileInputStream credentialsStream = new FileInputStream(new File(serviceAccountKeyFile));

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -33,8 +33,8 @@ import io.grpc.okhttp.internal.Platform;
 import io.netty.handler.ssl.SslContext;
 import java.io.File;
 import java.io.FileInputStream;
-import java.util.concurrent.TimeUnit;
 import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocketFactory;
 
 /**

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -279,8 +279,8 @@ public class TestServiceClient {
         break;
 
       case COMPUTE_ENGINE_CHANNEL_CREDENTIALS: {
-        ManagedChannel channel = ComputeEngineChannelBuilder.forAddress(
-            serverHost, serverPort).build();
+        ManagedChannel channel = ComputeEngineChannelBuilder
+            .forAddress(serverHost, serverPort).build();
         try {
           TestServiceGrpc.TestServiceBlockingStub computeEngineStub =
               TestServiceGrpc.newBlockingStub(channel);

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -33,6 +33,7 @@ import io.grpc.okhttp.internal.Platform;
 import io.netty.handler.ssl.SslContext;
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.concurrent.TimeUnit;
 import java.nio.charset.Charset;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -287,6 +288,7 @@ public class TestServiceClient {
           tester.computeEngineChannelCredentials(defaultServiceAccount, computeEngineStub);
         } finally {
           channel.shutdownNow();
+          channel.awaitTermination(5, TimeUnit.SECONDS);
         }
         break;
       }

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
@@ -47,6 +47,7 @@ public class TestCasesTest {
       "server_compressed_unary",
       "client_streaming",
       "client_compressed_streaming",
+      "compute_engine_channel_credentials",
       "server_streaming",
       "server_compressed_streaming",
       "ping_pong",


### PR DESCRIPTION
The new interop test case that this implements is described in https://github.com/grpc/grpc/pull/18370/files#diff-3472a48e65e8a5a8b22c53c0033c8dbd in open PR: https://github.com/grpc/grpc/pull/18370.

This PR allows https://github.com/grpc/grpc/pull/18370 to proceed (so that the test starts passing)

cc @jiangtaoli2016 