### PR TITLE
Revert "core, netty: add io.perfmark Annotations"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,6 @@ subprojects {
             opencensus_impl: "io.opencensus:opencensus-impl:${opencensusVersion}",
             opencensus_impl_lite: "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
             instrumentation_api: 'com.google.instrumentation:instrumentation-api:0.4.3',
-            perfmark: 'io.perfmark:perfmark-api:0.16.0',
             protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
             protobuf_lite: "com.google.protobuf:protobuf-lite:3.0.1",
             protoc_lite: "com.google.protobuf:protoc-gen-javalite:3.0.0",

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -1,3 +1,16 @@
+PERFMARK_INTERNAL_ACCESSOR_SRCS = glob(
+    [
+        "src/main/java/io/grpc/perfmark/Internal*.java",
+    ],
+)
+
+PERFMARK_SRCS = glob(
+    [
+        "src/main/java/io/grpc/perfmark/*.java",
+    ],
+    exclude = PERFMARK_INTERNAL_ACCESSOR_SRCS,
+)
+
 java_library(
     name = "core",
     visibility = ["//visibility:public"],
@@ -30,6 +43,7 @@ java_library(
     ]),
     visibility = ["//:__subpackages__"],
     deps = [
+        ":perfmark",
         "//api",
         "//context",
         "@com_google_android_annotations//jar",
@@ -40,7 +54,6 @@ java_library(
         "@com_google_j2objc_j2objc_annotations//jar",
         "@io_opencensus_opencensus_api//jar",
         "@io_opencensus_opencensus_contrib_grpc_metrics//jar",
-        "@io_perfmark_perfmark_api//jar",
         "@org_codehaus_mojo_animal_sniffer_annotations//jar",
     ],
 )
@@ -63,3 +76,12 @@ java_library(
     ],
 )
 
+java_library(
+    name = "perfmark",
+    srcs = PERFMARK_SRCS,
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@com_google_code_findbugs_jsr305//jar",
+        "@com_google_errorprone_error_prone_annotations//jar",
+    ],
+)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,7 +4,6 @@ dependencies {
     compile project(':grpc-api'),
             libraries.gson,
             libraries.android_annotations,
-            libraries.perfmark
     compile (libraries.opencensus_api) {
         // prefer 3.0.2 from libraries instead of 3.0.1
         exclude group: 'com.google.code.findbugs', module: 'jsr305'

--- a/core/src/main/java/io/grpc/perfmark/InternalPerfMark.java
+++ b/core/src/main/java/io/grpc/perfmark/InternalPerfMark.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.perfmark;
+
+
+/**
+ * Internal {@link PerfTag.TagFactory} and {@link PerfMarkTask} accessor. This is intended for use
+ * by io.grpc.perfmark, and the specifically supported packages that utilize PerfMark. If you
+ * *really* think you need to use this, contact the gRPC team first.
+ */
+public final class InternalPerfMark {
+
+  private InternalPerfMark() {}
+
+  /** Expose class to allow packages that utilize PerfMark to get PerfMarkTask instances. */
+  public abstract static class InternalPerfMarkTask extends PerfMarkTask {
+    public InternalPerfMarkTask() {}
+  }
+
+  /** Expose methods that create PerfTag to packages that utilize PerfMark. */
+  private static final long NULL_NUMERIC_TAG = 0;
+  private static final String NULL_STRING_TAG = null;
+
+  public static PerfTag createPerfTag(long numericTag, String stringTag) {
+    return PerfTag.TagFactory.create(numericTag, stringTag);
+  }
+
+  public static PerfTag createPerfTag(String stringTag) {
+    return PerfTag.TagFactory.create(NULL_NUMERIC_TAG, stringTag);
+  }
+
+  public static PerfTag createPerfTag(long numericTag) {
+    return PerfTag.TagFactory.create(numericTag, NULL_STRING_TAG);
+  }
+}

--- a/core/src/main/java/io/grpc/perfmark/PerfMark.java
+++ b/core/src/main/java/io/grpc/perfmark/PerfMark.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.perfmark;
+
+import com.google.errorprone.annotations.CompileTimeConstant;
+import io.grpc.perfmark.PerfTag.TagFactory;
+
+/**
+ * PerfMark is a collection of stub methods for marking key points in the RPC lifecycle.  This
+ * class is {@link io.grpc.Internal} and {@link io.grpc.ExperimentalApi}.  Do not use this yet.
+ */
+public final class PerfMark {
+  private PerfMark() {
+    throw new AssertionError("nope");
+  }
+
+  /**
+   * Start a Task with a Tag to identify it; a task represents some work that spans some time, and
+   * you are interested in both its start time and end time.
+   *
+   * @param tag a Tag object associated with the task. See {@link PerfTag} for description. Don't
+   *     use 0 for the {@code numericTag} of the Tag object. 0 is reserved to represent that a task
+   *     does not have a numeric tag associated. In this case, you are encouraged to use {@link
+   *     #taskStart(String)} or {@link PerfTag#create(String)}.
+   * @param taskName The name of the task. <b>This parameter must be a compile-time constant!</b>
+   *     Otherwise, instrumentation result will show "(invalid name)" for this task.
+   */
+  public static void taskStart(PerfTag tag, @CompileTimeConstant String taskName) {}
+
+  /**
+   * Start a Task; a task represents some work that spans some time, and you are interested in both
+   * its start time and end time.
+   *
+   * @param taskName The name of the task. <b>This parameter must be a compile-time constant!</b>
+   *     Otherwise, instrumentation result will show "(invalid name)" for this task.
+   */
+  public static void taskStart(@CompileTimeConstant String taskName) {}
+
+  /**
+   * End a Task with a Tag to identify it; a task represents some work that spans some time, and
+   * you are interested in both its start time and end time.
+   *
+   * @param tag a Tag object associated with the task start.  This should be the tag used for the
+   *     corresponding {@link #taskStart(PerfTag, String)} call.
+   * @param taskName The name of the task. <b>This parameter must be a compile-time constant!</b>
+   *     Otherwise, instrumentation result will show "(invalid name)" for this task.  This should
+   *     be the name used by the corresponding {@link #taskStart(PerfTag, String)} call.
+   */
+  public static void taskEnd(PerfTag tag, @CompileTimeConstant String taskName) {}
+
+  /**
+   * End a Task with a Tag to identify it; a task represents some work that spans some time, and
+   * you are interested in both its start time and end time.
+   *
+   * @param taskName The name of the task. <b>This parameter must be a compile-time constant!</b>
+   *     Otherwise, instrumentation result will show "(invalid name)" for this task.  This should
+   *     be the name used by the corresponding {@link #taskStart(String)} call.
+   */
+  public static void taskEnd(@CompileTimeConstant String taskName) {}
+
+  /**
+   * Start a Task with a Tag to identify it in a try-with-resource statement; a task represents some
+   * work that spans some time, and you are interested in both its start time and end time.
+   *
+   * <p>Use this in a try-with-resource statement so that task will end automatically.
+   *
+   * @param tag a Tag object associated with the task. See {@link PerfTag} for description. Don't
+   *     use 0 for the {@code numericTag} of the Tag object. 0 is reserved to represent that a task
+   *     does not have a numeric tag associated. In this case, you are encouraged to use {@link
+   *     #task(String)} or {@link PerfTag#create(String)}.
+   * @param taskName The name of the task. <b>This parameter must be a compile-time constant!</b>
+   *     Otherwise, instrumentation result will show "(invalid name)" for this task.
+   */
+  public static PerfMarkTask task(PerfTag tag, @CompileTimeConstant String taskName) {
+    return NoopTask.INSTANCE;
+  }
+
+  /**
+   * Start a Task it in a try-with-resource statement; a task represents some work that spans some
+   * time, and you are interested in both its start time and end time.
+   *
+   * <p>Use this in a try-with-resource statement so that task will end automatically.
+   *
+   * @param taskName The name of the task. <b>This parameter must be a compile-time constant!</b>
+   *     Otherwise, instrumentation result will show "(invalid name)" for this task.
+   */
+  public static PerfMarkTask task(@CompileTimeConstant String taskName) {
+    return NoopTask.INSTANCE;
+  }
+
+  /**
+   * Records an Event with a Tag to identify it.
+   *
+   * <p>An Event is different from a Task in that you don't care how much time it spanned. You are
+   * interested in only the time it happened.
+   *
+   * @param tag a Tag object associated with the task. See {@link PerfTag} for description. Don't
+   *     use 0 for the {@code numericTag} of the Tag object. 0 is reserved to represent that a task
+   *     does not have a numeric tag associated. In this case, you are encouraged to use {@link
+   *     #event(String)} or {@link PerfTag#create(String)}.
+   * @param eventName The name of the event. <b>This parameter must be a compile-time constant!</b>
+   *     Otherwise, instrumentation result will show "(invalid name)" for this event.
+   */
+  public static void event(PerfTag tag, @CompileTimeConstant String eventName) {}
+
+  /**
+   * Records an Event.
+   *
+   * <p>An Event is different from a Task in that you don't care how much time it spanned. You are
+   * interested in only the time it happened.
+   *
+   * @param eventName The name of the event. <b>This parameter must be a compile-time constant!</b>
+   *     Otherwise, instrumentation result will show "(invalid name)" for this event.
+   */
+  public static void event(@CompileTimeConstant String eventName) {}
+
+  /**
+   * If PerfMark instrumentation is not enabled, returns a Tag with numericTag = 0L. Replacement
+   * for {@link TagFactory#create(long, String)} if PerfMark agent is enabled.
+   *
+   */
+  public static PerfTag createTag(
+      @SuppressWarnings("unused") long numericTag, @SuppressWarnings("unused") String stringTag) {
+    // Warning suppression is safe as this method returns by default the NULL_PERF_TAG
+    return NULL_PERF_TAG;
+  }
+
+  /**
+   * If PerfMark instrumentation is not enabled returns a Tag with numericTag = 0L. Replacement
+   * for {@link TagFactory#create(String)} if PerfMark agent is enabled.
+   */
+  public static PerfTag createTag(@SuppressWarnings("unused") String stringTag) {
+    // Warning suppression is safe as this method returns by default the NULL_PERF_TAG
+    return NULL_PERF_TAG;
+  }
+
+  /**
+   * If PerfMark instrumentation is not enabled returns a Tag with numericTag = 0L. Replacement
+   * for {@link TagFactory#create(long)} if PerfMark agent is enabled.
+   */
+  public static PerfTag createTag(@SuppressWarnings("unused") long numericTag) {
+    // Warning suppression is safe as this method returns by default the NULL_PERF_TAG
+    return NULL_PERF_TAG;
+  }
+
+  private static final PerfTag NULL_PERF_TAG = TagFactory.create();
+
+  private static final class NoopTask extends PerfMarkTask {
+
+    private static final PerfMarkTask INSTANCE = new NoopTask();
+
+    NoopTask() {}
+
+    @Override
+    public void close() {}
+  }
+}

--- a/core/src/main/java/io/grpc/perfmark/PerfMarkTask.java
+++ b/core/src/main/java/io/grpc/perfmark/PerfMarkTask.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.perfmark;
+
+import java.io.Closeable;
+
+/**
+ * This class exists to make it easier for users to use the try-with-resource shorthand for
+ * starting and ending a PerfMark Task.  This class is {@link io.grpc.Internal} and
+ * {@link io.grpc.ExperimentalApi}.  Do not use this yet.
+ */
+public abstract class PerfMarkTask implements Closeable {
+  @Override
+  public abstract void close();
+
+  PerfMarkTask() {}
+}

--- a/core/src/main/java/io/grpc/perfmark/PerfMarker.java
+++ b/core/src/main/java/io/grpc/perfmark/PerfMarker.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.perfmark;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to add PerfMark instrumentation points surrounding method invocation.
+ *
+ * <p>This class is {@link io.grpc.Internal} and {@link io.grpc.ExperimentalApi}.  Do not use this
+ * yet.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+// TODO(carl-mastrangelo): Add this line back in and make it okay on Android
+//@IncompatibleModifiers(value = {Modifier.ABSTRACT, Modifier.NATIVE})
+public @interface PerfMarker {
+
+  /**
+   * The name of the task; e.g. `parseHeaders`.
+   */
+  String taskName();
+
+  /**
+   * An optional computed tag.
+   *
+   * <p>There are 3 supported references that can be used
+   * <ul>
+   *     <li>{@code "this"}:  Then the tag will be the {@link Object#toString} of the current class.
+   *     Only valid for instance methods.
+   *     <li>{@code "someFieldName"}: Then the tag will be the result of
+   *     calling {@link String#valueOf(Object)} on the field.  The field cannot be a primitive or
+   *     and array type. (Though we may revisit this in the future).
+   *     <li>{@code "$N"}: Then the tag will be the result of calling {@link String#valueOf(Object)}
+   *     on the Nth method parameter.  Parameters are {@code 0} indexed so {@code "$1"} is the
+   *     second parameter. The referenced parameter cannot be a primitive or an array type.
+   *     (Though we may revisit this in the future).
+   * </ul>
+   *
+   * <p>In general you should reference either {@code "this"} or {@code final} fields since
+   * in these cases we can cache the operations to decrease the cost of computing the tags.  A side
+   * effect of this is that for such references we will not have their tags recalculated after the
+   * first time. Thus it is best to use immutable objects for tags.
+   */
+  String computedTag() default "";
+
+  /**
+   * True if class with annotation is immutable and instrumentation must adhere to this restriction.
+   * If enableSampling is passed as argument to the agent, instrumentation points with <code>
+   * immutable = true </code> are ignored.
+   */
+  boolean immutable() default false;
+}
+

--- a/core/src/main/java/io/grpc/perfmark/PerfTag.java
+++ b/core/src/main/java/io/grpc/perfmark/PerfTag.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.perfmark;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A Tag is used to provide additional information to identify a task and consists of a 64-bit
+ * integer value and a string.
+ *
+ * <p>Both the {@code numericTag} and the {@code stringTag} are optional. The {@code numericTag}
+ * value can be used to identify the specific task being worked on (e.g. the id of the rpc call).
+ * The {@code stringTag} can be used to store any value that is not a compile-time constant (a
+ * restriction imposed for the name passed to PerfMark tasks and events). A value of 0 for the
+ * {@code numericTag} is considered null. Don't use 0 for the {@code numericTag} unless you intend
+ * to specify null. In that case you are encouraged to use {@link #create(String)}.
+ *
+ * <p>Invocations to {@code create} methods in this class are a no-op unless PerfMark
+ * instrumentation is enabled. If so, calls to {@code create} methods to this class are replaced for
+ * calls to {@link TagFactory} create methods.
+ *
+ * <p>This class is {@link io.grpc.Internal} and {@link io.grpc.ExperimentalApi}.  Do not use this
+ * yet.
+ */
+@Immutable
+public final class PerfTag {
+
+  private static final long NULL_NUMERIC_TAG = 0;
+  private static final String NULL_STRING_TAG = null;
+
+  private final long numericTag;
+  private final String stringTag;
+
+  private PerfTag(long numericTag, @Nullable String stringTag) {
+    this.numericTag = numericTag;
+    this.stringTag = stringTag;
+  }
+
+  /** Returns the numeric tag if set, or {@link #NULL_NUMERIC_TAG} instead. */
+  public long getNumericTag() {
+    return numericTag;
+  }
+
+  /** Returns the string tag if set, or {@link #NULL_STRING_TAG} instead. */
+  @Nullable public String getStringTag() {
+    return stringTag;
+  }
+
+  @Override
+  public String toString() {
+    return "Tag(numericTag=" + numericTag + ",stringTag='" + stringTag + "')";
+  }
+
+  @Override
+  public int hashCode() {
+    int longHashCode = (int)(numericTag ^ (numericTag >>> 32));
+    return longHashCode + (stringTag != null ? stringTag.hashCode() : 31);
+  }
+
+  @Override
+  @SuppressWarnings("ReferenceEquality") // No Java 8 yet.
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PerfTag)) {
+      return false;
+    }
+    PerfTag that = (PerfTag) obj;
+    return numericTag == that.numericTag
+        && (stringTag == that.stringTag || (stringTag != null && stringTag.equals(that.stringTag)));
+  }
+
+  /**
+   * Provides methods that create Tag instances which should not be directly invoked by clients.
+   *
+   * <p>Calls to {@link PerfMark#create(long)}, {@link PerfMark#create(long, String)} and {@link
+   * PerfMark#create(String)} are replaced with calls to the methods in this class using bytecode
+   * rewriting, if enabled.
+   */
+  static final class TagFactory {
+    /**
+     * This class should not be instantiated.
+     */
+    private TagFactory() {
+      throw new AssertionError("nope");
+    }
+
+    public static PerfTag create(long numericTag, String stringTag) {
+      return new PerfTag(numericTag, stringTag);
+    }
+
+    public static PerfTag create(String stringTag) {
+      return new PerfTag(NULL_NUMERIC_TAG, stringTag);
+    }
+
+    public static PerfTag create(long numericTag) {
+      return new PerfTag(numericTag, NULL_STRING_TAG);
+    }
+
+    static PerfTag create() {
+      return new PerfTag(NULL_NUMERIC_TAG, NULL_STRING_TAG);
+    }
+  }
+}
+

--- a/core/src/main/java/io/grpc/perfmark/package-info.java
+++ b/core/src/main/java/io/grpc/perfmark/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is an internal, experimental API and not subject to the normal compatibility guarantees.
+ *
+ * @see io.grpc.Internal
+ */
+@javax.annotation.CheckReturnValue
+@javax.annotation.ParametersAreNonnullByDefault
+package io.grpc.perfmark;

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -43,7 +43,6 @@ import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.internal.ServerCallImpl.ServerStreamListenerImpl;
 import io.grpc.internal.testing.SingleMessageProducer;
-import io.perfmark.PerfMark;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -91,7 +90,7 @@ public class ServerCallImplTest {
     context = Context.ROOT.withCancellation();
     call = new ServerCallImpl<>(stream, UNARY_METHOD, requestHeaders, context,
         DecompressorRegistry.getDefaultInstance(), CompressorRegistry.getDefaultInstance(),
-        serverCallTracer, PerfMark.createTag());
+        serverCallTracer);
   }
 
   @Test
@@ -114,7 +113,7 @@ public class ServerCallImplTest {
 
     call = new ServerCallImpl<>(stream, UNARY_METHOD, requestHeaders, context,
         DecompressorRegistry.getDefaultInstance(), CompressorRegistry.getDefaultInstance(),
-        tracer, PerfMark.createTag());
+        tracer);
 
     // required boilerplate
     call.sendHeaders(new Metadata());
@@ -225,8 +224,7 @@ public class ServerCallImplTest {
         context,
         DecompressorRegistry.getDefaultInstance(),
         CompressorRegistry.getDefaultInstance(),
-        serverCallTracer,
-        PerfMark.createTag());
+        serverCallTracer);
     serverCall.sendHeaders(new Metadata());
     serverCall.sendMessage(1L);
     verify(stream, times(1)).writeMessage(any(InputStream.class));
@@ -260,8 +258,7 @@ public class ServerCallImplTest {
         context,
         DecompressorRegistry.getDefaultInstance(),
         CompressorRegistry.getDefaultInstance(),
-        serverCallTracer,
-        PerfMark.createTag());
+        serverCallTracer);
     serverCall.sendHeaders(new Metadata());
     serverCall.sendMessage(1L);
     serverCall.sendMessage(1L);
@@ -298,8 +295,7 @@ public class ServerCallImplTest {
         context,
         DecompressorRegistry.getDefaultInstance(),
         CompressorRegistry.getDefaultInstance(),
-        serverCallTracer,
-        PerfMark.createTag());
+        serverCallTracer);
     serverCall.close(Status.OK, new Metadata());
     ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
     verify(stream, times(1)).cancel(statusCaptor.capture());

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -77,7 +77,6 @@ import io.grpc.internal.ServerImpl.JumpToApplicationThreadServerStreamListener;
 import io.grpc.internal.testing.SingleMessageProducer;
 import io.grpc.internal.testing.TestServerStreamTracer;
 import io.grpc.util.MutableHandlerRegistry;
-import io.perfmark.PerfMark;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -1141,8 +1140,7 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation(),
-            PerfMark.createTag());
+            Context.ROOT.withCancellation());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1167,8 +1165,7 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation(),
-            PerfMark.createTag());
+            Context.ROOT.withCancellation());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1193,8 +1190,7 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation(),
-            PerfMark.createTag());
+            Context.ROOT.withCancellation());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1217,8 +1213,7 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation(),
-            PerfMark.createTag());
+            Context.ROOT.withCancellation());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1241,8 +1236,7 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation(),
-            PerfMark.createTag());
+            Context.ROOT.withCancellation());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 
@@ -1265,8 +1259,7 @@ public class ServerImplTest {
             executor.getScheduledExecutorService(),
             executor.getScheduledExecutorService(),
             stream,
-            Context.ROOT.withCancellation(),
-            PerfMark.createTag());
+            Context.ROOT.withCancellation());
     ServerStreamListener mockListener = mock(ServerStreamListener.class);
     listener.setListener(mockListener);
 

--- a/netty/BUILD.bazel
+++ b/netty/BUILD.bazel
@@ -25,6 +25,5 @@ java_library(
         "@io_netty_netty_handler_proxy//jar",
         "@io_netty_netty_resolver//jar",
         "@io_netty_netty_transport//jar",
-        "@io_perfmark_perfmark_api//jar",
     ],
 )

--- a/netty/src/main/java/io/grpc/netty/NettyClientStream.java
+++ b/netty/src/main/java/io/grpc/netty/NettyClientStream.java
@@ -43,7 +43,6 @@ import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.AsciiString;
-import io.perfmark.PerfMark;
 import javax.annotation.Nullable;
 
 /**
@@ -115,18 +114,8 @@ class NettyClientStream extends AbstractClientStream {
   }
 
   private class Sink implements AbstractClientStream.Sink {
-
     @Override
     public void writeHeaders(Metadata headers, byte[] requestPayload) {
-      PerfMark.startTask("NettyClientStream$Sink.writeHeaders");
-      try {
-        writeHeadersInternal(headers, requestPayload);
-      } finally {
-        PerfMark.stopTask("NettyClientStream$Sink.writeHeaders");
-      }
-    }
-
-    private void writeHeadersInternal(Metadata headers, byte[] requestPayload) {
       // Convert the headers into Netty HTTP/2 headers.
       AsciiString defaultPath = (AsciiString) methodDescriptorAccessor.geRawMethodName(method);
       if (defaultPath == null) {
@@ -163,13 +152,15 @@ class NettyClientStream extends AbstractClientStream {
           }
         }
       };
+
       // Write the command requesting the creation of the stream.
       writeQueue.enqueue(
           new CreateStreamCommand(http2Headers, transportState(), shouldBeCountedForInUse(), get),
           !method.getType().clientSendsOneMessage() || get).addListener(failureListener);
     }
 
-    private void writeFrameInternal(
+    @Override
+    public void writeFrame(
         WritableBuffer frame, boolean endOfStream, boolean flush, final int numMessages) {
       Preconditions.checkArgument(numMessages >= 0);
       ByteBuf bytebuf = frame == null ? EMPTY_BUFFER : ((NettyWritableBuffer) frame).bytebuf();
@@ -193,23 +184,12 @@ class NettyClientStream extends AbstractClientStream {
             });
       } else {
         // The frame is empty and will not impact outbound flow control. Just send it.
-        writeQueue.enqueue(
-            new SendGrpcFrameCommand(transportState(), bytebuf, endOfStream), flush);
+        writeQueue.enqueue(new SendGrpcFrameCommand(transportState(), bytebuf, endOfStream), flush);
       }
     }
 
     @Override
-    public void writeFrame(
-        WritableBuffer frame, boolean endOfStream, boolean flush, int numMessages) {
-      PerfMark.startTask("NettyClientStream$Sink.writeFrame");
-      try {
-        writeFrameInternal(frame, endOfStream, flush, numMessages);
-      } finally {
-        PerfMark.stopTask("NettyClientStream$Sink.writeFrame");
-      }
-    }
-
-    private void requestInternal(final int numMessages) {
+    public void request(final int numMessages) {
       if (channel.eventLoop().inEventLoop()) {
         // Processing data read in the event loop so can call into the deframer immediately
         transportState().requestMessagesFromDeframer(numMessages);
@@ -224,23 +204,8 @@ class NettyClientStream extends AbstractClientStream {
     }
 
     @Override
-    public void request(int numMessages) {
-      PerfMark.startTask("NettyClientStream$Sink.request");
-      try {
-        requestInternal(numMessages);
-      } finally {
-        PerfMark.stopTask("NettyClientStream$Sink.request");
-      }
-    }
-
-    @Override
     public void cancel(Status status) {
-      PerfMark.startTask("NettyClientStream$Sink.cancel");
-      try {
-        writeQueue.enqueue(new CancelClientStreamCommand(transportState(), status), true);
-      } finally {
-        PerfMark.stopTask("NettyClientStream$Sink.cancel");
-      }
+      writeQueue.enqueue(new CancelClientStreamCommand(transportState(), status), true);
     }
   }
 

--- a/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
+++ b/netty/src/main/java/io/grpc/netty/SendGrpcFrameCommand.java
@@ -21,8 +21,6 @@ import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
-import io.perfmark.Link;
-import io.perfmark.PerfMark;
 
 /**
  * Command sent from the transport to the Netty channel to send a GRPC frame to the remote endpoint.
@@ -30,7 +28,6 @@ import io.perfmark.PerfMark;
 final class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQueue.QueuedCommand {
   private final StreamIdHolder stream;
   private final boolean endStream;
-  private final Link link;
 
   private ChannelPromise promise;
 
@@ -38,12 +35,6 @@ final class SendGrpcFrameCommand extends DefaultByteBufHolder implements WriteQu
     super(content);
     this.stream = stream;
     this.endStream = endStream;
-    this.link = PerfMark.link();
-  }
-
-  @Override
-  public Link getLink() {
-    return link;
   }
 
   int streamId() {

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -35,7 +35,6 @@ def grpc_java_repositories(
         omit_io_netty_tcnative_boringssl_static = False,
         omit_io_opencensus_api = False,
         omit_io_opencensus_grpc_metrics = False,
-        omit_io_perfmark = False,
         omit_javax_annotation = False,
         omit_junit_junit = False,
         omit_net_zlib = False,
@@ -104,8 +103,6 @@ def grpc_java_repositories(
         io_opencensus_api()
     if not omit_io_opencensus_grpc_metrics:
         io_opencensus_grpc_metrics()
-    if not omit_io_perfmark:
-        io_perfmark()
     if not omit_javax_annotation:
         javax_annotation()
     if not omit_junit_junit:
@@ -402,15 +399,6 @@ def io_opencensus_grpc_metrics():
         artifact = "io.opencensus:opencensus-contrib-grpc-metrics:0.21.0",
         server_urls = ["http://central.maven.org/maven2"],
         artifact_sha256 = "29fc79401082301542cab89d7054d2f0825f184492654c950020553ef4ff0ef8",
-        licenses = ["notice"],  # Apache 2.0
-    )
-
-def io_perfmark():
-    jvm_maven_import_external(
-        name = "io_perfmark_perfmark_api",
-        artifact = "io.perfmark:perfmark-api:0.16.0",
-        server_urls = ["http://central.maven.org/maven2"],
-        artifact_sha256 = "a93667875ea9d10315177768739a18d6c667df041c982d2841645ae8558d0af0",
         licenses = ["notice"],  # Apache 2.0
     )
 


### PR DESCRIPTION
This causes internal breakage which needs to be resolved before continuing.

This reverts commit 71967622d635160172e0739541f88197f9da70a2.