### PR TITLE
core: fix DNS JNDI not working if there is an unavailability cause

### DIFF
--- a/core/src/main/java/io/grpc/internal/DnsNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/DnsNameResolver.java
@@ -693,6 +693,7 @@ final class DnsNameResolver extends NameResolver {
           Level.FINE,
           "JndiResourceResolverFactory not available, skipping.",
           rrf.unavailabilityCause());
+      return null;
     }
     return rrf;
   }


### PR DESCRIPTION
This case was missed by oversight.    No tests because I have almost no way to test the class loading failure.