### PR TITLE
interop-testing: Only set okhttp's sslSocketFactory for test CA

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/TestServiceClient.java
@@ -433,14 +433,14 @@ public class TestServiceClient {
               GrpcUtil.authorityFromHostAndPort(serverHostOverride, serverPort));
         }
         if (useTls) {
-          try {
-            SSLSocketFactory factory = useTestCa
-                ? TestUtils.newSslSocketFactoryForCa(Platform.get().getProvider(),
-                    TestUtils.loadCert("ca.pem"))
-                : (SSLSocketFactory) SSLSocketFactory.getDefault();
-            okBuilder.sslSocketFactory(factory);
-          } catch (Exception e) {
-            throw new RuntimeException(e);
+          if (useTestCa) {
+            try {
+              SSLSocketFactory factory = TestUtils.newSslSocketFactoryForCa(
+                  Platform.get().getProvider(), TestUtils.loadCert("ca.pem"));
+              okBuilder.sslSocketFactory(factory);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
           }
         } else {
           okBuilder.usePlaintext();


### PR DESCRIPTION
We want the interop client to be configured like a normal user would,
and a normal user wouldn't call sslSocketFactory to use the default
roots.