### PR TITLE
xds/third_party: fixed compatibility issue of regex in BSD for import.sh sed command

### DIFF
--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -75,19 +75,19 @@ do
     # Import mangling.
     -e 's#import "gogoproto/gogo.proto";##'
     # Remove references to gogo.proto extensions.
-    -e 's#option (gogoproto\.[a-z_]\+) = \(true\|false\);##'
-    -e 's#\(, \)\?(gogoproto\.[a-z_]\+) = \(true\|false\),\?##'
+    -e 's#option \(gogoproto\.[a-z_]+\) = (true|false);##'
+    -e 's#(, )?\(gogoproto\.[a-z_]+\) = (true|false),?##'
     # gogoproto removal can result in empty brackets.
     -e 's# \[\]##'
     # gogoproto removal can result in four spaces on a line by itself.
     -e '/^    $/d'
   )
-  sed -i "${commands[@]}" "$f"
+  sed -E -i '' "${commands[@]}" "$f"
 
   # gogoproto removal can leave a comma on the last element in a list.
   # This needs to run separately after all the commands above have finished
   # since it is multi-line and rewrites the output of the above patterns.
-  sed -i -e '$!N; s#\(.*\),\([[:space:]]*\];\)#\1\2#; t; P; D;' "$f"
+  sed -E -i '' -e '$!N; s#(.*),([[:space:]]*\];)#\1\2#; t' -e 'P; D;' "$f"
 done
 popd
 

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -82,12 +82,15 @@ do
     # gogoproto removal can result in four spaces on a line by itself.
     -e '/^    $/d'
   )
-  sed -E -i '' "${commands[@]}" "$f"
+  # Use a temp file to workaround `sed -i` cross-platform compatibility issue.
+  tmpfile="$(mktemp)"
+  sed -E "${commands[@]}" "$f" > "$tmpfile"
 
   # gogoproto removal can leave a comma on the last element in a list.
   # This needs to run separately after all the commands above have finished
   # since it is multi-line and rewrites the output of the above patterns.
-  sed -E -i '' -e '$!N; s#(.*),([[:space:]]*\];)#\1\2#; t' -e 'P; D;' "$f"
+  sed -E -e '$!N; s#(.*),([[:space:]]*\];)#\1\2#; t' -e 'P; D;' "$tmpfile" > "$f"
+  rm "$tmpfile"
 done
 popd
 


### PR DESCRIPTION
Existing `import.sh` script uses `sed` to remove `gogoproto` dependencies in imported proto files, which has compatibility issues on macOS due to:
1. `\|` is not supported in basic regex for macOS, so matching for `gogoproto` option does not work as expeced.
2. Usage of `-i` is different.
3. `t` command goes until the end of line, which does not count `;`.

Changes made to avoid above usages and only with usages work for cross platform.
