### PR TITLE
 core: SubchannelStateListener continues to receive updates after LoadBalancer is shutdown.

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -349,9 +349,9 @@ public abstract class LoadBalancer {
   }
 
   /**
-   * The channel asks the load-balancer to shutdown.  No more callbacks will be called after this
-   * method.  The implementation should shutdown all Subchannels and OOB channels, and do any other
-   * cleanup as necessary.
+   * The channel asks the load-balancer to shutdown.  No more methods on this class will be called
+   * after this method.  The implementation should shutdown all Subchannels and OOB channels, and do
+   * any other cleanup as necessary.
    *
    * @since 1.2.0
    */

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1080,7 +1080,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
               if (LbHelperImpl.this != ManagedChannelImpl.this.lbHelper) {
                 return;
               }
-              System.err.println("XXX: " + newState);
               lb.handleSubchannelState(subchannel, newState);
             }
           };

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1454,11 +1454,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
         @Override
         void onStateChange(InternalSubchannel is, ConnectivityStateInfo newState) {
           handleInternalSubchannelState(newState);
-          // Call LB only if it's not shutdown.  If LB is shutdown, lbHelper won't match.
-          if (helper == ManagedChannelImpl.this.lbHelper) {
-            checkState(listener != null, "listener is null");
-            listener.onSubchannelState(newState);
-          }
+          checkState(listener != null, "listener is null");
+          listener.onSubchannelState(newState);
         }
 
         @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -791,6 +791,11 @@ final class ManagedChannelImpl extends ManagedChannel implements
     channelStateManager.gotoState(TRANSIENT_FAILURE);
   }
 
+  @VisibleForTesting
+  boolean isInPanicMode() {
+    return panicMode;
+  }
+
   // Called from syncContext
   private void updateSubchannelPicker(SubchannelPicker newPicker) {
     subchannelPicker = newPicker;
@@ -1071,6 +1076,11 @@ final class ManagedChannelImpl extends ManagedChannel implements
           new LoadBalancer.SubchannelStateListener() {
             @Override
             public void onSubchannelState(ConnectivityStateInfo newState) {
+              // Call LB only if it's not shutdown.  If LB is shutdown, lbHelper won't match.
+              if (LbHelperImpl.this != ManagedChannelImpl.this.lbHelper) {
+                return;
+              }
+              System.err.println("XXX: " + newState);
               lb.handleSubchannelState(subchannel, newState);
             }
           };


### PR DESCRIPTION
No more methods on the `LoadBalancer` will be called after
`LoadBalancer#shutdown()` is called.  This includes
`LoadBalancer#handleSubchannelState()` too.  `SubchannelStateListener`
inherited this restriction.  However, this special case makes
`onSubchannelState(SHUTDOWN)` an unreliable way of being notified
about `Subchannel` SHUTDOWN, and may confuse/complicate a
wrapping `LoadBalancer` that expects the full notification (e.g., #5875).

The javadoc isn't clear whether this restriction applies.  I think
it's more useful to make it no apply.
