### PR TITLE
alts: Use normal defaults in Alts{Channel,Server}Builder

### DIFF
--- a/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsChannelBuilder.java
@@ -41,7 +41,6 @@ import io.grpc.internal.ObjectPool;
 import io.grpc.internal.SharedResourcePool;
 import io.grpc.netty.InternalNettyChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -74,11 +73,7 @@ public final class AltsChannelBuilder extends ForwardingChannelBuilder<AltsChann
   }
 
   private AltsChannelBuilder(String target) {
-    delegate =
-        NettyChannelBuilder.forTarget(target)
-            .keepAliveTime(20, TimeUnit.SECONDS)
-            .keepAliveTimeout(10, TimeUnit.SECONDS)
-            .keepAliveWithoutCalls(true);
+    delegate = NettyChannelBuilder.forTarget(target);
     InternalNettyChannelBuilder.setProtocolNegotiatorFactory(
         delegate(), new ProtocolNegotiatorFactory());
   }

--- a/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
+++ b/alts/src/main/java/io/grpc/alts/AltsServerBuilder.java
@@ -70,13 +70,7 @@ public final class AltsServerBuilder extends ServerBuilder<AltsServerBuilder> {
 
   /** Creates a gRPC server builder for the given port. */
   public static AltsServerBuilder forPort(int port) {
-    NettyServerBuilder nettyDelegate =
-        NettyServerBuilder.forAddress(new InetSocketAddress(port))
-            .maxConnectionIdle(1, TimeUnit.HOURS)
-            .keepAliveTime(270, TimeUnit.SECONDS)
-            .keepAliveTimeout(20, TimeUnit.SECONDS)
-            .permitKeepAliveTime(10, TimeUnit.SECONDS)
-            .permitKeepAliveWithoutCalls(true);
+    NettyServerBuilder nettyDelegate = NettyServerBuilder.forAddress(new InetSocketAddress(port));
     return new AltsServerBuilder(nettyDelegate);
   }
 


### PR DESCRIPTION
The ALTS builders are supposed to act like ChannelCreds, as done in
other languages. ChannelCreds don't have the opportunity to change
settings like this. In addition, the options here weren't set in
GoogleDefaultChannelBuilder and ComputeEngineChannelBuilder.

CC @creamsoup 