### PR TITLE
core,netty: expose server stream id

### DIFF
--- a/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/core/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -608,6 +608,11 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       public StatsTraceContext statsTraceContext() {
         return statsTraceCtx;
       }
+
+      @Override
+      public int streamId() {
+        return -1;
+      }
     }
 
     private class InProcessClientStream implements ClientStream {

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -91,4 +91,9 @@ public interface ServerStream extends Stream {
    * The context for recording stats and traces for this stream.
    */
   StatsTraceContext statsTraceContext();
+
+  /**
+   * The HTTP/2 stream id, or {@code -1} if not supported.
+   */
+  int streamId();
 }

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -394,6 +394,11 @@ public class AbstractServerStreamTest {
         r.run();
       }
     }
+
+    @Override
+    public int streamId() {
+      return -1;
+    }
   }
 }
 

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -50,6 +50,7 @@ class NettyServerStream extends AbstractServerStream {
   private final Attributes attributes;
   private final String authority;
   private final TransportTracer transportTracer;
+  private final int streamId;
 
   public NettyServerStream(
       Channel channel,
@@ -65,6 +66,8 @@ class NettyServerStream extends AbstractServerStream {
     this.attributes = checkNotNull(transportAttrs);
     this.authority = authority;
     this.transportTracer = checkNotNull(transportTracer, "transportTracer");
+    // Read the id early to avoid reading transportState later.
+    this.streamId = transportState().id();
   }
 
   @Override
@@ -202,5 +205,10 @@ class NettyServerStream extends AbstractServerStream {
     public int id() {
       return http2Stream.id();
     }
+  }
+
+  @Override
+  public int streamId() {
+    return streamId;
   }
 }


### PR DESCRIPTION
This is to use in the PerfMark tag. (once that PR is submitted)