### PR TITLE
api: Fix doc for default value of idleTimeout()

### DIFF
--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -281,9 +281,7 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
    *
    * <p>In idle mode the channel shuts down all connections, the NameResolver and the
    * LoadBalancer. A new RPC would take the channel out of idle mode. A channel starts in idle mode.
-   *
-   * <p>By default the channel will never go to idle mode after it leaves the initial idle
-   * mode.
+   * Defaults to 30 minutes.
    *
    * <p>This is an advisory option. Do not rely on any specific behavior related to this option.
    *


### PR DESCRIPTION
It appears the docs were not updated when this was changed in d74091f5, which
was first released in v1.1.