### PR TITLE
core: make newNameResolver() change backward compatible for callers. (v1.19.x backport)

### DIFF
--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -115,6 +115,10 @@ public abstract class NameResolver {
     public static final Attributes.Key<ProxyDetector> PARAMS_PROXY_DETECTOR =
         Attributes.Key.create("params-proxy-detector");
 
+    @Deprecated
+    private static final Attributes.Key<SynchronizationContext> PARAMS_SYNC_CONTEXT =
+        Attributes.Key.create("params-sync-context");
+
     /**
      * Creates a {@link NameResolver} for the given target URI, or {@code null} if the given URI
      * cannot be resolved by this factory. The decision should be solely based on the scheme of the
@@ -131,8 +135,24 @@ public abstract class NameResolver {
      */
     @Nullable
     @Deprecated
-    public NameResolver newNameResolver(URI targetUri, Attributes params) {
-      throw new UnsupportedOperationException("This method is going to be deleted");
+    public NameResolver newNameResolver(URI targetUri, final Attributes params) {
+      Helper helper = new Helper() {
+          @Override
+          public int getDefaultPort() {
+            return checkNotNull(params.get(PARAMS_DEFAULT_PORT), "default port not available");
+          }
+
+          @Override
+          public ProxyDetector getProxyDetector() {
+            return checkNotNull(params.get(PARAMS_PROXY_DETECTOR), "proxy detector not available");
+          }
+
+          @Override
+          public SynchronizationContext getSynchronizationContext() {
+            return checkNotNull(params.get(PARAMS_SYNC_CONTEXT), "sync context not available");
+          }
+        };
+      return newNameResolver(targetUri, helper);
     }
 
     /**
@@ -153,6 +173,7 @@ public abstract class NameResolver {
           Attributes.newBuilder()
               .set(PARAMS_DEFAULT_PORT, helper.getDefaultPort())
               .set(PARAMS_PROXY_DETECTOR, helper.getProxyDetector())
+              .set(PARAMS_SYNC_CONTEXT, helper.getSynchronizationContext())
               .build());
     }
 

--- a/core/src/main/java/io/grpc/NameResolver.java
+++ b/core/src/main/java/io/grpc/NameResolver.java
@@ -16,6 +16,8 @@
 
 package io.grpc;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -115,10 +117,6 @@ public abstract class NameResolver {
     public static final Attributes.Key<ProxyDetector> PARAMS_PROXY_DETECTOR =
         Attributes.Key.create("params-proxy-detector");
 
-    @Deprecated
-    private static final Attributes.Key<SynchronizationContext> PARAMS_SYNC_CONTEXT =
-        Attributes.Key.create("params-sync-context");
-
     /**
      * Creates a {@link NameResolver} for the given target URI, or {@code null} if the given URI
      * cannot be resolved by this factory. The decision should be solely based on the scheme of the
@@ -146,11 +144,6 @@ public abstract class NameResolver {
           public ProxyDetector getProxyDetector() {
             return checkNotNull(params.get(PARAMS_PROXY_DETECTOR), "proxy detector not available");
           }
-
-          @Override
-          public SynchronizationContext getSynchronizationContext() {
-            return checkNotNull(params.get(PARAMS_SYNC_CONTEXT), "sync context not available");
-          }
         };
       return newNameResolver(targetUri, helper);
     }
@@ -173,7 +166,6 @@ public abstract class NameResolver {
           Attributes.newBuilder()
               .set(PARAMS_DEFAULT_PORT, helper.getDefaultPort())
               .set(PARAMS_PROXY_DETECTOR, helper.getProxyDetector())
-              .set(PARAMS_SYNC_CONTEXT, helper.getSynchronizationContext())
               .build());
     }
 

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -3381,7 +3381,6 @@ public class ManagedChannelImplTest {
     assertThat(helper).isNotNull();
     assertThat(helper.getDefaultPort()).isEqualTo(DEFAULT_PORT);
     assertThat(helper.getProxyDetector()).isSameAs(neverProxy);
-    assertThat(helper.getSynchronizationContext()).isSameAs(channel.syncContext);
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -3326,6 +3326,65 @@ public class ManagedChannelImplTest {
   }
 
   @Test
+  @Deprecated
+  public void nameResolverParams_forwardingResolverWithOldApi() {
+    final AtomicReference<NameResolver.Helper> capturedHelper = new AtomicReference<>();
+    final NameResolver noopResolver = new NameResolver() {
+        @Override
+        public String getServiceAuthority() {
+          return "fake-authority";
+        }
+
+        @Override
+        public void start(Listener listener) {
+        }
+
+        @Override
+        public void shutdown() {}
+      };
+    ProxyDetector neverProxy = new ProxyDetector() {
+        @Override
+        public ProxiedSocketAddress proxyFor(SocketAddress targetAddress) {
+          return null;
+        }
+      };
+    final NameResolver.Factory factory = new NameResolver.Factory() {
+        @Override
+        public NameResolver newNameResolver(URI targetUri, NameResolver.Helper helper) {
+          capturedHelper.set(helper);
+          return noopResolver;
+        }
+
+        @Override
+        public String getDefaultScheme() {
+          return "fakescheme";
+        }
+      };
+
+    // A forwarding factory still with the old API can forward to a delegate factory that has
+    // migrated to the new API.
+    NameResolver.Factory oldApiForwardingFactory = new NameResolver.Factory() {
+        @Override
+        public NameResolver newNameResolver(URI targetUri, Attributes params) {
+          return factory.newNameResolver(targetUri, params);
+        }
+
+        @Override
+        public String getDefaultScheme() {
+          return factory.getDefaultScheme();
+        }
+      };
+    channelBuilder.nameResolverFactory(oldApiForwardingFactory).proxyDetector(neverProxy);
+    createChannel();
+
+    NameResolver.Helper helper = capturedHelper.get();
+    assertThat(helper).isNotNull();
+    assertThat(helper.getDefaultPort()).isEqualTo(DEFAULT_PORT);
+    assertThat(helper.getProxyDetector()).isSameAs(neverProxy);
+    assertThat(helper.getSynchronizationContext()).isSameAs(channel.syncContext);
+  }
+
+  @Test
   public void getAuthorityAfterShutdown() throws Exception {
     createChannel();
     assertEquals(SERVICE_NAME, channel.authority());


### PR DESCRIPTION
We assumed that we were the only caller.  Turns out there are
forwarding NameResolver too.  Implementing the old override will give
them time to migrate to the new API.

Resolves #5556

Backport of #5560