### PR TITLE
netty: deflake ping flow control logic

### DIFF
--- a/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
+++ b/netty/src/main/java/io/grpc/netty/AbstractNettyHandler.java
@@ -206,9 +206,14 @@ abstract class AbstractNettyHandler extends GrpcHttp2ConnectionHandler {
       return dataSizeSincePing;
     }
 
-    @VisibleForTesting
-    void setDataSizeSincePing(int dataSize) {
+    private void setDataSizeSincePing(int dataSize) {
       dataSizeSincePing = dataSize;
+    }
+
+    @VisibleForTesting
+    void setDataSizeAndSincePing(int dataSize) {
+      setDataSizeSincePing(dataSize);
+      lastPingTime = System.nanoTime() - TimeUnit.SECONDS.toNanos(1);
     }
   }
 }

--- a/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
+++ b/netty/src/test/java/io/grpc/netty/NettyHandlerTestBase.java
@@ -440,7 +440,7 @@ public abstract class NettyHandlerTestBase<T extends Http2ConnectionHandler> {
     Http2LocalFlowController localFlowController = connection().local().flowController();
     int maxWindow = handler.flowControlPing().maxWindow();
 
-    handler.flowControlPing().setDataSizeSincePing(maxWindow);
+    handler.flowControlPing().setDataSizeAndSincePing(maxWindow);
     long payload = handler.flowControlPing().payload();
     channelRead(pingFrame(true, payload));
 


### PR DESCRIPTION
The last ping time was not set, leading to the bandwidth since last ping in `FlowControlPinger.updateWindow()` to always be zero.  

Fixes failures of the form:
```
io.grpc.netty.NettyClientHandlerTest > windowShouldNotExceedMaxWindowSize FAILED
    java.lang.AssertionError: expected:<8388608> but was:<65535>
```