### PR TITLE
netty-shaded: Use compile instead of runtime dependency in pom

### DIFF
--- a/netty/shaded/build.gradle
+++ b/netty/shaded/build.gradle
@@ -56,7 +56,7 @@ publishing {
                     dependencyNode.appendNode('artifactId', dep.name)
                     def version = (dep.name == 'grpc-core') ? '[' + dep.version + ']' : dep.version
                     dependencyNode.appendNode('version', version)
-                    dependencyNode.appendNode('scope', 'runtime')
+                    dependencyNode.appendNode('scope', 'compile')
                 }
             }
         }


### PR DESCRIPTION
Maven does not include transitive runtime dependencies in the
compile-time classpath (testing shows Gradle 4 does). So if a user
references the shaded NettyServerBuilder without also depending on
grpc-core directly, compilation will fail because
AbstractServerImplBuilder couldn't be found.

This isn't technically a problem, since we're not wanting to encourage
users to reference the shaded classes directly. But some users will
certainly reference the classes anyway and the error is pretty confusing
while also being trivially worked around. In other words: it justs
wastes people's time and benefits nobody.

Fixes #5881