### PR TITLE
services/grpclb: use Stopwatch to provide elapsed time for backoffs

### DIFF
--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
@@ -53,6 +54,7 @@ class GrpclbLoadBalancer extends LoadBalancer {
 
   private final Helper helper;
   private final TimeProvider time;
+  private final Stopwatch stopwatch;
   private final SubchannelPool subchannelPool;
   private final BackoffPolicy.Provider backoffPolicyProvider;
 
@@ -66,9 +68,11 @@ class GrpclbLoadBalancer extends LoadBalancer {
       Helper helper,
       SubchannelPool subchannelPool,
       TimeProvider time,
+      Stopwatch stopwatch,
       BackoffPolicy.Provider backoffPolicyProvider) {
     this.helper = checkNotNull(helper, "helper");
     this.time = checkNotNull(time, "time provider");
+    this.stopwatch = checkNotNull(stopwatch, "stopwatch");
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
     this.subchannelPool = checkNotNull(subchannelPool, "subchannelPool");
     this.subchannelPool.init(helper, this);
@@ -154,7 +158,8 @@ class GrpclbLoadBalancer extends LoadBalancer {
   private void recreateStates() {
     resetStates();
     checkState(grpclbState == null, "Should've been cleared");
-    grpclbState = new GrpclbState(mode, helper, subchannelPool, time, backoffPolicyProvider);
+    grpclbState = new GrpclbState(mode, helper, subchannelPool, time, stopwatch,
+        backoffPolicyProvider);
   }
 
   @Override

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
@@ -16,6 +16,7 @@
 
 package io.grpc.grpclb;
 
+import com.google.common.base.Stopwatch;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
@@ -58,6 +59,7 @@ public final class GrpclbLoadBalancerProvider extends LoadBalancerProvider {
   public LoadBalancer newLoadBalancer(LoadBalancer.Helper helper) {
     return new GrpclbLoadBalancer(
         helper, new CachedSubchannelPool(), TimeProvider.SYSTEM_TIME_PROVIDER,
+        Stopwatch.createUnstarted(),
         new ExponentialBackoffPolicy.Provider());
   }
 

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Durations;
@@ -52,7 +53,6 @@ import com.google.protobuf.util.Timestamps;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
-import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
@@ -291,6 +291,7 @@ public class GrpclbLoadBalancerTest {
     when(backoffPolicy2.nextBackoffNanos()).thenReturn(10L, 100L);
     when(backoffPolicyProvider.get()).thenReturn(backoffPolicy1, backoffPolicy2);
     balancer = new GrpclbLoadBalancer(helper, subchannelPool, fakeClock.getTimeProvider(),
+        Stopwatch.createUnstarted(fakeClock.getTicker()),
         backoffPolicyProvider);
     verify(subchannelPool).init(same(helper), same(balancer));
   }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -45,7 +45,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Durations;
@@ -291,7 +290,7 @@ public class GrpclbLoadBalancerTest {
     when(backoffPolicy2.nextBackoffNanos()).thenReturn(10L, 100L);
     when(backoffPolicyProvider.get()).thenReturn(backoffPolicy1, backoffPolicy2);
     balancer = new GrpclbLoadBalancer(helper, subchannelPool, fakeClock.getTimeProvider(),
-        Stopwatch.createUnstarted(fakeClock.getTicker()),
+        fakeClock.getStopwatchSupplier().get(),
         backoffPolicyProvider);
     verify(subchannelPool).init(same(helper), same(balancer));
   }

--- a/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerUtil.java
+++ b/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerUtil.java
@@ -16,13 +16,12 @@
 
 package io.grpc.services;
 
-import com.google.common.base.Stopwatch;
 import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Factory;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.internal.ExponentialBackoffPolicy;
-import io.grpc.internal.TimeProvider;
+import io.grpc.internal.GrpcUtil;
 
 /**
  * Utility for enabling
@@ -65,8 +64,7 @@ public final class HealthCheckingLoadBalancerUtil {
     HealthCheckingLoadBalancerFactory hcFactory =
         new HealthCheckingLoadBalancerFactory(
             factory, new ExponentialBackoffPolicy.Provider(),
-            TimeProvider.SYSTEM_TIME_PROVIDER,
-            Stopwatch.createUnstarted());
+            GrpcUtil.STOPWATCH_SUPPLIER);
     return hcFactory.newLoadBalancer(helper);
   }
 }

--- a/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerUtil.java
+++ b/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerUtil.java
@@ -16,6 +16,7 @@
 
 package io.grpc.services;
 
+import com.google.common.base.Stopwatch;
 import io.grpc.ExperimentalApi;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Factory;
@@ -63,7 +64,9 @@ public final class HealthCheckingLoadBalancerUtil {
   public static LoadBalancer newHealthCheckingLoadBalancer(Factory factory, Helper helper) {
     HealthCheckingLoadBalancerFactory hcFactory =
         new HealthCheckingLoadBalancerFactory(
-            factory, new ExponentialBackoffPolicy.Provider(), TimeProvider.SYSTEM_TIME_PROVIDER);
+            factory, new ExponentialBackoffPolicy.Provider(), TimeProvider.SYSTEM_TIME_PROVIDER,
+            Stopwatch
+                .createUnstarted());
     return hcFactory.newLoadBalancer(helper);
   }
 }

--- a/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerUtil.java
+++ b/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerUtil.java
@@ -64,9 +64,9 @@ public final class HealthCheckingLoadBalancerUtil {
   public static LoadBalancer newHealthCheckingLoadBalancer(Factory factory, Helper helper) {
     HealthCheckingLoadBalancerFactory hcFactory =
         new HealthCheckingLoadBalancerFactory(
-            factory, new ExponentialBackoffPolicy.Provider(), TimeProvider.SYSTEM_TIME_PROVIDER,
-            Stopwatch
-                .createUnstarted());
+            factory, new ExponentialBackoffPolicy.Provider(),
+            TimeProvider.SYSTEM_TIME_PROVIDER,
+            Stopwatch.createUnstarted());
     return hcFactory.newLoadBalancer(helper);
   }
 }

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -37,11 +37,11 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Attributes;
 import io.grpc.Channel;
 import io.grpc.ChannelLogger;
-import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
@@ -179,7 +179,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
     when(backoffPolicy2.nextBackoffNanos()).thenReturn(12L, 22L, 32L);
 
     hcLbFactory = new HealthCheckingLoadBalancerFactory(
-        origLbFactory, backoffPolicyProvider, clock.getTimeProvider());
+        origLbFactory, backoffPolicyProvider, clock.getTimeProvider(),
+        Stopwatch.createUnstarted(clock.getTicker()));
     hcLb = hcLbFactory.newLoadBalancer(origHelper);
     // Make sure all calls into the hcLb is from the syncContext
     hcLbEventDelivery = new LoadBalancer() {

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Attributes;
 import io.grpc.Channel;
@@ -178,9 +179,15 @@ public class HealthCheckingLoadBalancerFactoryTest {
     when(backoffPolicy1.nextBackoffNanos()).thenReturn(11L, 21L, 31L);
     when(backoffPolicy2.nextBackoffNanos()).thenReturn(12L, 22L, 32L);
 
+    Supplier<Stopwatch> fakeStopwatchSupplier = new Supplier<Stopwatch>() {
+      @Override
+      public Stopwatch get() {
+        return Stopwatch.createUnstarted(clock.getTicker());
+      }
+    };
     hcLbFactory = new HealthCheckingLoadBalancerFactory(
-        origLbFactory, backoffPolicyProvider, clock.getTimeProvider(),
-        Stopwatch.createUnstarted(clock.getTicker()));
+        origLbFactory, backoffPolicyProvider,
+        fakeStopwatchSupplier);
     hcLb = hcLbFactory.newLoadBalancer(origHelper);
     // Make sure all calls into the hcLb is from the syncContext
     hcLbEventDelivery = new LoadBalancer() {

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -37,8 +37,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Stopwatch;
-import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Attributes;
 import io.grpc.Channel;
@@ -179,15 +177,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
     when(backoffPolicy1.nextBackoffNanos()).thenReturn(11L, 21L, 31L);
     when(backoffPolicy2.nextBackoffNanos()).thenReturn(12L, 22L, 32L);
 
-    Supplier<Stopwatch> fakeStopwatchSupplier = new Supplier<Stopwatch>() {
-      @Override
-      public Stopwatch get() {
-        return Stopwatch.createUnstarted(clock.getTicker());
-      }
-    };
     hcLbFactory = new HealthCheckingLoadBalancerFactory(
         origLbFactory, backoffPolicyProvider,
-        fakeStopwatchSupplier);
+        clock.getStopwatchSupplier());
     hcLb = hcLbFactory.newLoadBalancer(origHelper);
     // Make sure all calls into the hcLb is from the syncContext
     hcLbEventDelivery = new LoadBalancer() {


### PR DESCRIPTION
Use a separate Stopwatch for Load Balancer to manage backoff time. Solves #5056