### PR TITLE
xds: not sending resource_name in EDS request

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsComms.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms.java
@@ -280,7 +280,6 @@ final class XdsComms {
                       .putFields(
                           "endpoints_required",
                           Value.newBuilder().setBoolValue(true).build())))
-              .addResourceNames(helper.getAuthority())
               .setTypeUrl(EDS_TYPE_URL).build());
     }
 


### PR DESCRIPTION
The `resource_name` field in EDS request should be the same as the one from a CDS response. Now we don't send CDS request, it's unclear what the value should be for now. In current integration test, the traffic director will fail with a wrong `resource_name` (authority is a wrong resource name), but with no `resource_name` it will succeed.