### PR TITLE
api: add getters for NameResolver.Args and NameResolverRegistry in LoadBalancer.Helper

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1136,6 +1136,22 @@ public abstract class LoadBalancer {
     public ChannelLogger getChannelLogger() {
       throw new UnsupportedOperationException();
     }
+
+    /**
+     * Returns the {@link NameResolver.Args} with which the {@link NameResolver} paired with
+     * this {@link LoadBalancer} was created.
+     */
+    public NameResolver.Args getNameResolverArgs() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the {@link NameResolverRegistry} from which the {@link NameResolver} paired with
+     * this {@link LoadBalancer} was created.
+     */
+    public NameResolverRegistry getNameResolverRegistry() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   /**

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1137,16 +1137,15 @@ public abstract class LoadBalancer {
     }
 
     /**
-     * Returns the {@link NameResolver.Args} with which the {@link NameResolver} paired with
-     * this {@link LoadBalancer} was created.
+     * Returns the {@link NameResolver.Args} that the Channel uses to create {@link NameResolver}s.
      */
     public NameResolver.Args getNameResolverArgs() {
       throw new UnsupportedOperationException();
     }
 
     /**
-     * Returns the {@link NameResolverRegistry} from which the {@link NameResolver} paired with
-     * this {@link LoadBalancer} was created.
+     * Returns the {@link NameResolverRegistry} that the Channel uses to look for {@link
+     * NameResolver}s.
      */
     public NameResolverRegistry getNameResolverRegistry() {
       throw new UnsupportedOperationException();

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1138,6 +1138,8 @@ public abstract class LoadBalancer {
 
     /**
      * Returns the {@link NameResolver.Args} that the Channel uses to create {@link NameResolver}s.
+     *
+     * @since 1.22.0
      */
     public NameResolver.Args getNameResolverArgs() {
       throw new UnsupportedOperationException();
@@ -1146,6 +1148,8 @@ public abstract class LoadBalancer {
     /**
      * Returns the {@link NameResolverRegistry} that the Channel uses to look for {@link
      * NameResolver}s.
+     *
+     * @since 1.22.0
      */
     public NameResolverRegistry getNameResolverRegistry() {
       throw new UnsupportedOperationException();

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1325,7 +1325,9 @@ final class ManagedChannelImpl extends ManagedChannel implements
     }
 
     @Override
-    public 
+    public NameResolverRegistry getNameResolverRegistry() {
+      return nameResolverRegistry;
+    }
   }
 
   private final class NameResolverObserver extends NameResolver.Observer {

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1315,6 +1315,14 @@ final class ManagedChannelImpl extends ManagedChannel implements
     public ChannelLogger getChannelLogger() {
       return channelLogger;
     }
+
+    @Override
+    public NameResolver.Args getNameResolverArgs() {
+      return nameResolverArgs;
+    }
+
+    @Override
+    public 
   }
 
   private final class NameResolverObserver extends NameResolver.Observer {

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
@@ -28,6 +28,7 @@ import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancer;
 import io.grpc.ManagedChannel;
 import io.grpc.NameResolver;
+import io.grpc.NameResolverRegistry;
 import io.grpc.SynchronizationContext;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -112,6 +113,16 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
   @Override
   public ChannelLogger getChannelLogger() {
     return delegate().getChannelLogger();
+  }
+
+  @Override
+  public NameResolver.Args getNameResolverArgs() {
+    return delegate().getNameResolverArgs();
+  }
+
+  @Override
+  public NameResolverRegistry getNameResolverRegistry() {
+    return delegate().getNameResolverRegistry();
   }
 
   @Override

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -95,6 +95,7 @@ import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.NameResolver.ResolutionResult;
+import io.grpc.NameResolverRegistry;
 import io.grpc.ProxiedSocketAddress;
 import io.grpc.ProxyDetector;
 import io.grpc.SecurityLevel;
@@ -1666,6 +1667,26 @@ public class ManagedChannelImplTest {
     } catch (UnsupportedOperationException e) {
       // exepcted
     }
+  }
+
+  @Test
+  public void lbHelper_getNameResolverArgs() {
+    createChannel();
+
+    NameResolver.Args args = helper.getNameResolverArgs();
+    assertThat(args.getDefaultPort()).isEqualTo(DEFAULT_PORT);
+    assertThat(args.getProxyDetector()).isSameInstanceAs(GrpcUtil.DEFAULT_PROXY_DETECTOR);
+    assertThat(args.getSynchronizationContext())
+        .isSameInstanceAs(helper.getSynchronizationContext());
+    assertThat(args.getServiceConfigParser()).isNotNull();
+  }
+
+  @Test
+  public void lbHelper_getNameResolverRegistry() {
+    createChannel();
+
+    assertThat(helper.getNameResolverRegistry())
+        .isSameInstanceAs(NameResolverRegistry.getDefaultRegistry());
   }
 
   @Test

--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Only run this script on Linux environment.
+
 # Update VERSION then in this directory run ./import.sh
 
 set -e
@@ -68,6 +70,8 @@ do
   cp -p "${tmpdir}/${SOURCE_PROTO_BASE_DIR}/${file}" "${file}"
 done
 
+# DO NOT TOUCH! The following section is upstreamed with an internal script.
+
 # See google internal third_party/envoy/envoy-update.sh
 # ===========================================================================
 # Fix up proto imports and remove references to gogoproto.
@@ -78,22 +82,19 @@ do
     # Import mangling.
     -e 's#import "gogoproto/gogo.proto";##'
     # Remove references to gogo.proto extensions.
-    -e 's#option \(gogoproto\.[a-z_]+\) = (true|false);##'
-    -e 's#(, )?\(gogoproto\.[a-z_]+\) = (true|false),?##'
+    -e 's#option (gogoproto\.[a-z_]\+) = \(true\|false\);##'
+    -e 's#\(, \)\?(gogoproto\.[a-z_]\+) = \(true\|false\),\?##'
     # gogoproto removal can result in empty brackets.
     -e 's# \[\]##'
     # gogoproto removal can result in four spaces on a line by itself.
     -e '/^    $/d'
   )
-  # Use a temp file to workaround `sed -i` cross-platform compatibility issue.
-  tmpfile="$(mktemp)"
-  sed -E "${commands[@]}" "$f" > "$tmpfile"
+  sed -i "${commands[@]}" "$f"
 
   # gogoproto removal can leave a comma on the last element in a list.
   # This needs to run separately after all the commands above have finished
   # since it is multi-line and rewrites the output of the above patterns.
-  sed -E -e '$!N; s#(.*),([[:space:]]*\];)#\1\2#; t' -e 'P; D;' "$tmpfile" > "$f"
-  rm "$tmpfile"
+  sed -i -e '$!N; s#\(.*\),\([[:space:]]*\];\)#\1\2#; t; P; D;' "$f"
 done
 popd
 


### PR DESCRIPTION
Hierarchical LoadBalancers such as xDS will need this to create NameResolvers to resolve locality target names.