### PR TITLE
docs: add note about directExecutor in example tests.

### DIFF
--- a/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldClientTest.java
+++ b/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldClientTest.java
@@ -39,6 +39,10 @@ import org.mockito.ArgumentMatchers;
  * For demonstrating how to write gRPC unit test only.
  * Not intended to provide a high code coverage or to test every major usecase.
  *
+ * directExecutor() makes it easier to have deterministic tests.
+ * However, if your implementation uses another thread and uses streaming it is better to use
+ * the default executor, to avoid hitting bug #3084.
+ *
  * <p>For more unit test examples see {@link io.grpc.examples.routeguide.RouteGuideClientTest} and
  * {@link io.grpc.examples.routeguide.RouteGuideServerTest}.
  */

--- a/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldServerTest.java
+++ b/examples/src/test/java/io/grpc/examples/helloworld/HelloWorldServerTest.java
@@ -32,6 +32,10 @@ import org.junit.runners.JUnit4;
  * For demonstrating how to write gRPC unit test only.
  * Not intended to provide a high code coverage or to test every major usecase.
  *
+ * directExecutor() makes it easier to have deterministic tests.
+ * However, if your implementation uses another thread and uses streaming it is better to use
+ * the default executor, to avoid hitting bug #3084.
+ *
  * <p>For more unit test examples see {@link io.grpc.examples.routeguide.RouteGuideClientTest} and
  * {@link io.grpc.examples.routeguide.RouteGuideServerTest}.
  */

--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideClientTest.java
@@ -53,6 +53,10 @@ import org.mockito.ArgumentCaptor;
  * For demonstrating how to write gRPC unit test only.
  * Not intended to provide a high code coverage or to test every major usecase.
  *
+ * directExecutor() makes it easier to have deterministic tests.
+ * However, if your implementation uses another thread and uses streaming it is better to use
+ * the default executor, to avoid hitting bug #3084.
+ *
  * <p>For basic unit test examples see {@link io.grpc.examples.helloworld.HelloWorldClientTest} and
  * {@link io.grpc.examples.helloworld.HelloWorldServerTest}.
  */

--- a/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
+++ b/examples/src/test/java/io/grpc/examples/routeguide/RouteGuideServerTest.java
@@ -49,6 +49,10 @@ import org.mockito.ArgumentCaptor;
  * For demonstrating how to write gRPC unit test only.
  * Not intended to provide a high code coverage or to test every major usecase.
  *
+ * directExecutor() makes it easier to have deterministic tests.
+ * However, if your implementation uses another thread and uses streaming it is better to use
+ * the default executor, to avoid hitting bug #3084.
+ *
  * <p>For basic unit test examples see {@link io.grpc.examples.helloworld.HelloWorldClientTest} and
  * {@link io.grpc.examples.helloworld.HelloWorldServerTest}.
  */


### PR DESCRIPTION
Since the HelloWorld tests are atm the "documentation" for how to do unit tests for grpc I think it would be good to add a note about the danger of the `directExecutor()`, particularly in bidirectional streaming.

I considered removing the `directExecutor ` but it seems a common pattern in the grpc test suite and has it's merits so warning devs seems like a better solution.

related: 
 - https://github.com/grpc/grpc-java/issues/3084
 - https://github.com/grpc/grpc-java/issues/2263