### PR TITLE
core: add discard method for Attributes

### DIFF
--- a/api/src/main/java/io/grpc/Attributes.java
+++ b/api/src/main/java/io/grpc/Attributes.java
@@ -232,6 +232,19 @@ public final class Attributes {
       return this;
     }
 
+    @ExperimentalApi("FIXME")
+    public <T> Builder discard(Key<T> key) {
+      if (base.data.containsKey(key)) {
+        Map<Key<?>, Object> newBaseData = new IdentityHashMap<>(base.data);
+        newBaseData.remove(key);
+        base = new Attributes(newBaseData);
+      }
+      if (newdata != null) {
+        newdata.remove(key);
+      }
+      return this;
+    }
+
     public <T> Builder setAll(Attributes other) {
       data(other.data.size()).putAll(other.data);
       return this;

--- a/api/src/main/java/io/grpc/Attributes.java
+++ b/api/src/main/java/io/grpc/Attributes.java
@@ -232,7 +232,14 @@ public final class Attributes {
       return this;
     }
 
-    @ExperimentalApi("FIXME")
+    /**
+     * Removes the key and associated value from the attribtues.
+     *
+     * @since 1.22.0
+     * @param key The key to remove
+     * @return this
+     */
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/5777")
     public <T> Builder discard(Key<T> key) {
       if (base.data.containsKey(key)) {
         Map<Key<?>, Object> newBaseData = new IdentityHashMap<>(base.data);

--- a/api/src/test/java/io/grpc/AttributesTest.java
+++ b/api/src/test/java/io/grpc/AttributesTest.java
@@ -19,6 +19,7 @@ package io.grpc;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
@@ -90,5 +91,41 @@ public class AttributesTest {
 
     assertEquals(attr1, attr2);
     assertEquals(attr1.hashCode(), attr2.hashCode());
+  }
+
+  @Test
+  public void discard_baseAttributes() {
+    Attributes attrs = Attributes.newBuilder().set(YOLO_KEY, "value").build();
+
+    Attributes newAttrs = attrs.toBuilder().discard(YOLO_KEY).build();
+    assertNull(newAttrs.get(YOLO_KEY));
+    assertThat(newAttrs.keysForTest()).doesNotContain(YOLO_KEY);
+  }
+
+  @Test
+  public void discard_noBase() {
+    Attributes.Builder attrs = Attributes.newBuilder().set(YOLO_KEY, "value");
+
+    Attributes newAttrs = attrs.discard(YOLO_KEY).build();
+    assertNull(newAttrs.get(YOLO_KEY));
+    assertThat(newAttrs.keysForTest()).doesNotContain(YOLO_KEY);
+  }
+
+  @Test
+  public void discard_baseAttributesAndBuilder() {
+    Attributes attrs = Attributes.newBuilder().set(YOLO_KEY, "value").build();
+
+    Attributes.Builder attrsBuilder = attrs.toBuilder().set(YOLO_KEY, "other value");
+    Attributes newAttrs = attrsBuilder.discard(YOLO_KEY).build();
+    assertNull(newAttrs.get(YOLO_KEY));
+    assertThat(newAttrs.keysForTest()).doesNotContain(YOLO_KEY);
+  }
+
+  @Test
+  public void discard_empty() {
+    Attributes newAttrs = Attributes.EMPTY.toBuilder().discard(YOLO_KEY).build();
+    
+    assertNull(newAttrs.get(YOLO_KEY));
+    assertThat(newAttrs.keysForTest()).doesNotContain(YOLO_KEY);
   }
 }


### PR DESCRIPTION
Some Protocol Negotiators want to remove or rewrite certain attribute keys as they propagate along.  Add a `discard()` method similar to Metadata 