### PR TITLE
xds: StatsStore#interceptPickResult should not intercept NO_RESULT

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
@@ -168,6 +168,8 @@ final class XdsLoadStatsStore implements StatsStore {
     }
     StatsCounter counter = localityLoadCounters.get(locality);
     if (counter == null) {
+      // TODO (chengyuanzhang): this should not happen if this method is called in a correct
+      //  order with other methods in this class, but we might want to have some logs or warnings.
       return pickResult;
     }
     ClientStreamTracer.Factory originFactory = pickResult.getStreamTracerFactory();

--- a/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
+++ b/xds/src/main/java/io/grpc/xds/XdsLoadStatsStore.java
@@ -163,6 +163,9 @@ final class XdsLoadStatsStore implements StatsStore {
     if (!pickResult.getStatus().isOk()) {
       return pickResult;
     }
+    if (pickResult.getSubchannel() == null) {
+      return pickResult;
+    }
     StatsCounter counter = localityLoadCounters.get(locality);
     if (counter == null) {
       return pickResult;

--- a/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
@@ -328,7 +328,7 @@ public class XdsLoadStatsStoreTest {
     when(mockFactory
         .newClientStreamTracer(any(ClientStreamTracer.StreamInfo.class), any(Metadata.class)))
         .thenReturn(mockTracer);
-    localityLoadCounters.put(LOCALITY1, new ClientLoadCounter());
+    localityLoadCounters.put(LOCALITY1, mock(StatsCounter.class));
     PickResult pickResult = PickResult.withSubchannel(mockSubchannel, mockFactory);
     PickResult interceptedPickResult = loadStore.interceptPickResult(pickResult, LOCALITY1);
     Metadata metadata = new Metadata();

--- a/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
@@ -316,9 +316,9 @@ public class XdsLoadStatsStoreTest {
     PickResult interceptedDroppedResult =
         loadStore.interceptPickResult(droppedResult, LOCALITY1);
     PickResult interceptedEmptyResult = loadStore.interceptPickResult(emptyResult, LOCALITY1);
-    assertThat(interceptedErrorResult).isEqualTo(errorResult);
-    assertThat(interceptedDroppedResult).isEqualTo(droppedResult);
-    assertThat(interceptedEmptyResult).isEqualTo(emptyResult);
+    assertThat(interceptedErrorResult).isSameInstanceAs(errorResult);
+    assertThat(interceptedDroppedResult).isSameInstanceAs(droppedResult);
+    assertThat(interceptedEmptyResult).isSameInstanceAs(emptyResult);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsLoadStatsStoreTest.java
@@ -308,14 +308,17 @@ public class XdsLoadStatsStoreTest {
 
   @Test
   public void invalidPickResultNotIntercepted() {
+    localityLoadCounters.put(LOCALITY1, mock(StatsCounter.class));
     PickResult errorResult = PickResult.withError(Status.UNAVAILABLE.withDescription("Error"));
     PickResult droppedResult = PickResult.withDrop(Status.UNAVAILABLE.withDescription("Dropped"));
-    // TODO (chengyuanzhang): for NoResult PickResult, do we still intercept?
+    PickResult emptyResult = PickResult.withNoResult();
     PickResult interceptedErrorResult = loadStore.interceptPickResult(errorResult, LOCALITY1);
     PickResult interceptedDroppedResult =
         loadStore.interceptPickResult(droppedResult, LOCALITY1);
-    assertThat(interceptedErrorResult.getStreamTracerFactory()).isNull();
-    assertThat(interceptedDroppedResult.getStreamTracerFactory()).isNull();
+    PickResult interceptedEmptyResult = loadStore.interceptPickResult(emptyResult, LOCALITY1);
+    assertThat(interceptedErrorResult).isEqualTo(errorResult);
+    assertThat(interceptedDroppedResult).isEqualTo(droppedResult);
+    assertThat(interceptedEmptyResult).isEqualTo(emptyResult);
   }
 
   @Test


### PR DESCRIPTION
Previously I forgot to handle the case when the original `PickResult` is `NO_RESULT` specially. In that case, the `PickResult`'s `status` is `OK` while it has no `Subchannel` (returns `null` when calling `PickResult#getSubchannel()`). We should not intercept `PickResult` with no `Subchannel` as `PickResult.withSubchannel()` has the check for non-null `Subchannel`.

The test case was actually incorrect as I forgot to add the locality counter in `StatsStore` before testing intercepting invalid `PickResult`s (which is an invalid use case for `StatsStore`). Therefore, it didn't really go through.  