### PR TITLE
Revert " core: deprecate NR.L and add NR.Results "

### DIFF
--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -20,13 +20,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -46,9 +43,9 @@ import javax.annotation.concurrent.ThreadSafe;
  * {@link #refresh()}.
  *
  * <p>Implementations <strong>don't need to be thread-safe</strong>.  All methods are guaranteed to
- * be called sequentially.  Additionally, all methods that have side-effects, i.e.,
- * {@link #start(Observer)}, {@link #shutdown} and {@link #refresh} are called from the same
- * {@link SynchronizationContext} as returned by {@link Helper#getSynchronizationContext}.
+ * be called sequentially.  Additionally, all methods that have side-effects, i.e., {@link #start},
+ * {@link #shutdown} and {@link #refresh} are called from the same {@link SynchronizationContext} as
+ * returned by {@link Helper#getSynchronizationContext}.
  *
  * @since 1.0.0
  */
@@ -71,23 +68,9 @@ public abstract class NameResolver {
    * Starts the resolution.
    *
    * @param listener used to receive updates on the target
-   * @deprecated override {@link #start(Observer)} instead.
    * @since 1.0.0
    */
-  @Deprecated
-  public void start(Listener listener) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
-
-  /**
-   * Starts the resolution.  This method will become abstract in 1.21.0.
-   *
-   * @param observer used to receive updates on the target
-   * @since 1.20.0
-   */
-  public void start(Observer observer) {
-    start((Listener) observer);
-  }
+  public abstract void start(Listener listener);
 
   /**
    * Stops the resolution. Updates to the Listener will stop.
@@ -197,12 +180,10 @@ public abstract class NameResolver {
    *
    * <p>All methods are expected to return quickly.
    *
-   * @deprecated use {@link Observer} instead.
    * @since 1.0.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
   @ThreadSafe
-  @Deprecated
   public interface Listener {
     /**
      * Handles updates on resolved addresses and attributes.
@@ -224,44 +205,6 @@ public abstract class NameResolver {
      * @since 1.0.0
      */
     void onError(Status error);
-  }
-
-  /**
-   * Receives address updates.
-   *
-   * <p>All methods are expected to return quickly.
-   *
-   * @since 1.20.0
-   */
-  public abstract static class Observer implements Listener {
-    /**
-     * @deprecated This will be removed in 1.21.0
-     */
-    @Override
-    @Deprecated
-    public final void onAddresses(
-        List<EquivalentAddressGroup> servers, @ResolutionResultAttr Attributes attributes) {
-      onResult(ResolutionResult.newBuilder().setServers(servers).setAttributes(attributes).build());
-    }
-
-    /**
-     * Handles updates on resolved addresses and attributes.  If
-     * {@link ResolutionResult#getServers()} is empty, {@link #onError(Status)} will be called.
-     *
-     * @param resolutionResult the resolved server addresses, attributes, and Service Config.
-     * @since 1.20.0
-     */
-    public abstract void onResult(ResolutionResult resolutionResult);
-
-    /**
-     * Handles an error from the resolver. The observer is responsible for eventually invoking
-     * {@link NameResolver#refresh()} to re-attempt resolution.
-     *
-     * @param error a non-OK status
-     * @since 1.20.0
-     */
-    @Override
-    public abstract void onError(Status error);
   }
 
   /**
@@ -296,8 +239,8 @@ public abstract class NameResolver {
     public abstract ProxyDetector getProxyDetector();
 
     /**
-     * Returns the {@link SynchronizationContext} where {@link #start(Observer)}, {@link #shutdown}
-     * and {@link #refresh} are run from.
+     * Returns the {@link SynchronizationContext} where {@link #start}, {@link #shutdown} and {@link
+     * #refresh} are run from.
      *
      * @since 1.20.0
      */
@@ -309,8 +252,7 @@ public abstract class NameResolver {
      * Parses and validates the service configuration chosen by the name resolver.  This will
      * return a {@link ConfigOrError} which contains either the successfully parsed config, or the
      * {@link Status} representing the failure to parse.  Implementations are expected to not throw
-     * exceptions but return a Status representing the failure.  The value inside the
-     * {@link ConfigOrError} should implement {@link Object#equals()} and {@link Object#hashCode()}.
+     * exceptions but return a Status representing the failure.
      *
      * @param rawServiceConfig The {@link Map} representation of the service config
      * @return a tuple of the fully parsed and validated channel configuration, else the Status.
@@ -404,145 +346,6 @@ public abstract class NameResolver {
               .add("error", status)
               .toString();
         }
-      }
-    }
-  }
-
-  /**
-   * Represents the results from a Name Resolver.
-   *
-   * @since 1.20.0
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
-  public static final class ResolutionResult {
-    private final List<EquivalentAddressGroup> servers;
-    @ResolutionResultAttr
-    private final Attributes attributes;
-    @Nullable
-    private final Object serviceConfig;
-
-    ResolutionResult(
-        List<EquivalentAddressGroup> servers,
-        @ResolutionResultAttr Attributes attributes,
-        Object serviceConfig) {
-      this.servers = Collections.unmodifiableList(new ArrayList<>(servers));
-      this.attributes = checkNotNull(attributes, "attributes");
-      this.serviceConfig = serviceConfig;
-    }
-
-    /**
-     * Constructs a new builder of a name resolution result.
-     *
-     * @since 1.20.0
-     */
-    public static Builder newBuilder() {
-      return new Builder();
-    }
-
-    /**
-     * Gets the servers resolved by name resolution.
-     *
-     * @since 1.20.0
-     */
-    public List<EquivalentAddressGroup> getServers() {
-      return servers;
-    }
-
-    /**
-     * Gets the attributes associated with the servers resolved by name resolution.
-     *
-     * @since 1.20.0
-     */
-    @ResolutionResultAttr
-    public Attributes getAttributes() {
-      return attributes;
-    }
-
-    /**
-     * Gets the Service Config parsed by {@link NameResolver.Helper#parseServiceConfig(Map)}.
-     *
-     * @since 1.20.0
-     */
-    @Nullable
-    public Object getServiceConfig() {
-      return serviceConfig;
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("servers", servers)
-          .add("attributes", attributes)
-          .add("serviceConfig", serviceConfig)
-          .toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof ResolutionResult)) {
-        return false;
-      }
-      ResolutionResult that = (ResolutionResult) obj;
-      return Objects.equal(this.servers, that.servers)
-          && Objects.equal(this.attributes, that.attributes)
-          && Objects.equal(this.serviceConfig, that.serviceConfig);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(servers, attributes, serviceConfig);
-    }
-
-    /**
-     * A builder for {@link ResolutionResult}.
-     *
-     * @since 1.20.0
-     */
-    public static final class Builder {
-      private List<EquivalentAddressGroup> servers = Collections.emptyList();
-      private Attributes attributes = Attributes.EMPTY;
-      @Nullable
-      private Object serviceConfig;
-
-      Builder() {}
-
-      /**
-       * Sets the servers resolved by name resolution.
-       *
-       * @since 1.20.0
-       */
-      public Builder setServers(List<EquivalentAddressGroup> servers) {
-        this.servers = servers;
-        return this;
-      }
-
-      /**
-       * Sets the attributes for the servers resolved by name resolution.
-       *
-       * @since 1.20.0
-       */
-      public Builder setAttributes(Attributes attributes) {
-        this.attributes = attributes;
-        return this;
-      }
-
-      /**
-       * Sets the Service Config parsed by {@link NameResolver.Helper#parseServiceConfig(Map)}.
-       *
-       * @since 1.20.0
-       */
-      public Builder setServiceConfig(@Nullable Object serviceConfig) {
-        this.serviceConfig = serviceConfig;
-        return this;
-      }
-
-      /**
-       * Constructs a new {@link ResolutionResult} from this builder.
-       *
-       * @since 1.20.0
-       */
-      public ResolutionResult build() {
-        return new ResolutionResult(servers, attributes, serviceConfig);
       }
     }
   }

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -603,12 +603,10 @@ public abstract class AbstractManagedChannelImplBuilder
         }
 
         @Override
-        public void start(Observer observer) {
-          observer.onResult(
-              ResolutionResult.newBuilder()
-                  .setServers(Collections.singletonList(new EquivalentAddressGroup(address)))
-                  .setAttributes(Attributes.EMPTY)
-                  .build());
+        public void start(final Listener listener) {
+          listener.onAddresses(
+              Collections.singletonList(new EquivalentAddressGroup(address)),
+              Attributes.EMPTY);
         }
 
         @Override

--- a/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
@@ -38,14 +38,8 @@ abstract class ForwardingNameResolver extends NameResolver {
   }
 
   @Override
-  @Deprecated
   public void start(Listener listener) {
     delegate.start(listener);
-  }
-
-  @Override
-  public void start(Observer observer) {
-    delegate.start(observer);
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/ForwardingNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingNameResolverTest.java
@@ -25,7 +25,6 @@ import io.grpc.Attributes;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ForwardingTestUtil;
 import io.grpc.NameResolver;
-import io.grpc.NameResolver.ResolutionResult;
 import io.grpc.Status;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -61,8 +60,7 @@ public class ForwardingNameResolverTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation") // this will be removed in 1.21.0
-  public void start_listener() {
+  public void start() {
     NameResolver.Listener listener = new NameResolver.Listener() {
       @Override
       public void onAddresses(List<EquivalentAddressGroup> servers, Attributes attributes) { }
@@ -73,22 +71,5 @@ public class ForwardingNameResolverTest {
 
     forwarder.start(listener);
     verify(delegate).start(listener);
-  }
-
-
-  @Test
-  public void start_observer() {
-    NameResolver.Observer observer = new NameResolver.Observer() {
-      @Override
-      public void onResult(ResolutionResult result) {
-
-      }
-
-      @Override
-      public void onError(Status error) { }
-    };
-
-    forwarder.start(observer);
-    verify(delegate).start(observer);
   }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -176,7 +176,7 @@ public class ManagedChannelImplGetNameResolverTest {
       return uri.getAuthority();
     }
 
-    @Override public void start(final Observer observer) {}
+    @Override public void start(final Listener listener) {}
 
     @Override public void shutdown() {}
   }

--- a/core/src/test/java/io/grpc/internal/OverrideAuthorityNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/OverrideAuthorityNameResolverTest.java
@@ -81,7 +81,7 @@ public class OverrideAuthorityNameResolverTest {
     NameResolver overrideResolver =
         factory.newNameResolver(URI.create("dns:///localhost:443"), HELPER);
     assertNotNull(overrideResolver);
-    NameResolver.Observer listener = mock(NameResolver.Observer.class);
+    NameResolver.Listener listener = mock(NameResolver.Listener.class);
 
     overrideResolver.start(listener);
     verify(mockResolver).start(listener);


### PR DESCRIPTION
This reverts commit f4a31ec62d038abf6faea7abaf377e2df3d308f0.

This change is part of a series of unfinished API changes and refactors for [Service Config Error Handling](https://github.com/grpc/proposal/blob/master/A21-service-config-error-handling.md#service-config-error-handling). It by its own should not go into the release.