### PR TITLE
xds: fix bug of using the wrong cluster name for client load reporting

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
@@ -72,9 +72,6 @@ final class XdsLoadReportClientImpl implements XdsLoadReportClient {
   private final StatsStore statsStore;
   private boolean started;
 
-  // The name for the google service the client talks to. Received on LRS responses.
-  @Nullable
-  private String clusterName;
   @Nullable
   private BackoffPolicy lrsRpcRetryPolicy;
   @Nullable
@@ -167,6 +164,10 @@ final class XdsLoadReportClientImpl implements XdsLoadReportClient {
     boolean closed;
     long loadReportIntervalNano = -1;
     ScheduledHandle loadReportTimer;
+
+    // The name for the google service the client talks to. Received on LRS responses.
+    @Nullable
+    String clusterName;
 
     LrsStream(LoadReportingServiceGrpc.LoadReportingServiceStub stub, Stopwatch stopwatch) {
       this.stub = checkNotNull(stub, "stub");

--- a/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
@@ -55,21 +55,18 @@ final class XdsLoadStatsStore implements StatsStore {
         }
       };
 
-  private final String clusterName;
   private final ConcurrentMap<XdsLocality, StatsCounter> localityLoadCounters;
   // Cluster level dropped request counts for each category specified in the DropOverload policy.
   private final ConcurrentMap<String, AtomicLong> dropCounters;
 
-  XdsLoadStatsStore(String clusterName) {
-    this(clusterName, new ConcurrentHashMap<XdsLocality, StatsCounter>(),
+  XdsLoadStatsStore() {
+    this(new ConcurrentHashMap<XdsLocality, StatsCounter>(),
         new ConcurrentHashMap<String, AtomicLong>());
   }
 
   @VisibleForTesting
-  XdsLoadStatsStore(String clusterName,
-      ConcurrentMap<XdsLocality, StatsCounter> localityLoadCounters,
+  XdsLoadStatsStore(ConcurrentMap<XdsLocality, StatsCounter> localityLoadCounters,
       ConcurrentMap<String, AtomicLong> dropCounters) {
-    this.clusterName = checkNotNull(clusterName, "clusterName");
     this.localityLoadCounters = checkNotNull(localityLoadCounters, "localityLoadCounters");
     this.dropCounters = checkNotNull(dropCounters, "dropCounters");
   }
@@ -80,7 +77,7 @@ final class XdsLoadStatsStore implements StatsStore {
    */
   @Override
   public ClusterStats generateLoadReport() {
-    ClusterStats.Builder statsBuilder = ClusterStats.newBuilder().setClusterName(clusterName);
+    ClusterStats.Builder statsBuilder = ClusterStats.newBuilder();
     for (Map.Entry<XdsLocality, StatsCounter> entry : localityLoadCounters.entrySet()) {
       ClientLoadSnapshot snapshot = entry.getValue().snapshot();
       UpstreamLocalityStats.Builder localityStatsBuilder =

--- a/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
@@ -56,7 +56,6 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link XdsLoadStatsStore}. */
 @RunWith(JUnit4.class)
 public class XdsLoadStatsStoreTest {
-  private static final String SERVICE_NAME = "api.google.com";
   private static final XdsLocality LOCALITY1 =
       new XdsLocality("test_region1", "test_zone", "test_subzone");
   private static final XdsLocality LOCALITY2 =
@@ -72,7 +71,7 @@ public class XdsLoadStatsStoreTest {
   public void setUp() {
     localityLoadCounters = new ConcurrentHashMap<>();
     dropCounters = new ConcurrentHashMap<>();
-    loadStore = new XdsLoadStatsStore(SERVICE_NAME, localityLoadCounters, dropCounters);
+    loadStore = new XdsLoadStatsStore(localityLoadCounters, dropCounters);
   }
 
   private static List<EndpointLoadMetricStats> buildEndpointLoadMetricStatsList(
@@ -117,8 +116,7 @@ public class XdsLoadStatsStoreTest {
   private static ClusterStats buildClusterStats(
       @Nullable List<UpstreamLocalityStats> upstreamLocalityStatsList,
       @Nullable List<DroppedRequests> droppedRequestsList) {
-    ClusterStats.Builder clusterStatsBuilder = ClusterStats.newBuilder()
-        .setClusterName(SERVICE_NAME);
+    ClusterStats.Builder clusterStatsBuilder = ClusterStats.newBuilder();
     if (upstreamLocalityStatsList != null) {
       clusterStatsBuilder.addAllUpstreamLocalityStats(upstreamLocalityStatsList);
     }


### PR DESCRIPTION
This is a bugfix as mentioned in #5863.

Fixed bug of using the wrong `cluster_name` in `ClusterStats` of `LoadStatsRequest`. This should be the GSLB service name, instead of the load-balanced service name (i.e., hostname) from client perspective. This `cluster_name` is received in `LoadStatsResponse` in load reporting response (as well as in EDS response). See [grpc-go](https://github.com/grpc/grpc-go/pull/2845)'s change as well.