### PR TITLE
api: patch CreateSubchannelArgs toString() with customOptions

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -23,6 +23,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -738,6 +739,7 @@ public abstract class LoadBalancer {
           .add("addrs", addrs)
           .add("attrs", attrs)
           .add("listener", stateListener)
+          .add("customOptions", Arrays.deepToString(customOptions))
           .toString();
     }
 

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -268,6 +268,22 @@ public class LoadBalancerTest {
     assertThat(args.getOption(testKey)).isEqualTo(testValue2);
   }
 
+  @Test
+  public void createSubchannelArgs_toString() {
+    CreateSubchannelArgs.Key<String> testKey = CreateSubchannelArgs.Key.create("test-key");
+    CreateSubchannelArgs args = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey, "test-value")
+        .build();
+    String str = args.toString();
+    assertThat(str).contains("addrs=");
+    assertThat(str).contains("attrs=");
+    assertThat(str).contains("listener=");
+    assertThat(str).contains("customOptions=");
+  }
+
   @Deprecated
   @Test
   public void handleResolvedAddressGroups_delegatesToHandleResolvedAddresses() {


### PR DESCRIPTION
This is something I missed in #5640.