### PR TITLE
core/util: create a ForwardingClientStreamTracer class for delegation use

### DIFF
--- a/core/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
@@ -18,9 +18,11 @@ package io.grpc.util;
 
 import com.google.common.base.MoreObjects;
 import io.grpc.ClientStreamTracer;
+import io.grpc.ExperimentalApi;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
+@ExperimentalApi("https://github.com/grpc/grpc-java/issues/2861")
 public abstract class ForwardingClientStreamTracer extends ClientStreamTracer {
   /** Returns the underlying {@code ClientStreamTracer}. */
   protected abstract ClientStreamTracer delegate();

--- a/core/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingClientStreamTracer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import com.google.common.base.MoreObjects;
+import io.grpc.ClientStreamTracer;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+public abstract class ForwardingClientStreamTracer extends ClientStreamTracer {
+  /** Returns the underlying {@code ClientStreamTracer}. */
+  protected abstract ClientStreamTracer delegate();
+
+  @Override
+  public void outboundHeaders() {
+    delegate().outboundHeaders();
+  }
+
+  @Override
+  public void inboundHeaders() {
+    delegate().inboundHeaders();
+  }
+
+  @Override
+  public void inboundTrailers(Metadata trailers) {
+    delegate().inboundTrailers(trailers);
+  }
+
+  @Override
+  public void streamClosed(Status status) {
+    delegate().streamClosed(status);
+  }
+
+  @Override
+  public void outboundMessage(int seqNo) {
+    delegate().outboundMessage(seqNo);
+  }
+
+  @Override
+  public void inboundMessage(int seqNo) {
+    delegate().inboundMessage(seqNo);
+  }
+
+  @Override
+  public void outboundMessageSent(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
+    delegate().outboundMessageSent(seqNo, optionalWireSize, optionalUncompressedSize);
+  }
+
+  @Override
+  public void inboundMessageRead(int seqNo, long optionalWireSize, long optionalUncompressedSize) {
+    delegate().inboundMessageRead(seqNo, optionalWireSize, optionalUncompressedSize);
+  }
+
+  @Override
+  public void outboundWireSize(long bytes) {
+    delegate().outboundWireSize(bytes);
+  }
+
+  @Override
+  public void outboundUncompressedSize(long bytes) {
+    delegate().outboundUncompressedSize(bytes);
+  }
+
+  @Override
+  public void inboundWireSize(long bytes) {
+    delegate().inboundWireSize(bytes);
+  }
+
+  @Override
+  public void inboundUncompressedSize(long bytes) {
+    delegate().inboundUncompressedSize(bytes);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
+  }
+}

--- a/core/src/test/java/io/grpc/util/ForwardingClientStreamTracerTest.java
+++ b/core/src/test/java/io/grpc/util/ForwardingClientStreamTracerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.util;
+
+import static org.mockito.Mockito.mock;
+
+import io.grpc.ClientStreamTracer;
+import io.grpc.ForwardingTestUtil;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ForwardingClientStreamTracer}. */
+@RunWith(JUnit4.class)
+public class ForwardingClientStreamTracerTest {
+  private final ClientStreamTracer mockDelegate = mock(ClientStreamTracer.class);
+
+  @Test
+  public void allMethodsForwarded() throws Exception {
+    ForwardingTestUtil.testMethodsForwarded(
+        ClientStreamTracer.class,
+        mockDelegate,
+        new ForwardingClientStreamTracerTest.TestClientStreamTracer(),
+        Collections.<Method>emptyList());
+  }
+
+  private final class TestClientStreamTracer extends ForwardingClientStreamTracer {
+    @Override
+    protected ClientStreamTracer delegate() {
+      return mockDelegate;
+    }
+  }
+}


### PR DESCRIPTION
A `ForwardClientStreamTracer` class is useful for intercepting an existing `ClientStreamTracer` instance.