### PR TITLE
core: only let ManagedChannelImpl convert empty resolution result to error

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -70,6 +70,7 @@ import io.grpc.ProxyDetector;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
+import io.grpc.internal.AutoConfiguredLoadBalancerFactory.AutoConfiguredLoadBalancer;
 import io.grpc.internal.ClientCallImpl.ClientTransportProvider;
 import io.grpc.internal.RetriableStream.ChannelBufferMeter;
 import io.grpc.internal.RetriableStream.Throttle;
@@ -1049,7 +1050,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
   }
 
   private class LbHelperImpl extends LoadBalancer.Helper {
-    LoadBalancer lb;
+    AutoConfiguredLoadBalancer lb;
 
     @Deprecated
     @Override
@@ -1332,21 +1333,19 @@ final class ManagedChannelImpl extends ManagedChannel implements
 
           // Call LB only if it's not shutdown.  If LB is shutdown, lbHelper won't match.
           if (NameResolverListener.this.helper == ManagedChannelImpl.this.lbHelper) {
-            if (servers.isEmpty() && !helper.lb.canHandleEmptyAddressListFromNameResolution()) {
-              handleErrorInSyncContext(Status.UNAVAILABLE.withDescription(
-                  "Name resolver " + resolver + " returned an empty list"));
-            } else {
-              Attributes effectiveAttrs = attrs;
-              if (effectiveServiceConfig != serviceConfig) {
-                effectiveAttrs = attrs.toBuilder()
-                    .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, effectiveServiceConfig)
-                    .build();
-              }
-              helper.lb.handleResolvedAddresses(
-                  ResolvedAddresses.newBuilder()
-                      .setAddresses(servers)
-                      .setAttributes(effectiveAttrs)
-                      .build());
+            Attributes effectiveAttrs = attrs;
+            if (effectiveServiceConfig != serviceConfig) {
+              effectiveAttrs = attrs.toBuilder()
+                  .set(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG, effectiveServiceConfig)
+                  .build();
+            }
+            Status handleResult = helper.lb.tryHandleResolvedAddresses(
+                ResolvedAddresses.newBuilder()
+                .setAddresses(servers)
+                .setAttributes(effectiveAttrs)
+                .build());
+            if (!handleResult.isOk()) {
+              handleErrorInSyncContext(handleResult.augmentDescription(resolver + " was used"));
             }
           }
         }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -952,6 +952,9 @@ public class ManagedChannelImplTest {
     Status status = statusCaptor.getValue();
     assertSame(Status.Code.UNAVAILABLE, status.getCode());
     Truth.assertThat(status.getDescription()).startsWith(errorDescription);
+
+    // A resolution retry has been scheduled
+    assertEquals(1, timer.numPendingTasks(NAME_RESOLVER_REFRESH_TASK_FILTER));
   }
 
   @Test
@@ -982,6 +985,9 @@ public class ManagedChannelImplTest {
     assertEquals(ImmutableMap.of("setting1", "high"), lbConfig);
     assertSame(
         serviceConfig, actualAttrs.get(GrpcAttributes.NAME_RESOLVER_SERVICE_CONFIG));
+
+    // A no resolution retry
+    assertEquals(0, timer.numPendingTasks(NAME_RESOLVER_REFRESH_TASK_FILTER));
   }
 
   @Test

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -931,7 +931,7 @@ public class ManagedChannelImplTest {
 
   @Test
   public void nameResolverReturnsEmptySubLists_becomeErrorByDefault() throws Exception {
-    String errorDescription = "Name resolver returned no usable address";
+    String errorDescription = "NameResolver returned no usable address";
 
     // Pass a FakeNameResolverFactory with an empty list and LB config
     FakeNameResolverFactory nameResolverFactory =


### PR DESCRIPTION
Previously, AutoConfiguredLoadBalancer was also handling it, but it
doesn't trigger retries.  By returning true for
canHandleEmptyAddressListFromNameResolution(),
AutoConfiguredLoadBalancer effectively by-passed the empty-result
handling logic in ManagedChannelImpl, thus resolution retries were
never triggered.

This change requires AutoConfiguredLoadBalancer to stop being a
LoadBalancer, for its tryHandleResolvedAddresses().  It doesn't
cause any trouble because AutoConfiguredLoadBalancer has become
less and less like a LoadBalancer during the service config changes.

Resolves #5692