### PR TITLE
core: Add migrating deframer

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -623,6 +623,9 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       }
 
       @Override
+      public void optimizeForDirectExecutor() {}
+
+      @Override
       public void setCompressor(Compressor compressor) {}
 
       @Override
@@ -817,6 +820,9 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       public Attributes getAttributes() {
         return attributes;
       }
+
+      @Override
+      public void optimizeForDirectExecutor() {}
 
       @Override
       public void setCompressor(Compressor compressor) {}

--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -81,13 +81,6 @@ public abstract class AbstractClientStream extends AbstractStream
         @Nullable WritableBuffer frame, boolean endOfStream, boolean flush, int numMessages);
 
     /**
-     * Requests up to the given number of messages from the call to be delivered to the client. This
-     * should end up triggering {@link TransportState#requestMessagesFromDeframer(int)} on the
-     * transport thread.
-     */
-    void request(int numMessages);
-
-    /**
      * Tears down the stream, typically in the event of a timeout. This method may be called
      * multiple times and from any thread.
      *
@@ -185,11 +178,6 @@ public abstract class AbstractClientStream extends AbstractStream
    */
   public final boolean shouldBeCountedForInUse() {
     return shouldBeCountedForInUse;
-  }
-
-  @Override
-  public final void request(int numMessages) {
-    abstractClientStreamSink().request(numMessages);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -62,12 +62,6 @@ public abstract class AbstractServerStream extends AbstractStream
     void writeTrailers(Metadata trailers, boolean headersSent, Status status);
 
     /**
-     * Requests up to the given number of messages from the call to be delivered. This should end up
-     * triggering {@link TransportState#requestMessagesFromDeframer(int)} on the transport thread.
-     */
-    void request(int numMessages);
-
-    /**
      * Tears down the stream, typically in the event of a timeout. This method may be called
      * multiple times and from any thread.
      *
@@ -99,11 +93,6 @@ public abstract class AbstractServerStream extends AbstractStream
   @Override
   protected final MessageFramer framer() {
     return framer;
-  }
-
-  @Override
-  public final void request(int numMessages) {
-    abstractServerStreamSink().request(numMessages);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ApplicationThreadDeframerListener.java
+++ b/core/src/main/java/io/grpc/internal/ApplicationThreadDeframerListener.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+/**
+ * Listener for when deframing on the application thread, which calls the real listener on the
+ * transport thread. May only be called on the application thread.
+ *
+ * <p>Does not call the delegate's {@code messagesAvailable()}. It's expected that
+ * {@code messageReadQueuePoll()} is called on the application thread from within a message producer
+ * managed elsewhere.
+ */
+final class ApplicationThreadDeframerListener implements MessageDeframer.Listener {
+  public interface TransportExecutor {
+    void runOnTransportThread(Runnable r);
+  }
+
+  private final TransportExecutor transportExecutor;
+  private final MessageDeframer.Listener storedListener;
+  /** Queue for messages returned by the deframer when deframing in the application thread. */
+  private final Queue<InputStream> messageReadQueue = new ArrayDeque<>();
+
+  public ApplicationThreadDeframerListener(
+      MessageDeframer.Listener listener, TransportExecutor transportExecutor) {
+    this.storedListener = checkNotNull(listener, "listener");
+    this.transportExecutor = checkNotNull(transportExecutor, "transportExecutor");
+  }
+
+  @Override
+  public void bytesRead(final int numBytes) {
+    transportExecutor.runOnTransportThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            storedListener.bytesRead(numBytes);
+          }
+        });
+  }
+
+  @Override
+  public void messagesAvailable(StreamListener.MessageProducer producer) {
+    InputStream message;
+    while ((message = producer.next()) != null) {
+      messageReadQueue.add(message);
+    }
+  }
+
+  @Override
+  public void deframerClosed(final boolean hasPartialMessage) {
+    transportExecutor.runOnTransportThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            storedListener.deframerClosed(hasPartialMessage);
+          }
+        });
+  }
+
+  @Override
+  public void deframeFailed(final Throwable cause) {
+    transportExecutor.runOnTransportThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            storedListener.deframeFailed(cause);
+          }
+        });
+  }
+
+  public InputStream messageReadQueuePoll() {
+    return messageReadQueue.poll();
+  }
+}

--- a/core/src/main/java/io/grpc/internal/DelayedStream.java
+++ b/core/src/main/java/io/grpc/internal/DelayedStream.java
@@ -337,6 +337,16 @@ class DelayedStream implements ClientStream {
   }
 
   @Override
+  public void optimizeForDirectExecutor() {
+    delayOrExecute(new Runnable() {
+      @Override
+      public void run() {
+        realStream.optimizeForDirectExecutor();
+      }
+    });
+  }
+
+  @Override
   public void setCompressor(final Compressor compressor) {
     checkNotNull(compressor, "compressor");
     delayOrExecute(new Runnable() {

--- a/core/src/main/java/io/grpc/internal/ForwardingClientStream.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingClientStream.java
@@ -48,6 +48,11 @@ abstract class ForwardingClientStream implements ClientStream {
   }
 
   @Override
+  public void optimizeForDirectExecutor() {
+    delegate().optimizeForDirectExecutor();
+  }
+
+  @Override
   public void setCompressor(Compressor compressor) {
     delegate().setCompressor(compressor);
   }

--- a/core/src/main/java/io/grpc/internal/ForwardingDeframerListener.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingDeframerListener.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+/**
+ * Forwards listener callbacks to a delegate.
+ */
+abstract class ForwardingDeframerListener implements MessageDeframer.Listener {
+  protected abstract MessageDeframer.Listener delegate();
+
+  @Override
+  public void bytesRead(int numBytes) {
+    delegate().bytesRead(numBytes);
+  }
+
+  @Override
+  public void messagesAvailable(StreamListener.MessageProducer producer) {
+    delegate().messagesAvailable(producer);
+  }
+
+  @Override
+  public void deframerClosed(boolean hasPartialMessage) {
+    delegate().deframerClosed(hasPartialMessage);
+  }
+
+  @Override
+  public void deframeFailed(Throwable cause) {
+    delegate().deframeFailed(cause);
+  }
+}

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -42,6 +42,7 @@ import io.grpc.Status;
 import io.grpc.internal.ClientStreamListener.RpcProgress;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.internal.StreamListener.MessageProducer;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
@@ -746,10 +747,10 @@ public final class GrpcUtil {
   }
 
   /**
-   * Closes an InputStream, ignoring IOExceptions.
+   * Closes a Closeable, ignoring IOExceptions.
    * This method exists because Guava's {@code Closeables.closeQuietly()} is beta.
    */
-  public static void closeQuietly(@Nullable InputStream message) {
+  public static void closeQuietly(@Nullable Closeable message) {
     if (message == null) {
       return;
     }

--- a/core/src/main/java/io/grpc/internal/MessageDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MessageDeframer.java
@@ -204,6 +204,10 @@ public class MessageDeframer implements Closeable, Deframer {
     stopDelivery = true;
   }
 
+  boolean hasPendingDeliveries() {
+    return pendingDeliveries != 0;
+  }
+
   @Override
   public void close() {
     if (isClosed()) {

--- a/core/src/main/java/io/grpc/internal/MigratingThreadDeframer.java
+++ b/core/src/main/java/io/grpc/internal/MigratingThreadDeframer.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.grpc.Decompressor;
+import java.io.Closeable;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * A deframer that moves decoding between the transport and app threads based on which is more
+ * efficient at that moment.
+ */
+final class MigratingThreadDeframer implements ThreadOptimizedDeframer {
+  private interface Op {
+    void run(boolean isDeframerOnTransportThread);
+  }
+
+  private final MessageDeframer.Listener transportListener;
+  private final ApplicationThreadDeframerListener appListener;
+  private final MigratingDeframerListener migratingListener;
+  private final ApplicationThreadDeframerListener.TransportExecutor transportExecutor;
+  private final MessageDeframer deframer;
+  private final DeframeMessageProducer messageProducer = new DeframeMessageProducer();
+
+  private final Object lock = new Object();
+  /**
+   * {@code true} means decoding on transport thread.
+   *
+   * <p>Invariant: if there are outstanding requests, then deframerOnTransportThread=true. Otherwise
+   * deframerOnTransportThread=false.
+   */
+  @GuardedBy("lock")
+  private boolean deframerOnTransportThread;
+  @GuardedBy("lock")
+  private final Queue<Op> opQueue = new ArrayDeque<>();
+  @GuardedBy("lock")
+  private boolean messageProducerEnqueued;
+
+  public MigratingThreadDeframer(
+      MessageDeframer.Listener listener,
+      ApplicationThreadDeframerListener.TransportExecutor transportExecutor,
+      MessageDeframer deframer) {
+    this.transportListener =
+        new SquelchLateMessagesAvailableDeframerListener(checkNotNull(listener, "listener"));
+    this.transportExecutor = checkNotNull(transportExecutor, "transportExecutor");
+    this.appListener = new ApplicationThreadDeframerListener(transportListener, transportExecutor);
+    // Starts on app thread
+    this.migratingListener = new MigratingDeframerListener(appListener);
+    deframer.setListener(migratingListener);
+    this.deframer = deframer;
+  }
+
+  @Override
+  public void setMaxInboundMessageSize(int messageSize) {
+    deframer.setMaxInboundMessageSize(messageSize);
+  }
+
+  @Override
+  public void setDecompressor(Decompressor decompressor) {
+    deframer.setDecompressor(decompressor);
+  }
+
+  @Override
+  public void setFullStreamDecompressor(GzipInflatingBuffer fullStreamDecompressor) {
+    deframer.setFullStreamDecompressor(fullStreamDecompressor);
+  }
+
+  private boolean runWhereAppropriate(Op op) {
+    return runWhereAppropriate(op, true);
+  }
+
+  private boolean runWhereAppropriate(Op op, boolean currentThreadIsTransportThread) {
+    boolean deframerOnTransportThreadCopy;
+    boolean alreadyEnqueued;
+    synchronized (lock) {
+      deframerOnTransportThreadCopy = deframerOnTransportThread;
+      alreadyEnqueued = messageProducerEnqueued;
+      if (!deframerOnTransportThreadCopy) {
+        opQueue.offer(op);
+        messageProducerEnqueued = true;
+      }
+    }
+    if (deframerOnTransportThreadCopy) {
+      op.run(/*isDeframerOnTransportThread=*/true);
+      return true;
+    } else {
+      if (!alreadyEnqueued) {
+        if (currentThreadIsTransportThread) {
+          transportListener.messagesAvailable(messageProducer);
+        } else {
+          // SLOW path. This is the "normal" thread-hopping approach for request() when _not_ using
+          // MigratingThreadDeframer
+          transportExecutor.runOnTransportThread(new Runnable() {
+            @Override public void run() {
+              transportListener.messagesAvailable(messageProducer);
+            }
+          });
+        }
+      }
+      return false;
+    }
+  }
+
+  // May be called from an arbitrary thread
+  @Override
+  public void request(final int numMessages) {
+    class RequestOp implements Op {
+      @Override public void run(boolean isDeframerOnTransportThread) {
+        if (isDeframerOnTransportThread) {
+          // We may not be currently on the transport thread, so jump over to it and then do the
+          // necessary processing
+          transportExecutor.runOnTransportThread(new Runnable() {
+            @Override public void run() {
+              // Since processing continues from transport thread while this runnable was
+              // enqueued, the state may have changed since we ran runOnTransportThread. So we
+              // must make sure deframerOnTransportThread==true
+              requestFromTransportThread(numMessages);
+            }
+          });
+          return;
+        }
+        try {
+          deframer.request(numMessages);
+        } catch (Throwable t) {
+          appListener.deframeFailed(t);
+          deframer.close(); // unrecoverable state
+        }
+      }
+    }
+
+    runWhereAppropriate(new RequestOp(), false);
+  }
+
+  private void requestFromTransportThread(final int numMessages) {
+    class RequestAgainOp implements Op {
+      @Override public void run(boolean isDeframerOnTransportThread) {
+        if (!isDeframerOnTransportThread) {
+          // State changed. Go back and try again
+          request(numMessages);
+          return;
+        }
+        try {
+          deframer.request(numMessages);
+        } catch (Throwable t) {
+          appListener.deframeFailed(t);
+          deframer.close(); // unrecoverable state
+        }
+        if (!deframer.hasPendingDeliveries()) {
+          synchronized (lock) {
+            migratingListener.setDelegate(appListener);
+            deframerOnTransportThread = false;
+          }
+        }
+      }
+    }
+
+    runWhereAppropriate(new RequestAgainOp());
+  }
+
+  @Override
+  public void deframe(final ReadableBuffer data) {
+    class DeframeOp implements Op, Closeable {
+      @Override public void run(boolean isDeframerOnTransportThread) {
+        if (isDeframerOnTransportThread) {
+          deframer.deframe(data);
+          return;
+        }
+
+        try {
+          deframer.deframe(data);
+        } catch (Throwable t) {
+          appListener.deframeFailed(t);
+          deframer.close(); // unrecoverable state
+        }
+      }
+
+      @Override public void close() {
+        data.close();
+      }
+    }
+
+    runWhereAppropriate(new DeframeOp());
+  }
+
+  @Override
+  public void closeWhenComplete() {
+    class CloseWhenCompleteOp implements Op {
+      @Override public void run(boolean isDeframerOnTransportThread) {
+        deframer.closeWhenComplete();
+      }
+    }
+
+    runWhereAppropriate(new CloseWhenCompleteOp());
+  }
+
+  @Override
+  public void close() {
+    class CloseOp implements Op {
+      @Override public void run(boolean isDeframerOnTransportThread) {
+        deframer.close();
+      }
+    }
+
+    if (!runWhereAppropriate(new CloseOp())) {
+      deframer.stopDelivery();
+    }
+  }
+
+  class DeframeMessageProducer implements StreamListener.MessageProducer, Closeable {
+    @Override
+    public InputStream next() {
+      while (true) {
+        InputStream is = appListener.messageReadQueuePoll();
+        if (is != null) {
+          return is;
+        }
+        Op op;
+        synchronized (lock) {
+          op = opQueue.poll();
+          if (op == null) {
+            if (deframer.hasPendingDeliveries()) {
+              migratingListener.setDelegate(transportListener);
+              deframerOnTransportThread = true;
+            }
+            messageProducerEnqueued = false;
+            return null;
+          }
+        }
+        op.run(/*isDeframerOnTransportThread=*/false);
+      }
+    }
+
+    @Override
+    public void close() {
+      while (true) {
+        Op op;
+        synchronized (lock) {
+          do {
+            op = opQueue.poll();
+          } while (!(op == null || op instanceof Closeable));
+          if (op == null) {
+            messageProducerEnqueued = false;
+            return;
+          }
+        }
+        GrpcUtil.closeQuietly((Closeable) op);
+      }
+    }
+  }
+
+  static class MigratingDeframerListener extends ForwardingDeframerListener {
+    private MessageDeframer.Listener delegate;
+
+    public MigratingDeframerListener(MessageDeframer.Listener delegate) {
+      setDelegate(delegate);
+    }
+
+    @Override
+    protected MessageDeframer.Listener delegate() {
+      return delegate;
+    }
+
+    public void setDelegate(MessageDeframer.Listener delegate) {
+      this.delegate = checkNotNull(delegate, "delegate");
+    }
+  }
+}

--- a/core/src/main/java/io/grpc/internal/NoopClientStream.java
+++ b/core/src/main/java/io/grpc/internal/NoopClientStream.java
@@ -67,6 +67,9 @@ public class NoopClientStream implements ClientStream {
   }
 
   @Override
+  public void optimizeForDirectExecutor() {}
+
+  @Override
   public void setCompressor(Compressor compressor) {}
 
   @Override

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -541,6 +541,18 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   }
 
   @Override
+  public void optimizeForDirectExecutor() {
+    class OptimizeDirectEntry implements BufferEntry {
+      @Override
+      public void runWith(Substream substream) {
+        substream.stream.optimizeForDirectExecutor();
+      }
+    }
+
+    delayOrExecute(new OptimizeDirectEntry());
+  }
+
+  @Override
   public final void setCompressor(final Compressor compressor) {
     class CompressorEntry implements BufferEntry {
       @Override

--- a/core/src/main/java/io/grpc/internal/SquelchLateMessagesAvailableDeframerListener.java
+++ b/core/src/main/java/io/grpc/internal/SquelchLateMessagesAvailableDeframerListener.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+import java.io.Closeable;
+
+/**
+ * A delegating Listener that throws away notifications of messagesAvailable() after the deframer
+ * has closed or failed. This can be used by deframers that "abuse" the MessageProducer to run work
+ * on the app thread, to avoid breaking the normal invariant that there are no messages after
+ * deframing is complete. Since the producer may not be run, it must not hold resources or
+ * it should implement {@link Closeable}.
+ */
+final class SquelchLateMessagesAvailableDeframerListener extends ForwardingDeframerListener {
+  private final MessageDeframer.Listener delegate;
+  private boolean closed;
+
+  public SquelchLateMessagesAvailableDeframerListener(MessageDeframer.Listener delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  protected MessageDeframer.Listener delegate() {
+    return delegate;
+  }
+
+  @Override
+  public void messagesAvailable(StreamListener.MessageProducer producer) {
+    if (closed) {
+      if (producer instanceof Closeable) {
+        GrpcUtil.closeQuietly((Closeable) producer);
+      }
+      return;
+    }
+    super.messagesAvailable(producer);
+  }
+
+  @Override
+  public void deframerClosed(boolean hasPartialMessage) {
+    closed = true;
+    super.deframerClosed(hasPartialMessage);
+  }
+
+  @Override
+  public void deframeFailed(Throwable cause) {
+    closed = true;
+    super.deframeFailed(cause);
+  }
+}
+

--- a/core/src/main/java/io/grpc/internal/Stream.java
+++ b/core/src/main/java/io/grpc/internal/Stream.java
@@ -68,6 +68,13 @@ public interface Stream {
   boolean isReady();
 
   /**
+   * Provides a hint that directExecutor is being used by the listener for callbacks to the
+   * application. No action is required. There is no requirement that this method actually matches
+   * the executor used.
+   */
+  void optimizeForDirectExecutor();
+
+  /**
    * Sets the compressor on the framer.
    *
    * @param compressor the compressor to use

--- a/core/src/main/java/io/grpc/internal/ThreadOptimizedDeframer.java
+++ b/core/src/main/java/io/grpc/internal/ThreadOptimizedDeframer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.internal;
+
+/**
+ * A {@code Deframer} that optimizations by taking over part of the thread safety.
+ */
+public interface ThreadOptimizedDeframer extends Deframer {
+  /**
+   * Behaves like {@link Deframer#request(int)} except it can be called from any thread. Must not
+   * throw exceptions in case of deframer error.
+   */
+  @Override
+  void request(int numMessages);
+}

--- a/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractClientStreamTest.java
@@ -333,9 +333,8 @@ public class AbstractClientStreamTest {
     AbstractClientStream stream =
         new BaseAbstractClientStream(allocator, statsTraceCtx, transportTracer);
     stream.start(mockListener);
-    // The application will call request when waiting for a message, which will in turn call this
-    // on the transport thread.
-    stream.transportState().requestMessagesFromDeframer(1);
+    // The application will call request when waiting for a message
+    stream.request(1);
     // Send first byte of 2 byte message
     stream.transportState().deframe(ReadableBuffers.wrap(new byte[] {0, 0, 0, 0, 2, 1}));
     Status status = Status.INTERNAL.withDescription("rst___stream");
@@ -359,7 +358,7 @@ public class AbstractClientStreamTest {
     Status status = Status.INTERNAL.withDescription("rst___stream");
     // Simulate getting a reset
     stream.transportState().transportReportStatus(status, false /*stop delivery*/, new Metadata());
-    stream.transportState().requestMessagesFromDeframer(1);
+    stream.request(1);
 
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(mockListener)
@@ -373,7 +372,7 @@ public class AbstractClientStreamTest {
         new BaseAbstractClientStream(allocator, statsTraceCtx, transportTracer);
     stream.start(mockListener);
 
-    stream.transportState().requestMessagesFromDeframer(1);
+    stream.request(1);
     stream.transportState().deframe(ReadableBuffers.wrap(new byte[] {0, 0, 0, 0, 2, 1}));
     stream.transportState().inboundTrailersReceived(new Metadata(), Status.OK);
 
@@ -390,7 +389,7 @@ public class AbstractClientStreamTest {
         new BaseAbstractClientStream(allocator, statsTraceCtx, transportTracer);
     stream.start(mockListener);
 
-    stream.transportState().requestMessagesFromDeframer(1);
+    stream.request(1);
     stream.transportState().deframe(ReadableBuffers.wrap(new byte[] {0, 0, 0, 0, 2, 1}));
     stream.transportState().inboundTrailersReceived(
         new Metadata(), Status.DATA_LOSS.withDescription("data___loss"));
@@ -550,9 +549,6 @@ public class AbstractClientStreamTest {
   private static class BaseSink implements AbstractClientStream.Sink {
     @Override
     public void writeHeaders(Metadata headers, byte[] payload) {}
-
-    @Override
-    public void request(int numMessages) {}
 
     @Override
     public void writeFrame(

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -163,7 +163,7 @@ public class AbstractServerStreamTest {
 
     // Queue a partial message in the deframer
     stream.transportState().inboundDataReceived(ReadableBuffers.wrap(new byte[] {1}), true);
-    stream.transportState().requestMessagesFromDeframer(1);
+    stream.request(1);
 
     Status status = closedFuture.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     assertEquals(Status.INTERNAL.getCode(), status.getCode());

--- a/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
+++ b/core/src/test/java/io/grpc/internal/ApplicationThreadDeframerTest.java
@@ -51,7 +51,7 @@ public class ApplicationThreadDeframerTest {
   @Before
   public void setUp() {
     // ApplicationThreadDeframer constructor injects itself as the wrapped deframer's listener.
-    verify(mockDeframer).setListener(applicationThreadDeframer);
+    verify(mockDeframer).setListener(applicationThreadDeframer.getAppListener());
   }
 
   @Test
@@ -90,7 +90,7 @@ public class ApplicationThreadDeframerTest {
 
   @Test
   public void bytesReadInvokesTransportExecutor() {
-    applicationThreadDeframer.bytesRead(1);
+    applicationThreadDeframer.getAppListener().bytesRead(1);
     assertEquals(0, listener.bytesRead);
     transportExecutor.runStoredRunnable();
     assertEquals(1, listener.bytesRead);
@@ -98,7 +98,7 @@ public class ApplicationThreadDeframerTest {
 
   @Test
   public void deframerClosedInvokesTransportExecutor() {
-    applicationThreadDeframer.deframerClosed(true);
+    applicationThreadDeframer.getAppListener().deframerClosed(true);
     assertFalse(listener.deframerClosedWithPartialMessage);
     transportExecutor.runStoredRunnable();
     assertTrue(listener.deframerClosedWithPartialMessage);
@@ -107,7 +107,7 @@ public class ApplicationThreadDeframerTest {
   @Test
   public void deframeFailedInvokesTransportExecutor() {
     Throwable cause = new Throwable("error");
-    applicationThreadDeframer.deframeFailed(cause);
+    applicationThreadDeframer.getAppListener().deframeFailed(cause);
     assertNull(listener.deframeFailedCause);
     transportExecutor.runStoredRunnable();
     assertEquals(cause, listener.deframeFailedCause);
@@ -122,7 +122,7 @@ public class ApplicationThreadDeframerTest {
       messages.add(new ByteArrayInputStream(messageBytes[i]));
     }
     MultiMessageProducer messageProducer = new MultiMessageProducer(messages);
-    applicationThreadDeframer.messagesAvailable(messageProducer);
+    applicationThreadDeframer.getAppListener().messagesAvailable(messageProducer);
     applicationThreadDeframer.request(1 /* value is ignored */);
     for (int i = 0; i < messageBytes.length; i++) {
       InputStream message = listener.storedProducer.next();

--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -124,6 +124,10 @@ class CronetClientStream extends AbstractClientStream {
     this.annotation = callOptions.getOption(CRONET_ANNOTATION_KEY);
     this.annotations = callOptions.getOption(CRONET_ANNOTATIONS_KEY);
     this.state = new TransportState(maxMessageSize, statsTraceCtx, lock, transportTracer);
+
+    // Tests expect the "plain" deframer behavior, not MigratingDeframer
+    // https://github.com/grpc/grpc-java/issues/7140
+    optimizeForDirectExecutor();
   }
 
   @Override
@@ -224,13 +228,6 @@ class CronetClientStream extends AbstractClientStream {
         } else {
           streamWrite(byteBuffer, endOfStream, flush);
         }
-      }
-    }
-
-    @Override
-    public void request(final int numMessages) {
-      synchronized (state.lock) {
-        state.requestMessagesFromDeframer(numMessages);
       }
     }
 

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -318,7 +318,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
     assertEquals("value",
         captor.getValue().get(Metadata.Key.of("magic", Metadata.ASCII_STRING_MARSHALLER)));
 
-    streamTransportState.requestMessagesFromDeframer(1);
+    streamTransportState.requestMessagesFromDeframerForTesting(1);
 
     // Create a data frame and then trigger the handler to read it.
     ByteBuf frame = grpcDataFrame(3, false, contentAsArray());

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientStream.java
@@ -186,18 +186,6 @@ class OkHttpClientStream extends AbstractClientStream {
     }
 
     @Override
-    public void request(final int numMessages) {
-      PerfMark.startTask("OkHttpClientStream$Sink.request");
-      try {
-        synchronized (state.lock) {
-          state.requestMessagesFromDeframer(numMessages);
-        }
-      } finally {
-        PerfMark.stopTask("OkHttpClientStream$Sink.request");
-      }
-    }
-
-    @Override
     public void cancel(Status reason) {
       PerfMark.startTask("OkHttpClientStream$Sink.cancel");
       try {


### PR DESCRIPTION
Possible alternative to #5800 which also helps reading many small messages. Not a direct replacement because onHalfClose() still delays the server from responding earlier when using our stubs.

CC @carl-mastrangelo 

I hacked the server stub to avoid waiting for onHalfClose for these numbers:
```
Before
After
Benchmark                                               (direct)  (transport)    Mode    Cnt        Score     Error  Units
Benchmark                                               (direct)  (transport)    Mode    Cnt         Score     Error  Units
TransportBenchmark.unaryCall1024                           false        NETTY  sample  55343   180432.321 ± 960.495  ns/op
TransportBenchmark.unaryCall1024                           false        NETTY  sample  63613   156958.498 ± 996.485  ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false        NETTY  sample          110464.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.00       false        NETTY  sample           97536.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false        NETTY  sample          173568.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.50       false        NETTY  sample          150528.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false        NETTY  sample          220672.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.90       false        NETTY  sample          194816.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false        NETTY  sample          240384.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.95       false        NETTY  sample          214528.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false        NETTY  sample          289280.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.99       false        NETTY  sample          263168.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false        NETTY  sample          401887.232            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.999      false        NETTY  sample          357259.264            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false        NETTY  sample         1002604.134            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p0.9999     false        NETTY  sample          946923.930            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false        NETTY  sample         9093120.000            ns/op
TransportBenchmark.unaryCall1024:unaryCall1024·p1.00       false        NETTY  sample        10747904.000            ns/op
```