### PR TITLE
alts: ensure only the first few bytes of key are used

### DIFF
--- a/alts/src/main/java/io/grpc/alts/internal/AltsHandshakerClient.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsHandshakerClient.java
@@ -136,7 +136,7 @@ class AltsHandshakerClient {
       throw new IllegalStateException("Could not get enough key data from the handshake.");
     }
     byte[] key = new byte[KEY_LENGTH];
-    result.getKeyData().copyTo(key, 0);
+    result.getKeyData().substring(0, KEY_LENGTH).copyTo(key, 0);
     return key;
   }
 


### PR DESCRIPTION
Fixes grpc/grpc#19271