### PR TITLE
api: deprecate Helper.updateSubchannelAddresses() and add equivalent on Subchannel

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -963,7 +963,9 @@ public abstract class LoadBalancer {
      * href="https://github.com/grpc/grpc-java/issues/5015">#5015</a> for the background.
      *
      * @since 1.4.0
+     * @deprecated use {@link Subchannel#updateAddresses} instead
      */
+    @Deprecated
     public final void updateSubchannelAddresses(
         Subchannel subchannel, EquivalentAddressGroup addrs) {
       checkNotNull(addrs, "addrs");
@@ -982,7 +984,9 @@ public abstract class LoadBalancer {
      * @throws IllegalArgumentException if {@code subchannel} was not returned from {@link
      *     #createSubchannel} or {@code addrs} is empty
      * @since 1.14.0
+     * @deprecated use {@link Subchannel#updateAddresses} instead
      */
+    @Deprecated
     public void updateSubchannelAddresses(
         Subchannel subchannel, List<EquivalentAddressGroup> addrs) {
       throw new UnsupportedOperationException();
@@ -1298,6 +1302,19 @@ public abstract class LoadBalancer {
      * @since 1.17.0
      */
     public ChannelLogger getChannelLogger() {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces the existing addresses used with this {@code Subchannel}. If the new and old
+     * addresses overlap, the Subchannel can continue using an existing connection.
+     *
+     * <p>It must be called from the Synchronization Context or will will throw.
+     *
+     * @throws IllegalArgumentException if {@code addrs} is empty
+     * @since 1.22.0
+     */
+    public void updateAddresses(List<EquivalentAddressGroup> addrs) {
       throw new UnsupportedOperationException();
     }
 

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -1309,7 +1309,7 @@ public abstract class LoadBalancer {
      * Replaces the existing addresses used with this {@code Subchannel}. If the new and old
      * addresses overlap, the Subchannel can continue using an existing connection.
      *
-     * <p>It must be called from the Synchronization Context or will will throw.
+     * <p>It must be called from the Synchronization Context or will throw.
      *
      * @throws IllegalArgumentException if {@code addrs} is empty
      * @since 1.22.0

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -170,6 +170,7 @@ public class LoadBalancerTest {
     }
   }
 
+  @Deprecated
   @Test
   public void helper_updateSubchannelAddresses_delegates() {
     class OverrideUpdateSubchannel extends NoopHelper {
@@ -190,6 +191,7 @@ public class LoadBalancerTest {
     assertThat(helper.ran).isTrue();
   }
 
+  @Deprecated
   @Test(expected = UnsupportedOperationException.class)
   public void helper_updateSubchannelAddressesList_throws() {
     new NoopHelper().updateSubchannelAddresses(null, Arrays.asList(eag));

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1132,6 +1132,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
       syncContext.execute(new LoadBalancerRefreshNameResolution());
     }
 
+    @Deprecated
     @Override
     public void updateSubchannelAddresses(
         LoadBalancer.Subchannel subchannel, List<EquivalentAddressGroup> addrs) {
@@ -1605,6 +1606,12 @@ final class ManagedChannelImpl extends ManagedChannel implements
     @Override
     public ChannelLogger getChannelLogger() {
       return subchannel.getChannelLogger();
+    }
+
+    @Override
+    public void updateAddresses(List<EquivalentAddressGroup> addrs) {
+      syncContext.throwIfNotInThisSynchronizationContext();
+      subchannel.updateAddresses(addrs);
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLoadBalancer.java
@@ -64,7 +64,7 @@ final class PickFirstLoadBalancer extends LoadBalancer {
       helper.updateBalancingState(CONNECTING, new Picker(PickResult.withSubchannel(subchannel)));
       subchannel.requestConnection();
     } else {
-      helper.updateSubchannelAddresses(subchannel, servers);
+      subchannel.updateAddresses(servers);
     }
   }
 

--- a/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
+++ b/core/src/main/java/io/grpc/util/ForwardingLoadBalancerHelper.java
@@ -51,6 +51,7 @@ public abstract class ForwardingLoadBalancerHelper extends LoadBalancer.Helper {
     return delegate().createSubchannel(args);
   }
 
+  @Deprecated
   @Override
   public void updateSubchannelAddresses(
       Subchannel subchannel, List<EquivalentAddressGroup> addrs) {

--- a/core/src/main/java/io/grpc/util/ForwardingSubchannel.java
+++ b/core/src/main/java/io/grpc/util/ForwardingSubchannel.java
@@ -75,6 +75,11 @@ public abstract class ForwardingSubchannel extends LoadBalancer.Subchannel {
   }
 
   @Override
+  public void updateAddresses(List<EquivalentAddressGroup> addrs) {
+    delegate().updateAddresses(addrs);
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplIdlenessTest.java
@@ -549,7 +549,7 @@ public class ManagedChannelImplIdlenessTest {
         new Runnable() {
           @Override
           public void run() {
-            helper.updateSubchannelAddresses(subchannel, addrs);
+            subchannel.updateAddresses(Collections.singletonList(addrs));
           }
         });
   }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -183,7 +183,16 @@ public class ManagedChannelImplTest {
           return "test-addr";
         }
       };
+  private final SocketAddress socketAddress2 =
+      new SocketAddress() {
+        @Override
+        public String toString() {
+          return "test-addr";
+        }
+      };
   private final EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(socketAddress);
+  private final EquivalentAddressGroup addressGroup2 =
+      new EquivalentAddressGroup(Arrays.asList(socketAddress, socketAddress2));
   private final FakeClock timer = new FakeClock();
   private final FakeClock executor = new FakeClock();
   private final FakeClock balancerRpcExecutor = new FakeClock();
@@ -1300,6 +1309,11 @@ public class ManagedChannelImplTest {
     verify(mockTransportFactory, times(2))
         .newClientTransport(
             eq(socketAddress), eq(clientTransportOptions), isA(TransportLogger.class));
+
+    // updateAddresses()
+    updateAddressesSafely(helper, sub1, Collections.singletonList(addressGroup2));
+    assertThat(((InternalSubchannel) sub1.getInternalSubchannel()).getAddressGroups())
+        .isEqualTo(Collections.singletonList(addressGroup2));
 
     // shutdown() has a delay
     shutdownSafely(helper, sub1);
@@ -4026,6 +4040,17 @@ public class ManagedChannelImplTest {
           @Override
           public void run() {
             helper.refreshNameResolution();
+          }
+        });
+  }
+
+  private static void updateAddressesSafely(
+      Helper helper, final Subchannel subchannel, final List<EquivalentAddressGroup> addrs) {
+    helper.getSynchronizationContext().execute(
+        new Runnable() {
+          @Override
+          public void run() {
+            subchannel.updateAddresses(addrs);
           }
         });
   }

--- a/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLoadBalancerTest.java
@@ -172,6 +172,7 @@ public class PickFirstLoadBalancerTest {
     verify(mockSubchannel).requestConnection();
     loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
+    verify(mockSubchannel).updateAddresses(eq(servers));
     verifyNoMoreInteractions(mockSubchannel);
 
     verify(mockHelper).createSubchannel(createArgsCaptor.capture());
@@ -179,8 +180,7 @@ public class PickFirstLoadBalancerTest {
     verify(mockHelper)
         .updateBalancingState(isA(ConnectivityState.class), isA(SubchannelPicker.class));
     // Updating the subchannel addresses is unnecessary, but doesn't hurt anything
-    verify(mockHelper).updateSubchannelAddresses(
-        eq(mockSubchannel), ArgumentMatchers.<EquivalentAddressGroup>anyList());
+    verify(mockSubchannel).updateAddresses(ArgumentMatchers.<EquivalentAddressGroup>anyList());
 
     verifyNoMoreInteractions(mockHelper);
   }
@@ -191,7 +191,7 @@ public class PickFirstLoadBalancerTest {
     List<EquivalentAddressGroup> newServers =
         Lists.newArrayList(new EquivalentAddressGroup(socketAddr));
 
-    InOrder inOrder = inOrder(mockHelper);
+    InOrder inOrder = inOrder(mockHelper, mockSubchannel);
 
     loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(servers).setAttributes(affinity).build());
@@ -205,7 +205,7 @@ public class PickFirstLoadBalancerTest {
 
     loadBalancer.handleResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(newServers).setAttributes(affinity).build());
-    inOrder.verify(mockHelper).updateSubchannelAddresses(eq(mockSubchannel), eq(newServers));
+    inOrder.verify(mockSubchannel).updateAddresses(eq(newServers));
 
     verifyNoMoreInteractions(mockSubchannel);
     verifyNoMoreInteractions(mockHelper);

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -438,7 +438,7 @@ final class GrpclbState {
         } else {
           checkState(subchannels.size() == 1, "Unexpected Subchannel count: %s", subchannels);
           subchannel = subchannels.values().iterator().next();
-          helper.updateSubchannelAddresses(subchannel, eagList);
+          subchannel.updateAddresses(eagList);
         }
         subchannels = Collections.singletonMap(eagList, subchannel);
         newBackendList.add(

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -1776,8 +1776,7 @@ public class GrpclbLoadBalancerTest {
     // createSubchannel() has ever been called only once
     verify(helper, times(1)).createSubchannel(any(List.class), any(Attributes.class));
     assertThat(mockSubchannels).isEmpty();
-    inOrder.verify(helper).updateSubchannelAddresses(
-        same(subchannel),
+    verify(subchannel).updateAddresses(
         eq(Arrays.asList(
                 new EquivalentAddressGroup(backends2.get(0).addr, eagAttrsWithToken("token0001")),
                 new EquivalentAddressGroup(backends2.get(2).addr,
@@ -1874,8 +1873,7 @@ public class GrpclbLoadBalancerTest {
     // createSubchannel() has ever been called only once
     verify(helper, times(1)).createSubchannel(any(List.class), any(Attributes.class));
     assertThat(mockSubchannels).isEmpty();
-    inOrder.verify(helper).updateSubchannelAddresses(
-        same(subchannel),
+    verify(subchannel).updateAddresses(
         eq(Arrays.asList(
                 new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
                 new EquivalentAddressGroup(backends1.get(1).addr,


### PR DESCRIPTION
Resolves #5676