### PR TITLE
core: annotate experimental API's inner classes.

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -159,6 +159,7 @@ public abstract class LoadBalancer {
    *
    * @since 1.21.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
   public static final class ResolvedAddresses {
     private final List<EquivalentAddressGroup> addresses;
     @NameResolver.ResolutionResultAttr
@@ -232,6 +233,7 @@ public abstract class LoadBalancer {
     /**
      * Builder for {@link ResolvedAddresses}.
      */
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
     public static final class Builder {
       private List<EquivalentAddressGroup> addresses;
       @NameResolver.ResolutionResultAttr
@@ -663,6 +665,7 @@ public abstract class LoadBalancer {
    *
    * @since 1.21.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
   public static final class CreateSubchannelArgs {
     private final List<EquivalentAddressGroup> addrs;
     private final Attributes attrs;
@@ -739,6 +742,7 @@ public abstract class LoadBalancer {
           && Objects.equal(stateListener, that.stateListener);
     }
 
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
     public static final class Builder {
       private List<EquivalentAddressGroup> addrs;
       private Attributes attrs = Attributes.EMPTY;

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -129,6 +129,7 @@ public abstract class NameResolver {
    *
    * @since 1.0.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
   public abstract static class Factory {
     /**
      * The port number used in case the target or the underlying naming system doesn't provide a
@@ -268,6 +269,7 @@ public abstract class NameResolver {
    *
    * @since 1.21.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
   public abstract static class Observer implements Listener {
     /**
      * @deprecated This will be removed in 1.21.0
@@ -314,6 +316,7 @@ public abstract class NameResolver {
    *
    * @since 1.19.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
   public abstract static class Helper {
     /**
      * The port number used in case the target or the underlying naming system doesn't provide a
@@ -466,6 +469,7 @@ public abstract class NameResolver {
      *
      * @since 1.21.0
      */
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
     public static final class Builder {
       private List<EquivalentAddressGroup> addresses = Collections.emptyList();
       private Attributes attributes = Attributes.EMPTY;
@@ -524,6 +528,7 @@ public abstract class NameResolver {
    *
    * @since 1.21.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
   public static final class ConfigOrError {
 
     /**


### PR DESCRIPTION
Annotations on outer class don't show on the javadoc of inner classes.

cc @voidzcy 