### PR TITLE
xds: integrate client load reporting with xds load balancer (part 2)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -70,6 +70,8 @@ interface LocalityStore {
 
   void handleSubchannelState(Subchannel subchannel, ConnectivityStateInfo newState);
 
+  StatsStore getStatsStore();
+
   final class LocalityStoreImpl implements LocalityStore {
     private static final String ROUND_ROBIN = "round_robin";
 
@@ -234,6 +236,11 @@ interface LocalityStore {
     @Override
     public void updateDropPercentage(ImmutableList<DropOverload> dropOverloads) {
       this.dropOverloads = checkNotNull(dropOverloads, "dropOverloads");
+    }
+
+    @Override
+    public StatsStore getStatsStore() {
+      return statsStore;
     }
 
     @Nullable

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -357,11 +357,24 @@ interface LocalityStore {
         checkNotNull(newState, "newState");
         checkNotNull(newPicker, "newPicker");
 
+        class LoadRecordPicker extends SubchannelPicker {
+          private final SubchannelPicker delegate;
+
+          private LoadRecordPicker(SubchannelPicker delegate) {
+            this.delegate = delegate;
+          }
+
+          @Override
+          public PickResult pickSubchannel(PickSubchannelArgs args) {
+            return statsStore.interceptPickResult(delegate.pickSubchannel(args), locality);
+          }
+        }
+
         currentChildState = newState;
-        currentChildPicker = newPicker;
+        currentChildPicker = new LoadRecordPicker(newPicker);
 
         // delegate to parent helper
-        updateChildState(locality, newState, newPicker);
+        updateChildState(locality, newState, currentChildPicker);
       }
 
       @Override

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -231,8 +231,8 @@ interface LocalityStore {
       // There is a race between picking a subchannel and updating localities, which leads to
       // the possibility that RPCs will be sent to a removed locality. As a result, those RPC
       // loads will not be recorded. We consider this to be natural. By removing locality counters
-      // after updating subchannel pickers, we further narrow down the window in which this race
-      // condition can happen.
+      // after updating subchannel pickers, we eliminate the race and conservatively record loads
+      // happening in that period.
       helper.getSynchronizationContext().execute(new Runnable() {
         @Override
         public void run() {

--- a/xds/src/main/java/io/grpc/xds/XdsComms.java
+++ b/xds/src/main/java/io/grpc/xds/XdsComms.java
@@ -343,11 +343,6 @@ final class XdsComms {
         checkNotNull(localityStore, "localityStore"));
   }
 
-  void shutdownChannel() {
-    channel.shutdown();
-    shutdownLbRpc("Loadbalancer client shutdown");
-  }
-
   void refreshAdsStream() {
     checkState(!channel.isShutdown(), "channel is alreday shutdown");
 
@@ -356,6 +351,8 @@ final class XdsComms {
     }
   }
 
+  // TODO: Change method name to shutdown or shutdownXdsComms if that gives better semantics (
+  //  cancel LB RPC and clean up retry timer).
   void shutdownLbRpc(String message) {
     adsStream.cancelRpc(message, null);
   }

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -188,7 +188,7 @@ final class XdsLoadBalancer extends LoadBalancer {
     LbConfig childPolicy = xdsConfig.childPolicy;
     ManagedChannel lbChannel;
     if (xdsLbState == null) {
-      lbChannel = initLbChannel(newBalancerName);
+      lbChannel = initLbChannel(helper, newBalancerName);
       lrsClient =
           lrsClientFactory.createLoadReportClient(lbChannel, helper, backoffPolicyProvider,
               localityStore.getStatsStore());
@@ -196,7 +196,7 @@ final class XdsLoadBalancer extends LoadBalancer {
       lrsClient.stopLoadReporting();
       ManagedChannel oldChannel = xdsLbState.shutdownAndReleaseChannel("Changing balancer name");
       oldChannel.shutdown();
-      lbChannel = initLbChannel(newBalancerName);
+      lbChannel = initLbChannel(helper, newBalancerName);
       lrsClient =
           lrsClientFactory.createLoadReportClient(lbChannel, helper, backoffPolicyProvider,
               localityStore.getStatsStore());
@@ -212,7 +212,7 @@ final class XdsLoadBalancer extends LoadBalancer {
             adsStreamCallback);
   }
 
-  private ManagedChannel initLbChannel(String balancerName) {
+  private static ManagedChannel initLbChannel(Helper helper, String balancerName) {
     ManagedChannel channel;
     try {
       channel = helper.createResolvingOobChannel(balancerName);

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -203,6 +203,7 @@ final class XdsLoadBalancer extends LoadBalancer {
     } else if (!Objects.equal(
         getPolicyNameOrNull(childPolicy),
         getPolicyNameOrNull(xdsLbState.childPolicy))) {
+      // Changing child policy does not affect load reporting.
       lbChannel = xdsLbState.shutdownAndReleaseChannel("Changing load balancing mode");
     } else { // effectively no change in policy, keep xdsLbState unchanged
       return;

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -194,7 +194,10 @@ final class XdsLoadBalancer extends LoadBalancer {
               localityStore.getStatsStore());
     } else if (!newBalancerName.equals(xdsLbState.balancerName)) {
       lrsClient.stopLoadReporting();
-      ManagedChannel oldChannel = xdsLbState.shutdownAndReleaseChannel("Changing balancer name");
+      ManagedChannel oldChannel =
+          xdsLbState.shutdownAndReleaseChannel(
+              String.format("Changing balancer name from %s to %s", xdsLbState.balancerName,
+                  newBalancerName));
       oldChannel.shutdown();
       lbChannel = initLbChannel(helper, newBalancerName);
       lrsClient =
@@ -204,7 +207,10 @@ final class XdsLoadBalancer extends LoadBalancer {
         getPolicyNameOrNull(childPolicy),
         getPolicyNameOrNull(xdsLbState.childPolicy))) {
       // Changing child policy does not affect load reporting.
-      lbChannel = xdsLbState.shutdownAndReleaseChannel("Changing load balancing mode");
+      lbChannel =
+          xdsLbState.shutdownAndReleaseChannel(
+              String.format("Changing child policy from %s to %s", xdsLbState.childPolicy,
+                  childPolicy));
     } else { // effectively no change in policy, keep xdsLbState unchanged
       return;
     }

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.grpc.ConnectivityState.READY;
 import static io.grpc.ConnectivityState.TRANSIENT_FAILURE;
 import static io.grpc.xds.XdsLoadBalancerProvider.XDS_POLICY_NAME;
+import static java.util.logging.Level.FINEST;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -33,18 +34,23 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerRegistry;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext.ScheduledHandle;
+import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.GrpcAttributes;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.xds.LocalityStore.LocalityStoreImpl;
 import io.grpc.xds.XdsComms.AdsStreamCallback;
+import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportClientFactory;
 import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
@@ -57,7 +63,14 @@ final class XdsLoadBalancer extends LoadBalancer {
   private final Helper helper;
   private final LoadBalancerRegistry lbRegistry;
   private final FallbackManager fallbackManager;
+  private final BackoffPolicy.Provider backoffPolicyProvider;
+  private final XdsLoadReportClientFactory lrsClientFactory;
 
+  @Nullable
+  private XdsLoadReportClient lrsClient;
+  @Nullable
+  private XdsLbState xdsLbState;
+  private boolean lrsWorking;
   private final AdsStreamCallback adsStreamCallback = new AdsStreamCallback() {
 
     @Override
@@ -68,6 +81,11 @@ final class XdsLoadBalancer extends LoadBalancer {
       }
 
       fallbackManager.childBalancerWorked = true;
+
+      if (!lrsWorking) {
+        lrsClient.startLoadReporting();
+        lrsWorking = true;
+      }
     }
 
     @Override
@@ -86,23 +104,51 @@ final class XdsLoadBalancer extends LoadBalancer {
     }
   };
 
-  @Nullable
-  private XdsLbState xdsLbState;
-
   private LbConfig fallbackPolicy;
 
-  XdsLoadBalancer(Helper helper, LoadBalancerRegistry lbRegistry) {
-    this.helper = helper;
-    this.lbRegistry = lbRegistry;
-    this.localityStore = new LocalityStoreImpl(new LocalityStoreHelper(), lbRegistry);
-    fallbackManager = new FallbackManager(helper, lbRegistry);
+  XdsLoadBalancer(Helper helper, LoadBalancerRegistry lbRegistry,
+      BackoffPolicy.Provider backoffPolicyProvider) {
+    this(helper, lbRegistry, backoffPolicyProvider, XdsLoadReportClientFactory.getInstance(),
+        new FallbackManager(helper, lbRegistry));
   }
 
-  private final class LocalityStoreHelper extends ForwardingLoadBalancerHelper {
+  private XdsLoadBalancer(Helper helper,
+      LoadBalancerRegistry lbRegistry,
+      BackoffPolicy.Provider backoffPolicyProvider,
+      XdsLoadReportClientFactory lrsClientFactory,
+      FallbackManager fallbackManager) {
+    this(helper, lbRegistry, backoffPolicyProvider, lrsClientFactory, fallbackManager,
+        new LocalityStoreImpl(new LocalityStoreHelper(helper, fallbackManager), lbRegistry));
+  }
+
+  @VisibleForTesting
+  XdsLoadBalancer(Helper helper,
+      LoadBalancerRegistry lbRegistry,
+      BackoffPolicy.Provider backoffPolicyProvider,
+      XdsLoadReportClientFactory lrsClientFactory,
+      FallbackManager fallbackManager,
+      LocalityStore localityStore) {
+    this.helper = checkNotNull(helper, "helper");
+    this.lbRegistry = checkNotNull(lbRegistry, "lbRegistry");
+    this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
+    this.lrsClientFactory = checkNotNull(lrsClientFactory, "lrsClientFactory");
+    this.fallbackManager = checkNotNull(fallbackManager, "fallbackManager");
+    this.localityStore = checkNotNull(localityStore, "localityStore");
+  }
+
+  private static final class LocalityStoreHelper extends ForwardingLoadBalancerHelper {
+
+    final Helper delegate;
+    final FallbackManager fallbackManager;
+
+    LocalityStoreHelper(Helper delegate, FallbackManager fallbackManager) {
+      this.delegate = checkNotNull(delegate, "delegate");
+      this.fallbackManager = checkNotNull(fallbackManager, "fallbackManager");
+    }
 
     @Override
     protected Helper delegate() {
-      return helper;
+      return delegate;
     }
 
     @Override
@@ -117,7 +163,7 @@ final class XdsLoadBalancer extends LoadBalancer {
       }
 
       if (!fallbackManager.isInFallbackMode()) {
-        helper.updateBalancingState(newState, newPicker);
+        delegate.updateBalancingState(newState, newPicker);
       }
     }
   }
@@ -145,30 +191,47 @@ final class XdsLoadBalancer extends LoadBalancer {
   private void handleNewConfig(XdsConfig xdsConfig) {
     String newBalancerName = xdsConfig.newBalancerName;
     LbConfig childPolicy = xdsConfig.childPolicy;
-    XdsComms xdsComms = null;
-    if (xdsLbState != null) { // may release and re-use/shutdown xdsComms from current xdsLbState
-      if (!newBalancerName.equals(xdsLbState.balancerName)) {
-        xdsComms = xdsLbState.shutdownAndReleaseXdsComms();
-        if (xdsComms != null) {
-          xdsComms.shutdownChannel();
-          xdsComms = null;
+    ManagedChannel lbChannel;
+    if (xdsLbState == null || !newBalancerName.equals(xdsLbState.balancerName)) {
+      if (xdsLbState != null) {
+        if (lrsWorking) {
+          lrsClient.stopLoadReporting();
+          lrsWorking = false;
         }
-      } else if (!Objects.equal(
-          getPolicyNameOrNull(childPolicy),
-          getPolicyNameOrNull(xdsLbState.childPolicy))) {
-        String cancelMessage = "Changing loadbalancing mode";
-        xdsComms = xdsLbState.shutdownAndReleaseXdsComms();
-        // close the stream but reuse the channel
-        if (xdsComms != null) {
-          xdsComms.shutdownLbRpc(cancelMessage);
-          xdsComms.refreshAdsStream();
-        }
-      } else { // effectively no change in policy, keep xdsLbState unchanged
-        return;
+        ManagedChannel oldChannel = xdsLbState.shutdownAndReleaseChannel("Client shutdown");
+        oldChannel.shutdown();
       }
+      try {
+        lbChannel = helper.createResolvingOobChannel(newBalancerName);
+      } catch (UnsupportedOperationException uoe) {
+        // Temporary solution until createResolvingOobChannel is implemented
+        // FIXME (https://github.com/grpc/grpc-java/issues/5495)
+        Logger logger = Logger.getLogger(XdsLoadBalancer.class.getName());
+        if (logger.isLoggable(FINEST)) {
+          logger.log(
+              FINEST,
+              "createResolvingOobChannel() not supported by the helper: " + helper,
+              uoe);
+          logger.log(
+              FINEST,
+              "creating oob channel for target {0} using default ManagedChannelBuilder",
+              newBalancerName);
+        }
+        lbChannel = ManagedChannelBuilder.forTarget(newBalancerName).build();
+      }
+      lrsClient =
+          lrsClientFactory.createLoadReportClient(lbChannel, helper, backoffPolicyProvider,
+              localityStore.getStatsStore());
+    } else if (!Objects.equal(
+        getPolicyNameOrNull(childPolicy),
+        getPolicyNameOrNull(xdsLbState.childPolicy))) {
+      lbChannel = xdsLbState.shutdownAndReleaseChannel("Changing load balancing mode");
+    } else { // effectively no change in policy, keep xdsLbState unchanged
+      return;
     }
-    xdsLbState = new XdsLbState(
-        newBalancerName, childPolicy, xdsComms, helper, localityStore, adsStreamCallback);
+    xdsLbState =
+        new XdsLbState(newBalancerName, childPolicy, helper, localityStore, lbChannel,
+            adsStreamCallback);
   }
 
   @Nullable
@@ -213,10 +276,13 @@ final class XdsLoadBalancer extends LoadBalancer {
   @Override
   public void shutdown() {
     if (xdsLbState != null) {
-      XdsComms xdsComms = xdsLbState.shutdownAndReleaseXdsComms();
-      if (xdsComms != null) {
-        xdsComms.shutdownChannel();
+      if (lrsWorking) {
+        lrsClient.stopLoadReporting();
+        lrsClient = null;
+        lrsWorking = false;
       }
+      ManagedChannel channel = xdsLbState.shutdownAndReleaseChannel("Client shutdown");
+      channel.shutdown();
       xdsLbState = null;
     }
     fallbackManager.cancelFallback();
@@ -257,8 +323,8 @@ final class XdsLoadBalancer extends LoadBalancer {
     private boolean childPolicyHasBeenReady;
 
     FallbackManager(Helper helper, LoadBalancerRegistry lbRegistry) {
-      this.helper = helper;
-      this.lbRegistry = lbRegistry;
+      this.helper = checkNotNull(helper, "helper");
+      this.lbRegistry = checkNotNull(lbRegistry, "lbRegistry");
     }
 
     /**

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancer.java
@@ -202,7 +202,7 @@ final class XdsLoadBalancer extends LoadBalancer {
         lrsClient.stopLoadReporting();
         lrsWorking = false;
       }
-      ManagedChannel oldChannel = xdsLbState.shutdownAndReleaseChannel("Client shutdown");
+      ManagedChannel oldChannel = xdsLbState.shutdownAndReleaseChannel("Changing balancer name");
       oldChannel.shutdown();
       lbChannel = initLbChannel(newBalancerName);
       lrsClient =

--- a/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadBalancerProvider.java
@@ -25,6 +25,7 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver.ConfigOrError;
 import io.grpc.Status;
+import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.ServiceConfigUtil;
 import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.xds.XdsLoadBalancer.XdsConfig;
@@ -62,7 +63,8 @@ public final class XdsLoadBalancerProvider extends LoadBalancerProvider {
 
   @Override
   public LoadBalancer newLoadBalancer(Helper helper) {
-    return new XdsLoadBalancer(helper, LoadBalancerRegistry.getDefaultRegistry());
+    return new XdsLoadBalancer(helper, LoadBalancerRegistry.getDefaultRegistry(),
+        new ExponentialBackoffPolicy.Provider());
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/XdsLoadReportClient.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadReportClient.java
@@ -28,10 +28,8 @@ interface XdsLoadReportClient {
 
   /**
    * Establishes load reporting communication and negotiates with the remote balancer to report load
-   * stats periodically.
-   *
-   * <p>This method should be the first method to be called in the lifecycle of {@link
-   * XdsLoadReportClient} and should only be called once.
+   * stats periodically. Calling this method on an already started {@link XdsLoadReportClient} is
+   * no-op.
    *
    * <p>This method is not thread-safe and should be called from the same synchronized context
    * returned by {@link XdsLoadBalancer.Helper#getSynchronizationContext}.
@@ -39,9 +37,8 @@ interface XdsLoadReportClient {
   void startLoadReporting();
 
   /**
-   * Terminates load reporting.
-   *
-   * <p>No method in {@link XdsLoadReportClient} should be called after calling this method.
+   * Terminates load reporting. Calling this method on an already stopped
+   * {@link XdsLoadReportClient} is no-op.
    *
    * <p>This method is not thread-safe and should be called from the same synchronized context
    * returned by {@link XdsLoadBalancer.Helper#getSynchronizationContext}.

--- a/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
@@ -108,19 +108,25 @@ final class XdsLoadReportClientImpl implements XdsLoadReportClient {
 
   @Override
   public void startLoadReporting() {
-    checkState(!started, "load reporting has already started");
+    if (started) {
+      return;
+    }
     started = true;
     startLrsRpc();
   }
 
   @Override
   public void stopLoadReporting() {
+    if (!started) {
+      return;
+    }
     if (lrsRpcRetryTimer != null) {
       lrsRpcRetryTimer.cancel();
     }
     if (lrsStream != null) {
       lrsStream.close(null);
     }
+    started = false;
     // Do not shutdown channel as it is not owned by LrsClient.
   }
 

--- a/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
@@ -338,13 +338,17 @@ final class XdsLoadReportClientImpl implements XdsLoadReportClient {
 
   abstract static class XdsLoadReportClientFactory {
 
-    static XdsLoadReportClientFactory DEFAULT_INSTANCE = new XdsLoadReportClientFactory() {
-      @Override
-      XdsLoadReportClient createLoadReportClient(ManagedChannel channel, Helper helper,
-          Provider backoffPolicyProvider, StatsStore statsStore) {
-        return new XdsLoadReportClientImpl(channel, helper, backoffPolicyProvider, statsStore);
-      }
-    };
+    private static final XdsLoadReportClientFactory DEFAULT_INSTANCE =
+        new XdsLoadReportClientFactory() {
+          @Override
+          XdsLoadReportClient createLoadReportClient(
+              ManagedChannel channel,
+              Helper helper,
+              Provider backoffPolicyProvider,
+              StatsStore statsStore) {
+            return new XdsLoadReportClientImpl(channel, helper, backoffPolicyProvider, statsStore);
+          }
+        };
 
     static XdsLoadReportClientFactory getInstance() {
       return DEFAULT_INSTANCE;

--- a/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadReportClientImpl.java
@@ -39,6 +39,7 @@ import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
+import io.grpc.internal.BackoffPolicy.Provider;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.stub.StreamObserver;
 import java.util.Collections;
@@ -333,5 +334,23 @@ final class XdsLoadReportClientImpl implements XdsLoadReportClient {
         lrsStream = null;
       }
     }
+  }
+
+  abstract static class XdsLoadReportClientFactory {
+
+    static XdsLoadReportClientFactory DEFAULT_INSTANCE = new XdsLoadReportClientFactory() {
+      @Override
+      XdsLoadReportClient createLoadReportClient(ManagedChannel channel, Helper helper,
+          Provider backoffPolicyProvider, StatsStore statsStore) {
+        return new XdsLoadReportClientImpl(channel, helper, backoffPolicyProvider, statsStore);
+      }
+    };
+
+    static XdsLoadReportClientFactory getInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    abstract XdsLoadReportClient createLoadReportClient(ManagedChannel channel, Helper helper,
+        BackoffPolicy.Provider backoffPolicyProvider, StatsStore statsStore);
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsCommsTest.java
@@ -171,14 +171,6 @@ public class XdsCommsTest {
   }
 
   @Test
-  public void shutdownLbComm() throws Exception {
-    xdsComms.shutdownChannel();
-    assertTrue(channel.isShutdown());
-    assertTrue(streamRecorder.awaitCompletion(1, TimeUnit.SECONDS));
-    assertEquals(Status.Code.CANCELLED, Status.fromThrowable(streamRecorder.getError()).getCode());
-  }
-
-  @Test
   public void shutdownLbRpc_verifyChannelNotShutdown() throws Exception {
     xdsComms.shutdownLbRpc("shutdown msg1");
     assertTrue(streamRecorder.awaitCompletion(1, TimeUnit.SECONDS));
@@ -298,7 +290,7 @@ public class XdsCommsTest {
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
         locality2, localityInfo2, locality1, localityInfo1).inOrder();
 
-    xdsComms.shutdownChannel();
+    xdsComms.shutdownLbRpc("End test");
   }
 
   @Test
@@ -434,7 +426,7 @@ public class XdsCommsTest {
     assertThat(localityEndpointsMappingCaptor.getValue()).containsExactly(
         locality2, localityInfo2, locality1, localityInfo1).inOrder();
 
-    xdsComms.shutdownChannel();
+    xdsComms.shutdownLbRpc("End test");
   }
 
   @Test
@@ -443,7 +435,5 @@ public class XdsCommsTest {
 
     verify(adsStreamCallback).onError();
     verifyNoMoreInteractions(adsStreamCallback);
-
-    xdsComms.shutdownChannel();
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerTest.java
@@ -71,6 +71,7 @@ import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.JsonParser;
 import io.grpc.internal.testing.StreamRecorder;
@@ -104,6 +105,8 @@ public class XdsLoadBalancerTest {
   private LoadBalancer fallbackBalancer1;
   @Mock
   private LoadBalancer fakeBalancer2;
+  @Mock
+  private BackoffPolicy.Provider backoffPolicyProvider;
   private XdsLoadBalancer lb;
 
   private final FakeClock fakeClock = new FakeClock();
@@ -224,7 +227,7 @@ public class XdsLoadBalancerTest {
     lbRegistry.register(lbProvider1);
     lbRegistry.register(lbProvider2);
     lbRegistry.register(roundRobin);
-    lb = new XdsLoadBalancer(helper, lbRegistry);
+    lb = new XdsLoadBalancer(helper, lbRegistry, backoffPolicyProvider);
     doReturn(syncContext).when(helper).getSynchronizationContext();
     doReturn(fakeClock.getScheduledExecutorService()).when(helper).getScheduledExecutorService();
     doReturn(mock(ChannelLogger.class)).when(helper).getChannelLogger();

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2019 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.LoadBalancer.ATTR_LOAD_BALANCING_CONFIG;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.Any;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase;
+import io.grpc.Attributes;
+import io.grpc.ChannelLogger;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
+import io.grpc.LoadBalancer.Helper;
+import io.grpc.LoadBalancer.ResolvedAddresses;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.SynchronizationContext;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.internal.BackoffPolicy;
+import io.grpc.internal.FakeClock;
+import io.grpc.internal.JsonParser;
+import io.grpc.internal.testing.StreamRecorder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.xds.XdsLoadBalancer.FallbackManager;
+import io.grpc.xds.XdsLoadReportClientImpl.XdsLoadReportClientFactory;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class XdsLoadBalancerWithLrsTest {
+  private static final String SERVICE_AUTHORITY = "test authority";
+
+  @Rule
+  public final GrpcCleanupRule cleanupRule = new GrpcCleanupRule();
+
+  private final SynchronizationContext syncContext = new SynchronizationContext(
+      new Thread.UncaughtExceptionHandler() {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+          throw new AssertionError(e);
+        }
+      });
+
+  @Mock
+  private Helper helper;
+  @Mock
+  private BackoffPolicy.Provider backoffPolicyProvider;
+  @Mock
+  private LocalityStore localityStore;
+  @Mock
+  private XdsLoadReportClientFactory lrsClientFactory;
+  @Mock
+  private XdsLoadReportClient lrsClient;
+  @Mock
+  private StatsStore statsStore;
+  @Mock
+  private LoadBalancer fallbackBalancer;
+  @Mock
+  private LoadBalancer mockBalancer;
+
+  private final FakeClock fakeClock = new FakeClock();
+  private final LoadBalancerRegistry lbRegistry = new LoadBalancerRegistry();
+  private final StreamRecorder<DiscoveryRequest> streamRecorder = StreamRecorder.create();
+  private final LoadBalancerProvider fallBackLbProvider = new LoadBalancerProvider() {
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    public int getPriority() {
+      return 5;
+    }
+
+    @Override
+    public String getPolicyName() {
+      return "fallback";
+    }
+
+    @Override
+    public LoadBalancer newLoadBalancer(Helper helper) {
+      fallBackLbHelper = helper;
+      return fallbackBalancer;
+    }
+  };
+  private final LoadBalancerProvider lbProvider = new LoadBalancerProvider() {
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    public int getPriority() {
+      return 5;
+    }
+
+    @Override
+    public String getPolicyName() {
+      return "supported";
+    }
+
+    @Override
+    public LoadBalancer newLoadBalancer(Helper helper) {
+      return mockBalancer;
+    }
+  };
+
+  private Helper fallBackLbHelper;
+  private StreamObserver<DiscoveryResponse> serverResponseWriter;
+  private ManagedChannel oobChannel1;
+  private ManagedChannel oobChannel2;
+  private ManagedChannel oobChannel3;
+  private LoadBalancer xdsLoadBalancer;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    String serverName = InProcessServerBuilder.generateName();
+    AggregatedDiscoveryServiceImplBase serviceImpl = new AggregatedDiscoveryServiceImplBase() {
+      @Override
+      public StreamObserver<DiscoveryRequest> streamAggregatedResources(
+          final StreamObserver<DiscoveryResponse> responseObserver) {
+        serverResponseWriter = responseObserver;
+
+        return new StreamObserver<DiscoveryRequest>() {
+
+          @Override
+          public void onNext(DiscoveryRequest value) {
+            streamRecorder.onNext(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            streamRecorder.onError(t);
+          }
+
+          @Override
+          public void onCompleted() {
+            streamRecorder.onCompleted();
+            responseObserver.onCompleted();
+          }
+        };
+      }
+    };
+    cleanupRule.register(
+        InProcessServerBuilder
+            .forName(serverName)
+            .directExecutor()
+            .addService(serviceImpl)
+            .build()
+            .start());
+
+    InProcessChannelBuilder channelBuilder =
+        InProcessChannelBuilder.forName(serverName).directExecutor();
+    oobChannel1 = mock(
+        ManagedChannel.class,
+        delegatesTo(cleanupRule.register(channelBuilder.build())));
+    oobChannel2 = mock(
+        ManagedChannel.class,
+        delegatesTo(cleanupRule.register(channelBuilder.build())));
+    oobChannel3 = mock(
+        ManagedChannel.class,
+        delegatesTo(cleanupRule.register(channelBuilder.build())));
+
+    lbRegistry.register(fallBackLbProvider);
+    lbRegistry.register(lbProvider);
+    when(helper.getSynchronizationContext()).thenReturn(syncContext);
+    when(helper.getScheduledExecutorService()).thenReturn(fakeClock.getScheduledExecutorService());
+    when(helper.getAuthority()).thenReturn(SERVICE_AUTHORITY);
+    when(helper.getChannelLogger()).thenReturn(mock(ChannelLogger.class));
+    when(helper.createResolvingOobChannel(anyString()))
+        .thenReturn(oobChannel1, oobChannel2, oobChannel3);
+    when(localityStore.getStatsStore()).thenReturn(statsStore);
+    when(lrsClientFactory.createLoadReportClient(any(ManagedChannel.class), any(Helper.class),
+        any(BackoffPolicy.Provider.class), any(StatsStore.class))).thenReturn(lrsClient);
+
+    xdsLoadBalancer =
+        new XdsLoadBalancer(helper, lbRegistry, backoffPolicyProvider, lrsClientFactory,
+            new FallbackManager(helper, lbRegistry), localityStore);
+  }
+
+  @After
+  public void tearDown() {
+    xdsLoadBalancer.shutdown();
+  }
+
+  /**
+   * Tests load reporting is initiated after receiving the first valid EDS response from the traffic
+   * director, then its operation is independent of load balancing until xDS load balancer is
+   * shutdown.
+   */
+  @Test
+  public void reportLoadAfterReceivingFirstEdsResponseUntilShutdown() throws Exception {
+    xdsLoadBalancer.handleResolvedAddresses(ResolvedAddresses.newBuilder()
+        .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
+        .setAttributes(standardModeWithFallbackAttributes())
+        .build());
+
+    verify(lrsClientFactory)
+        .createLoadReportClient(same(oobChannel1), same(helper), same(backoffPolicyProvider),
+            same(statsStore));
+    assertThat(streamRecorder.getValues()).hasSize(1);
+
+    // Let fallback timer elapse and xDS load balancer enters fallback mode on startup.
+    assertThat(fakeClock.getPendingTasks()).hasSize(1);
+    assertThat(fallBackLbHelper).isNull();
+    fakeClock.forwardTime(10, TimeUnit.SECONDS);
+    assertThat(fallBackLbHelper).isNotNull();
+
+    verify(lrsClient, never()).startLoadReporting();
+
+    // Simulates a syntactically incorrect EDS response.
+    serverResponseWriter.onNext(DiscoveryResponse.getDefaultInstance());
+    verify(lrsClient, never()).startLoadReporting();
+
+    // Simulate a syntactically correct EDS response.
+    DiscoveryResponse edsResponse =
+        DiscoveryResponse.newBuilder()
+            .addResources(Any.pack(ClusterLoadAssignment.getDefaultInstance()))
+            .setTypeUrl("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment")
+            .build();
+    serverResponseWriter.onNext(edsResponse);
+    verify(lrsClient).startLoadReporting();
+
+    // Simulate another EDS response from the same remote balancer.
+    serverResponseWriter.onNext(edsResponse);
+
+    // Simulate an EDS error response.
+    serverResponseWriter.onError(Status.ABORTED.asException());
+
+    // Shutdown xDS load balancer.
+    xdsLoadBalancer.shutdown();
+    verify(lrsClient).stopLoadReporting();
+
+    verifyNoMoreInteractions(lrsClientFactory, lrsClient);
+  }
+
+  /**
+   * Tests load report client sends load to new traffic director when xDS load balancer talks to
+   * the remote balancer.
+   */
+  @Test
+  @SuppressWarnings("unchecked")
+  public void reportLoadToNewTrafficDirectorAfterBalancerNameChange() throws Exception {
+    InOrder inOrder = inOrder(lrsClientFactory, lrsClient);
+    xdsLoadBalancer.handleResolvedAddresses(ResolvedAddresses.newBuilder()
+        .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
+        .setAttributes(standardModeWithFallbackAttributes())
+        .build());
+
+    inOrder.verify(lrsClientFactory)
+        .createLoadReportClient(same(oobChannel1), same(helper), same(backoffPolicyProvider),
+            same(statsStore));
+    assertThat(streamRecorder.getValues()).hasSize(1);
+    inOrder.verify(lrsClient, never()).startLoadReporting();
+
+    // Simulate receiving a new service config with balancer name changed before xDS protocol is
+    // established.
+    Map<String, ?> newLbConfig =
+        (Map<String, ?>) JsonParser.parse(
+            "{\"balancerName\" : \"dns:///another.balancer.example.com:8080\","
+                + "\"fallbackPolicy\" : [{\"fallback\" : { \"fallback_option\" : \"yes\"}}]}");
+
+    xdsLoadBalancer.handleResolvedAddresses(ResolvedAddresses.newBuilder()
+        .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
+        .setAttributes(Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, newLbConfig).build())
+        .build());
+
+    assertThat(oobChannel1.isShutdown()).isTrue();
+    assertThat(streamRecorder.getValues()).hasSize(2);
+    inOrder.verify(lrsClient, never()).stopLoadReporting();
+    inOrder.verify(lrsClientFactory)
+        .createLoadReportClient(same(oobChannel2), same(helper), same(backoffPolicyProvider),
+            same(statsStore));
+
+    // Simulate a syntactically correct EDS response.
+    DiscoveryResponse edsResponse =
+        DiscoveryResponse.newBuilder()
+            .addResources(Any.pack(ClusterLoadAssignment.getDefaultInstance()))
+            .setTypeUrl("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment")
+            .build();
+    serverResponseWriter.onNext(edsResponse);
+    inOrder.verify(lrsClient).startLoadReporting();
+
+    // Simulate receiving a new service config with balancer name changed.
+    newLbConfig = (Map<String, ?>) JsonParser.parse(
+        "{\"balancerName\" : \"dns:///third.balancer.example.com:8080\","
+            + "\"fallbackPolicy\" : [{\"fallback\" : { \"fallback_option\" : \"yes\"}}]}");
+
+    xdsLoadBalancer.handleResolvedAddresses(ResolvedAddresses.newBuilder()
+        .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
+        .setAttributes(Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, newLbConfig).build())
+        .build());
+
+    assertThat(oobChannel2.isShutdown()).isTrue();
+    assertThat(streamRecorder.getValues()).hasSize(3);
+    inOrder.verify(lrsClient).stopLoadReporting();
+    inOrder.verify(lrsClientFactory)
+        .createLoadReportClient(same(oobChannel3), same(helper), same(backoffPolicyProvider),
+            same(statsStore));
+
+    serverResponseWriter.onNext(edsResponse);
+    inOrder.verify(lrsClient).startLoadReporting();
+
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  /**
+   * Tests the case that load reporting is not interrupted when child balancing policy changes,
+   * even though xDS balancer refreshes discovery RPC with the traffic director.
+   */
+  @Test
+  public void loadReportNotAffectedWhenChildPolicyChanges() throws Exception {
+    xdsLoadBalancer.handleResolvedAddresses(ResolvedAddresses.newBuilder()
+        .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
+        .setAttributes(standardModeWithFallbackAttributes())
+        .build());
+
+    verify(lrsClientFactory)
+        .createLoadReportClient(same(oobChannel1), same(helper), same(backoffPolicyProvider),
+            same(statsStore));
+    assertThat(streamRecorder.getValues()).hasSize(1);
+
+    // Simulate a syntactically correct EDS response.
+    DiscoveryResponse edsResponse =
+        DiscoveryResponse.newBuilder()
+            .addResources(Any.pack(ClusterLoadAssignment.getDefaultInstance()))
+            .setTypeUrl("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment")
+            .build();
+    serverResponseWriter.onNext(edsResponse);
+    verify(lrsClient).startLoadReporting();
+
+    // Simulate receiving a new service config with child policy changed.
+    @SuppressWarnings("unchecked")
+    Map<String, ?> newLbConfig =
+        (Map<String, ?>) JsonParser.parse(
+            "{\"balancerName\" : \"dns:///balancer.example.com:8080\","
+                + "\"childPolicy\" : [{\"supported\" : {\"key\" : \"val\"}}],"
+                + "\"fallbackPolicy\" : [{\"fallback\" : { \"fallback_option\" : \"yes\"}}]}");
+
+    xdsLoadBalancer.handleResolvedAddresses(ResolvedAddresses.newBuilder()
+        .setAddresses(Collections.<EquivalentAddressGroup>emptyList())
+        .setAttributes(Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, newLbConfig).build())
+        .build());
+
+    assertThat(oobChannel1.isShutdown()).isFalse();
+    assertThat(Status.fromThrowable(streamRecorder.getError()).getCode())
+        .isEqualTo(Code.CANCELLED);
+    assertThat(streamRecorder.getValues()).hasSize(2);
+    verify(lrsClient, never()).stopLoadReporting();
+
+    verifyNoMoreInteractions(lrsClientFactory, lrsClient);
+  }
+
+  private static Attributes standardModeWithFallbackAttributes() throws Exception {
+    String lbConfigRaw = "{"
+        + "\"balancerName\" : \"dns:///balancer.example.com:8080\","
+        + "\"fallbackPolicy\" : [{\"fallback\" : { \"fallback_option\" : \"yes\"}}]"
+        + "}";
+    @SuppressWarnings("unchecked")
+    Map<String, ?> lbConfig = (Map<String, ?>) JsonParser.parse(lbConfigRaw);
+    return Attributes.newBuilder().set(ATTR_LOAD_BALANCING_CONFIG, lbConfig).build();
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadBalancerWithLrsTest.java
@@ -308,7 +308,6 @@ public class XdsLoadBalancerWithLrsTest {
 
     assertThat(oobChannel1.isShutdown()).isTrue();
     assertThat(streamRecorder.getValues()).hasSize(2);
-    inOrder.verify(lrsClient, never()).stopLoadReporting();
     inOrder.verify(lrsClientFactory)
         .createLoadReportClient(same(oobChannel2), same(helper), same(backoffPolicyProvider),
             same(statsStore));


### PR DESCRIPTION
This PR is the second part of #5836, which adds load reporting into xds load balancer.

There are two parts of client load reporting: a `StatsStore` for managing recorded stats (e.g., load data, backend metrics, drops) and an `XdsLoadReportClient` for sending load reports to the remote balancer. 

Some main changes:

- `XdsLoadReportClient` stays the same lifecycle as the balancer `Channel`, which only changes upon balance name change.

- `LocalityStore` creates and maintains the `StatsStore` and expose a method `getStatsStore()` to allow accessing it for creating a `XdsLoadReportClient` instance.
    - `addLocality()` and `removeLocality()` are called on `StatsStore` when `XdsComms` invokes `LocalityStore#updateLocalityStore()`.

- `XdsLoadBalancer` manages the lifecycle of balance channel as well as `XdsLoadReportClient`. So `XdsLoadReportClient` runs separately with `XdsLbState`.
    - Load reporting is triggered in the `AdsStreamCallback`.


Unit test for interactions between `XdsLoadBalancer` and `XdsLoadReportClient` is in `XdsLoadBalancerWithLrsTest.java`. Tests in `XdsLoadBalancerTest.java` are coupled with `LocalityStore` and they are more comprehensive tests for load balancer as a whole. Testing load reporting does not need that much. The only thing we need to verify is each time an `XdsLoadReportClient` is created, it should use the same `StatsStore`. 
