### PR TITLE
Update Protobuf to 3.7.1

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -44,7 +44,7 @@ For Linux, Mac and MinGW:
 ```
 $ git clone https://github.com/google/protobuf.git
 $ cd protobuf
-$ git checkout v3.7.0
+$ git checkout v3.7.1
 $ ./autogen.sh
 $ ./configure --disable-shared
 $ make
@@ -83,16 +83,16 @@ When building on Windows and VC++, you need to specify project properties for
 Gradle to find protobuf:
 ```
 .\gradlew publishToMavenLocal ^
-    -PvcProtobufInclude=C:\path\to\protobuf-3.7.0\src ^
-    -PvcProtobufLibs=C:\path\to\protobuf-3.7.0\vsprojects\Release ^
+    -PvcProtobufInclude=C:\path\to\protobuf-3.7.1\src ^
+    -PvcProtobufLibs=C:\path\to\protobuf-3.7.1\vsprojects\Release ^
     -PtargetArch=x86_32
 ```
 
 Since specifying those properties every build is bothersome, you can instead
 create ``<project-root>\gradle.properties`` with contents like:
 ```
-vcProtobufInclude=C:\\path\\to\\protobuf-3.7.0\\src
-vcProtobufLibs=C:\\path\\to\\protobuf-3.7.0\\vsprojects\\Release
+vcProtobufInclude=C:\\path\\to\\protobuf-3.7.1\\src
+vcProtobufLibs=C:\\path\\to\\protobuf-3.7.1\\vsprojects\\Release
 targetArch=x86_32
 ```
 

--- a/android-interop-testing/app/build.gradle
+++ b/android-interop-testing/app/build.gradle
@@ -39,7 +39,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.1' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.21.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
         nettyVersion = '4.1.34.Final'
         googleauthVersion = '0.13.0'
         guavaVersion = '26.0-android'
-        protobufVersion = '3.7.0'
+        protobufVersion = '3.7.1'
         protocVersion = protobufVersion
         protobufNanoVersion = '3.0.0-alpha-5'
         opencensusVersion = '0.19.2'

--- a/buildscripts/build_docker.sh
+++ b/buildscripts/build_docker.sh
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 
 readonly proto_dir="$(mktemp -d --tmpdir protobuf.XXXXXX)"
-wget -O - https://github.com/google/protobuf/archive/v3.7.0.tar.gz | tar xz -C "$proto_dir"
+wget -O - https://github.com/google/protobuf/archive/v3.7.1.tar.gz | tar xz -C "$proto_dir"
 
-docker build -t protoc-artifacts "$proto_dir"/protobuf-3.7.0/protoc-artifacts
+docker build -t protoc-artifacts "$proto_dir"/protobuf-3.7.1/protoc-artifacts
 rm -r "$proto_dir"

--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-set PROTOBUF_VER=3.7.0
+set PROTOBUF_VER=3.7.1
 set CMAKE_NAME=cmake-3.3.2-win32-x86
 
 if not exist "protobuf-%PROTOBUF_VER%\cmake\build\Release\" (

--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -3,7 +3,7 @@
 # Build protoc
 set -evux -o pipefail
 
-PROTOBUF_VERSION=3.7.0
+PROTOBUF_VERSION=3.7.1
 
 # ARCH is 64 bit unless otherwise specified.
 ARCH="${ARCH:-64}"

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.1' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.21.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -26,7 +26,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.1' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.21.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.21.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.7.0'
+def protobufVersion = '3.7.1'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.21.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.7.0'
+def protocVersion = '3.7.1'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.21.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.7.0'
+def protobufVersion = '3.7.1'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.21.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.7.0</protobuf.version>
+    <protobuf.version>3.7.1</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-kotlin/android/helloworld/app/build.gradle
+++ b/examples/example-kotlin/android/helloworld/app/build.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.1' }
     plugins {
         javalite { artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0" }
         grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.21.0-SNAPSHOT' // CURRENT_GRPC_VERSION

--- a/examples/example-kotlin/build.gradle
+++ b/examples/example-kotlin/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.7.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.7.1' }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
     }

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -24,7 +24,7 @@ targetCompatibility = 1.7
 // updating the version in our release process.
 def grpcVersion = '1.21.0-SNAPSHOT' // CURRENT_GRPC_VERSION
 def nettyTcNativeVersion = '2.0.20.Final'
-def protocVersion = '3.7.0'
+def protocVersion = '3.7.1'
 
 dependencies {
     implementation "io.grpc:grpc-netty:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.21.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.7.0</protoc.version>
+    <protoc.version>3.7.1</protoc.version>
     <netty.tcnative.version>2.0.20.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.21.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.7.0</protobuf.version>
-    <protoc.version>3.7.0</protoc.version>
+    <protobuf.version>3.7.1</protobuf.version>
+    <protoc.version>3.7.1</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -14,10 +14,8 @@ dependencies {
             project(':grpc-stub'),
             libraries.protobuf
     compile (libraries.protobuf_util) {
-        // prefer 2.3.2 from libraries instead of 2.1.3 from guava
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 1.17 from libraries instead of 1.14 from guava
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
+        // prefer 26.0-android from libraries instead of 20.0
+        exclude group: 'com.google.guava', module: 'guava'
     }
     compileOnly libraries.javax_annotation
     testCompile libraries.truth,

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -242,10 +242,9 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "8955eb28f9c6db71d013bfe8255e485837d473db8a5786f6a017e40934f304a7",
-        strip_prefix = "protobuf-4b9a5df4e8ba2066794da56598ad2905dc42051e",
-        # This is v3.7.0 with a Bazel compilation failure fix
-        urls = ["https://github.com/google/protobuf/archive/4b9a5df4e8ba2066794da56598ad2905dc42051e.zip"],
+        sha256 = "f976a4cd3f1699b6d20c1e944ca1de6754777918320c719742e1674fcf247b7e",
+        strip_prefix = "protobuf-3.7.1",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.7.1.zip"],
     )
 
 def com_google_protobuf_javalite():

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -21,10 +21,8 @@ dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub')
     compile (libraries.protobuf_util) {
-        // prefer 2.3.2 from libraries instead of 2.1.3 from guava
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 1.17 from libraries instead of 1.14 from guava
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
+        // prefer 26.0-android from libraries instead of 20.0
+        exclude group: 'com.google.guava', module: 'guava'
     }
     compile libraries.re2j
 

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -26,10 +26,8 @@ dependencies {
     compile project(':grpc-protobuf'),
             project(':grpc-stub')
     compile (libraries.protobuf_util) {
-        // prefer 2.3.2 from libraries instead of 2.1.3 from guava
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-        // prefer 1.17 from libraries instead of 1.14 from guava
-        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
+        // prefer 26.0-android from libraries instead of 20.0
+        exclude group: 'com.google.guava', module: 'guava'
     }
 
     testCompile project(':grpc-core').sourceSets.test.output


### PR DESCRIPTION
This mainly avoids protoc from 3.7.0 which has a dependency on libatomic. Most
of our systems have libatomic, so it mostly works, but the interop docker
container does not, so building fails. Version 3.7.1 was rebuilt to avoid
needing the libatomic shared library.

This has the added benefit that Bazel is now on the same version as Gradle, as
3.7.1 included fixes for Bazel.

----

This will be backported to 1.20, otherwise the release process will fail at the very end.