### PR TITLE
examples: make tls example easier to run

### DIFF
--- a/examples/example-tls/README.md
+++ b/examples/example-tls/README.md
@@ -42,8 +42,8 @@ You can use the following script to generate self-signed certificates for grpc-j
 ```bash
 mkdir -p /tmp/sslcert
 pushd /tmp/sslcert
-# Changes these CN's to match your hosts in your environment if needed.
-SERVER_CA_CN=localhost-ca # must be different than SERVER_CN
+# Change these CN's to match your hosts in your environment if needed.
+SERVER_CA_CN=localhost-ca
 SERVER_CN=localhost
 CLIENT_CN=localhost # Used when doing mutual TLS
 

--- a/examples/example-tls/README.md
+++ b/examples/example-tls/README.md
@@ -43,6 +43,7 @@ You can use the following script to generate self-signed certificates for grpc-j
 mkdir -p /tmp/sslcert
 pushd /tmp/sslcert
 # Changes these CN's to match your hosts in your environment if needed.
+SERVER_CA_CN=localhost-ca # must be different than SERVER_CN
 SERVER_CN=localhost
 CLIENT_CN=localhost # Used when doing mutual TLS
 
@@ -50,7 +51,7 @@ echo Generate CA key:
 openssl genrsa -passout pass:1111 -des3 -out ca.key 4096
 echo Generate CA certificate:
 # Generates ca.crt which is the trustCertCollectionFile
-openssl req -passin pass:1111 -new -x509 -days 365 -key ca.key -out ca.crt -subj "/CN=${SERVER_CN}"
+openssl req -passin pass:1111 -new -x509 -days 365 -key ca.key -out ca.crt -subj "/CN=${SERVER_CA_CN}"
 echo Generate server key:
 openssl genrsa -passout pass:1111 -des3 -out server.key 4096
 echo Generate server signing request:
@@ -90,9 +91,9 @@ popd
 
 ```bash
 # Run the server:
-./build/install/example-tls/bin/hello-world-tls-server localhost 54440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem /tmp/sslcert/ca.crt
+./build/install/example-tls/bin/hello-world-tls-server localhost 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem /tmp/sslcert/ca.crt
 # In another terminal run the client
-./build/install/example-tls/bin/hello-world-tls-client localhost 54440 /tmp/sslcert/ca.crt /tmp/sslcert/client.crt /tmp/sslcert/client.pem
+./build/install/example-tls/bin/hello-world-tls-client localhost 50440 /tmp/sslcert/ca.crt /tmp/sslcert/client.crt /tmp/sslcert/client.pem
 ```
 
 That's it!

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.22.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def nettyTcNativeVersion = '2.0.20.Final'
+def nettyTcNativeVersion = '2.0.22.Final'
 def protocVersion = '3.7.1'
 
 dependencies {


### PR DESCRIPTION
* Make the server cert able to be verified by the ca cert in openssl
* Make the port number consistent in each example (easy to copy paste wrong one)
* use correct netty-tcnative

cc: @jtattermusch 