### PR TITLE
api: add Subchannel.getInternalSubchannel().

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -490,8 +490,11 @@ public abstract class LoadBalancer {
     /**
      * A decision to proceed the RPC on a Subchannel.
      *
-     * <p>Only Subchannels returned by {@link Helper#createSubchannel Helper.createSubchannel()}
-     * will work.  DO NOT try to use your own implementations of Subchannels, as they won't work.
+     * <p>The Subchannel should either be an original Subchannel returned by {@link
+     * Helper#createSubchannel Helper.createSubchannel()}, or a wrapper of it preferrably based on
+     * {@code ForwardingSubchannel}.  At the very least its {@link Subchannel#getInternalSubchannel
+     * getInternalSubchannel()} must return the same object as the one returned by the original.
+     * Otherwise the Channel cannot use it for the RPC.
      *
      * <p>When the RPC tries to use the return Subchannel, which is briefly after this method
      * returns, the state of the Subchannel will decide where the RPC would go:
@@ -1295,6 +1298,21 @@ public abstract class LoadBalancer {
      * @since 1.17.0
      */
     public ChannelLogger getChannelLogger() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * (Internal use only) returns an object that represents the underlying subchannel that is used
+     * by the Channel for sending RPCs when this {@link Subchannel} is picked.  This is an opaque
+     * object that is both provided and consumed by the Channel.  Its type <strong>is not</strong>
+     * {@code Subchannel}.
+     *
+     * <p>Warning: this is INTERNAL API, is not supposed to be used by external users, and may
+     * change without notice. If you think you must use it, please file an issue and we can consider
+     * removing its "internal" status.
+     */
+    @Internal
+    public Object getInternalSubchannel() {
       throw new UnsupportedOperationException();
     }
   }

--- a/core/src/main/java/io/grpc/internal/AbstractSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/AbstractSubchannel.java
@@ -39,5 +39,5 @@ abstract class AbstractSubchannel extends LoadBalancer.Subchannel {
    * unit tests.
    */
   @VisibleForTesting
-  abstract InternalInstrumented<ChannelStats> getInternalSubchannel();
+  abstract InternalInstrumented<ChannelStats> getInstrumentedInternalSubchannel();
 }

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -689,7 +689,7 @@ public final class GrpcUtil {
     final ClientTransport transport;
     Subchannel subchannel = result.getSubchannel();
     if (subchannel != null) {
-      transport = ((AbstractSubchannel) subchannel).obtainActiveTransport();
+      transport = ((TransportProvider) subchannel.getInternalSubchannel()).obtainActiveTransport();
     } else {
       transport = null;
     }

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -65,7 +65,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Transports for a single {@link SocketAddress}.
  */
 @ThreadSafe
-final class InternalSubchannel implements InternalInstrumented<ChannelStats> {
+final class InternalSubchannel implements InternalInstrumented<ChannelStats>, TransportProvider {
   private static final Logger log = Logger.getLogger(InternalSubchannel.class.getName());
 
   private final InternalLogId logId;
@@ -192,13 +192,8 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats> {
     return channelLogger;
   }
 
-  /**
-   * Returns a READY transport that will be used to create new streams.
-   *
-   * <p>Returns {@code null} if the state is not READY.  Will try to connect if state is IDLE.
-   */
-  @Nullable
-  ClientTransport obtainActiveTransport() {
+  @Override
+  public ClientTransport obtainActiveTransport() {
     ClientTransport savedTransport = activeTransport;
     if (savedTransport != null) {
       return savedTransport;

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1138,7 +1138,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       checkArgument(subchannel instanceof SubchannelImpl,
           "subchannel must have been returned from createSubchannel");
       logWarningIfNotInSyncContext("updateSubchannelAddresses()");
-      ((SubchannelImpl) subchannel).subchannel.updateAddresses(addrs);
+      ((InternalSubchannel) subchannel.getInternalSubchannel()).updateAddresses(addrs);
     }
 
     @Override
@@ -1499,12 +1499,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
     }
 
     @Override
-    ClientTransport obtainActiveTransport() {
-      checkState(started, "Subchannel is not started");
-      return subchannel.obtainActiveTransport();
-    }
-
-    @Override
     InternalInstrumented<ChannelStats> getInstrumentedInternalSubchannel() {
       checkState(started, "not started");
       return subchannel;
@@ -1600,6 +1594,12 @@ final class ManagedChannelImpl extends ManagedChannel implements
           subchannel, balancerRpcExecutorHolder.getExecutor(),
           transportFactory.getScheduledExecutorService(),
           callTracerFactory.create());
+    }
+
+    @Override
+    public Object getInternalSubchannel() {
+      checkState(started, "Subchannel is not started");
+      return subchannel;
     }
 
     @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1505,7 +1505,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
     }
 
     @Override
-    InternalInstrumented<ChannelStats> getInternalSubchannel() {
+    InternalInstrumented<ChannelStats> getInstrumentedInternalSubchannel() {
       checkState(started, "not started");
       return subchannel;
     }

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -153,7 +153,7 @@ final class OobChannel extends ManagedChannel implements InternalInstrumented<Ch
         }
 
         @Override
-        InternalInstrumented<ChannelStats> getInternalSubchannel() {
+        InternalInstrumented<ChannelStats> getInstrumentedInternalSubchannel() {
           return subchannel;
         }
 

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -148,11 +148,6 @@ final class OobChannel extends ManagedChannel implements InternalInstrumented<Ch
         }
 
         @Override
-        ClientTransport obtainActiveTransport() {
-          return subchannel.obtainActiveTransport();
-        }
-
-        @Override
         InternalInstrumented<ChannelStats> getInstrumentedInternalSubchannel() {
           return subchannel;
         }
@@ -170,6 +165,11 @@ final class OobChannel extends ManagedChannel implements InternalInstrumented<Ch
         @Override
         public Attributes getAttributes() {
           return Attributes.EMPTY;
+        }
+
+        @Override
+        public Object getInternalSubchannel() {
+          return subchannel;
         }
     };
 

--- a/core/src/main/java/io/grpc/internal/TransportProvider.java
+++ b/core/src/main/java/io/grpc/internal/TransportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The gRPC Authors
+ * Copyright 2019 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,19 @@
 
 package io.grpc.internal;
 
-import com.google.common.annotations.VisibleForTesting;
-import io.grpc.InternalChannelz.ChannelStats;
-import io.grpc.InternalInstrumented;
-import io.grpc.LoadBalancer;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * The base interface of the Subchannels returned by {@link
- * io.grpc.LoadBalancer.Helper#createSubchannel}.
+ * Provides transports for sending RPCs.
  */
-abstract class AbstractSubchannel extends LoadBalancer.Subchannel {
-
+@ThreadSafe
+interface TransportProvider {
   /**
-   * Returns the InternalSubchannel as an {@code Instrumented<T>} for the sole purpose of channelz
-   * unit tests.
+   * Returns a READY transport that will be used to create new streams.
+   *
+   * <p>Returns {@code null} if the state is not READY.  Will try to connect if state is IDLE.
    */
-  @VisibleForTesting
-  abstract InternalInstrumented<ChannelStats> getInstrumentedInternalSubchannel();
+  @Nullable
+  ClientTransport obtainActiveTransport();
 }

--- a/core/src/main/java/io/grpc/util/ForwardingSubchannel.java
+++ b/core/src/main/java/io/grpc/util/ForwardingSubchannel.java
@@ -70,6 +70,11 @@ public abstract class ForwardingSubchannel extends LoadBalancer.Subchannel {
   }
 
   @Override
+  public Object getInternalSubchannel() {
+    return delegate().getInternalSubchannel();
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -475,9 +475,12 @@ public class ManagedChannelImplTest {
         (AbstractSubchannel) createSubchannelSafely(
             helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
     // subchannels are not root channels
-    assertNull(channelz.getRootChannel(subchannel.getInternalSubchannel().getLogId().getId()));
-    assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
-    assertThat(getStats(channel).subchannels).containsExactly(subchannel.getInternalSubchannel());
+    assertNull(
+        channelz.getRootChannel(subchannel.getInstrumentedInternalSubchannel().getLogId().getId()));
+    assertTrue(
+        channelz.containsSubchannel(subchannel.getInstrumentedInternalSubchannel().getLogId()));
+    assertThat(getStats(channel).subchannels)
+        .containsExactly(subchannel.getInstrumentedInternalSubchannel());
 
     requestConnectionSafely(helper, subchannel);
     MockClientTransportInfo transportInfo = transports.poll();
@@ -489,11 +492,13 @@ public class ManagedChannelImplTest {
     assertFalse(channelz.containsClientSocket(transportInfo.transport.getLogId()));
 
     // terminate subchannel
-    assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
+    assertTrue(
+        channelz.containsSubchannel(subchannel.getInstrumentedInternalSubchannel().getLogId()));
     shutdownSafely(helper, subchannel);
     timer.forwardTime(ManagedChannelImpl.SUBCHANNEL_SHUTDOWN_DELAY_SECONDS, TimeUnit.SECONDS);
     timer.runDueTasks();
-    assertFalse(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
+    assertFalse(
+        channelz.containsSubchannel(subchannel.getInstrumentedInternalSubchannel().getLogId()));
     assertThat(getStats(channel).subchannels).isEmpty();
 
     // channel still appears
@@ -511,9 +516,12 @@ public class ManagedChannelImplTest {
     assertTrue(channelz.containsSubchannel(oob.getLogId()));
 
     AbstractSubchannel subchannel = (AbstractSubchannel) oob.getSubchannel();
-    assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
-    assertThat(getStats(oob).subchannels).containsExactly(subchannel.getInternalSubchannel());
-    assertTrue(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
+    assertTrue(
+        channelz.containsSubchannel(subchannel.getInstrumentedInternalSubchannel().getLogId()));
+    assertThat(getStats(oob).subchannels)
+        .containsExactly(subchannel.getInstrumentedInternalSubchannel());
+    assertTrue(
+        channelz.containsSubchannel(subchannel.getInstrumentedInternalSubchannel().getLogId()));
 
     oob.getSubchannel().requestConnection();
     MockClientTransportInfo transportInfo = transports.poll();
@@ -528,7 +536,8 @@ public class ManagedChannelImplTest {
     oob.shutdown();
     assertFalse(channelz.containsSubchannel(oob.getLogId()));
     assertThat(getStats(channel).subchannels).isEmpty();
-    assertFalse(channelz.containsSubchannel(subchannel.getInternalSubchannel().getLogId()));
+    assertFalse(
+        channelz.containsSubchannel(subchannel.getInstrumentedInternalSubchannel().getLogId()));
 
     // channel still appears
     assertNotNull(channelz.getRootChannel(channel.getLogId().getId()));
@@ -2571,7 +2580,7 @@ public class ManagedChannelImplTest {
         .setDescription("Child Subchannel started")
         .setSeverity(ChannelTrace.Event.Severity.CT_INFO)
         .setTimestampNanos(timer.getTicker().read())
-        .setSubchannelRef(subchannel.getInternalSubchannel())
+        .setSubchannelRef(subchannel.getInstrumentedInternalSubchannel())
         .build());
     assertThat(getStats(subchannel).channelTrace.events).contains(new ChannelTrace.Event.Builder()
         .setDescription("Subchannel for [[[test-addr]/{}]] created")
@@ -3958,7 +3967,7 @@ public class ManagedChannelImplTest {
   }
 
   private static ChannelStats getStats(AbstractSubchannel subchannel) throws Exception {
-    return subchannel.getInternalSubchannel().getStats().get();
+    return subchannel.getInstrumentedInternalSubchannel().getStats().get();
   }
 
   private static ChannelStats getStats(

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -2751,7 +2751,7 @@ public class ManagedChannelImplTest {
         (AbstractSubchannel) createSubchannelSafely(
             helper, addressGroup, Attributes.EMPTY, subchannelStateListener);
     timer.forwardNanos(1234);
-    subchannel.obtainActiveTransport();
+    ((TransportProvider) subchannel.getInternalSubchannel()).obtainActiveTransport();
     assertThat(getStats(subchannel).channelTrace.events).contains(new ChannelTrace.Event.Builder()
         .setDescription("CONNECTING as requested")
         .setSeverity(ChannelTrace.Event.Severity.CT_INFO)


### PR DESCRIPTION
Previously PickResult's Subchannel must be the actual implementation
returned from the Channel's Helper, and Channel would cast it to the
implementation class in order to use it.  This will be broken if
Subchannel is wrapped in the case of hierarchical LoadBalancers.

getInternalSubchannel() is the guaranteed path for the Channel to get
the InternalSubchannel implementation.  It is friendly for wrapping.

Background: #5676