### PR TITLE
xds: populate XdsLoadBalancerProvider to ServiceLoader

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
@@ -39,7 +39,6 @@ import javax.annotation.Nullable;
  */
 @Internal
 public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
-  private final LoadBalancerRegistry registry = LoadBalancerRegistry.getDefaultRegistry();
 
   private static final LbConfig DEFAULT_FALLBACK_POLICY =
       new LbConfig("round_robin", ImmutableMap.<String, Void>of());
@@ -61,13 +60,14 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public LoadBalancer newLoadBalancer(Helper helper) {
-    return new XdsLoadBalancer(helper, registry);
+    return new XdsLoadBalancer(helper, LoadBalancerRegistry.getDefaultRegistry());
   }
 
   @Override
   public ConfigOrError parseLoadBalancingPolicyConfig(
       Map<String, ?> rawLoadBalancingPolicyConfig) {
-    return parseLoadBalancingConfigPolicy(rawLoadBalancingPolicyConfig, registry);
+    return parseLoadBalancingConfigPolicy(
+        rawLoadBalancingPolicyConfig, LoadBalancerRegistry.getDefaultRegistry());
   }
 
   static ConfigOrError parseLoadBalancingConfigPolicy(

--- a/xds/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
+++ b/xds/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
@@ -1,0 +1,1 @@
+io.grpc.xds.XdsLoadBalancerProvider


### PR DESCRIPTION
Also changed `XdsLoadBalancerProvider` to avoid initialization error when using `ServiceLoader`.