### PR TITLE
grpc-testing and grpc-interop-testing no longer transitively depend on mockito (v1.20.x)

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -23,12 +23,12 @@ dependencies {
             project(':grpc-testing'),
             libraries.google_auth_oauth2_http,
             libraries.junit,
-            libraries.mockito,
             libraries.truth
     compileOnly libraries.javax_annotation
     runtime libraries.opencensus_impl,
             libraries.netty_tcnative
-    testCompile project(':grpc-context').sourceSets.test.output
+    testCompile project(':grpc-context').sourceSets.test.output,
+            libraries.mockito
 }
 
 configureProtoCompilation()

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -4,7 +4,8 @@ dependencies {
     compile project(':grpc-core'),
             project(':grpc-stub'),
             libraries.junit
-    compile (libraries.mockito) {
+
+    testCompile (libraries.mockito) {
         // prefer 1.3 from JUnit instead of 1.1
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }


### PR DESCRIPTION
Cherry picks of 40526086eb612f07715b45b2181a7448d12a481f and 3325881eaec5b959b95915bdb83d0a9f0b61a06c

grpc-testing and grpc-interop-testing in v1.19.0 and earlier used to transitively depend on mockito 1. Now in v1.20.0, if they transitively depend on mocikito 2, it would be a bigger breaking change to our users than they are not depending on mockito at all. (And in next release (v1.21.0) they are no longer depending on mockito anyway.)

Also fixes #5523 in v1.20.x branch.