### PR TITLE
core: make the LoadBalancer.handleResolvedAddressGroups() change backward compatible

### DIFF
--- a/core/src/main/java/io/grpc/LoadBalancer.java
+++ b/core/src/main/java/io/grpc/LoadBalancer.java
@@ -131,7 +131,8 @@ public abstract class LoadBalancer {
   public void handleResolvedAddressGroups(
       List<EquivalentAddressGroup> servers,
       @NameResolver.ResolutionResultAttr Attributes attributes) {
-    throw new UnsupportedOperationException("Not implemented");
+    handleResolvedAddresses(
+        ResolvedAddresses.newBuilder().setServers(servers).setAttributes(attributes).build());
   }
 
   /**


### PR DESCRIPTION
This will give time for pre-existing external callers (e.g.,
forwarding LoadBalancers) to migrate to the new handleResolvedAddresses().