### PR TITLE
xds: handle 100% drop for fallback mode

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -289,6 +289,9 @@ interface LocalityStore {
 
       if (dropOverloads != null && !dropOverloads.isEmpty()) {
         picker = new DroppablePicker(dropOverloads, picker, random);
+        if (state == null) {
+          state = IDLE;
+        }
       }
 
       if (state != null) {

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -53,6 +53,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Manages EAG and locality info for a collection of subchannels, not including subchannels
@@ -222,8 +223,9 @@ interface LocalityStore {
       this.dropOverloads = checkNotNull(dropOverloads, "dropOverloads");
     }
 
+    @Nullable
     private static ConnectivityState aggregateState(
-        ConnectivityState overallState, ConnectivityState childState) {
+        @Nullable ConnectivityState overallState, @Nullable ConnectivityState childState) {
       if (overallState == null) {
         return childState;
       }
@@ -270,7 +272,8 @@ interface LocalityStore {
       updatePicker(overallState, childPickers);
     }
 
-    private void updatePicker(ConnectivityState state,  List<WeightedChildPicker> childPickers) {
+    private void updatePicker(
+        @Nullable ConnectivityState state,  List<WeightedChildPicker> childPickers) {
       childPickers = Collections.unmodifiableList(childPickers);
       SubchannelPicker picker;
       if (childPickers.isEmpty()) {

--- a/xds/src/main/java/io/grpc/xds/XdsComms.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms.java
@@ -258,9 +258,13 @@ final class XdsComms {
                           = ImmutableList.builder();
                       for (ClusterLoadAssignment.Policy.DropOverload dropOverload
                           : dropOverloadsProto) {
+                        int rateInMillion = rateInMillion(dropOverload.getDropPercentage());
                         dropOverloadsBuilder.add(new DropOverload(
-                            dropOverload.getCategory(),
-                            rateInMillion(dropOverload.getDropPercentage())));
+                            dropOverload.getCategory(), rateInMillion));
+                        if (rateInMillion == 1000_000) {
+                          adsStreamCallback.onAllDrop();
+                          break;
+                        }
                       }
 
                       dropOverloads = dropOverloadsBuilder.build();
@@ -426,5 +430,10 @@ final class XdsComms {
      * Once an error occurs in ADS stream.
      */
     void onError();
+
+    /**
+     * Once receives a response indicating that 100% of calls should be dropped.
+     */
+    void onAllDrop();
   }
 }

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -82,6 +82,11 @@ final class XdsLoadBalancer extends LoadBalancer {
         // TODO: schedule a timer for Fallback-After-Startup
       } // else: the Fallback-at-Startup timer is still pending, noop and wait
     }
+
+    @Override
+    public void onAllDrop() {
+      fallbackManager.cancelFallback();
+    }
   };
 
   @Nullable

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.ConnectivityState.CONNECTING;
+import static io.grpc.ConnectivityState.IDLE;
 import static io.grpc.ConnectivityState.READY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
@@ -31,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
+import io.grpc.ConnectivityState;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.Helper;
@@ -201,6 +203,8 @@ public class LocalityStoreTest {
     verify(loadBalancers.get(2)).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
     assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31, eag32);
     assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
+    verify(helper, never()).updateBalancingState(
+        any(ConnectivityState.class), any(SubchannelPicker.class));
 
     // subchannel12 goes to CONNECTING
     final Subchannel subchannel12 =
@@ -275,7 +279,16 @@ public class LocalityStoreTest {
   }
 
   @Test
+  public void updateLoaclityStore_withEmptyDropList() {
+    localityStore.updateDropPercentage(ImmutableList.<DropOverload>of());
+    updateLoaclityStore();
+  }
+
+  @Test
   public void updateLoaclityStore_withDrop() {
+    localityStore.updateDropPercentage(ImmutableList.of(
+        new DropOverload("throttle", 365),
+        new DropOverload("lb", 1234)));
     LocalityInfo localityInfo1 =
         new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
     LocalityInfo localityInfo2 =
@@ -285,9 +298,6 @@ public class LocalityStoreTest {
     Map<Locality, LocalityInfo> localityInfoMap = ImmutableMap.of(
         locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
     localityStore.updateLocalityStore(localityInfoMap);
-    localityStore.updateDropPercentage(ImmutableList.of(
-        new DropOverload("throttle", 365),
-        new DropOverload("lb", 1234)));
 
     assertThat(loadBalancers).hasSize(3);
     ArgumentCaptor<ResolvedAddresses> resolvedAddressesCaptor1 =
@@ -303,8 +313,32 @@ public class LocalityStoreTest {
     verify(loadBalancers.get(2)).handleResolvedAddresses(resolvedAddressesCaptor3.capture());
     assertThat(resolvedAddressesCaptor3.getValue().getAddresses()).containsExactly(eag31, eag32);
     assertThat(pickerFactory.totalReadyLocalities).isEqualTo(0);
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor =
+        ArgumentCaptor.forClass(SubchannelPicker.class);
+    verify(helper).updateBalancingState(same(IDLE), subchannelPickerCaptor.capture());
 
-    // subchannel12 goes to CONNECTING
+    int times = 0;
+    doReturn(365, 1234).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs))
+        .isEqualTo(PickResult.withNoResult());
+    verify(random, times(times += 2)).nextInt(1000_000);
+
+    doReturn(366, 1235).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs))
+        .isEqualTo(PickResult.withNoResult());
+    verify(random, times(times += 2)).nextInt(1000_000);
+
+    doReturn(364, 1234).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
+        .isTrue();
+    verify(random, times(times += 1)).nextInt(1000_000);
+
+    doReturn(365, 1233).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
+        .isTrue();
+    verify(random, times(times += 2)).nextInt(1000_000);
+
+    // subchannel12 goes to READY
     final Subchannel subchannel12 =
         helpers.get(0).createSubchannel(ImmutableList.of(eag12), Attributes.EMPTY);
     verify(helper).createSubchannel(ImmutableList.of(eag12), Attributes.EMPTY);
@@ -314,30 +348,54 @@ public class LocalityStoreTest {
         return PickResult.withSubchannel(subchannel12);
       }
     };
-    helpers.get(0).updateBalancingState(CONNECTING, subchannelPicker12);
+    helpers.get(0).updateBalancingState(READY, subchannelPicker12);
     ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor12 =
         ArgumentCaptor.forClass(SubchannelPicker.class);
-    verify(helper).updateBalancingState(same(CONNECTING), subchannelPickerCaptor12.capture());
+    verify(helper).updateBalancingState(same(READY), subchannelPickerCaptor12.capture());
 
     doReturn(365, 1234).when(random).nextInt(1000_000);
-    assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs))
-        .isEqualTo(PickResult.withNoResult());
-    verify(random, times(2)).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs)
+        .getSubchannel()).isEqualTo(subchannel12);
+    verify(random, times(times += 2)).nextInt(1000_000);
 
     doReturn(366, 1235).when(random).nextInt(1000_000);
-    assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs))
-        .isEqualTo(PickResult.withNoResult());
-    verify(random, times(4)).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs)
+        .getSubchannel()).isEqualTo(subchannel12);
+    verify(random, times(times += 2)).nextInt(1000_000);
 
     doReturn(364, 1234).when(random).nextInt(1000_000);
     assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
         .isTrue();
-    verify(random, times(5)).nextInt(1000_000);
+    verify(random, times(times += 1)).nextInt(1000_000);
 
     doReturn(365, 1233).when(random).nextInt(1000_000);
     assertThat(subchannelPickerCaptor12.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
         .isTrue();
-    verify(random, times(7)).nextInt(1000_000);
+    verify(random, times(times += 2)).nextInt(1000_000);
+  }
+
+  @Test
+  public void updateLoaclityStore_withAllDropBeforeLocalityUpdateConnectivityState() {
+    localityStore.updateDropPercentage(ImmutableList.of(
+        new DropOverload("throttle", 365),
+        new DropOverload("lb", 1000_000)));
+    LocalityInfo localityInfo1 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
+    LocalityInfo localityInfo2 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint21, lbEndpoint22), 2);
+    LocalityInfo localityInfo3 =
+        new LocalityInfo(ImmutableList.of(lbEndpoint31, lbEndpoint32), 3);
+    Map<Locality, LocalityInfo> localityInfoMap = ImmutableMap.of(
+        locality1, localityInfo1, locality2, localityInfo2, locality3, localityInfo3);
+    localityStore.updateLocalityStore(localityInfoMap);
+
+    ArgumentCaptor<SubchannelPicker> subchannelPickerCaptor =
+        ArgumentCaptor.forClass(SubchannelPicker.class);
+    verify(helper).updateBalancingState(same(IDLE), subchannelPickerCaptor.capture());
+    doReturn(999_999).when(random).nextInt(1000_000);
+    assertThat(subchannelPickerCaptor.getValue().pickSubchannel(pickSubchannelArgs).isDrop())
+        .isTrue();
+    verify(random, times(2)).nextInt(1000_000);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -178,7 +178,8 @@ public class LocalityStoreTest {
   }
 
   @Test
-  public void updateLoaclityStore() {
+  public void updateLoaclityStore_withEmptyDropList() {
+    localityStore.updateDropPercentage(ImmutableList.<DropOverload>of());
     LocalityInfo localityInfo1 =
         new LocalityInfo(ImmutableList.of(lbEndpoint11, lbEndpoint12), 1);
     LocalityInfo localityInfo2 =
@@ -276,12 +277,6 @@ public class LocalityStoreTest {
     assertThat(pickerFactory.totalReadyLocalities).isEqualTo(1);
 
     verify(random, never()).nextInt(1000_000);
-  }
-
-  @Test
-  public void updateLoaclityStore_withEmptyDropList() {
-    localityStore.updateDropPercentage(ImmutableList.<DropOverload>of());
-    updateLoaclityStore();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
@@ -292,7 +292,7 @@ public class XdsCommsTest {
     responseWriter.onNext(edsResponse);
 
     verify(adsStreamCallback, times(1)).onWorking();
-    verifyZeroInteractions(adsStreamCallback);
+    verifyNoMoreInteractions(adsStreamCallback);
     inOrder.verify(localityStore).updateDropPercentage(ImmutableList.<DropOverload>of());
     inOrder.verify(localityStore).updateLocalityStore(localityEndpointsMappingCaptor.capture());
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
@@ -376,7 +376,7 @@ public class XdsCommsTest {
     responseWriter.onNext(edsResponseWithDrops);
 
     verify(adsStreamCallback).onWorking();
-    verifyZeroInteractions(adsStreamCallback);
+    verifyNoMoreInteractions(adsStreamCallback);
     InOrder inOrder = inOrder(localityStore);
     inOrder.verify(localityStore).updateDropPercentage(ImmutableList.of(
         new DropOverload("throttle", 123),
@@ -457,7 +457,7 @@ public class XdsCommsTest {
     responseWriter.onCompleted();
 
     verify(adsStreamCallback).onError();
-    verifyZeroInteractions(adsStreamCallback);
+    verifyNoMoreInteractions(adsStreamCallback);
 
     xdsComms.shutdownChannel();
   }

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -64,6 +66,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -248,6 +251,8 @@ public class XdsCommsTest {
         .build();
     responseWriter.onNext(edsResponse);
 
+    verify(adsStreamCallback).onWorking();
+
     XdsComms.Locality locality1 = new XdsComms.Locality(localityProto1);
     LocalityInfo localityInfo1 = new LocalityInfo(
         ImmutableList.of(
@@ -261,8 +266,9 @@ public class XdsCommsTest {
         2);
     XdsComms.Locality locality2 = new XdsComms.Locality(localityProto2);
 
-    verify(localityStore).updateDropPercentage(ImmutableList.<DropOverload>of());
-    verify(localityStore).updateLocalityStore(localityEndpointsMappingCaptor.capture());
+    InOrder inOrder = inOrder(localityStore);
+    inOrder.verify(localityStore).updateDropPercentage(ImmutableList.<DropOverload>of());
+    inOrder.verify(localityStore).updateLocalityStore(localityEndpointsMappingCaptor.capture());
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
         locality1, localityInfo1, locality2, localityInfo2).inOrder();
 
@@ -284,8 +290,11 @@ public class XdsCommsTest {
         .build();
     responseWriter.onNext(edsResponse);
 
-    verify(localityStore, times(2)).updateDropPercentage(ImmutableList.<DropOverload>of());
-    verify(localityStore, times(2)).updateLocalityStore(localityEndpointsMappingCaptor.capture());
+    verify(adsStreamCallback, times(1)).onWorking();
+    verify(adsStreamCallback, never()).onAllDrop();
+    verify(adsStreamCallback, never()).onError();
+    inOrder.verify(localityStore).updateDropPercentage(ImmutableList.<DropOverload>of());
+    inOrder.verify(localityStore).updateLocalityStore(localityEndpointsMappingCaptor.capture());
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
         locality2, localityInfo2, locality1, localityInfo1).inOrder();
 
@@ -360,25 +369,21 @@ public class XdsCommsTest {
                         .setDropPercentage(FractionalPercent.newBuilder()
                             .setNumerator(78).setDenominator(DenominatorType.HUNDRED).build())
                         .build())
-                .addDropOverloads(
-                    io.envoyproxy.envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload
-                        .newBuilder()
-                        .setCategory("fake_category_2")
-                        .setDropPercentage(FractionalPercent.newBuilder()
-                            .setNumerator(789).setDenominator(DenominatorType.HUNDRED).build())
-                        .build())
                 .build())
             .build()))
         .setTypeUrl("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment")
         .build();
     responseWriter.onNext(edsResponseWithDrops);
 
-    verify(localityStore).updateDropPercentage(ImmutableList.of(
+    verify(adsStreamCallback).onWorking();
+    verify(adsStreamCallback, never()).onAllDrop();
+    verify(adsStreamCallback, never()).onError();
+    InOrder inOrder = inOrder(localityStore);
+    inOrder.verify(localityStore).updateDropPercentage(ImmutableList.of(
         new DropOverload("throttle", 123),
         new DropOverload("lb", 456_00),
-        new DropOverload("fake_category", 78_00_00),
-        new DropOverload("fake_category_2", 1000_000)));
-    verify(localityStore).updateLocalityStore(localityEndpointsMappingCaptor.capture());
+        new DropOverload("fake_category", 78_00_00)));
+    inOrder.verify(localityStore).updateLocalityStore(localityEndpointsMappingCaptor.capture());
 
     XdsComms.Locality locality1 = new XdsComms.Locality(localityProto1);
     LocalityInfo localityInfo1 = new LocalityInfo(
@@ -388,6 +393,63 @@ public class XdsCommsTest {
     XdsComms.Locality locality2 = new XdsComms.Locality(localityProto2);
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
         locality2, localityInfo2, locality1, localityInfo1).inOrder();
+
+    DiscoveryResponse edsResponseWithAllDrops = DiscoveryResponse.newBuilder()
+        .addResources(Any.pack(ClusterLoadAssignment.newBuilder()
+            .addEndpoints(LocalityLbEndpoints.newBuilder()
+                .setLocality(localityProto2)
+                .addLbEndpoints(endpoint21)
+                .setLoadBalancingWeight(UInt32Value.of(2)))
+            .addEndpoints(LocalityLbEndpoints.newBuilder()
+                .setLocality(localityProto1)
+                .addLbEndpoints(endpoint11)
+                .setLoadBalancingWeight(UInt32Value.of(1)))
+            .setPolicy(Policy.newBuilder()
+                .addDropOverloads(
+                    io.envoyproxy.envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload
+                        .newBuilder()
+                        .setCategory("throttle")
+                        .setDropPercentage(FractionalPercent.newBuilder()
+                            .setNumerator(123).setDenominator(DenominatorType.MILLION).build())
+                        .build())
+                .addDropOverloads(
+                    io.envoyproxy.envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload
+                        .newBuilder()
+                        .setCategory("lb")
+                        .setDropPercentage(FractionalPercent.newBuilder()
+                            .setNumerator(456).setDenominator(DenominatorType.TEN_THOUSAND).build())
+                        .build())
+                .addDropOverloads(
+                    io.envoyproxy.envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload
+                        .newBuilder()
+                        .setCategory("fake_category")
+                        .setDropPercentage(FractionalPercent.newBuilder()
+                            .setNumerator(789).setDenominator(DenominatorType.HUNDRED).build())
+                        .build())
+                .addDropOverloads(
+                    io.envoyproxy.envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload
+                        .newBuilder()
+                        .setCategory("fake_category_2")
+                        .setDropPercentage(FractionalPercent.newBuilder()
+                            .setNumerator(78).setDenominator(DenominatorType.HUNDRED).build())
+                        .build())
+                .build())
+            .build()))
+        .setTypeUrl("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment")
+        .build();
+    responseWriter.onNext(edsResponseWithAllDrops);
+
+    verify(adsStreamCallback, times(1)).onWorking();
+    verify(adsStreamCallback).onAllDrop();
+    verify(adsStreamCallback, never()).onError();
+    inOrder.verify(localityStore).updateDropPercentage(ImmutableList.of(
+        new DropOverload("throttle", 123),
+        new DropOverload("lb", 456_00),
+        new DropOverload("fake_category", 1000_000)));
+    inOrder.verify(localityStore).updateLocalityStore(localityEndpointsMappingCaptor.capture());
+    assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
+        locality2, localityInfo2, locality1, localityInfo1).inOrder();
+
     xdsComms.shutdownChannel();
   }
 
@@ -396,6 +458,8 @@ public class XdsCommsTest {
     responseWriter.onCompleted();
 
     verify(adsStreamCallback).onError();
+    verify(adsStreamCallback, never()).onWorking();
+    verify(adsStreamCallback, never()).onAllDrop();
 
     xdsComms.shutdownChannel();
   }

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
@@ -291,8 +292,7 @@ public class XdsCommsTest {
     responseWriter.onNext(edsResponse);
 
     verify(adsStreamCallback, times(1)).onWorking();
-    verify(adsStreamCallback, never()).onAllDrop();
-    verify(adsStreamCallback, never()).onError();
+    verifyZeroInteractions(adsStreamCallback);
     inOrder.verify(localityStore).updateDropPercentage(ImmutableList.<DropOverload>of());
     inOrder.verify(localityStore).updateLocalityStore(localityEndpointsMappingCaptor.capture());
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
@@ -376,8 +376,7 @@ public class XdsCommsTest {
     responseWriter.onNext(edsResponseWithDrops);
 
     verify(adsStreamCallback).onWorking();
-    verify(adsStreamCallback, never()).onAllDrop();
-    verify(adsStreamCallback, never()).onError();
+    verifyZeroInteractions(adsStreamCallback);
     InOrder inOrder = inOrder(localityStore);
     inOrder.verify(localityStore).updateDropPercentage(ImmutableList.of(
         new DropOverload("throttle", 123),
@@ -458,8 +457,7 @@ public class XdsCommsTest {
     responseWriter.onCompleted();
 
     verify(adsStreamCallback).onError();
-    verify(adsStreamCallback, never()).onWorking();
-    verify(adsStreamCallback, never()).onAllDrop();
+    verifyZeroInteractions(adsStreamCallback);
 
     xdsComms.shutdownChannel();
   }


### PR DESCRIPTION
- Cancel fallback timer and/or exit fallback mode once receiving an EDS response indicating 100% drop.
- Also update balancing state once receiving the first EDS response with drop information when the channel is at the initial IDLE state.