### PR TITLE
xds/third_part: revert change of envoy import script

### DIFF
--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Only run this script on Linux environment.
+
 # Update VERSION then in this directory run ./import.sh
 
 set -e
@@ -67,6 +69,8 @@ do
   mkdir -p "$(dirname "${file}")"
   cp -p "${tmpdir}/${SOURCE_PROTO_BASE_DIR}/${file}" "${file}"
 done
+
+# DO NOT TOUCH! The following section is upstreamed with an internal script.
 
 # See google internal third_party/envoy/envoy-update.sh
 # ===========================================================================

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -78,22 +78,19 @@ do
     # Import mangling.
     -e 's#import "gogoproto/gogo.proto";##'
     # Remove references to gogo.proto extensions.
-    -e 's#option \(gogoproto\.[a-z_]+\) = (true|false);##'
-    -e 's#(, )?\(gogoproto\.[a-z_]+\) = (true|false),?##'
+    -e 's#option (gogoproto\.[a-z_]\+) = \(true\|false\);##'
+    -e 's#\(, \)\?(gogoproto\.[a-z_]\+) = \(true\|false\),\?##'
     # gogoproto removal can result in empty brackets.
     -e 's# \[\]##'
     # gogoproto removal can result in four spaces on a line by itself.
     -e '/^    $/d'
   )
-  # Use a temp file to workaround `sed -i` cross-platform compatibility issue.
-  tmpfile="$(mktemp)"
-  sed -E "${commands[@]}" "$f" > "$tmpfile"
+  sed -i "${commands[@]}" "$f"
 
   # gogoproto removal can leave a comma on the last element in a list.
   # This needs to run separately after all the commands above have finished
   # since it is multi-line and rewrites the output of the above patterns.
-  sed -E -e '$!N; s#(.*),([[:space:]]*\];)#\1\2#; t' -e 'P; D;' "$tmpfile" > "$f"
-  rm "$tmpfile"
+  sed -i -e '$!N; s#\(.*\),\([[:space:]]*\];\)#\1\2#; t; P; D;' "$f"
 done
 popd
 


### PR DESCRIPTION
This reverts #5613 . The import script is synced with an internal upstream, we should not changed it manually.