### PR TITLE
travis.yml: Remove openjdk11 from matrix (v1.17.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ jdk:
   # processor based plugin.
   - oraclejdk8  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
   - oraclejdk9  # if both jdk 8 and 9 are removed, migrate to net.ltgt.errorprone-javacplugin (see above comment)
-  - openjdk11
 
 notifications:
   email: false


### PR DESCRIPTION
OpenJDK 11 is failing to compile because it refuses the -html4 option,
because we are using -Werror. Removing it instead of figuring out a fix.
It's unclear if/how it worked previously.

---

This problem only applies to v1.17.x.