### PR TITLE
xds: fix bug of missing total_dropped_requests field in ClusterStats proto

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
@@ -92,11 +92,15 @@ final class XdsLoadStatsStore implements StatsStore {
         localityLoadCounters.remove(entry.getKey());
       }
     }
+    long totalDrops = 0;
     for (Map.Entry<String, AtomicLong> entry : dropCounters.entrySet()) {
+      long drops = entry.getValue().getAndSet(0);
+      totalDrops += drops;
       statsBuilder.addDroppedRequests(DroppedRequests.newBuilder()
           .setCategory(entry.getKey())
-          .setDroppedCount(entry.getValue().getAndSet(0)));
+          .setDroppedCount(drops));
     }
+    statsBuilder.setTotalDroppedRequests(totalDrops);
     return statsBuilder.build();
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadReportClientImplTest.java
@@ -374,6 +374,7 @@ public class XdsLoadReportClientImplTest {
         .addDroppedRequests(DroppedRequests.newBuilder()
             .setCategory("throttle")
             .setDroppedCount(numThrottleDrops))
+        .setTotalDroppedRequests(numLbDrops + numThrottleDrops)
         .build();
     ClusterStats expectedStats2 = ClusterStats.newBuilder()
         .setClusterName(SERVICE_AUTHORITY)
@@ -387,6 +388,7 @@ public class XdsLoadReportClientImplTest {
         .addDroppedRequests(DroppedRequests.newBuilder()
             .setCategory("throttle")
             .setDroppedCount(0))
+        .setTotalDroppedRequests(0)
         .build();
     when(statsStore.generateLoadReport())
         .thenReturn(expectedStats1, expectedStats2);

--- a/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
@@ -135,6 +135,7 @@ public class XdsLoadStatsStoreTest {
   private static void assertClusterStatsEqual(ClusterStats expected, ClusterStats actual) {
     assertThat(actual.getClusterName()).isEqualTo(expected.getClusterName());
     assertThat(actual.getLoadReportInterval()).isEqualTo(expected.getLoadReportInterval());
+    assertThat(actual.getTotalDroppedRequests()).isEqualTo(expected.getTotalDroppedRequests());
     assertThat(actual.getDroppedRequestsCount()).isEqualTo(expected.getDroppedRequestsCount());
     assertThat(new HashSet<>(actual.getDroppedRequestsList()))
         .isEqualTo(new HashSet<>(expected.getDroppedRequestsList()));


### PR DESCRIPTION
[`total_dropped_requests`](https://github.com/envoyproxy/envoy/blob/68020a30525437ce3554f10e2fad7b02a5b9723c/api/envoy/api/v2/endpoint/load_report.proto#L131) should be set to sum of `dropped_count` in each `dropped_requests`. This is omitted in design doc, but the implementation has this.