### PR TITLE
xds: allow grpclb balancer addresses for backward compatibility

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -316,7 +316,7 @@ final class XdsLoadBalancer extends LoadBalancer {
       fallbackBalancer = lbRegistry.getProvider(fallbackPolicy.getPolicyName())
           .newLoadBalancer(fallbackBalancerHelper);
       fallbackBalancerHelper.balancer = fallbackBalancer;
-      handleFallbackAddressesOrNameResolutionError();
+      propagateFallbackAddresses();
     }
 
     void updateFallbackServers(
@@ -331,7 +331,7 @@ final class XdsLoadBalancer extends LoadBalancer {
       this.fallbackPolicy = fallbackPolicy;
       if (fallbackBalancer != null) {
         if (fallbackPolicy.getPolicyName().equals(currentFallbackPolicy.getPolicyName())) {
-          handleFallbackAddressesOrNameResolutionError();
+          propagateFallbackAddresses();
         } else {
           fallbackBalancer.shutdown();
           fallbackBalancer = null;
@@ -340,7 +340,7 @@ final class XdsLoadBalancer extends LoadBalancer {
       }
     }
 
-    private void handleFallbackAddressesOrNameResolutionError() {
+    private void propagateFallbackAddresses() {
       String fallbackPolicyName = fallbackPolicy.getPolicyName();
       List<EquivalentAddressGroup> servers = fallbackServers;
 
@@ -356,7 +356,7 @@ final class XdsLoadBalancer extends LoadBalancer {
         servers = backends.build();
       }
 
-      // FIXME: this is a temporary hack.
+      // TODO(zhangkun83): FIXME(#5496): this is a temporary hack.
       if (servers.isEmpty()
           && !fallbackBalancer.canHandleEmptyAddressListFromNameResolution()) {
         fallbackBalancer.handleNameResolutionError(Status.UNAVAILABLE.withDescription(

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -329,6 +329,9 @@ final class XdsLoadBalancer extends LoadBalancer {
         LbConfig fallbackPolicy) {
       this.fallbackServers = servers;
       String fallbackPolicyName = fallbackPolicy.getPolicyName();
+
+      // Some addresses in the list may be grpclb-v1 balancer addresses, so if the fallback policy
+      // does not support grpclb-v1 balancer addresses, then we need to exclude them from the list.
       if (!fallbackPolicyName.equals("grpclb") && !fallbackPolicyName.equals(XDS_POLICY_NAME)) {
         ImmutableList.Builder<EquivalentAddressGroup> backends = ImmutableList.builder();
         for (EquivalentAddressGroup eag : servers) {
@@ -338,6 +341,7 @@ final class XdsLoadBalancer extends LoadBalancer {
         }
         this.fallbackServers = backends.build();
       }
+
       this.fallbackAttributes = Attributes.newBuilder()
           .setAll(attributes)
           .set(ATTR_LOAD_BALANCING_CONFIG, fallbackPolicy.getRawConfigValue())

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
@@ -40,6 +40,8 @@ import javax.annotation.Nullable;
 @Internal
 public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
 
+  static final String XDS_POLICY_NAME = "xds_experimental";
+
   private static final LbConfig DEFAULT_FALLBACK_POLICY =
       new LbConfig("round_robin", ImmutableMap.<String, Void>of());
 
@@ -55,7 +57,7 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public String getPolicyName() {
-    return "xds_experimental";
+    return XDS_POLICY_NAME;
   }
 
   @Override

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
@@ -281,6 +281,9 @@ public class XdsLoadBalancerTest {
 
     doReturn(oobChannel1).doReturn(oobChannel2).doReturn(oobChannel3)
       .when(helper).createResolvingOobChannel(anyString());
+
+    // To write less tedious code for tests, allow fallbackBalancer to handle empty address list.
+    doReturn(true).when(fallbackBalancer1).canHandleEmptyAddressListFromNameResolution();
   }
 
   @After


### PR DESCRIPTION
During migration, the name resolver may not know when the client has been upgraded to xds, so it may still send grpclb v1 addresses with a list of policies including both grpclb v1 and xds.