### PR TITLE
netty: refine filtering for benign transport level exceptions

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -184,7 +184,7 @@ class NettyServerTransport implements ServerTransport {
   static Level getLogLevel(Throwable t) {
     if (t instanceof IOException && t.getMessage() != null) {
       for (String msg : QUIET_ERRORS) {
-        if (t.getMessage().equals(msg)) {
+        if (t.getMessage().contains(msg)) {
           return Level.FINE;
         }
       }

--- a/netty/src/test/java/io/grpc/netty/NettyServerTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerTransportTest.java
@@ -41,6 +41,12 @@ public class NettyServerTransportTest {
   }
 
   @Test
+  public void quiet_prefixed() {
+    assertEquals(Level.FINE, getLogLevel(new IOException(
+        "syscall:read(..) failed: Connection reset by peer")));
+  }
+
+  @Test
   public void nonquiet() {
     assertEquals(Level.INFO, getLogLevel(new IOException("foo")));
   }


### PR DESCRIPTION
Transport level exceptions (e.g. "Connection reset by peer") are not
useful and clutter the logs. `NettyServerTransport` contains logic to
log such exceptions at level `FINE`.

When running with epoll, transport level exceptions are prefixed with
additional contextual information (e.g. "syscall:read(..) failed:") that
causes the exceptions to be logged at level `INFO`.

Update the filtering logic to match on error messages _containing_ the
blacklisted messages, rather than using string equality.

Closes #5872.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>