### PR TITLE
java_grpc_library.bzl: Support alternative javac toolchains (1.21.x backport)

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -44,7 +44,7 @@ java_rpc_toolchain = rule(
             executable = True,
         ),
         "_java_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/jdk:toolchain"),
+            default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
         ),
         "_host_javabase": attr.label(
             cfg = "host",


### PR DESCRIPTION
Depending on jdk:toolchain causes java_grpc_library to always use the
_default_ toolchain, even if the user tried to override it. Changing to
:current_java_toolchain allows the rule to use the user-selected
toolchain when overridden.

Tested by adding to BUILD:
load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
default_java_toolchain(
    name = "mychain",
    misc = ["-Amy=flag"],
    visibility = ["//visibility:public"],
)

And then verifying -Amy=flag is in the output of:
bazel aquery --java_toolchain=:mychain services:_reflection_java_grpc

Fixes #5841

Backport of #5844