### PR TITLE
context: try out static final storage

### DIFF
--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -116,42 +116,42 @@ public class Context {
    */
   public static final Context ROOT = new Context(null, EMPTY_ENTRIES);
 
+  // Visible For testing
+  static Storage storage() {
+    return LazyStorage.storage;
+  }
+
   // Lazy-loaded storage. Delaying storage initialization until after class initialization makes it
   // much easier to avoid circular loading since there can still be references to Context as long as
   // they don't depend on storage, like key() and currentContextExecutor(). It also makes it easier
   // to handle exceptions.
-  private static final AtomicReference<Storage> storage = new AtomicReference<>();
+  private static final class LazyStorage {
+    static final Storage storage;
 
-  // For testing
-  static Storage storage() {
-    Storage tmp = storage.get();
-    if (tmp == null) {
-      tmp = createStorage();
-    }
-    return tmp;
-  }
-
-  private static Storage createStorage() {
-    // Note that this method may be run more than once
-    try {
-      Class<?> clazz = Class.forName("io.grpc.override.ContextStorageOverride");
-      // The override's constructor is prohibited from triggering any code that can loop back to
-      // Context
-      Storage newStorage = (Storage) clazz.getConstructor().newInstance();
-      storage.compareAndSet(null, newStorage);
-    } catch (ClassNotFoundException e) {
-      Storage newStorage = new ThreadLocalContextStorage();
-      // Must set storage before logging, since logging may call Context.current().
-      if (storage.compareAndSet(null, newStorage)) {
-        // Avoid logging if this thread lost the race, to avoid confusion
-        log.log(Level.FINE, "Storage override doesn't exist. Using default", e);
+    static {
+      AtomicReference<Throwable> deferredStorageFailure = new AtomicReference<>();
+      storage = createStorage(deferredStorageFailure);
+      Throwable failure;
+      // Logging must happen after storage has been set, as loggers may use Context.
+      if ((failure = deferredStorageFailure.get()) != null) {
+        log.log(Level.FINE, "Storage override doesn't exist. Using default", failure);
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Storage override failed to initialize", e);
     }
-    // Re-retreive from storage since compareAndSet may have failed (returned false) in case of
-    // race.
-    return storage.get();
+
+    private static Storage createStorage(
+        AtomicReference<? super ClassNotFoundException> deferredStorageFailure) {
+      try {
+        Class<?> clazz = Class.forName("io.grpc.override.ContextStorageOverride");
+        // The override's constructor is prohibited from triggering any code that can loop back to
+        // Context
+        return clazz.asSubclass(Storage.class).getConstructor().newInstance();
+      } catch (ClassNotFoundException e) {
+        deferredStorageFailure.set(e);
+        return new ThreadLocalContextStorage();
+      } catch (Exception e) {
+        throw new RuntimeException("Storage override failed to initialize", e);
+      }
+    }
   }
 
   /**

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -131,9 +131,9 @@ public class Context {
     static {
       AtomicReference<Throwable> deferredStorageFailure = new AtomicReference<>();
       storage = createStorage(deferredStorageFailure);
-      Throwable failure;
+      Throwable failure = deferredStorageFailure.get();
       // Logging must happen after storage has been set, as loggers may use Context.
-      if ((failure = deferredStorageFailure.get()) != null) {
+      if (failure!= null) {
         log.log(Level.FINE, "Storage override doesn't exist. Using default", failure);
       }
     }

--- a/context/src/main/java/io/grpc/Context.java
+++ b/context/src/main/java/io/grpc/Context.java
@@ -133,7 +133,7 @@ public class Context {
       storage = createStorage(deferredStorageFailure);
       Throwable failure = deferredStorageFailure.get();
       // Logging must happen after storage has been set, as loggers may use Context.
-      if (failure!= null) {
+      if (failure != null) {
         log.log(Level.FINE, "Storage override doesn't exist. Using default", failure);
       }
     }


### PR DESCRIPTION
I'm not totally convinced this is better than previously, but I believe it avoids the class initialization problem.  

The performance difference is minimal, but it does avoid the extra stack frame, and avoids the atomic compiler barrier (cheap).   storage() is called quite frequently, so there may be an aggregate benefit to making this fast.