### PR TITLE
 all: Upgrade OpenCensus versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ subprojects {
         protobufVersion = '3.7.1'
         protocVersion = protobufVersion
         protobufNanoVersion = '3.0.0-alpha-5'
-        opencensusVersion = '0.19.2'
+        opencensusVersion = '0.21.0'
 
         configureProtoCompilation = {
             String generatedSourcePath = "${projectDir}/src/generated"

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -18,7 +18,6 @@ package io.grpc.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static io.opencensus.tags.unsafe.ContextUtils.TAG_CONTEXT_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
@@ -48,6 +47,7 @@ import io.opencensus.tags.Tagger;
 import io.opencensus.tags.Tags;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagContextSerializationException;
+import io.opencensus.tags.unsafe.ContextUtils;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -654,7 +654,7 @@ public final class CensusStatsModule {
     @Override
     public Context filterContext(Context context) {
       if (!module.tagger.empty().equals(parentCtx)) {
-        return context.withValue(TAG_CONTEXT_KEY, parentCtx);
+        return ContextUtils.withValue(context, parentCtx);
       }
       return context;
     }

--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -356,7 +356,7 @@ public final class CensusStatsModule {
       this.parentCtx = checkNotNull(parentCtx);
       TagValue methodTag = TagValue.create(fullMethodName);
       this.startCtx = module.tagger.toBuilder(parentCtx)
-          .put(DeprecatedCensusConstants.RPC_METHOD, methodTag)
+          .putPropagating(DeprecatedCensusConstants.RPC_METHOD, methodTag)
           .build();
       this.stopwatch = module.stopwatchSupplier.get().start();
       if (module.recordStartedRpcs) {
@@ -442,7 +442,7 @@ public final class CensusStatsModule {
           module
               .tagger
               .toBuilder(startCtx)
-              .put(DeprecatedCensusConstants.RPC_STATUS, statusTag)
+              .putPropagating(DeprecatedCensusConstants.RPC_STATUS, statusTag)
               .build());
     }
   }
@@ -647,7 +647,7 @@ public final class CensusStatsModule {
           module
               .tagger
               .toBuilder(parentCtx)
-              .put(DeprecatedCensusConstants.RPC_STATUS, statusTag)
+              .putPropagating(DeprecatedCensusConstants.RPC_STATUS, statusTag)
               .build());
     }
 
@@ -672,7 +672,7 @@ public final class CensusStatsModule {
       parentCtx =
           tagger
               .toBuilder(parentCtx)
-              .put(DeprecatedCensusConstants.RPC_METHOD, methodTag)
+              .putPropagating(DeprecatedCensusConstants.RPC_METHOD, methodTag)
               .build();
       return new ServerTracer(CensusStatsModule.this, parentCtx);
     }

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -250,8 +250,13 @@ public class CensusModulesTest {
             censusStats.getClientInterceptor(), censusTracing.getClientInterceptor());
     ClientCall<String, String> call;
     if (nonDefaultContext) {
-      Context ctx = io.opencensus.tags.unsafe.ContextUtils.withValue(Context.ROOT, tagger.emptyBuilder().put(
-          StatsTestUtils.EXTRA_TAG, TagValue.create("extra value")).build());
+      Context ctx =
+          io.opencensus.tags.unsafe.ContextUtils.withValue(
+              Context.ROOT,
+              tagger
+                  .emptyBuilder()
+                  .putPropagating(StatsTestUtils.EXTRA_TAG, TagValue.create("extra value"))
+                  .build());
       ctx = ContextUtils.withValue(ctx, fakeClientParentSpan);
       Context origCtx = ctx.attach();
       try {
@@ -643,7 +648,7 @@ public class CensusModulesTest {
     // EXTRA_TAG is propagated by the FakeStatsContextFactory. Note that not all tags are
     // propagated.  The StatsContextFactory decides which tags are to propagated.  gRPC facilitates
     // the propagation by putting them in the headers.
-    TagContext clientCtx = tagger.emptyBuilder().put(
+    TagContext clientCtx = tagger.emptyBuilder().putPropagating(
         StatsTestUtils.EXTRA_TAG, TagValue.create("extra-tag-value-897")).build();
     CensusStatsModule census =
         new CensusStatsModule(
@@ -684,7 +689,7 @@ public class CensusModulesTest {
     // It also put clientCtx in the Context seen by the call handler
     assertEquals(
         tagger.toBuilder(clientCtx)
-            .put(
+            .putPropagating(
                 DeprecatedCensusConstants.RPC_METHOD,
                 TagValue.create(method.getFullMethodName()))
             .build(),
@@ -920,7 +925,7 @@ public class CensusModulesTest {
     assertEquals(
         tagger
             .emptyBuilder()
-            .put(
+            .putPropagating(
                 DeprecatedCensusConstants.RPC_METHOD,
                 TagValue.create(method.getFullMethodName()))
             .build(),

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1445,8 +1445,13 @@ public abstract class AbstractInteropTest {
     Span clientParentSpan = Tracing.getTracer().spanBuilder("Test.interopTest").startSpan();
     // A valid ID is guaranteed to be unique, so we can verify it is actually propagated.
     assertTrue(clientParentSpan.getContext().getTraceId().isValid());
-    Context ctx = io.opencensus.tags.unsafe.ContextUtils.withValue(Context.ROOT, tagger.emptyBuilder().put(
-        StatsTestUtils.EXTRA_TAG, TagValue.create("extra value")).build());
+    Context ctx =
+        io.opencensus.tags.unsafe.ContextUtils.withValue(
+            Context.ROOT,
+            tagger
+                .emptyBuilder()
+                .putPropagating(StatsTestUtils.EXTRA_TAG, TagValue.create("extra value"))
+                .build());
     ctx = ContextUtils.withValue(ctx, clientParentSpan);
     Context origCtx = ctx.attach();
     try {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -19,8 +19,6 @@ package io.grpc.testing.integration;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.opencensus.tags.unsafe.ContextUtils.TAG_CONTEXT_KEY;
-import static io.opencensus.trace.unsafe.ContextUtils.CONTEXT_SPAN_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -1447,20 +1445,17 @@ public abstract class AbstractInteropTest {
     Span clientParentSpan = Tracing.getTracer().spanBuilder("Test.interopTest").startSpan();
     // A valid ID is guaranteed to be unique, so we can verify it is actually propagated.
     assertTrue(clientParentSpan.getContext().getTraceId().isValid());
-    Context ctx =
-        Context.ROOT.withValues(
-            TAG_CONTEXT_KEY,
-            tagger.emptyBuilder().put(
-                StatsTestUtils.EXTRA_TAG, TagValue.create("extra value")).build(),
-            ContextUtils.CONTEXT_SPAN_KEY,
-            clientParentSpan);
+    Context ctx = io.opencensus.tags.unsafe.ContextUtils.withValue(Context.ROOT, tagger.emptyBuilder().put(
+        StatsTestUtils.EXTRA_TAG, TagValue.create("extra value")).build());
+    ctx = ContextUtils.withValue(ctx, clientParentSpan);
     Context origCtx = ctx.attach();
     try {
       blockingStub.unaryCall(SimpleRequest.getDefaultInstance());
       Context serverCtx = contextCapture.get();
       assertNotNull(serverCtx);
 
-      FakeTagContext statsCtx = (FakeTagContext) TAG_CONTEXT_KEY.get(serverCtx);
+      FakeTagContext statsCtx =
+          (FakeTagContext) io.opencensus.tags.unsafe.ContextUtils.getValue(serverCtx);
       assertNotNull(statsCtx);
       Map<TagKey, TagValue> tags = statsCtx.getTags();
       boolean tagFound = false;
@@ -1472,7 +1467,7 @@ public abstract class AbstractInteropTest {
       }
       assertTrue("tag not found", tagFound);
 
-      Span span = CONTEXT_SPAN_KEY.get(serverCtx);
+      Span span = ContextUtils.getValue(serverCtx);
       assertNotNull(span);
       SpanContext spanContext = span.getContext();
       assertEquals(clientParentSpan.getContext().getTraceId(), spanContext.getTraceId());

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -399,18 +399,18 @@ def io_netty_transport():
 def io_opencensus_api():
     jvm_maven_import_external(
         name = "io_opencensus_opencensus_api",
-        artifact = "io.opencensus:opencensus-api:0.19.2",
+        artifact = "io.opencensus:opencensus-api:0.21.0",
         server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "0e2e5d3f4f6fd296017a00b1cd8fb8e4261331cc0c3b6818c0533b01bf7945dc",
+        artifact_sha256 = "8e2cb0f6391d8eb0a1bcd01e7748883f0033b1941754f4ed3f19d2c3e4276fc8",
         licenses = ["notice"],  # Apache 2.0
     )
 
 def io_opencensus_grpc_metrics():
     jvm_maven_import_external(
         name = "io_opencensus_opencensus_contrib_grpc_metrics",
-        artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.19.2",
+        artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.21.0",
         server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "0e23c03414612c7fbef1fdb347076eb69368e596de768cd4b98e081d92206f15",
+        artifact_sha256 = "29fc79401082301542cab89d7054d2f0825f184492654c950020553ef4ff0ef8",
         licenses = ["notice"],  # Apache 2.0
     )
 

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -32,6 +32,8 @@ import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagMetadata;
+import io.opencensus.tags.TagMetadata.TagTtl;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
@@ -202,7 +204,7 @@ public class StatsTestUtils {
       String serializedString = new String(bytes, UTF_8);
       if (serializedString.startsWith(EXTRA_TAG_HEADER_VALUE_PREFIX)) {
         return tagger.emptyBuilder()
-            .put(EXTRA_TAG,
+            .putPropagating(EXTRA_TAG,
                 TagValue.create(serializedString.substring(EXTRA_TAG_HEADER_VALUE_PREFIX.length())))
             .build();
       } else {
@@ -257,6 +259,9 @@ public class StatsTestUtils {
     private static final FakeTagContext EMPTY =
         new FakeTagContext(ImmutableMap.<TagKey, TagValue>of());
 
+    private static final TagMetadata METADATA_PROPAGATING =
+        TagMetadata.create(TagTtl.UNLIMITED_PROPAGATION);
+
     private final ImmutableMap<TagKey, TagValue> tags;
 
     private FakeTagContext(ImmutableMap<TagKey, TagValue> tags) {
@@ -279,7 +284,7 @@ public class StatsTestUtils {
           new Function<Map.Entry<TagKey, TagValue>, Tag>() {
             @Override
             public Tag apply(@Nullable Map.Entry<TagKey, TagValue> entry) {
-              return Tag.create(entry.getKey(), entry.getValue());
+              return Tag.create(entry.getKey(), entry.getValue(), METADATA_PROPAGATING);
             }
           });
     }
@@ -293,6 +298,7 @@ public class StatsTestUtils {
       tagsBuilder.putAll(tags);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public TagContextBuilder put(TagKey key, TagValue value) {
       tagsBuilder.put(key, value);

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -23,6 +23,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
+import io.grpc.Context;
 import io.opencensus.common.Scope;
 import io.opencensus.stats.Measure;
 import io.opencensus.stats.MeasureMap;
@@ -168,7 +169,7 @@ public class StatsTestUtils {
 
     @Override
     public TagContext getCurrentTagContext() {
-      return ContextUtils.TAG_CONTEXT_KEY.get();
+      return ContextUtils.getValue(Context.current());
     }
 
     @Override


### PR DESCRIPTION
Also updated CensusModule to use the new helper methods `ContextUtils.withValue()` instead of directly manipulating the context keys. See https://github.com/census-instrumentation/opencensus-java/pull/1864.

/cc @bogdandrutu @dinooliva @zhangkun83 