### PR TITLE
examples: Use encouraged APIs and avoid over-specifying configuration

### DIFF
--- a/examples/example-tls/README.md
+++ b/examples/example-tls/README.md
@@ -24,7 +24,7 @@ Running the hello world with TLS is the same as the normal hello world, but take
 **hello-world-tls-server**:
 
 ```text
-USAGE: HelloWorldServerTls host port certChainFilePath privateKeyFilePath [trustCertCollectionFilePath]
+USAGE: HelloWorldServerTls port certChainFilePath privateKeyFilePath [trustCertCollectionFilePath]
   Note: You only need to supply trustCertCollectionFilePath if you want to enable Mutual TLS.
 ```
 
@@ -82,7 +82,7 @@ popd
 
 ```bash
 # Run the server:
-./build/install/example-tls/bin/hello-world-tls-server localhost 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem
+./build/install/example-tls/bin/hello-world-tls-server 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem
 # In another terminal run the client
 ./build/install/example-tls/bin/hello-world-tls-client localhost 50440 /tmp/sslcert/ca.crt
 ```
@@ -91,7 +91,7 @@ popd
 
 ```bash
 # Run the server:
-./build/install/example-tls/bin/hello-world-tls-server localhost 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem /tmp/sslcert/ca.crt
+./build/install/example-tls/bin/hello-world-tls-server 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem /tmp/sslcert/ca.crt
 # In another terminal run the client
 ./build/install/example-tls/bin/hello-world-tls-client localhost 50440 /tmp/sslcert/ca.crt /tmp/sslcert/client.crt /tmp/sslcert/client.pem
 ```
@@ -108,7 +108,7 @@ If you prefer to use Maven:
 ```
 $ mvn verify
 $ # Run the server
-$ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworldtls.HelloWorldServerTls -Dexec.args="localhost 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem"
+$ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworldtls.HelloWorldServerTls -Dexec.args="50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem"
 $ # In another terminal run the client
 $ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworldtls.HelloWorldClientTls -Dexec.args="localhost 50440 /tmp/sslcert/ca.crt"
 ```
@@ -119,7 +119,7 @@ If you prefer to use Bazel:
 ```
 $ bazel build :hello-world-tls-server :hello-world-tls-client
 $ # Run the server
-$ ../bazel-bin/hello-world-tls-server localhost 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem
+$ ../bazel-bin/hello-world-tls-server 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem
 $ # In another terminal run the client
 $ ../bazel-bin/hello-world-tls-client localhost 50440 /tmp/sslcert/ca.crt
 ```

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.22.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.7.1</protoc.version>
-    <netty.tcnative.version>2.0.20.Final</netty.tcnative.version>
+    <netty.tcnative.version>2.0.22.Final</netty.tcnative.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
+++ b/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
@@ -22,7 +22,6 @@ import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -63,7 +62,6 @@ public class HelloWorldClientTls {
                                SslContext sslContext) throws SSLException {
 
         this(NettyChannelBuilder.forAddress(host, port)
-                .negotiationType(NegotiationType.TLS)
                 .sslContext(sslContext)
                 .build());
     }

--- a/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldServerTls.java
+++ b/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldServerTls.java
@@ -65,12 +65,11 @@ public class HelloWorldServerTls {
             sslClientContextBuilder.trustManager(new File(trustCertCollectionFilePath));
             sslClientContextBuilder.clientAuth(ClientAuth.REQUIRE);
         }
-        return GrpcSslContexts.configure(sslClientContextBuilder,
-                SslProvider.OPENSSL);
+        return GrpcSslContexts.configure(sslClientContextBuilder);
     }
 
     private void start() throws IOException {
-        server = NettyServerBuilder.forAddress(new InetSocketAddress(host, port))
+        server = NettyServerBuilder.forPort(port)
                 .addService(new GreeterImpl())
                 .sslContext(getSslContextBuilder().build())
                 .build()

--- a/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldServerTls.java
+++ b/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldServerTls.java
@@ -40,18 +40,15 @@ public class HelloWorldServerTls {
 
     private Server server;
 
-    private final String host;
     private final int port;
     private final String certChainFilePath;
     private final String privateKeyFilePath;
     private final String trustCertCollectionFilePath;
 
-    public HelloWorldServerTls(String host,
-                               int port,
+    public HelloWorldServerTls(int port,
                                String certChainFilePath,
                                String privateKeyFilePath,
                                String trustCertCollectionFilePath) {
-        this.host = host;
         this.port = port;
         this.certChainFilePath = certChainFilePath;
         this.privateKeyFilePath = privateKeyFilePath;
@@ -106,19 +103,19 @@ public class HelloWorldServerTls {
      */
     public static void main(String[] args) throws IOException, InterruptedException {
 
-        if (args.length < 4 || args.length > 5) {
+        if (args.length < 3 || args.length > 4) {
             System.out.println(
-                    "USAGE: HelloWorldServerTls host port certChainFilePath privateKeyFilePath " +
+                    "USAGE: HelloWorldServerTls port certChainFilePath privateKeyFilePath " +
                     "[trustCertCollectionFilePath]\n  Note: You only need to supply trustCertCollectionFilePath if you want " +
                     "to enable Mutual TLS.");
             System.exit(0);
         }
 
-        final HelloWorldServerTls server = new HelloWorldServerTls(args[0],
-                Integer.parseInt(args[1]),
+        final HelloWorldServerTls server = new HelloWorldServerTls(
+                Integer.parseInt(args[0]),
+                args[1],
                 args[2],
-                args[3],
-                args.length == 5 ? args[4] : null);
+                args.length == 4 ? args[3] : null);
         server.start();
         server.blockUntilShutdown();
     }


### PR DESCRIPTION
Also fix tcnative, which was the wrong version and would cause a crash
with NoSuchMethodError.

As noticed when looking into #5737