### PR TITLE
core: Make OpenCensus tags non-propagating.

### DIFF
--- a/core/src/main/java/io/grpc/internal/CensusStatsModule.java
+++ b/core/src/main/java/io/grpc/internal/CensusStatsModule.java
@@ -356,7 +356,7 @@ public final class CensusStatsModule {
       this.parentCtx = checkNotNull(parentCtx);
       TagValue methodTag = TagValue.create(fullMethodName);
       this.startCtx = module.tagger.toBuilder(parentCtx)
-          .putPropagating(DeprecatedCensusConstants.RPC_METHOD, methodTag)
+          .putLocal(DeprecatedCensusConstants.RPC_METHOD, methodTag)
           .build();
       this.stopwatch = module.stopwatchSupplier.get().start();
       if (module.recordStartedRpcs) {
@@ -442,7 +442,7 @@ public final class CensusStatsModule {
           module
               .tagger
               .toBuilder(startCtx)
-              .putPropagating(DeprecatedCensusConstants.RPC_STATUS, statusTag)
+              .putLocal(DeprecatedCensusConstants.RPC_STATUS, statusTag)
               .build());
     }
   }
@@ -647,7 +647,7 @@ public final class CensusStatsModule {
           module
               .tagger
               .toBuilder(parentCtx)
-              .putPropagating(DeprecatedCensusConstants.RPC_STATUS, statusTag)
+              .putLocal(DeprecatedCensusConstants.RPC_STATUS, statusTag)
               .build());
     }
 
@@ -672,7 +672,7 @@ public final class CensusStatsModule {
       parentCtx =
           tagger
               .toBuilder(parentCtx)
-              .putPropagating(DeprecatedCensusConstants.RPC_METHOD, methodTag)
+              .putLocal(DeprecatedCensusConstants.RPC_METHOD, methodTag)
               .build();
       return new ServerTracer(CensusStatsModule.this, parentCtx);
     }

--- a/core/src/test/java/io/grpc/internal/CensusModulesTest.java
+++ b/core/src/test/java/io/grpc/internal/CensusModulesTest.java
@@ -255,7 +255,7 @@ public class CensusModulesTest {
               Context.ROOT,
               tagger
                   .emptyBuilder()
-                  .putPropagating(StatsTestUtils.EXTRA_TAG, TagValue.create("extra value"))
+                  .putLocal(StatsTestUtils.EXTRA_TAG, TagValue.create("extra value"))
                   .build());
       ctx = ContextUtils.withValue(ctx, fakeClientParentSpan);
       Context origCtx = ctx.attach();
@@ -648,7 +648,7 @@ public class CensusModulesTest {
     // EXTRA_TAG is propagated by the FakeStatsContextFactory. Note that not all tags are
     // propagated.  The StatsContextFactory decides which tags are to propagated.  gRPC facilitates
     // the propagation by putting them in the headers.
-    TagContext clientCtx = tagger.emptyBuilder().putPropagating(
+    TagContext clientCtx = tagger.emptyBuilder().putLocal(
         StatsTestUtils.EXTRA_TAG, TagValue.create("extra-tag-value-897")).build();
     CensusStatsModule census =
         new CensusStatsModule(
@@ -689,7 +689,7 @@ public class CensusModulesTest {
     // It also put clientCtx in the Context seen by the call handler
     assertEquals(
         tagger.toBuilder(clientCtx)
-            .putPropagating(
+            .putLocal(
                 DeprecatedCensusConstants.RPC_METHOD,
                 TagValue.create(method.getFullMethodName()))
             .build(),
@@ -925,7 +925,7 @@ public class CensusModulesTest {
     assertEquals(
         tagger
             .emptyBuilder()
-            .putPropagating(
+            .putLocal(
                 DeprecatedCensusConstants.RPC_METHOD,
                 TagValue.create(method.getFullMethodName()))
             .build(),

--- a/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.java
@@ -1450,7 +1450,7 @@ public abstract class AbstractInteropTest {
             Context.ROOT,
             tagger
                 .emptyBuilder()
-                .putPropagating(StatsTestUtils.EXTRA_TAG, TagValue.create("extra value"))
+                .putLocal(StatsTestUtils.EXTRA_TAG, TagValue.create("extra value"))
                 .build());
     ctx = ContextUtils.withValue(ctx, clientParentSpan);
     Context origCtx = ctx.attach();

--- a/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/StatsTestUtils.java
@@ -204,7 +204,7 @@ public class StatsTestUtils {
       String serializedString = new String(bytes, UTF_8);
       if (serializedString.startsWith(EXTRA_TAG_HEADER_VALUE_PREFIX)) {
         return tagger.emptyBuilder()
-            .putPropagating(EXTRA_TAG,
+            .putLocal(EXTRA_TAG,
                 TagValue.create(serializedString.substring(EXTRA_TAG_HEADER_VALUE_PREFIX.length())))
             .build();
       } else {


### PR DESCRIPTION
The `method` and `status` tags shouldn't be propagated in the first place,
but in previous OpenCensus implementation all tags are propagating by
default. Now with the TagMetadata it may make sense to change them to
local tags.

This will be a breaking change to users who depend on the behavior that
these tags propagate through process boundaries.