### PR TITLE
services: Remove dependency on re2j

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -19,7 +19,6 @@ def grpc_java_repositories(
         omit_com_google_protobuf_java = False,
         omit_com_google_protobuf_javalite = False,
         omit_com_google_protobuf_nano_protobuf_javanano = False,
-        omit_com_google_re2j = False,
         omit_com_google_truth_truth = False,
         omit_com_squareup_okhttp = False,
         omit_com_squareup_okio = False,
@@ -73,8 +72,6 @@ def grpc_java_repositories(
         com_google_protobuf_javalite()
     if not omit_com_google_protobuf_nano_protobuf_javanano:
         com_google_protobuf_nano_protobuf_javanano()
-    if not omit_com_google_re2j:
-        com_google_re2j()
     if not omit_com_google_truth_truth:
         com_google_truth_truth()
     if not omit_com_squareup_okhttp:
@@ -263,15 +260,6 @@ def com_google_protobuf_nano_protobuf_javanano():
         server_urls = ["http://central.maven.org/maven2"],
         artifact_sha256 = "6d30f1e667a8952e1c90a0a125f0ce0edf84d6b1d51c91d8555c4fb549e3d7a1",
         licenses = ["notice"],  # BSD 2-clause
-    )
-
-def com_google_re2j():
-    jvm_maven_import_external(
-        name = "com_google_re2j",
-        artifact = "com.google.re2j:re2j:1.2",
-        server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "e9dc705fd4c570344b54a7146b2e3a819cdc271a29793f4acc1a93b56a388e59",
-        licenses = ["notice"],  # Go License
     )
 
 def com_google_truth_truth():

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -19,7 +19,6 @@ java_library(
         "@com_google_guava_guava//jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
-        "@com_google_re2j//jar",
         "@io_grpc_grpc_proto//:binarylog_java_proto",
     ],
 )
@@ -60,7 +59,6 @@ java_library(
         "@com_google_guava_guava//jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
-        "@com_google_re2j//jar",
         "@io_grpc_grpc_proto//:reflection_java_proto_deprecated",
         "@javax_annotation_javax_annotation_api//jar",
     ],

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -24,7 +24,6 @@ dependencies {
         // prefer 26.0-android from libraries instead of 20.0
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile libraries.re2j
 
     compileOnly libraries.javax_annotation
     testCompile project(':grpc-testing'),


### PR DESCRIPTION
re2j is a fairly unnecessary dependency. Our usage of Pattern is quite limited
and isn't all that hard to do manually. Our usage would be safe to use normal
java.util.regex, but it's sort of annoying to keep re-explaining to others who
are (rightly) concerned with java.util.regex's poor pathological behavior.