### PR TITLE
travis.yml: Remove openjdk10 from matrix (v1.14.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ dist: trusty
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
 
 notifications:
   email: false


### PR DESCRIPTION
It isn't available any more.

-----

This is only applicable to v1.14.x