### PR TITLE
examples: use test certs for running example-tls

### DIFF
--- a/examples/example-tls/README.md
+++ b/examples/example-tls/README.md
@@ -40,6 +40,8 @@ You can run this example with our [test credentials](../../testing/src/main/reso
 in the test certificates. You can generate your own self-signed certificates with commands in the test certs
 [README](../../testing/src/main/resources/certs/README).
 
+- Note you can use system default certificate authority if you are using a real server certificate.
+
 #### Hello world example with TLS (no mutual auth):
 
 ```bash

--- a/examples/example-tls/README.md
+++ b/examples/example-tls/README.md
@@ -37,7 +37,7 @@ USAGE: HelloWorldClientTls host port trustCertCollectionFilePath [clientCertChai
 
 You can run this example with our [test credentials](../../testing/src/main/resources/certs) with 
 `.overrideAuthority("foo.test.google.fr")` for `ManagedChannelBuilder` to match the Subject Alternative Names
-in the test certificates. You can generate your own self-signed certificates with commends in the test certs
+in the test certificates. You can generate your own self-signed certificates with commands in the test certs
 [README](../../testing/src/main/resources/certs/README).
 
 #### Hello world example with TLS (no mutual auth):

--- a/examples/example-tls/README.md
+++ b/examples/example-tls/README.md
@@ -31,9 +31,10 @@ USAGE: HelloWorldServerTls port certChainFilePath privateKeyFilePath [trustCertC
 **hello-world-tls-client**:
 
 ```text
-USAGE: HelloWorldClientTls host port trustCertCollectionFilePath [clientCertChainFilePath clientPrivateKeyFilePath]
+USAGE: HelloWorldClientTls host port [trustCertCollectionFilePath [clientCertChainFilePath clientPrivateKeyFilePath]]
   Note: clientCertChainFilePath and clientPrivateKeyFilePath are only needed if mutual auth is desired.
 ```
+- Note `trustCertCollectionFilePath` is not needed if you are using system default certificate authority.
 
 You can run this example with our [test credentials](../../testing/src/main/resources/certs) with 
 `.overrideAuthority("foo.test.google.fr")` for `ManagedChannelBuilder` to match the Subject Alternative Names

--- a/examples/example-tls/README.md
+++ b/examples/example-tls/README.md
@@ -35,65 +35,27 @@ USAGE: HelloWorldClientTls host port trustCertCollectionFilePath [clientCertChai
   Note: clientCertChainFilePath and clientPrivateKeyFilePath are only needed if mutual auth is desired.
 ```
 
-#### Generating self-signed certificates for use with grpc
-
-You can use the following script to generate self-signed certificates for grpc-java including the hello world with TLS examples:
-
-```bash
-mkdir -p /tmp/sslcert
-pushd /tmp/sslcert
-# Change these CN's to match your hosts in your environment if needed.
-SERVER_CA_CN=localhost-ca
-SERVER_CN=localhost
-CLIENT_CN=localhost # Used when doing mutual TLS
-
-echo Generate CA key:
-openssl genrsa -passout pass:1111 -des3 -out ca.key 4096
-echo Generate CA certificate:
-# Generates ca.crt which is the trustCertCollectionFile
-openssl req -passin pass:1111 -new -x509 -days 365 -key ca.key -out ca.crt -subj "/CN=${SERVER_CA_CN}"
-echo Generate server key:
-openssl genrsa -passout pass:1111 -des3 -out server.key 4096
-echo Generate server signing request:
-openssl req -passin pass:1111 -new -key server.key -out server.csr -subj "/CN=${SERVER_CN}"
-echo Self-signed server certificate:
-# Generates server.crt which is the certChainFile for the server
-openssl x509 -req -passin pass:1111 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out server.crt 
-echo Remove passphrase from server key:
-openssl rsa -passin pass:1111 -in server.key -out server.key
-echo Generate client key
-openssl genrsa -passout pass:1111 -des3 -out client.key 4096
-echo Generate client signing request:
-openssl req -passin pass:1111 -new -key client.key -out client.csr -subj "/CN=${CLIENT_CN}"
-echo Self-signed client certificate:
-# Generates client.crt which is the clientCertChainFile for the client (need for mutual TLS only)
-openssl x509 -passin pass:1111 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out client.crt
-echo Remove passphrase from client key:
-openssl rsa -passin pass:1111 -in client.key -out client.key
-echo Converting the private keys to X.509:
-# Generates client.pem which is the clientPrivateKeyFile for the Client (needed for mutual TLS only)
-openssl pkcs8 -topk8 -nocrypt -in client.key -out client.pem
-# Generates server.pem which is the privateKeyFile for the Server
-openssl pkcs8 -topk8 -nocrypt -in server.key -out server.pem
-popd
-```
+You can run this example with our [test credentials](../../testing/src/main/resources/certs) with 
+`.overrideAuthority("foo.test.google.fr")` for `ManagedChannelBuilder` to match the Subject Alternative Names
+in the test certificates. You can generate your own self-signed certificates with commends in the test certs
+[README](../../testing/src/main/resources/certs/README).
 
 #### Hello world example with TLS (no mutual auth):
 
 ```bash
 # Run the server:
-./build/install/example-tls/bin/hello-world-tls-server 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem
+./build/install/example-tls/bin/hello-world-tls-server 50440 ../../testing/src/main/resources/certs/server1.pem ../../testing/src/main/resources/certs/server1.key
 # In another terminal run the client
-./build/install/example-tls/bin/hello-world-tls-client localhost 50440 /tmp/sslcert/ca.crt
+./build/install/example-tls/bin/hello-world-tls-client localhost 50440 ../../testing/src/main/resources/certs/ca.pem
 ```
 
 #### Hello world example with TLS with mutual auth:
 
 ```bash
 # Run the server:
-./build/install/example-tls/bin/hello-world-tls-server 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem /tmp/sslcert/ca.crt
+./build/install/example-tls/bin/hello-world-tls-server 50440 ../../testing/src/main/resources/certs/server1.pem ../../testing/src/main/resources/certs/server1.key ../../testing/src/main/resources/certs/ca.pem
 # In another terminal run the client
-./build/install/example-tls/bin/hello-world-tls-client localhost 50440 /tmp/sslcert/ca.crt /tmp/sslcert/client.crt /tmp/sslcert/client.pem
+./build/install/example-tls/bin/hello-world-tls-client localhost 50440 ../../testing/src/main/resources/certs/ca.pem ../../testing/src/main/resources/certs/client.pem ../../testing/src/main/resources/certs/client.key
 ```
 
 That's it!
@@ -108,9 +70,9 @@ If you prefer to use Maven:
 ```
 $ mvn verify
 $ # Run the server
-$ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworldtls.HelloWorldServerTls -Dexec.args="50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem"
+$ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworldtls.HelloWorldServerTls -Dexec.args="50440 ../../testing/src/main/resources/certs/server1.pem ../../testing/src/main/resources/certs/server1.key"
 $ # In another terminal run the client
-$ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworldtls.HelloWorldClientTls -Dexec.args="localhost 50440 /tmp/sslcert/ca.crt"
+$ mvn exec:java -Dexec.mainClass=io.grpc.examples.helloworldtls.HelloWorldClientTls -Dexec.args="localhost 50440 ../../testing/src/main/resources/certs/ca.pem"
 ```
 
 ## Bazel
@@ -119,7 +81,7 @@ If you prefer to use Bazel:
 ```
 $ bazel build :hello-world-tls-server :hello-world-tls-client
 $ # Run the server
-$ ../bazel-bin/hello-world-tls-server 50440 /tmp/sslcert/server.crt /tmp/sslcert/server.pem
+$ ../bazel-bin/hello-world-tls-server 50440 ../../testing/src/main/resources/certs/server1.pem ../../testing/src/main/resources/certs/server1.key
 $ # In another terminal run the client
-$ ../bazel-bin/hello-world-tls-client localhost 50440 /tmp/sslcert/ca.crt
+$ ../bazel-bin/hello-world-tls-client localhost 50440 ../../testing/src/main/resources/certs/ca.pem
 ```

--- a/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
+++ b/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
@@ -25,12 +25,11 @@ import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
-
-import javax.net.ssl.SSLException;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.net.ssl.SSLException;
 
 /**
  * A simple client that requests a greeting from the {@link HelloWorldServerTls} with TLS.
@@ -109,12 +108,19 @@ public class HelloWorldClientTls {
         }
 
         HelloWorldClientTls client;
-        if (args.length == 3) {
-            client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
-                buildSslContext(args[2], null, null));
-        } else {
-            client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
-                buildSslContext(args[2], args[3], args[4]));
+        switch (args.length) {
+            case 2:
+                /* Use default CA. Only for real server certificates. */
+                client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
+                        buildSslContext(null, null, null));
+                break;
+            case 3:
+                client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
+                        buildSslContext(args[2], null, null));
+                break;
+            default:
+                client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
+                        buildSslContext(args[2], args[3], args[4]));
         }
 
         try {

--- a/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
+++ b/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
@@ -102,7 +102,7 @@ public class HelloWorldClientTls {
     public static void main(String[] args) throws Exception {
 
         if (args.length < 2 || args.length == 4 || args.length > 5) {
-            System.out.println("USAGE: HelloWorldClientTls host port [trustCertCollectionFilePath] " +
+            System.out.println("USAGE: HelloWorldClientTls host port trustCertCollectionFilePath " +
                     "[clientCertChainFilePath clientPrivateKeyFilePath]\n  Note: clientCertChainFilePath and " +
                     "clientPrivateKeyFilePath are only needed if mutual auth is desired.");
             System.exit(0);

--- a/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
+++ b/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
@@ -62,6 +62,7 @@ public class HelloWorldClientTls {
                                SslContext sslContext) throws SSLException {
 
         this(NettyChannelBuilder.forAddress(host, port)
+                .overrideAuthority("foo.test.google.fr")  /* Only for using provided test certs. */
                 .sslContext(sslContext)
                 .build());
     }
@@ -108,27 +109,16 @@ public class HelloWorldClientTls {
         }
 
         HelloWorldClientTls client;
-        switch (args.length) {
-            case 2:
-                client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
-                        buildSslContext(null, null, null));
-                break;
-            case 3:
-                client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
-                        buildSslContext(args[2], null, null));
-                break;
-            default:
-                client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
-                        buildSslContext(args[2], args[3], args[4]));
+        if (args.length == 3) {
+            client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
+                buildSslContext(args[2], null, null));
+        } else {
+            client = new HelloWorldClientTls(args[0], Integer.parseInt(args[1]),
+                buildSslContext(args[2], args[3], args[4]));
         }
 
         try {
-            /* Access a service running on the local machine on port 50051 */
-            String user = "world";
-            if (args.length > 0) {
-                user = args[0]; /* Use the arg as the name to greet if provided */
-            }
-            client.greet(user);
+            client.greet(args[0]);
         } finally {
             client.shutdown();
         }

--- a/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
+++ b/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
@@ -101,8 +101,8 @@ public class HelloWorldClientTls {
     public static void main(String[] args) throws Exception {
 
         if (args.length < 2 || args.length == 4 || args.length > 5) {
-            System.out.println("USAGE: HelloWorldClientTls host port [trustCertCollectionFilePath] " +
-                    "[clientCertChainFilePath clientPrivateKeyFilePath]\n  Note: clientCertChainFilePath and " +
+            System.out.println("USAGE: HelloWorldClientTls host port [trustCertCollectionFilePath " +
+                    "[clientCertChainFilePath clientPrivateKeyFilePath]]\n  Note: clientCertChainFilePath and " +
                     "clientPrivateKeyFilePath are only needed if mutual auth is desired.");
             System.exit(0);
         }

--- a/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
+++ b/examples/example-tls/src/main/java/io/grpc/examples/helloworldtls/HelloWorldClientTls.java
@@ -102,7 +102,7 @@ public class HelloWorldClientTls {
     public static void main(String[] args) throws Exception {
 
         if (args.length < 2 || args.length == 4 || args.length > 5) {
-            System.out.println("USAGE: HelloWorldClientTls host port trustCertCollectionFilePath " +
+            System.out.println("USAGE: HelloWorldClientTls host port [trustCertCollectionFilePath] " +
                     "[clientCertChainFilePath clientPrivateKeyFilePath]\n  Note: clientCertChainFilePath and " +
                     "clientPrivateKeyFilePath are only needed if mutual auth is desired.");
             System.exit(0);


### PR DESCRIPTION
The way of generating self-signed keys and certificates in TLS example does not work, since the generated certificates does not contain Subject Alternative Names. 

Generating self-sign certificates (which requires special config for subject alternative names) is quite involved and users may encounter problems doing that (#5737). For maintainability, we do not provide a separate set of certs here. We recommend users to use our test certs for running the TLS example.