### PR TITLE
buildscripts: set bazel version to 0.20.0 (v1.18.x)

### DIFF
--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -3,6 +3,9 @@
 set -exu -o pipefail
 cat /VERSION
 
+use_bazel.sh 0.20.0
+bazel version
+
 cd github/grpc-java
 bazel build ...
 


### PR DESCRIPTION
For v1.18.x, we were using bazel 0.20.0. Using the version since newer version is no longer backward compatible.