### PR TITLE
Remove spotless plugin for gradle formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.13.0"
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.5'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
@@ -515,17 +514,5 @@ publicApiSubprojects.each { name ->
             // TODO(zpencer): enable after japicmp-gradle-plugin/pull/15
             // annotationExcludes = ['@io.grpc.ExperimentalApi']
         }
-    }
-}
-
-// format checkers
-apply plugin: "com.diffplug.gradle.spotless"
-apply plugin: 'groovy'
-spotless {
-    groovyGradle {
-        target '**/*.gradle'
-        greclipse()
-        indentWithSpaces()
-        paddedCell()
     }
 }


### PR DESCRIPTION
It is just causing trouble. When using paddedCell() it doesn't reliably
complain about failures and without paddedCell() it won't finish its
check. And when it does complain you have to guess what it wants from
you because unrelated changes are complained about at the same time.

It also caused trouble because **/*.gradle is overly aggressive; it
searchs build/ folders and bazel folders. But when trying to swap it to
per-project checks on the build.gradle I was unable to get it to fail,
even with obvious problems like using tabs.