### PR TITLE
api: expose if waitForReady has been set on CallOptions

### DIFF
--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -370,7 +370,7 @@ public final class CallOptions {
    * calls and 'wait for ready' is the opposite to it.
    */
   public boolean isWaitForReady() {
-    return waitForReady;
+    return Boolean.TRUE.equals(waitForReady);
   }
 
   Boolean getWaitForReady() {

--- a/api/src/main/java/io/grpc/CallOptions.java
+++ b/api/src/main/java/io/grpc/CallOptions.java
@@ -69,7 +69,8 @@ public final class CallOptions {
   /**
    * Opposite to fail fast.
    */
-  private boolean waitForReady;
+  @Nullable
+  private Boolean waitForReady;
 
   @Nullable
   private Integer maxInboundMessageSize;
@@ -154,7 +155,7 @@ public final class CallOptions {
    */
   public CallOptions withWaitForReady() {
     CallOptions newOptions = new CallOptions(this);
-    newOptions.waitForReady = true;
+    newOptions.waitForReady = Boolean.TRUE;
     return newOptions;
   }
 
@@ -164,7 +165,7 @@ public final class CallOptions {
    */
   public CallOptions withoutWaitForReady() {
     CallOptions newOptions = new CallOptions(this);
-    newOptions.waitForReady = false;
+    newOptions.waitForReady = Boolean.FALSE;
     return newOptions;
   }
 
@@ -369,6 +370,10 @@ public final class CallOptions {
    * calls and 'wait for ready' is the opposite to it.
    */
   public boolean isWaitForReady() {
+    return waitForReady;
+  }
+
+  Boolean getWaitForReady() {
     return waitForReady;
   }
 

--- a/api/src/main/java/io/grpc/InternalCallOptions.java
+++ b/api/src/main/java/io/grpc/InternalCallOptions.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+/**
+ * Internal accessor for {@link CallOptions}.
+ */
+@Internal
+public final class InternalCallOptions {
+  private InternalCallOptions() {}
+
+  /**
+   * Gets the waitForReady bit or {@code null} if it was never set.
+   */
+  public static Boolean getWaitForReady(CallOptions callOptions) {
+    return callOptions.getWaitForReady();
+  }
+}

--- a/api/src/test/java/io/grpc/CallOptionsTest.java
+++ b/api/src/test/java/io/grpc/CallOptionsTest.java
@@ -24,6 +24,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -232,6 +234,13 @@ public class CallOptionsTest {
     } catch (UnsupportedOperationException e) {
       // Expected
     }
+  }
+
+  @Test
+  public void getWaitForReady() {
+    assertNull(CallOptions.DEFAULT.getWaitForReady());
+    assertSame(CallOptions.DEFAULT.withWaitForReady().getWaitForReady(), Boolean.TRUE);
+    assertSame(CallOptions.DEFAULT.withoutWaitForReady().getWaitForReady(), Boolean.FALSE);
   }
 
   // Only used in noStrayModifications()


### PR DESCRIPTION
This is needed to properly implement the Service Config waitForReady underride.