### PR TITLE
buildscripts: Specify Bazel version to use (1.16.x backport)

### DIFF
--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -3,6 +3,8 @@
 set -exu -o pipefail
 cat /VERSION
 
+use_bazel.sh 0.19.0
+
 cd github/grpc-java
 bazel build ...
 

--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -3,7 +3,7 @@
 set -exu -o pipefail
 cat /VERSION
 
-use_bazel.sh 0.11.0
+use_bazel.sh 0.12.0
 
 cd github/grpc-java
 bazel build ...

--- a/buildscripts/kokoro/bazel.sh
+++ b/buildscripts/kokoro/bazel.sh
@@ -3,7 +3,7 @@
 set -exu -o pipefail
 cat /VERSION
 
-use_bazel.sh 0.19.0
+use_bazel.sh 0.11.0
 
 cd github/grpc-java
 bazel build ...


### PR DESCRIPTION
The version Kokoro uses changes over time. We need a stable version so
our build doesn't break when Bazel is upgraded.

Backport of #5739