### PR TITLE
core: Change DNS error handling to fail on all invalid configs

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -403,35 +403,29 @@ final class DnsNameResolver extends NameResolver {
     return new ResolutionResults(addresses, txtRecords, balancerAddresses);
   }
 
+  /**
+   *
+   * @param txtRecords
+   * @return
+   * @throws IOException if one of the txt records contains improperly formatted JSON.
+   */
   @SuppressWarnings("unchecked")
   @VisibleForTesting
-  static List<Map<String, ?>> parseTxtResults(List<String> txtRecords) {
-    List<Map<String, ?>> serviceConfigs = new ArrayList<>();
+  static List<Map<String, ?>> parseTxtResults(List<String> txtRecords) throws IOException {
+    List<Map<String, ?>> possibleServiceConfigChoices = new ArrayList<>();
     for (String txtRecord : txtRecords) {
-      if (txtRecord.startsWith(SERVICE_CONFIG_PREFIX)) {
-        List<Map<String, ?>> choices;
-        try {
-          Object rawChoices = JsonParser.parse(txtRecord.substring(SERVICE_CONFIG_PREFIX.length()));
-          if (!(rawChoices instanceof List)) {
-            throw new IOException("wrong type " + rawChoices);
-          }
-          List<?> listChoices = (List<?>) rawChoices;
-          for (Object obj : listChoices) {
-            if (!(obj instanceof Map)) {
-              throw new IOException("wrong element type " + rawChoices);
-            }
-          }
-          choices = (List<Map<String, ?>>) listChoices;
-        } catch (IOException e) {
-          logger.log(Level.WARNING, "Bad service config: " + txtRecord, e);
-          continue;
-        }
-        serviceConfigs.addAll(choices);
-      } else {
+      if (!txtRecord.startsWith(SERVICE_CONFIG_PREFIX)) {
         logger.log(Level.FINE, "Ignoring non service config {0}", new Object[]{txtRecord});
+        continue;
       }
+      Object rawChoices = JsonParser.parse(txtRecord.substring(SERVICE_CONFIG_PREFIX.length()));
+      if (!(rawChoices instanceof List)) {
+        throw new IOException("wrong type " + rawChoices);
+      }
+      List<?> listChoices = (List<?>) rawChoices;
+      possibleServiceConfigChoices.addAll(ServiceConfigUtil.checkObjectList(listChoices));
     }
-    return serviceConfigs;
+    return possibleServiceConfigChoices;
   }
 
   @Nullable

--- a/core/src/main/java/io/grpc/internal/JsonParser.java
+++ b/core/src/main/java/io/grpc/internal/JsonParser.java
@@ -27,20 +27,33 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Parses JSON with as few preconceived notions as possible.
  */
 public final class JsonParser {
+
+  private static final Logger logger = Logger.getLogger(JsonParser.class.getName());
+
   private JsonParser() {}
 
   /**
    * Parses a json string, returning either a {@code Map<String, ?>}, {@code List<?>},
    * {@code String}, {@code Double}, {@code Boolean}, or {@code null}.
    */
+  @SuppressWarnings("unchecked")
   public static Object parse(String raw) throws IOException {
-    try (JsonReader jr = new JsonReader(new StringReader(raw))) {
+    JsonReader jr = new JsonReader(new StringReader(raw));
+    try {
       return parseRecursive(jr);
+    } finally {
+      try {
+        jr.close();
+      } catch (IOException e) {
+        logger.log(Level.WARNING, "Failed to close", e);
+      }
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/JsonParser.java
+++ b/core/src/main/java/io/grpc/internal/JsonParser.java
@@ -27,33 +27,20 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Parses JSON with as few preconceived notions as possible.
  */
 public final class JsonParser {
-
-  private static final Logger logger = Logger.getLogger(JsonParser.class.getName());
-
   private JsonParser() {}
 
   /**
-   * Parses a json string, returning either a {@code Map<String, ?>}, {@code List<Object>},
+   * Parses a json string, returning either a {@code Map<String, ?>}, {@code List<?>},
    * {@code String}, {@code Double}, {@code Boolean}, or {@code null}.
    */
-  @SuppressWarnings("unchecked")
   public static Object parse(String raw) throws IOException {
-    JsonReader jr = new JsonReader(new StringReader(raw));
-    try {
+    try (JsonReader jr = new JsonReader(new StringReader(raw))) {
       return parseRecursive(jr);
-    } finally {
-      try {
-        jr.close();
-      } catch (IOException e) {
-        logger.log(Level.WARNING, "Failed to close", e);
-      }
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigUtil.java
@@ -530,7 +530,7 @@ public final class ServiceConfigUtil {
   }
 
   @SuppressWarnings("unchecked")
-  private static List<Map<String, ?>> checkObjectList(List<?> rawList) {
+  static List<Map<String, ?>> checkObjectList(List<?> rawList) {
     for (int i = 0; i < rawList.size(); i++) {
       if (!(rawList.get(i) instanceof Map)) {
         throw new ClassCastException(


### PR DESCRIPTION
The behavior of DNS error handling changed with proposal A5.  Now, if any service config is invalid they all  are considered bad.