### PR TITLE
xds: add counts for recently issued calls in client side load reporting

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
@@ -73,7 +73,8 @@ final class XdsLoadStatsStore implements StatsStore {
       localityStatsBuilder
           .setTotalSuccessfulRequests(snapshot.getCallsFinished() - snapshot.getCallsFailed())
           .setTotalErrorRequests(snapshot.getCallsFailed())
-          .setTotalRequestsInProgress(snapshot.getCallsInProgress());
+          .setTotalRequestsInProgress(snapshot.getCallsInProgress())
+          .setTotalIssuedRequests(snapshot.getCallsIssued());
       statsBuilder.addUpstreamLocalityStats(localityStatsBuilder);
       // Discard counters for localities that are no longer exposed by the remote balancer and
       // no RPCs ongoing.
@@ -150,7 +151,8 @@ final class XdsLoadStatsStore implements StatsStore {
   }
 
   /**
-   * Blueprint for counters that can can record number of calls in-progress, finished, failed.
+   * Blueprint for counters that can can record number of calls in-progress, finished, failed and
+   * issued.
    */
   abstract static class StatsCounter {
 
@@ -163,6 +165,8 @@ final class XdsLoadStatsStore implements StatsStore {
     abstract void incrementCallsFinished();
 
     abstract void incrementCallsFailed();
+
+    abstract void incrementCallsIssued();
 
     abstract ClientLoadSnapshot snapshot();
 

--- a/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
@@ -24,6 +24,7 @@ import io.envoyproxy.envoy.api.v2.core.Locality;
 import io.envoyproxy.envoy.api.v2.endpoint.ClusterStats;
 import io.envoyproxy.envoy.api.v2.endpoint.ClusterStats.DroppedRequests;
 import io.envoyproxy.envoy.api.v2.endpoint.UpstreamLocalityStats;
+import io.grpc.Status;
 import io.grpc.xds.ClientLoadCounter.ClientLoadSnapshot;
 import io.grpc.xds.XdsLoadReportClientImpl.StatsStore;
 import java.util.Map;
@@ -71,7 +72,7 @@ final class XdsLoadStatsStore implements StatsStore {
       UpstreamLocalityStats.Builder localityStatsBuilder =
           UpstreamLocalityStats.newBuilder().setLocality(entry.getKey());
       localityStatsBuilder
-          .setTotalSuccessfulRequests(snapshot.getCallsFinished() - snapshot.getCallsFailed())
+          .setTotalSuccessfulRequests(snapshot.getCallsSucceeded())
           .setTotalErrorRequests(snapshot.getCallsFailed())
           .setTotalRequestsInProgress(snapshot.getCallsInProgress())
           .setTotalIssuedRequests(snapshot.getCallsIssued());
@@ -151,22 +152,16 @@ final class XdsLoadStatsStore implements StatsStore {
   }
 
   /**
-   * Blueprint for counters that can can record number of calls in-progress, finished, failed and
+   * Blueprint for counters that can can record number of calls in-progress, succeeded, failed and
    * issued.
    */
   abstract static class StatsCounter {
 
     private boolean active = true;
 
-    abstract void incrementCallsInProgress();
+    abstract void recordCallStarted();
 
-    abstract void decrementCallsInProgress();
-
-    abstract void incrementCallsFinished();
-
-    abstract void incrementCallsFailed();
-
-    abstract void incrementCallsIssued();
+    abstract void recordCallFinished(Status status);
 
     abstract ClientLoadSnapshot snapshot();
 

--- a/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
@@ -50,39 +50,32 @@ public class ClientLoadCounterTest {
   public void setUp() {
     counter = new ClientLoadCounter();
     ClientLoadSnapshot emptySnapshot = counter.snapshot();
-    assertThat(emptySnapshot.getCallsInProgress()).isEqualTo(0);
-    assertThat(emptySnapshot.getCallsFinished()).isEqualTo(0);
-    assertThat(emptySnapshot.getCallsFailed()).isEqualTo(0);
-    assertThat(emptySnapshot.getCallsIssued()).isEqualTo(0);
+    assertSnapshot(emptySnapshot, 0, 0, 0, 0);
   }
 
   @Test
   public void snapshotContainsEverything() {
-    long numFinishedCalls = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+    long numSucceededCalls = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     long numInProgressCalls = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
-    long numFailedCalls = ThreadLocalRandom.current().nextLong(numFinishedCalls);
+    long numFailedCalls = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     long numIssuedCalls = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     counter =
-        new ClientLoadCounter(numFinishedCalls, numInProgressCalls, numFailedCalls, numIssuedCalls);
+        new ClientLoadCounter(numSucceededCalls, numInProgressCalls, numFailedCalls,
+            numIssuedCalls);
     ClientLoadSnapshot snapshot = counter.snapshot();
-    assertThat(snapshot.getCallsFinished()).isEqualTo(numFinishedCalls);
-    assertThat(snapshot.getCallsInProgress()).isEqualTo(numInProgressCalls);
-    assertThat(snapshot.getCallsFailed()).isEqualTo(numFailedCalls);
+    assertSnapshot(snapshot, numSucceededCalls, numInProgressCalls, numFailedCalls, numIssuedCalls);
     String snapshotStr = snapshot.toString();
-    assertThat(snapshotStr).contains("callsFinished=" + numFinishedCalls);
+    assertThat(snapshotStr).contains("callsSucceeded=" + numSucceededCalls);
     assertThat(snapshotStr).contains("callsInProgress=" + numInProgressCalls);
     assertThat(snapshotStr).contains("callsFailed=" + numFailedCalls);
     assertThat(snapshotStr).contains("callsIssued=" + numIssuedCalls);
 
     // Snapshot only accounts for stats happening after previous snapshot.
     snapshot = counter.snapshot();
-    assertThat(snapshot.getCallsFinished()).isEqualTo(0);
-    assertThat(snapshot.getCallsInProgress()).isEqualTo(numInProgressCalls);
-    assertThat(snapshot.getCallsFailed()).isEqualTo(0);
-    assertThat(snapshot.getCallsIssued()).isEqualTo(0);
+    assertSnapshot(snapshot, 0, numInProgressCalls, 0, 0);
 
     snapshotStr = snapshot.toString();
-    assertThat(snapshotStr).contains("callsFinished=0");
+    assertThat(snapshotStr).contains("callsSucceeded=0");
     assertThat(snapshotStr).contains("callsInProgress=" + numInProgressCalls);
     assertThat(snapshotStr).contains("callsFailed=0");
     assertThat(snapshotStr).contains("callsIssued=0");
@@ -90,25 +83,18 @@ public class ClientLoadCounterTest {
 
   @Test
   public void normalCountingOperations() {
-    ClientLoadSnapshot preSnapshot = counter.snapshot();
-    counter.incrementCallsInProgress();
-    ClientLoadSnapshot afterSnapshot = counter.snapshot();
-    assertThat(afterSnapshot.getCallsInProgress()).isEqualTo(preSnapshot.getCallsInProgress() + 1);
-    counter.decrementCallsInProgress();
-    afterSnapshot = counter.snapshot();
-    assertThat(afterSnapshot.getCallsInProgress()).isEqualTo(preSnapshot.getCallsInProgress());
+    counter.recordCallStarted();
+    ClientLoadSnapshot snapshot = counter.snapshot();
+    assertSnapshot(snapshot, 0, 1, 0, 1);
 
-    counter.incrementCallsFinished();
-    afterSnapshot = counter.snapshot();
-    assertThat(afterSnapshot.getCallsFinished()).isEqualTo(1);
+    counter.recordCallFinished(Status.OK);
+    snapshot = counter.snapshot();
+    assertSnapshot(snapshot, 1, 0, 0, 0);
 
-    counter.incrementCallsFailed();
-    afterSnapshot = counter.snapshot();
-    assertThat(afterSnapshot.getCallsFailed()).isEqualTo(1);
-
-    counter.incrementCallsIssued();
-    afterSnapshot = counter.snapshot();
-    assertThat(afterSnapshot.getCallsIssued()).isEqualTo(1);
+    counter.recordCallStarted();
+    counter.recordCallFinished(Status.CANCELLED);
+    snapshot = counter.snapshot();
+    assertSnapshot(snapshot, 0, 0, 1, 1);
   }
 
   @Test
@@ -117,16 +103,10 @@ public class ClientLoadCounterTest {
         new XdsClientLoadRecorder(counter, NOOP_CLIENT_STREAM_TRACER_FACTORY);
     ClientStreamTracer tracer = recorder1.newClientStreamTracer(STREAM_INFO, new Metadata());
     ClientLoadSnapshot snapshot = counter.snapshot();
-    assertThat(snapshot.getCallsFinished()).isEqualTo(0);
-    assertThat(snapshot.getCallsInProgress()).isEqualTo(1);
-    assertThat(snapshot.getCallsFailed()).isEqualTo(0);
-    assertThat(snapshot.getCallsIssued()).isEqualTo(1);
+    assertSnapshot(snapshot, 0, 1, 0, 1);
     tracer.streamClosed(Status.OK);
     snapshot = counter.snapshot();
-    assertThat(snapshot.getCallsFinished()).isEqualTo(1);
-    assertThat(snapshot.getCallsInProgress()).isEqualTo(0);
-    assertThat(snapshot.getCallsFailed()).isEqualTo(0);
-    assertThat(snapshot.getCallsIssued()).isEqualTo(0);
+    assertSnapshot(snapshot, 1, 0, 0, 0);
 
     // Create a second XdsClientLoadRecorder with the same counter, stats are aggregated together.
     XdsClientLoadRecorder recorder2 =
@@ -134,9 +114,17 @@ public class ClientLoadCounterTest {
     recorder1.newClientStreamTracer(STREAM_INFO, new Metadata()).streamClosed(Status.ABORTED);
     recorder2.newClientStreamTracer(STREAM_INFO, new Metadata()).streamClosed(Status.CANCELLED);
     snapshot = counter.snapshot();
-    assertThat(snapshot.getCallsFinished()).isEqualTo(2);
-    assertThat(snapshot.getCallsInProgress()).isEqualTo(0);
-    assertThat(snapshot.getCallsFailed()).isEqualTo(2);
-    assertThat(snapshot.getCallsIssued()).isEqualTo(2);
+    assertSnapshot(snapshot, 0, 0, 2, 2);
+  }
+
+  private void assertSnapshot(ClientLoadSnapshot snapshot,
+      long callsSucceeded,
+      long callsInProgress,
+      long callsFailed,
+      long callsIssued) {
+    assertThat(snapshot.getCallsSucceeded()).isEqualTo(callsSucceeded);
+    assertThat(snapshot.getCallsInProgress()).isEqualTo(callsInProgress);
+    assertThat(snapshot.getCallsFailed()).isEqualTo(callsFailed);
+    assertThat(snapshot.getCallsIssued()).isEqualTo(callsIssued);
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
@@ -353,8 +353,8 @@ public class XdsLoadReportClientImplTest {
     inOrder.verify(requestObserver).onNext(EXPECTED_INITIAL_REQ);
 
     long callsInProgress = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
-    long callsFinished = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
-    long callsFailed = callsFinished - ThreadLocalRandom.current().nextLong(callsFinished);
+    long callsSucceeded = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+    long callsFailed = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     long callsIssued = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     long numLbDrops = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     long numThrottleDrops = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
@@ -365,7 +365,7 @@ public class XdsLoadReportClientImplTest {
         .addUpstreamLocalityStats(UpstreamLocalityStats.newBuilder()
             .setLocality(TEST_LOCALITY)
             .setTotalRequestsInProgress(callsInProgress)
-            .setTotalSuccessfulRequests(callsFinished - callsFailed)
+            .setTotalSuccessfulRequests(callsSucceeded)
             .setTotalErrorRequests(callsFailed)
             .setTotalIssuedRequests(callsIssued))
         .addDroppedRequests(DroppedRequests.newBuilder()

--- a/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
@@ -355,6 +355,7 @@ public class XdsLoadReportClientImplTest {
     long callsInProgress = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     long callsFinished = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     long callsFailed = callsFinished - ThreadLocalRandom.current().nextLong(callsFinished);
+    long callsIssued = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     long numLbDrops = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     long numThrottleDrops = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
 
@@ -365,7 +366,8 @@ public class XdsLoadReportClientImplTest {
             .setLocality(TEST_LOCALITY)
             .setTotalRequestsInProgress(callsInProgress)
             .setTotalSuccessfulRequests(callsFinished - callsFailed)
-            .setTotalErrorRequests(callsFailed))
+            .setTotalErrorRequests(callsFailed)
+            .setTotalIssuedRequests(callsIssued))
         .addDroppedRequests(DroppedRequests.newBuilder()
             .setCategory("lb")
             .setDroppedCount(numLbDrops))

--- a/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
@@ -230,8 +230,8 @@ public class XdsLoadStatsStoreTest {
     ClusterStats expectedReport =
         buildClusterStats(
             Arrays.asList(
-                buildUpstreamLocalityStats(LOCALITY1, 4315 - 23, 3421, 23, 593, null),
-                buildUpstreamLocalityStats(LOCALITY2, 41234 - 431, 432, 431, 702, null)
+                buildUpstreamLocalityStats(LOCALITY1, 4315, 3421, 23, 593, null),
+                buildUpstreamLocalityStats(LOCALITY2, 41234, 432, 431, 702, null)
             ),
             null);
 

--- a/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
@@ -76,13 +76,15 @@ public class XdsLoadStatsStoreTest {
       long callsSucceed,
       long callsInProgress,
       long callsFailed,
+      long callsIssued,
       @Nullable List<EndpointLoadMetricStats> metrics) {
     UpstreamLocalityStats.Builder builder =
         UpstreamLocalityStats.newBuilder()
             .setLocality(locality)
             .setTotalSuccessfulRequests(callsSucceed)
             .setTotalErrorRequests(callsFailed)
-            .setTotalRequestsInProgress(callsInProgress);
+            .setTotalRequestsInProgress(callsInProgress)
+            .setTotalIssuedRequests(callsIssued);
     if (metrics != null) {
       builder.addAllLoadMetricStats(metrics);
     }
@@ -216,11 +218,11 @@ public class XdsLoadStatsStoreTest {
     StatsCounter counter1 = mock(StatsCounter.class);
     when(counter1.isActive()).thenReturn(true);
     when(counter1.snapshot())
-        .thenReturn(new ClientLoadSnapshot(4315, 3421, 23),
-            new ClientLoadSnapshot(0, 543, 0));
+        .thenReturn(new ClientLoadSnapshot(4315, 3421, 23, 593),
+            new ClientLoadSnapshot(0, 543, 0, 0));
     StatsCounter counter2 = mock(StatsCounter.class);
-    when(counter2.snapshot()).thenReturn(new ClientLoadSnapshot(41234, 432, 431),
-        new ClientLoadSnapshot(0, 432, 0));
+    when(counter2.snapshot()).thenReturn(new ClientLoadSnapshot(41234, 432, 431, 702),
+        new ClientLoadSnapshot(0, 432, 0, 0));
     when(counter2.isActive()).thenReturn(true);
     localityLoadCounters.put(LOCALITY1, counter1);
     localityLoadCounters.put(LOCALITY2, counter2);
@@ -228,8 +230,8 @@ public class XdsLoadStatsStoreTest {
     ClusterStats expectedReport =
         buildClusterStats(
             Arrays.asList(
-                buildUpstreamLocalityStats(LOCALITY1, 4315 - 23, 3421, 23, null),
-                buildUpstreamLocalityStats(LOCALITY2, 41234 - 431, 432, 431, null)
+                buildUpstreamLocalityStats(LOCALITY1, 4315 - 23, 3421, 23, 593, null),
+                buildUpstreamLocalityStats(LOCALITY2, 41234 - 431, 432, 431, 702, null)
             ),
             null);
 
@@ -240,10 +242,8 @@ public class XdsLoadStatsStoreTest {
     expectedReport =
         buildClusterStats(
             Arrays.asList(
-                buildUpstreamLocalityStats(LOCALITY1, 0, 543, 0,
-                    null),
-                buildUpstreamLocalityStats(LOCALITY2, 0, 432, 0,
-                    null)
+                buildUpstreamLocalityStats(LOCALITY1, 0, 543, 0, 0, null),
+                buildUpstreamLocalityStats(LOCALITY2, 0, 432, 0, 0, null)
             ),
             null);
     assertClusterStatsEqual(expectedReport, loadStore.generateLoadReport());


### PR DESCRIPTION
This supports the recent change of adding the [new field](https://github.com/envoyproxy/envoy/blob/c054a0faf1a7c959476ffcc1c4cfdcc77adff090/api/envoy/api/v2/endpoint/load_report.proto#L42) in load reporting proto.