### PR TITLE
Optimize server wake up

### DIFF
--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -90,7 +90,7 @@ public class ServerCallImplTest {
     context = Context.ROOT.withCancellation();
     call = new ServerCallImpl<>(stream, UNARY_METHOD, requestHeaders, context,
         DecompressorRegistry.getDefaultInstance(), CompressorRegistry.getDefaultInstance(),
-        serverCallTracer);
+        serverCallTracer, false);
   }
 
   @Test
@@ -113,7 +113,7 @@ public class ServerCallImplTest {
 
     call = new ServerCallImpl<>(stream, UNARY_METHOD, requestHeaders, context,
         DecompressorRegistry.getDefaultInstance(), CompressorRegistry.getDefaultInstance(),
-        tracer);
+        tracer, false);
 
     // required boilerplate
     call.sendHeaders(new Metadata());
@@ -224,7 +224,7 @@ public class ServerCallImplTest {
         context,
         DecompressorRegistry.getDefaultInstance(),
         CompressorRegistry.getDefaultInstance(),
-        serverCallTracer);
+        serverCallTracer, false);
     serverCall.sendHeaders(new Metadata());
     serverCall.sendMessage(1L);
     verify(stream, times(1)).writeMessage(any(InputStream.class));
@@ -258,7 +258,7 @@ public class ServerCallImplTest {
         context,
         DecompressorRegistry.getDefaultInstance(),
         CompressorRegistry.getDefaultInstance(),
-        serverCallTracer);
+        serverCallTracer, false);
     serverCall.sendHeaders(new Metadata());
     serverCall.sendMessage(1L);
     serverCall.sendMessage(1L);
@@ -295,7 +295,7 @@ public class ServerCallImplTest {
         context,
         DecompressorRegistry.getDefaultInstance(),
         CompressorRegistry.getDefaultInstance(),
-        serverCallTracer);
+        serverCallTracer, false);
     serverCall.close(Status.OK, new Metadata());
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(stream, times(1)).cancel(statusCaptor.capture());

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1140,7 +1140,8 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation());
+            Context.ROOT.withCancellation(),
+            false);
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1165,7 +1166,8 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation());
+            Context.ROOT.withCancellation(),
+            false);
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1190,7 +1192,8 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation());
+            Context.ROOT.withCancellation(),
+            false);
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1213,7 +1216,8 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation());
+            Context.ROOT.withCancellation(),
+            false);
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1236,7 +1240,8 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation());
+            Context.ROOT.withCancellation(),
+            false);
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1259,7 +1264,8 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation());
+            Context.ROOT.withCancellation(),
+            false);
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 

--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -121,7 +121,7 @@ public final class ServerCalls {
       // We expect only 1 request, but we ask for 2 requests here so that if a misbehaving client
       // sends more than 1 requests, ServerCall will catch it. Note that disabling auto
       // inbound flow control has no effect on unary calls.
-      call.request(2);
+      call.request(1);
       return new UnaryServerCallListener(responseObserver, call);
     }
 


### PR DESCRIPTION
Full description to come, but basically this issues a fake request() call which is delivered to the application once a real request comes in.  The previous flow looks like:

1.  ELG: Server stream created
2.  (Hop and wake) (App) Server Call Created
3.  ELG goes to sleep 
4.  (App) Server Call tries to request  (wakes ups ELG and then goes to sleep)
5.  ELG wakes up and delivers message (wakes up App Thread)

This change avoids the multiple wakeups (put still involves the thread hop.


Before
```
Benchmark                                               (direct)  (transport)    Mode     Cnt         Score     Error  Units
TransportBenchmark.unaryCall1024                            true    INPROCESS  sample  295507      2187.397 ±  26.742  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true    INPROCESS  sample              1870.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true    INPROCESS  sample              2080.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true    INPROCESS  sample              2212.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true    INPROCESS  sample              2312.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true    INPROCESS  sample              3344.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true    INPROCESS  sample             18080.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true    INPROCESS  sample             27751.872            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true    INPROCESS  sample            784384.000            ns/op
TransportBenchmark.unaryCall1024                            true        NETTY  sample  109098     46012.846 ± 174.786  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true        NETTY  sample             36992.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true        NETTY  sample             43904.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true        NETTY  sample             49728.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true        NETTY  sample             53760.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true        NETTY  sample             75520.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true        NETTY  sample            126835.328            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true        NETTY  sample            522259.354            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true        NETTY  sample           4177920.000            ns/op
TransportBenchmark.unaryCall1024                            true  NETTY_LOCAL  sample  118522     42331.110 ± 116.612  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true  NETTY_LOCAL  sample             32896.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true  NETTY_LOCAL  sample             41984.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true  NETTY_LOCAL  sample             46528.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true  NETTY_LOCAL  sample             50176.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true  NETTY_LOCAL  sample             67840.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true  NETTY_LOCAL  sample            129280.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true  NETTY_LOCAL  sample            797043.917            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true  NETTY_LOCAL  sample            996352.000            ns/op
TransportBenchmark.unaryCall1024                            true       OKHTTP  sample  121499     41435.287 ± 112.022  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true       OKHTTP  sample             30848.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true       OKHTTP  sample             39040.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true       OKHTTP  sample             45120.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true       OKHTTP  sample             49472.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true       OKHTTP  sample             79232.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true       OKHTTP  sample            134144.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true       OKHTTP  sample            556288.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true       OKHTTP  sample            968704.000            ns/op
TransportBenchmark.unaryCall1024                           false    INPROCESS  sample  226241     11179.208 ±  38.668  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false    INPROCESS  sample              5672.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false    INPROCESS  sample             10960.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false    INPROCESS  sample             11360.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false    INPROCESS  sample             11760.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false    INPROCESS  sample             17664.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false    INPROCESS  sample             55600.512            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false    INPROCESS  sample            212833.843            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false    INPROCESS  sample           1017856.000            ns/op
TransportBenchmark.unaryCall1024                           false        NETTY  sample  160492     62233.943 ± 146.606  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false        NETTY  sample             47680.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false        NETTY  sample             60160.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false        NETTY  sample             67456.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false        NETTY  sample             71808.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false        NETTY  sample             88832.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false        NETTY  sample            137601.792            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false        NETTY  sample            373071.309            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false        NETTY  sample           4243456.000            ns/op
TransportBenchmark.unaryCall1024                           false  NETTY_LOCAL  sample  161290     61923.387 ± 288.956  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false  NETTY_LOCAL  sample             45056.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false  NETTY_LOCAL  sample             61632.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false  NETTY_LOCAL  sample             66688.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false  NETTY_LOCAL  sample             70656.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false  NETTY_LOCAL  sample             85376.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false  NETTY_LOCAL  sample            149941.504            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false  NETTY_LOCAL  sample            457495.040            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false  NETTY_LOCAL  sample          13484032.000            ns/op
TransportBenchmark.unaryCall1024                           false       OKHTTP  sample  162733     61374.192 ±  81.989  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false       OKHTTP  sample             46208.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false       OKHTTP  sample             59648.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false       OKHTTP  sample             66176.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false       OKHTTP  sample             70656.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false       OKHTTP  sample             87680.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false       OKHTTP  sample            129698.048            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false       OKHTTP  sample            460537.651            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false       OKHTTP  sample           1253376.000            ns/op
```


After:

```
NO request2
Benchmark                                               (direct)  (transport)    Mode     Cnt        Score     Error  Units
TransportBenchmark.unaryCall1024                            true    INPROCESS  sample  300344     2131.219 ±  22.084  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true    INPROCESS  sample             1848.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true    INPROCESS  sample             2034.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true    INPROCESS  sample             2160.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true    INPROCESS  sample             2268.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true    INPROCESS  sample             3340.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true    INPROCESS  sample            17952.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true    INPROCESS  sample            23388.688            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true    INPROCESS  sample           792576.000            ns/op
TransportBenchmark.unaryCall1024                            true        NETTY  sample  113794    44187.839 ± 202.543  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true        NETTY  sample            35904.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true        NETTY  sample            42240.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true        NETTY  sample            47808.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true        NETTY  sample            51840.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true        NETTY  sample            73088.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true        NETTY  sample           139008.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true        NETTY  sample           667787.264            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true        NETTY  sample          4210688.000            ns/op
TransportBenchmark.unaryCall1024                            true  NETTY_LOCAL  sample  113402    44239.876 ± 159.380  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true  NETTY_LOCAL  sample            32608.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true  NETTY_LOCAL  sample            43584.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true  NETTY_LOCAL  sample            47872.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true  NETTY_LOCAL  sample            51520.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true  NETTY_LOCAL  sample            70912.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true  NETTY_LOCAL  sample           138851.328            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true  NETTY_LOCAL  sample           867655.066            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true  NETTY_LOCAL  sample          3305472.000            ns/op
TransportBenchmark.unaryCall1024                            true       OKHTTP  sample  119716    42030.275 ± 113.636  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00        true       OKHTTP  sample            30208.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50        true       OKHTTP  sample            39680.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90        true       OKHTTP  sample            46080.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95        true       OKHTTP  sample            50624.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99        true       OKHTTP  sample            80362.240            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999       true       OKHTTP  sample           136008.448            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999      true       OKHTTP  sample           566097.920            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00        true       OKHTTP  sample           966656.000            ns/op
TransportBenchmark.unaryCall1024                           false    INPROCESS  sample  217810    11616.582 ±  41.963  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false    INPROCESS  sample             6616.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false    INPROCESS  sample            11312.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false    INPROCESS  sample            11664.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false    INPROCESS  sample            12112.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false    INPROCESS  sample            18144.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false    INPROCESS  sample            57676.096            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false    INPROCESS  sample           225848.038            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false    INPROCESS  sample           962560.000            ns/op
TransportBenchmark.unaryCall1024                           false        NETTY  sample  188966    52848.500 ± 118.499  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false        NETTY  sample            44352.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false        NETTY  sample            50816.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false        NETTY  sample            57536.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false        NETTY  sample            61568.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false        NETTY  sample            77184.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false        NETTY  sample           130436.224            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false        NETTY  sample           343869.338            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false        NETTY  sample          4182016.000            ns/op
TransportBenchmark.unaryCall1024                           false  NETTY_LOCAL  sample  191197    52227.475 ± 110.090  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false  NETTY_LOCAL  sample            42752.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false  NETTY_LOCAL  sample            51584.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false  NETTY_LOCAL  sample            56640.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false  NETTY_LOCAL  sample            60608.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false  NETTY_LOCAL  sample            77056.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false  NETTY_LOCAL  sample           133581.312            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false  NETTY_LOCAL  sample           553493.299            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false  NETTY_LOCAL  sample          3670016.000            ns/op
TransportBenchmark.unaryCall1024                           false       OKHTTP  sample  195784    51003.501 ±  78.501  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false       OKHTTP  sample            39040.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false       OKHTTP  sample            49088.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false       OKHTTP  sample            55808.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false       OKHTTP  sample            60288.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false       OKHTTP  sample            76288.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false       OKHTTP  sample           122651.520            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false       OKHTTP  sample           388079.360            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false       OKHTTP  sample          1959936.000            ns/op
```