### PR TITLE
 core: add getService to MethodDescriptor

### DIFF
--- a/api/src/main/java/io/grpc/MethodDescriptor.java
+++ b/api/src/main/java/io/grpc/MethodDescriptor.java
@@ -262,7 +262,7 @@ public final class MethodDescriptor<ReqT, RespT> {
    * @since 1.21.0
    */
   @Nullable
-  @ExperimentalApi("FIXME")
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5635")
   public String getServiceName() {
     return serviceName;
   }

--- a/api/src/main/java/io/grpc/MethodDescriptor.java
+++ b/api/src/main/java/io/grpc/MethodDescriptor.java
@@ -41,6 +41,7 @@ public final class MethodDescriptor<ReqT, RespT> {
 
   private final MethodType type;
   private final String fullMethodName;
+  @Nullable private final String serviceName;
   private final Marshaller<ReqT> requestMarshaller;
   private final Marshaller<RespT> responseMarshaller;
   private final @Nullable Object schemaDescriptor;
@@ -226,6 +227,7 @@ public final class MethodDescriptor<ReqT, RespT> {
 
     this.type = Preconditions.checkNotNull(type, "type");
     this.fullMethodName = Preconditions.checkNotNull(fullMethodName, "fullMethodName");
+    this.serviceName = extractFullServiceName(fullMethodName);
     this.requestMarshaller = Preconditions.checkNotNull(requestMarshaller, "requestMarshaller");
     this.responseMarshaller = Preconditions.checkNotNull(responseMarshaller, "responseMarshaller");
     this.schemaDescriptor = schemaDescriptor;
@@ -252,6 +254,17 @@ public final class MethodDescriptor<ReqT, RespT> {
    */
   public String getFullMethodName() {
     return fullMethodName;
+  }
+
+  /**
+   * A convenience method for {@code extractFullServiceName(getFullMethodName())}.
+   *
+   * @since 1.21.0
+   */
+  @Nullable
+  @ExperimentalApi("FIXME")
+  public String getServiceName() {
+    return serviceName;
   }
 
   /**

--- a/api/src/main/java/io/grpc/ServerServiceDefinition.java
+++ b/api/src/main/java/io/grpc/ServerServiceDefinition.java
@@ -106,7 +106,7 @@ public final class ServerServiceDefinition {
     public <ReqT, RespT> Builder addMethod(ServerMethodDefinition<ReqT, RespT> def) {
       MethodDescriptor<ReqT, RespT> method = def.getMethodDescriptor();
       checkArgument(
-          serviceName.equals(MethodDescriptor.extractFullServiceName(method.getFullMethodName())),
+          serviceName.equals(method.getServiceName()),
           "Method name should be prefixed with service name and separated with '/'. "
                   + "Expected service name: '%s'. Actual fully qualifed method name: '%s'.",
           serviceName, method.getFullMethodName());

--- a/api/src/main/java/io/grpc/ServiceDescriptor.java
+++ b/api/src/main/java/io/grpc/ServiceDescriptor.java
@@ -110,8 +110,7 @@ public final class ServiceDescriptor {
     Set<String> allNames = new HashSet<>(methods.size());
     for (MethodDescriptor<?, ?> method : methods) {
       checkNotNull(method, "method");
-      String methodServiceName =
-          MethodDescriptor.extractFullServiceName(method.getFullMethodName());
+      String methodServiceName = method.getServiceName();
       checkArgument(serviceName.equals(methodServiceName),
           "service names %s != %s", methodServiceName, serviceName);
       checkArgument(allNames.add(method.getFullMethodName()),

--- a/api/src/test/java/io/grpc/MethodDescriptorTest.java
+++ b/api/src/test/java/io/grpc/MethodDescriptorTest.java
@@ -20,9 +20,12 @@ import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import io.grpc.MethodDescriptor.Marshaller;
 import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.testing.TestMethodDescriptors;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -133,6 +136,28 @@ public class MethodDescriptorTest {
         .setSampledToLocalTracing(true)
         .build();
     assertTrue(md4.isSampledToLocalTracing());
+  }
+
+  @Test
+  public void getServiceName_extractsService() {
+    Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
+    MethodDescriptor<?, ?> md = MethodDescriptor.newBuilder(marshaller, marshaller)
+        .setType(MethodType.UNARY)
+        .setFullMethodName("foo/bar")
+        .build();
+
+    assertEquals("foo", md.getServiceName());
+  }
+
+  @Test
+  public void getServiceName_returnsNull() {
+    Marshaller<Void> marshaller = TestMethodDescriptors.voidMarshaller();
+    MethodDescriptor<?, ?> md = MethodDescriptor.newBuilder(marshaller, marshaller)
+        .setType(MethodType.UNARY)
+        .setFullMethodName("foo-bar")
+        .build();
+
+    assertNull(md.getServiceName());
   }
 
   @Test

--- a/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
+++ b/auth/src/main/java/io/grpc/auth/ClientAuthInterceptor.java
@@ -102,7 +102,7 @@ public final class ClientAuthInterceptor implements ClientInterceptor {
     // Always use HTTPS, by definition.
     final String scheme = "https";
     final int defaultPort = 443;
-    String path = "/" + MethodDescriptor.extractFullServiceName(method.getFullMethodName());
+    String path = "/" + method.getServiceName();
     URI uri;
     try {
       uri = new URI(scheme, authority, path, null, null);

--- a/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
+++ b/auth/src/main/java/io/grpc/auth/GoogleAuthLibraryCallCredentials.java
@@ -159,7 +159,7 @@ final class GoogleAuthLibraryCallCredentials extends io.grpc.CallCredentials2 {
     // Always use HTTPS, by definition.
     final String scheme = "https";
     final int defaultPort = 443;
-    String path = "/" + MethodDescriptor.extractFullServiceName(method.getFullMethodName());
+    String path = "/" + method.getServiceName();
     URI uri;
     try {
       uri = new URI(scheme, authority, path, null, null);

--- a/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigInterceptor.java
@@ -195,7 +195,7 @@ final class ServiceConfigInterceptor implements ClientInterceptor {
       info = mcsc.getServiceMethodMap().get(method.getFullMethodName());
     }
     if (info == null && mcsc != null) {
-      String serviceName = MethodDescriptor.extractFullServiceName(method.getFullMethodName());
+      String serviceName = method.getServiceName();
       info = mcsc.getServiceMap().get(serviceName);
     }
     return info;


### PR DESCRIPTION
This method is needed for serviceConfig enforcement, and some security checks.  Rather than recreate the string each time, just cache it on the MD.