### PR TITLE
interop-test: add test case for "pick_first" picking behavior

### DIFF
--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -89,13 +89,6 @@ task stresstest_client(type: CreateStartScripts) {
     ]
 }
 
-task grpclb_test_client(type: CreateStartScripts) {
-    mainClassName = "io.grpc.testing.integration.GrpclbTestClient"
-    applicationName = "grpclb-test-client"
-    outputDir = new File(project.buildDir, 'tmp')
-    classpath = jar.outputs.files + configurations.runtime
-}
-
 task http2_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.Http2Client"
     applicationName = "http2-client"
@@ -108,7 +101,6 @@ applicationDistribution.into("bin") {
     from(test_server)
     from(reconnect_test_client)
     from(stresstest_client)
-    from(grpclb_test_client)
     from(http2_client)
     fileMode = 0755
 }

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -26,7 +26,8 @@ dependencies {
             libraries.truth
     compileOnly libraries.javax_annotation
     runtime libraries.opencensus_impl,
-            libraries.netty_tcnative
+            libraries.netty_tcnative,
+            project(':grpc-grpclb')
     testCompile project(':grpc-context').sourceSets.test.output,
             libraries.mockito
 }
@@ -88,6 +89,13 @@ task stresstest_client(type: CreateStartScripts) {
     ]
 }
 
+task grpclb_test_client(type: CreateStartScripts) {
+    mainClassName = "io.grpc.testing.integration.GrpclbTestClient"
+    applicationName = "grpclb-test-client"
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + configurations.runtime
+}
+
 task http2_client(type: CreateStartScripts) {
     mainClassName = "io.grpc.testing.integration.Http2Client"
     applicationName = "http2-client"
@@ -100,6 +108,7 @@ applicationDistribution.into("bin") {
     from(test_server)
     from(reconnect_test_client)
     from(stresstest_client)
+    from(grpclb_test_client)
     from(http2_client)
     fileMode = 0755
 }

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestCases.java
@@ -53,7 +53,8 @@ public enum TestCases {
   CANCEL_AFTER_BEGIN("cancel stream after starting it"),
   CANCEL_AFTER_FIRST_RESPONSE("cancel on first response"),
   TIMEOUT_ON_SLEEPING_SERVER("timeout before receiving a response"),
-  VERY_LARGE_REQUEST("very large request");
+  VERY_LARGE_REQUEST("very large request"),
+  PICK_FIRST_UNARY("all requests are sent to one server despite multiple servers are resolved");
 
   private final String description;
 

--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -377,6 +377,11 @@ public class TestServiceClient {
         break;
       }
 
+      case PICK_FIRST_UNARY: {
+        tester.pickFirstUnary();
+        break;
+      }
+
       default:
         throw new IllegalArgumentException("Unknown test case: " + testCase);
     }

--- a/interop-testing/src/main/proto/grpc/testing/messages.proto
+++ b/interop-testing/src/main/proto/grpc/testing/messages.proto
@@ -68,6 +68,9 @@ message SimpleRequest {
 
   // Whether the server should expect this request to be compressed.
   BoolValue expect_compressed = 8;
+
+  // Whether SimpleResponse should include server_id.
+  bool fill_server_id = 9;
 }
 
 // Unary response, as configured by the request.
@@ -79,6 +82,9 @@ message SimpleResponse {
   string username = 2;
   // OAuth scope.
   string oauth_scope = 3;
+  // Server ID. This must be unique among different server instances,
+  // but the same across all RPC's made to a particular server instance.
+  string server_id = 4;
 }
 
 message SimpleContext {

--- a/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/TestCasesTest.java
@@ -72,7 +72,8 @@ public class TestCasesTest {
     String[] additionalTestCases = {
       "client_compressed_unary_noprobe",
       "client_compressed_streaming_noprobe",
-      "very_large_request"
+      "very_large_request",
+      "pick_first_unary"
     };
 
     assertEquals(testCases.length + additionalTestCases.length, TestCases.values().length);


### PR DESCRIPTION
New fields are added to the test protos according to https://github.com/grpc/grpc-proto/pull/51

This test needs to be run in an environment where "pick_first" or "grpclb" with child policy "pick_first" is configured.

/cc @apolcyn 