### PR TITLE
buildscripts: Specify Bazel version to use (v1.19.x)

### DIFF
--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -4,6 +4,8 @@ set -exu -o pipefail
 cat /VERSION
 bazel version
 
+use_bazel.sh 0.19.0
+
 cd github/grpc-java
 bazel build ...
 


### PR DESCRIPTION
The version Kokoro uses changes over time. We need a stable version so
our build doesn't break when Bazel is upgraded.

------

This was done for v1.20.x and later in #5411