### PR TITLE
Revert "core: pass Subchannel state updates to SubchannelStateListene…

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -16,14 +16,12 @@
 
 package io.grpc;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -337,16 +335,9 @@ public abstract class LoadBalancer {
    * @param subchannel the involved Subchannel
    * @param stateInfo the new state
    * @since 1.2.0
-   * @deprecated This method will be removed.  Stop overriding it.  Instead, pass {@link
-   *             SubchannelStateListener} to {@link Helper#createSubchannel(CreateSubchannelArgs)}
-   *             to receive Subchannel state updates
    */
-  @Deprecated
-  public void handleSubchannelState(
-      Subchannel subchannel, ConnectivityStateInfo stateInfo) {
-    // Do nothing.  If the implemetation doesn't implement this, it will get subchannel states from
-    // the new API.  We don't throw because there may be forwarding LoadBalancers still plumb this.
-  }
+  public abstract void handleSubchannelState(
+      Subchannel subchannel, ConnectivityStateInfo stateInfo);
 
   /**
    * The channel asks the load-balancer to shutdown.  No more callbacks will be called after this
@@ -661,243 +652,6 @@ public abstract class LoadBalancer {
   }
 
   /**
-   * Arguments for {@link Helper#createSubchannel(CreateSubchannelArgs)}.
-   *
-   * @since 1.21.0
-   */
-  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
-  public static final class CreateSubchannelArgs {
-    private final List<EquivalentAddressGroup> addrs;
-    private final Attributes attrs;
-    private final SubchannelStateListener stateListener;
-    private final Object[][] customOptions;
-
-    private CreateSubchannelArgs(
-        List<EquivalentAddressGroup> addrs, Attributes attrs, Object[][] customOptions,
-        SubchannelStateListener stateListener) {
-      this.addrs = checkNotNull(addrs, "addresses are not set");
-      this.attrs = checkNotNull(attrs, "attrs");
-      this.customOptions = checkNotNull(customOptions, "customOptions");
-      this.stateListener = checkNotNull(stateListener, "SubchannelStateListener is not set");
-    }
-
-    /**
-     * Returns the addresses, which is an unmodifiable list.
-     */
-    public List<EquivalentAddressGroup> getAddresses() {
-      return addrs;
-    }
-
-    /**
-     * Returns the attributes.
-     */
-    public Attributes getAttributes() {
-      return attrs;
-    }
-
-    /**
-     * Get the value for a custom option or its inherent default.
-     *
-     * @param key Key identifying option
-     */
-    @SuppressWarnings("unchecked")
-    public <T> T getOption(Key<T> key) {
-      Preconditions.checkNotNull(key, "key");
-      for (int i = 0; i < customOptions.length; i++) {
-        if (key.equals(customOptions[i][0])) {
-          return (T) customOptions[i][1];
-        }
-      }
-      return key.defaultValue;
-    }
-
-    /**
-     * Returns the state listener.
-     */
-    public SubchannelStateListener getStateListener() {
-      return stateListener;
-    }
-
-    /**
-     * Returns a builder with the same initial values as this object.
-     */
-    public Builder toBuilder() {
-      return newBuilder().setAddresses(addrs).setAttributes(attrs).setStateListener(stateListener)
-          .copyCustomOptions(customOptions);
-    }
-
-    /**
-     * Creates a new builder.
-     */
-    public static Builder newBuilder() {
-      return new Builder();
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("addrs", addrs)
-          .add("attrs", attrs)
-          .add("listener", stateListener)
-          .add("customOptions", Arrays.deepToString(customOptions))
-          .toString();
-    }
-
-    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
-    public static final class Builder {
-
-      private List<EquivalentAddressGroup> addrs;
-      private Attributes attrs = Attributes.EMPTY;
-      private SubchannelStateListener stateListener;
-      private Object[][] customOptions = new Object[0][2];
-
-      Builder() {
-      }
-
-      private <T> Builder copyCustomOptions(Object[][] options) {
-        customOptions = new Object[options.length][2];
-        System.arraycopy(options, 0, customOptions, 0, options.length);
-        return this;
-      }
-
-      /**
-       * Add a custom option. Any existing value for the key is overwritten.
-       *
-       * <p>This is an <strong>optional</strong> property.
-       *
-       * @param key the option key
-       * @param value the option value
-       */
-      public <T> Builder addOption(Key<T> key, T value) {
-        Preconditions.checkNotNull(key, "key");
-        Preconditions.checkNotNull(value, "value");
-
-        int existingIdx = -1;
-        for (int i = 0; i < customOptions.length; i++) {
-          if (key.equals(customOptions[i][0])) {
-            existingIdx = i;
-            break;
-          }
-        }
-
-        if (existingIdx == -1) {
-          Object[][] newCustomOptions = new Object[customOptions.length + 1][2];
-          System.arraycopy(customOptions, 0, newCustomOptions, 0, customOptions.length);
-          customOptions = newCustomOptions;
-          existingIdx = customOptions.length - 1;
-        }
-        customOptions[existingIdx] = new Object[]{key, value};
-        return this;
-      }
-
-      /**
-       * The addresses to connect to.  All addresses are considered equivalent and will be tried
-       * in the order they are provided.
-       */
-      public Builder setAddresses(EquivalentAddressGroup addrs) {
-        this.addrs = Collections.singletonList(addrs);
-        return this;
-      }
-
-      /**
-       * The addresses to connect to.  All addresses are considered equivalent and will
-       * be tried in the order they are provided.
-       *
-       * <p>This is a <strong>required</strong> property.
-       *
-       * @throws IllegalArgumentException if {@code addrs} is empty
-       */
-      public Builder setAddresses(List<EquivalentAddressGroup> addrs) {
-        checkArgument(!addrs.isEmpty(), "addrs is empty");
-        this.addrs = Collections.unmodifiableList(new ArrayList<>(addrs));
-        return this;
-      }
-
-      /**
-       * Attributes provided here will be included in {@link Subchannel#getAttributes}.
-       *
-       * <p>This is an <strong>optional</strong> property.  Default is empty if not set.
-       */
-      public Builder setAttributes(Attributes attrs) {
-        this.attrs = checkNotNull(attrs, "attrs");
-        return this;
-      }
-
-      /**
-       * Receives state changes of the created Subchannel.  The listener is called from
-       * the {@link Helper#getSynchronizationContext Synchronization Context}.  It's safe to share
-       * the listener among multiple Subchannels.
-       *
-       * <p>This is a <strong>required</strong> property.
-       */
-      public Builder setStateListener(SubchannelStateListener listener) {
-        this.stateListener = checkNotNull(listener, "listener");
-        return this;
-      }
-
-      /**
-       * Creates a new args object.
-       */
-      public CreateSubchannelArgs build() {
-        return new CreateSubchannelArgs(addrs, attrs, customOptions, stateListener);
-      }
-    }
-
-    /**
-     * Key for a key-value pair. Uses reference equality.
-     */
-    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1771")
-    public static final class Key<T> {
-
-      private final String debugString;
-      private final T defaultValue;
-
-      private Key(String debugString, T defaultValue) {
-        this.debugString = debugString;
-        this.defaultValue = defaultValue;
-      }
-
-      /**
-       * Factory method for creating instances of {@link Key}. The default value of the key is
-       * {@code null}.
-       *
-       * @param debugString a debug string that describes this key.
-       * @param <T> Key type
-       * @return Key object
-       */
-      public static <T> Key<T> create(String debugString) {
-        Preconditions.checkNotNull(debugString, "debugString");
-        return new Key<>(debugString, /*defaultValue=*/ null);
-      }
-
-      /**
-       * Factory method for creating instances of {@link Key}.
-       *
-       * @param debugString a debug string that describes this key.
-       * @param defaultValue default value to return when value for key not set
-       * @param <T> Key type
-       * @return Key object
-       */
-      public static <T> Key<T> createWithDefault(String debugString, T defaultValue) {
-        Preconditions.checkNotNull(debugString, "debugString");
-        return new Key<>(debugString, defaultValue);
-      }
-
-      /**
-       * Returns the user supplied default value for this key.
-       */
-      public T getDefault() {
-        return defaultValue;
-      }
-
-      @Override
-      public String toString() {
-        return debugString;
-      }
-    }
-  }
-
-  /**
    * Provides essentials for LoadBalancer implementations.
    *
    * @since 1.2.0
@@ -910,11 +664,7 @@ public abstract class LoadBalancer {
      * EquivalentAddressGroup}.
      *
      * @since 1.2.0
-     * @deprecated Use {@link #createSubchannel(CreateSubchannelArgs)} instead. Note the new API
-     *             must be called from {@link #getSynchronizationContext the Synchronization
-     *             Context}.
      */
-    @Deprecated
     public final Subchannel createSubchannel(EquivalentAddressGroup addrs, Attributes attrs) {
       checkNotNull(addrs, "addrs");
       return createSubchannel(Collections.singletonList(addrs), attrs);
@@ -935,32 +685,8 @@ public abstract class LoadBalancer {
      *
      * @throws IllegalArgumentException if {@code addrs} is empty
      * @since 1.14.0
-     * @deprecated Use {@link #createSubchannel(CreateSubchannelArgs)} instead. Note the new API
-     *             must be called from {@link #getSynchronizationContext the Synchronization
-     *             Context}.
      */
-    @Deprecated
     public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
-      throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Creates a Subchannel, which is a logical connection to the given group of addresses which are
-     * considered equivalent.  The {@code attrs} are custom attributes associated with this
-     * Subchannel, and can be accessed later through {@link Subchannel#getAttributes
-     * Subchannel.getAttributes()}.
-     *
-     * <p>This method <strong>must be called from the {@link #getSynchronizationContext
-     * Synchronization Context}</strong>, otherwise it may throw. This is to avoid the race between
-     * the caller and {@link SubchannelStateListener#onSubchannelState}.  See <a
-     * href="https://github.com/grpc/grpc-java/issues/5015">#5015</a> for more discussions.
-     *
-     * <p>The LoadBalancer is responsible for closing unused Subchannels, and closing all
-     * Subchannels within {@link #shutdown}.
-     *
-     * @since 1.21.0
-     */
-    public Subchannel createSubchannel(CreateSubchannelArgs args) {
       throw new UnsupportedOperationException();
     }
 
@@ -1180,7 +906,7 @@ public abstract class LoadBalancer {
      */
     public final EquivalentAddressGroup getAddresses() {
       List<EquivalentAddressGroup> groups = getAllAddresses();
-      Preconditions.checkState(groups.size() == 1, "%s does not have exactly one group", groups);
+      Preconditions.checkState(groups.size() == 1, "Does not have exactly one group");
       return groups.get(0);
     }
 
@@ -1239,39 +965,6 @@ public abstract class LoadBalancer {
     public ChannelLogger getChannelLogger() {
       throw new UnsupportedOperationException();
     }
-  }
-
-  /**
-   * Receives state changes for one or more {@link Subchannel}s. All methods are run under {@link
-   * Helper#getSynchronizationContext}.
-   *
-   * @since 1.21.0
-   */
-  public interface SubchannelStateListener {
-    
-    /**
-     * Handles a state change on a Subchannel.
-     *
-     * <p>The initial state of a Subchannel is IDLE. You won't get a notification for the initial
-     * IDLE state.
-     *
-     * <p>If the new state is not SHUTDOWN, this method should create a new picker and call {@link
-     * Helper#updateBalancingState Helper.updateBalancingState()}.  Failing to do so may result in
-     * unnecessary delays of RPCs. Please refer to {@link PickResult#withSubchannel
-     * PickResult.withSubchannel()}'s javadoc for more information.
-     *
-     * <p>SHUTDOWN can only happen in two cases.  One is that LoadBalancer called {@link
-     * Subchannel#shutdown} earlier, thus it should have already discarded this Subchannel.  The
-     * other is that Channel is doing a {@link ManagedChannel#shutdownNow forced shutdown} or has
-     * already terminated, thus there won't be further requests to LoadBalancer.  Therefore,
-     * SHUTDOWN can be safely ignored.
-     *
-     * @param subchannel the involved Subchannel
-     * @param newState the new state
-     *
-     * @since 1.21.0
-     */
-    void onSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState);
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -78,6 +78,9 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
     public void handleNameResolutionError(Status error) {}
 
     @Override
+    public void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {}
+
+    @Override
     public void shutdown() {}
   }
 
@@ -162,7 +165,6 @@ public final class AutoConfiguredLoadBalancerFactory extends LoadBalancer.Factor
       getDelegate().handleNameResolutionError(error);
     }
 
-    @Deprecated
     @Override
     public void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
       getDelegate().handleSubchannelState(subchannel, stateInfo);

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancer.java
@@ -51,7 +51,6 @@ public abstract class ForwardingLoadBalancer extends LoadBalancer {
     delegate().handleNameResolutionError(error);
   }
 
-  @Deprecated
   @Override
   public void handleSubchannelState(
       Subchannel subchannel, ConnectivityStateInfo stateInfo) {

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
@@ -22,7 +22,6 @@ import io.grpc.ChannelLogger;
 import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.ExperimentalApi;
-import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancer;
@@ -39,15 +38,9 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
    */
   protected abstract LoadBalancer.Helper delegate();
 
-  @Deprecated
   @Override
   public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
     return delegate().createSubchannel(addrs, attrs);
-  }
-
-  @Override
-  public Subchannel createSubchannel(CreateSubchannelArgs args) {
-    return delegate().createSubchannel(args);
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
+++ b/core/src/test/java/io/grpc/internal/AutoConfiguredLoadBalancerFactoryTest.java
@@ -41,12 +41,10 @@ import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
@@ -136,7 +134,6 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     assertThat(lb.getDelegate()).isSameInstanceAs(testLbBalancer);
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void forwardsCalls() {
     AutoConfiguredLoadBalancer lb =
@@ -179,9 +176,9 @@ public class AutoConfiguredLoadBalancerFactoryTest {
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
     Helper helper = new TestHelper() {
       @Override
-      public Subchannel createSubchannel(CreateSubchannelArgs args) {
-        assertThat(args.getAddresses()).isEqualTo(servers);
-        return new TestSubchannel(args);
+      public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
+        assertThat(addrs).isEqualTo(servers);
+        return new TestSubchannel(addrs, attrs);
       }
     };
     AutoConfiguredLoadBalancer lb =
@@ -209,9 +206,9 @@ public class AutoConfiguredLoadBalancerFactoryTest {
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
     Helper helper = new TestHelper() {
       @Override
-      public Subchannel createSubchannel(CreateSubchannelArgs args) {
-        assertThat(args.getAddresses()).isEqualTo(servers);
-        return new TestSubchannel(args);
+      public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
+        assertThat(addrs).isEqualTo(servers);
+        return new TestSubchannel(addrs, attrs);
       }
     };
     AutoConfiguredLoadBalancer lb =
@@ -221,6 +218,11 @@ public class AutoConfiguredLoadBalancerFactoryTest {
 
       @Override
       public void handleNameResolutionError(Status error) {
+        // noop
+      }
+
+      @Override
+      public void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
         // noop
       }
 
@@ -702,18 +704,8 @@ public class AutoConfiguredLoadBalancerFactoryTest {
         Collections.singletonList(new EquivalentAddressGroup(new SocketAddress(){}));
     Helper helper = new TestHelper() {
       @Override
-      @Deprecated
       public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
-        return new TestSubchannel(CreateSubchannelArgs.newBuilder()
-            .setAddresses(addrs)
-            .setAttributes(attrs)
-            .setStateListener(mock(SubchannelStateListener.class))
-            .build());
-      }
-
-      @Override
-      public Subchannel createSubchannel(CreateSubchannelArgs args) {
-        return new TestSubchannel(args);
+        return new TestSubchannel(addrs, attrs);
       }
 
       @Override
@@ -831,6 +823,11 @@ public class AutoConfiguredLoadBalancerFactoryTest {
     }
 
     @Override
+    public void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo stateInfo) {
+      delegate().handleSubchannelState(subchannel, stateInfo);
+    }
+
+    @Override
     public void shutdown() {
       delegate().shutdown();
     }
@@ -865,9 +862,9 @@ public class AutoConfiguredLoadBalancerFactoryTest {
   }
 
   private static class TestSubchannel extends Subchannel {
-    TestSubchannel(CreateSubchannelArgs args) {
-      this.addrs = args.getAddresses();
-      this.attrs = args.getAttributes();
+    TestSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
+      this.addrs = addrs;
+      this.attrs = attrs;
     }
 
     final List<EquivalentAddressGroup> addrs;

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -41,14 +41,12 @@ import io.grpc.ClientInterceptor;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.IntegerMarshaller;
 import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
@@ -115,7 +113,6 @@ public class ManagedChannelImplIdlenessTest {
 
   @Mock private ClientTransportFactory mockTransportFactory;
   @Mock private LoadBalancer mockLoadBalancer;
-  @Mock private SubchannelStateListener subchannelStateListener;
   private final LoadBalancerProvider mockLoadBalancerProvider =
       mock(LoadBalancerProvider.class, delegatesTo(new LoadBalancerProvider() {
           @Override
@@ -503,19 +500,14 @@ public class ManagedChannelImplIdlenessTest {
   }
 
   // We need this because createSubchannel() should be called from the SynchronizationContext
-  private Subchannel createSubchannelSafely(
+  private static Subchannel createSubchannelSafely(
       final Helper helper, final EquivalentAddressGroup addressGroup, final Attributes attrs) {
     final AtomicReference<Subchannel> resultCapture = new AtomicReference<>();
     helper.getSynchronizationContext().execute(
         new Runnable() {
           @Override
           public void run() {
-            resultCapture.set(
-                helper.createSubchannel(CreateSubchannelArgs.newBuilder()
-                    .setAddresses(addressGroup)
-                    .setAttributes(attrs)
-                    .setStateListener(subchannelStateListener)
-                    .build()));
+            resultCapture.set(helper.createSubchannel(addressGroup, attrs));
           }
         });
     return resultCapture.get();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -78,14 +78,12 @@ import io.grpc.InternalChannelz.ChannelStats;
 import io.grpc.InternalChannelz.ChannelTrace;
 import io.grpc.InternalInstrumented;
 import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
@@ -209,8 +207,6 @@ public class ManagedChannelImplTest {
   private ArgumentCaptor<CallOptions> callOptionsCaptor;
   @Mock
   private LoadBalancer mockLoadBalancer;
-  @Mock
-  private SubchannelStateListener subchannelStateListener;
   private final LoadBalancerProvider mockLoadBalancerProvider =
       mock(LoadBalancerProvider.class, delegatesTo(new LoadBalancerProvider() {
           @Override
@@ -338,9 +334,8 @@ public class ManagedChannelImplTest {
     LoadBalancerRegistry.getDefaultRegistry().deregister(mockLoadBalancerProvider);
   }
 
-  @Deprecated
   @Test
-  public void createSubchannel_old_outsideSynchronizationContextShouldLogWarning() {
+  public void createSubchannelOutsideSynchronizationContextShouldLogWarning() {
     createChannel();
     final AtomicReference<LogRecord> logRef = new AtomicReference<>();
     Handler handler = new Handler() {
@@ -368,48 +363,6 @@ public class ManagedChannelImplTest {
       assertThat(record.getThrown()).isInstanceOf(IllegalStateException.class);
     } finally {
       logger.removeHandler(handler);
-    }
-  }
-
-  @Deprecated
-  @Test
-  public void createSubchannel_old_propagateSubchannelStatesToOldApi() {
-    createChannel();
-    final AtomicReference<Subchannel> subchannelCapture = new AtomicReference<>();
-    helper.getSynchronizationContext().execute(new Runnable() {
-        @Override
-        public void run() {
-          subchannelCapture.set(helper.createSubchannel(addressGroup, Attributes.EMPTY));
-        }
-      });
-
-    Subchannel subchannel = subchannelCapture.get();
-    subchannel.requestConnection();
-
-    verify(mockTransportFactory)
-        .newClientTransport(
-            any(SocketAddress.class), any(ClientTransportOptions.class), any(ChannelLogger.class));
-    verify(mockLoadBalancer).handleSubchannelState(
-        same(subchannel), eq(ConnectivityStateInfo.forNonError(CONNECTING)));
-
-    MockClientTransportInfo transportInfo = transports.poll();
-    transportInfo.listener.transportReady();
-
-    verify(mockLoadBalancer).handleSubchannelState(
-        same(subchannel), eq(ConnectivityStateInfo.forNonError(READY)));
-  }
-
-  @Test
-  public void createSubchannel_outsideSynchronizationContextShouldThrow() {
-    createChannel();
-    try {
-      helper.createSubchannel(CreateSubchannelArgs.newBuilder()
-          .setAddresses(addressGroup)
-          .setStateListener(subchannelStateListener)
-          .build());
-      fail("Should throw");
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Not called from the SynchronizationContext");
     }
   }
 
@@ -473,8 +426,7 @@ public class ManagedChannelImplTest {
     assertNotNull(channelz.getRootChannel(channel.getLogId().getId()));
 
     AbstractSubchannel subchannel =
-        (AbstractSubchannel) createSubchannelSafely(
-            helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+        (AbstractSubchannel) createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     // subchannels are not root channels
     assertNull(channelz.getRootChannel(subchannel.getInternalSubchannel().getLogId().getId()));
     assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
@@ -566,8 +518,7 @@ public class ManagedChannelImplTest {
 
     // Configure the picker so that first RPC goes to delayed transport, and second RPC goes to
     // real transport.
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     subchannel.requestConnection();
     verify(mockTransportFactory)
         .newClientTransport(
@@ -706,12 +657,8 @@ public class ManagedChannelImplTest {
             .setAttributes(Attributes.EMPTY)
             .build());
 
-    SubchannelStateListener stateListener1 = mock(SubchannelStateListener.class);
-    SubchannelStateListener stateListener2 = mock(SubchannelStateListener.class);
-    Subchannel subchannel1 =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, stateListener1);
-    Subchannel subchannel2 =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, stateListener2);
+    Subchannel subchannel1 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
+    Subchannel subchannel2 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     subchannel1.requestConnection();
     subchannel2.requestConnection();
     verify(mockTransportFactory, times(2))
@@ -722,14 +669,13 @@ public class ManagedChannelImplTest {
 
     // LoadBalancer receives all sorts of callbacks
     transportInfo1.listener.transportReady();
-
-    verify(stateListener1, times(2))
-        .onSubchannelState(same(subchannel1), stateInfoCaptor.capture());
+    verify(mockLoadBalancer, times(2))
+        .handleSubchannelState(same(subchannel1), stateInfoCaptor.capture());
     assertSame(CONNECTING, stateInfoCaptor.getAllValues().get(0).getState());
     assertSame(READY, stateInfoCaptor.getAllValues().get(1).getState());
 
-    verify(stateListener2)
-        .onSubchannelState(same(subchannel2), stateInfoCaptor.capture());
+    verify(mockLoadBalancer)
+        .handleSubchannelState(same(subchannel2), stateInfoCaptor.capture());
     assertSame(CONNECTING, stateInfoCaptor.getValue().getState());
 
     resolver.observer.onError(resolutionError);
@@ -778,8 +724,7 @@ public class ManagedChannelImplTest {
     call.start(mockCallListener, headers);
 
     // Make the transport available
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     verify(mockTransportFactory, never())
         .newClientTransport(
             any(SocketAddress.class), any(ClientTransportOptions.class), any(ChannelLogger.class));
@@ -1016,7 +961,7 @@ public class ManagedChannelImplTest {
           return "badAddress";
         }
       };
-    InOrder inOrder = inOrder(mockLoadBalancer, subchannelStateListener);
+    InOrder inOrder = inOrder(mockLoadBalancer);
 
     List<SocketAddress> resolvedAddrs = Arrays.asList(badAddress, goodAddress);
     FakeNameResolverFactory nameResolverFactory =
@@ -1038,13 +983,12 @@ public class ManagedChannelImplTest {
         ResolvedAddresses.newBuilder()
             .setAddresses(Arrays.asList(addressGroup))
             .build());
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class)))
         .thenReturn(PickResult.withSubchannel(subchannel));
     subchannel.requestConnection();
-    inOrder.verify(subchannelStateListener)
-        .onSubchannelState(same(subchannel), stateInfoCaptor.capture());
+    inOrder.verify(mockLoadBalancer).handleSubchannelState(
+        same(subchannel), stateInfoCaptor.capture());
     assertEquals(CONNECTING, stateInfoCaptor.getValue().getState());
 
     // The channel will starts with the first address (badAddress)
@@ -1070,8 +1014,8 @@ public class ManagedChannelImplTest {
         .thenReturn(mock(ClientStream.class));
 
     goodTransportInfo.listener.transportReady();
-    inOrder.verify(subchannelStateListener)
-        .onSubchannelState(same(subchannel), stateInfoCaptor.capture());
+    inOrder.verify(mockLoadBalancer).handleSubchannelState(
+        same(subchannel), stateInfoCaptor.capture());
     assertEquals(READY, stateInfoCaptor.getValue().getState());
 
     // A typical LoadBalancer will call this once the subchannel becomes READY
@@ -1161,7 +1105,7 @@ public class ManagedChannelImplTest {
           return "addr2";
         }
       };
-    InOrder inOrder = inOrder(mockLoadBalancer, subchannelStateListener);
+    InOrder inOrder = inOrder(mockLoadBalancer);
 
     List<SocketAddress> resolvedAddrs = Arrays.asList(addr1, addr2);
 
@@ -1189,14 +1133,13 @@ public class ManagedChannelImplTest {
         ResolvedAddresses.newBuilder()
             .setAddresses(Arrays.asList(addressGroup))
             .build());
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class)))
         .thenReturn(PickResult.withSubchannel(subchannel));
     subchannel.requestConnection();
 
-    inOrder.verify(subchannelStateListener)
-        .onSubchannelState(same(subchannel), stateInfoCaptor.capture());
+    inOrder.verify(mockLoadBalancer).handleSubchannelState(
+        same(subchannel), stateInfoCaptor.capture());
     assertEquals(CONNECTING, stateInfoCaptor.getValue().getState());
 
     // Connecting to server1, which will fail
@@ -1219,8 +1162,8 @@ public class ManagedChannelImplTest {
 
     // ... which makes the subchannel enter TRANSIENT_FAILURE. The last error Status is propagated
     // to LoadBalancer.
-    inOrder.verify(subchannelStateListener)
-        .onSubchannelState(same(subchannel), stateInfoCaptor.capture());
+    inOrder.verify(mockLoadBalancer).handleSubchannelState(
+        same(subchannel), stateInfoCaptor.capture());
     assertEquals(TRANSIENT_FAILURE, stateInfoCaptor.getValue().getState());
     assertSame(server2Error, stateInfoCaptor.getValue().getStatus());
 
@@ -1249,10 +1192,8 @@ public class ManagedChannelImplTest {
     // createSubchannel() always return a new Subchannel
     Attributes attrs1 = Attributes.newBuilder().set(SUBCHANNEL_ATTR_KEY, "attr1").build();
     Attributes attrs2 = Attributes.newBuilder().set(SUBCHANNEL_ATTR_KEY, "attr2").build();
-    SubchannelStateListener listener1 = mock(SubchannelStateListener.class);
-    SubchannelStateListener listener2 = mock(SubchannelStateListener.class);
-    Subchannel sub1 = createSubchannelSafely(helper, addressGroup, attrs1, listener1);
-    Subchannel sub2 = createSubchannelSafely(helper, addressGroup, attrs2, listener2);
+    Subchannel sub1 = createSubchannelSafely(helper, addressGroup, attrs1);
+    Subchannel sub2 = createSubchannelSafely(helper, addressGroup, attrs2);
     assertNotSame(sub1, sub2);
     assertNotSame(attrs1, attrs2);
     assertSame(attrs1, sub1.getAttributes());
@@ -1319,10 +1260,8 @@ public class ManagedChannelImplTest {
   @Test
   public void subchannelsWhenChannelShutdownNow() {
     createChannel();
-    Subchannel sub1 =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
-    Subchannel sub2 =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel sub1 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
+    Subchannel sub2 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     sub1.requestConnection();
     sub2.requestConnection();
 
@@ -1349,10 +1288,8 @@ public class ManagedChannelImplTest {
   @Test
   public void subchannelsNoConnectionShutdown() {
     createChannel();
-    Subchannel sub1 =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
-    Subchannel sub2 =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel sub1 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
+    Subchannel sub2 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
 
     channel.shutdown();
     verify(mockLoadBalancer).shutdown();
@@ -1368,8 +1305,8 @@ public class ManagedChannelImplTest {
   @Test
   public void subchannelsNoConnectionShutdownNow() {
     createChannel();
-    createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
-    createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
+    createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     channel.shutdownNow();
 
     verify(mockLoadBalancer).shutdown();
@@ -1551,8 +1488,7 @@ public class ManagedChannelImplTest {
   @Test
   public void subchannelChannel_normalUsage() {
     createChannel();
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     verify(balancerRpcExecutorPool, never()).getObject();
 
     Channel sChannel = subchannel.asChannel();
@@ -1583,8 +1519,7 @@ public class ManagedChannelImplTest {
   @Test
   public void subchannelChannel_failWhenNotReady() {
     createChannel();
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     Channel sChannel = subchannel.asChannel();
     Metadata headers = new Metadata();
 
@@ -1612,8 +1547,7 @@ public class ManagedChannelImplTest {
   @Test
   public void subchannelChannel_failWaitForReady() {
     createChannel();
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     Channel sChannel = subchannel.asChannel();
     Metadata headers = new Metadata();
 
@@ -1700,8 +1634,7 @@ public class ManagedChannelImplTest {
       OobChannel oobChannel = (OobChannel) helper.createOobChannel(addressGroup, "oobAuthority");
       oobChannel.getSubchannel().requestConnection();
     } else {
-      Subchannel subchannel =
-          createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+      Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
       subchannel.requestConnection();
     }
 
@@ -1788,8 +1721,7 @@ public class ManagedChannelImplTest {
 
     // Simulate name resolution results
     EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(socketAddress);
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     subchannel.requestConnection();
     verify(mockTransportFactory)
         .newClientTransport(
@@ -1862,8 +1794,7 @@ public class ManagedChannelImplTest {
     ClientStreamTracer.Factory factory1 = mock(ClientStreamTracer.Factory.class);
     ClientStreamTracer.Factory factory2 = mock(ClientStreamTracer.Factory.class);
     createChannel();
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     subchannel.requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
     transportInfo.listener.transportReady();
@@ -1901,8 +1832,7 @@ public class ManagedChannelImplTest {
     ClientCall<String, Integer> call = channel.newCall(method, callOptions);
     call.start(mockCallListener, new Metadata());
 
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     subchannel.requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
     transportInfo.listener.transportReady();
@@ -2277,8 +2207,7 @@ public class ManagedChannelImplTest {
     Helper helper2 = helperCaptor.getValue();
 
     // Establish a connection
-    Subchannel subchannel =
-        createSubchannelSafely(helper2, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper2, addressGroup, Attributes.EMPTY);
     subchannel.requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
     ConnectionClientTransport mockTransport = transportInfo.transport;
@@ -2346,8 +2275,7 @@ public class ManagedChannelImplTest {
     Helper helper2 = helperCaptor.getValue();
 
     // Establish a connection
-    Subchannel subchannel =
-        createSubchannelSafely(helper2, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper2, addressGroup, Attributes.EMPTY);
     subchannel.requestConnection();
     ClientStream mockStream = mock(ClientStream.class);
     MockClientTransportInfo transportInfo = transports.poll();
@@ -2376,10 +2304,8 @@ public class ManagedChannelImplTest {
     call.start(mockCallListener, new Metadata());
 
     // Make the transport available with subchannel2
-    Subchannel subchannel1 =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
-    Subchannel subchannel2 =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel1 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
+    Subchannel subchannel2 = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     subchannel2.requestConnection();
 
     MockClientTransportInfo transportInfo = transports.poll();
@@ -2518,8 +2444,7 @@ public class ManagedChannelImplTest {
     createChannel();
     assertEquals(TARGET, getStats(channel).target);
 
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     assertEquals(Collections.singletonList(addressGroup).toString(),
         getStats((AbstractSubchannel) subchannel).target);
   }
@@ -2542,8 +2467,7 @@ public class ManagedChannelImplTest {
     createChannel();
     timer.forwardNanos(1234);
     AbstractSubchannel subchannel =
-        (AbstractSubchannel) createSubchannelSafely(
-            helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+        (AbstractSubchannel) createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     assertThat(getStats(channel).channelTrace.events).contains(new ChannelTrace.Event.Builder()
         .setDescription("Child Subchannel created")
         .setSeverity(ChannelTrace.Event.Severity.CT_INFO)
@@ -2716,8 +2640,7 @@ public class ManagedChannelImplTest {
     channelBuilder.maxTraceEvents(10);
     createChannel();
     AbstractSubchannel subchannel =
-        (AbstractSubchannel) createSubchannelSafely(
-            helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+        (AbstractSubchannel) createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     timer.forwardNanos(1234);
     subchannel.obtainActiveTransport();
     assertThat(getStats(subchannel).channelTrace.events).contains(new ChannelTrace.Event.Builder()
@@ -2780,8 +2703,7 @@ public class ManagedChannelImplTest {
     assertEquals(CONNECTING, getStats(channel).state);
 
     AbstractSubchannel subchannel =
-        (AbstractSubchannel) createSubchannelSafely(
-            helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+        (AbstractSubchannel) createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
 
     assertEquals(IDLE, getStats(subchannel).state);
     subchannel.requestConnection();
@@ -2835,8 +2757,7 @@ public class ManagedChannelImplTest {
     ClientStream mockStream = mock(ClientStream.class);
     ClientStreamTracer.Factory factory = mock(ClientStreamTracer.Factory.class);
     AbstractSubchannel subchannel =
-        (AbstractSubchannel) createSubchannelSafely(
-            helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+        (AbstractSubchannel) createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     subchannel.requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
     transportInfo.listener.transportReady();
@@ -3073,8 +2994,7 @@ public class ManagedChannelImplTest {
             .build());
 
     // simulating request connection and then transport ready after resolved address
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = createSubchannelSafely(helper, addressGroup, Attributes.EMPTY);
     when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class)))
         .thenReturn(PickResult.withSubchannel(subchannel));
     subchannel.requestConnection();
@@ -3173,8 +3093,7 @@ public class ManagedChannelImplTest {
             .build());
 
     // simulating request connection and then transport ready after resolved address
-    Subchannel subchannel =
-        createSubchannelSafely(helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
+    Subchannel subchannel = helper.createSubchannel(addressGroup, Attributes.EMPTY);
     when(mockPicker.pickSubchannel(any(PickSubchannelArgs.class)))
         .thenReturn(PickResult.withSubchannel(subchannel));
     subchannel.requestConnection();
@@ -3961,18 +3880,13 @@ public class ManagedChannelImplTest {
 
   // We need this because createSubchannel() should be called from the SynchronizationContext
   private static Subchannel createSubchannelSafely(
-      final Helper helper, final EquivalentAddressGroup addressGroup, final Attributes attrs,
-      final SubchannelStateListener stateListener) {
+      final Helper helper, final EquivalentAddressGroup addressGroup, final Attributes attrs) {
     final AtomicReference<Subchannel> resultCapture = new AtomicReference<>();
     helper.getSynchronizationContext().execute(
         new Runnable() {
           @Override
           public void run() {
-            resultCapture.set(helper.createSubchannel(CreateSubchannelArgs.newBuilder()
-                    .setAddresses(addressGroup)
-                    .setAttributes(attrs)
-                    .setStateListener(stateListener)
-                    .build()));
+            resultCapture.set(helper.createSubchannel(addressGroup, attrs));
           }
         });
     return resultCapture.get();

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbLoadBalancer.java
@@ -24,6 +24,7 @@ import com.google.common.base.Stopwatch;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
+import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.Status;
@@ -74,9 +75,16 @@ class GrpclbLoadBalancer extends LoadBalancer {
     this.stopwatch = checkNotNull(stopwatch, "stopwatch");
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
     this.subchannelPool = checkNotNull(subchannelPool, "subchannelPool");
-    this.subchannelPool.init(helper);
+    this.subchannelPool.init(helper, this);
     recreateStates();
     checkNotNull(grpclbState, "grpclbState");
+  }
+
+  @Override
+  public void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState) {
+    // grpclbState should never be null here since handleSubchannelState cannot be called while the
+    // lb is shutdown.
+    grpclbState.handleSubchannelState(subchannel, newState);
   }
 
   @Override

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -35,13 +35,11 @@ import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -83,7 +81,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * switches away from GRPCLB mode.
  */
 @NotThreadSafe
-final class GrpclbState implements SubchannelStateListener {
+final class GrpclbState {
   static final long FALLBACK_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
   private static final Attributes LB_PROVIDED_BACKEND_ATTRS =
       Attributes.newBuilder().set(GrpcAttributes.ATTR_LB_PROVIDED_BACKEND, true).build();
@@ -173,12 +171,14 @@ final class GrpclbState implements SubchannelStateListener {
     this.logger = checkNotNull(helper.getChannelLogger(), "logger");
   }
 
-  @Override
-  public void onSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState) {
+  void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState) {
     if (newState.getState() == SHUTDOWN) {
       return;
     }
     if (!subchannels.values().contains(subchannel)) {
+      if (subchannelPool != null ) {
+        subchannelPool.handleSubchannelState(subchannel, newState);
+      }
       return;
     }
     if (mode == Mode.ROUND_ROBIN && newState.getState() == IDLE) {
@@ -323,7 +323,7 @@ final class GrpclbState implements SubchannelStateListener {
         // We close the subchannels through subchannelPool instead of helper just for convenience of
         // testing.
         for (Subchannel subchannel : subchannels.values()) {
-          subchannelPool.returnSubchannel(subchannel);
+          returnSubchannelToPool(subchannel);
         }
         subchannelPool.clear();
         break;
@@ -345,6 +345,10 @@ final class GrpclbState implements SubchannelStateListener {
       maybeUpdatePicker(
           TRANSIENT_FAILURE, new RoundRobinPicker(dropList, Arrays.asList(new ErrorEntry(status))));
     }
+  }
+
+  private void returnSubchannelToPool(Subchannel subchannel) {
+    subchannelPool.returnSubchannel(subchannel, subchannel.getAttributes().get(STATE_INFO).get());
   }
 
   @VisibleForTesting
@@ -377,8 +381,7 @@ final class GrpclbState implements SubchannelStateListener {
           if (subchannel == null) {
             subchannel = subchannels.get(eagAsList);
             if (subchannel == null) {
-              subchannel = subchannelPool.takeOrCreateSubchannel(
-                  eag, createSubchannelAttrs(), this);
+              subchannel = subchannelPool.takeOrCreateSubchannel(eag, createSubchannelAttrs());
               subchannel.requestConnection();
             }
             newSubchannelMap.put(eagAsList, subchannel);
@@ -396,7 +399,7 @@ final class GrpclbState implements SubchannelStateListener {
         for (Entry<List<EquivalentAddressGroup>, Subchannel> entry : subchannels.entrySet()) {
           List<EquivalentAddressGroup> eagList = entry.getKey();
           if (!newSubchannelMap.containsKey(eagList)) {
-            subchannelPool.returnSubchannel(entry.getValue());
+            returnSubchannelToPool(entry.getValue());
           }
         }
         subchannels = Collections.unmodifiableMap(newSubchannelMap);
@@ -419,12 +422,7 @@ final class GrpclbState implements SubchannelStateListener {
         }
         Subchannel subchannel;
         if (subchannels.isEmpty()) {
-          subchannel =
-              helper.createSubchannel(CreateSubchannelArgs.newBuilder()
-                  .setAddresses(eagList)
-                  .setAttributes(createSubchannelAttrs())
-                  .setStateListener(this)
-                  .build());
+          subchannel = helper.createSubchannel(eagList, createSubchannelAttrs());
         } else {
           checkState(subchannels.size() == 1, "Unexpected Subchannel count: %s", subchannels);
           subchannel = subchannels.values().iterator().next();

--- a/grpclb/src/test/java/io/grpc/grpclb/CachedSubchannelPoolTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/CachedSubchannelPoolTest.java
@@ -19,8 +19,9 @@ package io.grpc.grpclb;
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.grpclb.CachedSubchannelPool.SHUTDOWN_TIMEOUT_MS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -32,26 +33,24 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
-import io.grpc.LoadBalancer.CreateSubchannelArgs;
+import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.Subchannel;
-import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
+import io.grpc.grpclb.CachedSubchannelPool.ShutdownSubchannelTask;
 import io.grpc.internal.FakeClock;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.hamcrest.MockitoHamcrest;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -65,11 +64,23 @@ public class CachedSubchannelPoolTest {
   private static final Attributes.Key<String> ATTR_KEY = Attributes.Key.create("test-attr");
   private static final Attributes ATTRS1 = Attributes.newBuilder().set(ATTR_KEY, "1").build();
   private static final Attributes ATTRS2 = Attributes.newBuilder().set(ATTR_KEY, "2").build();
+  
+  private static final ConnectivityStateInfo READY_STATE =
+      ConnectivityStateInfo.forNonError(ConnectivityState.READY);
   private static final ConnectivityStateInfo TRANSIENT_FAILURE_STATE =
       ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE.withDescription("Simulated"));
+  private static final FakeClock.TaskFilter SHUTDOWN_TASK_FILTER =
+      new FakeClock.TaskFilter() {
+        @Override
+        public boolean shouldAccept(Runnable command) {
+          // The task is wrapped by SynchronizationContext, so we can't compare the type
+          // directly.
+          return command.toString().contains(ShutdownSubchannelTask.class.getSimpleName());
+        }
+      };
 
   private final Helper helper = mock(Helper.class);
-  private final SubchannelStateListener mockListener = mock(SubchannelStateListener.class);
+  private final LoadBalancer balancer = mock(LoadBalancer.class);
   private final FakeClock clock = new FakeClock();
   private final SynchronizationContext syncContext = new SynchronizationContext(
       new Thread.UncaughtExceptionHandler() {
@@ -80,8 +91,6 @@ public class CachedSubchannelPoolTest {
       });
   private final CachedSubchannelPool pool = new CachedSubchannelPool();
   private final ArrayList<Subchannel> mockSubchannels = new ArrayList<>();
-  // Listeners seen by the Helper
-  private final Map<Subchannel, SubchannelStateListener> stateListeners = new HashMap<>();
 
   @Before
   @SuppressWarnings("unchecked")
@@ -90,17 +99,26 @@ public class CachedSubchannelPoolTest {
         @Override
         public Subchannel answer(InvocationOnMock invocation) throws Throwable {
           Subchannel subchannel = mock(Subchannel.class);
-          CreateSubchannelArgs args = (CreateSubchannelArgs) invocation.getArguments()[0];
-          when(subchannel.getAllAddresses()).thenReturn(args.getAddresses());
-          when(subchannel.getAttributes()).thenReturn(args.getAttributes());
+          List<EquivalentAddressGroup> eagList =
+              (List<EquivalentAddressGroup>) invocation.getArguments()[0];
+          Attributes attrs = (Attributes) invocation.getArguments()[1];
+          when(subchannel.getAllAddresses()).thenReturn(eagList);
+          when(subchannel.getAttributes()).thenReturn(attrs);
           mockSubchannels.add(subchannel);
-          stateListeners.put(subchannel, args.getStateListener());
           return subchannel;
         }
-      }).when(helper).createSubchannel(any(CreateSubchannelArgs.class));
+      }).when(helper).createSubchannel(any(List.class), any(Attributes.class));
+    doAnswer(new Answer<Void>() {
+        @Override
+        public Void answer(InvocationOnMock invocation) throws Throwable {
+          syncContext.throwIfNotInThisSynchronizationContext();
+          return null;
+        }
+      }).when(balancer).handleSubchannelState(
+          any(Subchannel.class), any(ConnectivityStateInfo.class));
     when(helper.getSynchronizationContext()).thenReturn(syncContext);
     when(helper.getScheduledExecutorService()).thenReturn(clock.getScheduledExecutorService());
-    pool.init(helper);
+    pool.init(helper, balancer);
   }
 
   @After
@@ -109,26 +127,29 @@ public class CachedSubchannelPoolTest {
     for (Subchannel subchannel : mockSubchannels) {
       verify(subchannel, atMost(1)).shutdown();
     }
+    verify(balancer, atLeast(0))
+        .handleSubchannelState(any(Subchannel.class), any(ConnectivityStateInfo.class));
+    verifyNoMoreInteractions(balancer);
   }
 
   @Test
   public void subchannelExpireAfterReturned() {
-    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener);
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
     assertThat(subchannel1).isNotNull();
-    verify(helper).createSubchannel(argsWith(EAG1, "1"));
+    verify(helper).createSubchannel(eq(Arrays.asList(EAG1)), same(ATTRS1));
 
-    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2, mockListener);
+    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
     assertThat(subchannel2).isNotNull();
     assertThat(subchannel2).isNotSameInstanceAs(subchannel1);
-    verify(helper).createSubchannel(argsWith(EAG2, "2"));
+    verify(helper).createSubchannel(eq(Arrays.asList(EAG2)), same(ATTRS2));
 
-    pool.returnSubchannel(subchannel1);
+    pool.returnSubchannel(subchannel1, READY_STATE);
 
     // subchannel1 is 1ms away from expiration.
     clock.forwardTime(SHUTDOWN_TIMEOUT_MS - 1, MILLISECONDS);
     verify(subchannel1, never()).shutdown();
 
-    pool.returnSubchannel(subchannel2);
+    pool.returnSubchannel(subchannel2, READY_STATE);
 
     // subchannel1 expires. subchannel2 is (SHUTDOWN_TIMEOUT_MS - 1) away from expiration.
     clock.forwardTime(1, MILLISECONDS);
@@ -143,25 +164,25 @@ public class CachedSubchannelPoolTest {
 
   @Test
   public void subchannelReused() {
-    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener);
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
     assertThat(subchannel1).isNotNull();
-    verify(helper).createSubchannel(argsWith(EAG1, "1"));
+    verify(helper).createSubchannel(eq(Arrays.asList(EAG1)), same(ATTRS1));
 
-    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2, mockListener);
+    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
     assertThat(subchannel2).isNotNull();
     assertThat(subchannel2).isNotSameInstanceAs(subchannel1);
-    verify(helper).createSubchannel(argsWith(EAG2, "2"));
+    verify(helper).createSubchannel(eq(Arrays.asList(EAG2)), same(ATTRS2));
 
-    pool.returnSubchannel(subchannel1);
+    pool.returnSubchannel(subchannel1, READY_STATE);
 
     // subchannel1 is 1ms away from expiration.
     clock.forwardTime(SHUTDOWN_TIMEOUT_MS - 1, MILLISECONDS);
 
     // This will cancel the shutdown timer for subchannel1
-    Subchannel subchannel1a = pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener);
+    Subchannel subchannel1a = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
     assertThat(subchannel1a).isSameInstanceAs(subchannel1);
 
-    pool.returnSubchannel(subchannel2);
+    pool.returnSubchannel(subchannel2, READY_STATE);
 
     // subchannel2 expires SHUTDOWN_TIMEOUT_MS after being returned
     clock.forwardTime(SHUTDOWN_TIMEOUT_MS - 1, MILLISECONDS);
@@ -170,12 +191,12 @@ public class CachedSubchannelPoolTest {
     verify(subchannel2).shutdown();
 
     // pool will create a new channel for EAG2 when requested
-    Subchannel subchannel2a = pool.takeOrCreateSubchannel(EAG2, ATTRS2, mockListener);
+    Subchannel subchannel2a = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
     assertThat(subchannel2a).isNotSameInstanceAs(subchannel2);
-    verify(helper, times(2)).createSubchannel(argsWith(EAG2, "2"));
+    verify(helper, times(2)).createSubchannel(eq(Arrays.asList(EAG2)), same(ATTRS2));
 
     // subchannel1 expires SHUTDOWN_TIMEOUT_MS after being returned
-    pool.returnSubchannel(subchannel1a);
+    pool.returnSubchannel(subchannel1a, READY_STATE);
     clock.forwardTime(SHUTDOWN_TIMEOUT_MS - 1, MILLISECONDS);
     verify(subchannel1a, never()).shutdown();
     clock.forwardTime(1, MILLISECONDS);
@@ -186,138 +207,93 @@ public class CachedSubchannelPoolTest {
 
   @Test
   public void updateStateWhileInPool() {
-    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener);
-    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2, mockListener);
-
-    // Simulate state updates while they are in the pool
-    stateListeners.get(subchannel1).onSubchannelState(subchannel1, TRANSIENT_FAILURE_STATE);
-    stateListeners.get(subchannel2).onSubchannelState(subchannel1, TRANSIENT_FAILURE_STATE);
-
-    verify(mockListener).onSubchannelState(same(subchannel1), same(TRANSIENT_FAILURE_STATE));
-    verify(mockListener).onSubchannelState(same(subchannel2), same(TRANSIENT_FAILURE_STATE));
-
-    pool.returnSubchannel(subchannel1);
-    pool.returnSubchannel(subchannel2);
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
+    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
+    pool.returnSubchannel(subchannel1, READY_STATE);
+    pool.returnSubchannel(subchannel2, TRANSIENT_FAILURE_STATE);
 
     ConnectivityStateInfo anotherFailureState =
         ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE.withDescription("Another"));
 
-    // Simulate a subchannel state update while it's in the pool
-    stateListeners.get(subchannel1).onSubchannelState(subchannel1, anotherFailureState);
+    pool.handleSubchannelState(subchannel1, anotherFailureState);
 
-    SubchannelStateListener mockListener1 = mock(SubchannelStateListener.class);
-    SubchannelStateListener mockListener2 = mock(SubchannelStateListener.class);
+    verify(balancer, never())
+        .handleSubchannelState(any(Subchannel.class), any(ConnectivityStateInfo.class));
 
-    // Saved state is populated to new mockListeners
-    assertThat(pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener1))
-        .isSameInstanceAs(subchannel1);
-    verify(mockListener1).onSubchannelState(same(subchannel1), same(anotherFailureState));
-    verifyNoMoreInteractions(mockListener1);
+    assertThat(pool.takeOrCreateSubchannel(EAG1, ATTRS1)).isSameInstanceAs(subchannel1);
+    verify(balancer).handleSubchannelState(same(subchannel1), same(anotherFailureState));
+    verifyNoMoreInteractions(balancer);
 
-    assertThat(pool.takeOrCreateSubchannel(EAG2, ATTRS2, mockListener2))
-        .isSameInstanceAs(subchannel2);
-    verify(mockListener2).onSubchannelState(same(subchannel2), same(TRANSIENT_FAILURE_STATE));
-    verifyNoMoreInteractions(mockListener2);
-
-    // The old mockListener doesn't receive more updates
-    verifyNoMoreInteractions(mockListener);
+    assertThat(pool.takeOrCreateSubchannel(EAG2, ATTRS2)).isSameInstanceAs(subchannel2);
+    verify(balancer).handleSubchannelState(same(subchannel2), same(TRANSIENT_FAILURE_STATE));
+    verifyNoMoreInteractions(balancer);
   }
 
   @Test
-  public void takeTwice_willThrow() {
-    Subchannel unused = pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener);
-    try {
-      pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener);
-      fail("Should throw");
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().contains("Already out of pool");
-    }
+  public void updateStateWhileInPool_notSameObject() {
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
+    pool.returnSubchannel(subchannel1, READY_STATE);
+
+    Subchannel subchannel2 = helper.createSubchannel(EAG1, ATTRS1);
+    Subchannel subchannel3 = helper.createSubchannel(EAG2, ATTRS2);
+
+    // subchannel2 is not in the pool, although with the same address
+    pool.handleSubchannelState(subchannel2, TRANSIENT_FAILURE_STATE);
+
+    // subchannel3 is not in the pool.  In fact its address is not in the pool
+    pool.handleSubchannelState(subchannel3, TRANSIENT_FAILURE_STATE);
+
+    assertThat(pool.takeOrCreateSubchannel(EAG1, ATTRS1)).isSameInstanceAs(subchannel1);
+
+    // subchannel1's state is unchanged
+    verify(balancer).handleSubchannelState(same(subchannel1), same(READY_STATE));
+    verifyNoMoreInteractions(balancer);
   }
 
   @Test
-  public void returnTwice_willThrow() {
-    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener);
-    pool.returnSubchannel(subchannel1);
-    try {
-      pool.returnSubchannel(subchannel1);
-      fail("Should throw");
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().contains("Already in pool");
-    }
-  }
+  public void returnDuplicateAddressSubchannel() {
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
+    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG1, ATTRS2);
+    Subchannel subchannel3 = pool.takeOrCreateSubchannel(EAG2, ATTRS1);
+    assertThat(subchannel1).isNotSameInstanceAs(subchannel2);
 
-  @Test
-  public void returnNonPoolSubchannelWillThrow_noSuchAddress() {
-    Subchannel subchannel1 = helper.createSubchannel(
-        CreateSubchannelArgs.newBuilder()
-            .setAddresses(EAG1).setStateListener(mockListener)
-            .build());
-    try {
-      pool.returnSubchannel(subchannel1);
-      fail("Should throw");
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().contains("not found");
-    }
-  }
+    assertThat(clock.getPendingTasks(SHUTDOWN_TASK_FILTER)).isEmpty();
+    pool.returnSubchannel(subchannel2, READY_STATE);
+    assertThat(clock.getPendingTasks(SHUTDOWN_TASK_FILTER)).hasSize(1);
 
-  @Test
-  public void returnNonPoolSubchannelWillThrow_unmatchedSubchannel() {
-    Subchannel subchannel1 = helper.createSubchannel(
-        CreateSubchannelArgs.newBuilder()
-            .setAddresses(EAG1).setStateListener(mockListener)
-            .build());
-    Subchannel subchannel1c = pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener);
-    assertThat(subchannel1).isNotSameInstanceAs(subchannel1c);
-    try {
-      pool.returnSubchannel(subchannel1);
-      fail("Should throw");
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().contains("doesn't match the cache");
-    }
+    // If the subchannel being returned has an address that is the same as a subchannel in the pool,
+    // the returned subchannel will be shut down.
+    verify(subchannel1, never()).shutdown();
+    pool.returnSubchannel(subchannel1, READY_STATE);
+    assertThat(clock.getPendingTasks(SHUTDOWN_TASK_FILTER)).hasSize(1);
+    verify(subchannel1).shutdown();
+
+    pool.returnSubchannel(subchannel3, READY_STATE);
+    assertThat(clock.getPendingTasks(SHUTDOWN_TASK_FILTER)).hasSize(2);
+    // Returning the same subchannel twice has no effect.
+    pool.returnSubchannel(subchannel3, READY_STATE);
+    assertThat(clock.getPendingTasks(SHUTDOWN_TASK_FILTER)).hasSize(2);
+
+    verify(subchannel2, never()).shutdown();
+    verify(subchannel3, never()).shutdown();
   }
 
   @Test
   public void clear() {
-    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1, mockListener);
-    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2, mockListener);
+    Subchannel subchannel1 = pool.takeOrCreateSubchannel(EAG1, ATTRS1);
+    Subchannel subchannel2 = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
+    Subchannel subchannel3 = pool.takeOrCreateSubchannel(EAG2, ATTRS2);
 
-    pool.returnSubchannel(subchannel1);
+    pool.returnSubchannel(subchannel1, READY_STATE);
+    pool.returnSubchannel(subchannel2, READY_STATE);
 
     verify(subchannel1, never()).shutdown();
     verify(subchannel2, never()).shutdown();
     pool.clear();
     verify(subchannel1).shutdown();
     verify(subchannel2).shutdown();
+
+    verify(subchannel3, never()).shutdown();
     assertThat(clock.numPendingTasks()).isEqualTo(0);
   }
-
-  private CreateSubchannelArgs argsWith(
-      final EquivalentAddressGroup expectedEag, final Object expectedValue) {
-    return MockitoHamcrest.argThat(
-        new org.hamcrest.BaseMatcher<CreateSubchannelArgs>() {
-          @Override
-          public boolean matches(Object item) {
-            if (!(item instanceof CreateSubchannelArgs)) {
-              return false;
-            }
-            CreateSubchannelArgs that = (CreateSubchannelArgs) item;
-            List<EquivalentAddressGroup> expectedEagList = Collections.singletonList(expectedEag);
-            if (!expectedEagList.equals(that.getAddresses())) {
-              return false;
-            }
-            if (!expectedValue.equals(that.getAttributes().get(ATTR_KEY))) {
-              return false;
-            }
-            return true;
-          }
-
-          @Override
-          public void describeTo(org.hamcrest.Description desc) {
-            desc.appendText(
-                "Matches Attributes that includes " + expectedEag + " and "
-                + ATTR_KEY + "=" + expectedValue);
-          }
-        });
-  }
-
 }

--- a/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
@@ -16,7 +16,6 @@
 
 package io.grpc.services;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.grpc.ConnectivityState.CONNECTING;
@@ -28,17 +27,17 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
+import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ClientCall;
 import io.grpc.ConnectivityStateInfo;
+import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.Factory;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.Subchannel;
-import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -54,6 +53,7 @@ import io.grpc.internal.ServiceConfigUtil;
 import io.grpc.util.ForwardingLoadBalancer;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -70,6 +70,8 @@ import javax.annotation.Nullable;
  * SynchronizationContext, or it will throw.
  */
 final class HealthCheckingLoadBalancerFactory extends Factory {
+  private static final Attributes.Key<HealthCheckState> KEY_HEALTH_CHECK_STATE =
+      Attributes.Key.create("io.grpc.services.HealthCheckingLoadBalancerFactory.healthCheckState");
   private static final Logger logger =
       Logger.getLogger(HealthCheckingLoadBalancerFactory.class.getName());
 
@@ -89,13 +91,15 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
   public LoadBalancer newLoadBalancer(Helper helper) {
     HelperImpl wrappedHelper = new HelperImpl(helper);
     LoadBalancer delegateBalancer = delegateFactory.newLoadBalancer(wrappedHelper);
+    wrappedHelper.init(delegateBalancer);
     return new HealthCheckingLoadBalancer(wrappedHelper, delegateBalancer);
   }
 
   private final class HelperImpl extends ForwardingLoadBalancerHelper {
     private final Helper delegate;
     private final SynchronizationContext syncContext;
-
+    
+    private LoadBalancer delegateBalancer;
     @Nullable String healthCheckedService;
     private boolean balancerShutdown;
 
@@ -106,21 +110,26 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
       this.syncContext = checkNotNull(delegate.getSynchronizationContext(), "syncContext");
     }
 
+    void init(LoadBalancer delegateBalancer) {
+      checkState(this.delegateBalancer == null, "init() already called");
+      this.delegateBalancer = checkNotNull(delegateBalancer, "delegateBalancer");
+    }
+
     @Override
     protected Helper delegate() {
       return delegate;
     }
 
     @Override
-    public Subchannel createSubchannel(CreateSubchannelArgs args) {
+    public Subchannel createSubchannel(List<EquivalentAddressGroup> addrs, Attributes attrs) {
       // HealthCheckState is not thread-safe, we are requiring the original LoadBalancer calls
       // createSubchannel() from the SynchronizationContext.
       syncContext.throwIfNotInThisSynchronizationContext();
       HealthCheckState hcState = new HealthCheckState(
-          this, args.getStateListener(), syncContext, delegate.getScheduledExecutorService());
+          this, delegateBalancer, syncContext, delegate.getScheduledExecutorService());
       hcStates.add(hcState);
-      Subchannel subchannel =
-          super.createSubchannel(args.toBuilder().setStateListener(hcState).build());
+      Subchannel subchannel = super.createSubchannel(
+          addrs, attrs.toBuilder().set(KEY_HEALTH_CHECK_STATE, hcState).build());
       hcState.init(subchannel);
       if (healthCheckedService != null) {
         hcState.setServiceName(healthCheckedService);
@@ -169,14 +178,26 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
     }
 
     @Override
+    public void handleSubchannelState(
+        Subchannel subchannel, ConnectivityStateInfo stateInfo) {
+      HealthCheckState hcState =
+          checkNotNull(subchannel.getAttributes().get(KEY_HEALTH_CHECK_STATE), "hcState");
+      hcState.updateRawState(stateInfo);
+
+      if (Objects.equal(stateInfo.getState(), SHUTDOWN)) {
+        helper.hcStates.remove(hcState);
+      }
+    }
+
+    @Override
     public void shutdown() {
       super.shutdown();
       helper.balancerShutdown = true;
       for (HealthCheckState hcState : helper.hcStates) {
-        // ManagedChannel will stop calling onSubchannelState() after shutdown() is called,
+        // ManagedChannel will stop calling handleSubchannelState() after shutdown() is called,
         // which is required by LoadBalancer API semantics. We need to deliver the final SHUTDOWN
         // signal to health checkers so that they can cancel the streams.
-        hcState.onSubchannelState(hcState.subchannel, ConnectivityStateInfo.forNonError(SHUTDOWN));
+        hcState.updateRawState(ConnectivityStateInfo.forNonError(SHUTDOWN));
       }
       helper.hcStates.clear();
     }
@@ -189,7 +210,7 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
 
   
   // All methods are run from syncContext
-  private final class HealthCheckState implements SubchannelStateListener {
+  private final class HealthCheckState {
     private final Runnable retryTask = new Runnable() {
         @Override
         public void run() {
@@ -197,7 +218,7 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
         }
       };
 
-    private final SubchannelStateListener stateListener;
+    private final LoadBalancer delegate;
     private final SynchronizationContext syncContext;
     private final ScheduledExecutorService timerService;
     private final HelperImpl helperImpl;
@@ -225,10 +246,10 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
 
     HealthCheckState(
         HelperImpl helperImpl,
-        SubchannelStateListener stateListener, SynchronizationContext syncContext,
+        LoadBalancer delegate, SynchronizationContext syncContext,
         ScheduledExecutorService timerService) {
       this.helperImpl = checkNotNull(helperImpl, "helperImpl");
-      this.stateListener = checkNotNull(stateListener, "stateListener");
+      this.delegate = checkNotNull(delegate, "delegate");
       this.syncContext = checkNotNull(syncContext, "syncContext");
       this.timerService = checkNotNull(timerService, "timerService");
     }
@@ -253,18 +274,12 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
       adjustHealthCheck();
     }
 
-    @Override
-    public void onSubchannelState(Subchannel subchannel, ConnectivityStateInfo rawState) {
-      checkArgument(subchannel == this.subchannel,
-          "Subchannel mismatch: %s vs %s", subchannel, this.subchannel);
+    void updateRawState(ConnectivityStateInfo rawState) {
       if (Objects.equal(this.rawState.getState(), READY)
           && !Objects.equal(rawState.getState(), READY)) {
         // A connection was lost.  We will reset disabled flag because health check
         // may be available on the new connection.
         disabled = false;
-      }
-      if (Objects.equal(rawState.getState(), SHUTDOWN)) {
-        helperImpl.hcStates.remove(this);
       }
       this.rawState = rawState;
       adjustHealthCheck();
@@ -324,7 +339,7 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
       checkState(subchannel != null, "init() not called");
       if (!helperImpl.balancerShutdown && !Objects.equal(concludedState, newState)) {
         concludedState = newState;
-        stateListener.onSubchannelState(subchannel, concludedState);
+        delegate.handleSubchannelState(subchannel, concludedState);
       }
     }
 


### PR DESCRIPTION
…r rather than LoadBalancer (#5503)"

This reverts commit 62b03fd7e6936b7b1e78e4f13e9944d5a6da0771.

Effectively reverts its follow-up commits:
dc218b6d4d212d52688b7b0be7a13db7f1de1e7f
405d8c3865fa31132db08dc5b5609dff3b2fa0f8
44840fe813764167fc10102bf1fbe9fa1a8f5f5a

In order to fix #5676, we need to make a tweak to `SubchannelStateListener` and some other APIs. Since it has never been in any releases, it's better to avoid it in the upcoming 1.21 so that we don't have to deal with yet another migration.
