### PR TITLE
core,netty: use PerfMark tags with the HTTP/2 stream ids

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -466,7 +466,7 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
     @Override
     public void streamCreated(ServerStream stream, String methodName, Metadata headers) {
-      Tag tag = PerfMark.createTag(methodName, stream.hashCode());
+      Tag tag = PerfMark.createTag(methodName, stream.streamId());
       PerfMark.startTask("ServerTransportListener.streamCreated", tag);
       try {
         streamCreatedInternal(stream, methodName, headers, tag);

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -483,10 +483,12 @@ public class ServerImplTest {
 
     transportListener.streamCreated(stream, "Waiter/nonexist", requestHeaders);
 
+    verify(stream).streamId();
     verify(stream).close(statusCaptor.capture(), any(Metadata.class));
     Status status = statusCaptor.getValue();
     assertEquals(Status.Code.UNIMPLEMENTED, status.getCode());
     assertEquals("Can't find decompressor for " + decompressorName, status.getDescription());
+
     verifyNoMoreInteractions(stream);
   }
 
@@ -786,6 +788,7 @@ public class ServerImplTest {
     when(stream.statsTraceContext()).thenReturn(statsTraceCtx);
 
     transportListener.streamCreated(stream, "Waiter/serve", requestHeaders);
+    verify(stream).streamId();
     verify(stream).setListener(streamListenerCaptor.capture());
     ServerStreamListener streamListener = streamListenerCaptor.getValue();
     assertNotNull(streamListener);

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -44,6 +44,7 @@ import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.AsciiString;
 import io.perfmark.PerfMark;
+import io.perfmark.Tag;
 import javax.annotation.Nullable;
 
 /**
@@ -249,20 +250,25 @@ class NettyClientStream extends AbstractClientStream {
       implements StreamIdHolder {
     private static final int NON_EXISTENT_ID = -1;
 
+    private final String methodName;
     private final NettyClientHandler handler;
     private final EventLoop eventLoop;
     private int id;
     private Http2Stream http2Stream;
+    private Tag tag;
 
     public TransportState(
         NettyClientHandler handler,
         EventLoop eventLoop,
         int maxMessageSize,
         StatsTraceContext statsTraceCtx,
-        TransportTracer transportTracer) {
+        TransportTracer transportTracer,
+        String methodName) {
       super(maxMessageSize, statsTraceCtx, transportTracer);
+      this.methodName = checkNotNull(methodName, "methodName");
       this.handler = checkNotNull(handler, "handler");
       this.eventLoop = checkNotNull(eventLoop, "eventLoop");
+      tag = PerfMark.createTag(methodName);
     }
 
     @Override
@@ -275,6 +281,7 @@ class NettyClientStream extends AbstractClientStream {
       checkArgument(id > 0, "id must be positive %s", id);
       checkState(this.id == 0, "id has been previously set: %s", this.id);
       this.id = id;
+      this.tag = PerfMark.createTag(methodName, id);
     }
 
     /**
@@ -358,6 +365,11 @@ class NettyClientStream extends AbstractClientStream {
 
     void transportDataReceived(ByteBuf frame, boolean endOfStream) {
       transportDataReceived(new NettyReadableBuffer(frame.retain()), endOfStream);
+    }
+
+    @Override
+    public final Tag tag() {
+      return tag;
     }
   }
 }

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -43,6 +43,7 @@ import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.AsciiString;
+import io.perfmark.Link;
 import io.perfmark.PerfMark;
 import io.perfmark.Tag;
 import javax.annotation.Nullable;
@@ -216,9 +217,20 @@ class NettyClientStream extends AbstractClientStream {
         transportState().requestMessagesFromDeframer(numMessages);
       } else {
         channel.eventLoop().execute(new Runnable() {
+          final Link link = PerfMark.link();
           @Override
           public void run() {
-            transportState().requestMessagesFromDeframer(numMessages);
+            PerfMark.startTask(
+                "NettyClientStream$Sink.requestMessagesFromDeframer",
+                transportState().tag());
+            link.link();
+            try {
+              transportState().requestMessagesFromDeframer(numMessages);
+            } finally {
+              PerfMark.stopTask(
+                  "NettyClientStream$Sink.requestMessagesFromDeframer",
+                  transportState().tag());
+            }
           }
         });
       }

--- a/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientTransport.java
@@ -176,7 +176,8 @@ class NettyClientTransport implements ConnectionClientTransport {
             channel.eventLoop(),
             maxMessageSize,
             statsTraceCtx,
-            transportTracer) {
+            transportTracer,
+            method.getFullMethodName()) {
           @Override
           protected Status statusFromFailedFuture(ChannelFuture f) {
             return NettyClientTransport.this.statusFromFailedFuture(f);

--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -83,6 +83,8 @@ import io.netty.handler.codec.http2.WeightedFairQueueByteDistributor;
 import io.netty.handler.logging.LogLevel;
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
+import io.perfmark.PerfMark;
+import io.perfmark.Tag;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
@@ -427,18 +429,25 @@ class NettyServerHandler extends AbstractNettyHandler {
           http2Stream,
           maxMessageSize,
           statsTraceCtx,
-          transportTracer);
-      String authority = getOrUpdateAuthority((AsciiString) headers.authority());
-      NettyServerStream stream = new NettyServerStream(
-          ctx.channel(),
-          state,
-          attributes,
-          authority,
-          statsTraceCtx,
-          transportTracer);
-      transportListener.streamCreated(stream, method, metadata);
-      state.onStreamAllocated();
-      http2Stream.setProperty(streamKey, state);
+          transportTracer,
+          method);
+
+      PerfMark.startTask("NettyServerHandler.onHeadersRead", state.tag());
+      try {
+        String authority = getOrUpdateAuthority((AsciiString) headers.authority());
+        NettyServerStream stream = new NettyServerStream(
+            ctx.channel(),
+            state,
+            attributes,
+            authority,
+            statsTraceCtx,
+            transportTracer);
+        transportListener.streamCreated(stream, method, metadata);
+        state.onStreamAllocated();
+        http2Stream.setProperty(streamKey, state);
+      } finally {
+        PerfMark.stopTask("NettyServerHandler.onHeadersRead", state.tag());
+      }
     } catch (Exception e) {
       logger.log(Level.WARNING, "Exception in onHeadersRead()", e);
       // Throw an exception that will get handled by onStreamError.
@@ -463,7 +472,12 @@ class NettyServerHandler extends AbstractNettyHandler {
     flowControlPing().onDataRead(data.readableBytes(), padding);
     try {
       NettyServerStream.TransportState stream = serverStream(requireHttp2Stream(streamId));
-      stream.inboundDataReceived(data, endOfStream);
+      PerfMark.startTask("NettyServerHandler.onDataRead", stream.tag());
+      try {
+        stream.inboundDataReceived(data, endOfStream);
+      } finally {
+        PerfMark.stopTask("NettyServerHandler.onDataRead", stream.tag());
+      }
     } catch (Throwable e) {
       logger.log(Level.WARNING, "Exception in onDataRead()", e);
       // Throw an exception that will get handled by onStreamError.
@@ -475,8 +489,13 @@ class NettyServerHandler extends AbstractNettyHandler {
     try {
       NettyServerStream.TransportState stream = serverStream(connection().stream(streamId));
       if (stream != null) {
-        stream.transportReportStatus(
-            Status.CANCELLED.withDescription("RST_STREAM received for code " + errorCode));
+        PerfMark.startTask("NettyServerHandler.onRstStreamRead", stream.tag());
+        try {
+          stream.transportReportStatus(
+              Status.CANCELLED.withDescription("RST_STREAM received for code " + errorCode));
+        } finally {
+          PerfMark.stopTask("NettyServerHandler.onRstStreamRead", stream.tag());
+        }
       }
     } catch (Throwable e) {
       logger.log(Level.WARNING, "Exception in onRstStreamRead()", e);
@@ -499,12 +518,18 @@ class NettyServerHandler extends AbstractNettyHandler {
     logger.log(Level.WARNING, "Stream Error", cause);
     NettyServerStream.TransportState serverStream = serverStream(
         connection().stream(Http2Exception.streamId(http2Ex)));
-    if (serverStream != null) {
-      serverStream.transportReportStatus(Utils.statusFromThrowable(cause));
+    Tag tag = serverStream != null ? serverStream.tag() : PerfMark.createTag();
+    PerfMark.startTask("NettyServerHandler.onStreamError", tag);
+    try {
+      if (serverStream != null) {
+        serverStream.transportReportStatus(Utils.statusFromThrowable(cause));
+      }
+      // TODO(ejona): Abort the stream by sending headers to help the client with debugging.
+      // Delegate to the base class to send a RST_STREAM.
+      super.onStreamError(ctx, outbound, cause, http2Ex);
+    } finally {
+      PerfMark.stopTask("NettyServerHandler.onStreamError", tag);
     }
-    // TODO(ejona): Abort the stream by sending headers to help the client with debugging.
-    // Delegate to the base class to send a RST_STREAM.
-    super.onStreamError(ctx, outbound, cause, http2Ex);
   }
 
   @Override
@@ -623,11 +648,17 @@ class NettyServerHandler extends AbstractNettyHandler {
    */
   private void sendGrpcFrame(ChannelHandlerContext ctx, SendGrpcFrameCommand cmd,
       ChannelPromise promise) throws Http2Exception {
-    if (cmd.endStream()) {
-      closeStreamWhenDone(promise, cmd.streamId());
+    PerfMark.startTask("NettyServerHandler.sendGrpcFrame", cmd.stream().tag());
+    cmd.getLink().link();
+    try {
+      if (cmd.endStream()) {
+        closeStreamWhenDone(promise, cmd.stream().id());
+      }
+      // Call the base class to write the HTTP/2 DATA frame.
+      encoder().writeData(ctx, cmd.stream().id(), cmd.content(), 0, cmd.endStream(), promise);
+    } finally {
+      PerfMark.stopTask("NettyServerHandler.sendGrpcFrame", cmd.stream().tag());
     }
-    // Call the base class to write the HTTP/2 DATA frame.
-    encoder().writeData(ctx, cmd.streamId(), cmd.content(), 0, cmd.endStream(), promise);
   }
 
   /**
@@ -635,26 +666,38 @@ class NettyServerHandler extends AbstractNettyHandler {
    */
   private void sendResponseHeaders(ChannelHandlerContext ctx, SendResponseHeadersCommand cmd,
       ChannelPromise promise) throws Http2Exception {
-    // TODO(carl-mastrangelo): remove this check once https://github.com/netty/netty/issues/6296 is
-    // fixed.
-    int streamId = cmd.stream().id();
-    Http2Stream stream = connection().stream(streamId);
-    if (stream == null) {
-      resetStream(ctx, streamId, Http2Error.CANCEL.code(), promise);
-      return;
+    PerfMark.startTask("NettyServerHandler.sendResponseHeaders", cmd.stream().tag());
+    cmd.getLink().link();
+    try {
+      // TODO(carl-mastrangelo): remove this check once https://github.com/netty/netty/issues/6296
+      // is fixed.
+      int streamId = cmd.stream().id();
+      Http2Stream stream = connection().stream(streamId);
+      if (stream == null) {
+        resetStream(ctx, streamId, Http2Error.CANCEL.code(), promise);
+        return;
+      }
+      if (cmd.endOfStream()) {
+        closeStreamWhenDone(promise, streamId);
+      }
+      encoder().writeHeaders(ctx, streamId, cmd.headers(), 0, cmd.endOfStream(), promise);
+    } finally {
+      PerfMark.stopTask("NettyServerHandler.sendResponseHeaders", cmd.stream().tag());
     }
-    if (cmd.endOfStream()) {
-      closeStreamWhenDone(promise, streamId);
-    }
-    encoder().writeHeaders(ctx, streamId, cmd.headers(), 0, cmd.endOfStream(), promise);
   }
 
   private void cancelStream(ChannelHandlerContext ctx, CancelServerStreamCommand cmd,
       ChannelPromise promise) {
-    // Notify the listener if we haven't already.
-    cmd.stream().transportReportStatus(cmd.reason());
-    // Terminate the stream.
-    encoder().writeRstStream(ctx, cmd.stream().id(), Http2Error.CANCEL.code(), promise);
+    PerfMark.startTask("NettyServerHandler.cancelStream", cmd.stream().tag());
+    cmd.getLink().link();
+    try {
+      // Notify the listener if we haven't already.
+      cmd.stream().transportReportStatus(cmd.reason());
+      // Terminate the stream.
+      encoder().writeRstStream(ctx, cmd.stream().id(), Http2Error.CANCEL.code(), promise);
+    } finally {
+      PerfMark.stopTask("NettyServerHandler.cancelStream", cmd.stream().tag());
+    }
   }
 
   private void forcefulClose(final ChannelHandlerContext ctx, final ForcefulCloseCommand msg,
@@ -665,8 +708,14 @@ class NettyServerHandler extends AbstractNettyHandler {
       public boolean visit(Http2Stream stream) throws Http2Exception {
         NettyServerStream.TransportState serverStream = serverStream(stream);
         if (serverStream != null) {
-          serverStream.transportReportStatus(msg.getStatus());
-          resetStream(ctx, stream.id(), Http2Error.CANCEL.code(), ctx.newPromise());
+          PerfMark.startTask("NettyServerHandler.forcefulClose", serverStream.tag());
+          msg.getLink().link();
+          try {
+            serverStream.transportReportStatus(msg.getStatus());
+            resetStream(ctx, stream.id(), Http2Error.CANCEL.code(), ctx.newPromise());
+          } finally {
+            PerfMark.stopTask("NettyServerHandler.forcefulClose", serverStream.tag());
+          }
         }
         stream.close();
         return true;

--- a/netty/src/main/java/io/grpc/netty/NettyServerStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerStream.java
@@ -34,6 +34,7 @@ import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.perfmark.PerfMark;
+import io.perfmark.Tag;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -195,6 +196,7 @@ class NettyServerStream extends AbstractServerStream {
     private final Http2Stream http2Stream;
     private final NettyServerHandler handler;
     private final EventLoop eventLoop;
+    private final Tag tag;
 
     public TransportState(
         NettyServerHandler handler,
@@ -202,11 +204,13 @@ class NettyServerStream extends AbstractServerStream {
         Http2Stream http2Stream,
         int maxMessageSize,
         StatsTraceContext statsTraceCtx,
-        TransportTracer transportTracer) {
+        TransportTracer transportTracer,
+        String methodName) {
       super(maxMessageSize, statsTraceCtx, transportTracer);
       this.http2Stream = checkNotNull(http2Stream, "http2Stream");
       this.handler = checkNotNull(handler, "handler");
       this.eventLoop = eventLoop;
+      this.tag = PerfMark.createTag(methodName, http2Stream.id());
     }
 
     @Override
@@ -239,6 +243,11 @@ class NettyServerStream extends AbstractServerStream {
     @Override
     public int id() {
       return http2Stream.id();
+    }
+
+    @Override
+    public Tag tag() {
+      return tag;
     }
   }
 

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -46,8 +46,8 @@ final class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQu
     return link;
   }
 
-  int streamId() {
-    return stream.id();
+  StreamIdHolder stream() {
+    return stream;
   }
 
   boolean endStream() {
@@ -100,7 +100,7 @@ final class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQu
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(streamId=" + streamId()
+    return getClass().getSimpleName() + "(streamId=" + stream.id()
         + ", endStream=" + endStream + ", content=" + content()
         + ")";
   }

--- a/netty/src/main/java/io/grpc/netty/StreamIdHolder.java
+++ b/netty/src/main/java/io/grpc/netty/StreamIdHolder.java
@@ -16,10 +16,14 @@
 
 package io.grpc.netty;
 
+import io.perfmark.Tag;
+
 /** Container for stream ids. */
 interface StreamIdHolder {
   /**
    * Returns the id.
    */
   int id();
+
+  Tag tag();
 }

--- a/netty/src/main/java/io/grpc/netty/WriteQueue.java
+++ b/netty/src/main/java/io/grpc/netty/WriteQueue.java
@@ -112,13 +112,7 @@ class WriteQueue {
       int i = 0;
       boolean flushedOnce = false;
       while ((cmd = queue.poll()) != null) {
-        PerfMark.startTask("WriteQueue.run");
-        try {
-          cmd.getLink().link();
-          cmd.run(channel);
-        } finally {
-          PerfMark.stopTask("WriteQueue.run");
-        }
+        cmd.run(channel);
         if (++i == DEQUE_CHUNK_SIZE) {
           i = 0;
           // Flush each chunk so we are releasing buffers periodically. In theory this loop

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -789,7 +789,13 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
         EventLoop eventLoop,
         int maxMessageSize,
         TransportTracer transportTracer) {
-      super(handler, eventLoop, maxMessageSize, StatsTraceContext.NOOP, transportTracer, "name");
+      super(
+          handler,
+          eventLoop,
+          maxMessageSize,
+          StatsTraceContext.NOOP,
+          transportTracer,
+          "methodName");
     }
 
     @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
@@ -789,7 +789,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
         EventLoop eventLoop,
         int maxMessageSize,
         TransportTracer transportTracer) {
-      super(handler, eventLoop, maxMessageSize, StatsTraceContext.NOOP, transportTracer);
+      super(handler, eventLoop, maxMessageSize, StatsTraceContext.NOOP, transportTracer, "name");
     }
 
     @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -550,7 +550,13 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
 
   private class TransportStateImpl extends NettyClientStream.TransportState {
     public TransportStateImpl(NettyClientHandler handler, int maxMessageSize) {
-      super(handler, channel.eventLoop(), maxMessageSize, StatsTraceContext.NOOP, transportTracer);
+      super(
+          handler,
+          channel.eventLoop(),
+          maxMessageSize,
+          StatsTraceContext.NOOP,
+          transportTracer,
+          "no name");
     }
 
     @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientStreamTest.java
@@ -556,7 +556,7 @@ public class NettyClientStreamTest extends NettyStreamTestBase<NettyClientStream
           maxMessageSize,
           StatsTraceContext.NOOP,
           transportTracer,
-          "no name");
+          "methodName");
     }
 
     @Override

--- a/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerStreamTest.java
@@ -287,7 +287,7 @@ public class NettyServerStreamTest extends NettyStreamTestBase<NettyServerStream
     TransportTracer transportTracer = new TransportTracer();
     NettyServerStream.TransportState state = new NettyServerStream.TransportState(
         handler, channel.eventLoop(), http2Stream, DEFAULT_MAX_MESSAGE_SIZE, statsTraceCtx,
-        transportTracer);
+        transportTracer, "method");
     NettyServerStream stream = new NettyServerStream(channel, state, Attributes.EMPTY,
         "test-authority", statsTraceCtx, transportTracer);
     stream.transportState().setListener(serverListener);


### PR DESCRIPTION
This change removes the WriteQueue linking and splits it out into each
of the commands, so that the trace is more precise, and the tag
information is correct.

It is still unclear what the initial Tag should be for ClientCallImpl,
since it should not access the TransportState to get the HTTP/2 stream id.