### PR TITLE
xds/third_party: import proto files from envoy repo

### DIFF
--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ClusterDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/api/v2/ClusterDiscoveryServiceGrpc.java
@@ -62,36 +62,36 @@ public final class ClusterDiscoveryServiceGrpc {
      return getStreamClustersMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest,
-      io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> getIncrementalClustersMethod;
+  private static volatile io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest,
+      io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> getDeltaClustersMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "IncrementalClusters",
-      requestType = io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest.class,
-      responseType = io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse.class,
+      fullMethodName = SERVICE_NAME + '/' + "DeltaClusters",
+      requestType = io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest.class,
+      responseType = io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-  public static io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest,
-      io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> getIncrementalClustersMethod() {
-    io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest, io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> getIncrementalClustersMethod;
-    if ((getIncrementalClustersMethod = ClusterDiscoveryServiceGrpc.getIncrementalClustersMethod) == null) {
+  public static io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest,
+      io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> getDeltaClustersMethod() {
+    io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest, io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> getDeltaClustersMethod;
+    if ((getDeltaClustersMethod = ClusterDiscoveryServiceGrpc.getDeltaClustersMethod) == null) {
       synchronized (ClusterDiscoveryServiceGrpc.class) {
-        if ((getIncrementalClustersMethod = ClusterDiscoveryServiceGrpc.getIncrementalClustersMethod) == null) {
-          ClusterDiscoveryServiceGrpc.getIncrementalClustersMethod = getIncrementalClustersMethod = 
-              io.grpc.MethodDescriptor.<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest, io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse>newBuilder()
+        if ((getDeltaClustersMethod = ClusterDiscoveryServiceGrpc.getDeltaClustersMethod) == null) {
+          ClusterDiscoveryServiceGrpc.getDeltaClustersMethod = getDeltaClustersMethod = 
+              io.grpc.MethodDescriptor.<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest, io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
               .setFullMethodName(generateFullMethodName(
-                  "envoy.api.v2.ClusterDiscoveryService", "IncrementalClusters"))
+                  "envoy.api.v2.ClusterDiscoveryService", "DeltaClusters"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest.getDefaultInstance()))
+                  io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse.getDefaultInstance()))
-                  .setSchemaDescriptor(new ClusterDiscoveryServiceMethodDescriptorSupplier("IncrementalClusters"))
+                  io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new ClusterDiscoveryServiceMethodDescriptorSupplier("DeltaClusters"))
                   .build();
           }
         }
      }
-     return getIncrementalClustersMethod;
+     return getDeltaClustersMethod;
   }
 
   private static volatile io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DiscoveryRequest,
@@ -165,9 +165,9 @@ public final class ClusterDiscoveryServiceGrpc {
 
     /**
      */
-    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest> incrementalClusters(
-        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getIncrementalClustersMethod(), responseObserver);
+    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest> deltaClusters(
+        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(getDeltaClustersMethod(), responseObserver);
     }
 
     /**
@@ -187,12 +187,12 @@ public final class ClusterDiscoveryServiceGrpc {
                 io.envoyproxy.envoy.api.v2.DiscoveryResponse>(
                   this, METHODID_STREAM_CLUSTERS)))
           .addMethod(
-            getIncrementalClustersMethod(),
+            getDeltaClustersMethod(),
             asyncBidiStreamingCall(
               new MethodHandlers<
-                io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest,
-                io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse>(
-                  this, METHODID_INCREMENTAL_CLUSTERS)))
+                io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest,
+                io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse>(
+                  this, METHODID_DELTA_CLUSTERS)))
           .addMethod(
             getFetchClustersMethod(),
             asyncUnaryCall(
@@ -235,10 +235,10 @@ public final class ClusterDiscoveryServiceGrpc {
 
     /**
      */
-    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest> incrementalClusters(
-        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> responseObserver) {
+    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest> deltaClusters(
+        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getIncrementalClustersMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getDeltaClustersMethod(), getCallOptions()), responseObserver);
     }
 
     /**
@@ -311,7 +311,7 @@ public final class ClusterDiscoveryServiceGrpc {
 
   private static final int METHODID_FETCH_CLUSTERS = 0;
   private static final int METHODID_STREAM_CLUSTERS = 1;
-  private static final int METHODID_INCREMENTAL_CLUSTERS = 2;
+  private static final int METHODID_DELTA_CLUSTERS = 2;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -347,9 +347,9 @@ public final class ClusterDiscoveryServiceGrpc {
         case METHODID_STREAM_CLUSTERS:
           return (io.grpc.stub.StreamObserver<Req>) serviceImpl.streamClusters(
               (io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DiscoveryResponse>) responseObserver);
-        case METHODID_INCREMENTAL_CLUSTERS:
-          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.incrementalClusters(
-              (io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse>) responseObserver);
+        case METHODID_DELTA_CLUSTERS:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.deltaClusters(
+              (io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse>) responseObserver);
         default:
           throw new AssertionError();
       }
@@ -402,7 +402,7 @@ public final class ClusterDiscoveryServiceGrpc {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new ClusterDiscoveryServiceFileDescriptorSupplier())
               .addMethod(getStreamClustersMethod())
-              .addMethod(getIncrementalClustersMethod())
+              .addMethod(getDeltaClustersMethod())
               .addMethod(getFetchClustersMethod())
               .build();
         }

--- a/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/AggregatedDiscoveryServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/envoy/service/discovery/v2/AggregatedDiscoveryServiceGrpc.java
@@ -67,36 +67,36 @@ public final class AggregatedDiscoveryServiceGrpc {
      return getStreamAggregatedResourcesMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest,
-      io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> getIncrementalAggregatedResourcesMethod;
+  private static volatile io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest,
+      io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> getDeltaAggregatedResourcesMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "IncrementalAggregatedResources",
-      requestType = io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest.class,
-      responseType = io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse.class,
+      fullMethodName = SERVICE_NAME + '/' + "DeltaAggregatedResources",
+      requestType = io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest.class,
+      responseType = io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-  public static io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest,
-      io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> getIncrementalAggregatedResourcesMethod() {
-    io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest, io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> getIncrementalAggregatedResourcesMethod;
-    if ((getIncrementalAggregatedResourcesMethod = AggregatedDiscoveryServiceGrpc.getIncrementalAggregatedResourcesMethod) == null) {
+  public static io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest,
+      io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> getDeltaAggregatedResourcesMethod() {
+    io.grpc.MethodDescriptor<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest, io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> getDeltaAggregatedResourcesMethod;
+    if ((getDeltaAggregatedResourcesMethod = AggregatedDiscoveryServiceGrpc.getDeltaAggregatedResourcesMethod) == null) {
       synchronized (AggregatedDiscoveryServiceGrpc.class) {
-        if ((getIncrementalAggregatedResourcesMethod = AggregatedDiscoveryServiceGrpc.getIncrementalAggregatedResourcesMethod) == null) {
-          AggregatedDiscoveryServiceGrpc.getIncrementalAggregatedResourcesMethod = getIncrementalAggregatedResourcesMethod = 
-              io.grpc.MethodDescriptor.<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest, io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse>newBuilder()
+        if ((getDeltaAggregatedResourcesMethod = AggregatedDiscoveryServiceGrpc.getDeltaAggregatedResourcesMethod) == null) {
+          AggregatedDiscoveryServiceGrpc.getDeltaAggregatedResourcesMethod = getDeltaAggregatedResourcesMethod = 
+              io.grpc.MethodDescriptor.<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest, io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
               .setFullMethodName(generateFullMethodName(
-                  "envoy.service.discovery.v2.AggregatedDiscoveryService", "IncrementalAggregatedResources"))
+                  "envoy.service.discovery.v2.AggregatedDiscoveryService", "DeltaAggregatedResources"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest.getDefaultInstance()))
+                  io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse.getDefaultInstance()))
-                  .setSchemaDescriptor(new AggregatedDiscoveryServiceMethodDescriptorSupplier("IncrementalAggregatedResources"))
+                  io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new AggregatedDiscoveryServiceMethodDescriptorSupplier("DeltaAggregatedResources"))
                   .build();
           }
         }
      }
-     return getIncrementalAggregatedResourcesMethod;
+     return getDeltaAggregatedResourcesMethod;
   }
 
   /**
@@ -146,9 +146,9 @@ public final class AggregatedDiscoveryServiceGrpc {
 
     /**
      */
-    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest> incrementalAggregatedResources(
-        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> responseObserver) {
-      return asyncUnimplementedStreamingCall(getIncrementalAggregatedResourcesMethod(), responseObserver);
+    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest> deltaAggregatedResources(
+        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> responseObserver) {
+      return asyncUnimplementedStreamingCall(getDeltaAggregatedResourcesMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -161,12 +161,12 @@ public final class AggregatedDiscoveryServiceGrpc {
                 io.envoyproxy.envoy.api.v2.DiscoveryResponse>(
                   this, METHODID_STREAM_AGGREGATED_RESOURCES)))
           .addMethod(
-            getIncrementalAggregatedResourcesMethod(),
+            getDeltaAggregatedResourcesMethod(),
             asyncBidiStreamingCall(
               new MethodHandlers<
-                io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest,
-                io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse>(
-                  this, METHODID_INCREMENTAL_AGGREGATED_RESOURCES)))
+                io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest,
+                io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse>(
+                  this, METHODID_DELTA_AGGREGATED_RESOURCES)))
           .build();
     }
   }
@@ -210,10 +210,10 @@ public final class AggregatedDiscoveryServiceGrpc {
 
     /**
      */
-    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryRequest> incrementalAggregatedResources(
-        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse> responseObserver) {
+    public io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryRequest> deltaAggregatedResources(
+        io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse> responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getIncrementalAggregatedResourcesMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getDeltaAggregatedResourcesMethod(), getCallOptions()), responseObserver);
     }
   }
 
@@ -272,7 +272,7 @@ public final class AggregatedDiscoveryServiceGrpc {
   }
 
   private static final int METHODID_STREAM_AGGREGATED_RESOURCES = 0;
-  private static final int METHODID_INCREMENTAL_AGGREGATED_RESOURCES = 1;
+  private static final int METHODID_DELTA_AGGREGATED_RESOURCES = 1;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -304,9 +304,9 @@ public final class AggregatedDiscoveryServiceGrpc {
         case METHODID_STREAM_AGGREGATED_RESOURCES:
           return (io.grpc.stub.StreamObserver<Req>) serviceImpl.streamAggregatedResources(
               (io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DiscoveryResponse>) responseObserver);
-        case METHODID_INCREMENTAL_AGGREGATED_RESOURCES:
-          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.incrementalAggregatedResources(
-              (io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.IncrementalDiscoveryResponse>) responseObserver);
+        case METHODID_DELTA_AGGREGATED_RESOURCES:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.deltaAggregatedResources(
+              (io.grpc.stub.StreamObserver<io.envoyproxy.envoy.api.v2.DeltaDiscoveryResponse>) responseObserver);
         default:
           throw new AssertionError();
       }
@@ -359,7 +359,7 @@ public final class AggregatedDiscoveryServiceGrpc {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new AggregatedDiscoveryServiceFileDescriptorSupplier())
               .addMethod(getStreamAggregatedResourcesMethod())
-              .addMethod(getIncrementalAggregatedResourcesMethod())
+              .addMethod(getDeltaAggregatedResourcesMethod())
               .build();
         }
       }

--- a/xds/src/generated/main/grpc/io/envoyproxy/udpa/service/orca/v1/OpenRcaServiceGrpc.java
+++ b/xds/src/generated/main/grpc/io/envoyproxy/udpa/service/orca/v1/OpenRcaServiceGrpc.java
@@ -1,0 +1,323 @@
+package io.envoyproxy.udpa.service.orca.v1;
+
+import static io.grpc.MethodDescriptor.generateFullMethodName;
+import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
+import static io.grpc.stub.ClientCalls.asyncUnaryCall;
+import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
+import static io.grpc.stub.ClientCalls.blockingUnaryCall;
+import static io.grpc.stub.ClientCalls.futureUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncUnaryCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
+import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
+
+/**
+ * <pre>
+ * Out-of-band (OOB) load reporting service for the additional load reporting
+ * agent that does not sit in the request path. Reports are periodically sampled
+ * with sufficient frequency to provide temporal association with requests.
+ * OOB reporting compensates the limitation of in-band reporting in revealing
+ * costs for backends that do not provide a steady stream of telemetry such as
+ * long running stream operations and zero QPS services. This is a server
+ * streaming service, client needs to terminate current RPC and initiate
+ * a new call to change backend reporting frequency.
+ * </pre>
+ */
+@javax.annotation.Generated(
+    value = "by gRPC proto compiler",
+    comments = "Source: udpa/service/orca/v1/orca.proto")
+public final class OpenRcaServiceGrpc {
+
+  private OpenRcaServiceGrpc() {}
+
+  public static final String SERVICE_NAME = "udpa.service.orca.v1.OpenRcaService";
+
+  // Static method descriptors that strictly reflect the proto.
+  private static volatile io.grpc.MethodDescriptor<io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest,
+      io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport> getStreamCoreMetricsMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "StreamCoreMetrics",
+      requestType = io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest.class,
+      responseType = io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+  public static io.grpc.MethodDescriptor<io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest,
+      io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport> getStreamCoreMetricsMethod() {
+    io.grpc.MethodDescriptor<io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest, io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport> getStreamCoreMetricsMethod;
+    if ((getStreamCoreMetricsMethod = OpenRcaServiceGrpc.getStreamCoreMetricsMethod) == null) {
+      synchronized (OpenRcaServiceGrpc.class) {
+        if ((getStreamCoreMetricsMethod = OpenRcaServiceGrpc.getStreamCoreMetricsMethod) == null) {
+          OpenRcaServiceGrpc.getStreamCoreMetricsMethod = getStreamCoreMetricsMethod = 
+              io.grpc.MethodDescriptor.<io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest, io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "udpa.service.orca.v1.OpenRcaService", "StreamCoreMetrics"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport.getDefaultInstance()))
+                  .setSchemaDescriptor(new OpenRcaServiceMethodDescriptorSupplier("StreamCoreMetrics"))
+                  .build();
+          }
+        }
+     }
+     return getStreamCoreMetricsMethod;
+  }
+
+  /**
+   * Creates a new async stub that supports all call types for the service
+   */
+  public static OpenRcaServiceStub newStub(io.grpc.Channel channel) {
+    return new OpenRcaServiceStub(channel);
+  }
+
+  /**
+   * Creates a new blocking-style stub that supports unary and streaming output calls on the service
+   */
+  public static OpenRcaServiceBlockingStub newBlockingStub(
+      io.grpc.Channel channel) {
+    return new OpenRcaServiceBlockingStub(channel);
+  }
+
+  /**
+   * Creates a new ListenableFuture-style stub that supports unary calls on the service
+   */
+  public static OpenRcaServiceFutureStub newFutureStub(
+      io.grpc.Channel channel) {
+    return new OpenRcaServiceFutureStub(channel);
+  }
+
+  /**
+   * <pre>
+   * Out-of-band (OOB) load reporting service for the additional load reporting
+   * agent that does not sit in the request path. Reports are periodically sampled
+   * with sufficient frequency to provide temporal association with requests.
+   * OOB reporting compensates the limitation of in-band reporting in revealing
+   * costs for backends that do not provide a steady stream of telemetry such as
+   * long running stream operations and zero QPS services. This is a server
+   * streaming service, client needs to terminate current RPC and initiate
+   * a new call to change backend reporting frequency.
+   * </pre>
+   */
+  public static abstract class OpenRcaServiceImplBase implements io.grpc.BindableService {
+
+    /**
+     */
+    public void streamCoreMetrics(io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest request,
+        io.grpc.stub.StreamObserver<io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport> responseObserver) {
+      asyncUnimplementedUnaryCall(getStreamCoreMetricsMethod(), responseObserver);
+    }
+
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+      return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            getStreamCoreMetricsMethod(),
+            asyncServerStreamingCall(
+              new MethodHandlers<
+                io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest,
+                io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport>(
+                  this, METHODID_STREAM_CORE_METRICS)))
+          .build();
+    }
+  }
+
+  /**
+   * <pre>
+   * Out-of-band (OOB) load reporting service for the additional load reporting
+   * agent that does not sit in the request path. Reports are periodically sampled
+   * with sufficient frequency to provide temporal association with requests.
+   * OOB reporting compensates the limitation of in-band reporting in revealing
+   * costs for backends that do not provide a steady stream of telemetry such as
+   * long running stream operations and zero QPS services. This is a server
+   * streaming service, client needs to terminate current RPC and initiate
+   * a new call to change backend reporting frequency.
+   * </pre>
+   */
+  public static final class OpenRcaServiceStub extends io.grpc.stub.AbstractStub<OpenRcaServiceStub> {
+    private OpenRcaServiceStub(io.grpc.Channel channel) {
+      super(channel);
+    }
+
+    private OpenRcaServiceStub(io.grpc.Channel channel,
+        io.grpc.CallOptions callOptions) {
+      super(channel, callOptions);
+    }
+
+    @java.lang.Override
+    protected OpenRcaServiceStub build(io.grpc.Channel channel,
+        io.grpc.CallOptions callOptions) {
+      return new OpenRcaServiceStub(channel, callOptions);
+    }
+
+    /**
+     */
+    public void streamCoreMetrics(io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest request,
+        io.grpc.stub.StreamObserver<io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport> responseObserver) {
+      asyncServerStreamingCall(
+          getChannel().newCall(getStreamCoreMetricsMethod(), getCallOptions()), request, responseObserver);
+    }
+  }
+
+  /**
+   * <pre>
+   * Out-of-band (OOB) load reporting service for the additional load reporting
+   * agent that does not sit in the request path. Reports are periodically sampled
+   * with sufficient frequency to provide temporal association with requests.
+   * OOB reporting compensates the limitation of in-band reporting in revealing
+   * costs for backends that do not provide a steady stream of telemetry such as
+   * long running stream operations and zero QPS services. This is a server
+   * streaming service, client needs to terminate current RPC and initiate
+   * a new call to change backend reporting frequency.
+   * </pre>
+   */
+  public static final class OpenRcaServiceBlockingStub extends io.grpc.stub.AbstractStub<OpenRcaServiceBlockingStub> {
+    private OpenRcaServiceBlockingStub(io.grpc.Channel channel) {
+      super(channel);
+    }
+
+    private OpenRcaServiceBlockingStub(io.grpc.Channel channel,
+        io.grpc.CallOptions callOptions) {
+      super(channel, callOptions);
+    }
+
+    @java.lang.Override
+    protected OpenRcaServiceBlockingStub build(io.grpc.Channel channel,
+        io.grpc.CallOptions callOptions) {
+      return new OpenRcaServiceBlockingStub(channel, callOptions);
+    }
+
+    /**
+     */
+    public java.util.Iterator<io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport> streamCoreMetrics(
+        io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest request) {
+      return blockingServerStreamingCall(
+          getChannel(), getStreamCoreMetricsMethod(), getCallOptions(), request);
+    }
+  }
+
+  /**
+   * <pre>
+   * Out-of-band (OOB) load reporting service for the additional load reporting
+   * agent that does not sit in the request path. Reports are periodically sampled
+   * with sufficient frequency to provide temporal association with requests.
+   * OOB reporting compensates the limitation of in-band reporting in revealing
+   * costs for backends that do not provide a steady stream of telemetry such as
+   * long running stream operations and zero QPS services. This is a server
+   * streaming service, client needs to terminate current RPC and initiate
+   * a new call to change backend reporting frequency.
+   * </pre>
+   */
+  public static final class OpenRcaServiceFutureStub extends io.grpc.stub.AbstractStub<OpenRcaServiceFutureStub> {
+    private OpenRcaServiceFutureStub(io.grpc.Channel channel) {
+      super(channel);
+    }
+
+    private OpenRcaServiceFutureStub(io.grpc.Channel channel,
+        io.grpc.CallOptions callOptions) {
+      super(channel, callOptions);
+    }
+
+    @java.lang.Override
+    protected OpenRcaServiceFutureStub build(io.grpc.Channel channel,
+        io.grpc.CallOptions callOptions) {
+      return new OpenRcaServiceFutureStub(channel, callOptions);
+    }
+  }
+
+  private static final int METHODID_STREAM_CORE_METRICS = 0;
+
+  private static final class MethodHandlers<Req, Resp> implements
+      io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
+      io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
+      io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
+      io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
+    private final OpenRcaServiceImplBase serviceImpl;
+    private final int methodId;
+
+    MethodHandlers(OpenRcaServiceImplBase serviceImpl, int methodId) {
+      this.serviceImpl = serviceImpl;
+      this.methodId = methodId;
+    }
+
+    @java.lang.Override
+    @java.lang.SuppressWarnings("unchecked")
+    public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
+      switch (methodId) {
+        case METHODID_STREAM_CORE_METRICS:
+          serviceImpl.streamCoreMetrics((io.envoyproxy.udpa.service.orca.v1.OrcaLoadReportRequest) request,
+              (io.grpc.stub.StreamObserver<io.envoyproxy.udpa.data.orca.v1.OrcaLoadReport>) responseObserver);
+          break;
+        default:
+          throw new AssertionError();
+      }
+    }
+
+    @java.lang.Override
+    @java.lang.SuppressWarnings("unchecked")
+    public io.grpc.stub.StreamObserver<Req> invoke(
+        io.grpc.stub.StreamObserver<Resp> responseObserver) {
+      switch (methodId) {
+        default:
+          throw new AssertionError();
+      }
+    }
+  }
+
+  private static abstract class OpenRcaServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+    OpenRcaServiceBaseDescriptorSupplier() {}
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
+      return io.envoyproxy.udpa.service.orca.v1.OrcaProto.getDescriptor();
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
+      return getFileDescriptor().findServiceByName("OpenRcaService");
+    }
+  }
+
+  private static final class OpenRcaServiceFileDescriptorSupplier
+      extends OpenRcaServiceBaseDescriptorSupplier {
+    OpenRcaServiceFileDescriptorSupplier() {}
+  }
+
+  private static final class OpenRcaServiceMethodDescriptorSupplier
+      extends OpenRcaServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoMethodDescriptorSupplier {
+    private final String methodName;
+
+    OpenRcaServiceMethodDescriptorSupplier(String methodName) {
+      this.methodName = methodName;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
+      return getServiceDescriptor().findMethodByName(methodName);
+    }
+  }
+
+  private static volatile io.grpc.ServiceDescriptor serviceDescriptor;
+
+  public static io.grpc.ServiceDescriptor getServiceDescriptor() {
+    io.grpc.ServiceDescriptor result = serviceDescriptor;
+    if (result == null) {
+      synchronized (OpenRcaServiceGrpc.class) {
+        result = serviceDescriptor;
+        if (result == null) {
+          serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
+              .setSchemaDescriptor(new OpenRcaServiceFileDescriptorSupplier())
+              .addMethod(getStreamCoreMetricsMethod())
+              .build();
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -18,12 +18,14 @@
 set -e
 BRANCH=master
 # import VERSION from one of the google internal CLs
-VERSION=cdcdfa6914f88b537122ed039fd0de5f78c0f209
+VERSION=109d23a6648b1ac7723c4b2f125e913125bb9a84
 GIT_REPO="https://github.com/envoyproxy/envoy.git"
 GIT_BASE_DIR=envoy
 SOURCE_PROTO_BASE_DIR=envoy/api
 TARGET_PROTO_BASE_DIR=src/main/proto
 FILES=(
+udpa/data/orca/v1/orca_load_report.proto
+udpa/service/orca/v1/orca.proto
 envoy/api/v2/auth/cert.proto
 envoy/api/v2/cds.proto
 envoy/api/v2/cluster/circuit_breaker.proto
@@ -41,6 +43,7 @@ envoy/api/v2/endpoint/load_report.proto
 envoy/service/discovery/v2/ads.proto
 envoy/service/load_stats/v2/lrs.proto
 envoy/type/percent.proto
+envoy/type/range.proto
 )
 
 # clone the envoy github repo in a tmp directory

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/cert.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/auth/cert.proto
@@ -248,7 +248,7 @@ message CertificateValidationContext {
   google.protobuf.BoolValue require_signed_certificate_timestamp = 6;
 
   // An optional `certificate revocation list
-  // <http://https://en.wikipedia.org/wiki/Certificate_revocation_list>`_
+  // <https://en.wikipedia.org/wiki/Certificate_revocation_list>`_
   // (in PEM format). If specified, Envoy will verify that the presented peer
   // certificate has not been revoked by this CRL. If this DataSource contains
   // multiple CRLs, all of them will be used.

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cds.proto
@@ -31,13 +31,13 @@ import "validate/validate.proto";
 
 
 
+
 // Return list of all clusters this proxy will load balance to.
 service ClusterDiscoveryService {
   rpc StreamClusters(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
   }
 
-  rpc IncrementalClusters(stream IncrementalDiscoveryRequest)
-      returns (stream IncrementalDiscoveryResponse) {
+  rpc DeltaClusters(stream DeltaDiscoveryRequest) returns (stream DeltaDiscoveryResponse) {
   }
 
   rpc FetchClusters(DiscoveryRequest) returns (DiscoveryResponse) {
@@ -51,7 +51,7 @@ service ClusterDiscoveryService {
 // [#protodoc-title: Clusters]
 
 // Configuration for a single upstream cluster.
-// [#comment:next free field: 38]
+// [#comment:next free field: 39]
 message Cluster {
   // Supplies the name of the cluster which must be unique across all clusters.
   // The cluster name is used when emitting
@@ -95,9 +95,25 @@ message Cluster {
     // for an explanation.
     ORIGINAL_DST = 4;
   }
-  // The :ref:`service discovery type <arch_overview_service_discovery_types>`
-  // to use for resolving the cluster.
-  DiscoveryType type = 2 [(validate.rules).enum.defined_only = true];
+
+  // Extended cluster type.
+  message CustomClusterType {
+    // The type of the cluster to instantiate. The name must match a supported cluster type.
+    string name = 1 [(validate.rules).string.min_bytes = 1];
+
+    // Cluster specific configuration which depends on the cluster being instantiated.
+    // See the supported cluster for further documentation.
+    google.protobuf.Any typed_config = 2;
+  }
+
+  oneof cluster_discovery_type {
+    // The :ref:`service discovery type <arch_overview_service_discovery_types>`
+    // to use for resolving the cluster.
+    DiscoveryType type = 2 [(validate.rules).enum.defined_only = true];
+
+    // The custom cluster type.
+    CustomClusterType cluster_type = 38;
+  }
 
   // Only valid when discovery type is EDS.
   message EdsClusterConfig {
@@ -176,7 +192,7 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>` clusters.
   // This field supersedes :ref:`hosts<envoy_api_field_Cluster.hosts>` field.
-  // [#comment:TODO(dio): Deprecate the hosts field and add it to DEPRECATED.md
+  // [#comment:TODO(dio): Deprecate the hosts field and add it to :ref:`deprecated log<deprecated>`
   // once load_assignment is implemented.]
   //
   // .. attention::
@@ -233,7 +249,7 @@ message Cluster {
   // for upstream connections. The key should match the extension filter name, such as
   // "envoy.filters.network.thrift_proxy". See the extension's documentation for details on
   // specific options.
-  map<string, google.protobuf.Struct> extension_protocol_options = 35 [deprecated = true];
+  map<string, google.protobuf.Struct> extension_protocol_options = 35;
 
   // The extension_protocol_options field is used to provide extension-specific protocol options
   // for upstream connections. The key should match the extension filter name, such as
@@ -383,6 +399,14 @@ message Cluster {
     // going to an individual locality if said locality is disproportionally affected by the
     // subset predicate.
     bool scale_locality_weight = 5;
+
+    // If true, when a fallback policy is configured and its corresponding subset fails to find
+    // a host this will cause any host to be selected instead.
+    //
+    // This is useful when using the default subset as the fallback policy, given the default
+    // subset might become empty. With this option enabled, if that happens the LB will attempt
+    // to select a host from the entire cluster.
+    bool panic_mode_any = 6;
   }
 
   // Configuration for load balancing subsetting.
@@ -398,24 +422,13 @@ message Cluster {
   // Specific configuration for the :ref:`RingHash<arch_overview_load_balancing_types_ring_hash>`
   // load balancing policy.
   message RingHashLbConfig {
-    // Minimum hash ring size, i.e. total virtual nodes. A larger size
-    // will provide better request distribution since each host in the
-    // cluster will have more virtual nodes. Defaults to 1024. In the case
-    // that total number of hosts is greater than the minimum, each host will
-    // be allocated a single virtual node. This field is limited to 8M to bound
-    // resource use.
+    // Minimum hash ring size. The larger the ring is (that is, the more hashes there are for each
+    // provided host) the better the request distribution will reflect the desired weights. Defaults
+    // to 1024 entries, and limited to 8M entries. See also
+    // :ref:`maximum_ring_size<envoy_api_field_Cluster.RingHashLbConfig.maximum_ring_size>`.
     google.protobuf.UInt64Value minimum_ring_size = 1 [(validate.rules).uint64.lte = 8388608];
 
-    // [#not-implemented-hide:] Hide from docs.
-    message DeprecatedV1 {
-      // Defaults to false, meaning that `xxHash <https://github.com/Cyan4973/xxHash>`_
-      // is to hash hosts onto the ketama ring.
-      google.protobuf.BoolValue use_std_hash = 1;
-    }
-
-    // Deprecated settings from v1 config.
-    // [#not-implemented-hide:] Hide from docs.
-    DeprecatedV1 deprecated_v1 = 2 [deprecated = true];
+    reserved 2;
 
     // The hash function used to hash hosts onto the ketama ring.
     enum HashFunction {
@@ -430,6 +443,11 @@ message Cluster {
     // The hash function used to hash hosts onto the ketama ring. The value defaults to
     // :ref:`XX_HASH<envoy_api_enum_value_Cluster.RingHashLbConfig.HashFunction.XX_HASH>`.
     HashFunction hash_function = 3 [(validate.rules).enum.defined_only = true];
+
+    // Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries, but can be lowered
+    // to further constrain resource use. See also
+    // :ref:`minimum_ring_size<envoy_api_field_Cluster.RingHashLbConfig.minimum_ring_size>`.
+    google.protobuf.UInt64Value maximum_ring_size = 4 [(validate.rules).uint64.lte = 8388608];
   }
 
   // Specific configuration for the

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cluster/circuit_breaker.proto
@@ -46,6 +46,18 @@ message CircuitBreakers {
     // The maximum number of parallel retries that Envoy will allow to the
     // upstream cluster. If not specified, the default is 3.
     google.protobuf.UInt32Value max_retries = 5;
+
+    // If track_remaining is true, then stats will be published that expose
+    // the number of resources remaining until the circuit breakers open. If
+    // not specified, the default is false.
+    bool track_remaining = 6;
+
+    // The maximum number of connection pools per cluster that Envoy will concurrently support at
+    // once. If not specified, the default is unlimited. Set this for clusters which create a
+    // large number of connection pools. See
+    // :ref:`Circuit Breaking <arch_overview_circuit_break_cluster_maximum_connection_pools>` for
+    // more details.
+    google.protobuf.UInt32Value max_connection_pools = 7;
   }
 
   // If multiple :ref:`Thresholds<envoy_api_msg_cluster.CircuitBreakers.Thresholds>`

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/base.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/base.proto
@@ -18,6 +18,7 @@ import "envoy/type/percent.proto";
 
 
 
+
 // [#protodoc-title: Common types]
 
 // Identifies location of where either Envoy runs or where upstream hosts run.
@@ -164,6 +165,11 @@ message HeaderValueOption {
   google.protobuf.BoolValue append = 2;
 }
 
+// Wrapper for a set of headers.
+message HeaderMap {
+  repeated HeaderValue headers = 1;
+}
+
 // Data source consisting of either a file or an inline value.
 message DataSource {
   oneof specifier {
@@ -192,7 +198,7 @@ message TransportSocket {
   // Implementation specific configuration which depends on the implementation being instantiated.
   // See the supported transport socket implementations for further documentation.
   oneof config_type {
-    google.protobuf.Struct config = 2 [deprecated = true];
+    google.protobuf.Struct config = 2;
 
     google.protobuf.Any typed_config = 3;
   }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/config_source.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/config_source.proto
@@ -32,6 +32,13 @@ message ApiConfigSource {
     REST = 1;
     // gRPC v2 API.
     GRPC = 2;
+    // Using the delta xDS gRPC service, i.e. DeltaDiscovery{Request,Response}
+    // rather than Discovery{Request,Response}. Rather than sending Envoy the entire state
+    // with every update, the xDS server only sends what has changed since the last update.
+    //
+    // DELTA_GRPC is not yet entirely implemented! Initially, only CDS is available.
+    // Do not use for other xDSes. TODO(fredlas) update/remove this warning when appropriate.
+    DELTA_GRPC = 3;
   }
   ApiType api_type = 1 [(validate.rules).enum.defined_only = true];
   // Cluster names should be used only with REST. If > 1
@@ -104,4 +111,14 @@ message ConfigSource {
     // source in the bootstrap configuration is used.
     AggregatedConfigSource ads = 3;
   }
+
+  // Optional initialization timeout.
+  // When this timeout is specified, Envoy will wait no longer than the specified time for first
+  // config response on this xDS subscription during the :ref:`initialization process
+  // <arch_overview_initialization>`. After reaching the timeout, Envoy will move to the next
+  // initialization phase, even if the first config is not delivered yet. The timer is activated
+  // when the xDS API subscription starts, and is disarmed on first config update or on error. 0
+  // means no timeout - Envoy will wait indefinitely for the first xDS config (unless another
+  // timeout applies). Default 0.
+  google.protobuf.Duration initial_fetch_timeout = 4;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/grpc_service.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/grpc_service.proto
@@ -84,7 +84,7 @@ message GrpcService {
       message MetadataCredentialsFromPlugin {
         string name = 1;
         oneof config_type {
-          google.protobuf.Struct config = 2 [deprecated = true];
+          google.protobuf.Struct config = 2;
 
           google.protobuf.Any typed_config = 3;
         }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
@@ -7,6 +7,7 @@ option java_multiple_files = true;
 option java_package = "io.envoyproxy.envoy.api.v2.core";
 
 import "envoy/api/v2/core/base.proto";
+import "envoy/type/range.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
@@ -82,7 +83,7 @@ message HealthCheck {
     }
   }
 
-  // [#comment:next free field: 9]
+  // [#comment:next free field: 10]
   message HttpHealthCheck {
     // The value of the host header in the HTTP health check request. If
     // left empty (default value), the name of the cluster this health check is associated
@@ -117,6 +118,11 @@ message HealthCheck {
 
     // If set, health checks will be made using http/2.
     bool use_http2 = 7;
+
+    // Specifies a list of HTTP response statuses considered healthy. If provided, replaces default
+    // 200-only policy - 200 must be included explicitly as needed. Ranges follow half-open
+    // semantics of :ref:`Int64Range <envoy_api_msg_type.Int64Range>`.
+    repeated envoy.type.Int64Range expected_statuses = 9;
   }
 
   message TcpHealthCheck {
@@ -163,7 +169,7 @@ message HealthCheck {
     // A custom health checker specific configuration which depends on the custom health checker
     // being instantiated. See :api:`envoy/config/health_checker` for reference.
     oneof config_type {
-      google.protobuf.Struct config = 2 [deprecated = true];
+      google.protobuf.Struct config = 2;
 
       google.protobuf.Any typed_config = 3;
     }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/protocol.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/protocol.proto
@@ -50,20 +50,20 @@ message Http1ProtocolOptions {
 }
 
 message Http2ProtocolOptions {
-  // `Maximum table size <http://httpwg.org/specs/rfc7541.html#rfc.section.4.2>`_
+  // `Maximum table size <https://httpwg.org/specs/rfc7541.html#rfc.section.4.2>`_
   // (in octets) that the encoder is permitted to use for the dynamic HPACK table. Valid values
   // range from 0 to 4294967295 (2^32 - 1) and defaults to 4096. 0 effectively disables header
   // compression.
   google.protobuf.UInt32Value hpack_table_size = 1;
 
-  // `Maximum concurrent streams <http://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2>`_
+  // `Maximum concurrent streams <https://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2>`_
   // allowed for peer on one HTTP/2 connection. Valid values range from 1 to 2147483647 (2^31 - 1)
   // and defaults to 2147483647.
   google.protobuf.UInt32Value max_concurrent_streams = 2
       [(validate.rules).uint32 = {gte: 1, lte: 2147483647}];
 
   // `Initial stream-level flow-control window
-  // <http://httpwg.org/specs/rfc7540.html#rfc.section.6.9.2>`_ size. Valid values range from 65535
+  // <https://httpwg.org/specs/rfc7540.html#rfc.section.6.9.2>`_ size. Valid values range from 65535
   // (2^16 - 1, HTTP/2 default) to 2147483647 (2^31 - 1, HTTP/2 maximum) and defaults to 268435456
   // (256 * 1024 * 1024).
   //

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
@@ -15,6 +15,7 @@ import "google/rpc/status.proto";
 
 
 
+
 // [#protodoc-title: Common discovery API components]
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
@@ -102,33 +103,32 @@ message DiscoveryResponse {
   core.ControlPlane control_plane = 6;
 }
 
-// IncrementalDiscoveryRequest and IncrementalDiscoveryResponse are used in a
-// new gRPC endpoint for Incremental xDS. The feature is not supported for REST
-// management servers.
+// DeltaDiscoveryRequest and DeltaDiscoveryResponse are used in a new gRPC
+// endpoint for Delta xDS.
 //
-// With Incremental xDS, the IncrementalDiscoveryResponses do not need to
-// include a full snapshot of the tracked resources. Instead
-// IncrementalDiscoveryResponses are a diff to the state of a xDS client.
-// In Incremental XDS there are per resource versions which allows to track
-// state at the resource granularity.
-// An xDS Incremental session is always in the context of a gRPC bidirectional
+// With Delta xDS, the DeltaDiscoveryResponses do not need to include a full
+// snapshot of the tracked resources. Instead, DeltaDiscoveryResponses are a
+// diff to the state of a xDS client.
+// In Delta XDS there are per resource versions, which allow tracking state at
+// the resource granularity.
+// An xDS Delta session is always in the context of a gRPC bidirectional
 // stream. This allows the xDS server to keep track of the state of xDS clients
 // connected to it.
 //
-// In Incremental xDS the nonce field is required and used to pair
-// IncrementalDiscoveryResponse to a IncrementalDiscoveryRequest ACK or NACK.
+// In Delta xDS the nonce field is required and used to pair
+// DeltaDiscoveryResponse to a DeltaDiscoveryRequest ACK or NACK.
 // Optionally, a response message level system_version_info is present for
 // debugging purposes only.
 //
-// IncrementalDiscoveryRequest can be sent in 3 situations:
+// DeltaDiscoveryRequest can be sent in 3 situations:
 //   1. Initial message in a xDS bidirectional gRPC stream.
-//   2. As a ACK or NACK response to a previous IncrementalDiscoveryResponse.
+//   2. As a ACK or NACK response to a previous DeltaDiscoveryResponse.
 //      In this case the response_nonce is set to the nonce value in the Response.
 //      ACK or NACK is determined by the absence or presence of error_detail.
-//   3. Spontaneous IncrementalDiscoveryRequest from the client.
+//   3. Spontaneous DeltaDiscoveryRequest from the client.
 //      This can be done to dynamically add or remove elements from the tracked
 //      resource_names set. In this case response_nonce must be omitted.
-message IncrementalDiscoveryRequest {
+message DeltaDiscoveryRequest {
   // The node making the request.
   core.Node node = 1;
 
@@ -138,18 +138,18 @@ message IncrementalDiscoveryRequest {
   // required for ADS.
   string type_url = 2;
 
-  // IncrementalDiscoveryRequests allow the client to add or remove individual
+  // DeltaDiscoveryRequests allow the client to add or remove individual
   // resources to the set of tracked resources in the context of a stream.
   // All resource names in the resource_names_subscribe list are added to the
   // set of tracked resources and all resource names in the resource_names_unsubscribe
   // list are removed from the set of tracked resources.
-  // Unlike in non incremental xDS, an empty resource_names_subscribe or
+  // Unlike in state-of-the-world xDS, an empty resource_names_subscribe or
   // resource_names_unsubscribe list simply means that no resources are to be
   // added or removed to the resource list.
   // The xDS server must send updates for all tracked resources but can also
   // send updates for resources the client has not subscribed to. This behavior
-  // is similar to non incremental xDS.
-  // These two fields can be set for all types of IncrementalDiscoveryRequests
+  // is similar to state-of-the-world xDS.
+  // These two fields can be set for all types of DeltaDiscoveryRequests
   // (initial, ACK/NACK or spontaneous).
   //
   // A list of Resource names to add to the list of tracked resources.
@@ -158,15 +158,17 @@ message IncrementalDiscoveryRequest {
   // A list of Resource names to remove from the list of tracked resources.
   repeated string resource_names_unsubscribe = 4;
 
-  // This map must be populated when the IncrementalDiscoveryRequest is the
-  // first in a stream. The keys are the resources names of the xDS resources
+  // This map must be populated when the DeltaDiscoveryRequest is the
+  // first in a stream (assuming there are any resources - this field's purpose is to enable
+  // a session to continue in a reconnected gRPC stream, and so will not be used in the very
+  // first stream of a session). The keys are the resources names of the xDS resources
   // known to the xDS client. The values in the map are the associated resource
   // level version info.
   map<string, string> initial_resource_versions = 5;
 
-  // When the IncrementalDiscoveryRequest is a ACK or NACK message in response
-  // to a previous IncrementalDiscoveryResponse, the response_nonce must be the
-  // nonce in the IncrementalDiscoveryResponse.
+  // When the DeltaDiscoveryRequest is a ACK or NACK message in response
+  // to a previous DeltaDiscoveryResponse, the response_nonce must be the
+  // nonce in the DeltaDiscoveryResponse.
   // Otherwise response_nonce must be omitted.
   string response_nonce = 6;
 
@@ -176,24 +178,31 @@ message IncrementalDiscoveryRequest {
   google.rpc.Status error_detail = 7;
 }
 
-message IncrementalDiscoveryResponse {
+message DeltaDiscoveryResponse {
   // The version of the response data (used for debugging).
   string system_version_info = 1;
 
   // The response resources. These are typed resources that match the type url
-  // in the IncrementalDiscoveryRequest.
+  // in the DeltaDiscoveryRequest.
   repeated Resource resources = 2;
 
   // Resources names of resources that have be deleted and to be removed from the xDS Client.
   // Removed resources for missing resources can be ignored.
   repeated string removed_resources = 6;
 
-  // The nonce provides a way for IncrementalDiscoveryRequests to uniquely
-  // reference a IncrementalDiscoveryResponse. The nonce is required.
+  // The nonce provides a way for DeltaDiscoveryRequests to uniquely
+  // reference a DeltaDiscoveryResponse. The nonce is required.
   string nonce = 5;
 }
 
 message Resource {
+  // The resource's name, to distinguish it from others of the same type of resource.
+  string name = 3;
+
+  // [#not-implemented-hide:]
+  // The aliases are a list of other names that this resource can go by.
+  repeated string aliases = 4;
+
   // The resource level version. It allows xDS to track the state of individual
   // resources.
   string version = 1;

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/eds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/eds.proto
@@ -17,6 +17,8 @@ import "google/api/annotations.proto";
 import "validate/validate.proto";
 
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/duration.proto";
+
 
 
 
@@ -42,9 +44,10 @@ service EndpointDiscoveryService {
 //
 // With EDS, each cluster is treated independently from a LB perspective, with
 // LB taking place between the Localities within a cluster and at a finer
-// granularity between the hosts within a locality. For a given cluster, the
-// effective weight of a host is its load_balancing_weight multiplied by the
-// load_balancing_weight of its Locality.
+// granularity between the hosts within a locality. The percentage of traffic
+// for each endpoint is determined by both its load_balancing_weight, and the
+// load_balancing_weight of its locality. First, a locality will be selected,
+// then an endpoint within that locality will be chose based on its weight.
 message ClusterLoadAssignment {
   // Name of the cluster. This will be the :ref:`service_name
   // <envoy_api_field_Cluster.EdsClusterConfig.service_name>` value if specified
@@ -105,6 +108,12 @@ message ClusterLoadAssignment {
     // Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>` and
     // :ref:`localities <arch_overview_load_balancing_locality_weighted_lb>`.
     google.protobuf.UInt32Value overprovisioning_factor = 3 [(validate.rules).uint32.gt = 0];
+
+    // The max time until which the endpoints from this assignment can be used.
+    // If no new assignments are received before this time expires the endpoints
+    // are considered stale and should be marked unhealthy.
+    // Defaults to 0 which means endpoints never go stale.
+    google.protobuf.Duration endpoint_stale_after = 4 [(validate.rules).duration.gt.seconds = 0];
   }
 
   // Load balancing policy settings.

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
@@ -117,9 +117,15 @@ message EndpointLoadMetricStats {
 // Per cluster load stats. Envoy reports these stats a management server in a
 // :ref:`LoadStatsRequest<envoy_api_msg_load_stats.LoadStatsRequest>`
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
+// Next ID: 7
 message ClusterStats {
   // The name of the cluster.
   string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The eds_cluster_config service_name of the cluster.
+  // It's possible that two clusters send the same service_name to EDS,
+  // in that case, the management server is supposed to do aggregation on the load reports.
+  string cluster_service_name = 6;
 
   // Need at least one.
   repeated UpstreamLocalityStats upstream_locality_stats = 2

--- a/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v2/ads.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/service/discovery/v2/ads.proto
@@ -32,7 +32,7 @@ service AggregatedDiscoveryService {
       returns (stream envoy.api.v2.DiscoveryResponse) {
   }
 
-  rpc IncrementalAggregatedResources(stream envoy.api.v2.IncrementalDiscoveryRequest)
-      returns (stream envoy.api.v2.IncrementalDiscoveryResponse) {
+  rpc DeltaAggregatedResources(stream envoy.api.v2.DeltaDiscoveryRequest)
+      returns (stream envoy.api.v2.DeltaDiscoveryResponse) {
   }
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/type/range.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/type/range.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package envoy.type;
+
+option java_outer_classname = "RangeProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.envoy.type";
+option go_package = "envoy_type";
+
+
+
+
+
+// [#protodoc-title: Range]
+
+// Specifies the int64 start and end of the range using half-open interval semantics [start,
+// end).
+message Int64Range {
+  // start of the range (inclusive)
+  int64 start = 1;
+
+  // end of the range (exclusive)
+  int64 end = 2;
+}
+
+// Specifies the double start and end of the range using half-open interval semantics [start,
+// end).
+message DoubleRange {
+  // start of the range (inclusive)
+  double start = 1;
+
+  // end of the range (exclusive)
+  double end = 2;
+}

--- a/xds/third_party/envoy/src/main/proto/udpa/data/orca/v1/orca_load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/udpa/data/orca/v1/orca_load_report.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package udpa.data.orca.v1;
+
+option java_outer_classname = "OrcaLoadReportProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.udpa.data.orca.v1";
+option go_package = "v1";
+
+import "validate/validate.proto";
+
+// See section `ORCA load report format` of the design document in
+// :ref:`https://github.com/envoyproxy/envoy/issues/6614`.
+
+message OrcaLoadReport {
+  // CPU utilization expressed as a fraction of available CPU resources. This
+  // should be derived from a sample or measurement taken during the request.
+  double cpu_utilization = 1 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
+
+  // Memory utilization expressed as a fraction of available memory
+  // resources. This should be derived from a sample or measurement taken
+  // during the request.
+  double mem_utilization = 2 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
+
+  // Application specific requests costs. Each value may be an absolute cost (e.g.
+  // 3487 bytes of storage) or utilization associated with the request,
+  // expressed as a fraction of total resources available. Utilization
+  // metrics should be derived from a sample or measurement taken
+  // during the request.
+  map<string, double> request_cost_or_utilization = 3;
+}

--- a/xds/third_party/envoy/src/main/proto/udpa/service/orca/v1/orca.proto
+++ b/xds/third_party/envoy/src/main/proto/udpa/service/orca/v1/orca.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package udpa.service.orca.v1;
+
+option java_outer_classname = "OrcaProto";
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.udpa.service.orca.v1";
+option go_package = "v1";
+
+import "udpa/data/orca/v1/orca_load_report.proto";
+
+import "google/protobuf/duration.proto";
+
+import "validate/validate.proto";
+
+// See section `Out-of-band (OOB) reporting` of the design document in
+// :ref:`https://github.com/envoyproxy/envoy/issues/6614`.
+
+// Out-of-band (OOB) load reporting service for the additional load reporting
+// agent that does not sit in the request path. Reports are periodically sampled
+// with sufficient frequency to provide temporal association with requests.
+// OOB reporting compensates the limitation of in-band reporting in revealing
+// costs for backends that do not provide a steady stream of telemetry such as
+// long running stream operations and zero QPS services. This is a server
+// streaming service, client needs to terminate current RPC and initiate
+// a new call to change backend reporting frequency.
+service OpenRcaService {
+  rpc StreamCoreMetrics(OrcaLoadReportRequest) returns (stream udpa.data.orca.v1.OrcaLoadReport);
+}
+
+message OrcaLoadReportRequest {
+  // Interval for generating Open RCA core metric responses.
+  google.protobuf.Duration report_interval = 1;
+  // Request costs to collect. If this is empty, all known requests costs tracked by
+  // the load reporting agent will be returned. This provides an opportunity for
+  // the client to selectively obtain a subset of tracked costs.
+  repeated string request_cost_names = 2;
+}


### PR DESCRIPTION
- Ran `xds/third_party/envoy/import.sh` to sync proto dependencies from [envoy](https://github.com/envoyproxy/envoy) repository.
- New proto files for Open Request Cost Aggregation (ORCA) are introduced, which will be used for xDS backend cost metrics report.
- Envoy made some small changes to existing api protos we are currently using. Most of them are doc references in comments. Changes would not break out current usage.