### PR TITLE
core,grpclb: refactor SubchannelPool to SubchannelPoolHelper

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1136,6 +1136,15 @@ public abstract class LoadBalancer {
     public ChannelLogger getChannelLogger() {
       throw new UnsupportedOperationException();
     }
+
+    /**
+     * Once called, all the subchannels that the helper has created will be cleared.
+     *
+     * @since 1.21.0
+     */
+    public void shutdown() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   /**

--- a/api/src/test/java/io/grpc/ForwardingTestUtil.java
+++ b/api/src/test/java/io/grpc/ForwardingTestUtil.java
@@ -83,6 +83,7 @@ public final class ForwardingTestUtil {
     for (Method method : delegateClass.getDeclaredMethods()) {
       if (Modifier.isStatic(method.getModifiers())
           || Modifier.isPrivate(method.getModifiers())
+          || Modifier.isFinal(method.getModifiers())
           || skippedMethods.contains(method)) {
         continue;
       }

--- a/core/src/main/java/io/grpc/internal/ForwardingSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingSubchannel.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import com.google.common.base.MoreObjects;
+import io.grpc.Attributes;
+import io.grpc.Channel;
+import io.grpc.ChannelLogger;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer.Subchannel;
+import java.util.List;
+
+class ForwardingSubchannel extends Subchannel {
+
+  final Subchannel delegate;
+
+  ForwardingSubchannel(Subchannel delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  public void requestConnection() {
+    delegate.requestConnection();
+  }
+
+  @Override
+  public Attributes getAttributes() {
+    return delegate.getAttributes();
+  }
+
+  @Override
+  public List<EquivalentAddressGroup> getAllAddresses() {
+    return delegate.getAllAddresses();
+  }
+
+  @Override
+  public Channel asChannel() {
+    return delegate.asChannel();
+  }
+
+  @Override
+  public ChannelLogger getChannelLogger() {
+    return delegate.getChannelLogger();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("delegate", delegate).toString();
+  }
+}

--- a/core/src/main/java/io/grpc/internal/SubchannelPoolHelper.java
+++ b/core/src/main/java/io/grpc/internal/SubchannelPoolHelper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import io.grpc.LoadBalancer.CreateSubchannelArgs;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.Subchannel;
+import io.grpc.util.ForwardingLoadBalancerHelper;
+
+/**
+ * A loadbalancer {@link Helper} that uses a {@linke SubchannelPool} to manage the lifecycle of
+ * subchannels.
+ */
+public final class SubchannelPoolHelper extends ForwardingLoadBalancerHelper {
+
+  private final Helper delegate;
+  private final SubchannelPool subchannelPool;
+
+  public SubchannelPoolHelper(Helper delegate) {
+    this(delegate, new CachedSubchannelPool());
+  }
+
+  /**
+   * TODO: make it package private. Right now it has to be public for grpclb testing.
+   */
+  public SubchannelPoolHelper(Helper delegate, SubchannelPool subchannelPool) {
+    this.delegate = delegate;
+    this.subchannelPool = subchannelPool;
+    subchannelPool.init(delegate);
+  }
+
+
+  @Override
+  protected Helper delegate() {
+    return delegate;
+  }
+
+  @Override
+  public Subchannel createSubchannel(CreateSubchannelArgs args) {
+    return subchannelPool.takeOrCreateSubchannel(args);
+  }
+
+  @Override
+  public void shutdown() {
+    subchannelPool.clear();
+  }
+}

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
@@ -115,6 +115,11 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
   }
 
   @Override
+  public void shutdown() {
+    delegate().shutdown();
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }

--- a/core/src/test/java/io/grpc/internal/FakeSocketAddress.java
+++ b/core/src/test/java/io/grpc/internal/FakeSocketAddress.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package io.grpc.grpclb;
+package io.grpc.internal;
 
 import java.net.SocketAddress;
 
-final class FakeSocketAddress extends SocketAddress {
+public final class FakeSocketAddress extends SocketAddress {
   final String name;
 
-  FakeSocketAddress(String name) {
+  public FakeSocketAddress(String name) {
     this.name = name;
   }
 

--- a/core/src/test/java/io/grpc/internal/ForwardingSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingSubchannelTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static org.mockito.Mockito.mock;
+
+import io.grpc.ForwardingTestUtil;
+import io.grpc.LoadBalancer.Subchannel;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link ForwardingSubchannel}.
+ */
+@RunWith(JUnit4.class)
+public class ForwardingSubchannelTest {
+  @Test
+  public void allMethodsForwarded() throws Exception {
+    Subchannel mockDelegate = mock(Subchannel.class);
+    ForwardingSubchannel testChannelBuilder = new ForwardingSubchannel(mockDelegate);
+
+    ForwardingTestUtil.testMethodsForwarded(
+        Subchannel.class,
+        mockDelegate,
+        testChannelBuilder,
+        Collections.<Method>emptyList());
+  }
+}

--- a/core/src/test/java/io/grpc/internal/SubchannelPoolHelperTest.java
+++ b/core/src/test/java/io/grpc/internal/SubchannelPoolHelperTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer.CreateSubchannelArgs;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.SubchannelStateListener;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * Tests for {@link SubchannelPoolHelper}.
+ */
+@RunWith(JUnit4.class)
+public class SubchannelPoolHelperTest {
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock
+  private Helper helper;
+
+  @Mock
+  private SubchannelPool subchannelPool;
+
+  private final CreateSubchannelArgs args =
+      CreateSubchannelArgs.newBuilder()
+          .setAddresses(new EquivalentAddressGroup(new FakeSocketAddress("fake")))
+          .setStateListener(mock(SubchannelStateListener.class))
+          .build();
+
+  @Test
+  public void createSubchannel() {
+    SubchannelPoolHelper subchannelPoolHelper = new SubchannelPoolHelper(helper, subchannelPool);
+
+    subchannelPoolHelper.createSubchannel(args);
+
+    verify(subchannelPool).takeOrCreateSubchannel(args);
+  }
+
+  @Test
+  public void shutdown() {
+    SubchannelPoolHelper subchannelPoolHelper = new SubchannelPoolHelper(helper, subchannelPool);
+
+    subchannelPoolHelper.createSubchannel(args);
+    subchannelPoolHelper.shutdown();
+
+    verify(subchannelPool).clear();
+  }
+
+}

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -29,9 +29,11 @@ import io.grpc.LoadBalancer;
 import io.grpc.Status;
 import io.grpc.grpclb.GrpclbState.Mode;
 import io.grpc.internal.BackoffPolicy;
+import io.grpc.internal.CachedSubchannelPool;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ServiceConfigUtil;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
+import io.grpc.internal.SubchannelPool;
 import io.grpc.internal.TimeProvider;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -65,6 +67,15 @@ class GrpclbLoadBalancer extends LoadBalancer {
 
   GrpclbLoadBalancer(
       Helper helper,
+      TimeProvider time,
+      Stopwatch stopwatch,
+      BackoffPolicy.Provider backoffPolicyProvider) {
+    this(helper, new CachedSubchannelPool(), time, stopwatch, backoffPolicyProvider);
+  }
+
+  @VisibleForTesting
+  GrpclbLoadBalancer(
+      Helper helper,
       SubchannelPool subchannelPool,
       TimeProvider time,
       Stopwatch stopwatch,
@@ -74,7 +85,6 @@ class GrpclbLoadBalancer extends LoadBalancer {
     this.stopwatch = checkNotNull(stopwatch, "stopwatch");
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
     this.subchannelPool = checkNotNull(subchannelPool, "subchannelPool");
-    this.subchannelPool.init(helper);
     recreateStates();
     checkNotNull(grpclbState, "grpclbState");
   }

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancerProvider.java
@@ -23,6 +23,7 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.grpclb.GrpclbState.Mode;
+import io.grpc.internal.CachedSubchannelPool;
 import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.ServiceConfigUtil;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;


### PR DESCRIPTION
- `SubchannelPool` class is moved from `grpclb` to `internal`.
- Add `Helper.shutdown()` that is equivalent to `SubchannelPool.clear()`
- Right now still expose `SubchannelPool` class to `grpclb` (for testing only) because `GrpclbLoadBalancerTest` was heavily testing actions on `SubchannelPool`. We could do further so that `SubchannelPool` is trashed/package private and `grpclb` only uses `SubchannelPoolHelper`, but that would be more work than just refactoring because we need to change the way of testing `GrpclbLoadBalancer` and `GrpclbState` (namely, "Test behaviors, not methods").