### PR TITLE
core: factor service config state management out of ManagedChannelImpl

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServiceConfigState.java
+++ b/core/src/main/java/io/grpc/internal/ServiceConfigState.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import javax.annotation.Nullable;
+
+/**
+ * {@link ServiceConfigState} holds the state of the current service config.  It must be mutated
+ * and read from {@link ManagedChannelImpl} constructor or the provided syncContext.
+ */
+final class ServiceConfigState {
+  @Nullable private final ManagedChannelServiceConfig defaultServiceConfig;
+  private final boolean lookUpServiceConfig;
+  private final SynchronizationContext syncCtx;
+
+  // mutable state
+  @Nullable private ManagedChannelServiceConfig currentServiceConfig;
+  @Nullable private Status currentError;
+
+  /**
+   * @param defaultServiceConfig The initial service config, or {@code null} if absent.
+   * @param lookUpServiceConfig {@code true} if service config updates might occur.
+   * @param syncCtx The synchronization context that this is accessed from.
+   */
+  ServiceConfigState(
+      @Nullable ManagedChannelServiceConfig defaultServiceConfig,
+      boolean lookUpServiceConfig,
+      SynchronizationContext syncCtx) {
+    this.defaultServiceConfig = defaultServiceConfig;
+    this.lookUpServiceConfig = lookUpServiceConfig;
+    this.syncCtx = checkNotNull(syncCtx, "syncCtx");
+    if (!lookUpServiceConfig) {
+      this.currentServiceConfig = defaultServiceConfig;
+    }
+  }
+
+  /**
+   * Returns {@code true} if it RPCs should wait on a service config resolution.  This can return
+   * {@code false} if:
+   *
+   * <ul>
+   *   <li>There is a valid service config from the name resolver
+   *   <li>There is a valid default service config and a service config error from the name
+   *       resolver
+   *   <li>No service config from the name resolver, and no intent to lookup a service config.
+   *
+   * In the final case, the default service config may be present or absent, and will be the
+   * current service config.
+   */
+  boolean waitOnServiceConfig() {
+    syncCtx.throwIfNotInThisSynchronizationContext();
+    if (currentServiceConfig != null || currentError != null) {
+      return false;
+    } else {
+      return expectUpdates();
+    }
+  }
+
+  /**
+   * Gets the current service config.
+   *
+   * @throws IllegalStateException if the service config has not yet been updated.
+   */
+  @Nullable ManagedChannelServiceConfig getCurrentServiceConfig() {
+    checkState(!waitOnServiceConfig(), "still waiting on service config");
+    return currentServiceConfig;
+  }
+
+  /**
+   * Gets the current service config error.
+   *
+   * @throws IllegalStateException if the service config has not yet been updated.
+   */
+  @Nullable Status getCurrentError() {
+    checkState(!waitOnServiceConfig(), "still waiting on service config");
+    return currentError;
+  }
+
+  /**
+   * Returns {@code true} if the update was successfully applied, else {@code false}.
+   */
+  boolean update(Status error) {
+    checkNotNull(error, "error");
+    checkArgument(!error.isOk(), "can't use OK error");
+    syncCtx.throwIfNotInThisSynchronizationContext();
+    checkState(expectUpdates(), "unexpected service config update");
+
+    if (currentServiceConfig == null) {
+      if (defaultServiceConfig != null) {
+        currentServiceConfig = defaultServiceConfig;
+        return false;
+      } else {
+        currentError = error;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns {@code} if the update was successfully applied, else {@code false}.
+   */
+  void update(ManagedChannelServiceConfig newServiceConfig) {
+    checkNotNull(newServiceConfig, "newServiceConfig");
+    syncCtx.throwIfNotInThisSynchronizationContext();
+    checkState(expectUpdates(), "unexpected service config update");
+
+    currentServiceConfig = newServiceConfig;
+    currentError = null;
+  }
+
+  boolean expectUpdates() {
+    return lookUpServiceConfig;
+  }
+}

--- a/core/src/test/java/io/grpc/internal/ServiceConfigStateTest.java
+++ b/core/src/test/java/io/grpc/internal/ServiceConfigStateTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.base.Throwables;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.internal.ManagedChannelServiceConfig.MethodInfo;
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.Collections;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link ServiceConfigState}.
+ */
+@RunWith(JUnit4.class)
+public class ServiceConfigStateTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  private final ManagedChannelServiceConfig config1 = new ManagedChannelServiceConfig(
+      Collections.<String, MethodInfo>emptyMap(),
+      Collections.<String, MethodInfo>emptyMap(),
+      null,
+      null);
+  private final ManagedChannelServiceConfig config2 = new ManagedChannelServiceConfig(
+      Collections.<String, MethodInfo>emptyMap(),
+      Collections.<String, MethodInfo>emptyMap(),
+      null,
+      null);
+  private final SynchronizationContext syncCtx = new SynchronizationContext(
+      new UncaughtExceptionHandler() {
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
+    }
+  });
+
+  @Test
+  public void expectUpdates() {
+    boolean lookupServiceConfig = true;
+    ServiceConfigState scs = new ServiceConfigState(config1, lookupServiceConfig, syncCtx);
+
+    assertTrue(scs.expectUpdates());
+  }
+
+  @Test
+  public void expectUpdates_noUpdates() {
+    boolean lookupServiceConfig = false;
+    ServiceConfigState scs = new ServiceConfigState(config1, lookupServiceConfig, syncCtx);
+
+    assertFalse(scs.expectUpdates());
+  }
+
+  @Test
+  public void failsOnNullSync() {
+    boolean lookupServiceConfig = true;
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("syncCtx");
+
+    ServiceConfigState scs = new ServiceConfigState(config1, lookupServiceConfig, null);
+  }
+
+  @Test
+  public void waitOnServiceConfig_waitsNoDefault() {
+    boolean lookupServiceConfig = true;
+    final ServiceConfigState scs = new ServiceConfigState(null, lookupServiceConfig, syncCtx);
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        assertTrue(scs.waitOnServiceConfig());
+      }
+    });
+  }
+
+  @Test
+  public void waitOnServiceConfig_waitsWithDefault() {
+    boolean lookupServiceConfig = true;
+    final ServiceConfigState scs = new ServiceConfigState(config1, lookupServiceConfig, syncCtx);
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        assertTrue(scs.waitOnServiceConfig());
+      }
+    });
+  }
+
+  @Test
+  public void waitOnServiceConfig_noWaitWithDefault() {
+    boolean lookupServiceConfig = false;
+    final ServiceConfigState scs = new ServiceConfigState(config1, lookupServiceConfig, syncCtx);
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        assertFalse(scs.waitOnServiceConfig());
+        assertSame(config1, scs.getCurrentServiceConfig());
+      }
+    });
+  }
+
+  @Test
+  public void waitOnServiceConfig_noWaitWithNoDefault() {
+    boolean lookupServiceConfig = false;
+    final ServiceConfigState scs = new ServiceConfigState(null, lookupServiceConfig, syncCtx);
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        assertFalse(scs.waitOnServiceConfig());
+        assertNull(scs.getCurrentServiceConfig());
+      }
+    });
+  }
+
+  @Test
+  public void getCurrentServiceConfig_failsOnUnresolvedConfig() {
+    boolean lookupServiceConfig = true;
+    final ServiceConfigState scs = new ServiceConfigState(config1, lookupServiceConfig, syncCtx);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("still waiting");
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        scs.getCurrentServiceConfig();
+      }
+    });
+  }
+
+  @Test
+  public void getCurrentServiceConfig_defaultWithErrorWorks() {
+    boolean lookupServiceConfig = true;
+    final ServiceConfigState scs = new ServiceConfigState(config1, lookupServiceConfig, syncCtx);
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        assertFalse(scs.update(Status.INTERNAL.withDescription("bang")));
+        assertSame(config1, scs.getCurrentServiceConfig());
+      }
+    });
+  }
+
+  @Test
+  public void getCurrentServiceConfig_errorThenSuccess() {
+    boolean lookupServiceConfig = true;
+    final ServiceConfigState scs = new ServiceConfigState(config1, lookupServiceConfig, syncCtx);
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        assertFalse(scs.update(Status.INTERNAL.withDescription("bang")));
+        scs.update(config2);
+        assertSame(config2, scs.getCurrentServiceConfig());
+      }
+    });
+  }
+
+  @Test
+  public void getCurrentServiceConfig_successThenError() {
+    boolean lookupServiceConfig = true;
+    final ServiceConfigState scs = new ServiceConfigState(config1, lookupServiceConfig, syncCtx);
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        scs.update(config2);
+        assertFalse(scs.update(Status.INTERNAL.withDescription("bang")));
+        assertSame(config2, scs.getCurrentServiceConfig());
+      }
+    });
+  }
+
+  @Test
+  public void getCurrentServiceConfig_noDefaultWithError() {
+    boolean lookupServiceConfig = true;
+    final ServiceConfigState scs = new ServiceConfigState(null, lookupServiceConfig, syncCtx);
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        Status s = Status.INTERNAL.withDescription("bang");
+        assertTrue(scs.update(s));
+        assertSame(s, scs.getCurrentError());
+        assertNull(scs.getCurrentServiceConfig());
+      }
+    });
+  }
+
+  @Test
+  public void update_errorsOverwrite() {
+    boolean lookupServiceConfig = true;
+    final ServiceConfigState scs = new ServiceConfigState(null, lookupServiceConfig, syncCtx);
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        assertTrue(scs.update(Status.INTERNAL.withDescription("boom")));
+
+        Status s = Status.INTERNAL.withDescription("bang");
+        assertTrue(scs.update(s));
+        assertSame(s, scs.getCurrentError());
+        assertNull(scs.getCurrentServiceConfig());
+      }
+    });
+  }
+
+  @Test
+  public void update_failsOnUnexpectedError() {
+    boolean lookupServiceConfig = false;
+    final ServiceConfigState scs = new ServiceConfigState(null, lookupServiceConfig, syncCtx);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("unexpected service config update");
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        scs.update(Status.INTERNAL.withDescription("boom"));
+      }
+    });
+  }
+
+  @Test
+  public void update_failsOnUnexpectedSuccess() {
+    boolean lookupServiceConfig = false;
+    final ServiceConfigState scs = new ServiceConfigState(null, lookupServiceConfig, syncCtx);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("unexpected service config update");
+
+    syncCtx.execute(new Runnable() {
+      @Override
+      public void run() {
+        scs.update(config2);
+      }
+    });
+  }
+
+  @Test
+  public void update_failsOnOutsideOfSync() {
+    boolean lookupServiceConfig = false;
+    final ServiceConfigState scs = new ServiceConfigState(null, lookupServiceConfig, syncCtx);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Not called from the SynchronizationContext");
+
+    scs.update(config2);
+  }
+}


### PR DESCRIPTION
This class was an internal class in another branch, but it is somewhat too big.  I have factored it out into a reviewable piece.  It enforces all the ServiceConfig state transitions.