### PR TITLE
core: refactor lookUpServiceConfig(boolean) to disableServiceConfigLookUp()

### DIFF
--- a/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ForwardingChannelBuilder.java
@@ -251,8 +251,8 @@ public abstract class ForwardingChannelBuilder<T extends ForwardingChannelBuilde
   }
 
   @Override
-  public T lookUpServiceConfig(boolean enable) {
-    delegate().lookUpServiceConfig(enable);
+  public T disableServiceConfigLookUp() {
+    delegate().disableServiceConfigLookUp();
     return thisT();
   }
 

--- a/core/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/core/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -542,7 +542,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   /**
    * Provides a service config to the channel. The channel will use the default service config when
    * the name resolver provides no service config or if the channel disables lookup service config
-   * from name resolver (see {@link #lookUpServiceConfig(boolean)}). The argument
+   * from name resolver (see {@link #disableServiceConfigLookUp()}). The argument
    * {@code serviceConfig} is a nested map representing a Json object in the most natural way:
    *
    *        <table border="1">
@@ -583,13 +583,13 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
-   * Enables or disables service config look-up from the naming system. Enabled by default.
+   * Disables service config look-up from the naming system, which is enabled by default.
    *
    * @return this
    * @since 1.20.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5189")
-  public T lookUpServiceConfig(boolean enable) {
+  public T disableServiceConfigLookUp() {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -452,8 +452,8 @@ public abstract class AbstractManagedChannelImplBuilder
   }
 
   @Override
-  public T lookUpServiceConfig(boolean enable) {
-    this.lookUpServiceConfig = enable;
+  public T disableServiceConfigLookUp() {
+    this.lookUpServiceConfig = false;
     return thisT();
   }
 

--- a/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractManagedChannelImplBuilderTest.java
@@ -493,7 +493,7 @@ public class AbstractManagedChannelImplBuilderTest {
     Builder builder = new Builder("target");
     assertThat(builder.lookUpServiceConfig).isTrue();
 
-    builder.lookUpServiceConfig(false);
+    builder.disableServiceConfigLookUp();
     assertThat(builder.lookUpServiceConfig).isFalse();
   }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -3515,7 +3515,7 @@ public class ManagedChannelImplTest {
           new FakeNameResolverFactory.Builder(expectedUri)
               .setServers(ImmutableList.of(addressGroup)).build();
       channelBuilder.nameResolverFactory(nameResolverFactory);
-      channelBuilder.lookUpServiceConfig(false);
+      channelBuilder.disableServiceConfigLookUp();
 
       Map<String, Object> serviceConfig =
           parseConfig("{\"methodConfig\":[{"
@@ -3549,7 +3549,7 @@ public class ManagedChannelImplTest {
           new FakeNameResolverFactory.Builder(expectedUri)
               .setServers(ImmutableList.of(addressGroup)).build();
       channelBuilder.nameResolverFactory(nameResolverFactory);
-      channelBuilder.lookUpServiceConfig(false);
+      channelBuilder.disableServiceConfigLookUp();
       Map<String, Object> defaultServiceConfig =
           parseConfig("{\"methodConfig\":[{"
               + "\"name\":[{\"service\":\"SimpleService1\"}],"
@@ -3734,7 +3734,7 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup)).build();
     channelBuilder.nameResolverFactory(nameResolverFactory);
-    channelBuilder.lookUpServiceConfig(false);
+    channelBuilder.disableServiceConfigLookUp();
     Map<String, Object> defaultServiceConfig =
         parseConfig("{\"methodConfig\":[{"
             + "\"name\":[{\"service\":\"SimpleService1\"}],"
@@ -3760,7 +3760,6 @@ public class ManagedChannelImplTest {
         new FakeNameResolverFactory.Builder(expectedUri)
             .setServers(ImmutableList.of(addressGroup)).build();
     channelBuilder.nameResolverFactory(nameResolverFactory);
-    channelBuilder.lookUpServiceConfig(true);
     Map<String, Object> defaultServiceConfig =
         parseConfig("{\"methodConfig\":[{"
             + "\"name\":[{\"service\":\"SimpleService1\"}],"


### PR DESCRIPTION
Refactor as discussed in #5189. Will backport to v1.20.0 to reduce a cycle of deprecation process.