### PR TITLE
xds: integrate receiving per-request backend metrics for client load reporting in xds load balancer

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -291,15 +291,15 @@ final class ClientLoadCounter {
 
   /**
    * Listener implementation to receive backend metrics and record metric values in the provided
-   * {@link StatsCounter}.
+   * {@link ClientLoadCounter}.
    */
   @ThreadSafe
   static final class MetricsRecordingListener implements OrcaPerRequestReportListener,
       OrcaOobReportListener {
 
-    private final StatsCounter counter;
+    private final ClientLoadCounter counter;
 
-    MetricsRecordingListener(StatsCounter counter) {
+    MetricsRecordingListener(ClientLoadCounter counter) {
       this.counter = checkNotNull(counter, "counter");
     }
 
@@ -313,7 +313,7 @@ final class ClientLoadCounter {
     }
 
     @VisibleForTesting
-    StatsCounter getCounter() {
+    ClientLoadCounter getCounter() {
       return counter;
     }
   }

--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -293,7 +293,6 @@ final class ClientLoadCounter {
    * Listener implementation to receive backend metrics and record metric values in the provided
    * {@link StatsCounter}.
    */
-  @VisibleForTesting
   @ThreadSafe
   static final class MetricsRecordingListener implements OrcaPerRequestReportListener,
       OrcaOobReportListener {
@@ -312,34 +311,10 @@ final class ClientLoadCounter {
         counter.recordMetric(entry.getKey(), entry.getValue());
       }
     }
-  }
 
-  /**
-   * Factory class for creating {@link OrcaPerRequestReportListener} and
-   * {@link OrcaOobReportListener} that record received metric values in the provided
-   * {@link StatsCounter}.
-   */
-  abstract static class XdsMetricsRecordingListenerFactory {
-
-    private static final XdsMetricsRecordingListenerFactory DEFAULT_INSTANCE =
-        new XdsMetricsRecordingListenerFactory() {
-          @Override
-          OrcaPerRequestReportListener createOrcaPerRequestReportListener(StatsCounter counter) {
-            return new MetricsRecordingListener(counter);
-          }
-
-          @Override
-          OrcaOobReportListener createOrcaOobReportListener(StatsCounter counter) {
-            return new MetricsRecordingListener(counter);
-          }
-        };
-
-    static XdsMetricsRecordingListenerFactory getInstance() {
-      return DEFAULT_INSTANCE;
+    @VisibleForTesting
+    StatsCounter getCounter() {
+      return counter;
     }
-
-    abstract OrcaPerRequestReportListener createOrcaPerRequestReportListener(StatsCounter counter);
-
-    abstract OrcaOobReportListener createOrcaOobReportListener(StatsCounter counter);
   }
 }

--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -296,9 +296,9 @@ final class ClientLoadCounter {
   static final class LocalityMetricsListener implements OrcaPerRequestReportListener,
       OrcaOobReportListener {
 
-    private final ClientLoadCounter counter;
+    private final StatsCounter counter;
 
-    LocalityMetricsListener(ClientLoadCounter counter) {
+    LocalityMetricsListener(StatsCounter counter) {
       this.counter = checkNotNull(counter, "counter");
     }
 

--- a/xds/src/main/java/io/grpc/xds/LocalityStore.java
+++ b/xds/src/main/java/io/grpc/xds/LocalityStore.java
@@ -47,7 +47,6 @@ import io.grpc.xds.InterLocalityPicker.WeightedChildPicker;
 import io.grpc.xds.OrcaPerRequestUtil.OrcaPerRequestReportListener;
 import io.grpc.xds.XdsComms.DropOverload;
 import io.grpc.xds.XdsComms.LocalityInfo;
-import io.grpc.xds.XdsLoadStatsStore.StatsCounter;
 import io.grpc.xds.XdsSubchannelPickers.ErrorPicker;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -427,7 +426,7 @@ interface LocalityStore {
             if (result.getSubchannel() == null) {
               return result;
             }
-            StatsCounter localityCounter = statsStore.getLocalityCounter(locality);
+            ClientLoadCounter localityCounter = statsStore.getLocalityCounter(locality);
             if (localityCounter == null) {
               getChannelLogger().log(ChannelLogLevel.ERROR,
                   "Locality counter for {0} does not exist, cannot record backend metrics.",

--- a/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClientLoadCounterTest.java
@@ -24,8 +24,8 @@ import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.xds.ClientLoadCounter.ClientLoadSnapshot;
-import io.grpc.xds.ClientLoadCounter.LocalityMetricsListener;
 import io.grpc.xds.ClientLoadCounter.MetricValue;
+import io.grpc.xds.ClientLoadCounter.MetricsRecordingListener;
 import io.grpc.xds.ClientLoadCounter.XdsClientLoadRecorder;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Before;
@@ -141,7 +141,7 @@ public class ClientLoadCounterTest {
 
   @Test
   public void metricListener_backendMetricsAggregation() {
-    LocalityMetricsListener listener1 = new LocalityMetricsListener(counter);
+    MetricsRecordingListener listener1 = new MetricsRecordingListener(counter);
     OrcaLoadReport report =
         OrcaLoadReport.newBuilder()
             .setCpuUtilization(0.5345)
@@ -174,7 +174,7 @@ public class ClientLoadCounterTest {
     snapshot = counter.snapshot();
     assertThat(snapshot.getMetricValues()).isEmpty();
 
-    LocalityMetricsListener listener2 = new LocalityMetricsListener(counter);
+    MetricsRecordingListener listener2 = new MetricsRecordingListener(counter);
     report =
         OrcaLoadReport.newBuilder()
             .setCpuUtilization(0.3423)

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -177,6 +177,8 @@ public class LocalityStoreTest {
   private ThreadSafeRandom random;
   @Mock
   private StatsStore statsStore;
+  @Mock
+  private OrcaPerRequestUtil orcaPerRequestUtil;
 
   private LocalityStore localityStore;
 
@@ -188,7 +190,9 @@ public class LocalityStoreTest {
     doAnswer(returnsFirstArg())
         .when(statsStore).interceptPickResult(any(PickResult.class), any(XdsLocality.class));
     lbRegistry.register(lbProvider);
-    localityStore = new LocalityStoreImpl(helper, pickerFactory, lbRegistry, random, statsStore);
+    localityStore =
+        new LocalityStoreImpl(helper, pickerFactory, lbRegistry, random, statsStore,
+            orcaPerRequestUtil);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/LocalityStoreTest.java
@@ -60,7 +60,6 @@ import io.grpc.xds.OrcaPerRequestUtil.OrcaPerRequestReportListener;
 import io.grpc.xds.XdsComms.DropOverload;
 import io.grpc.xds.XdsComms.LbEndpoint;
 import io.grpc.xds.XdsComms.LocalityInfo;
-import io.grpc.xds.XdsLoadStatsStore.StatsCounter;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.HashMap;
@@ -241,8 +240,8 @@ public class LocalityStoreTest {
 
     verify(statsStore).addLocality(locality1);
     verify(statsStore).addLocality(locality2);
-    StatsCounter localityCounter1 = mock(StatsCounter.class);
-    StatsCounter localityCounter2 = mock(StatsCounter.class);
+    ClientLoadCounter localityCounter1 = new ClientLoadCounter();
+    ClientLoadCounter localityCounter2 = new ClientLoadCounter();
     when(statsStore.getLocalityCounter(locality1)).thenReturn(localityCounter1);
     when(statsStore.getLocalityCounter(locality2)).thenReturn(localityCounter2);
     ArgumentCaptor<OrcaPerRequestReportListener> orcaPerRequestReportListenerCaptor1 =


### PR DESCRIPTION
Main idea:

Wrap another layer of `PickResult` when child picker makes a pick decision. The wrapped `PickResult` has a `ClientStreamTracer.Factory`, which is created by `OrcaPerRequestUtil` and has an `OrcaPerRequestReportListener` that receives backend metrics.