### PR TITLE
testing: Close cert files to avoid resource leak

### DIFF
--- a/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
@@ -189,10 +189,11 @@ public class TestUtils {
     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null, null);
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
-    X509Certificate cert = (X509Certificate) cf.generateCertificate(
-        new BufferedInputStream(new FileInputStream(certChainFile)));
-    X500Principal principal = cert.getSubjectX500Principal();
-    ks.setCertificateEntry(principal.getName("RFC2253"), cert);
+    try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(certChainFile))) {
+      X509Certificate cert = (X509Certificate) cf.generateCertificate(in);
+      X500Principal principal = cert.getSubjectX500Principal();
+      ks.setCertificateEntry(principal.getName("RFC2253"), cert);
+    }
 
     // Set up trust manager factory to use our key store.
     TrustManagerFactory trustManagerFactory =

--- a/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/internal/testing/TestUtils.java
@@ -189,10 +189,13 @@ public class TestUtils {
     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null, null);
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
-    try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(certChainFile))) {
+    BufferedInputStream in = new BufferedInputStream(new FileInputStream(certChainFile));
+    try {
       X509Certificate cert = (X509Certificate) cf.generateCertificate(in);
       X500Principal principal = cert.getSubjectX500Principal();
       ks.setCertificateEntry(principal.getName("RFC2253"), cert);
+    } finally {
+      in.close();
     }
 
     // Set up trust manager factory to use our key store.

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -120,10 +120,11 @@ public class TestUtils {
     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null, null);
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
-    X509Certificate cert = (X509Certificate) cf.generateCertificate(
-        new BufferedInputStream(new FileInputStream(certChainFile)));
-    X500Principal principal = cert.getSubjectX500Principal();
-    ks.setCertificateEntry(principal.getName("RFC2253"), cert);
+    try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(certChainFile))) {
+      X509Certificate cert = (X509Certificate) cf.generateCertificate(in);
+      X500Principal principal = cert.getSubjectX500Principal();
+      ks.setCertificateEntry(principal.getName("RFC2253"), cert);
+    }
 
     // Set up trust manager factory to use our key store.
     TrustManagerFactory trustManagerFactory =

--- a/testing/src/main/java/io/grpc/testing/TestUtils.java
+++ b/testing/src/main/java/io/grpc/testing/TestUtils.java
@@ -120,10 +120,13 @@ public class TestUtils {
     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null, null);
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
-    try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(certChainFile))) {
+    BufferedInputStream in = new BufferedInputStream(new FileInputStream(certChainFile));
+    try {
       X509Certificate cert = (X509Certificate) cf.generateCertificate(in);
       X500Principal principal = cert.getSubjectX500Principal();
       ks.setCertificateEntry(principal.getName("RFC2253"), cert);
+    } finally {
+      in.close();
     }
 
     // Set up trust manager factory to use our key store.


### PR DESCRIPTION
Without this, test failures are generated within google3 for our
(firestore) integration tests.