### PR TITLE
buildscripts/kokoro: add command to do clean before build in android kokoro test

### DIFF
--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -21,6 +21,7 @@ echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 # Proto deps
 buildscripts/make_dependencies.sh
 
+./gradlew clean
 ./gradlew publishToMavenLocal
 
 

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -21,6 +21,7 @@ echo y | ${ANDROID_HOME}/tools/bin/sdkmanager "build-tools;28.0.3"
 # Proto deps
 buildscripts/make_dependencies.sh
 
+./gradlew clean
 ./gradlew publishToMavenLocal
 
 # Build grpc-cronet


### PR DESCRIPTION
Current Android Kokoro test does not do gradle clean before build, which causes build failure in Android test when we have proto updates.

Changes made to do a clean before build.