### PR TITLE
Allow TCP_USER_TIMEOUT for Netty client and ComputeEngineChannelBuilder.

### DIFF
--- a/netty/src/main/java/io/grpc/netty/EpollUtils.java
+++ b/netty/src/main/java/io/grpc/netty/EpollUtils.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import javax.annotation.Nullable;
+
+/**
+ * Common utility methods for Epoll.
+ */
+public final class EpollUtils {
+
+  // prevents instantiation.
+  private EpollUtils() {}
+
+  /**
+   * Returns TCP_USER_TIMEOUT channel option for Epoll channel if Epoll is available, otherwise
+   * null.
+   */
+  @Nullable
+  public static ChannelOption<Integer> maybeGetTcpUserTimeoutOption() {
+    return getEpollChannelOption("TCP_USER_TIMEOUT");
+  }
+
+  @Nullable
+  @SuppressWarnings("unchecked")
+  private static <T> ChannelOption<T> getEpollChannelOption(String optionName) {
+    if (isEpollAvailable()) {
+      try {
+        return
+            (ChannelOption<T>) Class.forName("io.netty.channel.epoll.EpollChannelOption")
+                .getField(optionName)
+                .get(null);
+      } catch (Exception e) {
+        throw new RuntimeException("ChannelOption(" + optionName + ") is not available", e);
+      }
+    }
+    return null;
+  }
+
+  /** Checks if Epoll is available or not. */
+  public static boolean isEpollAvailable() {
+    try {
+      return (boolean) (Boolean)
+          Class
+              .forName("io.netty.channel.epoll.Epoll")
+              .getDeclaredMethod("isAvailable")
+              .invoke(null);
+    } catch (ClassNotFoundException e) {
+      // this is normal if netty-epoll runtime dependency doesn't exist.
+      return false;
+    } catch (Exception e) {
+      throw new RuntimeException("Exception while checking Epoll availability", e);
+    }
+  }
+
+  static Throwable getEpollUnavailabilityCause() {
+    try {
+      return (Throwable)
+          Class
+              .forName("io.netty.channel.epoll.Epoll")
+              .getDeclaredMethod("unavailabilityCause")
+              .invoke(null);
+    } catch (Exception e) {
+      return e;
+    }
+  }
+
+  // Must call when epoll is available
+  static Class<? extends Channel> epollChannelType() {
+    try {
+      return Class.forName("io.netty.channel.epoll.EpollSocketChannel").asSubclass(Channel.class);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Cannot load EpollSocketChannel", e);
+    }
+  }
+
+  // Must call when epoll is available
+  static Class<? extends EventLoopGroup> epollEventLoopGroupType() {
+    try {
+      return Class
+          .forName("io.netty.channel.epoll.EpollEventLoopGroup").asSubclass(EventLoopGroup.class);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Cannot load EpollEventLoopGroup", e);
+    }
+  }
+
+  // Must call when epoll is available
+  static Class<? extends ServerChannel> epollServerChannelType() {
+    try {
+      return Class
+          .forName("io.netty.channel.epoll.EpollServerSocketChannel")
+          .asSubclass(ServerChannel.class);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Cannot load EpollServerSocketChannel", e);
+    }
+  }
+}

--- a/netty/src/test/java/io/grpc/netty/EpollUtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/EpollUtilsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.netty;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link EpollUtils}. */
+@RunWith(JUnit4.class)
+public class EpollUtilsTest {
+
+  @Test
+  public void maybeGetTcpUserTimeoutOption() {
+    assume().that(EpollUtils.isEpollAvailable()).isTrue();
+
+    assertThat(EpollUtils.maybeGetTcpUserTimeoutOption()).isNotNull();
+  }
+}

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -18,6 +18,7 @@ package io.grpc.netty;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.grpc.internal.GrpcUtil.DEFAULT_SERVER_KEEPALIVE_TIMEOUT_NANOS;
 import static io.grpc.internal.GrpcUtil.DEFAULT_SERVER_KEEPALIVE_TIME_NANOS;
@@ -69,6 +70,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -480,7 +482,8 @@ public class NettyClientTransportTest {
     startServer();
     NettyClientTransport transport = newTransport(newNegotiator(),
         DEFAULT_MAX_MESSAGE_SIZE, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, "testUserAgent", true,
-        new ReflectiveChannelFactory<>(NioSocketChannel.class));
+        TimeUnit.SECONDS.toNanos(10L), new ReflectiveChannelFactory<>(NioSocketChannel.class),
+        group);
 
     callMeMaybe(transport.start(clientTransportListener));
 
@@ -493,7 +496,7 @@ public class NettyClientTransportTest {
     startServer();
     NettyClientTransport transport = newTransport(newNegotiator(),
         DEFAULT_MAX_MESSAGE_SIZE, GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, "testUserAgent", true,
-        new ReflectiveChannelFactory<>(LocalChannel.class));
+        TimeUnit.SECONDS.toNanos(10L), new ReflectiveChannelFactory<>(LocalChannel.class), group);
 
     callMeMaybe(transport.start(clientTransportListener));
 
@@ -609,6 +612,145 @@ public class NettyClientTransportTest {
     assertNull(transport.keepAliveManager());
   }
 
+  @Test
+  public void keepAliveEnabled_shouldSetTcpUserTimeout() throws Exception {
+    assume().that(EpollUtils.isEpollAvailable()).isTrue();
+
+    startServer();
+    EventLoopGroup epollGroup = Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP.create();
+    int keepAliveTimeMillis = 1234567;
+    try {
+      NettyClientTransport transport = newTransport(newNegotiator(), DEFAULT_MAX_MESSAGE_SIZE,
+          GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, null /* user agent */, true /* keep alive */,
+          TimeUnit.MILLISECONDS.toNanos(keepAliveTimeMillis),
+          new ReflectiveChannelFactory<>(Utils.DEFAULT_CLIENT_CHANNEL_TYPE), epollGroup);
+
+      callMeMaybe(transport.start(clientTransportListener));
+
+      ChannelOption<Integer> tcpUserTimeoutOption = EpollUtils.maybeGetTcpUserTimeoutOption();
+      assertThat(tcpUserTimeoutOption).isNotNull();
+      // on some linux based system, the integer value may have error (usually +-1)
+      assertThat((double) transport.channel().config().getOption(tcpUserTimeoutOption))
+          .isWithin(5.0).of((double) keepAliveTimeMillis);
+    } finally {
+      epollGroup.shutdownGracefully();
+    }
+  }
+
+  @Test
+  public void keepAliveDisabled_shouldNotSetTcpUserTimeout() throws Exception {
+    assume().that(EpollUtils.isEpollAvailable()).isTrue();
+
+    startServer();
+    EventLoopGroup epollGroup = Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP.create();
+    int keepAliveTimeMillis = 12345670;
+    try {
+      NettyClientTransport transport = newTransport(newNegotiator(), DEFAULT_MAX_MESSAGE_SIZE,
+          GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, null /* user agent */, false /* keep alive */,
+          TimeUnit.MILLISECONDS.toNanos(keepAliveTimeMillis),
+          new ReflectiveChannelFactory<>(Utils.DEFAULT_CLIENT_CHANNEL_TYPE), epollGroup);
+
+      callMeMaybe(transport.start(clientTransportListener));
+
+      ChannelOption<Integer> tcpUserTimeoutOption = EpollUtils.maybeGetTcpUserTimeoutOption();
+      assertThat(tcpUserTimeoutOption).isNotNull();
+      // default TCP_USER_TIMEOUT=0 (use the system default)
+      assertThat(transport.channel().config().getOption(tcpUserTimeoutOption)).isEqualTo(0);
+    } finally {
+      epollGroup.shutdownGracefully();
+    }
+  }
+
+  @Test
+  public void keepAliveDisabled_TcpUserTimeoutProvided() throws Exception {
+    assume().that(EpollUtils.isEpollAvailable()).isTrue();
+
+    startServer();
+    EventLoopGroup epollGroup = Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP.create();
+    int tcpUserTimeoutMillis = 12345670;
+    Map<ChannelOption<?>, Object> channelOptionMap = new HashMap<>();
+    try {
+      ChannelOption<Integer> tcpUserTimeoutOption = EpollUtils.maybeGetTcpUserTimeoutOption();
+      channelOptionMap.put(tcpUserTimeoutOption, tcpUserTimeoutMillis);
+
+      NettyClientTransport transport = newTransport(newNegotiator(), DEFAULT_MAX_MESSAGE_SIZE,
+          GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, null /* user agent */, false /* keep alive */,
+          TimeUnit.SECONDS.toNanos(10L),
+          new ReflectiveChannelFactory<>(Utils.DEFAULT_CLIENT_CHANNEL_TYPE), epollGroup,
+          channelOptionMap);
+
+      callMeMaybe(transport.start(clientTransportListener));
+
+      assertThat(tcpUserTimeoutOption).isNotNull();
+      assertThat((double) transport.channel().config().getOption(tcpUserTimeoutOption))
+          .isWithin(5.0).of(tcpUserTimeoutMillis);
+    } finally {
+      epollGroup.shutdownGracefully();
+    }
+  }
+
+  @Test
+  public void keepAliveEnabled_biggerTcpUserTimeoutProvided() throws Exception {
+    assume().that(EpollUtils.isEpollAvailable()).isTrue();
+
+    startServer();
+    EventLoopGroup epollGroup = Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP.create();
+    int tcpUserTimeoutMillis = 12345670;
+    long keepAliveTimeNano = TimeUnit.SECONDS.toNanos(10L);
+    Map<ChannelOption<?>, Object> channelOptionMap = new HashMap<>();
+    try {
+      ChannelOption<Integer> tcpUserTimeoutOption = EpollUtils.maybeGetTcpUserTimeoutOption();
+      channelOptionMap.put(tcpUserTimeoutOption, tcpUserTimeoutMillis);
+      assertThat(tcpUserTimeoutMillis)
+          .isGreaterThan((int) TimeUnit.NANOSECONDS.toMillis(keepAliveTimeNano));
+
+      NettyClientTransport transport = newTransport(newNegotiator(), DEFAULT_MAX_MESSAGE_SIZE,
+          GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, null /* user agent */, true /* keep alive */,
+          keepAliveTimeNano,
+          new ReflectiveChannelFactory<>(Utils.DEFAULT_CLIENT_CHANNEL_TYPE), epollGroup,
+          channelOptionMap);
+
+      callMeMaybe(transport.start(clientTransportListener));
+
+      assertThat(tcpUserTimeoutOption).isNotNull();
+      assertThat((double) transport.channel().config().getOption(tcpUserTimeoutOption))
+          .isWithin(5.0).of(TimeUnit.NANOSECONDS.toMillis(keepAliveTimeNano));
+    } finally {
+      epollGroup.shutdownGracefully();
+    }
+  }
+
+  @Test
+  public void keepAliveEnabled_smallerTcpUserTimeoutProvided() throws Exception {
+    assume().that(EpollUtils.isEpollAvailable()).isTrue();
+
+    startServer();
+    EventLoopGroup epollGroup = Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP.create();
+    int tcpUserTimeoutMillis = 120;
+    long keepAliveTimeNano = TimeUnit.SECONDS.toNanos(10L);
+    Map<ChannelOption<?>, Object> channelOptionMap = new HashMap<>();
+    try {
+      ChannelOption<Integer> tcpUserTimeoutOption = EpollUtils.maybeGetTcpUserTimeoutOption();
+      channelOptionMap.put(tcpUserTimeoutOption, tcpUserTimeoutMillis);
+      assertThat(tcpUserTimeoutMillis)
+          .isLessThan((int) TimeUnit.NANOSECONDS.toMillis(keepAliveTimeNano));
+
+      NettyClientTransport transport = newTransport(newNegotiator(), DEFAULT_MAX_MESSAGE_SIZE,
+          GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE, null /* user agent */, true /* keep alive */,
+          keepAliveTimeNano,
+          new ReflectiveChannelFactory<>(Utils.DEFAULT_CLIENT_CHANNEL_TYPE), epollGroup,
+          channelOptionMap);
+
+      callMeMaybe(transport.start(clientTransportListener));
+
+      assertThat(tcpUserTimeoutOption).isNotNull();
+      assertThat((double) transport.channel().config().getOption(tcpUserTimeoutOption))
+          .isWithin(5.0).of(tcpUserTimeoutMillis);
+    } finally {
+      epollGroup.shutdownGracefully();
+    }
+  }
+
   private Throwable getRootCause(Throwable t) {
     if (t.getCause() == null) {
       return t;
@@ -631,19 +773,28 @@ public class NettyClientTransportTest {
   private NettyClientTransport newTransport(ProtocolNegotiator negotiator, int maxMsgSize,
       int maxHeaderListSize, String userAgent, boolean enableKeepAlive) {
     return newTransport(negotiator, maxMsgSize, maxHeaderListSize, userAgent, enableKeepAlive,
-        new ReflectiveChannelFactory<>(NioSocketChannel.class));
+        TimeUnit.SECONDS.toNanos(10L), new ReflectiveChannelFactory<>(NioSocketChannel.class),
+        group);
   }
 
   private NettyClientTransport newTransport(ProtocolNegotiator negotiator, int maxMsgSize,
-      int maxHeaderListSize, String userAgent, boolean enableKeepAlive,
-      ChannelFactory<? extends Channel> channelFactory) {
-    long keepAliveTimeNano = KEEPALIVE_TIME_NANOS_DISABLED;
+      int maxHeaderListSize, String userAgent, boolean enableKeepAlive, long keepAliveTimeNano,
+      ChannelFactory<? extends Channel> channelFactory, EventLoopGroup group) {
+    return newTransport(
+        negotiator, maxMsgSize, maxHeaderListSize, userAgent, enableKeepAlive, keepAliveTimeNano,
+        channelFactory, group, new HashMap<ChannelOption<?>, Object>());
+  }
+
+  private NettyClientTransport newTransport(ProtocolNegotiator negotiator, int maxMsgSize,
+      int maxHeaderListSize, String userAgent, boolean enableKeepAlive, long keepAliveTimeNano,
+      ChannelFactory<? extends Channel> channelFactory, EventLoopGroup group,
+      Map<ChannelOption<?>, Object> channelOptionMap) {
     long keepAliveTimeoutNano = TimeUnit.SECONDS.toNanos(1L);
-    if (enableKeepAlive) {
-      keepAliveTimeNano = TimeUnit.SECONDS.toNanos(10L);
+    if (!enableKeepAlive) {
+      keepAliveTimeNano = KEEPALIVE_TIME_NANOS_DISABLED;
     }
     NettyClientTransport transport = new NettyClientTransport(
-        address, channelFactory, new HashMap<ChannelOption<?>, Object>(), group,
+        address, channelFactory, channelOptionMap, group,
         negotiator, DEFAULT_WINDOW_SIZE, maxMsgSize, maxHeaderListSize,
         keepAliveTimeNano, keepAliveTimeoutNano,
         false, authority, userAgent, tooManyPingsRunnable,

--- a/netty/src/test/java/io/grpc/netty/UtilsTest.java
+++ b/netty/src/test/java/io/grpc/netty/UtilsTest.java
@@ -179,7 +179,7 @@ public class UtilsTest {
 
   @Test
   public void defaultEventLoopGroup_whenEpollIsAvailable() {
-    assume().that(Utils.isEpollAvailable()).isTrue();
+    assume().that(EpollUtils.isEpollAvailable()).isTrue();
 
     EventLoopGroup defaultBossGroup = Utils.DEFAULT_BOSS_EVENT_LOOP_GROUP.create();
     EventLoopGroup defaultWorkerGroup = Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP.create();
@@ -195,7 +195,7 @@ public class UtilsTest {
 
   @Test
   public void defaultClientChannelType_whenEpollIsAvailable() {
-    assume().that(Utils.isEpollAvailable()).isTrue();
+    assume().that(EpollUtils.isEpollAvailable()).isTrue();
 
     Class<? extends Channel> clientChannelType = Utils.DEFAULT_CLIENT_CHANNEL_TYPE;
 
@@ -205,7 +205,7 @@ public class UtilsTest {
 
   @Test
   public void defaultServerChannelType_whenEpollIsAvailable() {
-    assume().that(Utils.isEpollAvailable()).isTrue();
+    assume().that(EpollUtils.isEpollAvailable()).isTrue();
 
     Class<? extends Channel> clientChannelType = Utils.DEFAULT_SERVER_CHANNEL_TYPE;
 


### PR DESCRIPTION
moved Epoll related methods to EpollUtils. which can expose some of its utility methods especially ChannelOption TCP_USER_TIMEOUT. 
Alternatively, we can open the channel option in ComputeEngineChannelBuilder. 

This introduces conflict between TCP_USER_TIMEOUT using keepAliveTime. Current approach is using smaller value of this. This can be debatable, should we always favor ChannelOption?