### PR TITLE
xds: add missing test coverage for interactions between XdsLoadStatsStore and XdsClientLoadRecorder

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
+++ b/xds/src/main/java/io/grpc/xds/ClientLoadCounter.java
@@ -287,6 +287,11 @@ final class ClientLoadCounter {
         }
       };
     }
+
+    @VisibleForTesting
+    ClientLoadCounter getCounter() {
+      return counter;
+    }
   }
 
   /**


### PR DESCRIPTION
As mentioned in https://github.com/grpc/grpc-java/pull/5878#discussion_r293913334, `XdsLoadStatsStoreTest` is missing the coverage for testing the interaction between `XdsLoadStatsStore` and `XdsClientLoadRecorder`, which applies the load recording logic to `PickResult`. This fills the test coverage gap between how client counts load and how it is recorded in `StatsCounter`.