### PR TITLE
xds/third_party: update xds load report proto by importing latest files from envoy repo

### DIFF
--- a/xds/third_party/envoy/import.sh
+++ b/xds/third_party/envoy/import.sh
@@ -20,7 +20,7 @@
 set -e
 BRANCH=master
 # import VERSION from one of the google internal CLs
-VERSION=109d23a6648b1ac7723c4b2f125e913125bb9a84
+VERSION=228a963d1308eb1b06e2e8b7387e0bfa72fe77ea
 GIT_REPO="https://github.com/envoyproxy/envoy.git"
 GIT_BASE_DIR=envoy
 SOURCE_PROTO_BASE_DIR=envoy/api

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/cds.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/cds.proto
@@ -58,9 +58,6 @@ message Cluster {
   // :ref:`statistics <config_cluster_manager_cluster_stats>` if :ref:`alt_stat_name
   // <envoy_api_field_Cluster.alt_stat_name>` is not provided.
   // Any ``:`` in the cluster name will be converted to ``_`` when emitting statistics.
-  // By default, the maximum length of a cluster name is limited to 60
-  // characters. This limit can be increased by setting the
-  // :option:`--max-obj-name-len` command line argument to the desired value.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // An optional alternative to the cluster name to be used while emitting stats.
@@ -527,6 +524,27 @@ message Cluster {
     // because merging those updates isn't currently safe. See
     // https://github.com/envoyproxy/envoy/pull/3941.
     google.protobuf.Duration update_merge_window = 4;
+
+    // If set to true, Envoy will not consider new hosts when computing load balancing weights until
+    // they have been health checked for the first time. This will have no effect unless
+    // active health checking is also configured.
+    //
+    // Ignoring a host means that for any load balancing calculations that adjust weights based
+    // on the ratio of eligible hosts and total hosts (priority spillover, locality weighting and
+    // panic mode) Envoy will exclude these hosts in the denominator.
+    //
+    // For example, with hosts in two priorities P0 and P1, where P0 looks like
+    // {healthy, unhealthy (new), unhealthy (new)}
+    // and where P1 looks like
+    // {healthy, healthy}
+    // all traffic will still hit P0, as 1 / (3 - 2) = 1.
+    //
+    // Enabling this will allow scaling up the number of hosts for a given cluster without entering
+    // panic mode or triggering priority spillover, assuming the hosts pass the first health check.
+    //
+    // If panic mode is triggered, new hosts are still eligible for traffic; they simply do not
+    // contribute to the calculation when deciding whether panic mode is enabled or not.
+    bool ignore_new_hosts_until_first_hc = 5;
   }
 
   // Common configuration for all load balancer implementations.

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/address.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/address.proto
@@ -52,10 +52,11 @@ message SocketAddress {
     // named resolver is capable of named port resolution.
     string named_port = 4;
   }
-  // The name of the resolver. This must have been registered with Envoy. If this is
-  // empty, a context dependent default applies. If address is a hostname this
-  // should be set for resolution other than DNS. If the address is a concrete
-  // IP address, no resolution will occur.
+  // The name of the custom resolver. This must have been registered with Envoy. If
+  // this is empty, a context dependent default applies. If the address is a concrete
+  // IP address, no resolution will occur. If address is a hostname this
+  // should be set for resolution other than DNS. Specifying a custom resolver with
+  // *STRICT_DNS* or *LOGICAL_DNS* will generate an error at runtime.
   string resolver_name = 5;
 
   // When binding to an IPv6 address above, this enables `IPv4 compatibility

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/core/health_check.proto
@@ -42,6 +42,11 @@ message HealthCheck {
     }
   ];
 
+  // An optional jitter amount in milliseconds. If specified, Envoy will start health
+  // checking after for a random time in ms between 0 and initial_jitter. This only
+  // applies to the first health check.
+  google.protobuf.Duration initial_jitter = 20;
+
   // An optional jitter amount in milliseconds. If specified, during every
   // interval Envoy will add interval_jitter to the wait time.
   google.protobuf.Duration interval_jitter = 3;

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/discovery.proto
@@ -152,6 +152,11 @@ message DeltaDiscoveryRequest {
   // These two fields can be set for all types of DeltaDiscoveryRequests
   // (initial, ACK/NACK or spontaneous).
   //
+  // NOTE: the server must respond with all resources listed in resource_names_subscribe,
+  // even if it believes the client has the most recent version of them. The reason:
+  // the client may have dropped them, but then regained interest before it had a chance
+  // to send the unsubscribe message. See DeltaSubscriptionStateTest.RemoveThenAdd.
+  //
   // A list of Resource names to add to the list of tracked resources.
   repeated string resource_names_subscribe = 3;
 

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/endpoint.proto
@@ -132,4 +132,12 @@ message LocalityLbEndpoints {
   //
   // Priorities should range from 0 (highest) to N (lowest) without skipping.
   uint32 priority = 5 [(validate.rules).uint32 = {lte: 128}];
+
+  // Optional: Per locality proximity value which indicates how close this
+  // locality is from the source locality. This value only provides ordering
+  // information (lower the value, closer it is to the source locality).
+  // This will be consumed by load balancing schemes that need proximity order
+  // to determine where to route the requests.
+  // [#not-implemented-hide:]
+  google.protobuf.UInt32Value proximity = 6;
 }

--- a/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/envoy/api/v2/endpoint/load_report.proto
@@ -25,15 +25,6 @@ message UpstreamLocalityStats {
   // collected from. Zone and region names could be empty if unknown.
   core.Locality locality = 1;
 
-  // The total number of requests sent by this Envoy since the last report. This
-  // information is aggregated over all the upstream Endpoints. total_requests
-  // can be inferred from:
-  //
-  // .. code-block:: none
-  //
-  //   total_requests = total_successful_requests + total_requests_in_progress +
-  //     total_error_requests
-  //
   // The total number of requests successfully completed by the endpoints in the
   // locality.
   uint64 total_successful_requests = 2;
@@ -44,6 +35,11 @@ message UpstreamLocalityStats {
   // The total number of requests that failed due to errors at the endpoint,
   // aggregated over all endpoints in the locality.
   uint64 total_error_requests = 4;
+
+  // The total number of requests that were issued by this Envoy since
+  // the last report. This information is aggregated over all the
+  // upstream endpoints in the locality.
+  uint64 total_issued_requests = 8;
 
   // Stats for multi-dimensional load balancing.
   repeated EndpointLoadMetricStats load_metric_stats = 5;
@@ -66,16 +62,6 @@ message UpstreamEndpointStats {
   // endpoint. Envoy will pass this directly to the management server.
   google.protobuf.Struct metadata = 6;
 
-  // The total number of requests successfully completed by the endpoint. A
-  // single HTTP or gRPC request or stream is counted as one request. A TCP
-  // connection is also treated as one request. There is no explicit
-  // total_requests field below for an endpoint, but it may be inferred from:
-  //
-  // .. code-block:: none
-  //
-  //   total_requests = total_successful_requests + total_requests_in_progress +
-  //     total_error_requests
-  //
   // The total number of requests successfully completed by the endpoints in the
   // locality. These include non-5xx responses for HTTP, where errors
   // originate at the client and the endpoint responded successfully. For gRPC,
@@ -96,6 +82,11 @@ message UpstreamEndpointStats {
   //   - Unknown
   //   - DataLoss
   uint64 total_error_requests = 4;
+
+  // The total number of requests that were issued to this endpoint
+  // since the last report. A single TCP connection, HTTP or gRPC
+  // request or stream is counted as one request.
+  uint64 total_issued_requests = 7;
 
   // Stats for multi-dimensional load balancing.
   repeated EndpointLoadMetricStats load_metric_stats = 5;
@@ -133,13 +124,7 @@ message ClusterStats {
 
   // Cluster-level stats such as total_successful_requests may be computed by
   // summing upstream_locality_stats. In addition, below there are additional
-  // cluster-wide stats. The following total_requests equality holds at the
-  // cluster-level:
-  //
-  // .. code-block:: none
-  //
-  //   sum_locality(total_successful_requests) + sum_locality(total_requests_in_progress) +
-  //     sum_locality(total_error_requests) + total_dropped_requests`
+  // cluster-wide stats.
   //
   // The total number of dropped requests. This covers requests
   // deliberately dropped by the drop_overload policy and circuit breaking.

--- a/xds/third_party/envoy/src/main/proto/udpa/data/orca/v1/orca_load_report.proto
+++ b/xds/third_party/envoy/src/main/proto/udpa/data/orca/v1/orca_load_report.proto
@@ -22,10 +22,14 @@ message OrcaLoadReport {
   // during the request.
   double mem_utilization = 2 [(validate.rules).double.gte = 0, (validate.rules).double.lte = 1];
 
+  // Total RPS being served by an endpoint. This should cover all services that an endpoint is
+  // responsible for.
+  uint64 rps = 3;
+
   // Application specific requests costs. Each value may be an absolute cost (e.g.
   // 3487 bytes of storage) or utilization associated with the request,
   // expressed as a fraction of total resources available. Utilization
   // metrics should be derived from a sample or measurement taken
   // during the request.
-  map<string, double> request_cost_or_utilization = 3;
+  map<string, double> request_cost_or_utilization = 4;
 }


### PR DESCRIPTION
Envoy's xds load_report proto added a [new field](https://github.com/envoyproxy/envoy/blob/5a92867ab5437861b072921b11e9083cf0c63aa5/api/envoy/api/v2/endpoint/load_report.proto#L42) to `LoadStatsRequest`.