### PR TITLE
api: Rename NameResolver.Observer to Listener2

### DIFF
--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -47,7 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>Implementations <strong>don't need to be thread-safe</strong>.  All methods are guaranteed to
  * be called sequentially.  Additionally, all methods that have side-effects, i.e.,
- * {@link #start(Observer)}, {@link #shutdown} and {@link #refresh} are called from the same
+ * {@link #start(Listener2)}, {@link #shutdown} and {@link #refresh} are called from the same
  * {@link SynchronizationContext} as returned by {@link Helper#getSynchronizationContext}.
  *
  * @since 1.0.0
@@ -71,15 +71,15 @@ public abstract class NameResolver {
    * Starts the resolution.
    *
    * @param listener used to receive updates on the target
-   * @deprecated override {@link #start(Observer)} instead.
+   * @deprecated override {@link #start(Listener2)} instead.
    * @since 1.0.0
    */
   @Deprecated
   public void start(final Listener listener) {
-    if (listener instanceof Observer) {
-      start((Observer) listener);
+    if (listener instanceof Listener2) {
+      start((Listener2) listener);
     } else {
-      start(new Observer() {
+      start(new Listener2() {
           @Override
           public void onError(Status error) {
             listener.onError(error);
@@ -96,11 +96,11 @@ public abstract class NameResolver {
   /**
    * Starts the resolution.  This method will become abstract in 1.21.0.
    *
-   * @param observer used to receive updates on the target
+   * @param listener used to receive updates on the target
    * @since 1.21.0
    */
-  public void start(Observer observer) {
-    start((Listener) observer);
+  public void start(Listener2 listener) {
+    start((Listener) listener);
   }
 
   /**
@@ -270,7 +270,7 @@ public abstract class NameResolver {
    *
    * <p>All methods are expected to return quickly.
    *
-   * @deprecated use {@link Observer} instead.
+   * @deprecated use {@link Listener2} instead.
    * @since 1.0.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
@@ -307,7 +307,7 @@ public abstract class NameResolver {
    * @since 1.21.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1770")
-  public abstract static class Observer implements Listener {
+  public abstract static class Listener2 implements Listener {
     /**
      * @deprecated This will be removed in 1.21.0
      */
@@ -329,7 +329,7 @@ public abstract class NameResolver {
     public abstract void onResult(ResolutionResult resolutionResult);
 
     /**
-     * Handles an error from the resolver. The observer is responsible for eventually invoking
+     * Handles an error from the resolver. The listener is responsible for eventually invoking
      * {@link NameResolver#refresh()} to re-attempt resolution.
      *
      * @param error a non-OK status
@@ -374,7 +374,7 @@ public abstract class NameResolver {
     public abstract ProxyDetector getProxyDetector();
 
     /**
-     * Returns the {@link SynchronizationContext} where {@link #start(Observer)}, {@link #shutdown}
+     * Returns the {@link SynchronizationContext} where {@link #start(Listener2)}, {@link #shutdown}
      * and {@link #refresh} are run from.
      *
      * @since 1.20.0
@@ -442,7 +442,7 @@ public abstract class NameResolver {
     }
 
     /**
-     * Returns the {@link SynchronizationContext} where {@link #start(Observer)}, {@link #shutdown}
+     * Returns the {@link SynchronizationContext} where {@link #start(Listener2)}, {@link #shutdown}
      * and {@link #refresh} are run from.
      *
      * @since 1.21.0

--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -117,7 +117,7 @@ public class NameResolverRegistryTest {
         throw new UnsupportedOperationException();
       }
 
-      @Override public void start(Observer observer) {
+      @Override public void start(Listener2 listener) {
         throw new UnsupportedOperationException();
       }
 

--- a/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java
@@ -590,8 +590,8 @@ public abstract class AbstractManagedChannelImplBuilder
         }
 
         @Override
-        public void start(Observer observer) {
-          observer.onResult(
+        public void start(Listener2 listener) {
+          listener.onResult(
               ResolutionResult.newBuilder()
                   .setAddresses(Collections.singletonList(new EquivalentAddressGroup(address)))
                   .setAttributes(Attributes.EMPTY)

--- a/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingNameResolver.java
@@ -44,8 +44,8 @@ abstract class ForwardingNameResolver extends NameResolver {
   }
 
   @Override
-  public void start(Observer observer) {
-    delegate.start(observer);
+  public void start(Listener2 listener) {
+    delegate.start(listener);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -376,8 +376,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
     // may throw. We don't want to confuse our state, even if we will enter panic mode.
     this.lbHelper = lbHelper;
 
-    NameResolverObserver observer = new NameResolverObserver(lbHelper, nameResolver);
-    nameResolver.start(observer);
+    NameResolverListener listener = new NameResolverListener(lbHelper, nameResolver);
+    nameResolver.start(listener);
     nameResolverStarted = true;
   }
 
@@ -1317,11 +1317,11 @@ final class ManagedChannelImpl extends ManagedChannel implements
     }
   }
 
-  private final class NameResolverObserver extends NameResolver.Observer {
+  private final class NameResolverListener extends NameResolver.Listener2 {
     final LbHelperImpl helper;
     final NameResolver resolver;
 
-    NameResolverObserver(LbHelperImpl helperImpl, NameResolver resolver) {
+    NameResolverListener(LbHelperImpl helperImpl, NameResolver resolver) {
       this.helper = checkNotNull(helperImpl, "helperImpl");
       this.resolver = checkNotNull(resolver, "resolver");
     }
@@ -1389,7 +1389,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
           }
 
           // Call LB only if it's not shutdown.  If LB is shutdown, lbHelper won't match.
-          if (NameResolverObserver.this.helper == ManagedChannelImpl.this.lbHelper) {
+          if (NameResolverListener.this.helper == ManagedChannelImpl.this.lbHelper) {
             if (servers.isEmpty() && !helper.lb.canHandleEmptyAddressListFromNameResolution()) {
               handleErrorInSyncContext(Status.UNAVAILABLE.withDescription(
                   "Name resolver " + resolver + " returned an empty list"));
@@ -1434,7 +1434,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
         haveBackends = false;
       }
       // Call LB only if it's not shutdown.  If LB is shutdown, lbHelper won't match.
-      if (NameResolverObserver.this.helper != ManagedChannelImpl.this.lbHelper) {
+      if (NameResolverListener.this.helper != ManagedChannelImpl.this.lbHelper) {
         return;
       }
       helper.lb.handleNameResolutionError(error);

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -131,7 +131,7 @@ public class DnsNameResolverTest {
       };
 
   @Mock
-  private NameResolver.Observer mockObserver;
+  private NameResolver.Listener2 mockListener;
   @Captor
   private ArgumentCaptor<ResolutionResult> resultCaptor;
   @Nullable
@@ -274,15 +274,15 @@ public class DnsNameResolverTest {
     when(mockResolver.resolveAddress(anyString())).thenReturn(answer1).thenReturn(answer2);
     resolver.setAddressResolver(mockResolver);
 
-    resolver.start(mockObserver);
+    resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(mockObserver).onResult(resultCaptor.capture());
+    verify(mockListener).onResult(resultCaptor.capture());
     assertAnswerMatches(answer1, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
     resolver.refresh();
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(mockObserver, times(2)).onResult(resultCaptor.capture());
+    verify(mockListener, times(2)).onResult(resultCaptor.capture());
     assertAnswerMatches(answer2, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
@@ -301,12 +301,12 @@ public class DnsNameResolverTest {
       }
     });
 
-    nr.start(mockObserver);
+    nr.start(mockListener);
     assertThat(fakeExecutor.runDueTasks()).isEqualTo(1);
 
     ArgumentCaptor<Status> ac = ArgumentCaptor.forClass(Status.class);
-    verify(mockObserver).onError(ac.capture());
-    verifyNoMoreInteractions(mockObserver);
+    verify(mockListener).onError(ac.capture());
+    verifyNoMoreInteractions(mockListener);
     assertThat(ac.getValue().getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(ac.getValue().getDescription()).contains("No DNS backend or balancer addresses");
   }
@@ -326,9 +326,9 @@ public class DnsNameResolverTest {
         .thenThrow(new AssertionError("should not called twice"));
     resolver.setAddressResolver(mockResolver);
 
-    resolver.start(mockObserver);
+    resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(mockObserver).onResult(resultCaptor.capture());
+    verify(mockListener).onResult(resultCaptor.capture());
     assertAnswerMatches(answer1, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
@@ -336,7 +336,7 @@ public class DnsNameResolverTest {
     resolver.refresh();
     assertEquals(0, fakeExecutor.runDueTasks());
     assertEquals(0, fakeClock.numPendingTasks());
-    verifyNoMoreInteractions(mockObserver);
+    verifyNoMoreInteractions(mockListener);
 
     resolver.shutdown();
 
@@ -359,9 +359,9 @@ public class DnsNameResolverTest {
         .thenThrow(new AssertionError("should not reach here."));
     resolver.setAddressResolver(mockResolver);
 
-    resolver.start(mockObserver);
+    resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(mockObserver).onResult(resultCaptor.capture());
+    verify(mockListener).onResult(resultCaptor.capture());
     assertAnswerMatches(answer, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
@@ -370,7 +370,7 @@ public class DnsNameResolverTest {
     resolver.refresh();
     assertEquals(0, fakeExecutor.runDueTasks());
     assertEquals(0, fakeClock.numPendingTasks());
-    verifyNoMoreInteractions(mockObserver);
+    verifyNoMoreInteractions(mockListener);
 
     resolver.shutdown();
 
@@ -393,16 +393,16 @@ public class DnsNameResolverTest {
         .thenReturn(answer2);
     resolver.setAddressResolver(mockResolver);
 
-    resolver.start(mockObserver);
+    resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(mockObserver).onResult(resultCaptor.capture());
+    verify(mockListener).onResult(resultCaptor.capture());
     assertAnswerMatches(answer1, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
     fakeTicker.advance(ttl + 1, TimeUnit.SECONDS);
     resolver.refresh();
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(mockObserver, times(2)).onResult(resultCaptor.capture());
+    verify(mockListener, times(2)).onResult(resultCaptor.capture());
     assertAnswerMatches(answer2, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
@@ -435,9 +435,9 @@ public class DnsNameResolverTest {
     when(mockResolver.resolveAddress(anyString())).thenReturn(answer1).thenReturn(answer2);
     resolver.setAddressResolver(mockResolver);
 
-    resolver.start(mockObserver);
+    resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(mockObserver).onResult(resultCaptor.capture());
+    verify(mockListener).onResult(resultCaptor.capture());
     assertAnswerMatches(answer1, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
@@ -445,12 +445,12 @@ public class DnsNameResolverTest {
     resolver.refresh();
     assertEquals(0, fakeExecutor.runDueTasks());
     assertEquals(0, fakeClock.numPendingTasks());
-    verifyNoMoreInteractions(mockObserver);
+    verifyNoMoreInteractions(mockListener);
 
     fakeTicker.advance(1, TimeUnit.SECONDS);
     resolver.refresh();
     assertEquals(1, fakeExecutor.runDueTasks());
-    verify(mockObserver, times(2)).onResult(resultCaptor.capture());
+    verify(mockListener, times(2)).onResult(resultCaptor.capture());
     assertAnswerMatches(answer2, 81, resultCaptor.getValue());
     assertEquals(0, fakeClock.numPendingTasks());
 
@@ -612,10 +612,10 @@ public class DnsNameResolverTest {
     AddressResolver mockAddressResolver = mock(AddressResolver.class);
     when(mockAddressResolver.resolveAddress(anyString())).thenThrow(new AssertionError());
     resolver.setAddressResolver(mockAddressResolver);
-    resolver.start(mockObserver);
+    resolver.start(mockListener);
     assertEquals(1, fakeExecutor.runDueTasks());
 
-    verify(mockObserver).onResult(resultCaptor.capture());
+    verify(mockListener).onResult(resultCaptor.capture());
     List<EquivalentAddressGroup> result = resultCaptor.getValue().getAddresses();
     assertThat(result).hasSize(1);
     EquivalentAddressGroup eag = result.get(0);

--- a/core/src/test/java/io/grpc/internal/ForwardingNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingNameResolverTest.java
@@ -78,7 +78,7 @@ public class ForwardingNameResolverTest {
 
   @Test
   public void start_observer() {
-    NameResolver.Observer observer = new NameResolver.Observer() {
+    NameResolver.Listener2 listener = new NameResolver.Listener2() {
       @Override
       public void onResult(ResolutionResult result) {
 
@@ -88,7 +88,7 @@ public class ForwardingNameResolverTest {
       public void onError(Status error) { }
     };
 
-    forwarder.start(observer);
-    verify(delegate).start(observer);
+    forwarder.start(listener);
+    verify(delegate).start(listener);
   }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -175,7 +175,7 @@ public class ManagedChannelImplGetNameResolverTest {
       return uri.getAuthority();
     }
 
-    @Override public void start(final Observer observer) {}
+    @Override public void start(final Listener2 listener) {}
 
     @Override public void shutdown() {}
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -143,7 +143,7 @@ public class ManagedChannelImplIdlenessTest {
   @Mock private NameResolver.Factory mockNameResolverFactory;
   @Mock private ClientCall.Listener<Integer> mockCallListener;
   @Mock private ClientCall.Listener<Integer> mockCallListener2;
-  @Captor private ArgumentCaptor<NameResolver.Observer> nameResolverObserverCaptor;
+  @Captor private ArgumentCaptor<NameResolver.Listener2> nameResolverListenerCaptor;
   private BlockingQueue<MockClientTransportInfo> newTransports;
 
   @Before
@@ -199,7 +199,7 @@ public class ManagedChannelImplIdlenessTest {
         any(ClientTransportFactory.ClientTransportOptions.class),
         any(ChannelLogger.class));
     verify(mockNameResolver, never()).start(any(NameResolver.Listener.class));
-    verify(mockNameResolver, never()).start(any(NameResolver.Observer.class));
+    verify(mockNameResolver, never()).start(any(NameResolver.Listener2.class));
   }
 
   @After
@@ -223,7 +223,7 @@ public class ManagedChannelImplIdlenessTest {
 
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
 
-    verify(mockNameResolver).start(nameResolverObserverCaptor.capture());
+    verify(mockNameResolver).start(nameResolverListenerCaptor.capture());
     // Simulate new address resolved to make sure the LoadBalancer is correctly linked to
     // the NameResolver.
     ResolutionResult resolutionResult =
@@ -231,7 +231,7 @@ public class ManagedChannelImplIdlenessTest {
             .setAddresses(servers)
             .setAttributes(Attributes.EMPTY)
             .build();
-    nameResolverObserverCaptor.getValue().onResult(resolutionResult);
+    nameResolverListenerCaptor.getValue().onResult(resolutionResult);
     verify(mockLoadBalancer).handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(Attributes.EMPTY)
             .build());

--- a/core/src/test/java/io/grpc/internal/OverrideAuthorityNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/OverrideAuthorityNameResolverTest.java
@@ -79,7 +79,7 @@ public class OverrideAuthorityNameResolverTest {
     NameResolver overrideResolver =
         factory.newNameResolver(URI.create("dns:///localhost:443"), ARGS);
     assertNotNull(overrideResolver);
-    NameResolver.Observer listener = mock(NameResolver.Observer.class);
+    NameResolver.Listener2 listener = mock(NameResolver.Listener2.class);
 
     overrideResolver.start(listener);
     verify(mockResolver).start(listener);


### PR DESCRIPTION
This follows the sort of changes we've done in the past, where the '2'
implies "version 2." We can end up reclaiming the original name if we
wish in the future.

The main reason for this change is to avoid changing to Observer since
the rest of io.grpc consistently uses Listener.

CC @zhangkun83 