### PR TITLE
core: disable stats and tracing when OpenCensus impls aren't present

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -172,11 +172,11 @@ public abstract class AbstractManagedChannelImplBuilder
     return maxInboundMessageSize;
   }
 
-  private boolean statsEnabled = true;
+  private boolean statsEnabled = CensusStatsModule.OPENCENSUS_IMPL_PRESENT;
   private boolean recordStartedRpcs = true;
   private boolean recordFinishedRpcs = true;
   private boolean recordRealTimeMetrics = false;
-  private boolean tracingEnabled = true;
+  private boolean tracingEnabled = CensusTracingModule.OPENCENSUS_IMPL_PRESENT;
 
   @Nullable
   private CensusStatsModule censusStatsOverride;

--- a/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerImplBuilder.java
@@ -79,11 +79,11 @@ public abstract class AbstractServerImplBuilder<T extends AbstractServerImplBuil
   CompressorRegistry compressorRegistry = DEFAULT_COMPRESSOR_REGISTRY;
   long handshakeTimeoutMillis = DEFAULT_HANDSHAKE_TIMEOUT_MILLIS;
   @Nullable private CensusStatsModule censusStatsOverride;
-  private boolean statsEnabled = true;
+  private boolean statsEnabled = CensusStatsModule.OPENCENSUS_IMPL_PRESENT;
   private boolean recordStartedRpcs = true;
   private boolean recordFinishedRpcs = true;
   private boolean recordRealTimeMetrics = false;
-  private boolean tracingEnabled = true;
+  private boolean tracingEnabled = CensusTracingModule.OPENCENSUS_IMPL_PRESENT;
   @Nullable BinaryLog binlog;
   TransportTracer.Factory transportTracerFactory = TransportTracer.getDefaultFactory();
   InternalChannelz channelz = InternalChannelz.instance();

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -71,6 +71,15 @@ public final class CensusStatsModule {
   private static final Logger logger = Logger.getLogger(CensusStatsModule.class.getName());
   private static final double NANOS_PER_MILLI = TimeUnit.MILLISECONDS.toNanos(1);
 
+  static final boolean OPENCENSUS_IMPL_PRESENT;
+
+  static {
+    ClassLoader loader = io.opencensus.stats.StatsComponent.class.getClassLoader();
+    OPENCENSUS_IMPL_PRESENT =
+        GrpcUtil.classIsFound("io.opencensus.impl.stats.StatsComponentImpl", loader)
+        || GrpcUtil.classIsFound("io.opencensus.impllite.stats.StatsComponentImplLite", loader);
+  }
+
   private final Tagger tagger;
   private final StatsRecorder statsRecorder;
   private final Supplier<Stopwatch> stopwatchSupplier;

--- a/core/src/main/java/io/grpc/internal/CensusTracingModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusTracingModule.java
@@ -60,6 +60,8 @@ import javax.annotation.Nullable;
 final class CensusTracingModule {
   private static final Logger logger = Logger.getLogger(CensusTracingModule.class.getName());
 
+  static final boolean OPENCENSUS_IMPL_PRESENT;
+
   @Nullable private static final AtomicIntegerFieldUpdater<ClientCallTracer> callEndedUpdater;
 
   @Nullable private static final AtomicIntegerFieldUpdater<ServerTracer> streamClosedUpdater;
@@ -84,6 +86,11 @@ final class CensusTracingModule {
     }
     callEndedUpdater = tmpCallEndedUpdater;
     streamClosedUpdater = tmpStreamClosedUpdater;
+    
+    ClassLoader loader = io.opencensus.trace.TraceComponent.class.getClassLoader();
+    OPENCENSUS_IMPL_PRESENT =
+        GrpcUtil.classIsFound("io.opencensus.impl.trace.TraceComponentImpl", loader)
+        || GrpcUtil.classIsFound("io.opencensus.impllite.trace.TraceComponentImplLite", loader);
   }
 
   private final Tracer censusTracer;

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -781,5 +781,18 @@ public final class GrpcUtil {
     return false;
   }
 
+  /**
+   * Returns true if the specified class is found on the classpath, false otherwise.
+   */
+  public static boolean classIsFound(String className, ClassLoader classLoader) {
+    try {
+      Class.forName(className, /* initialize = */ false, classLoader);
+      return true;
+    } catch (ClassNotFoundException e) {
+      // no problem
+    }
+    return false;
+  }
+
   private GrpcUtil() {}
 }

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -296,43 +296,43 @@ public class AbstractManagedChannelImplBuilderTest {
   public void getEffectiveInterceptors_default() {
     builder.intercept(DUMMY_USER_INTERCEPTOR);
     List<ClientInterceptor> effectiveInterceptors = builder.getEffectiveInterceptors();
+    assertThat(effectiveInterceptors).containsExactly(DUMMY_USER_INTERCEPTOR);
+  }
+
+  @Test
+  public void getEffectiveInterceptors_enableStats() {
+    builder.intercept(DUMMY_USER_INTERCEPTOR);
+    builder.setStatsEnabled(true);
+    List<ClientInterceptor> effectiveInterceptors = builder.getEffectiveInterceptors();
+    assertEquals(2, effectiveInterceptors.size());
+    assertThat(effectiveInterceptors.get(0))
+        .isInstanceOf(CensusStatsModule.StatsClientInterceptor.class);
+    assertThat(effectiveInterceptors.get(1)).isSameAs(DUMMY_USER_INTERCEPTOR);
+  }
+
+  @Test
+  public void getEffectiveInterceptors_enableTracing() {
+    builder.intercept(DUMMY_USER_INTERCEPTOR);
+    builder.setTracingEnabled(true);
+    List<ClientInterceptor> effectiveInterceptors = builder.getEffectiveInterceptors();
+    assertEquals(2, effectiveInterceptors.size());
+    assertThat(effectiveInterceptors.get(0))
+        .isInstanceOf(CensusTracingModule.TracingClientInterceptor.class);
+    assertThat(effectiveInterceptors.get(1)).isSameAs(DUMMY_USER_INTERCEPTOR);
+  }
+
+  @Test
+  public void getEffectiveInterceptors_enableBoth() {
+    builder.intercept(DUMMY_USER_INTERCEPTOR);
+    builder.setStatsEnabled(true);
+    builder.setTracingEnabled(true);
+    List<ClientInterceptor> effectiveInterceptors = builder.getEffectiveInterceptors();
     assertEquals(3, effectiveInterceptors.size());
     assertThat(effectiveInterceptors.get(0))
         .isInstanceOf(CensusTracingModule.TracingClientInterceptor.class);
     assertThat(effectiveInterceptors.get(1))
         .isInstanceOf(CensusStatsModule.StatsClientInterceptor.class);
     assertThat(effectiveInterceptors.get(2)).isSameAs(DUMMY_USER_INTERCEPTOR);
-  }
-
-  @Test
-  public void getEffectiveInterceptors_disableStats() {
-    builder.intercept(DUMMY_USER_INTERCEPTOR);
-    builder.setStatsEnabled(false);
-    List<ClientInterceptor> effectiveInterceptors = builder.getEffectiveInterceptors();
-    assertEquals(2, effectiveInterceptors.size());
-    assertThat(effectiveInterceptors.get(0))
-        .isInstanceOf(CensusTracingModule.TracingClientInterceptor.class);
-    assertThat(effectiveInterceptors.get(1)).isSameAs(DUMMY_USER_INTERCEPTOR);
-  }
-
-  @Test
-  public void getEffectiveInterceptors_disableTracing() {
-    builder.intercept(DUMMY_USER_INTERCEPTOR);
-    builder.setTracingEnabled(false);
-    List<ClientInterceptor> effectiveInterceptors = builder.getEffectiveInterceptors();
-    assertEquals(2, effectiveInterceptors.size());
-    assertThat(effectiveInterceptors.get(0))
-        .isInstanceOf(CensusStatsModule.StatsClientInterceptor.class);
-    assertThat(effectiveInterceptors.get(1)).isSameAs(DUMMY_USER_INTERCEPTOR);
-  }
-
-  @Test
-  public void getEffectiveInterceptors_disableBoth() {
-    builder.intercept(DUMMY_USER_INTERCEPTOR);
-    builder.setStatsEnabled(false);
-    builder.setTracingEnabled(false);
-    List<ClientInterceptor> effectiveInterceptors = builder.getEffectiveInterceptors();
-    assertThat(effectiveInterceptors).containsExactly(DUMMY_USER_INTERCEPTOR);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerImplBuilderTest.java
@@ -49,17 +49,25 @@ public class AbstractServerImplBuilderTest {
     builder.addStreamTracerFactory(DUMMY_USER_TRACER);
 
     List<? extends ServerStreamTracer.Factory> factories = builder.getTracerFactories();
-
-    assertEquals(3, factories.size());
-    assertThat(factories.get(0)).isInstanceOf(CensusStatsModule.ServerTracerFactory.class);
-    assertThat(factories.get(1)).isInstanceOf(CensusTracingModule.ServerTracerFactory.class);
-    assertThat(factories.get(2)).isSameAs(DUMMY_USER_TRACER);
+    assertThat(factories).containsExactly(DUMMY_USER_TRACER);
   }
 
   @Test
-  public void getTracerFactories_disableStats() {
+  public void getTracerFactories_enableStats() {
     builder.addStreamTracerFactory(DUMMY_USER_TRACER);
-    builder.setStatsEnabled(false);
+    builder.setStatsEnabled(true);
+
+    List<? extends ServerStreamTracer.Factory> factories = builder.getTracerFactories();
+
+    assertEquals(2, factories.size());
+    assertThat(factories.get(0)).isInstanceOf(CensusStatsModule.ServerTracerFactory.class);
+    assertThat(factories.get(1)).isSameAs(DUMMY_USER_TRACER);
+  }
+
+  @Test
+  public void getTracerFactories_enableTracing() {
+    builder.addStreamTracerFactory(DUMMY_USER_TRACER);
+    builder.setTracingEnabled(true);
 
     List<? extends ServerStreamTracer.Factory> factories = builder.getTracerFactories();
 
@@ -69,24 +77,15 @@ public class AbstractServerImplBuilderTest {
   }
 
   @Test
-  public void getTracerFactories_disableTracing() {
+  public void getTracerFactories_enableBoth() {
     builder.addStreamTracerFactory(DUMMY_USER_TRACER);
-    builder.setTracingEnabled(false);
-
+    builder.setTracingEnabled(true);
+    builder.setStatsEnabled(true);
     List<? extends ServerStreamTracer.Factory> factories = builder.getTracerFactories();
-
-    assertEquals(2, factories.size());
+    assertEquals(3, factories.size());
     assertThat(factories.get(0)).isInstanceOf(CensusStatsModule.ServerTracerFactory.class);
-    assertThat(factories.get(1)).isSameAs(DUMMY_USER_TRACER);
-  }
-
-  @Test
-  public void getTracerFactories_disableBoth() {
-    builder.addStreamTracerFactory(DUMMY_USER_TRACER);
-    builder.setTracingEnabled(false);
-    builder.setStatsEnabled(false);
-    List<? extends ServerStreamTracer.Factory> factories = builder.getTracerFactories();
-    assertThat(factories).containsExactly(DUMMY_USER_TRACER);
+    assertThat(factories.get(1)).isInstanceOf(CensusTracingModule.ServerTracerFactory.class);
+    assertThat(factories.get(2)).isSameAs(DUMMY_USER_TRACER);
   }
 
   static class Builder extends AbstractServerImplBuilder<Builder> {


### PR DESCRIPTION
The interceptors do nothing when the OpenCensus implementation classes aren't loadable, yet still have significant overhead. So this change should not break any existing users of opencensus. See #5510 for example of the performance benefit to other users.

Contributes to #5510.