### PR TITLE
core: Handle IDLE MODE race in DelayedClientTransport (v1.21.x backport)

### DIFF
--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -579,4 +579,24 @@ public class DelayedClientTransportTest {
     verify(picker2).pickSubchannel(args);
     verify(picker2).pickSubchannel(args);
   }
+
+  @Test
+  public void newStream_racesWithReprocessIdleMode() throws Exception {
+    SubchannelPicker picker = new SubchannelPicker() {
+      @Override public PickResult pickSubchannel(PickSubchannelArgs args) {
+        // Assume entering idle mode raced with the pick
+        delayedTransport.reprocess(null);
+        // Act like IDLE LB
+        return PickResult.withNoResult();
+      }
+    };
+
+    // Because there is no pending stream yet, it will do nothing but save the picker.
+    delayedTransport.reprocess(picker);
+
+    ClientStream stream = delayedTransport.newStream(method, headers, callOptions);
+    stream.start(streamListener);
+    assertTrue(delayedTransport.hasPendingStreams());
+    verify(transportListener).transportInUse(true);
+  }
 }


### PR DESCRIPTION
We check for idle mode the first time we try newStream(), but failed to when
newStream races with reprocess(). This would normally be a very rare race,
except when you consider that AbstractChannelBuilder will call
managedChannel.enterIdle() when the network changes.

Fixes #5729

-------

This is a backport of #5749