### PR TITLE
java_grpc_library: Use toolchain to enable DexArchiveAspect

### DIFF
--- a/compiler/BUILD.bazel
+++ b/compiler/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//:java_grpc_library.bzl", "java_rpc_toolchain")
+
 cc_binary(
     name = "grpc_java_plugin",
     srcs = [
@@ -5,8 +7,47 @@ cc_binary(
         "src/java_plugin/cpp/java_generator.h",
         "src/java_plugin/cpp/java_plugin.cpp",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:protoc_lib",
     ],
+)
+
+java_library(
+    name = "java_grpc_library_deps__do_not_reference",
+    exports = [
+        "//api",
+        "//protobuf",
+        "//stub",
+        "//stub:javax_annotation",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf//:protobuf_java",
+    ],
+)
+
+java_library(
+    name = "java_lite_grpc_library_deps__do_not_reference",
+    exports = [
+        "//api",
+        "//protobuf-lite",
+        "//stub",
+        "//stub:javax_annotation",
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_guava_guava//jar",
+    ],
+)
+
+java_rpc_toolchain(
+    name = "java_grpc_library_toolchain",
+    plugin = "//compiler:grpc_java_plugin",
+    runtime = [":java_grpc_library_deps__do_not_reference"],
+    visibility = ["//visibility:public"],
+)
+
+java_rpc_toolchain(
+    name = "java_lite_grpc_library_toolchain",
+    plugin = "//compiler:grpc_java_plugin",
+    plugin_arg = "lite",
+    runtime = [":java_lite_grpc_library_deps__do_not_reference"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This removes the "java_import to work around error with android_binary"
hack; see the b/78647825 references to see the really important parts.
But in general using a toolchain cleans up the code considerably and
allows us to reduce the visibility of our protoc plugin. It also is
useful to enable using aspects in the future to avoid using
make_non_strict() which would improve compilation speed avoid avoid many
unnecessary rebuilds.

This is an export of cl/229763103 and brings external up-to-sync with
internal.