### PR TITLE
services: fix HealthCheckingLoadBalancer.shutdown().

### DIFF
--- a/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
@@ -121,7 +121,7 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
       HealthCheckState hcState = new HealthCheckState(
           this, originalSubchannel, syncContext, delegate.getScheduledExecutorService());
       hcStates.add(hcState);
-      Subchannel subchannel = new SubchannelImpl(originalSubchannel, hcState);
+      Subchannel subchannel = new SubchannelImpl(originalSubchannel, this, hcState);
       if (healthCheckedService != null) {
         hcState.setServiceName(healthCheckedService);
       }
@@ -144,10 +144,12 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
   @VisibleForTesting
   static final class SubchannelImpl extends ForwardingSubchannel {
     final Subchannel delegate;
+    final HelperImpl helperImpl;
     final HealthCheckState hcState;
 
-    SubchannelImpl(Subchannel delegate, HealthCheckState hcState) {
+    SubchannelImpl(Subchannel delegate, HelperImpl helperImpl, HealthCheckState hcState) {
       this.delegate = checkNotNull(delegate, "delegate");
+      this.helperImpl = checkNotNull(helperImpl, "helperImpl");
       this.hcState = checkNotNull(hcState, "hcState");
     }
 
@@ -160,6 +162,12 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
     public void start(final SubchannelStateListener listener) {
       hcState.init(listener);
       delegate().start(hcState);
+    }
+
+    @Override
+    public void shutdown() {
+      helperImpl.getSynchronizationContext().throwIfNotInThisSynchronizationContext();
+      helperImpl.hcStates.remove(hcState);
     }
   }
 
@@ -281,9 +289,6 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
         // A connection was lost.  We will reset disabled flag because health check
         // may be available on the new connection.
         disabled = false;
-      }
-      if (Objects.equal(rawState.getState(), SHUTDOWN)) {
-        helperImpl.hcStates.remove(this);
       }
       this.rawState = rawState;
       adjustHealthCheck();

--- a/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/services/HealthCheckingLoadBalancerFactory.java
@@ -167,6 +167,7 @@ final class HealthCheckingLoadBalancerFactory extends Factory {
     @Override
     public void shutdown() {
       helperImpl.getSynchronizationContext().throwIfNotInThisSynchronizationContext();
+      delegate().shutdown();
       helperImpl.hcStates.remove(hcState);
     }
   }


### PR DESCRIPTION
HealthCheckingLoadBalancer.shutdown() calls
hcState.onSubchannelState(SHUTDOWN) which removes that hcState from
helper.hcStates.  Therefore, if more than one Subchannels are present,
ConcurrentModificationException will be thrown.

Since HealthCheckingLoadBalancer.shutdown() will clear the hcStates
set after the loop, it's unnecessary to do the deletion within the
loop.  However, when a Subchannel is shutdown by LoadBalancer, its
HcState still needs to be removed.  To do that, change moves the
deletion to Subchannel.shutdown().