### PR TITLE
examples: add example of how to set log scoped data with log4j

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     compileOnly "javax.annotation:javax.annotation-api:1.2"
+    compile "org.apache.logging.log4j:log4j-api:2.11.2"
 
     // examples/advanced need this for JsonFormat
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"

--- a/examples/src/main/java/io/grpc/examples/logcontext/Client.java
+++ b/examples/src/main/java/io/grpc/examples/logcontext/Client.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.logcontext;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A simple client that like {@link io.grpc.examples.helloworld.HelloWorldClient}.
+ * This client can help you create custom headers.
+ */
+public class Client {
+  private static final Logger logger = Logger.getLogger(Client.class.getName());
+
+  private final ManagedChannel originChannel;
+  private final GreeterGrpc.GreeterBlockingStub blockingStub;
+
+  /**
+   * A custom client.
+   */
+  private Client(String host, int port) {
+    originChannel = ManagedChannelBuilder.forAddress(host, port)
+        .usePlaintext()
+        .build();
+
+    blockingStub = GreeterGrpc.newBlockingStub(originChannel).withInterceptors(
+        new ClientInterceptor() {
+          @Override
+          public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+              MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+            return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+              @Override
+              public void start(Listener<RespT> responseListener, Metadata headers) {
+                try {
+                  headers.put(
+                      HeaderServerInterceptor.CLIENT_NAME_KEY,
+                      InetAddress.getLocalHost().getHostName());
+                } catch (UnknownHostException e) {
+                  throw new RuntimeException(e);
+                }
+                super.start(responseListener, headers);
+              }
+            };
+          }
+        });
+  }
+
+  private void shutdown() throws InterruptedException {
+    originChannel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+  }
+
+  /**
+   * A simple client method that like {@link io.grpc.examples.helloworld.HelloWorldClient}.
+   */
+  private void greet(String name) {
+    logger.info("Will try to greet " + name + " ...");
+    HelloRequest request = HelloRequest.newBuilder().setName(name).build();
+    HelloReply response;
+    try {
+      response = blockingStub.sayHello(request);
+    } catch (StatusRuntimeException e) {
+      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
+      return;
+    }
+    logger.info("Greeting: " + response.getMessage());
+  }
+
+  /**
+   * Main start the client from the command line.
+   */
+  public static void main(String[] args) throws Exception {
+    Client client = new Client("localhost", 50051);
+    try {
+      /* Access a service running on the local machine on port 50051 */
+      String user = "world";
+      if (args.length > 0) {
+        user = args[0]; /* Use the arg as the name to greet if provided */
+      }
+      client.greet(user);
+    } finally {
+      client.shutdown();
+    }
+  }
+}

--- a/examples/src/main/java/io/grpc/examples/logcontext/CustomLogServer.java
+++ b/examples/src/main/java/io/grpc/examples/logcontext/CustomLogServer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.logcontext;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptors;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.message.ReusableMessageFactory;
+import org.apache.logging.log4j.simple.SimpleLogger;
+import org.apache.logging.log4j.util.PropertiesUtil;
+
+/**
+ * A simple server that like {@link io.grpc.examples.helloworld.HelloWorldServer}.
+ * It uses
+ */
+public class CustomLogServer {
+
+  private static final org.apache.logging.log4j.Logger logger = new SimpleLogger(
+      CustomLogServer.class.getName(),
+      Level.INFO, /* showLogName= */ false,
+      /*showShortLogName=*/ false,
+      /*showDateTime=*/ true,
+      /*showContextMap=*/ true,
+      "yyyy/MM/dd HH:mm:ss:SSS zzz",
+      new ReusableMessageFactory(),
+      PropertiesUtil.getProperties(),
+      System.err);
+
+  /* The port on which the server should run */
+  private static final int PORT = 50051;
+  private Server server;
+
+  private void start() throws IOException {
+    server = ServerBuilder.forPort(PORT)
+        .addService(ServerInterceptors.intercept(new GreeterImpl(), new HeaderServerInterceptor()))
+        .build()
+        .start();
+    logger.info("Server started, listening on " + PORT);
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+        System.err.println("*** shutting down gRPC server since JVM is shutting down");
+        CustomLogServer.this.stop();
+        System.err.println("*** server shut down");
+      }
+    });
+  }
+
+  private void stop() {
+    if (server != null) {
+      server.shutdown();
+    }
+  }
+
+  /**
+   * Await termination on the main thread since the grpc library uses daemon threads.
+   */
+  private void blockUntilShutdown() throws InterruptedException {
+    if (server != null) {
+      server.awaitTermination();
+    }
+  }
+
+  /**
+   * Main launches the server from the command line.
+   */
+  public static void main(String[] args) throws IOException, InterruptedException {
+    final CustomLogServer server = new CustomLogServer();
+    server.start();
+    server.blockUntilShutdown();
+  }
+
+  private static class GreeterImpl extends GreeterGrpc.GreeterImplBase {
+
+    @Override
+    public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {
+      logger.info("Got a request");
+      HelloReply reply = HelloReply.newBuilder().setMessage("Hello " + req.getName()).build();
+      responseObserver.onNext(reply);
+      responseObserver.onCompleted();
+    }
+  }
+}

--- a/examples/src/main/java/io/grpc/examples/logcontext/HeaderServerInterceptor.java
+++ b/examples/src/main/java/io/grpc/examples/logcontext/HeaderServerInterceptor.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.examples.logcontext;
+
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import java.util.UUID;
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * A interceptor to handle server header.
+ */
+public class HeaderServerInterceptor implements ServerInterceptor {
+  
+  private static final String REQUEST_ID_NAME = "requestId";
+
+  static final Metadata.Key<String> CLIENT_NAME_KEY =
+      Metadata.Key.of("clientName", Metadata.ASCII_STRING_MARSHALLER);
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call,
+      final Metadata requestHeaders,
+      ServerCallHandler<ReqT, RespT> next) {
+
+    final String requestId = UUID.randomUUID().toString();
+    final String clientName = String.valueOf(requestHeaders.get(CLIENT_NAME_KEY));
+
+    return new SimpleForwardingServerCallListener<ReqT>(next.startCall(call, requestHeaders)) {
+      @Override
+      public void onCancel() {
+        ThreadContext.put(REQUEST_ID_NAME, requestId);
+        ThreadContext.put(CLIENT_NAME_KEY.name(), clientName);
+        try {
+          super.onCancel();
+        } finally {
+          ThreadContext.remove(REQUEST_ID_NAME);
+          ThreadContext.remove(CLIENT_NAME_KEY.name());
+        }
+      }
+
+      @Override
+      public void onComplete() {
+        ThreadContext.put(REQUEST_ID_NAME, requestId);
+        ThreadContext.put(CLIENT_NAME_KEY.name(), clientName);
+        try {
+          super.onComplete();
+        } finally {
+          ThreadContext.remove(REQUEST_ID_NAME);
+          ThreadContext.remove(CLIENT_NAME_KEY.name());
+        }
+      }
+
+      @Override
+      public void onMessage(ReqT message) {
+        ThreadContext.put(REQUEST_ID_NAME, requestId);
+        ThreadContext.put(CLIENT_NAME_KEY.name(), clientName);
+        try {
+          super.onMessage(message);
+        } finally {
+          ThreadContext.remove(REQUEST_ID_NAME);
+          ThreadContext.remove(CLIENT_NAME_KEY.name());
+        }
+      }
+
+      @Override
+      public void onReady() {
+        ThreadContext.put(REQUEST_ID_NAME, requestId);
+        ThreadContext.put(CLIENT_NAME_KEY.name(), clientName);
+        try {
+          super.onReady();
+        } finally {
+          ThreadContext.remove(REQUEST_ID_NAME);
+          ThreadContext.remove(CLIENT_NAME_KEY.name());
+        }
+      }
+
+      @Override
+      public void onHalfClose() {
+        ThreadContext.put(REQUEST_ID_NAME, requestId);
+        ThreadContext.put(CLIENT_NAME_KEY.name(), clientName);
+        try {
+          super.onHalfClose();
+        } finally {
+          ThreadContext.remove(REQUEST_ID_NAME);
+          ThreadContext.remove(CLIENT_NAME_KEY.name());
+        }
+      }
+    };
+  }
+}


### PR DESCRIPTION
This came up on [Stack Overflow](https://stackoverflow.com/questions/56396647/what-is-the-proper-way-to-set-mdc-for-logging-in-grpc-java-with-serverintercepto/).  The example shows how to use non-`io.grpc.Context`   scoped values.  In this case, it adds data that will be included in the log statement.

cc @ejona86 

