### PR TITLE
api: fix bugs of missing to copy customOptions when converting to a new builder, also trash hashCode/equals

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -745,44 +744,6 @@ public abstract class LoadBalancer {
           .toString();
     }
 
-    @Override
-    public int hashCode() {
-      Map<Object, Object> map = new HashMap<>();
-      for (Object[] pair : customOptions) {
-        map.put(pair[0], pair[1]);
-      }
-      return Objects.hashCode(addrs, attrs, stateListener, map);
-    }
-
-    /**
-     * Returns true if the {@code List<EquivalentAddressGroup>}, {@link Attributes},
-     * {@link SubchannelStateListener} all match and two instances contain the same set of
-     * custom options.
-     */
-    @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof CreateSubchannelArgs)) {
-        return false;
-      }
-      CreateSubchannelArgs that = (CreateSubchannelArgs) other;
-      if (customOptions.length != that.customOptions.length) {
-        return false;
-      }
-      if (customOptions.length > 0) {
-        Map<Object, Object> thisOptionMap = new HashMap<>();
-        Map<Object, Object> thatOptionMap = new HashMap<>();
-        for (int i = 0; i < customOptions.length; i++) {
-          thisOptionMap.put(customOptions[i][0], customOptions[i][1]);
-          thatOptionMap.put(that.customOptions[i][0], that.customOptions[i][1]);
-        }
-        if (!thisOptionMap.equals(thatOptionMap)) {
-          return false;
-        }
-      }
-      return Objects.equal(addrs, that.addrs) && Objects.equal(attrs, that.attrs)
-          && Objects.equal(stateListener, that.stateListener);
-    }
-
     @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
     public static final class Builder {
 
@@ -796,7 +757,7 @@ public abstract class LoadBalancer {
 
       private <T> Builder copyCustomOptions(Object[][] options) {
         customOptions = new Object[options.length][2];
-        System.arraycopy(customOptions, 0, options, 0, options.length);
+        System.arraycopy(options, 0, customOptions, 0, options.length);
         return this;
       }
 

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -269,6 +269,103 @@ public class LoadBalancerTest {
   }
 
   @Test
+  public void createSubchannelArgs_build() {
+    CreateSubchannelArgs.Key<String> testKey = CreateSubchannelArgs.Key.create("test-key");
+    CreateSubchannelArgs args = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey, "test-value")
+        .build();
+    assertThat(args.toBuilder().addOption(testKey, "test-value-2").build()).isNotEqualTo(args);
+    assertThat(args.toBuilder().build()).isEqualTo(args);
+  }
+
+  @Test
+  public void createSubchannelArgs_equality() {
+    // Custom option's equality are based on identity-based key and value.
+    CreateSubchannelArgs.Key<Object> testKey1 = CreateSubchannelArgs.Key.create("test-key1");
+    CreateSubchannelArgs.Key<Object> testKey2 = CreateSubchannelArgs.Key.create("test-key2");
+    Object testValue1 = new Object();
+    Object testValue2 = new Object();
+    CreateSubchannelArgs args1 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(CreateSubchannelArgs.Key.create("test-key"), testValue1)
+        .build();
+    CreateSubchannelArgs args2 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(CreateSubchannelArgs.Key.create("test-key"), testValue1)
+        .build();
+    assertThat(args1).isNotEqualTo(args2);
+
+    args1 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey1, new Object())
+        .build();
+    args2 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey1, new Object())
+        .build();
+    assertThat(args1).isNotEqualTo(args2);
+
+    args1 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey1, testValue1)
+        .build();
+    args2 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey1, testValue1)
+        .build();
+    assertThat(args1).isEqualTo(args2);
+
+    // Order of custom options does not matter.
+    args1 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey1, testValue1)
+        .addOption(testKey2, testValue2)
+        .build();
+    args2 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey2, testValue2)
+        .addOption(testKey1, testValue1)
+        .build();
+    assertThat(args1).isEqualTo(args2);
+
+    // But key-value mapping does matter.
+    args1 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey1, testValue1)
+        .addOption(testKey2, testValue2)
+        .build();
+    args2 = CreateSubchannelArgs.newBuilder()
+        .setAddresses(eag)
+        .setAttributes(attrs)
+        .setStateListener(subchannelStateListener)
+        .addOption(testKey1, testValue2)
+        .addOption(testKey2, testValue1)
+        .build();
+    assertThat(args1).isNotEqualTo(args2);
+  }
+
+  @Test
   public void createSubchannelArgs_toString() {
     CreateSubchannelArgs.Key<String> testKey = CreateSubchannelArgs.Key.create("test-key");
     CreateSubchannelArgs args = CreateSubchannelArgs.newBuilder()

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -270,99 +270,19 @@ public class LoadBalancerTest {
 
   @Test
   public void createSubchannelArgs_build() {
-    CreateSubchannelArgs.Key<String> testKey = CreateSubchannelArgs.Key.create("test-key");
+    CreateSubchannelArgs.Key<Object> testKey = CreateSubchannelArgs.Key.create("test-key");
+    Object testValue = new Object();
     CreateSubchannelArgs args = CreateSubchannelArgs.newBuilder()
         .setAddresses(eag)
         .setAttributes(attrs)
         .setStateListener(subchannelStateListener)
-        .addOption(testKey, "test-value")
+        .addOption(testKey, testValue)
         .build();
-    assertThat(args.toBuilder().addOption(testKey, "test-value-2").build()).isNotEqualTo(args);
-    assertThat(args.toBuilder().build()).isEqualTo(args);
-  }
-
-  @Test
-  public void createSubchannelArgs_equality() {
-    // Custom option's equality are based on identity-based key and value.
-    CreateSubchannelArgs.Key<Object> testKey1 = CreateSubchannelArgs.Key.create("test-key1");
-    CreateSubchannelArgs.Key<Object> testKey2 = CreateSubchannelArgs.Key.create("test-key2");
-    Object testValue1 = new Object();
-    Object testValue2 = new Object();
-    CreateSubchannelArgs args1 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(CreateSubchannelArgs.Key.create("test-key"), testValue1)
-        .build();
-    CreateSubchannelArgs args2 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(CreateSubchannelArgs.Key.create("test-key"), testValue1)
-        .build();
-    assertThat(args1).isNotEqualTo(args2);
-
-    args1 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(testKey1, new Object())
-        .build();
-    args2 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(testKey1, new Object())
-        .build();
-    assertThat(args1).isNotEqualTo(args2);
-
-    args1 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(testKey1, testValue1)
-        .build();
-    args2 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(testKey1, testValue1)
-        .build();
-    assertThat(args1).isEqualTo(args2);
-
-    // Order of custom options does not matter.
-    args1 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(testKey1, testValue1)
-        .addOption(testKey2, testValue2)
-        .build();
-    args2 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(testKey2, testValue2)
-        .addOption(testKey1, testValue1)
-        .build();
-    assertThat(args1).isEqualTo(args2);
-
-    // But key-value mapping does matter.
-    args1 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(testKey1, testValue1)
-        .addOption(testKey2, testValue2)
-        .build();
-    args2 = CreateSubchannelArgs.newBuilder()
-        .setAddresses(eag)
-        .setAttributes(attrs)
-        .setStateListener(subchannelStateListener)
-        .addOption(testKey1, testValue2)
-        .addOption(testKey2, testValue1)
-        .build();
-    assertThat(args1).isNotEqualTo(args2);
+    CreateSubchannelArgs rebuildedArgs = args.toBuilder().build();
+    assertThat(rebuildedArgs.getAddresses()).containsExactly(eag);
+    assertThat(rebuildedArgs.getAttributes()).isSameInstanceAs(attrs);
+    assertThat(rebuildedArgs.getStateListener()).isSameInstanceAs(subchannelStateListener);
+    assertThat(rebuildedArgs.getOption(testKey)).isSameInstanceAs(testValue);
   }
 
   @Test


### PR DESCRIPTION
This is the second (last) thing I missed in #5640 . 