### PR TITLE
travis.yml: Choose dist trusty to fix Java 8 (1.16.x backport)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ after_success:
 os:
   - linux
 
+dist: trusty
+
 jdk:
   # net.ltgt.errorprone supports jdk8 and jdk9, but has problems with jdk10
   # For jdk10, we need to switch over to using net.ltgt.errorprone-javacplugin,


### PR DESCRIPTION
The upgrade to Xenial broke Java 8, as Trusty contained Java 8 whereas
Xenial uses Java 11. So this "flipped" which version was necessary to be
downloaded from Java 11 to Java 8. And Java 8 is not supported by
install-jdk.sh.

Workaround as seen at:
https://travis-ci.community/t/oracle-jdk-11-and-10-are-pre-installed-not-the-openjdk-builds/785/16

I hope this is temporary.

Backport of #5659