### PR TITLE
Ensure ELGs used by TransportBenchmark.NETTY_LOCAL are shutdown

### DIFF
--- a/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
+++ b/benchmarks/src/jmh/java/io/grpc/benchmarks/TransportBenchmark.java
@@ -105,6 +105,7 @@ public class TransportBenchmark {
             .eventLoopGroup(group)
             .channelType(LocalChannel.class)
             .negotiationType(NegotiationType.PLAINTEXT);
+        groupToShutdown = group;
         break;
       }
       case NETTY_EPOLL:


### PR DESCRIPTION
This was an omission from #5492, sorry! Without it there are some ugly warnings in the log.