### PR TITLE
Update Android Build Tools to 3.3.2, and Gradle to 4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.5'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
   }
 }
 

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
+        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.6"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ subprojects {
             protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",
             protobuf_nano: "com.google.protobuf.nano:protobuf-javanano:${protobufNanoVersion}",
             protoc_nano: "com.google.protobuf:protoc:3.5.1-1",
-            protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.5',
+            protobuf_plugin: 'com.google.protobuf:protobuf-gradle-plugin:0.8.8',
             protobuf_util: "com.google.protobuf:protobuf-java-util:${protobufVersion}",
             lang: "org.apache.commons:commons-lang3:3.5",
 

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
         jcenter()
     }
-    dependencies { classpath 'com.android.tools.build:gradle:3.0.1' }
+    dependencies { classpath 'com.android.tools.build:gradle:3.3.2' }
 }
 
 allprojects {

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
+        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
+        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
+        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/example-kotlin/android/helloworld/build.gradle
+++ b/examples/example-kotlin/android/helloworld/build.gradle
@@ -9,8 +9,8 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
+        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is intended to fix android-interop build failures as seen in
https://source.cloud.google.com/results/invocations/dc18ac18-556a-4871-b5ce-78b07f783e9e/log:
.../byte-buddy-agent-1.9.7.jar: D8: Illegal class file: Class module-info is missing a super type.

The new version of Android Build Tools requires Gradle 4.10+, so upgrading it
as well.

Protobuf-gradle-plugin was upgraded to 0.8.8 for compatibility with the newer
Android plugin.

------

I verified locally this fixed the android-interop-testing build. Fixes #5523

CC @TimvdLippe 
CC @zhangkun83 (as FYI the protobuf-gradle plugin is being upgraded)