### PR TITLE
kokoro: Add android-interop-test to android build

### DIFF
--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -35,6 +35,12 @@ pushd android
 ../gradlew build
 popd
 
+# Build android-interop-testing
+
+pushd android-interop-testing
+../gradlew build
+popd
+
 # Build examples
 
 cd ./examples/android/clientcache


### PR DESCRIPTION
It is already being built as part of android-interop, but android-interop is
only run post-submit. We want to notice compilation errors before that point.

-----

Since the android-interop-test build is currently broken, this depends on #5537.