### PR TITLE
Explain why client stub mocking is discouraged

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -107,11 +107,11 @@ We encourage users to leverage `InProcessTransport` as demonstrated in the examp
 write unit tests. `InProcessTransport` is light-weight and runs the server
 and client in the same process without any socket/TCP connection.
 
-Mocking the client stub provides a false sense of security when writing tests. Mocking stubs and responses allows for tests
-that don't map to reality, causing the tests to pass, but the system-under-test to fail. Example bugs not caught by mocked 
-stub tests include:
+Mocking the client stub provides a false sense of security when writing tests. Mocking stubs and responses 
+allows for teststhat don't map to reality, causing the tests to pass, but the system-under-test to fail. 
+Example bugs not caught by mocked stub tests include:
 
-* Calling the stub with a NULL message
+* Calling the stub with a `null` message
 * Not calling `close()`
 * Sending invalid headers
 * Ignoring deadlines

--- a/examples/README.md
+++ b/examples/README.md
@@ -107,8 +107,11 @@ We encourage users to leverage `InProcessTransport` as demonstrated in the examp
 write unit tests. `InProcessTransport` is light-weight and runs the server
 and client in the same process without any socket/TCP connection.
 
-Mocking the client stub provides a false sense of security when writing tests. Mocking stubs and responses 
+Mocking the client stub provides a false sense of security when writing tests. Mocking stubs and responses
 allows for tests that don't map to reality, causing the tests to pass, but the system-under-test to fail. 
+The gRPC client library is complicated, and accurately reproducing that complexity with mocks very hard.
+You will be better off and write less code by using `InProcessTransport` instead.
+
 Example bugs not caught by mocked stub tests include:
 
 * Calling the stub with a `null` message

--- a/examples/README.md
+++ b/examples/README.md
@@ -107,6 +107,16 @@ We encourage users to leverage `InProcessTransport` as demonstrated in the examp
 write unit tests. `InProcessTransport` is light-weight and runs the server
 and client in the same process without any socket/TCP connection.
 
+Mocking the client stub provides a false sense of security when writing tests. Mocking stubs and responses allows for tests
+that don't map to reality, causing the tests to pass, but the system-under-test to fail. Example bugs not caught by mocked 
+stub tests include:
+
+* Calling the stub with a NULL message
+* Not calling `close()`
+* Sending invalid headers
+* Ignoring deadlines
+* Ignoring cancellation
+
 For testing a gRPC client, create the client with a real stub
 using an
 [InProcessChannel](../core/src/main/java/io/grpc/inprocess/InProcessChannelBuilder.java),

--- a/examples/README.md
+++ b/examples/README.md
@@ -108,7 +108,7 @@ write unit tests. `InProcessTransport` is light-weight and runs the server
 and client in the same process without any socket/TCP connection.
 
 Mocking the client stub provides a false sense of security when writing tests. Mocking stubs and responses 
-allows for teststhat don't map to reality, causing the tests to pass, but the system-under-test to fail. 
+allows for tests that don't map to reality, causing the tests to pass, but the system-under-test to fail. 
 Example bugs not caught by mocked stub tests include:
 
 * Calling the stub with a `null` message

--- a/examples/README.md
+++ b/examples/README.md
@@ -109,7 +109,7 @@ and client in the same process without any socket/TCP connection.
 
 Mocking the client stub provides a false sense of security when writing tests. Mocking stubs and responses
 allows for tests that don't map to reality, causing the tests to pass, but the system-under-test to fail. 
-The gRPC client library is complicated, and accurately reproducing that complexity with mocks very hard.
+The gRPC client library is complicated, and accurately reproducing that complexity with mocks is very hard.
 You will be better off and write less code by using `InProcessTransport` instead.
 
 Example bugs not caught by mocked stub tests include:


### PR DESCRIPTION
As seen in hacker news comment https://news.ycombinator.com/item?id=20025085 of story https://news.ycombinator.com/item?id=20021759.