### PR TITLE
all: add LoadBalancer overload for Resolution results

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -205,7 +205,8 @@ public abstract class LoadBalancer {
     }
 
     /**
-     * Gets the attributes associated with these addresses.
+     * Gets the attributes associated with these addresses.  If this was not previously set,
+     * {@link Attributes#EMPTY} will be returned.
      *
      * @since 1.21.0
      */
@@ -238,7 +239,7 @@ public abstract class LoadBalancer {
       Builder() {}
 
       /**
-       * Sets the servers.
+       * Sets the servers.  This field is required.
        *
        * @return this.
        */
@@ -248,7 +249,8 @@ public abstract class LoadBalancer {
       }
 
       /**
-       * Sets the attributes.
+       * Sets the attributes.  This field is optional; if not called, {@link Attributes#EMPTY}
+       * will be used.
        *
        * @return this.
        */
@@ -258,7 +260,7 @@ public abstract class LoadBalancer {
       }
 
       /**
-       * Sets the load balancing policy config.
+       * Sets the load balancing policy config. This field is optional.
        *
        * @return this.
        */
@@ -300,10 +302,6 @@ public abstract class LoadBalancer {
           && Objects.equal(this.loadBalancingPolicyConfig, that.loadBalancingPolicyConfig);
     }
   }
-
-
-
-
 
   /**
    * Handles an error from the name resolution system.

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -142,7 +142,7 @@ public abstract class LoadBalancer {
    * <p>Implementations should not modify the given {@code servers}.
    *
    * @param resolvedAddresses the resolved server addresses, attributes, and config.
-   * @since 1.20.0
+   * @since 1.21.0
    */
   @SuppressWarnings("deprecation")
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
@@ -154,7 +154,7 @@ public abstract class LoadBalancer {
    * balancing policy config.  The config is from the {@link
    * LoadBalancerProvider#parseLoadBalancingPolicyConfig(Map)}.
    *
-   * @since 1.20.0
+   * @since 1.21.0
    */
   public static final class ResolvedAddresses {
     private final List<EquivalentAddressGroup> servers;
@@ -162,6 +162,7 @@ public abstract class LoadBalancer {
     private final Attributes attributes;
     @Nullable
     private final Object loadBalancingPolicyConfig;
+    // Make sure to update toBuilder() below!
 
     private ResolvedAddresses(
         List<EquivalentAddressGroup> servers,
@@ -173,10 +174,20 @@ public abstract class LoadBalancer {
       this.loadBalancingPolicyConfig = loadBalancingPolicyConfig;
     }
 
+    /**
+     * Factory for constructing a new Builder.
+     *
+     * @since 1.21.0
+     */
     public static Builder newBuilder() {
       return new Builder();
     }
 
+    /**
+     * Converts this back to a builder.
+     *
+     * @since 1.21.0
+     */
     public Builder toBuilder() {
       return newBuilder()
           .setServers(servers)
@@ -184,15 +195,31 @@ public abstract class LoadBalancer {
           .setLoadBalancingPolicyConfig(loadBalancingPolicyConfig);
     }
 
+    /**
+     * Gets the server addresses.
+     *
+     * @since 1.21.0
+     */
     public List<EquivalentAddressGroup> getServers() {
       return servers;
     }
 
+    /**
+     * Gets the attributes associated with these addresses.
+     *
+     * @since 1.21.0
+     */
     @NameResolver.ResolutionResultAttr
     public Attributes getAttributes() {
       return attributes;
     }
 
+    /**
+     * Gets the domain specific load balancing policy.  This is the config produced by
+     * {@link LoadBalancerProvider#parseLoadBalancingPolicyConfig(Map)}.
+     *
+     * @since 1.21.0
+     */
     @Nullable
     public Object getLoadBalancingPolicyConfig() {
       return loadBalancingPolicyConfig;
@@ -211,7 +238,8 @@ public abstract class LoadBalancer {
       Builder() {}
 
       /**
-       * Sets the servers
+       * Sets the servers.
+       *
        * @return this.
        */
       public Builder setServers(List<EquivalentAddressGroup> servers) {
@@ -219,16 +247,29 @@ public abstract class LoadBalancer {
         return this;
       }
 
+      /**
+       * Sets the attributes.
+       *
+       * @return this.
+       */
       public Builder setAttributes(@NameResolver.ResolutionResultAttr Attributes attributes) {
         this.attributes = attributes;
         return this;
       }
 
+      /**
+       * Sets the load balancing policy config.
+       *
+       * @return this.
+       */
       public Builder setLoadBalancingPolicyConfig(@Nullable Object loadBalancingPolicyConfig) {
         this.loadBalancingPolicyConfig = loadBalancingPolicyConfig;
         return this;
       }
 
+      /**
+       * Constructs the {@link ResolvedAddresses}.
+       */
       public ResolvedAddresses build() {
         return new ResolvedAddresses(servers, attributes, loadBalancingPolicyConfig);
       }

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -177,6 +177,13 @@ public abstract class LoadBalancer {
       return new Builder();
     }
 
+    public Builder toBuilder() {
+      return newBuilder()
+          .setServers(servers)
+          .setAttributes(attributes)
+          .setLoadBalancingPolicyConfig(loadBalancingPolicyConfig);
+    }
+
     public List<EquivalentAddressGroup> getServers() {
       return servers;
     }

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -231,7 +231,7 @@ public abstract class LoadBalancer {
     public static final class Builder {
       private List<EquivalentAddressGroup> servers;
       @NameResolver.ResolutionResultAttr
-      private Attributes attributes;
+      private Attributes attributes = Attributes.EMPTY;
       @Nullable
       private Object loadBalancingPolicyConfig;
 

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -300,10 +300,10 @@ public abstract class LoadBalancer {
 
   /**
    * Whether this LoadBalancer can handle empty address group list to be passed to {@link
-   * #handleResolvedAddressGroups}.  The default implementation returns {@code false}, meaning that
-   * if the NameResolver returns an empty list, the Channel will turn that into an error and call
-   * {@link #handleNameResolutionError}.  LoadBalancers that want to accept empty lists should
-   * override this method and return {@code true}.
+   * #handleResolvedAddresses(ResolvedAddresses)}.  The default implementation returns
+   * {@code false}, meaning that if the NameResolver returns an empty list, the Channel will turn
+   * that into an error and call {@link #handleNameResolutionError}.  LoadBalancers that want to
+   * accept empty lists should override this method and return {@code true}.
    *
    * <p>This method should always return a constant value.  It's not specified when this will be
    * called.

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -124,15 +124,14 @@ public abstract class LoadBalancer {
    *
    * @param servers the resolved server addresses, never empty.
    * @param attributes extra information from naming system.
-   * @deprecated use {@link #handleResolvedAddresses(ResolvedAddresses) instead}
+   * @deprecated override {@link #handleResolvedAddresses(ResolvedAddresses) instead}
    * @since 1.2.0
    */
   @Deprecated
   public void handleResolvedAddressGroups(
       List<EquivalentAddressGroup> servers,
       @NameResolver.ResolutionResultAttr Attributes attributes) {
-    handleResolvedAddresses(
-        ResolvedAddresses.newBuilder().setServers(servers).setAttributes(attributes).build());
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   /**
@@ -145,8 +144,9 @@ public abstract class LoadBalancer {
    * @param resolvedAddresses the resolved server addresses, attributes, and config.
    * @since 1.20.0
    */
+  @SuppressWarnings("deprecation")
   public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
-    throw new UnsupportedOperationException("Not implemented");
+    handleResolvedAddressGroups(resolvedAddresses.getServers(), resolvedAddresses.getAttributes());
   }
 
   /**

--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -128,9 +128,12 @@ public abstract class LoadBalancer {
    * @since 1.2.0
    */
   @Deprecated
-  public abstract void handleResolvedAddressGroups(
+  public void handleResolvedAddressGroups(
       List<EquivalentAddressGroup> servers,
-      @NameResolver.ResolutionResultAttr Attributes attributes);
+      @NameResolver.ResolutionResultAttr Attributes attributes) {
+    handleResolvedAddresses(
+        ResolvedAddresses.newBuilder().setServers(servers).setAttributes(attributes).build());
+  }
 
   /**
    * Handles newly resolved server groups and metadata attributes from name resolution system.
@@ -172,6 +175,20 @@ public abstract class LoadBalancer {
 
     public static Builder newBuilder() {
       return new Builder();
+    }
+
+    public List<EquivalentAddressGroup> getServers() {
+      return servers;
+    }
+
+    @NameResolver.ResolutionResultAttr
+    public Attributes getAttributes() {
+      return attributes;
+    }
+
+    @Nullable
+    public Object getLoadBalancingPolicyConfig() {
+      return loadBalancingPolicyConfig;
     }
 
     /**

--- a/core/src/main/java/io/grpc/LoadBalancerProvider.java
+++ b/core/src/main/java/io/grpc/LoadBalancerProvider.java
@@ -55,7 +55,9 @@ public abstract class LoadBalancerProvider extends LoadBalancer.Factory {
    * Parses the config for the Load Balancing policy unpacked from the service config.  This will
    * return a {@link ConfigOrError} which contains either the successfully parsed config, or the
    * {@link Status} representing the failure to parse.  Implementations are expected to not throw
-   * exceptions but return a Status representing the failure.
+   * exceptions but return a Status representing the failure.  If successful, the load balancing
+   * policy config should be immutable, and implement {@link Object#equals(Object)} and
+   * {@link Object#hashCode()}.
    *
    * @param rawLoadBalancingPolicyConfig The {@link Map} representation of the load balancing
    *     policy choice.

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -152,7 +152,11 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
                 "Name resolver returned no usable address. addrs="
                 + servers + ", attrs=" + attributes));
       } else {
-        delegate.handleResolvedAddressGroups(selection.serverList, attributes);
+        delegate.handleResolvedAddresses(
+            ResolvedAddresses.newBuilder()
+                .setServers(selection.serverList)
+                .setAttributes(attributes)
+                .build());
       }
     }
 

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -68,7 +68,11 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
   private static final class NoopLoadBalancer extends LoadBalancer {
 
     @Override
+    @Deprecated
     public void handleResolvedAddressGroups(List<EquivalentAddressGroup> s, Attributes a) {}
+
+    @Override
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {}
 
     @Override
     public void handleNameResolutionError(Status error) {}
@@ -100,8 +104,9 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
 
     //  Must be run inside ChannelExecutor.
     @Override
-    public void handleResolvedAddressGroups(
-        List<EquivalentAddressGroup> servers, Attributes attributes) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      List<EquivalentAddressGroup> servers = resolvedAddresses.getServers();
+      Attributes attributes = resolvedAddresses.getAttributes();
       if (attributes.get(ATTR_LOAD_BALANCING_CONFIG) != null) {
         throw new IllegalArgumentException(
             "Unexpected ATTR_LOAD_BALANCING_CONFIG from upstream: "

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -55,6 +55,7 @@ import io.grpc.InternalWithLogId;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
@@ -1385,7 +1386,11 @@ final class ManagedChannelImpl extends ManagedChannel implements
                     .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, effectiveServiceConfig)
                     .build();
               }
-              helper.lb.handleResolvedAddressGroups(servers, effectiveAttrs);
+              helper.lb.handleResolvedAddresses(
+                  ResolvedAddresses.newBuilder()
+                      .setServers(servers)
+                      .setAttributes(effectiveAttrs)
+                      .build());
             }
           }
         }

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -48,8 +48,8 @@ final class PickFirstLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddressGroups(
-      List<EquivalentAddressGroup> servers, Attributes attributes) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    List<EquivalentAddressGroup> servers = resolvedAddresses.getServers();
     if (subchannel == null) {
       subchannel = helper.createSubchannel(servers, Attributes.EMPTY);
 

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -35,10 +35,16 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
   protected abstract LoadBalancer delegate();
 
   @Override
+  @Deprecated
   public void handleResolvedAddressGroups(
         List<EquivalentAddressGroup> servers,
         @NameResolver.ResolutionResultAttr Attributes attributes) {
     delegate().handleResolvedAddressGroups(servers, attributes);
+  }
+
+  @Override
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    delegate().handleResolvedAddresses(resolvedAddresses);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -21,7 +21,6 @@ import io.grpc.Attributes;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ExperimentalApi;
-import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer;
 import io.grpc.NameResolver;
 import io.grpc.Status;

--- a/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/RoundRobinLoadBalancer.java
@@ -87,8 +87,9 @@ final class RoundRobinLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddressGroups(
-      List<EquivalentAddressGroup> servers, Attributes attributes) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    List<EquivalentAddressGroup> servers = resolvedAddresses.getServers();
+    Attributes attributes = resolvedAddresses.getAttributes();
     Set<EquivalentAddressGroup> currentAddrs = subchannels.keySet();
     Set<EquivalentAddressGroup> latestAddrs = stripAttrs(servers);
     Set<EquivalentAddressGroup> addedAddrs = setsDifference(latestAddrs, currentAddrs);

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -756,9 +756,15 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     }
 
     @Override
+    @Deprecated
     public void handleResolvedAddressGroups(
         List<EquivalentAddressGroup> servers, Attributes attributes) {
       delegate().handleResolvedAddressGroups(servers, attributes);
+    }
+
+    @Override
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      delegate().handleResolvedAddresses(resolvedAddresses);
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -44,6 +44,7 @@ import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
@@ -228,7 +229,8 @@ public class ManagedChannelImplIdlenessTest {
             .setAttributes(Attributes.EMPTY)
             .build();
     nameResolverObserverCaptor.getValue().onResult(resolutionResult);
-    verify(mockLoadBalancer).handleResolvedAddressGroups(servers, Attributes.EMPTY);
+    verify(mockLoadBalancer).handleResolvedAddresses(
+        ResolvedAddresses.newBuilder().setServers(servers).setAttributes(Attributes.EMPTY).build());
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -81,6 +81,7 @@ import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancerProvider;
@@ -651,8 +652,11 @@ public class ManagedChannelImplTest {
 
     FakeNameResolverFactory.FakeNameResolver resolver = nameResolverFactory.resolvers.get(0);
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
-    verify(mockLoadBalancer).handleResolvedAddressGroups(
-        eq(Arrays.asList(addressGroup)), eq(Attributes.EMPTY));
+    verify(mockLoadBalancer).handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Arrays.asList(addressGroup))
+            .setAttributes(Attributes.EMPTY)
+            .build());
 
     Subchannel subchannel1 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     Subchannel subchannel2 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
@@ -890,14 +894,15 @@ public class ManagedChannelImplTest {
 
     // LoadBalancer received the empty list and the LB config
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
-    ArgumentCaptor<Attributes> attrsCaptor = ArgumentCaptor.forClass(null);
-    verify(mockLoadBalancer).handleResolvedAddressGroups(
-        eq(ImmutableList.<EquivalentAddressGroup>of()), attrsCaptor.capture());
-    Map<String, ?> lbConfig =
-        attrsCaptor.getValue().get(LoadBalancer.ATTR_LOAD_BALANCING_CONFIG);
-    assertEquals(ImmutableMap.<String, String>of("setting1", "high"), lbConfig);
+    ArgumentCaptor<ResolvedAddresses> resultCaptor =
+        ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+    assertThat(resultCaptor.getValue().getServers()).isEmpty();
+    Attributes actualAttrs = resultCaptor.getValue().getAttributes();
+    Map<String, ?> lbConfig = actualAttrs.get(LoadBalancer.ATTR_LOAD_BALANCING_CONFIG);
+    assertEquals(ImmutableMap.of("setting1", "high"), lbConfig);
     assertSame(
-        serviceConfig, attrsCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG));
+        serviceConfig, actualAttrs.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG));
   }
 
   @Test
@@ -960,8 +965,12 @@ public class ManagedChannelImplTest {
 
     // LoadBalancer received the empty list and the LB config
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
-    verify(mockLoadBalancer).handleResolvedAddressGroups(
-        eq(ImmutableList.<EquivalentAddressGroup>of()), same(serviceConfigAttrs));
+    verify(mockLoadBalancer).handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(serviceConfigAttrs)
+            .build());
+
   }
 
   @Test
@@ -977,8 +986,7 @@ public class ManagedChannelImplTest {
     createChannel();
 
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
-    doThrow(ex).when(mockLoadBalancer).handleResolvedAddressGroups(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), any(Attributes.class));
+    doThrow(ex).when(mockLoadBalancer).handleResolvedAddresses(any(ResolvedAddresses.class));
 
     // NameResolver returns addresses.
     nameResolverFactory.allResolved();
@@ -1040,8 +1048,11 @@ public class ManagedChannelImplTest {
 
     // Simulate name resolution results
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(resolvedAddrs);
-    inOrder.verify(mockLoadBalancer).handleResolvedAddressGroups(
-        eq(Arrays.asList(addressGroup)), eq(Attributes.EMPTY));
+    inOrder.verify(mockLoadBalancer).handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Arrays.asList(addressGroup))
+            .setAttributes(Attributes.EMPTY)
+            .build());
     Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class)))
         .thenReturn(PickResult.withSubchannel(subchannel));
@@ -1188,8 +1199,11 @@ public class ManagedChannelImplTest {
 
     // Simulate name resolution results
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(resolvedAddrs);
-    inOrder.verify(mockLoadBalancer).handleResolvedAddressGroups(
-        eq(Arrays.asList(addressGroup)), eq(Attributes.EMPTY));
+    inOrder.verify(mockLoadBalancer).handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Arrays.asList(addressGroup))
+            .setAttributes(Attributes.EMPTY)
+            .build());
     Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class)))
         .thenReturn(PickResult.withSubchannel(subchannel));
@@ -3044,9 +3058,11 @@ public class ManagedChannelImplTest {
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
-    verify(mockLoadBalancer)
-        .handleResolvedAddressGroups(
-            eq(nameResolverFactory.servers), same(attributesWithRetryPolicy));
+    verify(mockLoadBalancer).handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(nameResolverFactory.servers)
+            .setAttributes(attributesWithRetryPolicy)
+            .build());
 
     // simulating request connection and then transport ready after resolved address
     Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
@@ -3141,8 +3157,11 @@ public class ManagedChannelImplTest {
     ArgumentCaptor<Helper> helperCaptor = ArgumentCaptor.forClass(Helper.class);
     verify(mockLoadBalancerProvider).newLoadBalancer(helperCaptor.capture());
     helper = helperCaptor.getValue();
-    verify(mockLoadBalancer)
-        .handleResolvedAddressGroups(nameResolverFactory.servers, attributesWithRetryPolicy);
+    verify(mockLoadBalancer).handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(nameResolverFactory.servers)
+            .setAttributes(attributesWithRetryPolicy)
+            .build());
 
     // simulating request connection and then transport ready after resolved address
     Subchannel subchannel = helper.createSubchannel(addressGroup, Attributes.EMPTY);
@@ -3509,12 +3528,13 @@ public class ManagedChannelImplTest {
       nameResolverFactory.nextResolvedAttributes.set(serviceConfigAttrs);
 
       createChannel();
-      ArgumentCaptor<Attributes> attributesCaptor = ArgumentCaptor.forClass(Attributes.class);
-      verify(mockLoadBalancer).handleResolvedAddressGroups(
-          eq(ImmutableList.of(addressGroup)),
-          attributesCaptor.capture());
-      assertThat(attributesCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
-          .isNull();
+
+      ArgumentCaptor<ResolvedAddresses> resultCaptor =
+          ArgumentCaptor.forClass(ResolvedAddresses.class);
+      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      assertThat(resultCaptor.getValue().getServers()).containsExactly(addressGroup);
+      Attributes actualAttrs = resultCaptor.getValue().getAttributes();
+      assertThat(actualAttrs.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG)).isNull();
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
       LoadBalancerRegistry.getDefaultRegistry().deregister(mockLoadBalancerProvider);
@@ -3544,11 +3564,14 @@ public class ManagedChannelImplTest {
       nameResolverFactory.nextResolvedAttributes.set(serviceConfigAttrs);
 
       createChannel();
-      ArgumentCaptor<Attributes> attributesCaptor = ArgumentCaptor.forClass(Attributes.class);
-      verify(mockLoadBalancer).handleResolvedAddressGroups(
-          eq(ImmutableList.of(addressGroup)),
-          attributesCaptor.capture());
-      assertThat(attributesCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
+
+      ArgumentCaptor<ResolvedAddresses> resultCaptor =
+          ArgumentCaptor.forClass(ResolvedAddresses.class);
+      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      assertThat(resultCaptor.getValue().getServers()).containsExactly(addressGroup);
+      Attributes actualAttrs = resultCaptor.getValue().getAttributes();
+
+      assertThat(actualAttrs.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
           .isEqualTo(defaultServiceConfig);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
@@ -3576,11 +3599,13 @@ public class ManagedChannelImplTest {
       nameResolverFactory.nextResolvedAttributes.set(serviceConfigAttrs);
 
       createChannel();
-      ArgumentCaptor<Attributes> attributesCaptor = ArgumentCaptor.forClass(Attributes.class);
-      verify(mockLoadBalancer).handleResolvedAddressGroups(
-          eq(ImmutableList.of(addressGroup)),
-          attributesCaptor.capture());
-      assertThat(attributesCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
+      ArgumentCaptor<ResolvedAddresses> resultCaptor =
+          ArgumentCaptor.forClass(ResolvedAddresses.class);
+      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      assertThat(resultCaptor.getValue().getServers()).containsExactly(addressGroup);
+      Attributes actualAttrs = resultCaptor.getValue().getAttributes();
+
+      assertThat(actualAttrs.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
           .isEqualTo(serviceConfig);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
 
@@ -3596,11 +3621,11 @@ public class ManagedChannelImplTest {
       nameResolverFactory.nextResolvedAttributes.set(serviceConfigAttrs);
       nameResolverFactory.allResolved();
 
-      attributesCaptor = ArgumentCaptor.forClass(Attributes.class);
-      verify(mockLoadBalancer, times(2)).handleResolvedAddressGroups(
-          eq(ImmutableList.of(addressGroup)),
-          attributesCaptor.capture());
-      assertThat(attributesCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
+      resultCaptor = ArgumentCaptor.forClass(ResolvedAddresses.class);
+      verify(mockLoadBalancer, times(2)).handleResolvedAddresses(resultCaptor.capture());
+      assertThat(resultCaptor.getValue().getServers()).containsExactly(addressGroup);
+      actualAttrs = resultCaptor.getValue().getAttributes();
+      assertThat(actualAttrs.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
           .isEqualTo(serviceConfig);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
@@ -3633,11 +3658,12 @@ public class ManagedChannelImplTest {
       nameResolverFactory.nextResolvedAttributes.set(serviceConfigAttrs);
 
       createChannel();
-      ArgumentCaptor<Attributes> attributesCaptor = ArgumentCaptor.forClass(Attributes.class);
-      verify(mockLoadBalancer).handleResolvedAddressGroups(
-          eq(ImmutableList.of(addressGroup)),
-          attributesCaptor.capture());
-      assertThat(attributesCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
+      ArgumentCaptor<ResolvedAddresses> resultCaptor =
+          ArgumentCaptor.forClass(ResolvedAddresses.class);
+      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      assertThat(resultCaptor.getValue().getServers()).containsExactly(addressGroup);
+      Attributes actualAttrs = resultCaptor.getValue().getAttributes();
+      assertThat(actualAttrs.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
           .isEqualTo(serviceConfig);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
@@ -3664,11 +3690,12 @@ public class ManagedChannelImplTest {
       nameResolverFactory.nextResolvedAttributes.set(serviceConfigAttrs);
 
       createChannel();
-      ArgumentCaptor<Attributes> attributesCaptor = ArgumentCaptor.forClass(Attributes.class);
-      verify(mockLoadBalancer).handleResolvedAddressGroups(
-          eq(ImmutableList.of(addressGroup)),
-          attributesCaptor.capture());
-      assertThat(attributesCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
+      ArgumentCaptor<ResolvedAddresses> resultCaptor =
+          ArgumentCaptor.forClass(ResolvedAddresses.class);
+      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      assertThat(resultCaptor.getValue().getServers()).containsExactly(addressGroup);
+      Attributes actualAttrs = resultCaptor.getValue().getAttributes();
+      assertThat(actualAttrs.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
           .isEqualTo(defaultServiceConfig);
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
@@ -3689,12 +3716,12 @@ public class ManagedChannelImplTest {
       nameResolverFactory.nextResolvedAttributes.set(serviceConfigAttrs);
 
       createChannel();
-      ArgumentCaptor<Attributes> attributesCaptor = ArgumentCaptor.forClass(Attributes.class);
-      verify(mockLoadBalancer).handleResolvedAddressGroups(
-          eq(ImmutableList.of(addressGroup)),
-          attributesCaptor.capture());
-      assertThat(attributesCaptor.getValue().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG))
-          .isNull();
+      ArgumentCaptor<ResolvedAddresses> resultCaptor =
+          ArgumentCaptor.forClass(ResolvedAddresses.class);
+      verify(mockLoadBalancer).handleResolvedAddresses(resultCaptor.capture());
+      assertThat(resultCaptor.getValue().getServers()).containsExactly(addressGroup);
+      Attributes actualAttrs = resultCaptor.getValue().getAttributes();
+      assertThat(actualAttrs.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG)).isNull();
       verify(mockLoadBalancer, never()).handleNameResolutionError(any(Status.class));
     } finally {
       LoadBalancerRegistry.getDefaultRegistry().deregister(mockLoadBalancerProvider);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -141,7 +141,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -84,8 +84,9 @@ class GrpclbLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddressGroups(
-      List<EquivalentAddressGroup> updatedServers, Attributes attributes) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    List<EquivalentAddressGroup> updatedServers = resolvedAddresses.getServers();
+    Attributes attributes = resolvedAddresses.getAttributes();
     // LB addresses and backend addresses are treated separately
     List<LbAddressGroup> newLbAddressGroups = new ArrayList<>();
     List<EquivalentAddressGroup> newBackendServers = new ArrayList<>();

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -61,6 +61,7 @@ import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.ManagedChannel;
@@ -2099,7 +2100,8 @@ public class GrpclbLoadBalancerTest {
     syncContext.execute(new Runnable() {
         @Override
         public void run() {
-          balancer.handleResolvedAddressGroups(addrs, attrs);
+          balancer.handleResolvedAddresses(
+              ResolvedAddresses.newBuilder().setServers(addrs).setAttributes(attrs).build());
         }
       });
   }

--- a/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
@@ -167,13 +167,12 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
     }
 
     @Override
-    public void handleResolvedAddressGroups(
-        List<EquivalentAddressGroup> servers, Attributes attributes) {
+    public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
       Map<String, ?> serviceConfig =
-          attributes.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
+          resolvedAddresses.getAttributes().get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG);
       String serviceName = ServiceConfigUtil.getHealthCheckedServiceName(serviceConfig);
       helper.setHealthCheckedService(serviceName);
-      super.handleResolvedAddressGroups(servers, attributes);
+      super.handleResolvedAddresses(resolvedAddresses);
     }
 
     @Override

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -41,7 +41,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Attributes;
 import io.grpc.Channel;
 import io.grpc.ChannelLogger;
-import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
@@ -50,6 +49,7 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Factory;
 import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.ManagedChannel;
@@ -187,13 +187,12 @@ public class HealthCheckingLoadBalancerFactoryTest {
         boolean shutdown;
 
         @Override
-        public void handleResolvedAddressGroups(
-            final List<EquivalentAddressGroup> servers, final Attributes attributes) {
+        public void handleResolvedAddresses(final ResolvedAddresses resolvedAddresses) {
           syncContext.execute(new Runnable() {
               @Override
               public void run() {
                 if (!shutdown) {
-                  hcLb.handleResolvedAddressGroups(servers, attributes);
+                  hcLb.handleResolvedAddresses(resolvedAddresses);
                 }
               }
             });
@@ -265,9 +264,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void typicalWorkflow() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("FooService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result);
     verify(origHelper, atLeast(0)).getSynchronizationContext();
     verify(origHelper, atLeast(0)).getScheduledExecutorService();
     verifyNoMoreInteractions(origHelper);
@@ -372,9 +375,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void healthCheckDisabledWhenServiceNotImplemented() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("BarService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     // We create 2 Subchannels. One of them connects to a server that doesn't implement health check
@@ -441,9 +448,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void backoffRetriesWhenServerErroneouslyClosesRpcBeforeAnyResponse() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     FakeSubchannel subchannel = (FakeSubchannel) createSubchannel(0, Attributes.EMPTY);
@@ -509,9 +520,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void serverRespondResetsBackoff() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -599,9 +614,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void serviceConfigHasNoHealthCheckingInitiallyButDoesLater() {
     // No service config, thus no health check.
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, Attributes.EMPTY);
+    ResolvedAddresses result1 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(Attributes.EMPTY)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(Attributes.EMPTY));
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     // First, create Subchannels 0
@@ -618,9 +637,12 @@ public class HealthCheckingLoadBalancerFactoryTest {
 
     // Service config enables health check
     Attributes resolutionAttrs = attrsWithHealthCheckService("FooService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
-    verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(resolutionAttrs));
+    ResolvedAddresses result2 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result2);
+    verify(origLb).handleResolvedAddresses(result2);
 
     // Health check started on existing Subchannel
     assertThat(healthImpls[0].calls).hasSize(1);
@@ -639,9 +661,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void serviceConfigDisablesHealthCheckWhenRpcActive() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result1 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -658,7 +684,11 @@ public class HealthCheckingLoadBalancerFactoryTest {
     assertThat(serverCall.cancelled).isFalse();
 
     // NameResolver gives an update without service config, thus health check will be disabled
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, Attributes.EMPTY);
+    ResolvedAddresses result2 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(Attributes.EMPTY)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
     // Health check RPC cancelled.
     assertThat(serverCall.cancelled).isTrue();
@@ -666,8 +696,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verify(origLb).handleSubchannelState(
         same(subchannel), eq(ConnectivityStateInfo.forNonError(READY)));
 
-    inOrder.verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(Attributes.EMPTY));
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     verifyNoMoreInteractions(origLb);
     assertThat(healthImpl.calls).isEmpty();
@@ -676,9 +705,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void serviceConfigDisablesHealthCheckWhenRetryPending() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -702,7 +735,11 @@ public class HealthCheckingLoadBalancerFactoryTest {
             "Health-check stream unexpectedly closed with " + Status.OK + " for 'TeeService'"));
 
     // NameResolver gives an update without service config, thus health check will be disabled
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, Attributes.EMPTY);
+    ResolvedAddresses result2 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(Attributes.EMPTY)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
     // Retry timer is cancelled
     assertThat(clock.getPendingTasks()).isEmpty();
@@ -714,8 +751,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verify(origLb).handleSubchannelState(
         same(subchannel), eq(ConnectivityStateInfo.forNonError(READY)));
 
-    inOrder.verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(Attributes.EMPTY));
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     verifyNoMoreInteractions(origLb);
   }
@@ -723,9 +759,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void serviceConfigDisablesHealthCheckWhenRpcInactive() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result1= ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -741,10 +781,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verifyNoMoreInteractions();
 
     // NameResolver gives an update without service config, thus health check will be disabled
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, Attributes.EMPTY);
+    ResolvedAddresses result2 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(Attributes.EMPTY)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
-    inOrder.verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(Attributes.EMPTY));
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     // Underlying subchannel is now ready
     hcLbEventDelivery.handleSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
@@ -762,9 +805,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void serviceConfigChangesServiceNameWhenRpcActive() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result1 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -787,18 +834,19 @@ public class HealthCheckingLoadBalancerFactoryTest {
         same(subchannel), eq(ConnectivityStateInfo.forNonError(READY)));
 
     // Service config returns with the same health check name.
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(resolutionAttrs));
+    inOrder.verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     // Service config returns a different health check name.
     resolutionAttrs = attrsWithHealthCheckService("FooService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
-
-    inOrder.verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(resolutionAttrs));
+    ResolvedAddresses result2 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result2);
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     // Current health check RPC cancelled.
     assertThat(serverCall.cancelled).isTrue();
@@ -816,9 +864,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void serviceConfigChangesServiceNameWhenRetryPending() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result1 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -846,24 +898,27 @@ public class HealthCheckingLoadBalancerFactoryTest {
             "Health-check stream unexpectedly closed with " + Status.OK + " for 'TeeService'"));
 
     // Service config returns with the same health check name.
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+
+    hcLbEventDelivery.handleResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(resolutionAttrs));
+    inOrder.verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
     assertThat(clock.getPendingTasks()).hasSize(1);
     assertThat(healthImpl.calls).isEmpty();
 
     // Service config returns a different health check name.
     resolutionAttrs = attrsWithHealthCheckService("FooService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result2 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
     // Concluded CONNECTING state
     inOrder.verify(origLb).handleSubchannelState(
         same(subchannel), eq(ConnectivityStateInfo.forNonError(CONNECTING)));
 
-    inOrder.verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(resolutionAttrs));
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     // Current retry timer cancelled
     assertThat(clock.getPendingTasks()).isEmpty();
@@ -880,9 +935,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void serviceConfigChangesServiceNameWhenRpcInactive() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result1 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -899,19 +958,21 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verifyNoMoreInteractions();
 
     // Service config returns with the same health check name.
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    hcLbEventDelivery.handleResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(resolutionAttrs));
+    inOrder.verify(origLb).handleResolvedAddresses(result1);
     assertThat(healthImpl.calls).isEmpty();
     verifyNoMoreInteractions(origLb);
 
     // Service config returns a different health check name.
     resolutionAttrs = attrsWithHealthCheckService("FooService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result2 = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result2);
 
-    inOrder.verify(origLb).handleResolvedAddressGroups(
-        same(resolvedAddressList), same(resolutionAttrs));
+    inOrder.verify(origLb).handleResolvedAddresses(result2);
 
     // Underlying subchannel is now ready
     hcLbEventDelivery.handleSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
@@ -959,9 +1020,13 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void balancerShutdown() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
+    ResolvedAddresses result = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    verify(origLb).handleResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY);
@@ -1011,8 +1076,12 @@ public class HealthCheckingLoadBalancerFactoryTest {
 
     // Verify that HC works
     Attributes resolutionAttrs = attrsWithHealthCheckService("BarService");
-    hcLbEventDelivery.handleResolvedAddressGroups(resolvedAddressList, resolutionAttrs);
-    verify(origLb).handleResolvedAddressGroups(same(resolvedAddressList), same(resolutionAttrs));
+    ResolvedAddresses result = ResolvedAddresses.newBuilder()
+        .setServers(resolvedAddressList)
+        .setAttributes(resolutionAttrs)
+        .build();
+    hcLbEventDelivery.handleResolvedAddresses(result);
+    verify(origLb).handleResolvedAddresses(result);
     createSubchannel(0, Attributes.EMPTY);
     assertThat(healthImpls[0].calls).isEmpty();
     hcLbEventDelivery.handleSubchannelState(

--- a/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -759,7 +759,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
   @Test
   public void serviceConfigDisablesHealthCheckWhenRpcInactive() {
     Attributes resolutionAttrs = attrsWithHealthCheckService("TeeService");
-    ResolvedAddresses result1= ResolvedAddresses.newBuilder()
+    ResolvedAddresses result1 = ResolvedAddresses.newBuilder()
         .setServers(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -84,8 +84,9 @@ final class XdsLoadBalancer extends LoadBalancer {
   }
 
   @Override
-  public void handleResolvedAddressGroups(
-      List<EquivalentAddressGroup> servers, Attributes attributes) {
+  public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+    List<EquivalentAddressGroup> servers = resolvedAddresses.getServers();
+    Attributes attributes = resolvedAddresses.getAttributes();
     Map<String, ?> newRawLbConfig = checkNotNull(
         attributes.get(ATTR_LOAD_BALANCING_CONFIG), "ATTR_LOAD_BALANCING_CONFIG not available");
 

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -253,7 +253,12 @@ final class XdsLoadBalancer extends LoadBalancer {
           ChannelLogLevel.INFO, "Using fallback policy");
       fallbackBalancer = lbRegistry.getProvider(fallbackPolicy.getPolicyName())
           .newLoadBalancer(helper);
-      fallbackBalancer.handleResolvedAddressGroups(fallbackServers, fallbackAttributes);
+      // TODO(carl-mastrangelo): propagate the load balancing config policy
+      fallbackBalancer.handleResolvedAddresses(
+          ResolvedAddresses.newBuilder()
+              .setServers(fallbackServers)
+              .setAttributes(fallbackAttributes)
+              .build());
       // TODO: maybe update picker
     }
 
@@ -269,7 +274,12 @@ final class XdsLoadBalancer extends LoadBalancer {
       this.fallbackPolicy = fallbackPolicy;
       if (fallbackBalancer != null) {
         if (fallbackPolicy.getPolicyName().equals(currentFallbackPolicy.getPolicyName())) {
-          fallbackBalancer.handleResolvedAddressGroups(fallbackServers, fallbackAttributes);
+          // TODO(carl-mastrangelo): propagate the load balancing config policy
+          fallbackBalancer.handleResolvedAddresses(
+              ResolvedAddresses.newBuilder()
+                  .setServers(fallbackServers)
+                  .setAttributes(fallbackAttributes)
+                  .build());
         } else {
           fallbackBalancer.shutdown();
           fallbackBalancer = null;

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -259,6 +259,7 @@ final class XdsLoadBalancer extends LoadBalancer {
               .setServers(fallbackServers)
               .setAttributes(fallbackAttributes)
               .build());
+
       // TODO: maybe update picker
     }
 

--- a/xds/src/test/java/io/grpc/xds/FallbackManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/FallbackManagerTest.java
@@ -17,8 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -28,6 +26,7 @@ import io.grpc.ChannelLogger;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.SynchronizationContext;
@@ -122,16 +121,20 @@ public class FallbackManagerTest {
     fallbackManager.updateFallbackServers(
         eags, Attributes.EMPTY, fallbackPolicy);
 
-    verify(fakeLb, never()).handleResolvedAddressGroups(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), ArgumentMatchers.<Attributes>any());
+    verify(fakeLb, never()).handleResolvedAddresses(ArgumentMatchers.any(ResolvedAddresses.class));
 
     fakeClock.forwardTime(FALLBACK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-    verify(fakeLb).handleResolvedAddressGroups(
-        same(eags),
-        eq(Attributes.newBuilder()
-            .set(LoadBalancer.ATTR_LOAD_BALANCING_CONFIG, fallbackPolicy.getRawConfigValue())
-            .build()));
+    verify(fakeLb).handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(eags)
+            .setAttributes(
+                Attributes.newBuilder()
+                    .set(
+                        LoadBalancer.ATTR_LOAD_BALANCING_CONFIG,
+                        fallbackPolicy.getRawConfigValue())
+                    .build())
+            .build());
   }
 
   @Test
@@ -145,7 +148,6 @@ public class FallbackManagerTest {
 
     fakeClock.forwardTime(FALLBACK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
-    verify(fakeLb, never()).handleResolvedAddressGroups(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), ArgumentMatchers.<Attributes>any());
+    verify(fakeLb, never()).handleResolvedAddresses(ArgumentMatchers.any(ResolvedAddresses.class));
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
@@ -40,6 +40,7 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
@@ -260,7 +261,11 @@ public class XdsLoadBalancerTest {
     Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
 
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
 
     XdsLbState xdsLbState1 = lb.getXdsLbStateForTest();
     assertThat(xdsLbState1.childPolicy).isNull();
@@ -278,7 +283,11 @@ public class XdsLoadBalancerTest {
     Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
 
     XdsLbState xdsLbState2 = lb.getXdsLbStateForTest();
     assertThat(xdsLbState2.childPolicy).isNull();
@@ -303,7 +312,11 @@ public class XdsLoadBalancerTest {
     Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
 
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
     verify(helper).createOobChannel(ArgumentMatchers.<EquivalentAddressGroup>any(), anyString());
     verify(oobChannel1)
         .newCall(ArgumentMatchers.<MethodDescriptor<?, ?>>any(),
@@ -318,7 +331,11 @@ public class XdsLoadBalancerTest {
     Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
 
     assertThat(lb.getXdsLbStateForTest().childPolicy).isNotNull();
 
@@ -341,7 +358,11 @@ public class XdsLoadBalancerTest {
     Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
 
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
     verify(helper).createOobChannel(ArgumentMatchers.<EquivalentAddressGroup>any(), anyString());
     verify(oobChannel1)
         .newCall(ArgumentMatchers.<MethodDescriptor<?, ?>>any(),
@@ -358,7 +379,11 @@ public class XdsLoadBalancerTest {
     Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
 
     assertThat(lb.getXdsLbStateForTest().childPolicy).isNull();
 
@@ -380,8 +405,11 @@ public class XdsLoadBalancerTest {
     @SuppressWarnings("unchecked")
     Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
-
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
 
     assertThat(lb.getXdsLbStateForTest().childPolicy).isNotNull();
     verify(helper).createOobChannel(ArgumentMatchers.<EquivalentAddressGroup>any(), anyString());
@@ -398,7 +426,11 @@ public class XdsLoadBalancerTest {
     Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
 
     assertThat(lb.getXdsLbStateForTest().childPolicy).isNotNull();
     // verify oobChannel is unchanged
@@ -420,7 +452,11 @@ public class XdsLoadBalancerTest {
     Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
 
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
     verify(helper).createOobChannel(ArgumentMatchers.<EquivalentAddressGroup>any(), anyString());
     verify(oobChannel1)
         .newCall(ArgumentMatchers.<MethodDescriptor<?, ?>>any(),
@@ -435,7 +471,11 @@ public class XdsLoadBalancerTest {
     Map<String, ?> lbConfig2 = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig2).build();
 
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
 
     assertThat(lb.getXdsLbStateForTest().childPolicy).isNotNull();
 
@@ -453,63 +493,71 @@ public class XdsLoadBalancerTest {
 
   @Test
   public void fallback_AdsNotWorkingYetTimerExpired() throws Exception {
-    lb.handleResolvedAddressGroups(
-        Collections.<EquivalentAddressGroup>emptyList(), standardModeWithFallback1Attributes());
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(standardModeWithFallback1Attributes())
+            .build());
 
     assertThat(fakeClock.forwardTime(10, TimeUnit.SECONDS)).isEqualTo(1);
     assertThat(fakeClock.getPendingTasks()).isEmpty();
 
-    ArgumentCaptor<Attributes> captor = ArgumentCaptor.forClass(Attributes.class);
-    verify(fakeBalancer1).handleResolvedAddressGroups(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), captor.capture());
-    assertThat(captor.getValue().get(ATTR_LOAD_BALANCING_CONFIG))
+    ArgumentCaptor<ResolvedAddresses> captor = ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(fakeBalancer1).handleResolvedAddresses(captor.capture());
+    assertThat(captor.getValue().getAttributes().get(ATTR_LOAD_BALANCING_CONFIG))
         .containsExactly("supported_1_option", "yes");
   }
 
   @Test
   public void fallback_AdsWorkingTimerCancelled() throws Exception {
-    lb.handleResolvedAddressGroups(
-        Collections.<EquivalentAddressGroup>emptyList(), standardModeWithFallback1Attributes());
-
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(standardModeWithFallback1Attributes())
+            .build());
     serverResponseWriter.onNext(DiscoveryResponse.getDefaultInstance());
 
     assertThat(fakeClock.getPendingTasks()).isEmpty();
-    verify(fakeBalancer1, never()).handleResolvedAddressGroups(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), ArgumentMatchers.<Attributes>any());
+    verify(fakeBalancer1, never()).handleResolvedAddresses(
+        ArgumentMatchers.any(ResolvedAddresses.class));
   }
 
   @Test
   public void fallback_AdsErrorAndNoActiveSubchannel() throws Exception {
-    lb.handleResolvedAddressGroups(
-        Collections.<EquivalentAddressGroup>emptyList(), standardModeWithFallback1Attributes());
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(standardModeWithFallback1Attributes())
+            .build());
 
     serverResponseWriter.onError(new Exception("fake error"));
 
-    ArgumentCaptor<Attributes> captor = ArgumentCaptor.forClass(Attributes.class);
-    verify(fakeBalancer1).handleResolvedAddressGroups(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), captor.capture());
-    assertThat(captor.getValue().get(ATTR_LOAD_BALANCING_CONFIG))
+    ArgumentCaptor<ResolvedAddresses> captor = ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(fakeBalancer1).handleResolvedAddresses(captor.capture());
+    assertThat(captor.getValue().getAttributes().get(ATTR_LOAD_BALANCING_CONFIG))
         .containsExactly("supported_1_option", "yes");
 
     assertThat(fakeClock.forwardTime(10, TimeUnit.SECONDS)).isEqualTo(1);
     assertThat(fakeClock.getPendingTasks()).isEmpty();
 
-    // verify handleResolvedAddressGroups() is not called again
-    verify(fakeBalancer1).handleResolvedAddressGroups(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), ArgumentMatchers.<Attributes>any());
+    // verify handleResolvedAddresses() is not called again
+    verify(fakeBalancer1).handleResolvedAddresses(ArgumentMatchers.any(ResolvedAddresses.class));
   }
 
   @Test
   public void fallback_AdsErrorWithActiveSubchannel() throws Exception {
-    lb.handleResolvedAddressGroups(
-        Collections.<EquivalentAddressGroup>emptyList(), standardModeWithFallback1Attributes());
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(standardModeWithFallback1Attributes())
+            .build());
 
     serverResponseWriter.onNext(DiscoveryResponse.getDefaultInstance());
     doReturn(true).when(fakeSubchannelStore).hasReadyBackends();
     serverResponseWriter.onError(new Exception("fake error"));
 
-    verify(fakeBalancer1, never()).handleResolvedAddressGroups(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), ArgumentMatchers.<Attributes>any());
+    verify(fakeBalancer1, never()).handleResolvedAddresses(
+        ArgumentMatchers.any(ResolvedAddresses.class));
 
     Subchannel subchannel = new Subchannel() {
       @Override
@@ -533,10 +581,9 @@ public class XdsLoadBalancerTest {
     lb.handleSubchannelState(subchannel, ConnectivityStateInfo.forTransientFailure(
         Status.UNAVAILABLE));
 
-    ArgumentCaptor<Attributes> captor = ArgumentCaptor.forClass(Attributes.class);
-    verify(fakeBalancer1).handleResolvedAddressGroups(
-        ArgumentMatchers.<List<EquivalentAddressGroup>>any(), captor.capture());
-    assertThat(captor.getValue().get(ATTR_LOAD_BALANCING_CONFIG))
+    ArgumentCaptor<ResolvedAddresses> captor = ArgumentCaptor.forClass(ResolvedAddresses.class);
+    verify(fakeBalancer1).handleResolvedAddresses(captor.capture());
+    assertThat(captor.getValue().getAttributes().get(ATTR_LOAD_BALANCING_CONFIG))
         .containsExactly("supported_1_option", "yes");
   }
 
@@ -560,7 +607,11 @@ public class XdsLoadBalancerTest {
     @SuppressWarnings("unchecked")
     Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
     Attributes attrs = Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
-    lb.handleResolvedAddressGroups(Collections.<EquivalentAddressGroup>emptyList(), attrs);
+    lb.handleResolvedAddresses(
+        ResolvedAddresses.newBuilder()
+            .setServers(Collections.<EquivalentAddressGroup>emptyList())
+            .setAttributes(attrs)
+            .build());
 
     assertThat(fakeClock.getPendingTasks()).isNotEmpty();
     lb.shutdown();


### PR DESCRIPTION
This allows the load balancer to accept the service config object.   It is **not** yet wired up, this only creates the API do so.   